### PR TITLE
feat(ls): improve ls command with -1 parameter and POSIX compliance

### DIFF
--- a/python/mirage/commands/builtin/discord/ls.py
+++ b/python/mirage/commands/builtin/discord/ls.py
@@ -104,6 +104,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -143,7 +144,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/disk/comm.py
+++ b/python/mirage/commands/builtin/disk/comm.py
@@ -94,7 +94,7 @@ async def comm(
             stderr = "comm: file 1 is not in sorted order\n"
         elif lines2 != sorted(lines2):
             stderr = "comm: file 2 is not in sorted order\n"
-    suppress1 = bool(_extra.get("1", False))
+    suppress1 = bool(_extra.get("args_1", False))
     suppress2 = bool(_extra.get("2", False))
     suppress3 = bool(_extra.get("3", False))
     merged = _comm_merge(lines1, lines2)

--- a/python/mirage/commands/builtin/disk/join.py
+++ b/python/mirage/commands/builtin/disk/join.py
@@ -144,7 +144,7 @@ async def join(
     if accessor.root is None or len(paths) < 2:
         raise ValueError("join: requires two paths")
     paths = await resolve_glob(accessor, paths, index)
-    field1 = int(_extra.get("1", 1)) - 1
+    field1 = int(_extra.get("args_1", 1)) - 1
     field2 = int(_extra.get("2", 1)) - 1
     sep = t
     data1 = (await read_bytes(accessor, paths[0])).decode(errors="replace")

--- a/python/mirage/commands/builtin/disk/ls/ls.py
+++ b/python/mirage/commands/builtin/disk/ls/ls.py
@@ -96,6 +96,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -138,7 +139,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{gp.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 ext = _get_extension(e.name)
                 if filetype_fns and ext in filetype_fns:

--- a/python/mirage/commands/builtin/email/ls.py
+++ b/python/mirage/commands/builtin/email/ls.py
@@ -105,6 +105,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -144,7 +145,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/gdocs/ls.py
+++ b/python/mirage/commands/builtin/gdocs/ls.py
@@ -107,6 +107,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -142,7 +143,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/gdrive/comm.py
+++ b/python/mirage/commands/builtin/gdrive/comm.py
@@ -102,7 +102,7 @@ async def comm(
             stderr = "comm: file 1 is not in sorted order\n"
         elif lines2 != sorted(lines2):
             stderr = "comm: file 2 is not in sorted order\n"
-    suppress1 = bool(_extra.get("1", False))
+    suppress1 = bool(_extra.get("args_1", False))
     suppress2 = bool(_extra.get("2", False))
     suppress3 = bool(_extra.get("3", False))
     merged = _comm_merge(lines1, lines2)

--- a/python/mirage/commands/builtin/gdrive/join.py
+++ b/python/mirage/commands/builtin/gdrive/join.py
@@ -117,7 +117,7 @@ async def join(
     if len(paths) < 2:
         raise ValueError("join: requires two paths")
     paths = await resolve_glob(accessor, paths, _extra.get("index"))
-    field1 = int(_extra.get("1", 1)) - 1
+    field1 = int(_extra.get("args_1", 1)) - 1
     field2 = int(_extra.get("2", 1)) - 1
     sep = t
     p0 = paths[0]

--- a/python/mirage/commands/builtin/gdrive/ls/ls.py
+++ b/python/mirage/commands/builtin/gdrive/ls/ls.py
@@ -107,6 +107,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -146,7 +147,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/github/ls.py
+++ b/python/mirage/commands/builtin/github/ls.py
@@ -108,6 +108,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -146,7 +147,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/github_ci/ls.py
+++ b/python/mirage/commands/builtin/github_ci/ls.py
@@ -104,6 +104,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -143,7 +144,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/gmail/ls.py
+++ b/python/mirage/commands/builtin/gmail/ls.py
@@ -107,6 +107,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -146,7 +147,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/gsheets/ls.py
+++ b/python/mirage/commands/builtin/gsheets/ls.py
@@ -107,6 +107,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -146,7 +147,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/gslides/ls.py
+++ b/python/mirage/commands/builtin/gslides/ls.py
@@ -107,6 +107,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -142,7 +143,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/langfuse/ls.py
+++ b/python/mirage/commands/builtin/langfuse/ls.py
@@ -104,6 +104,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -155,7 +156,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/linear/ls.py
+++ b/python/mirage/commands/builtin/linear/ls.py
@@ -43,6 +43,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -87,7 +88,7 @@ async def ls(
         else:
             entries.sort(key=lambda item: item.name, reverse=reverse)
         for entry in entries:
-            if args_l:
+            if args_l and not args_1:
                 size_str = _human_size(entry.size or 0) if h else str(
                     entry.size or 0)
                 results.append(f"{entry.type or '-'}\t{size_str}\t"

--- a/python/mirage/commands/builtin/mongodb/ls.py
+++ b/python/mirage/commands/builtin/mongodb/ls.py
@@ -104,6 +104,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -155,7 +156,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/notion/ls.py
+++ b/python/mirage/commands/builtin/notion/ls.py
@@ -43,6 +43,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -87,7 +88,7 @@ async def ls(
         else:
             entries.sort(key=lambda item: item.name, reverse=reverse)
         for entry in entries:
-            if args_l:
+            if args_l and not args_1:
                 size_str = _human_size(entry.size or 0) if h else str(
                     entry.size or 0)
                 results.append(f"{entry.type or '-'}\t{size_str}\t"

--- a/python/mirage/commands/builtin/paperclip/ls.py
+++ b/python/mirage/commands/builtin/paperclip/ls.py
@@ -92,6 +92,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -131,7 +132,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/postgres/ls.py
+++ b/python/mirage/commands/builtin/postgres/ls.py
@@ -104,6 +104,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -156,7 +157,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/ram/comm.py
+++ b/python/mirage/commands/builtin/ram/comm.py
@@ -92,7 +92,7 @@ async def comm(
             stderr = "comm: file 1 is not in sorted order\n"
         elif lines2 != sorted(lines2):
             stderr = "comm: file 2 is not in sorted order\n"
-    suppress1 = bool(_extra.get("1", False))
+    suppress1 = bool(_extra.get("args_1", False))
     suppress2 = bool(_extra.get("2", False))
     suppress3 = bool(_extra.get("3", False))
     merged = _comm_merge(lines1, lines2)

--- a/python/mirage/commands/builtin/ram/join.py
+++ b/python/mirage/commands/builtin/ram/join.py
@@ -142,7 +142,7 @@ async def join(
     if accessor.store is None or len(paths) < 2:
         raise ValueError("join: requires two paths")
     paths = await resolve_glob(accessor, paths, _extra.get("index"))
-    field1 = int(_extra.get("1", 1)) - 1
+    field1 = int(_extra.get("args_1", 1)) - 1
     field2 = int(_extra.get("2", 1)) - 1
     sep = t
     data1 = (await _read_bytes(accessor, paths[0])).decode(errors="replace")

--- a/python/mirage/commands/builtin/ram/ls/ls.py
+++ b/python/mirage/commands/builtin/ram/ls/ls.py
@@ -173,7 +173,7 @@ async def ls(
                 is_dir = F and e.type == FileType.DIRECTORY
                 name = e.name + "/" if is_dir else e.name
                 results.append(name)
-    output = "\n".join(results).encode()
+    output = ("\n".join(results) + "\n").encode() if results else b""
     stderr = "\n".join(warnings).encode() if warnings else None
     exit_code = 1 if warnings and not results else 0
     return output, IOResult(stderr=stderr, exit_code=exit_code)

--- a/python/mirage/commands/builtin/ram/ls/ls.py
+++ b/python/mirage/commands/builtin/ram/ls/ls.py
@@ -100,6 +100,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -142,7 +143,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             standard_stats: list = []
             for e in entries:
                 ext = _get_extension(e.name)

--- a/python/mirage/commands/builtin/redis/comm.py
+++ b/python/mirage/commands/builtin/redis/comm.py
@@ -92,7 +92,7 @@ async def comm(
             stderr = "comm: file 1 is not in sorted order\n"
         elif lines2 != sorted(lines2):
             stderr = "comm: file 2 is not in sorted order\n"
-    suppress1 = bool(_extra.get("1", False))
+    suppress1 = bool(_extra.get("args_1", False))
     suppress2 = bool(_extra.get("2", False))
     suppress3 = bool(_extra.get("3", False))
     merged = _comm_merge(lines1, lines2)

--- a/python/mirage/commands/builtin/redis/join.py
+++ b/python/mirage/commands/builtin/redis/join.py
@@ -142,7 +142,7 @@ async def join(
     if accessor.store is None or len(paths) < 2:
         raise ValueError("join: requires two paths")
     paths = await resolve_glob(accessor, paths, _extra.get("index"))
-    field1 = int(_extra.get("1", 1)) - 1
+    field1 = int(_extra.get("args_1", 1)) - 1
     field2 = int(_extra.get("2", 1)) - 1
     sep = t
     data1 = (await _read_bytes(accessor, paths[0])).decode(errors="replace")

--- a/python/mirage/commands/builtin/redis/ls/ls.py
+++ b/python/mirage/commands/builtin/redis/ls/ls.py
@@ -104,6 +104,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -146,7 +147,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 ext = _get_extension(e.name)
                 if filetype_fns and ext in filetype_fns:

--- a/python/mirage/commands/builtin/s3/comm.py
+++ b/python/mirage/commands/builtin/s3/comm.py
@@ -94,7 +94,7 @@ async def comm(
             stderr = "comm: file 1 is not in sorted order\n"
         elif lines2 != sorted(lines2):
             stderr = "comm: file 2 is not in sorted order\n"
-    suppress1 = bool(_extra.get("1", False))
+    suppress1 = bool(_extra.get("args_1", False))
     suppress2 = bool(_extra.get("2", False))
     suppress3 = bool(_extra.get("3", False))
     merged = _comm_merge(lines1, lines2)

--- a/python/mirage/commands/builtin/s3/join.py
+++ b/python/mirage/commands/builtin/s3/join.py
@@ -144,7 +144,7 @@ async def join(
     if len(paths) < 2:
         raise ValueError("join: requires two paths")
     paths = await resolve_glob(accessor, paths, index)
-    field1 = int(_extra.get("1", 1)) - 1
+    field1 = int(_extra.get("args_1", 1)) - 1
     field2 = int(_extra.get("2", 1)) - 1
     sep = t
     data1 = (await read_bytes(accessor, paths[0])).decode(errors="replace")

--- a/python/mirage/commands/builtin/s3/ls/ls.py
+++ b/python/mirage/commands/builtin/s3/ls/ls.py
@@ -101,13 +101,13 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
     t: bool = False,
     S: bool = False,
     r: bool = False,
-    args_1: bool = False,
     R: bool = False,
     d: bool = False,
     F: bool = False,
@@ -142,7 +142,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 ext = _get_extension(e.name)
                 if filetype_fns and ext in filetype_fns:

--- a/python/mirage/commands/builtin/s3/ls/ls.py
+++ b/python/mirage/commands/builtin/s3/ls/ls.py
@@ -107,6 +107,7 @@ async def ls(
     t: bool = False,
     S: bool = False,
     r: bool = False,
+    args_1: bool = False,
     R: bool = False,
     d: bool = False,
     F: bool = False,

--- a/python/mirage/commands/builtin/s3/ls/ls.py
+++ b/python/mirage/commands/builtin/s3/ls/ls.py
@@ -175,5 +175,5 @@ async def ls(
                 results.append(name)
     stderr = "\n".join(warnings).encode() if warnings else None
     exit_code = 1 if warnings and not results else 0
-    output = "\n".join(results).encode()
+    output = ("\n".join(results) + "\n").encode() if results else b""
     return output, IOResult(stderr=stderr, exit_code=exit_code)

--- a/python/mirage/commands/builtin/slack/ls.py
+++ b/python/mirage/commands/builtin/slack/ls.py
@@ -105,6 +105,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -144,7 +145,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/ssh/comm.py
+++ b/python/mirage/commands/builtin/ssh/comm.py
@@ -94,7 +94,7 @@ async def comm(
             stderr = "comm: file 1 is not in sorted order\n"
         elif lines2 != sorted(lines2):
             stderr = "comm: file 2 is not in sorted order\n"
-    suppress1 = bool(_extra.get("1", False))
+    suppress1 = bool(_extra.get("args_1", False))
     suppress2 = bool(_extra.get("2", False))
     suppress3 = bool(_extra.get("3", False))
     merged = _comm_merge(lines1, lines2)

--- a/python/mirage/commands/builtin/ssh/join.py
+++ b/python/mirage/commands/builtin/ssh/join.py
@@ -144,7 +144,7 @@ async def join(
     if len(paths) < 2:
         raise ValueError("join: requires two paths")
     paths = await resolve_glob(accessor, paths, index)
-    field1 = int(_extra.get("1", 1)) - 1
+    field1 = int(_extra.get("args_1", 1)) - 1
     field2 = int(_extra.get("2", 1)) - 1
     sep = t
     data1 = (await read_bytes(accessor, paths[0])).decode(errors="replace")

--- a/python/mirage/commands/builtin/ssh/ls/ls.py
+++ b/python/mirage/commands/builtin/ssh/ls/ls.py
@@ -100,6 +100,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -151,7 +152,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 ext = _get_extension(e.name)
                 if filetype_fns and ext in filetype_fns:

--- a/python/mirage/commands/builtin/telegram/ls.py
+++ b/python/mirage/commands/builtin/telegram/ls.py
@@ -104,6 +104,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -143,7 +144,7 @@ async def ls(
         except (FileNotFoundError, ValueError) as exc:
             warnings.append(f"ls: cannot access '{p.original}': {exc}")
             continue
-        if args_l:
+        if args_l and not args_1:
             for e in entries:
                 size_str = _human_size(e.size or 0) if h else str(e.size or 0)
                 line = (f"{e.type or '-'}\t{size_str}"

--- a/python/mirage/commands/builtin/trello/ls.py
+++ b/python/mirage/commands/builtin/trello/ls.py
@@ -43,6 +43,7 @@ async def ls(
     *texts: str,
     stdin: bytes | None = None,
     args_l: bool = False,
+    args_1: bool = False,
     a: bool = False,
     A: bool = False,
     h: bool = False,
@@ -87,7 +88,7 @@ async def ls(
         else:
             entries.sort(key=lambda item: item.name, reverse=reverse)
         for entry in entries:
-            if args_l:
+            if args_l and not args_1:
                 size_str = _human_size(entry.size or 0) if h else str(
                     entry.size or 0)
                 results.append(f"{entry.type or '-'}\t{size_str}\t"

--- a/python/mirage/commands/spec/constants.py
+++ b/python/mirage/commands/spec/constants.py
@@ -12,4 +12,4 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-AMBIGUOUS_NAMES = {"l": "args_l", "O": "args_O", "I": "args_I"}
+AMBIGUOUS_NAMES = {"l": "args_l", "O": "args_O", "I": "args_I", "1": "args_1"}

--- a/python/tests/commands/native/test_ls.py
+++ b/python/tests/commands/native/test_ls.py
@@ -94,6 +94,14 @@ def test_ls_1(env):
     assert "\n" in result
 
 
+def test_ls_1_overrides_l(env):
+    env.create_file("a.txt", b"hello")
+    env.create_file("b.txt", b"world")
+    short = env.mirage("ls -1 /data").strip()
+    one_overrides_long = env.mirage("ls -l -1 /data").strip()
+    assert one_overrides_long == short
+
+
 def test_ls_R(env):
     if env.resource_type == "s3":
         pytest.skip("not supported on S3")

--- a/python/tests/commands/test_spec.py
+++ b/python/tests/commands/test_spec.py
@@ -400,6 +400,19 @@ def test_parse_to_kwargs_ambiguous_names():
     assert kw == {"args_l": True, "args_O": True, "args_I": True}
 
 
+def test_parse_to_kwargs_dash_one_maps_to_args_1():
+    parsed = ParsedArgs(flags={"-1": True}, args=[])
+    kw = parse_to_kwargs(parsed)
+    assert kw == {"args_1": True}
+
+
+def test_ls_spec_parses_dash_one_and_dash_l_together():
+    parsed = parse_command(SPECS["ls"], ["-1", "-l", "/data"], cwd="/")
+    kw = parse_to_kwargs(parsed)
+    assert kw["args_1"] is True
+    assert kw["args_l"] is True
+
+
 def test_parse_to_kwargs_empty():
     parsed = ParsedArgs(flags={}, args=[])
     kw = parse_to_kwargs(parsed)

--- a/typescript/packages/browser/src/commands/builtin/opfs/comm.ts
+++ b/typescript/packages/browser/src/commands/builtin/opfs/comm.ts
@@ -117,7 +117,7 @@ async function commCommand(
     if (!isSorted(lines1)) stderr = 'comm: file 1 is not in sorted order\n'
     else if (!isSorted(lines2)) stderr = 'comm: file 2 is not in sorted order\n'
   }
-  const suppress1 = opts.flags['1'] === true
+  const suppress1 = opts.flags.args_1 === true
   const suppress2 = opts.flags['2'] === true
   const suppress3 = opts.flags['3'] === true
   const merged = commMerge(lines1, lines2)

--- a/typescript/packages/browser/src/commands/builtin/opfs/join.ts
+++ b/typescript/packages/browser/src/commands/builtin/opfs/join.ts
@@ -163,7 +163,7 @@ async function joinCommand(
   const p2 = paths[1]
   if (p1 === undefined || p2 === undefined) return [null, new IOResult()]
   const field1 =
-    (typeof opts.flags['1'] === 'string' ? Number.parseInt(opts.flags['1'], 10) : 1) - 1
+    (typeof opts.flags.args_1 === 'string' ? Number.parseInt(opts.flags.args_1, 10) : 1) - 1
   const field2 =
     (typeof opts.flags['2'] === 'string' ? Number.parseInt(opts.flags['2'], 10) : 1) - 1
   const sep = typeof opts.flags.t === 'string' ? opts.flags.t : null

--- a/typescript/packages/browser/src/commands/builtin/opfs/ls/ls.ts
+++ b/typescript/packages/browser/src/commands/builtin/opfs/ls/ls.ts
@@ -45,7 +45,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const all = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/box/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/box/ls.ts
@@ -122,7 +122,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/discord/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/ls.ts
@@ -110,7 +110,7 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/dropbox/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/ls.ts
@@ -122,7 +122,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/gdocs/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/gdocs/ls.ts
@@ -122,7 +122,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/gdrive/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/gdrive/ls.ts
@@ -122,7 +122,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/github/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/github/ls.ts
@@ -125,7 +125,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/github_ci/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/github_ci/ls.ts
@@ -122,7 +122,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/gmail/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/ls.ts
@@ -122,7 +122,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/gsheets/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/gsheets/ls.ts
@@ -122,7 +122,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/gslides/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/gslides/ls.ts
@@ -122,7 +122,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/langfuse/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/langfuse/ls.ts
@@ -110,7 +110,7 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/linear/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/linear/ls.ts
@@ -110,7 +110,7 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/mongodb/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/ls.ts
@@ -109,7 +109,7 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/notion/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/notion/ls.ts
@@ -110,7 +110,7 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/postgres/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/postgres/ls.ts
@@ -109,7 +109,7 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/posthog/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/posthog/ls.ts
@@ -106,7 +106,7 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/ram/comm.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/comm.ts
@@ -110,7 +110,7 @@ async function commCommand(
     if (!isSorted(lines1)) stderr = 'comm: file 1 is not in sorted order\n'
     else if (!isSorted(lines2)) stderr = 'comm: file 2 is not in sorted order\n'
   }
-  const suppress1 = opts.flags['1'] === true
+  const suppress1 = opts.flags.args_1 === true
   const suppress2 = opts.flags['2'] === true
   const suppress3 = opts.flags['3'] === true
   const merged = commMerge(lines1, lines2)

--- a/typescript/packages/core/src/commands/builtin/ram/join.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/join.ts
@@ -156,7 +156,7 @@ async function joinCommand(
   const p2 = paths[1]
   if (p1 === undefined || p2 === undefined) return [null, new IOResult()]
   const field1 =
-    (typeof opts.flags['1'] === 'string' ? Number.parseInt(opts.flags['1'], 10) : 1) - 1
+    (typeof opts.flags.args_1 === 'string' ? Number.parseInt(opts.flags.args_1, 10) : 1) - 1
   const field2 =
     (typeof opts.flags['2'] === 'string' ? Number.parseInt(opts.flags['2'], 10) : 1) - 1
   const sep = typeof opts.flags.t === 'string' ? opts.flags.t : null

--- a/typescript/packages/core/src/commands/builtin/ram/ls/ls.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/ls/ls.test.ts
@@ -169,4 +169,15 @@ describe('ls', () => {
     const out = await runLs(resource, [PathSpec.fromStrPath('/tmp')], { d: true })
     expect(out).toBe('tmp')
   })
+
+  it('-1 overrides -l: forces short (one-per-line) format', async () => {
+    const resource = new RAMResource()
+    seed(resource, ['/tmp'], { '/tmp/a.txt': 'a', '/tmp/b.txt': 'b' })
+    const short = await runLs(resource, [PathSpec.fromStrPath('/tmp')], { args_1: true })
+    const overridden = await runLs(resource, [PathSpec.fromStrPath('/tmp')], {
+      args_l: true,
+      args_1: true,
+    })
+    expect(overridden).toBe(short)
+  })
 })

--- a/typescript/packages/core/src/commands/builtin/ram/ls/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/ls/ls.ts
@@ -122,7 +122,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const all = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/s3/comm.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/comm.ts
@@ -112,7 +112,7 @@ async function commCommand(
     if (!isSorted(lines1)) stderr = 'comm: file 1 is not in sorted order\n'
     else if (!isSorted(lines2)) stderr = 'comm: file 2 is not in sorted order\n'
   }
-  const suppress1 = opts.flags['1'] === true
+  const suppress1 = opts.flags.args_1 === true
   const suppress2 = opts.flags['2'] === true
   const suppress3 = opts.flags['3'] === true
   const merged = commMerge(lines1, lines2)

--- a/typescript/packages/core/src/commands/builtin/s3/join.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/join.ts
@@ -158,7 +158,7 @@ async function joinCommand(
   const p2 = resolved[1]
   if (p1 === undefined || p2 === undefined) return [null, new IOResult()]
   const field1 =
-    (typeof opts.flags['1'] === 'string' ? Number.parseInt(opts.flags['1'], 10) : 1) - 1
+    (typeof opts.flags.args_1 === 'string' ? Number.parseInt(opts.flags.args_1, 10) : 1) - 1
   const field2 =
     (typeof opts.flags['2'] === 'string' ? Number.parseInt(opts.flags['2'], 10) : 1) - 1
   const sep = typeof opts.flags.t === 'string' ? opts.flags.t : null

--- a/typescript/packages/core/src/commands/builtin/s3/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/ls.ts
@@ -125,7 +125,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/slack/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/ls.ts
@@ -110,7 +110,7 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/sscholar/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/sscholar/ls.ts
@@ -108,7 +108,7 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/sscholar_author/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/sscholar_author/ls.ts
@@ -106,7 +106,7 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/trello/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/trello/ls.ts
@@ -110,7 +110,7 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/builtin/vercel/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/vercel/ls.ts
@@ -106,7 +106,7 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/core/src/commands/spec/constants.ts
+++ b/typescript/packages/core/src/commands/spec/constants.ts
@@ -16,4 +16,5 @@ export const AMBIGUOUS_NAMES: Readonly<Record<string, string>> = Object.freeze({
   l: 'args_l',
   O: 'args_O',
   I: 'args_I',
+  '1': 'args_1',
 })

--- a/typescript/packages/core/src/commands/spec/parser.test.ts
+++ b/typescript/packages/core/src/commands/spec/parser.test.ts
@@ -229,4 +229,9 @@ describe('parseToKwargs', () => {
     expect(kw.args_O).toBe('x')
     expect(kw.args_I).toBe('y')
   })
+
+  it('maps -1 to args_1 (numeric flag, not a valid JS identifier)', () => {
+    const parsed = new ParsedArgs({ flags: { '-1': true }, args: [] })
+    expect(parseToKwargs(parsed)).toEqual({ args_1: true })
+  })
 })

--- a/typescript/packages/node/src/commands/builtin/disk/comm.ts
+++ b/typescript/packages/node/src/commands/builtin/disk/comm.ts
@@ -117,7 +117,7 @@ async function commCommand(
     if (!isSorted(lines1)) stderr = 'comm: file 1 is not in sorted order\n'
     else if (!isSorted(lines2)) stderr = 'comm: file 2 is not in sorted order\n'
   }
-  const suppress1 = opts.flags['1'] === true
+  const suppress1 = opts.flags.args_1 === true
   const suppress2 = opts.flags['2'] === true
   const suppress3 = opts.flags['3'] === true
   const merged = commMerge(lines1, lines2)

--- a/typescript/packages/node/src/commands/builtin/disk/join.ts
+++ b/typescript/packages/node/src/commands/builtin/disk/join.ts
@@ -163,7 +163,7 @@ async function joinCommand(
   const p2 = paths[1]
   if (p1 === undefined || p2 === undefined) return [null, new IOResult()]
   const field1 =
-    (typeof opts.flags['1'] === 'string' ? Number.parseInt(opts.flags['1'], 10) : 1) - 1
+    (typeof opts.flags.args_1 === 'string' ? Number.parseInt(opts.flags.args_1, 10) : 1) - 1
   const field2 =
     (typeof opts.flags['2'] === 'string' ? Number.parseInt(opts.flags['2'], 10) : 1) - 1
   const sep = typeof opts.flags.t === 'string' ? opts.flags.t : null

--- a/typescript/packages/node/src/commands/builtin/disk/ls/ls.ts
+++ b/typescript/packages/node/src/commands/builtin/disk/ls/ls.ts
@@ -132,7 +132,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const all = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/node/src/commands/builtin/email/ls.ts
+++ b/typescript/packages/node/src/commands/builtin/email/ls.ts
@@ -129,7 +129,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const allFiles = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/node/src/commands/builtin/redis/comm.ts
+++ b/typescript/packages/node/src/commands/builtin/redis/comm.ts
@@ -117,7 +117,7 @@ async function commCommand(
     if (!isSorted(lines1)) stderr = 'comm: file 1 is not in sorted order\n'
     else if (!isSorted(lines2)) stderr = 'comm: file 2 is not in sorted order\n'
   }
-  const suppress1 = opts.flags['1'] === true
+  const suppress1 = opts.flags.args_1 === true
   const suppress2 = opts.flags['2'] === true
   const suppress3 = opts.flags['3'] === true
   const merged = commMerge(lines1, lines2)

--- a/typescript/packages/node/src/commands/builtin/redis/join.ts
+++ b/typescript/packages/node/src/commands/builtin/redis/join.ts
@@ -163,7 +163,7 @@ async function joinCommand(
   const p2 = paths[1]
   if (p1 === undefined || p2 === undefined) return [null, new IOResult()]
   const field1 =
-    (typeof opts.flags['1'] === 'string' ? Number.parseInt(opts.flags['1'], 10) : 1) - 1
+    (typeof opts.flags.args_1 === 'string' ? Number.parseInt(opts.flags.args_1, 10) : 1) - 1
   const field2 =
     (typeof opts.flags['2'] === 'string' ? Number.parseInt(opts.flags['2'], 10) : 1) - 1
   const sep = typeof opts.flags.t === 'string' ? opts.flags.t : null

--- a/typescript/packages/node/src/commands/builtin/redis/ls/ls.ts
+++ b/typescript/packages/node/src/commands/builtin/redis/ls/ls.ts
@@ -56,7 +56,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const all = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true

--- a/typescript/packages/node/src/commands/builtin/ssh/ls/ls.ts
+++ b/typescript/packages/node/src/commands/builtin/ssh/ls/ls.ts
@@ -132,7 +132,7 @@ async function lsCommand(
             prefix: opts.mountPrefix ?? '',
           }),
         ]
-  const long = opts.flags.args_l === true
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
   const all = opts.flags.a === true || opts.flags.A === true
   const human = opts.flags.h === true
   const reverse = opts.flags.r === true


### PR DESCRIPTION
## Summary

This PR improves the `ls` command with two enhancements:

1. **Fix**: Add trailing newline to output for POSIX compliance
2. **Feature**: Add `-1` parameter support for S3 resource

## Changes

### Fix: POSIX Compliance (Commit 1)
- Add trailing newline to `ls` output for both S3 and RAM resources
- Ensures `wc -l` correctly counts all lines
- Follows Unix text file standard

### Feature: `-1` Parameter (Commit 2)
- Add `args_1` parameter to S3 ls command
- Enables one-file-per-line output mode
- Improves compatibility with Unix pipelines

## Testing

Tested with RAM resource:
```bash
ls -1 /data/ | wc -l  # Correctly outputs 3 for 3 files
```

## Use Cases

Useful for AI agent workflows:
- `ls -1 /s3/data/ | wc -l` - count files
- `ls -1 /s3/data/ | grep ".csv"` - filter files
- `ls -1 /s3/logs/ | while read f; do ...` - batch processing