### PR TITLE
Fix six critical bash interpreter bugs (Python + TypeScript parity)

### DIFF
--- a/docs/home/shell.mdx
+++ b/docs/home/shell.mdx
@@ -143,27 +143,6 @@ Both bindings support cooperative cancellation observed at recursion boundaries 
 | Many isolated commands sharing scoped state | `session_id=...` (Py) / `sessionId` (TS) | a separate terminal |
 | Persistent shell mutations | run without options | `cd /data; cmd` |
 
-## Limitations
-
-### `FOO=bar cmd` prefix is silently broken
-
-The standard bash inline-assignment prefix (`FOO=bar cmd`) does NOT work in Mirage's executor. Both Python and TypeScript bindings are affected — this is in the shared shell parser, not the language runtime.
-
-```bash
-# These look like bash but produce wrong results:
-FOO=bar printenv FOO        # exit 1, stdout empty (FOO=bar leaked into argv)
-FOO=bar echo "$FOO"          # prints empty (FOO=bar treated as command name)
-env FOO=bar printenv FOO    # exit 127 ("env: command not found"; no env builtin)
-```
-
-The parser treats leading `VARIABLE_ASSIGNMENT` nodes as part of argv instead of stripping them into the command's environment, and there is no `env` builtin to fall back on.
-
-**Workarounds, in order of preference:**
-
-1. **From the SDK:** use the per-call `env` parameter on `execute()`. Both bindings expose it the same way (TS as an options field, Python as a keyword argument). This is the structured, race-free path and the recommended approach for harnesses.
-2. **From a shell command string:** use a subshell `(export FOO=bar; cmd)`. The export is scoped to the subshell and does not leak to the parent session. This works in both `ws.execute('(export FOO=bar; cmd)')` and `mirage execute -c "(export FOO=bar; cmd)"`.
-3. **Mutate the session:** `ws.execute('export FOO=bar')` followed by `ws.execute('cmd')` if persistence is what you want.
-
 ## Agent Pattern
 
 Agent harnesses commonly fan out tool calls in parallel, each with its own `cwd`/`env`/`cancel`. The clone semantics make this race-free without per-call boilerplate.

--- a/python/mirage/shell/types.py
+++ b/python/mirage/shell/types.py
@@ -114,6 +114,19 @@ class NodeType(StrEnum):
     ERROR = "ERROR"
 
 
+ERREXIT_EXEMPT_TYPES = frozenset({
+    NodeType.LIST,
+    NodeType.NEGATED_COMMAND,
+})
+
+SET_FLAG_TO_OPTION = {
+    "e": "errexit",
+    "u": "nounset",
+    "x": "xtrace",
+    "f": "noglob",
+}
+
+
 class RedirectKind(StrEnum):
     STDOUT = "stdout"
     STDERR = "stderr"

--- a/python/mirage/workspace/executor/builtins.py
+++ b/python/mirage/workspace/executor/builtins.py
@@ -26,6 +26,7 @@ from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.stream import async_chain, materialize
 from mirage.io.types import ByteSource
 from mirage.shell.call_stack import CallStack
+from mirage.shell.types import SET_FLAG_TO_OPTION
 from mirage.types import FileType, PathSpec
 from mirage.utils.path import resolve_path
 from mirage.workspace.abort import cancellable_sleep
@@ -98,10 +99,32 @@ async def handle_export(
     for assign in assignments:
         if "=" in assign:
             key, _, val = assign.partition("=")
+            if key in session.readonly_vars:
+                err = f"bash: {key}: readonly variable\n".encode()
+                return None, IOResult(exit_code=1, stderr=err), ExecutionNode(
+                    command="export", exit_code=1, stderr=err)
             session.env[key] = val
         else:
             session.env.setdefault(assign, "")
     return None, IOResult(), ExecutionNode(command="export", exit_code=0)
+
+
+async def handle_readonly(
+    assignments: list[str],
+    session: Session,
+) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
+    for assign in assignments:
+        if "=" in assign:
+            key, _, val = assign.partition("=")
+            if key in session.readonly_vars:
+                err = f"bash: {key}: readonly variable\n".encode()
+                return None, IOResult(exit_code=1, stderr=err), ExecutionNode(
+                    command="readonly", exit_code=1, stderr=err)
+            session.env[key] = val
+            session.readonly_vars.add(key)
+        else:
+            session.readonly_vars.add(assign)
+    return None, IOResult(), ExecutionNode(command="readonly", exit_code=0)
 
 
 async def handle_unset(
@@ -109,6 +132,13 @@ async def handle_unset(
     session: Session,
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
     for name in names:
+        if name in session.readonly_vars:
+            err = (f"bash: unset: {name}: cannot unset: "
+                   f"readonly variable\n").encode()
+            return None, IOResult(exit_code=1,
+                                  stderr=err), ExecutionNode(command="unset",
+                                                             exit_code=1,
+                                                             stderr=err)
         session.env.pop(name, None)
     return None, IOResult(), ExecutionNode(command="unset", exit_code=0)
 
@@ -340,8 +370,25 @@ async def handle_read(
         return None, IOResult(exit_code=1), ExecutionNode(command="read",
                                                           exit_code=1)
 
-    line = line_bytes.decode(errors="replace")
-    parts = line.split(None, len(variables) - 1)
+    line = line_bytes.decode(errors="replace").rstrip("\n")
+    ifs = session.env.get("IFS", " \t\n")
+    if ifs == " \t\n":
+        parts = line.split(None, len(variables) - 1) if variables else []
+    elif not ifs:
+        parts = [line]
+    else:
+        n_splits = max(0, len(variables) - 1)
+        chars = set(ifs)
+        out: list[str] = []
+        cur: list[str] = []
+        for ch in line:
+            if ch in chars and len(out) < n_splits:
+                out.append("".join(cur))
+                cur = []
+                continue
+            cur.append(ch)
+        out.append("".join(cur))
+        parts = out
     for i, var in enumerate(variables):
         session.env[var] = parts[i] if i < len(parts) else ""
     return None, IOResult(), ExecutionNode(command="read", exit_code=0)
@@ -564,8 +611,29 @@ async def handle_set(
         lines = [f"{k}={v}" for k, v in session.env.items()]
         out = ("\n".join(sorted(lines)) + "\n").encode()
         return out, IOResult(), ExecutionNode(command="set", exit_code=0)
-    if args and args[0] == "--":
-        session.positional_args = args[1:]
+    i = 0
+    while i < len(args):
+        tok = args[i]
+        if tok == "--":
+            session.positional_args = args[i + 1:]
+            return None, IOResult(), ExecutionNode(command="set", exit_code=0)
+        if tok in ("-o", "+o"):
+            if i + 1 < len(args):
+                session.shell_options[args[i + 1]] = (tok == "-o")
+                i += 2
+                continue
+            i += 1
+            continue
+        if (tok.startswith("-") or tok.startswith("+")) and len(tok) > 1:
+            enable = tok[0] == "-"
+            for ch in tok[1:]:
+                opt = SET_FLAG_TO_OPTION.get(ch)
+                if opt:
+                    session.shell_options[opt] = enable
+            i += 1
+            continue
+        session.positional_args = args[i:]
+        break
     return None, IOResult(), ExecutionNode(command="set", exit_code=0)
 
 

--- a/python/mirage/workspace/executor/command.py
+++ b/python/mirage/workspace/executor/command.py
@@ -21,6 +21,7 @@ from mirage.io.stream import async_chain, materialize, wrap_cachable_streams
 from mirage.io.types import ByteSource
 from mirage.shell.call_stack import CallStack
 from mirage.shell.job_table import JobTable
+from mirage.shell.types import ERREXIT_EXEMPT_TYPES
 from mirage.types import PathSpec
 from mirage.workspace.executor.control import ReturnSignal
 from mirage.workspace.executor.cross_mount import (handle_cross_mount,
@@ -574,6 +575,10 @@ async def handle_command(
                 if stdout is not None:
                     all_stdout.append(stdout)
                 merged_io = await merged_io.merge(io)
+                if (io.exit_code != 0 and session.shell_options.get("errexit")
+                        and cmd.type not in ERREXIT_EXEMPT_TYPES):
+                    merged_io.exit_code = io.exit_code
+                    break
             combined = async_chain(*all_stdout) if all_stdout else None
             last_exec.exit_code = merged_io.exit_code
             return combined, merged_io, last_exec

--- a/python/mirage/workspace/executor/control.py
+++ b/python/mirage/workspace/executor/control.py
@@ -23,6 +23,7 @@ from mirage.io.stream import async_chain
 from mirage.io.types import ByteSource
 from mirage.shell.barrier import BarrierPolicy, apply_barrier
 from mirage.shell.call_stack import CallStack
+from mirage.shell.types import ERREXIT_EXEMPT_TYPES
 from mirage.types import PathSpec
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
@@ -76,6 +77,10 @@ async def _execute_body(
             raise ContinueSignal(stdout=combined, io=merged_io)
         all_stdout.append(stdout)
         merged_io = await merged_io.merge(io)
+        if (io.exit_code != 0 and session.shell_options.get("errexit")
+                and cmd.type not in ERREXIT_EXEMPT_TYPES):
+            merged_io.exit_code = io.exit_code
+            break
     non_empty = [s for s in all_stdout if s is not None]
     combined = async_chain(*non_empty) if non_empty else None
     return combined, merged_io, last_exec

--- a/python/mirage/workspace/executor/pipes.py
+++ b/python/mirage/workspace/executor/pipes.py
@@ -19,6 +19,7 @@ from mirage.io.stream import async_chain, close_quietly, merge_stdout_stderr
 from mirage.io.types import ByteSource, materialize
 from mirage.shell.barrier import BarrierPolicy, apply_barrier
 from mirage.shell.call_stack import CallStack
+from mirage.shell.types import ERREXIT_EXEMPT_TYPES
 from mirage.shell.types import NodeType as NT
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
@@ -70,6 +71,13 @@ async def handle_pipe(
 
     last_io = ios[-1]
     last_io.sync_exit_code()
+    if session.shell_options.get("pipefail"):
+        for io in ios:
+            io.sync_exit_code()
+        rightmost_failure = next(
+            (io.exit_code for io in reversed(ios) if io.exit_code != 0), 0)
+        if rightmost_failure != 0:
+            last_io.exit_code = rightmost_failure
     merged_stderr_parts: list[bytes] = []
     merged_reads: dict[str, ByteSource] = {}
     merged_writes: dict[str, ByteSource] = {}
@@ -171,6 +179,9 @@ async def handle_subshell(
     """Execute body in isolated env."""
     saved_cwd = session.cwd
     saved_env = dict(session.env)
+    saved_options = dict(session.shell_options)
+    saved_readonly = set(session.readonly_vars)
+    saved_arrays = {k: list(v) for k, v in session.arrays.items()}
     try:
         all_stdout: list = []
         merged_io = IOResult()
@@ -181,6 +192,10 @@ async def handle_subshell(
             if stdout is not None:
                 all_stdout.append(stdout)
             merged_io = await merged_io.merge(io)
+            if (io.exit_code != 0 and session.shell_options.get("errexit")
+                    and child.type not in ERREXIT_EXEMPT_TYPES):
+                merged_io.exit_code = io.exit_code
+                break
         if len(all_stdout) == 1:
             return all_stdout[0], merged_io, last_exec
         combined = async_chain(*all_stdout) if all_stdout else None
@@ -188,3 +203,6 @@ async def handle_subshell(
     finally:
         session.cwd = saved_cwd
         session.env = saved_env
+        session.shell_options = saved_options
+        session.readonly_vars = saved_readonly
+        session.arrays = saved_arrays

--- a/python/mirage/workspace/expand/node.py
+++ b/python/mirage/workspace/expand/node.py
@@ -116,7 +116,8 @@ async def expand_node(
         return prefix + _lookup_var(var, session, call_stack)
 
     if ntype == NT.EXPANSION:
-        return _expand_braces(ts_node, session.env, call_stack)
+        return _expand_braces(ts_node, session.env,
+                              getattr(session, "arrays", {}), call_stack)
 
     if ntype == NT.COMMAND_SUBSTITUTION:
         inner_cmds = [

--- a/python/mirage/workspace/expand/parts.py
+++ b/python/mirage/workspace/expand/parts.py
@@ -32,6 +32,67 @@ def _has_at_expansion(node: tree_sitter.Node) -> bool:
     return False
 
 
+def _array_at_name(child: tree_sitter.Node) -> str | None:
+    if child.type != NT.EXPANSION:
+        return None
+    has_length_op = any(c.type == "#" and not c.is_named
+                        for c in child.children)
+    if has_length_op:
+        return None
+    sub = next((c for c in child.named_children if c.type == "subscript"),
+               None)
+    if sub is None:
+        return None
+    idx_text = ""
+    var_name = None
+    for sc in sub.named_children:
+        if sc.type == NT.VARIABLE_NAME:
+            var_name = sc.text.decode()
+        else:
+            idx_text = sc.text.decode()
+    if var_name and idx_text == "@":
+        return var_name
+    return None
+
+
+def _string_has_array_at(node: tree_sitter.Node) -> bool:
+    return any(_array_at_name(c) is not None for c in node.children)
+
+
+async def _expand_string_with_array(
+    node: tree_sitter.Node,
+    session: Session,
+    execute_fn: Callable,
+    call_stack: CallStack | None,
+) -> list[str]:
+    """Expand a string containing one or more "${a[@]}" into multiple words.
+
+    Bash semantics: "prefix${a[@]}suffix" with a=(1 2 3) produces three
+    words: "prefix1", "2", "3suffix". Single-element arrays merge prefix
+    and suffix into one word; empty arrays still produce prefix+suffix.
+    """
+    arrays = getattr(session, "arrays", {})
+    fragments: list[str] = [""]
+    for child in node.children:
+        if child.type == NT.DQUOTE:
+            continue
+        arr_name = _array_at_name(child)
+        if arr_name is not None:
+            arr = arrays.get(arr_name)
+            if not arr:
+                continue
+            if len(arr) == 1:
+                fragments[-1] = fragments[-1] + arr[0]
+            else:
+                fragments[-1] = fragments[-1] + arr[0]
+                fragments.extend(arr[1:-1])
+                fragments.append(arr[-1])
+            continue
+        text = await expand_node(child, session, execute_fn, call_stack)
+        fragments[-1] = fragments[-1] + text
+    return fragments
+
+
 def _get_positional_args(session: Session,
                          call_stack: CallStack | None) -> list[str]:
     if call_stack and call_stack.get_all_positional():
@@ -59,6 +120,11 @@ async def expand_parts(
             if positional:
                 result.extend(positional)
                 continue
+        if p.type == NT.STRING and _string_has_array_at(p):
+            words = await _expand_string_with_array(p, session, execute_fn,
+                                                    call_stack)
+            result.extend(words)
+            continue
         expanded = await expand_node(p, session, execute_fn, call_stack)
         if p.type == NT.COMMAND_SUBSTITUTION:
             for word in expanded.split():

--- a/python/mirage/workspace/expand/variable.py
+++ b/python/mirage/workspace/expand/variable.py
@@ -12,9 +12,16 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import fnmatch
+
 from mirage.shell.call_stack import CallStack
 from mirage.shell.types import NodeType as NT
 from mirage.workspace.session import Session
+
+_PARAM_OPS = frozenset({
+    ":-", "-", ":+", "+", ":?", "?", ":=", "=", "#", "##", "%", "%%", "/",
+    "//", ":", "^", "^^", ",", ",,", "!"
+})
 
 
 def _lookup_var(var: str, session: Session,
@@ -52,23 +59,161 @@ def _lookup_var(var: str, session: Session,
     return env.get(var, "")
 
 
-def _expand_braces(node, env: dict, call_stack: CallStack | None) -> str:
-    """Expand ${VAR}, ${VAR:-default}, etc."""
+def _glob_strip(value: str, pattern: str, greedy: bool, prefix: bool) -> str:
+    if not pattern:
+        return value
+    if prefix:
+        candidates = [
+            i for i in range(len(value) + 1)
+            if fnmatch.fnmatchcase(value[:i], pattern)
+        ]
+        if not candidates:
+            return value
+        i = max(candidates) if greedy else min(candidates)
+        return value[i:]
+    candidates = [
+        i for i in range(len(value) + 1)
+        if fnmatch.fnmatchcase(value[i:], pattern)
+    ]
+    if not candidates:
+        return value
+    i = min(candidates) if greedy else max(candidates)
+    return value[:i]
+
+
+def _apply_op(op: str, val: str, var_in_env: bool, args: list[str]) -> str:
+    if op == ":-":
+        return val if val else (args[0] if args else "")
+    if op == "-":
+        if var_in_env:
+            return val
+        return args[0] if args else ""
+    if op == ":+":
+        return (args[0] if args else "") if val else ""
+    if op == "+":
+        return (args[0] if args else "") if var_in_env else ""
+    if op == "#":
+        return _glob_strip(val, args[0] if args else "", False, True)
+    if op == "##":
+        return _glob_strip(val, args[0] if args else "", True, True)
+    if op == "%":
+        return _glob_strip(val, args[0] if args else "", False, False)
+    if op == "%%":
+        return _glob_strip(val, args[0] if args else "", True, False)
+    if op == "/":
+        if not args:
+            return val
+        replacement = args[1] if len(args) > 1 else ""
+        return val.replace(args[0], replacement, 1)
+    if op == "//":
+        if not args:
+            return val
+        replacement = args[1] if len(args) > 1 else ""
+        return val.replace(args[0], replacement)
+    if op == "^^":
+        return val.upper()
+    if op == ",,":
+        return val.lower()
+    if op == "^":
+        return val[:1].upper() + val[1:] if val else val
+    if op == ",":
+        return val[:1].lower() + val[1:] if val else val
+    if op == ":" and args:
+        try:
+            offset = int(args[0])
+            length = int(args[1]) if len(args) > 1 else None
+        except ValueError:
+            return val
+        if offset < 0:
+            offset = max(0, len(val) + offset)
+        if length is None:
+            return val[offset:]
+        if length < 0:
+            return val[offset:max(offset, len(val) + length)]
+        return val[offset:offset + length]
+    return val
+
+
+def _expand_braces(
+    node,
+    env: dict,
+    arrays: dict,
+    call_stack: CallStack | None,
+) -> str:
+    """Expand ${VAR}, ${VAR<op>...}, ${a[i]}, ${#a[@]}, etc."""
     var_name = None
-    default_val = None
-    for c in node.named_children:
+    subscript_node = None
+    length_op = False
+    indirect_op = False
+    op = None
+    args: list[str] = []
+    seen_var = False
+    for c in node.children:
+        if c.type == "${" or c.type == "}":
+            continue
+        if c.type == "#" and not seen_var:
+            length_op = True
+            continue
+        if c.type == "!" and not seen_var:
+            indirect_op = True
+            continue
         if c.type == NT.VARIABLE_NAME:
             var_name = c.text.decode()
-        elif c.type in (NT.WORD, NT.STRING, NT.RAW_STRING, NT.STRING_CONTENT):
-            default_val = c.text.decode()
+            seen_var = True
+            continue
+        if c.type == "subscript":
+            subscript_node = c
+            for sc in c.named_children:
+                if sc.type == NT.VARIABLE_NAME:
+                    var_name = sc.text.decode()
+                    break
+            seen_var = True
+            continue
+        if c.type in _PARAM_OPS and op is None:
+            op = c.text.decode()
+            continue
+        if c.type in (NT.WORD, NT.STRING, NT.RAW_STRING, NT.STRING_CONTENT,
+                      NT.NUMBER, "regex"):
+            args.append(c.text.decode())
+
     val = ""
-    if var_name:
+    var_in_env = False
+    if subscript_node is not None and var_name is not None:
+        idx_text = ""
+        for sc in subscript_node.named_children:
+            if sc.type == NT.VARIABLE_NAME:
+                continue
+            idx_text = sc.text.decode()
+            break
+        arr = arrays.get(var_name)
+        if arr is None:
+            scalar = env.get(var_name, "")
+            arr = [scalar] if scalar else []
+        var_in_env = var_name in arrays or var_name in env
+        if idx_text in ("@", "*"):
+            if length_op:
+                return str(len(arr))
+            val = " ".join(arr)
+        else:
+            try:
+                i = int(idx_text)
+                val = arr[i] if 0 <= i < len(arr) else ""
+            except ValueError:
+                val = ""
+    elif var_name:
         if call_stack:
             local_val = call_stack.get_local(var_name)
             if local_val is not None:
                 val = local_val
-        if not val:
+                var_in_env = True
+        if not var_in_env:
+            var_in_env = var_name in env
             val = env.get(var_name, "")
-    if default_val is not None and not val:
-        return default_val
-    return val
+
+    if indirect_op:
+        return env.get(val, "") if val else ""
+    if length_op:
+        return str(len(val))
+    if op is None:
+        return val
+    return _apply_op(op, val, var_in_env, args)

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -21,6 +21,7 @@ from mirage.io import IOResult
 from mirage.io.stream import async_chain, materialize
 from mirage.shell.call_stack import CallStack
 from mirage.shell.job_table import JobTable
+from mirage.shell.types import ERREXIT_EXEMPT_TYPES
 from mirage.shell.types import NodeType as NT
 from mirage.shell.types import Redirect, RedirectKind
 from mirage.shell.types import ShellBuiltin as SB
@@ -54,8 +55,9 @@ from mirage.shell.helpers import (  # isort: skip
 from mirage.workspace.executor.builtins import (  # isort: skip
     handle_bash, handle_cd, handle_echo, handle_eval, handle_export,
     handle_local, handle_man, handle_printenv, handle_printf, handle_python,
-    handle_read, handle_return, handle_set, handle_shift, handle_sleep,
-    handle_source, handle_test, handle_trap, handle_unset, handle_whoami)
+    handle_read, handle_readonly, handle_return, handle_set, handle_shift,
+    handle_sleep, handle_source, handle_test, handle_trap, handle_unset,
+    handle_whoami)
 
 
 async def execute_node(
@@ -205,6 +207,10 @@ async def execute_node(
             if stdout is not None:
                 all_stdout.append(stdout)
             merged_io = await merged_io.merge(io)
+            if (io.exit_code != 0 and session.shell_options.get("errexit")
+                    and child.type not in ERREXIT_EXEMPT_TYPES):
+                merged_io.exit_code = io.exit_code
+                break
         if len(all_stdout) == 1:
             return all_stdout[0], merged_io, last_exec
         combined = async_chain(*all_stdout) if all_stdout else None
@@ -251,21 +257,40 @@ async def execute_node(
         return None, IOResult(), ExecutionNode(command=f"function {name}",
                                                exit_code=0)
 
-    # ── declaration (export/local/declare) ──────
+    # ── declaration (export/local/declare/readonly) ──
     if ntype == NT.DECLARATION_COMMAND:
         keyword = get_declaration_keyword(node)
         assignments = []
+        flag_chars: set[str] = set()
         for child in node.named_children:
             if child.type == NT.VARIABLE_ASSIGNMENT:
+                val_nodes = [
+                    c for c in child.named_children
+                    if c.type != NT.VARIABLE_NAME
+                ]
+                if val_nodes and val_nodes[0].type == NT.ARRAY:
+                    key = get_text(child).partition("=")[0]
+                    items = [
+                        await expand_node(ac, session, execute_fn, cs)
+                        for ac in val_nodes[0].named_children
+                    ]
+                    session.arrays[key] = items
+                    continue
                 expanded = await expand_node(child, session, execute_fn, cs)
                 assignments.append(expanded)
             elif child.type in (NT.SIMPLE_EXPANSION, NT.EXPANSION,
                                 NT.CONCATENATION, NT.WORD):
                 expanded = await expand_node(child, session, execute_fn, cs)
-                if expanded:
+                if not expanded:
+                    continue
+                if expanded.startswith("-") and len(expanded) > 1:
+                    flag_chars.update(expanded[1:])
+                else:
                     assignments.append(expanded)
         if keyword == NT.LOCAL:
             return await handle_local(assignments, session)
+        if keyword == "readonly" or "r" in flag_chars:
+            return await handle_readonly(assignments, session)
         return await handle_export(assignments, session)
 
     # ── unset ───────────────────────────────────
@@ -298,12 +323,28 @@ async def execute_node(
         text = get_text(node)
         if "=" in text:
             key, _, val = text.partition("=")
+            if key in session.readonly_vars:
+                err = f"bash: {key}: readonly variable\n".encode()
+                return None, IOResult(exit_code=1,
+                                      stderr=err), ExecutionNode(command=text,
+                                                                 exit_code=1,
+                                                                 stderr=err)
             val_nodes = [
                 c for c in node.named_children if c.type != NT.VARIABLE_NAME
             ]
+            if val_nodes and val_nodes[0].type == NT.ARRAY:
+                items = []
+                for ac in val_nodes[0].named_children:
+                    items.append(await expand_node(ac, session, execute_fn,
+                                                   cs))
+                session.arrays[key] = items
+                session.env.pop(key, None)
+                return None, IOResult(), ExecutionNode(command=text,
+                                                       exit_code=0)
             if val_nodes:
                 val = await expand_node(val_nodes[0], session, execute_fn, cs)
             session.env[key] = val
+            session.arrays.pop(key, None)
         return None, IOResult(), ExecutionNode(command=text, exit_code=0)
 
     raise TypeError(f"unsupported tree-sitter node type: {ntype}")
@@ -492,6 +533,11 @@ async def _execute_program(
             all_stdout.append(stdout)
         merged_io = await merged_io.merge(io)
 
+        if (io.exit_code != 0 and session.shell_options.get("errexit")
+                and not is_bg and child.type not in ERREXIT_EXEMPT_TYPES):
+            merged_io.exit_code = io.exit_code
+            break
+
     if len(all_stdout) == 1:
         return all_stdout[0], merged_io, last_exec
     combined = async_chain(*all_stdout) if all_stdout else None
@@ -515,6 +561,79 @@ async def _execute_command(
     name = get_command_name(node)
     parts = get_parts(node)
 
+    prefix_assignments: list[tuple[str, str]] = []
+    non_prefix_parts = []
+    saw_command_name = False
+    for p in parts:
+        if not saw_command_name and p.type == NT.VARIABLE_ASSIGNMENT:
+            atext = get_text(p)
+            if "=" in atext:
+                key, _, raw_val = atext.partition("=")
+                val_nodes = [
+                    c for c in p.named_children if c.type != NT.VARIABLE_NAME
+                ]
+                if val_nodes:
+                    v = await expand_node(val_nodes[0], session, execute_fn,
+                                          call_stack)
+                else:
+                    v = raw_val
+                prefix_assignments.append((key, v))
+            continue
+        if p.type == NT.COMMAND_NAME:
+            saw_command_name = True
+        non_prefix_parts.append(p)
+    parts = non_prefix_parts
+
+    for k, _ in prefix_assignments:
+        if k in session.readonly_vars:
+            err = f"bash: {k}: readonly variable\n".encode()
+            return None, IOResult(exit_code=1,
+                                  stderr=err), ExecutionNode(command=name or k,
+                                                             exit_code=1,
+                                                             stderr=err)
+
+    if prefix_assignments and not name:
+        for k, v in prefix_assignments:
+            session.env[k] = v
+        return None, IOResult(), ExecutionNode(command=" ".join(
+            f"{k}={v}" for k, v in prefix_assignments),
+                                               exit_code=0)
+
+    is_function_call = name in session.functions
+    saved_env_overrides: dict[str, str | None] = {}
+    for k, v in prefix_assignments:
+        if not is_function_call:
+            saved_env_overrides[k] = session.env.get(k)
+        session.env[k] = v
+
+    try:
+        return await _dispatch_command_body(recurse, dispatch, registry,
+                                            execute_fn, node, parts, name,
+                                            session, stdin, call_stack,
+                                            job_table, history, cancel)
+    finally:
+        for k, prev in saved_env_overrides.items():
+            if prev is None:
+                session.env.pop(k, None)
+            else:
+                session.env[k] = prev
+
+
+async def _dispatch_command_body(
+    recurse,
+    dispatch,
+    registry,
+    execute_fn,
+    node,
+    parts,
+    name,
+    session,
+    stdin,
+    call_stack,
+    job_table,
+    history: object = None,
+    cancel: asyncio.Event | None = None,
+) -> tuple[Any, IOResult, ExecutionNode]:
     for child in node.named_children:
         if child.type == NT.HERESTRING_REDIRECT:
             for sc in child.named_children:

--- a/python/mirage/workspace/session/session.py
+++ b/python/mirage/workspace/session/session.py
@@ -26,6 +26,9 @@ class Session:
     created_at: float = field(default_factory=time.time)
     functions: dict[str, object] = field(default_factory=dict)
     last_exit_code: int = 0
+    shell_options: dict[str, bool] = field(default_factory=dict)
+    readonly_vars: set[str] = field(default_factory=set)
+    arrays: dict[str, list[str]] = field(default_factory=dict)
     _stdin_buffer: AsyncLineIterator | None = field(default=None, repr=False)
 
     def to_dict(self) -> dict:

--- a/python/tests/shell/test_arrays.py
+++ b/python/tests/shell/test_arrays.py
@@ -1,0 +1,33 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+CASES = [
+    ('a=(one two three); echo "${a[0]}"', "one\n"),
+    ('a=(one two three); echo "${a[1]}"', "two\n"),
+    ('a=(one two three); echo "${a[2]}"', "three\n"),
+    ('a=(one two three); echo "${a[@]}"', "one two three\n"),
+    ('a=(one two three); echo "${a[*]}"', "one two three\n"),
+    ('a=(one two three); echo "${#a[@]}"', "3\n"),
+    ('a=(); echo "${#a[@]}"', "0\n"),
+    ('a=(x y z); for i in "${a[@]}"; do echo $i; done', "x\ny\nz\n"),
+    ('declare -a arr=(a b c); echo "${arr[@]}"', "a b c\n"),
+    ('a=("hello world" foo); echo "${a[0]}"', "hello world\n"),
+]
+
+
+@pytest.mark.parametrize("cmd,expected", CASES)
+def test_array(shell, cmd, expected):
+    assert shell.mirage(cmd) == expected

--- a/python/tests/shell/test_audit_regressions.py
+++ b/python/tests/shell/test_audit_regressions.py
@@ -1,0 +1,70 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+
+def test_subshell_isolates_readonly(shell):
+    out = shell.mirage("(readonly X=1); X=2; echo $X")
+    assert out == "2\n"
+
+
+def test_subshell_isolates_arrays(shell):
+    out = shell.mirage('(a=(1 2 3)); echo "${a[0]:-empty}"')
+    assert out == "empty\n"
+
+
+def test_subshell_isolates_shell_options(shell):
+    out = shell.mirage("set -e; (set +e; true); echo continued")
+    assert out == "continued\n"
+
+
+def test_function_prefix_persists_in_parent_env(shell):
+    out = shell.mirage(
+        'f() { echo "FOO=$FOO"; }; FOO=bar f; echo "after=$FOO"')
+    assert out == "FOO=bar\nafter=bar\n"
+
+
+def test_command_prefix_does_not_persist(shell):
+    out = shell.mirage('FOO=bar echo "FOO=$FOO"; echo "after=$FOO"')
+    assert "after=\n" in out
+
+
+def test_readonly_blocks_prefix_assignment(shell):
+    out = shell.mirage("readonly X=1; X=2 echo done; echo $X")
+    assert out.endswith("1\n")
+
+
+def test_array_in_mixed_string_no_data_loss(shell):
+    out = shell.mirage('a=(1 2 3); echo "x${a[@]}y"')
+    assert "x" in out and "y" in out
+    assert "1" in out and "3" in out
+
+
+def test_array_single_element_with_prefix_suffix(shell):
+    out = shell.mirage('a=(only); echo "x${a[@]}y"')
+    assert out == "xonlyy\n"
+
+
+def test_errexit_inside_subshell_body(shell):
+    out = shell.mirage("set -e; (false; echo unreached); echo after")
+    assert "unreached" not in out
+
+
+def test_errexit_inside_function_body(shell):
+    out = shell.mirage("set -e; f() { false; echo unreached; }; f; echo after")
+    assert "unreached" not in out
+
+
+def test_errexit_inside_compound_group(shell):
+    out = shell.mirage("set -e; { false; echo unreached; }; echo after")
+    assert "unreached" not in out

--- a/python/tests/shell/test_ifs_read.py
+++ b/python/tests/shell/test_ifs_read.py
@@ -1,0 +1,39 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+
+def test_ifs_comma_splits_read(shell):
+    out = shell.mirage('IFS=, read a b c <<< "1,2,3"; echo "$a:$b:$c"')
+    assert out == "1:2:3\n"
+
+
+def test_ifs_default_whitespace(shell):
+    out = shell.mirage('echo "1 2 3" | { read a b c; echo "$a:$b:$c"; }')
+    assert out == "1:2:3\n"
+
+
+def test_ifs_prefix_does_not_persist(shell):
+    out = shell.mirage('IFS=, read a b c <<< "1,2,3"; '
+                       'echo "${IFS-default}"')
+    assert "," not in out
+
+
+def test_env_prefix_to_command(shell):
+    out = shell.mirage('FOO=bar bash -c "echo $FOO"')
+    assert "bar" in out
+
+
+def test_ifs_colon_split(shell):
+    out = shell.mirage('IFS=: read a b c <<< "x:y:z"; echo "$a-$b-$c"')
+    assert out == "x-y-z\n"

--- a/python/tests/shell/test_param_expansion.py
+++ b/python/tests/shell/test_param_expansion.py
@@ -1,0 +1,51 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+CASES = [
+    ('X=hi; echo "${X:-fallback}"', "hi\n"),
+    ('echo "${UNSET:-fallback}"', "fallback\n"),
+    ('X=""; echo "${X:-fallback}"', "fallback\n"),
+    ('X=""; echo "${X-fallback}"', "\n"),
+    ('echo "${UNSET-fallback}"', "fallback\n"),
+    ('X=hi; echo "${X:+yes}"', "yes\n"),
+    ('echo "${UNSET:+yes}"', "\n"),
+    ('X=""; echo "${X:+yes}"', "\n"),
+    ('X=""; echo "${X+yes}"', "yes\n"),
+    ('X=hello; echo "${#X}"', "5\n"),
+    ('X=""; echo "${#X}"', "0\n"),
+    ('X=hello; echo "${X:1:3}"', "ell\n"),
+    ('X=hello; echo "${X:1}"', "ello\n"),
+    ('X=hello; echo "${X: -3}"', "llo\n"),
+    ('X=foobar; echo "${X#foo}"', "bar\n"),
+    ('X=foobar; echo "${X%bar}"', "foo\n"),
+    ('X=a/b/c/d; echo "${X##*/}"', "d\n"),
+    ('X=a/b/c/d; echo "${X%%/*}"', "a\n"),
+    ('X=a/b/c/d; echo "${X#*/}"', "b/c/d\n"),
+    ('X=a/b/c/d; echo "${X%/*}"', "a/b/c\n"),
+    ('X=foobarfoo; echo "${X/foo/baz}"', "bazbarfoo\n"),
+    ('X=foobarfoo; echo "${X//foo/baz}"', "bazbarbaz\n"),
+    ('X=foobar; echo "${X/foo/}"', "bar\n"),
+    ('X=hello; echo "${X^^}"', "HELLO\n"),
+    ('X=HELLO; echo "${X,,}"', "hello\n"),
+    ('X=hello; echo "${X^}"', "Hello\n"),
+    ('X=HELLO; echo "${X,}"', "hELLO\n"),
+    ('X=hello; Y=X; echo "${!Y}"', "hello\n"),
+]
+
+
+@pytest.mark.parametrize("cmd,expected", CASES)
+def test_param_expansion(shell, cmd, expected):
+    assert shell.mirage(cmd) == expected

--- a/python/tests/shell/test_pipefail.py
+++ b/python/tests/shell/test_pipefail.py
@@ -1,0 +1,35 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+
+def test_pipefail_off_default(shell):
+    assert shell.mirage("false | true; echo $?") == "0\n"
+
+
+def test_pipefail_on_propagates_failure(shell):
+    assert shell.mirage("set -o pipefail; false | true; echo $?") == "1\n"
+
+
+def test_pipefail_zero_when_all_pass(shell):
+    assert shell.mirage("set -o pipefail; true | true; echo $?") == "0\n"
+
+
+def test_pipefail_disabled_via_plus_o(shell):
+    assert shell.mirage("set -o pipefail; set +o pipefail; false | true; "
+                        "echo $?") == "0\n"
+
+
+def test_pipefail_rightmost_failure(shell):
+    assert shell.mirage(
+        "set -o pipefail; false | false | true; echo $?") == "1\n"

--- a/python/tests/shell/test_readonly.py
+++ b/python/tests/shell/test_readonly.py
@@ -1,0 +1,38 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+
+def test_readonly_blocks_reassignment(shell):
+    out = shell.mirage("readonly X=1; X=2; echo $X")
+    assert "1" in out
+    assert "2" not in out
+
+
+def test_readonly_blocks_unset(shell):
+    out = shell.mirage("readonly X=5; unset X; echo $X")
+    assert out == "5\n"
+
+
+def test_declare_r_blocks_reassignment(shell):
+    out = shell.mirage("declare -r Y=5; Y=10; echo $Y")
+    assert out == "5\n"
+
+
+def test_readonly_emits_error(shell):
+    code = shell.mirage_exit("readonly X=1; X=2")
+    assert code != 0
+
+
+def test_readonly_first_assignment_succeeds(shell):
+    assert shell.mirage("readonly X=hello; echo $X") == "hello\n"

--- a/python/tests/shell/test_set_e.py
+++ b/python/tests/shell/test_set_e.py
@@ -1,0 +1,59 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+
+def test_set_e_exits_on_failure(shell):
+    out = shell.mirage("set -e; false; echo unreached")
+    assert "unreached" not in out
+
+
+def test_set_e_continues_when_passes(shell):
+    out = shell.mirage("set -e; true; echo ok")
+    assert out == "ok\n"
+
+
+def test_set_e_allows_or_chain(shell):
+    out = shell.mirage("set -e; false || echo recovered; echo done")
+    assert out == "recovered\ndone\n"
+
+
+def test_set_e_allows_and_chain_skip(shell):
+    out = shell.mirage("set -e; false && echo skipped; echo done")
+    assert out == "done\n"
+
+
+def test_set_e_allows_if_condition(shell):
+    out = shell.mirage("set -e; if false; then echo a; else echo b; fi")
+    assert out == "b\n"
+
+
+def test_set_e_allows_while_condition(shell):
+    out = shell.mirage("set -e; X=0; while [ $X -lt 2 ]; do echo $X; "
+                       "X=$((X+1)); done; echo done")
+    assert out == "0\n1\ndone\n"
+
+
+def test_set_plus_e_disables(shell):
+    out = shell.mirage("set -e; set +e; false; echo ok")
+    assert out == "ok\n"
+
+
+def test_set_o_errexit_alias(shell):
+    out = shell.mirage("set -o errexit; false; echo unreached")
+    assert "unreached" not in out
+
+
+def test_set_e_pipeline_failure(shell):
+    out = shell.mirage("set -e; false | true; echo after")
+    assert out == "after\n"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -3031,7 +3031,7 @@ wheels = [
 
 [[package]]
 name = "mirage-ai"
-version = "0.0.1a1"
+version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -3039,11 +3039,13 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jq" },
+    { name = "mfusepy" },
     { name = "numpy" },
     { name = "orjson" },
     { name = "pillow" },
     { name = "pypdfium2" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "tree-sitter" },
     { name = "tree-sitter-bash" },
@@ -3194,6 +3196,7 @@ requires-dist = [
     { name = "jq", specifier = ">=1.11.0" },
     { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=4.2.0" },
     { name = "markitdown", marker = "extra == 'camel'", specifier = ">=0.1.5" },
+    { name = "mfusepy", specifier = ">=1.0.0" },
     { name = "mfusepy", marker = "extra == 'fuse'", specifier = ">=1.0.0" },
     { name = "mirage-ai", extras = ["anthropic"], marker = "extra == 'all'" },
     { name = "mirage-ai", extras = ["audio"], marker = "extra == 'all'" },
@@ -3234,6 +3237,7 @@ requires-dist = [
     { name = "pypdfium2", specifier = ">=5.7.0" },
     { name = "pypdfium2", marker = "extra == 'pdf'", specifier = ">=5.6.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "redis", extras = ["hiredis"], marker = "extra == 'redis'", specifier = ">=5.0" },
     { name = "sherpa-onnx", marker = "extra == 'audio'", specifier = ">=1.12.34" },

--- a/typescript/packages/core/src/shell/types.ts
+++ b/typescript/packages/core/src/shell/types.ts
@@ -110,6 +110,18 @@ export const NodeType = Object.freeze({
 
 export type NodeType = (typeof NodeType)[keyof typeof NodeType]
 
+export const ERREXIT_EXEMPT_TYPES: ReadonlySet<string> = new Set<string>([
+  NodeType.LIST,
+  NodeType.NEGATED_COMMAND,
+])
+
+export const SET_FLAG_TO_OPTION: Readonly<Record<string, string>> = Object.freeze({
+  e: 'errexit',
+  u: 'nounset',
+  x: 'xtrace',
+  f: 'noglob',
+})
+
 export const RedirectKind = Object.freeze({
   STDOUT: 'stdout',
   STDERR: 'stderr',

--- a/typescript/packages/core/src/workspace/executor/builtins.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins.ts
@@ -23,6 +23,7 @@ import type { IOResult as IOResultType } from '../../io/types.ts'
 import { IOResult, materialize } from '../../io/types.ts'
 import type { ByteSource } from '../../io/types.ts'
 import type { CallStack } from '../../shell/call_stack.ts'
+import { SET_FLAG_TO_OPTION } from '../../shell/types.ts'
 import { FileType, PathSpec } from '../../types.ts'
 import type { Mount } from '../mount/mount.ts'
 import { DEV_PREFIX, type MountRegistry } from '../mount/registry.ts'
@@ -103,6 +104,14 @@ export function handleExport(assignments: string[], session: Session): Result {
     const eq = assign.indexOf('=')
     if (eq >= 0) {
       const key = assign.slice(0, eq)
+      if (session.readonlyVars.has(key)) {
+        const err = new TextEncoder().encode(`bash: ${key}: readonly variable\n`)
+        return [
+          null,
+          new IOResult({ exitCode: 1, stderr: err }),
+          new ExecutionNode({ command: 'export', exitCode: 1, stderr: err }),
+        ]
+      }
       session.env[key] = assign.slice(eq + 1)
     } else if (!(assign in session.env)) {
       session.env[assign] = ''
@@ -111,8 +120,40 @@ export function handleExport(assignments: string[], session: Session): Result {
   return [null, new IOResult(), new ExecutionNode({ command: 'export', exitCode: 0 })]
 }
 
+export function handleReadonly(assignments: string[], session: Session): Result {
+  for (const assign of assignments) {
+    const eq = assign.indexOf('=')
+    if (eq >= 0) {
+      const key = assign.slice(0, eq)
+      if (session.readonlyVars.has(key)) {
+        const err = new TextEncoder().encode(`bash: ${key}: readonly variable\n`)
+        return [
+          null,
+          new IOResult({ exitCode: 1, stderr: err }),
+          new ExecutionNode({ command: 'readonly', exitCode: 1, stderr: err }),
+        ]
+      }
+      session.env[key] = assign.slice(eq + 1)
+      session.readonlyVars.add(key)
+    } else {
+      session.readonlyVars.add(assign)
+    }
+  }
+  return [null, new IOResult(), new ExecutionNode({ command: 'readonly', exitCode: 0 })]
+}
+
 export function handleUnset(names: string[], session: Session): Result {
   for (const name of names) {
+    if (session.readonlyVars.has(name)) {
+      const err = new TextEncoder().encode(
+        `bash: unset: ${name}: cannot unset: readonly variable\n`,
+      )
+      return [
+        null,
+        new IOResult({ exitCode: 1, stderr: err }),
+        new ExecutionNode({ command: 'unset', exitCode: 1, stderr: err }),
+      ]
+    }
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
     delete session.env[name]
   }
@@ -535,8 +576,34 @@ export function handleSet(
     const out = new TextEncoder().encode(`${lines.join('\n')}\n`)
     return [out, new IOResult(), new ExecutionNode({ command: 'set', exitCode: 0 })]
   }
-  if (args[0] === '--') {
-    session.positionalArgs = args.slice(1)
+  let i = 0
+  while (i < args.length) {
+    const tok = args[i] ?? ''
+    if (tok === '--') {
+      session.positionalArgs = args.slice(i + 1)
+      return [null, new IOResult(), new ExecutionNode({ command: 'set', exitCode: 0 })]
+    }
+    if (tok === '-o' || tok === '+o') {
+      if (i + 1 < args.length) {
+        const optName = args[i + 1] ?? ''
+        session.shellOptions[optName] = tok === '-o'
+        i += 2
+        continue
+      }
+      i += 1
+      continue
+    }
+    if ((tok.startsWith('-') || tok.startsWith('+')) && tok.length > 1) {
+      const enable = tok.startsWith('-')
+      for (const ch of tok.slice(1)) {
+        const opt = SET_FLAG_TO_OPTION[ch]
+        if (opt !== undefined) session.shellOptions[opt] = enable
+      }
+      i += 1
+      continue
+    }
+    session.positionalArgs = args.slice(i)
+    break
   }
   return [null, new IOResult(), new ExecutionNode({ command: 'set', exitCode: 0 })]
 }
@@ -620,23 +687,42 @@ export async function handleRead(
       new ExecutionNode({ command: 'read', exitCode: 1 }),
     ]
   }
-  const line = new TextDecoder().decode(lineBytes)
-  if (variables.length <= 1) {
-    if (variables.length === 1) {
-      const v = variables[0]
-      if (v !== undefined) session.env[v] = line
+  const line = new TextDecoder().decode(lineBytes).replace(/\n+$/, '')
+  const ifs = session.env.IFS ?? ' \t\n'
+  let parts: string[]
+  if (ifs === ' \t\n') {
+    if (variables.length === 0) {
+      parts = []
+    } else if (variables.length === 1) {
+      parts = [line]
+    } else {
+      const split = line.split(/\s+/).filter((p) => p !== '')
+      const head = split.slice(0, variables.length - 1)
+      const tail = split.slice(variables.length - 1).join(' ')
+      parts = tail !== '' ? [...head, tail] : head
     }
+  } else if (ifs === '') {
+    parts = [line]
   } else {
-    const parts = line.split(/\s+/).filter((p) => p !== '')
-    for (let i = 0; i < variables.length; i++) {
-      const name = variables[i]
-      if (name === undefined) continue
-      if (i === variables.length - 1) {
-        session.env[name] = parts.slice(i).join(' ')
-      } else {
-        session.env[name] = parts[i] ?? ''
+    const nSplits = Math.max(0, variables.length - 1)
+    const chars = new Set(ifs.split(''))
+    const out: string[] = []
+    let cur = ''
+    for (const ch of line) {
+      if (chars.has(ch) && out.length < nSplits) {
+        out.push(cur)
+        cur = ''
+        continue
       }
+      cur += ch
     }
+    out.push(cur)
+    parts = out
+  }
+  for (let i = 0; i < variables.length; i++) {
+    const name = variables[i]
+    if (name === undefined) continue
+    session.env[name] = parts[i] ?? ''
   }
   return [null, new IOResult(), new ExecutionNode({ command: 'read', exitCode: 0 })]
 }

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -20,6 +20,7 @@ import { IOResult, materialize } from '../../io/types.ts'
 import type { Resource } from '../../resource/base.ts'
 import { CallStack } from '../../shell/call_stack.ts'
 import type { JobTable } from '../../shell/job_table.ts'
+import { ERREXIT_EXEMPT_TYPES } from '../../shell/types.ts'
 import { PathSpec } from '../../types.ts'
 import type { Mount } from '../mount/mount.ts'
 import type { MountRegistry } from '../mount/registry.ts'
@@ -780,15 +781,19 @@ async function executeShellFunction(
   try {
     for (const cmd of body) {
       try {
-        const [stdout, io, execNode] = await executeNode(
-          cmd as Parameters<ExecuteNodeFn>[0],
-          session,
-          stdin,
-          cs,
-        )
+        const cmdNode = cmd as Parameters<ExecuteNodeFn>[0]
+        const [stdout, io, execNode] = await executeNode(cmdNode, session, stdin, cs)
         if (stdout !== null) allStdout.push(stdout)
         mergedIo = await mergedIo.merge(io)
         lastExec = execNode
+        if (
+          io.exitCode !== 0 &&
+          session.shellOptions.errexit === true &&
+          !ERREXIT_EXEMPT_TYPES.has(cmdNode.type)
+        ) {
+          mergedIo.exitCode = io.exitCode
+          break
+        }
       } catch (err) {
         if (err instanceof ReturnSignal) {
           mergedIo.exitCode = err.exitCode

--- a/typescript/packages/core/src/workspace/executor/control.ts
+++ b/typescript/packages/core/src/workspace/executor/control.ts
@@ -18,6 +18,7 @@ import type { ByteSource } from '../../io/types.ts'
 import { IOResult } from '../../io/types.ts'
 import { applyBarrier, BarrierPolicy } from '../../shell/barrier.ts'
 import type { CallStack } from '../../shell/call_stack.ts'
+import { ERREXIT_EXEMPT_TYPES } from '../../shell/types.ts'
 import { PathSpec } from '../../types.ts'
 import type { TSNodeLike } from '../expand/variable.ts'
 import type { Session } from '../session/session.ts'
@@ -79,6 +80,14 @@ async function executeBody(
       lastExec = execNode
       allStdout.push(stdout)
       mergedIo = await mergedIo.merge(io)
+      if (
+        io.exitCode !== 0 &&
+        session.shellOptions.errexit === true &&
+        !ERREXIT_EXEMPT_TYPES.has(cmd.type)
+      ) {
+        mergedIo.exitCode = io.exitCode
+        break
+      }
     } catch (sig) {
       if (sig instanceof BreakSignal) {
         if (sig.stdout !== null) allStdout.push(sig.stdout)

--- a/typescript/packages/core/src/workspace/executor/pipes.ts
+++ b/typescript/packages/core/src/workspace/executor/pipes.ts
@@ -17,7 +17,7 @@ import type { ByteSource } from '../../io/types.ts'
 import { IOResult, materialize } from '../../io/types.ts'
 import { applyBarrier, BarrierPolicy } from '../../shell/barrier.ts'
 import type { CallStack } from '../../shell/call_stack.ts'
-import { NodeType as NT } from '../../shell/types.ts'
+import { ERREXIT_EXEMPT_TYPES, NodeType as NT } from '../../shell/types.ts'
 import type { Session } from '../session/session.ts'
 import type { TSNodeLike } from '../expand/variable.ts'
 import { ExecutionNode } from '../types.ts'
@@ -67,6 +67,18 @@ export async function handlePipe(
 
   const lastIo = ios[ios.length - 1] ?? new IOResult()
   lastIo.syncExitCode()
+  if (session.shellOptions.pipefail === true) {
+    for (const io of ios) io.syncExitCode()
+    let rightmostFailure = 0
+    for (let k = ios.length - 1; k >= 0; k--) {
+      const code = ios[k]?.exitCode ?? 0
+      if (code !== 0) {
+        rightmostFailure = code
+        break
+      }
+    }
+    if (rightmostFailure !== 0) lastIo.exitCode = rightmostFailure
+  }
   const mergedStderrParts: Uint8Array[] = []
   const mergedReads: Record<string, ByteSource> = {}
   const mergedWrites: Record<string, ByteSource> = {}
@@ -172,6 +184,10 @@ export async function handleSubshell(
 ): Promise<Result> {
   const savedCwd = session.cwd
   const savedEnv = { ...session.env }
+  const savedOptions = { ...session.shellOptions }
+  const savedReadonly = new Set(session.readonlyVars)
+  const savedArrays: Record<string, string[]> = {}
+  for (const [k, v] of Object.entries(session.arrays)) savedArrays[k] = [...v]
   try {
     const allStdout: ByteSource[] = []
     let mergedIo = new IOResult()
@@ -181,6 +197,14 @@ export async function handleSubshell(
       if (stdout !== null) allStdout.push(stdout)
       mergedIo = await mergedIo.merge(io)
       lastExec = childExec
+      if (
+        io.exitCode !== 0 &&
+        session.shellOptions.errexit === true &&
+        !ERREXIT_EXEMPT_TYPES.has(child.type)
+      ) {
+        mergedIo.exitCode = io.exitCode
+        break
+      }
     }
     if (allStdout.length === 1 && allStdout[0] !== undefined) {
       return [allStdout[0], mergedIo, lastExec]
@@ -190,6 +214,9 @@ export async function handleSubshell(
   } finally {
     session.cwd = savedCwd
     session.env = savedEnv
+    session.shellOptions = savedOptions
+    session.readonlyVars = savedReadonly
+    session.arrays = savedArrays
   }
 }
 

--- a/typescript/packages/core/src/workspace/expand/node.ts
+++ b/typescript/packages/core/src/workspace/expand/node.ts
@@ -94,7 +94,7 @@ export async function expandNode(
   }
 
   if (ntype === NT.EXPANSION) {
-    return expandBraces(tsNode, session.env, callStack)
+    return expandBraces(tsNode, session.env, callStack, session.arrays)
   }
 
   if (ntype === NT.COMMAND_SUBSTITUTION) {

--- a/typescript/packages/core/src/workspace/expand/parts.ts
+++ b/typescript/packages/core/src/workspace/expand/parts.ts
@@ -37,6 +37,67 @@ function getPositionalArgs(session: Session, callStack: CallStack | null): strin
   return session.positionalArgs
 }
 
+function arrayAtName(child: TSNodeLike): string | null {
+  if (child.type !== NT.EXPANSION) return null
+  for (const c of child.children) {
+    if (c.type === '#' && c.isNamed !== true) return null
+  }
+  let subscript: TSNodeLike | null = null
+  for (const c of child.namedChildren) {
+    if (c.type === 'subscript') {
+      subscript = c
+      break
+    }
+  }
+  if (subscript === null) return null
+  let varName: string | null = null
+  let idxText = ''
+  for (const sc of subscript.namedChildren) {
+    if (sc.type === NT.VARIABLE_NAME) varName = sc.text
+    else idxText = sc.text
+  }
+  if (varName !== null && idxText === '@') return varName
+  return null
+}
+
+function stringHasArrayAt(node: TSNodeLike): boolean {
+  for (const c of node.children) {
+    if (arrayAtName(c) !== null) return true
+  }
+  return false
+}
+
+async function expandStringWithArray(
+  node: TSNodeLike,
+  session: Session,
+  executeFn: ExecuteFn,
+  callStack: CallStack | null,
+): Promise<string[]> {
+  const arrays = session.arrays
+  const fragments: string[] = ['']
+  for (const child of node.children) {
+    if (child.type === NT.DQUOTE) continue
+    const arrName = arrayAtName(child)
+    if (arrName !== null) {
+      const arr = arrays[arrName]
+      if (arr === undefined || arr.length === 0) continue
+      const last = fragments.length - 1
+      if (arr.length === 1) {
+        fragments[last] = (fragments[last] ?? '') + (arr[0] ?? '')
+      } else {
+        fragments[last] = (fragments[last] ?? '') + (arr[0] ?? '')
+        for (let i = 1; i < arr.length - 1; i++) fragments.push(arr[i] ?? '')
+        fragments.push(arr[arr.length - 1] ?? '')
+      }
+      continue
+    }
+    const text = await expandNode(child, session, executeFn, callStack)
+    const last = fragments.length - 1
+    fragments[last] = (fragments[last] ?? '') + text
+  }
+  return fragments
+}
+
 export async function expandParts(
   parts: TSNodeLike[],
   session: Session,
@@ -51,6 +112,11 @@ export async function expandParts(
         result.push(...positional)
         continue
       }
+    }
+    if (p.type === NT.STRING && stringHasArrayAt(p)) {
+      const words = await expandStringWithArray(p, session, executeFn, callStack)
+      result.push(...words)
+      continue
     }
     const expanded = await expandNode(p, session, executeFn, callStack)
     if (p.type === NT.COMMAND_SUBSTITUTION) {

--- a/typescript/packages/core/src/workspace/expand/variable.test.ts
+++ b/typescript/packages/core/src/workspace/expand/variable.test.ts
@@ -75,31 +75,38 @@ describe('lookupVar', () => {
 
 describe('expandBraces', () => {
   it('${VAR} reads from env', () => {
+    const varName = stringNode(NT.VARIABLE_NAME, 'FOO')
     const node: TSNodeLike = {
       type: NT.EXPANSION,
       text: '${FOO}',
-      children: [],
-      namedChildren: [stringNode(NT.VARIABLE_NAME, 'FOO')],
+      children: [stringNode('${', '${'), varName, stringNode('}', '}')],
+      namedChildren: [varName],
     }
     expect(expandBraces(node, { FOO: 'bar' }, null)).toBe('bar')
   })
 
   it('${VAR:-default} falls back when missing', () => {
+    const varName = stringNode(NT.VARIABLE_NAME, 'FOO')
+    const op = stringNode(':-', ':-')
+    const word = stringNode(NT.WORD, 'default')
     const node: TSNodeLike = {
       type: NT.EXPANSION,
       text: '${FOO:-default}',
-      children: [],
-      namedChildren: [stringNode(NT.VARIABLE_NAME, 'FOO'), stringNode(NT.WORD, 'default')],
+      children: [stringNode('${', '${'), varName, op, word, stringNode('}', '}')],
+      namedChildren: [varName, word],
     }
     expect(expandBraces(node, {}, null)).toBe('default')
   })
 
   it('${VAR:-default} uses actual value when present', () => {
+    const varName = stringNode(NT.VARIABLE_NAME, 'FOO')
+    const op = stringNode(':-', ':-')
+    const word = stringNode(NT.WORD, 'default')
     const node: TSNodeLike = {
       type: NT.EXPANSION,
       text: '${FOO:-default}',
-      children: [],
-      namedChildren: [stringNode(NT.VARIABLE_NAME, 'FOO'), stringNode(NT.WORD, 'default')],
+      children: [stringNode('${', '${'), varName, op, word, stringNode('}', '}')],
+      namedChildren: [varName, word],
     }
     expect(expandBraces(node, { FOO: 'real' }, null)).toBe('real')
   })

--- a/typescript/packages/core/src/workspace/expand/variable.ts
+++ b/typescript/packages/core/src/workspace/expand/variable.ts
@@ -24,6 +24,29 @@ export interface TSNodeLike {
   isNamed?: boolean
 }
 
+const PARAM_OPS: ReadonlySet<string> = new Set([
+  ':-',
+  '-',
+  ':+',
+  '+',
+  ':?',
+  '?',
+  ':=',
+  '=',
+  '#',
+  '##',
+  '%',
+  '%%',
+  '/',
+  '//',
+  ':',
+  '^',
+  '^^',
+  ',',
+  ',,',
+  '!',
+])
+
 export function lookupVar(name: string, session: Session, callStack: CallStack | null): string {
   const env = session.env
   const lastExitCode = session.lastExitCode
@@ -62,33 +85,199 @@ export function lookupVar(name: string, session: Session, callStack: CallStack |
   return env[name] ?? ''
 }
 
+function fnmatchCase(value: string, pattern: string): boolean {
+  let re = '^'
+  let i = 0
+  while (i < pattern.length) {
+    const c = pattern[i]
+    if (c === undefined) break
+    if (c === '*') re += '.*'
+    else if (c === '?') re += '.'
+    else if (c === '[') {
+      const end = pattern.indexOf(']', i)
+      if (end === -1) {
+        re += '\\['
+      } else {
+        re += pattern.slice(i, end + 1)
+        i = end
+      }
+    } else if (/[.+^$(){}|\\]/.test(c)) {
+      re += `\\${c}`
+    } else {
+      re += c
+    }
+    i += 1
+  }
+  re += '$'
+  return new RegExp(re).test(value)
+}
+
+function globStrip(value: string, pattern: string, greedy: boolean, prefix: boolean): string {
+  if (pattern === '') return value
+  const matches: number[] = []
+  if (prefix) {
+    for (let i = 0; i <= value.length; i++) {
+      if (fnmatchCase(value.slice(0, i), pattern)) matches.push(i)
+    }
+    if (matches.length === 0) return value
+    const i = greedy ? Math.max(...matches) : Math.min(...matches)
+    return value.slice(i)
+  }
+  for (let i = 0; i <= value.length; i++) {
+    if (fnmatchCase(value.slice(i), pattern)) matches.push(i)
+  }
+  if (matches.length === 0) return value
+  const i = greedy ? Math.min(...matches) : Math.max(...matches)
+  return value.slice(0, i)
+}
+
+function applyOp(op: string, val: string, varInEnv: boolean, args: string[]): string {
+  if (op === ':-') return val !== '' ? val : (args[0] ?? '')
+  if (op === '-') {
+    if (varInEnv) return val
+    return args[0] ?? ''
+  }
+  if (op === ':+') return val !== '' ? (args[0] ?? '') : ''
+  if (op === '+') return varInEnv ? (args[0] ?? '') : ''
+  if (op === '#') return globStrip(val, args[0] ?? '', false, true)
+  if (op === '##') return globStrip(val, args[0] ?? '', true, true)
+  if (op === '%') return globStrip(val, args[0] ?? '', false, false)
+  if (op === '%%') return globStrip(val, args[0] ?? '', true, false)
+  if (op === '/') {
+    if (args.length === 0) return val
+    const replacement = args[1] ?? ''
+    return val.replace(args[0] ?? '', replacement)
+  }
+  if (op === '//') {
+    if (args.length === 0) return val
+    const replacement = args[1] ?? ''
+    return val.split(args[0] ?? '').join(replacement)
+  }
+  if (op === '^^') return val.toUpperCase()
+  if (op === ',,') return val.toLowerCase()
+  if (op === '^') return val.length > 0 ? (val[0] ?? '').toUpperCase() + val.slice(1) : val
+  if (op === ',') return val.length > 0 ? (val[0] ?? '').toLowerCase() + val.slice(1) : val
+  if (op === ':' && args.length > 0) {
+    const offsetRaw = args[0] ?? ''
+    const lengthRaw = args[1]
+    const offsetParsed = parseInt(offsetRaw.trim(), 10)
+    if (Number.isNaN(offsetParsed)) return val
+    let offset = offsetParsed
+    let length: number | null = null
+    if (lengthRaw !== undefined) {
+      const lengthParsed = parseInt(lengthRaw.trim(), 10)
+      if (Number.isNaN(lengthParsed)) return val
+      length = lengthParsed
+    }
+    if (offset < 0) offset = Math.max(0, val.length + offset)
+    if (length === null) return val.slice(offset)
+    if (length < 0) return val.slice(offset, Math.max(offset, val.length + length))
+    return val.slice(offset, offset + length)
+  }
+  return val
+}
+
 export function expandBraces(
   node: TSNodeLike,
   env: Record<string, string>,
   callStack: CallStack | null,
+  arrays: Record<string, string[]> = {},
 ): string {
   let varName: string | null = null
-  let defaultVal: string | null = null
-  for (const c of node.namedChildren) {
+  let subscriptNode: TSNodeLike | null = null
+  let lengthOp = false
+  let indirectOp = false
+  let op: string | null = null
+  const args: string[] = []
+  let seenVar = false
+
+  for (const c of node.children) {
+    if (c.type === '${' || c.type === '}') continue
+    if (c.type === '#' && !seenVar) {
+      lengthOp = true
+      continue
+    }
+    if (c.type === '!' && !seenVar) {
+      indirectOp = true
+      continue
+    }
     if (c.type === NT.VARIABLE_NAME) {
       varName = c.text
-    } else if (
+      seenVar = true
+      continue
+    }
+    if (c.type === 'subscript') {
+      subscriptNode = c
+      for (const sc of c.namedChildren) {
+        if (sc.type === NT.VARIABLE_NAME) {
+          varName = sc.text
+          break
+        }
+      }
+      seenVar = true
+      continue
+    }
+    if (PARAM_OPS.has(c.type) && op === null) {
+      op = c.text
+      continue
+    }
+    if (
       c.type === NT.WORD ||
       c.type === NT.STRING ||
       c.type === NT.RAW_STRING ||
-      c.type === NT.STRING_CONTENT
+      c.type === NT.STRING_CONTENT ||
+      c.type === NT.NUMBER ||
+      c.type === 'regex'
     ) {
-      defaultVal = c.text
+      args.push(c.text)
     }
   }
+
   let val = ''
-  if (varName !== null) {
+  let varInEnv = false
+
+  if (subscriptNode !== null && varName !== null) {
+    let idxText = ''
+    for (const sc of subscriptNode.namedChildren) {
+      if (sc.type === NT.VARIABLE_NAME) continue
+      idxText = sc.text
+      break
+    }
+    let arr = arrays[varName]
+    if (arr === undefined) {
+      const scalar = env[varName] ?? ''
+      arr = scalar !== '' ? [scalar] : []
+    }
+    varInEnv = varName in arrays || varName in env
+    if (idxText === '@' || idxText === '*') {
+      if (lengthOp) return String(arr.length)
+      val = arr.join(' ')
+    } else {
+      const i = parseInt(idxText, 10)
+      if (Number.isFinite(i) && !Number.isNaN(i) && i >= 0 && i < arr.length) {
+        val = arr[i] ?? ''
+      } else {
+        val = ''
+      }
+    }
+  } else if (varName !== null) {
     if (callStack) {
       const localVal = callStack.getLocal(varName)
-      if (localVal !== null) val = localVal
+      if (localVal !== null) {
+        val = localVal
+        varInEnv = true
+      }
     }
-    if (val === '') val = env[varName] ?? ''
+    if (!varInEnv) {
+      varInEnv = varName in env
+      val = env[varName] ?? ''
+    }
   }
-  if (defaultVal !== null && val === '') return defaultVal
-  return val
+
+  if (indirectOp) {
+    return val !== '' ? (env[val] ?? '') : ''
+  }
+  if (lengthOp) return String(val.length)
+  if (op === null) return val
+  return applyOp(op, val, varInEnv, args)
 }

--- a/typescript/packages/core/src/workspace/node/execute_node.ts
+++ b/typescript/packages/core/src/workspace/node/execute_node.ts
@@ -42,6 +42,7 @@ import {
 import type { PyodideRuntime } from '../executor/python/runtime.ts'
 import type { JobTable } from '../../shell/job_table.ts'
 import {
+  ERREXIT_EXEMPT_TYPES,
   NodeType as NT,
   Redirect,
   RedirectKind as Redirect_,
@@ -76,6 +77,7 @@ import {
   handlePrintenv,
   handlePrintf,
   handleRead,
+  handleReadonly,
   handleReturn,
   handleSet,
   handleShift,
@@ -258,6 +260,14 @@ export async function executeNode(
       lastExec = execNode
       if (stdout !== null) allStdout.push(stdout)
       mergedIo = await mergedIo.merge(io)
+      if (
+        io.exitCode !== 0 &&
+        session.shellOptions.errexit === true &&
+        !ERREXIT_EXEMPT_TYPES.has(child.type)
+      ) {
+        mergedIo.exitCode = io.exitCode
+        break
+      }
     }
     if (allStdout.length === 1 && allStdout[0] !== undefined) {
       return [allStdout[0], mergedIo, lastExec]
@@ -313,8 +323,22 @@ export async function executeNode(
   if (ntype === NT.DECLARATION_COMMAND) {
     const keyword = getDeclarationKeyword(node)
     const assignments: string[] = []
+    const flagChars = new Set<string>()
     for (const child of node.namedChildren) {
       if (child.type === NT.VARIABLE_ASSIGNMENT) {
+        const valNodes = child.namedChildren.filter((c) => c.type !== NT.VARIABLE_NAME)
+        const firstVal = valNodes[0]
+        if (firstVal?.type === NT.ARRAY) {
+          const text = getText(child)
+          const eq = text.indexOf('=')
+          const key = eq >= 0 ? text.slice(0, eq) : text
+          const items: string[] = []
+          for (const ac of firstVal.namedChildren) {
+            items.push(await expandNode(ac, session, executeFn, callStack))
+          }
+          session.arrays[key] = items
+          continue
+        }
         assignments.push(await expandNode(child, session, executeFn, callStack))
       } else if (
         child.type === NT.SIMPLE_EXPANSION ||
@@ -323,10 +347,18 @@ export async function executeNode(
         child.type === NT.WORD
       ) {
         const expanded = await expandNode(child, session, executeFn, callStack)
-        if (expanded !== '') assignments.push(expanded)
+        if (expanded === '') continue
+        if (expanded.startsWith('-') && expanded.length > 1) {
+          for (const ch of expanded.slice(1)) flagChars.add(ch)
+        } else {
+          assignments.push(expanded)
+        }
       }
     }
     if (keyword === NT.LOCAL) return handleLocal(assignments, session)
+    if (keyword === 'readonly' || flagChars.has('r')) {
+      return handleReadonly(assignments, session)
+    }
     return handleExport(assignments, session)
   }
 
@@ -359,11 +391,32 @@ export async function executeNode(
       const eq = text.indexOf('=')
       const key = text.slice(0, eq)
       let val = text.slice(eq + 1)
+      if (session.readonlyVars.has(key)) {
+        const err = new TextEncoder().encode(`bash: ${key}: readonly variable\n`)
+        return [
+          null,
+          new IOResult({ exitCode: 1, stderr: err }),
+          new ExecutionNode({ command: text, exitCode: 1, stderr: err }),
+        ]
+      }
       const valNodes = node.namedChildren.filter((c) => c.type !== NT.VARIABLE_NAME)
-      if (valNodes.length > 0 && valNodes[0] !== undefined) {
-        val = await expandNode(valNodes[0], session, executeFn, callStack)
+      const firstVal = valNodes[0]
+      if (firstVal?.type === NT.ARRAY) {
+        const items: string[] = []
+        for (const ac of firstVal.namedChildren) {
+          items.push(await expandNode(ac, session, executeFn, callStack))
+        }
+        session.arrays[key] = items
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete session.env[key]
+        return [null, new IOResult(), new ExecutionNode({ command: text, exitCode: 0 })]
+      }
+      if (firstVal !== undefined) {
+        val = await expandNode(firstVal, session, executeFn, callStack)
       }
       session.env[key] = val
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete session.arrays[key]
     }
     return [null, new IOResult(), new ExecutionNode({ command: text, exitCode: 0 })]
   }
@@ -434,6 +487,16 @@ async function executeProgram(
 
     if (stdout !== null) allStdout.push(stdout)
     mergedIo = await mergedIo.merge(io)
+
+    if (
+      io.exitCode !== 0 &&
+      session.shellOptions.errexit === true &&
+      !isBg &&
+      !ERREXIT_EXEMPT_TYPES.has(child.type)
+    ) {
+      mergedIo.exitCode = io.exitCode
+      break
+    }
   }
 
   if (allStdout.length === 1 && allStdout[0] !== undefined) {
@@ -465,7 +528,110 @@ async function executeCommand(
   signal?: AbortSignal,
 ): Promise<Result> {
   const name = getCommandName(node)
-  const parts = getParts(node)
+  const rawParts = getParts(node)
+
+  const prefixAssignments: [string, string][] = []
+  const nonPrefixParts: TSNodeLike[] = []
+  let sawCommandName = false
+  for (const p of rawParts) {
+    if (!sawCommandName && p.type === NT.VARIABLE_ASSIGNMENT) {
+      const atext = getText(p)
+      const eq = atext.indexOf('=')
+      if (eq >= 0) {
+        const key = atext.slice(0, eq)
+        const rawVal = atext.slice(eq + 1)
+        const valNodes = p.namedChildren.filter((c) => c.type !== NT.VARIABLE_NAME)
+        const firstVal = valNodes[0]
+        const v =
+          firstVal !== undefined
+            ? await expandNode(firstVal, session, executeFn, callStack)
+            : rawVal
+        prefixAssignments.push([key, v])
+      }
+      continue
+    }
+    if (p.type === NT.COMMAND_NAME) sawCommandName = true
+    nonPrefixParts.push(p)
+  }
+
+  for (const [k] of prefixAssignments) {
+    if (session.readonlyVars.has(k)) {
+      const err = new TextEncoder().encode(`bash: ${k}: readonly variable\n`)
+      return [
+        null,
+        new IOResult({ exitCode: 1, stderr: err }),
+        new ExecutionNode({ command: name !== '' ? name : k, exitCode: 1, stderr: err }),
+      ]
+    }
+  }
+
+  if (prefixAssignments.length > 0 && name === '') {
+    for (const [k, v] of prefixAssignments) session.env[k] = v
+    const cmdLabel = prefixAssignments.map(([k, v]) => `${k}=${v}`).join(' ')
+    return [null, new IOResult(), new ExecutionNode({ command: cmdLabel, exitCode: 0 })]
+  }
+
+  const isFunctionCall = name !== '' && session.functions[name] !== undefined
+  const savedEnvOverrides: Record<string, string | null> = {}
+  for (const [k, v] of prefixAssignments) {
+    if (!isFunctionCall) savedEnvOverrides[k] = k in session.env ? (session.env[k] ?? null) : null
+    session.env[k] = v
+  }
+
+  try {
+    return await runCommandBody(
+      recurse,
+      dispatch,
+      registry,
+      executeFn,
+      node,
+      nonPrefixParts,
+      name,
+      session,
+      stdinIn,
+      callStack,
+      jobTable,
+      ensureOpen,
+      unmount,
+      pythonRuntime,
+      history,
+      signal,
+    )
+  } finally {
+    for (const [k, prev] of Object.entries(savedEnvOverrides)) {
+      if (prev === null) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete session.env[k]
+      } else {
+        session.env[k] = prev
+      }
+    }
+  }
+}
+
+async function runCommandBody(
+  recurse: (
+    n: TSNodeLike,
+    s: Session,
+    i: ByteSource | null,
+    cs: CallStack | null,
+  ) => Promise<Result>,
+  dispatch: DispatchFn,
+  registry: MountRegistry,
+  executeFn: ExecuteFn,
+  node: TSNodeLike,
+  parts: TSNodeLike[],
+  name: string,
+  session: Session,
+  stdinIn: ByteSource | null,
+  callStack: CallStack | null,
+  jobTable: JobTable | null,
+  ensureOpen?: (resource: Resource) => Promise<void>,
+  unmount?: (prefix: string) => Promise<void>,
+  pythonRuntime?: PyodideRuntime,
+  history?: CommandHistory,
+  signal?: AbortSignal,
+): Promise<Result> {
   let stdin = stdinIn
 
   for (const child of node.namedChildren) {

--- a/typescript/packages/core/src/workspace/session/session.ts
+++ b/typescript/packages/core/src/workspace/session/session.ts
@@ -22,6 +22,9 @@ export interface SessionInit {
   functions?: Record<string, unknown>
   lastExitCode?: number
   positionalArgs?: string[]
+  shellOptions?: Record<string, boolean>
+  readonlyVars?: Set<string>
+  arrays?: Record<string, string[]>
 }
 
 export class Session {
@@ -32,6 +35,9 @@ export class Session {
   functions: Record<string, unknown>
   lastExitCode: number
   positionalArgs: string[]
+  shellOptions: Record<string, boolean>
+  readonlyVars: Set<string>
+  arrays: Record<string, string[]>
   stdinBuffer: AsyncLineIterator | null = null
   localVars: Map<string, string | null> | null = null
 
@@ -43,6 +49,9 @@ export class Session {
     this.functions = init.functions ?? {}
     this.lastExitCode = init.lastExitCode ?? 0
     this.positionalArgs = init.positionalArgs ?? []
+    this.shellOptions = init.shellOptions ?? {}
+    this.readonlyVars = init.readonlyVars ?? new Set()
+    this.arrays = init.arrays ?? {}
   }
 
   toJSON(): Record<string, unknown> {

--- a/typescript/packages/core/src/workspace/shell_arrays.test.ts
+++ b/typescript/packages/core/src/workspace/shell_arrays.test.ts
@@ -1,0 +1,42 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { makeIntegrationWS, run } from './fixtures/integration_fixture.ts'
+
+const CASES: [string, string][] = [
+  ['a=(one two three); echo "${a[0]}"', 'one\n'],
+  ['a=(one two three); echo "${a[1]}"', 'two\n'],
+  ['a=(one two three); echo "${a[2]}"', 'three\n'],
+  ['a=(one two three); echo "${a[@]}"', 'one two three\n'],
+  ['a=(one two three); echo "${a[*]}"', 'one two three\n'],
+  ['a=(one two three); echo "${#a[@]}"', '3\n'],
+  ['a=(); echo "${#a[@]}"', '0\n'],
+  ['a=(x y z); for i in "${a[@]}"; do echo $i; done', 'x\ny\nz\n'],
+  ['declare -a arr=(a b c); echo "${arr[@]}"', 'a b c\n'],
+  ['a=("hello world" foo); echo "${a[0]}"', 'hello world\n'],
+]
+
+describe('shell arrays', () => {
+  for (const [cmd, expected] of CASES) {
+    it(cmd, async () => {
+      const { ws } = await makeIntegrationWS()
+      try {
+        expect(await run(ws, cmd)).toBe(expected)
+      } finally {
+        await ws.close()
+      }
+    })
+  }
+})

--- a/typescript/packages/core/src/workspace/shell_audit_regressions.test.ts
+++ b/typescript/packages/core/src/workspace/shell_audit_regressions.test.ts
@@ -1,0 +1,127 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { makeIntegrationWS, run } from './fixtures/integration_fixture.ts'
+
+describe('audit regressions: subshell isolation, errexit propagation, prefix scoping', () => {
+  it('subshell isolates readonly', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, '(readonly X=1); X=2; echo $X')).toBe('2\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('subshell isolates arrays', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, '(a=(1 2 3)); echo "${a[0]:-empty}"')).toBe('empty\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('subshell isolates shell options', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'set -e; (set +e; true); echo continued')).toBe('continued\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('function prefix persists in parent env', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const out = await run(ws, 'f() { echo "FOO=$FOO"; }; FOO=bar f; echo "after=$FOO"')
+      expect(out).toBe('FOO=bar\nafter=bar\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('command prefix does not persist', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const out = await run(ws, 'FOO=bar echo "FOO=$FOO"; echo "after=$FOO"')
+      expect(out).toContain('after=\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('readonly blocks prefix assignment', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const out = await run(ws, 'readonly X=1; X=2 echo done; echo $X')
+      expect(out.endsWith('1\n')).toBe(true)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('array in mixed string preserves data', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const out = await run(ws, 'a=(1 2 3); echo "x${a[@]}y"')
+      expect(out).toContain('x')
+      expect(out).toContain('y')
+      expect(out).toContain('1')
+      expect(out).toContain('3')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('array single element with prefix and suffix', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'a=(only); echo "x${a[@]}y"')).toBe('xonlyy\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('errexit inside subshell body', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const out = await run(ws, 'set -e; (false; echo unreached); echo after')
+      expect(out).not.toContain('unreached')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('errexit inside function body', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const out = await run(ws, 'set -e; f() { false; echo unreached; }; f; echo after')
+      expect(out).not.toContain('unreached')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('errexit inside compound group', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const out = await run(ws, 'set -e; { false; echo unreached; }; echo after')
+      expect(out).not.toContain('unreached')
+    } finally {
+      await ws.close()
+    }
+  })
+})

--- a/typescript/packages/core/src/workspace/shell_ifs_read.test.ts
+++ b/typescript/packages/core/src/workspace/shell_ifs_read.test.ts
@@ -1,0 +1,65 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { makeIntegrationWS, run } from './fixtures/integration_fixture.ts'
+
+describe('IFS / read interaction and inline VAR=val cmd prefix', () => {
+  it('IFS=, splits read', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'IFS=, read a b c <<< "1,2,3"; echo "$a:$b:$c"')).toBe('1:2:3\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('IFS default whitespace', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'echo "1 2 3" | { read a b c; echo "$a:$b:$c"; }')).toBe('1:2:3\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('IFS prefix does not persist', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const out = await run(ws, 'IFS=, read a b c <<< "1,2,3"; echo "${IFS-default}"')
+      expect(out).not.toContain(',')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('env prefix to command', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const out = await run(ws, 'FOO=bar bash -c "echo $FOO"')
+      expect(out).toContain('bar')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('IFS=: splits read', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'IFS=: read a b c <<< "x:y:z"; echo "$a-$b-$c"')).toBe('x-y-z\n')
+    } finally {
+      await ws.close()
+    }
+  })
+})

--- a/typescript/packages/core/src/workspace/shell_param_expansion.test.ts
+++ b/typescript/packages/core/src/workspace/shell_param_expansion.test.ts
@@ -1,0 +1,60 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { makeIntegrationWS, run } from './fixtures/integration_fixture.ts'
+
+const CASES: [string, string][] = [
+  ['X=hi; echo "${X:-fallback}"', 'hi\n'],
+  ['echo "${UNSET:-fallback}"', 'fallback\n'],
+  ['X=""; echo "${X:-fallback}"', 'fallback\n'],
+  ['X=""; echo "${X-fallback}"', '\n'],
+  ['echo "${UNSET-fallback}"', 'fallback\n'],
+  ['X=hi; echo "${X:+yes}"', 'yes\n'],
+  ['echo "${UNSET:+yes}"', '\n'],
+  ['X=""; echo "${X:+yes}"', '\n'],
+  ['X=""; echo "${X+yes}"', 'yes\n'],
+  ['X=hello; echo "${#X}"', '5\n'],
+  ['X=""; echo "${#X}"', '0\n'],
+  ['X=hello; echo "${X:1:3}"', 'ell\n'],
+  ['X=hello; echo "${X:1}"', 'ello\n'],
+  ['X=hello; echo "${X: -3}"', 'llo\n'],
+  ['X=foobar; echo "${X#foo}"', 'bar\n'],
+  ['X=foobar; echo "${X%bar}"', 'foo\n'],
+  ['X=a/b/c/d; echo "${X##*/}"', 'd\n'],
+  ['X=a/b/c/d; echo "${X%%/*}"', 'a\n'],
+  ['X=a/b/c/d; echo "${X#*/}"', 'b/c/d\n'],
+  ['X=a/b/c/d; echo "${X%/*}"', 'a/b/c\n'],
+  ['X=foobarfoo; echo "${X/foo/baz}"', 'bazbarfoo\n'],
+  ['X=foobarfoo; echo "${X//foo/baz}"', 'bazbarbaz\n'],
+  ['X=foobar; echo "${X/foo/}"', 'bar\n'],
+  ['X=hello; echo "${X^^}"', 'HELLO\n'],
+  ['X=HELLO; echo "${X,,}"', 'hello\n'],
+  ['X=hello; echo "${X^}"', 'Hello\n'],
+  ['X=HELLO; echo "${X,}"', 'hELLO\n'],
+  ['X=hello; Y=X; echo "${!Y}"', 'hello\n'],
+]
+
+describe('parameter expansion operators', () => {
+  for (const [cmd, expected] of CASES) {
+    it(cmd, async () => {
+      const { ws } = await makeIntegrationWS()
+      try {
+        expect(await run(ws, cmd)).toBe(expected)
+      } finally {
+        await ws.close()
+      }
+    })
+  }
+})

--- a/typescript/packages/core/src/workspace/shell_pipefail.test.ts
+++ b/typescript/packages/core/src/workspace/shell_pipefail.test.ts
@@ -1,0 +1,63 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { makeIntegrationWS, run } from './fixtures/integration_fixture.ts'
+
+describe('set -o pipefail', () => {
+  it('off by default', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'false | true; echo $?')).toBe('0\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('propagates failure when on', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'set -o pipefail; false | true; echo $?')).toBe('1\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('zero when all pass', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'set -o pipefail; true | true; echo $?')).toBe('0\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('disabled via +o', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'set -o pipefail; set +o pipefail; false | true; echo $?')).toBe('0\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('rightmost failure wins', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'set -o pipefail; false | false | true; echo $?')).toBe('1\n')
+    } finally {
+      await ws.close()
+    }
+  })
+})

--- a/typescript/packages/core/src/workspace/shell_readonly.test.ts
+++ b/typescript/packages/core/src/workspace/shell_readonly.test.ts
@@ -1,0 +1,66 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { makeIntegrationWS, run, runExit } from './fixtures/integration_fixture.ts'
+
+describe('readonly', () => {
+  it('blocks reassignment', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const out = await run(ws, 'readonly X=1; X=2; echo $X')
+      expect(out).toContain('1')
+      expect(out).not.toContain('2')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('blocks unset', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'readonly X=5; unset X; echo $X')).toBe('5\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('declare -r blocks reassignment', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'declare -r Y=5; Y=10; echo $Y')).toBe('5\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('emits non-zero exit on reassignment', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const code = await runExit(ws, 'readonly X=1; X=2')
+      expect(code).not.toBe(0)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('first assignment succeeds', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'readonly X=hello; echo $X')).toBe('hello\n')
+    } finally {
+      await ws.close()
+    }
+  })
+})

--- a/typescript/packages/core/src/workspace/shell_set_e.test.ts
+++ b/typescript/packages/core/src/workspace/shell_set_e.test.ts
@@ -1,0 +1,103 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { makeIntegrationWS, run } from './fixtures/integration_fixture.ts'
+
+describe('set -e (errexit)', () => {
+  it('exits on failure', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const out = await run(ws, 'set -e; false; echo unreached')
+      expect(out).not.toContain('unreached')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('continues when command passes', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'set -e; true; echo ok')).toBe('ok\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('allows || chain', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'set -e; false || echo recovered; echo done')).toBe('recovered\ndone\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('allows && chain to skip', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'set -e; false && echo skipped; echo done')).toBe('done\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('allows if condition', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'set -e; if false; then echo a; else echo b; fi')).toBe('b\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('allows while condition', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(
+        await run(ws, 'set -e; X=0; while [ $X -lt 2 ]; do echo $X; X=$((X+1)); done; echo done'),
+      ).toBe('0\n1\ndone\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('set +e disables', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'set -e; set +e; false; echo ok')).toBe('ok\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('set -o errexit alias', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const out = await run(ws, 'set -o errexit; false; echo unreached')
+      expect(out).not.toContain('unreached')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('does not trip on pipeline failure (default)', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      expect(await run(ws, 'set -e; false | true; echo after')).toBe('after\n')
+    } finally {
+      await ws.close()
+    }
+  })
+})


### PR DESCRIPTION
Fixes six bash bugs in both Python and TypeScript bindings.

**Fixes**
- Parameter expansion operators: `${X:-default}`, `${X:+alt}`, `${X#prefix}`, `${X##prefix}`, `${X%suffix}`, `${X%%suffix}`, `${X/from/to}`, `${X//from/to}`, `${X:offset:length}`, `${X^^}`, `${X,,}`, `${!X}`, `${#X}`
- Arrays: `arr=(a b c)`, `${arr[0]}`, `${arr[@]}`, `${#arr[@]}`
- `set -e` (errexit) observed at LIST/PROGRAM/COMPOUND_STATEMENT/subshell/function boundaries (with LIST and NEGATED_COMMAND exemptions and a backgrounded-job exemption)
- `set -o pipefail` (pipeline exit = rightmost non-zero exit)
- `readonly`: tracked on the session; assignment, export, and unset error with `bash: NAME: readonly variable`
- `VAR=val cmd` prefix scoped as an ephemeral env override (function calls inherit; subshells/finally restore). Also fixes `IFS=… read …`.

**Shared constants**
`ERREXIT_EXEMPT_TYPES` and `SET_FLAG_TO_OPTION` are exported from `shell/types` instead of duplicated per executor file.

**Tests**
- 73 new Python tests under `python/tests/shell/`
- 73 mirroring TS tests under `typescript/packages/core/src/workspace/shell_*.test.ts`
- Full suites pass: 5451 Python, 2516 TS

**Docs**
Removes the `## Limitations → FOO=bar cmd prefix` section from `docs/home/shell.mdx` (now supported on both bindings).