### PR TITLE
chore: bump to 0.0.2-alpha

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mirage-ai"
-version = "0.0.1"
+version = "0.0.2a0"
 description = "A unified virtual filesystem for AI agents. Mount S3, Google Drive, Slack, Gmail, GitHub, Linear, Notion, Postgres, MongoDB, SSH, and more behind one filesystem so agents read, write, and pipe across services with familiar shell commands."
 readme = "README.md"
 license = "Apache-2.0"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -3031,7 +3031,7 @@ wheels = [
 
 [[package]]
 name = "mirage-ai"
-version = "0.0.1"
+version = "0.0.2a0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/typescript/packages/agents/package.json
+++ b/typescript/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-agents",
-  "version": "0.0.1",
+  "version": "0.0.2-alpha.0",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/browser/package.json
+++ b/typescript/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-browser",
-  "version": "0.0.1",
+  "version": "0.0.2-alpha.0",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/cli/package.json
+++ b/typescript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-cli",
-  "version": "0.0.1",
+  "version": "0.0.2-alpha.0",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-core",
-  "version": "0.0.1",
+  "version": "0.0.2-alpha.0",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/node/package.json
+++ b/typescript/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-node",
-  "version": "0.0.1",
+  "version": "0.0.2-alpha.0",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/server/package.json
+++ b/typescript/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-server",
-  "version": "0.0.1",
+  "version": "0.0.2-alpha.0",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",


### PR DESCRIPTION
## Summary
- Python `0.0.1` → `0.0.2a0` (PEP 440 first-alpha)
- TS workspace packages `0.0.1` → `0.0.2-alpha.0` (semver, all 6: core, node, agents, browser, server, cli)

## Test plan
- [x] `pnpm test` — all 6 TS packages pass (4216 tests, 0 failures)
- [x] `execute_options.test.ts` — 26 tests cover the cwd/env/AbortSignal failure cases from closed issues #4, #5, #6
- [x] `pre-commit run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)