### PR TITLE
fix: clear shell errors (#19), cache write-through (#18), per-session mount capability (#17)

### DIFF
--- a/docs/home/shell.mdx
+++ b/docs/home/shell.mdx
@@ -160,7 +160,7 @@ The shell is a tree-sitter-bash parser plus a custom executor. It implements the
 
 ### Unsupported (returns clear error)
 
-- **Job control:** `fg`, `bg`, `jobs`, `wait`, `disown`. Use the `--background` flag and `mirage job` CLI to manage long-running work.
+- **Job control:** `bg`, `disown`. (`fg`, `jobs`, `wait`, `kill`, `ps` work; use the `--background` flag and `mirage job` CLI for long-running work.)
 - **Shell internals:** `exec`, `complete`, `compgen`, `ulimit`.
 - **Output process substitution:** `>(cmd)` (the `<(cmd)` direction works).
 

--- a/docs/home/shell.mdx
+++ b/docs/home/shell.mdx
@@ -174,6 +174,47 @@ Commands the parser cannot make sense of return `exit_code 2` with stderr `mirag
 
 The daemon's `--background` flag detaches a job and returns a job id. It is not the same as the bash `&` operator, which the shell does support inline (`sleep 30 &`). Use `&` for in-shell job parallelism, `--background` (or `mirage job`) for long-lived work that should outlive the request.
 
+## Per-session mount capability
+
+A session can be created with an explicit allowlist of mount prefixes. Any command whose path resolves to a mount outside that list is rejected with `mirage: session 'agent' not allowed to access mount '/X'` and exit code 1. Default sessions (no allowlist) keep their current unrestricted behavior, so existing code is unaffected.
+
+This is a soft boundary, enforced inside the daemon process, not an OS or process-level isolation. Use it to shrink the blast radius of prompt-injection in multi-agent workspaces: a Slack-only agent cannot pivot to read `/linear`, `/github`, or any other mount it was not given.
+
+The check fires for every code path that reaches a mount: shell commands (`cat`, `ls`, ...), redirects (`>`, `<`), cross-mount `cp`/`mv`, `wget -O`, `curl -o`, command substitution `$(...)`, subshells `(...)`, pipes, `&&`/`||` chains, background jobs, and the programmatic `ws.ops.read/write/...` API. Two infrastructure prefixes are always allowed regardless of the allowlist: the observer prefix (`/.sessions`, where command history is recorded) and the cache mount (`/_default`, where stateless text-processing commands like `wc` live).
+
+<Tabs>
+  <Tab title="Python" icon="/images/python-logo.svg">
+    ```python
+    ws = Workspace({
+        "/s3": s3,
+        "/slack": slack,
+        "/linear": linear,
+    })
+
+    ws.create_session("slack-agent", allowed_mounts={"/slack"})
+    ws.create_session("data-agent", allowed_mounts={"/s3"})
+
+    await ws.execute("ls /slack", session_id="slack-agent")  # ok
+    await ws.execute("cat /linear/issues/SEC-42",
+                     session_id="slack-agent")
+    # exit_code=1, stderr=b"session 'slack-agent' not allowed to "
+    #                     b"access mount '/linear'\n"
+    ```
+  </Tab>
+  <Tab title="CLI" icon="terminal">
+    ```bash
+    # Repeat --mount (or -m) per allowed prefix
+    mirage session create demo --id slack-agent --mount /slack
+    mirage session create demo --id data-agent  -m /s3 -m /github
+
+    mirage execute -w demo -s slack-agent -c "cat /linear/issues/SEC-42"
+    # mirage: session 'slack-agent' not allowed to access mount '/linear'
+    ```
+  </Tab>
+</Tabs>
+
+The allowlist is a property of the session, so it covers every command issued under that `session_id`, including subshells, pipelines, and recursive `bash -c '...'`. It does not change `MountMode`: a write to a mount in the allowlist is still rejected if the mount is `READ`. The two checks compose.
+
 ## Agent Pattern
 
 Agent harnesses commonly fan out tool calls in parallel, each with its own `cwd`/`env`/`cancel`. The clone semantics make this race-free without per-call boilerplate.

--- a/docs/home/shell.mdx
+++ b/docs/home/shell.mdx
@@ -143,6 +143,37 @@ Both bindings support cooperative cancellation observed at recursion boundaries 
 | Many isolated commands sharing scoped state | `session_id=...` (Py) / `sessionId` (TS) | a separate terminal |
 | Persistent shell mutations | run without options | `cd /data; cmd` |
 
+## Supported bash syntax
+
+The shell is a tree-sitter-bash parser plus a custom executor. It implements the constructs LLMs reach for most often. What is not supported returns a clear, parseable error so an agent can self-correct on its next turn.
+
+### Supported
+
+- **Operators:** pipes `|`, `|&`; lists `&&`, `||`, `;`; background `&`.
+- **Redirects:** `>`, `>>`, `<`, `2>`, `2>&1`, `&>`, `&>>`, heredoc `<<`, herestring `<<<`.
+- **Substitutions:** command substitution `` `cmd` `` and `$(cmd)`; arithmetic `$((expr))`; parameter expansion `${VAR}`, `${VAR:-default}`, `${VAR%suffix}`, etc.; input-direction process substitution `<(cmd)`.
+- **Control flow:** `if`/`elif`/`else`/`fi`, `for`, `while`, `until`, `case`, `select`, `function name() {}`, `break`, `continue`, `return`.
+- **Grouping:** subshells `(cmd)`, compound `{ cmd; }`, negation `! cmd`.
+- **Builtins:** `cd`, `pwd`, `echo`, `printf`, `printenv`, `read`, `source`, `.`, `eval`, `export`, `unset`, `local`, `set`, `shift`, `trap` (no-op), `test`, `[`, `[[`, `true`, `false`, `sleep`, `xargs`, `timeout`, `bash`, `sh`, `python`, `python3`.
+- **Globs:** `*`, `?`, `[...]` resolved by the shell or pushed down to the resource.
+- **Comments:** `#`.
+
+### Unsupported (returns clear error)
+
+- **Job control:** `fg`, `bg`, `jobs`, `wait`, `disown`. Use the `--background` flag and `mirage job` CLI to manage long-running work.
+- **Shell internals:** `exec`, `complete`, `compgen`, `ulimit`.
+- **Output process substitution:** `>(cmd)` (the `<(cmd)` direction works).
+
+Each returns `exit_code 2` with stderr `mirage: unsupported builtin: <name>` or `mirage: unsupported: process substitution >(...)`.
+
+### Syntax errors
+
+Commands the parser cannot make sense of return `exit_code 2` with stderr `mirage: syntax error near '<token>'`. Earlier versions silently ran whatever fragment did parse; that no longer happens.
+
+### What `--background` is and isn't
+
+The daemon's `--background` flag detaches a job and returns a job id. It is not the same as the bash `&` operator, which the shell does support inline (`sleep 30 &`). Use `&` for in-shell job parallelism, `--background` (or `mirage job`) for long-lived work that should outlive the request.
+
 ## Agent Pattern
 
 Agent harnesses commonly fan out tool calls in parallel, each with its own `cwd`/`env`/`cancel`. The clone semantics make this race-free without per-call boilerplate.

--- a/python/mirage/cli/session.py
+++ b/python/mirage/cli/session.py
@@ -26,10 +26,19 @@ def create_cmd(
     session_id: str | None = typer.Option(None,
                                           "--id",
                                           help="Explicit session id."),
+    mount: list[str] = typer.Option(
+        [],
+        "--mount",
+        "-m",
+        help=("Restrict this session to the listed mount prefix. "
+              "Repeat to allow multiple mounts; omit for unrestricted."),
+    ),
 ) -> None:
     body: dict = {}
     if session_id:
         body["session_id"] = session_id
+    if mount:
+        body["allowed_mounts"] = mount
     with make_client() as client:
         client.ensure_running(allow_spawn=False)
         r = client.request("POST",

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -24,8 +24,8 @@ from mirage.observe import OpRecord
 from mirage.observe.context import set_virtual_prefix
 from mirage.ops.config import OpsMount
 from mirage.ops.registry import OpsRegistry, RegisteredOp
-from mirage.types import FileStat, MountMode, PathSpec
 from mirage.runtime import assert_mount_allowed
+from mirage.types import FileStat, MountMode, PathSpec
 
 
 class Ops:

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -25,6 +25,7 @@ from mirage.observe.context import set_virtual_prefix
 from mirage.ops.config import OpsMount
 from mirage.ops.registry import OpsRegistry, RegisteredOp
 from mirage.types import FileStat, MountMode, PathSpec
+from mirage.runtime import assert_mount_allowed
 
 
 class Ops:
@@ -132,9 +133,10 @@ class Ops:
                     **kwargs):
         start = int(time.monotonic() * 1000)
         resource_type, rel_path, accessor, index, mode = self._resolve(path)
+        mount_prefix = self._mount_prefix(path)
+        assert_mount_allowed(mount_prefix)
         if write and mode == MountMode.READ:
             raise PermissionError(f"mount at {path!r} is read-only")
-        mount_prefix = self._mount_prefix(path)
         set_virtual_prefix(mount_prefix)
         filetype = self._get_filetype(rel_path)
         scope = PathSpec(

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -163,11 +163,6 @@ class Ops:
         self._record(op, path, resource_type, nbytes, start)
         if write:
             await self._invalidate(path)
-            # Invalidate the parent directory listing in the index cache
-            # so the next readdir/stat sees the mutation.
-            if index is not None:
-                parent = scope.original.rsplit("/", 1)[0] or "/"
-                await index.invalidate_dir(parent)
         return result
 
     async def read(self,

--- a/python/mirage/runtime/__init__.py
+++ b/python/mirage/runtime/__init__.py
@@ -12,14 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.runtime import (assert_mount_allowed, get_current_session,
-                             reset_current_session, set_current_session)
-from mirage.workspace.session.manager import SessionManager
-from mirage.workspace.session.session import Session
+from mirage.runtime.session_context import (assert_mount_allowed,
+                                             get_current_session,
+                                             reset_current_session,
+                                             set_current_session)
 
 __all__ = [
-    "Session",
-    "SessionManager",
     "assert_mount_allowed",
     "get_current_session",
     "reset_current_session",

--- a/python/mirage/runtime/__init__.py
+++ b/python/mirage/runtime/__init__.py
@@ -13,9 +13,9 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.runtime.session_context import (assert_mount_allowed,
-                                             get_current_session,
-                                             reset_current_session,
-                                             set_current_session)
+                                            get_current_session,
+                                            reset_current_session,
+                                            set_current_session)
 
 __all__ = [
     "assert_mount_allowed",

--- a/python/mirage/runtime/session_context.py
+++ b/python/mirage/runtime/session_context.py
@@ -60,6 +60,5 @@ def assert_mount_allowed(mount_prefix: str) -> None:
     norm = "/" + mount_prefix.strip("/") if mount_prefix.strip("/") else "/"
     if norm == "/" or norm in sess.allowed_mounts:
         return
-    raise PermissionError(
-        f"session {sess.session_id!r} not allowed to access "
-        f"mount {norm!r}")
+    raise PermissionError(f"session {sess.session_id!r} not allowed to access "
+                          f"mount {norm!r}")

--- a/python/mirage/runtime/session_context.py
+++ b/python/mirage/runtime/session_context.py
@@ -13,16 +13,18 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from contextvars import ContextVar, Token
+from typing import TYPE_CHECKING
 
-from mirage.workspace.session.session import Session
+if TYPE_CHECKING:
+    from mirage.workspace.session.session import Session
 
-_current_session: ContextVar[Session | None] = ContextVar(
+_current_session: ContextVar["Session | None"] = ContextVar(
     "mirage_current_session",
     default=None,
 )
 
 
-def set_current_session(session: Session | None) -> Token:
+def set_current_session(session: "Session | None") -> Token:
     """Bind ``session`` to the current async context."""
     return _current_session.set(session)
 
@@ -32,7 +34,7 @@ def reset_current_session(token: Token) -> None:
     _current_session.reset(token)
 
 
-def get_current_session() -> Session | None:
+def get_current_session() -> "Session | None":
     """Return the session bound to the current async context, if any."""
     return _current_session.get()
 
@@ -52,7 +54,7 @@ def assert_mount_allowed(mount_prefix: str) -> None:
     Raises:
         PermissionError: the mount lies outside the session's allowlist.
     """
-    sess = get_current_session()
+    sess = _current_session.get()
     if sess is None or sess.allowed_mounts is None:
         return
     norm = "/" + mount_prefix.strip("/") if mount_prefix.strip("/") else "/"

--- a/python/mirage/server/routers/sessions.py
+++ b/python/mirage/server/routers/sessions.py
@@ -20,6 +20,7 @@ router = APIRouter(prefix="/v1/workspaces/{workspace_id}/sessions")
 
 class CreateSessionRequest(BaseModel):
     session_id: str | None = None
+    allowed_mounts: list[str] | None = None
 
 
 class SessionResponse(BaseModel):
@@ -47,7 +48,9 @@ async def create_session(workspace_id: str, req: CreateSessionRequest,
     if any(s.session_id == sid for s in entry.runner.ws.list_sessions()):
         raise HTTPException(status_code=409,
                             detail=f"session id already exists: {sid!r}")
-    sess = entry.runner.ws.create_session(sid)
+    allowed = (frozenset(req.allowed_mounts)
+               if req.allowed_mounts else None)
+    sess = entry.runner.ws.create_session(sid, allowed_mounts=allowed)
     return SessionResponse(session_id=sess.session_id, cwd=sess.cwd)
 
 

--- a/python/mirage/server/routers/sessions.py
+++ b/python/mirage/server/routers/sessions.py
@@ -48,8 +48,7 @@ async def create_session(workspace_id: str, req: CreateSessionRequest,
     if any(s.session_id == sid for s in entry.runner.ws.list_sessions()):
         raise HTTPException(status_code=409,
                             detail=f"session id already exists: {sid!r}")
-    allowed = (frozenset(req.allowed_mounts)
-               if req.allowed_mounts else None)
+    allowed = (frozenset(req.allowed_mounts) if req.allowed_mounts else None)
     sess = entry.runner.ws.create_session(sid, allowed_mounts=allowed)
     return SessionResponse(session_id=sess.session_id, cwd=sess.cwd)
 

--- a/python/mirage/shell/helpers.py
+++ b/python/mirage/shell/helpers.py
@@ -12,10 +12,17 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from enum import StrEnum
+
 import tree_sitter
 
 from mirage.shell.types import NodeType as NT
 from mirage.shell.types import Redirect, RedirectKind
+
+
+class ProcessSubDirection(StrEnum):
+    INPUT = "input"
+    OUTPUT = "output"
 
 
 def get_text(node: tree_sitter.Node) -> str:
@@ -411,6 +418,23 @@ def get_herestring_content(node: tree_sitter.Node) -> str:
 def get_process_sub_command(node: tree_sitter.Node) -> tree_sitter.Node:
     """Get inner command from process_substitution."""
     return node.named_children[0]
+
+
+def get_process_sub_direction(
+        node: tree_sitter.Node) -> ProcessSubDirection | None:
+    """Return the direction marker on a process_substitution node.
+
+    `<(cmd)` is INPUT (inner stdout feeds our stdin), `>(cmd)` is OUTPUT
+    (our stdout feeds inner stdin). Returns None if the open token is missing.
+    """
+    if not node.children:
+        return None
+    open_token = node.children[0].type
+    if open_token == "<(":
+        return ProcessSubDirection.INPUT
+    if open_token == ">(":
+        return ProcessSubDirection.OUTPUT
+    return None
 
 
 def get_function_name(node: tree_sitter.Node) -> str:

--- a/python/mirage/shell/parse.py
+++ b/python/mirage/shell/parse.py
@@ -28,8 +28,39 @@ def parse(command: str) -> tree_sitter.Node:
     return tree.root_node
 
 
+_BASH_KEYWORDS = frozenset({
+    "if", "then", "else", "elif", "fi",
+    "for", "while", "until", "do", "done",
+    "case", "esac", "in", "function", "select",
+})
+
+_STRUCTURAL_TOKENS = frozenset({
+    "(", ")", "{", "}", "[", "]",
+    '"', "'", "`",
+})
+
+
+def _is_structural_error(node: tree_sitter.Node) -> bool:
+    """True if an ERROR node represents a real syntactic problem.
+
+    Tree-sitter occasionally emits ERROR nodes for stray statement
+    separators that bash itself accepts (notably ``& ;``). A real
+    syntax error contains a bash keyword, a bracket / quote token,
+    or a named subtree the parser tried to recover; stand-alone
+    statement separators (``;``, ``&``, ``|``) are not enough.
+    """
+    for child in node.children:
+        if child.is_named:
+            return True
+        if child.type in _BASH_KEYWORDS:
+            return True
+        if child.type in _STRUCTURAL_TOKENS:
+            return True
+    return False
+
+
 def find_syntax_error(node: tree_sitter.Node) -> str | None:
-    """Locate the first ERROR or missing node in a parsed AST.
+    """Locate a top-level structural syntax error in a parsed AST.
 
     Args:
         node (tree_sitter.Node): root node from parse().
@@ -39,13 +70,11 @@ def find_syntax_error(node: tree_sitter.Node) -> str | None:
     """
     if not node.has_error:
         return None
-    stack: list[tree_sitter.Node] = [node]
-    while stack:
-        current = stack.pop()
-        if current.type == "ERROR" or current.is_missing:
-            text = current.text
+    for child in node.children:
+        if child.is_missing:
+            text = child.text
             return text.decode(errors="replace") if text else ""
-        for child in current.children:
-            if child.has_error:
-                stack.append(child)
-    return ""
+        if child.type == "ERROR" and _is_structural_error(child):
+            text = child.text
+            return text.decode(errors="replace") if text else ""
+    return None

--- a/python/mirage/shell/parse.py
+++ b/python/mirage/shell/parse.py
@@ -26,3 +26,26 @@ def parse(command: str) -> tree_sitter.Node:
     """
     tree = TS_PARSER.parse(command.encode())
     return tree.root_node
+
+
+def find_syntax_error(node: tree_sitter.Node) -> str | None:
+    """Locate the first ERROR or missing node in a parsed AST.
+
+    Args:
+        node (tree_sitter.Node): root node from parse().
+
+    Returns:
+        str | None: text of the offending region, or None if the AST is clean.
+    """
+    if not node.has_error:
+        return None
+    stack: list[tree_sitter.Node] = [node]
+    while stack:
+        current = stack.pop()
+        if current.type == "ERROR" or current.is_missing:
+            text = current.text
+            return text.decode(errors="replace") if text else ""
+        for child in current.children:
+            if child.has_error:
+                stack.append(child)
+    return ""

--- a/python/mirage/shell/parse.py
+++ b/python/mirage/shell/parse.py
@@ -29,14 +29,33 @@ def parse(command: str) -> tree_sitter.Node:
 
 
 _BASH_KEYWORDS = frozenset({
-    "if", "then", "else", "elif", "fi",
-    "for", "while", "until", "do", "done",
-    "case", "esac", "in", "function", "select",
+    "if",
+    "then",
+    "else",
+    "elif",
+    "fi",
+    "for",
+    "while",
+    "until",
+    "do",
+    "done",
+    "case",
+    "esac",
+    "in",
+    "function",
+    "select",
 })
 
 _STRUCTURAL_TOKENS = frozenset({
-    "(", ")", "{", "}", "[", "]",
-    '"', "'", "`",
+    "(",
+    ")",
+    "{",
+    "}",
+    "[",
+    "]",
+    '"',
+    "'",
+    "`",
 })
 
 

--- a/python/mirage/workspace/executor/command.py
+++ b/python/mirage/workspace/executor/command.py
@@ -29,7 +29,7 @@ from mirage.workspace.executor.cross_mount import (handle_cross_mount,
 from mirage.workspace.executor.jobs import (handle_jobs, handle_kill,
                                             handle_ps, handle_wait)
 from mirage.workspace.mount import MountRegistry
-from mirage.workspace.session import Session
+from mirage.workspace.session import Session, assert_mount_allowed
 from mirage.workspace.types import ExecutionNode
 
 _JOB_BUILTINS = frozenset({"wait", "fg", "kill", "jobs", "ps"})
@@ -638,6 +638,18 @@ async def handle_command(
             exit_code=127,
             stderr=f"{cmd_name}: command not found".encode(),
         ), ExecutionNode(command=cmd_str, exit_code=127)
+
+    try:
+        assert_mount_allowed(mount.prefix)
+        for ps in path_scopes:
+            target = registry.mount_for(ps.original)
+            assert_mount_allowed(target.prefix)
+    except PermissionError as exc:
+        err = f"{exc}\n".encode()
+        return None, IOResult(exit_code=1,
+                              stderr=err), ExecutionNode(command=cmd_str,
+                                                         exit_code=1,
+                                                         stderr=err)
 
     # Parse flags upstream — mount receives clean args
     paths, texts, flag_kwargs = _parse_flags(parts[1:], mount, cmd_name,

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -654,11 +654,21 @@ async def _dispatch_command_body(
                 stdin = content.encode() + b"\n"
                 break
 
-    # Process substitution: <(cmd) → execute inner cmd, use output as stdin
+    # Process substitution: <(cmd) feeds inner stdout as stdin.
+    # Output direction >(cmd) is unsupported; reject early so the
+    # caller sees a capability gap rather than a silent no-op.
     proc_sub_parts = []
     clean_parts = []
     for p in parts:
         if hasattr(p, "type") and p.type == NT.PROCESS_SUBSTITUTION:
+            direction = p.children[0].type if p.children else ""
+            if direction == ">(":
+                err = b"mirage: unsupported: process substitution >(...)\n"
+                return None, IOResult(
+                    exit_code=2,
+                    stderr=err), ExecutionNode(command=name or "process_sub",
+                                               exit_code=2,
+                                               stderr=err)
             inner_cmds = [c for c in p.named_children if c.type == NT.COMMAND]
             if inner_cmds:
                 io_ps = await execute_fn(get_text(inner_cmds[0]),

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -661,11 +661,8 @@ async def _dispatch_command_body(
             direction = p.children[0].type if p.children else ""
             if direction == ">(":
                 err = b"mirage: unsupported: process substitution >(...)\n"
-                return None, IOResult(
-                    exit_code=2,
-                    stderr=err), ExecutionNode(command=name or "process_sub",
-                                               exit_code=2,
-                                               stderr=err)
+                return None, IOResult(exit_code=2, stderr=err), ExecutionNode(
+                    command=name or "process_sub", exit_code=2, stderr=err)
             inner_cmds = [c for c in p.named_children if c.type == NT.COMMAND]
             if inner_cmds:
                 io_ps = await execute_fn(get_text(inner_cmds[0]),

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -47,11 +47,11 @@ from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
 
 from mirage.shell.helpers import (  # isort: skip
-    get_case_items, get_case_word, get_command_name, get_declaration_keyword,
-    get_for_parts, get_function_body, get_function_name, get_if_branches,
-    get_list_parts, get_negated_command, get_parts, get_pipeline_commands,
-    get_redirects, get_subshell_body, get_text, get_unset_names,
-    get_while_parts)
+    ProcessSubDirection, get_case_items, get_case_word, get_command_name,
+    get_declaration_keyword, get_for_parts, get_function_body,
+    get_function_name, get_if_branches, get_list_parts, get_negated_command,
+    get_parts, get_pipeline_commands, get_process_sub_direction, get_redirects,
+    get_subshell_body, get_text, get_unset_names, get_while_parts)
 from mirage.workspace.executor.builtins import (  # isort: skip
     handle_bash, handle_cd, handle_echo, handle_eval, handle_export,
     handle_local, handle_man, handle_printenv, handle_printf, handle_python,
@@ -658,8 +658,7 @@ async def _dispatch_command_body(
     clean_parts = []
     for p in parts:
         if hasattr(p, "type") and p.type == NT.PROCESS_SUBSTITUTION:
-            direction = p.children[0].type if p.children else ""
-            if direction == ">(":
+            if get_process_sub_direction(p) == ProcessSubDirection.OUTPUT:
                 err = b"mirage: unsupported: process substitution >(...)\n"
                 return None, IOResult(exit_code=2, stderr=err), ExecutionNode(
                     command=name or "process_sub", exit_code=2, stderr=err)

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -59,6 +59,18 @@ from mirage.workspace.executor.builtins import (  # isort: skip
     handle_sleep, handle_source, handle_test, handle_trap, handle_unset,
     handle_whoami)
 
+_UNSUPPORTED_BUILTINS = frozenset({
+    "fg",
+    "bg",
+    "jobs",
+    "wait",
+    "disown",
+    "exec",
+    "complete",
+    "compgen",
+    "ulimit",
+})
+
 
 async def execute_node(
     dispatch: Callable,
@@ -685,6 +697,17 @@ async def _dispatch_command_body(
     # each resource can handle pattern pushdown.
     resolved = await resolve_globs(classified, registry, text_args=text_args)
     expanded = [p.original if isinstance(p, PathSpec) else p for p in resolved]
+
+    # ── unsupported bash builtins ──────────────
+    # Constructs the parser accepts but the executor cannot honor.
+    # Returning a clear error lets LLMs detect a capability gap instead
+    # of treating it as a missing binary or a silent no-op.
+    if name in _UNSUPPORTED_BUILTINS:
+        err = f"mirage: unsupported builtin: {name}\n".encode()
+        return None, IOResult(exit_code=2,
+                              stderr=err), ExecutionNode(command=name,
+                                                         exit_code=2,
+                                                         stderr=err)
 
     # ── shell builtins ──────────────────────────
     if name == SB.PWD:

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -60,10 +60,7 @@ from mirage.workspace.executor.builtins import (  # isort: skip
     handle_whoami)
 
 _UNSUPPORTED_BUILTINS = frozenset({
-    "fg",
     "bg",
-    "jobs",
-    "wait",
     "disown",
     "exec",
     "complete",

--- a/python/mirage/workspace/session/__init__.py
+++ b/python/mirage/workspace/session/__init__.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.runtime import (assert_mount_allowed, get_current_session,
-                             reset_current_session, set_current_session)
+                            reset_current_session, set_current_session)
 from mirage.workspace.session.manager import SessionManager
 from mirage.workspace.session.session import Session
 

--- a/python/mirage/workspace/session/__init__.py
+++ b/python/mirage/workspace/session/__init__.py
@@ -12,7 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from mirage.workspace.session.context import (assert_mount_allowed,
+                                               get_current_session,
+                                               reset_current_session,
+                                               set_current_session)
 from mirage.workspace.session.manager import SessionManager
 from mirage.workspace.session.session import Session
 
-__all__ = ["Session", "SessionManager"]
+__all__ = [
+    "Session",
+    "SessionManager",
+    "assert_mount_allowed",
+    "get_current_session",
+    "reset_current_session",
+    "set_current_session",
+]

--- a/python/mirage/workspace/session/context.py
+++ b/python/mirage/workspace/session/context.py
@@ -1,0 +1,63 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from contextvars import ContextVar, Token
+
+from mirage.workspace.session.session import Session
+
+_current_session: ContextVar[Session | None] = ContextVar(
+    "mirage_current_session",
+    default=None,
+)
+
+
+def set_current_session(session: Session | None) -> Token:
+    """Bind ``session`` to the current async context."""
+    return _current_session.set(session)
+
+
+def reset_current_session(token: Token) -> None:
+    """Restore the previous session binding."""
+    _current_session.reset(token)
+
+
+def get_current_session() -> Session | None:
+    """Return the session bound to the current async context, if any."""
+    return _current_session.get()
+
+
+def assert_mount_allowed(mount_prefix: str) -> None:
+    """Raise PermissionError if the current session may not touch this mount.
+
+    No-op when no session is bound or the session is unrestricted
+    (``allowed_mounts is None``). The session's ``allowed_mounts`` is
+    expected to already include any infrastructure prefixes (observer,
+    ``/dev``) added at session-creation time.
+
+    Args:
+        mount_prefix (str): the mount's prefix, e.g. ``/s3`` or ``/`` for the
+            cache root.
+
+    Raises:
+        PermissionError: the mount lies outside the session's allowlist.
+    """
+    sess = get_current_session()
+    if sess is None or sess.allowed_mounts is None:
+        return
+    norm = "/" + mount_prefix.strip("/") if mount_prefix.strip("/") else "/"
+    if norm == "/" or norm in sess.allowed_mounts:
+        return
+    raise PermissionError(
+        f"session {sess.session_id!r} not allowed to access "
+        f"mount {norm!r}")

--- a/python/mirage/workspace/session/manager.py
+++ b/python/mirage/workspace/session/manager.py
@@ -47,10 +47,12 @@ class SessionManager:
     def env(self, value: dict[str, str]) -> None:
         self._sessions[self._default_id].env = value
 
-    def create(self, session_id: str) -> Session:
+    def create(self,
+               session_id: str,
+               allowed_mounts: frozenset[str] | None = None) -> Session:
         if session_id in self._sessions:
             raise ValueError(f"Session {session_id!r} already exists")
-        session = Session(session_id=session_id)
+        session = Session(session_id=session_id, allowed_mounts=allowed_mounts)
         self._sessions[session_id] = session
         self._locks[session_id] = asyncio.Lock()
         return session

--- a/python/mirage/workspace/session/session.py
+++ b/python/mirage/workspace/session/session.py
@@ -29,6 +29,7 @@ class Session:
     shell_options: dict[str, bool] = field(default_factory=dict)
     readonly_vars: set[str] = field(default_factory=set)
     arrays: dict[str, list[str]] = field(default_factory=dict)
+    allowed_mounts: frozenset[str] | None = None
     _stdin_buffer: AsyncLineIterator | None = field(default=None, repr=False)
 
     def to_dict(self) -> dict:

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -145,7 +145,7 @@ class Workspace:
         self._registry.mount(observe_prefix, observe_resource, MountMode.READ)
 
         self._ops = Ops(self._registry.ops_mounts(),
-                        on_write=self._invalidate_cache_if_remote,
+                        on_write=self._invalidate_after_write_by_path,
                         observer=self.observer,
                         agent_id=agent_id,
                         session_id=session_id)
@@ -456,18 +456,23 @@ class Workspace:
             return False
         return mount.resource.is_remote is True
 
-    async def _invalidate_cache_if_remote(self, path: str) -> None:
-        if self._is_cacheable_path(path):
-            await self._cache.remove(path)
+    async def _invalidate_after_write_by_path(self, path: str) -> None:
+        """Drop file-cache + stale parent index after a write to `path`.
+
+        Single source of truth for post-write invalidation. Called from
+        both `Workspace.dispatch()` and `Ops._call(write=True)` so a
+        write through any code path sees the same invalidation rules:
+        file cache is dropped only for remote-backed mounts, and the
+        parent directory index is dirtied for any mount that maintains
+        an index. No-op for paths that resolve to no known mount.
+        """
+        try:
+            mount = self._registry.mount_for(path)
+        except ValueError:
+            return
+        await self._invalidate_after_write(mount, path)
 
     async def _invalidate_after_write(self, mount: Mount, path: str) -> None:
-        """Drop file-cache entry and stale parent index after a write.
-
-        Closes the gap where dispatch-level writes (cross-mount cp,
-        wget -O, curl -o, redirect) would update the file cache but
-        leave readdir/stat returning the previously cached parent
-        directory listing.
-        """
         if mount.resource.is_remote is True:
             await self._cache.remove(path)
         idx = getattr(mount.resource, "index", None)

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -365,13 +365,27 @@ class Workspace:
             allowed_mounts: frozenset[str] | None = None) -> Session:
         if allowed_mounts is not None:
             normalized = {("/" + m.strip("/")) for m in allowed_mounts}
-            normalized.add("/dev")
-            normalized.add("/_default")
-            if self.observer is not None:
-                normalized.add("/" + self.observer.prefix.strip("/"))
+            normalized.update(self._infrastructure_mount_prefixes())
             allowed_mounts = frozenset(normalized)
         return self._session_mgr.create(session_id,
                                         allowed_mounts=allowed_mounts)
+
+    def _infrastructure_mount_prefixes(self) -> set[str]:
+        """Mount prefixes a session is always allowed to touch.
+
+        The cache mount (where text-processing commands like ``wc``
+        without a path argument resolve), the device mount, and the
+        observer log are infrastructure: they hold no user
+        credentials, and rejecting them would break common shell
+        idioms or audit logging.
+        """
+        prefixes = {"/dev"}
+        default_mount = self._registry.default_mount
+        if default_mount is not None:
+            prefixes.add("/" + default_mount.prefix.strip("/"))
+        if self.observer is not None:
+            prefixes.add("/" + self.observer.prefix.strip("/"))
+        return prefixes
 
     def get_session(self, session_id: str) -> Session:
         return self._session_mgr.get(session_id)

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -356,8 +356,11 @@ class Workspace:
 
     # ── session lifecycle ──────────────────────────────────────────────────
 
-    def create_session(self, session_id: str) -> Session:
-        return self._session_mgr.create(session_id)
+    def create_session(self,
+                       session_id: str,
+                       allowed_mounts: frozenset[str] | None = None) -> Session:
+        return self._session_mgr.create(session_id,
+                                        allowed_mounts=allowed_mounts)
 
     def get_session(self, session_id: str) -> Session:
         return self._session_mgr.get(session_id)

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -41,7 +41,7 @@ from mirage.resource.base import BaseResource
 from mirage.resource.ram import RAMResource
 from mirage.shell.barrier import BarrierPolicy, apply_barrier
 from mirage.shell.job_table import JobTable
-from mirage.shell.parse import parse
+from mirage.shell.parse import find_syntax_error, parse
 from mirage.types import (DEFAULT_AGENT_ID, DEFAULT_SESSION_ID,
                           ConsistencyPolicy, FileStat, MountMode, PathSpec)
 from mirage.workspace.abort import MirageAbortError
@@ -547,6 +547,16 @@ class Workspace:
 
         try:
             ast = parse(command)
+            offending = find_syntax_error(ast)
+            if offending is not None:
+                snippet = offending.strip()[:40]
+                err = (f"mirage: syntax error near {snippet!r}\n".encode()
+                       if snippet else b"mirage: syntax error in command\n")
+                io = IOResult(exit_code=2, stderr=err)
+                exec_node = ExecutionNode(command=command,
+                                          stderr=err,
+                                          exit_code=2)
+                return io
             if provision:
                 return await provision_node(self._registry, self.dispatch,
                                             _exec_for_recursion, ast,

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -52,9 +52,9 @@ from mirage.workspace.native import native_exec
 from mirage.workspace.node import execute_node as _execute_node
 from mirage.workspace.node import provision_node
 from mirage.workspace.session import (Session, SessionManager,
-                                       assert_mount_allowed,
-                                       reset_current_session,
-                                       set_current_session)
+                                      assert_mount_allowed,
+                                      reset_current_session,
+                                      set_current_session)
 from mirage.workspace.snapshot import (apply_state_dict, build_mount_args,
                                        norm_mount_prefix, read_tar)
 from mirage.workspace.snapshot import snapshot as _write_snapshot
@@ -359,9 +359,10 @@ class Workspace:
 
     # ── session lifecycle ──────────────────────────────────────────────────
 
-    def create_session(self,
-                       session_id: str,
-                       allowed_mounts: frozenset[str] | None = None) -> Session:
+    def create_session(
+            self,
+            session_id: str,
+            allowed_mounts: frozenset[str] | None = None) -> Session:
         if allowed_mounts is not None:
             normalized = {("/" + m.strip("/")) for m in allowed_mounts}
             normalized.add("/dev")

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -399,8 +399,8 @@ class Workspace:
                     return cached, IOResult(reads={path.original: cached})
 
         result = await mount.execute_op(op, path.original, **kwargs)
-        if cacheable and op in _DISPATCH_WRITE_OPS:
-            await self._cache.remove(path.original)
+        if op in _DISPATCH_WRITE_OPS:
+            await self._invalidate_after_write(mount, path.original)
         return result, IOResult()
 
     async def stat(self, path: str) -> FileStat:
@@ -430,6 +430,22 @@ class Workspace:
     async def _invalidate_cache_if_remote(self, path: str) -> None:
         if self._is_cacheable_path(path):
             await self._cache.remove(path)
+
+    async def _invalidate_after_write(self, mount: Mount, path: str) -> None:
+        """Drop file-cache entry and stale parent index after a write.
+
+        Closes the gap where dispatch-level writes (cross-mount cp,
+        wget -O, curl -o, redirect) would update the file cache but
+        leave readdir/stat returning the previously cached parent
+        directory listing.
+        """
+        if mount.resource.is_remote is True:
+            await self._cache.remove(path)
+        idx = getattr(mount.resource, "index", None)
+        if idx is not None:
+            parent = path.rsplit("/", 1)[0] or "/"
+            await idx.invalidate_dir(parent)
+            await idx.invalidate_dir(parent + "/")
 
     async def _invalidate_index_dirs(self, io: IOResult) -> None:
         dirs_seen: set[str] = set()

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -366,6 +366,7 @@ class Workspace:
         if allowed_mounts is not None:
             normalized = {("/" + m.strip("/")) for m in allowed_mounts}
             normalized.add("/dev")
+            normalized.add("/_default")
             if self.observer is not None:
                 normalized.add("/" + self.observer.prefix.strip("/"))
             allowed_mounts = frozenset(normalized)

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -51,7 +51,10 @@ from mirage.workspace.mount import Mount, MountRegistry
 from mirage.workspace.native import native_exec
 from mirage.workspace.node import execute_node as _execute_node
 from mirage.workspace.node import provision_node
-from mirage.workspace.session import Session, SessionManager
+from mirage.workspace.session import (Session, SessionManager,
+                                       assert_mount_allowed,
+                                       reset_current_session,
+                                       set_current_session)
 from mirage.workspace.snapshot import (apply_state_dict, build_mount_args,
                                        norm_mount_prefix, read_tar)
 from mirage.workspace.snapshot import snapshot as _write_snapshot
@@ -359,6 +362,12 @@ class Workspace:
     def create_session(self,
                        session_id: str,
                        allowed_mounts: frozenset[str] | None = None) -> Session:
+        if allowed_mounts is not None:
+            normalized = {("/" + m.strip("/")) for m in allowed_mounts}
+            normalized.add("/dev")
+            if self.observer is not None:
+                normalized.add("/" + self.observer.prefix.strip("/"))
+            allowed_mounts = frozenset(normalized)
         return self._session_mgr.create(session_id,
                                         allowed_mounts=allowed_mounts)
 
@@ -379,6 +388,7 @@ class Workspace:
     async def dispatch(self, op: str, path: PathSpec,
                        **kwargs: Any) -> tuple[Any, IOResult]:
         mount = self._registry.mount_for(path.original)
+        assert_mount_allowed(mount.prefix)
         cacheable = mount.resource.is_remote is True
 
         if cacheable and op in _DISPATCH_READ_OPS:
@@ -564,6 +574,7 @@ class Workspace:
         async def _exec_for_recursion(cmd: str, **opts: Any) -> Any:
             return await self.execute(cmd, cancel=cancel, **opts)
 
+        session_token = set_current_session(effective_session)
         try:
             ast = parse(command)
             offending = find_syntax_error(ast)
@@ -610,5 +621,6 @@ class Workspace:
                                       exit_code=1)
             return io
         finally:
+            reset_current_session(session_token)
             await self._record_execution(command, io, exec_node, agent_id,
                                          session_id, stdin, provision)

--- a/python/tests/cli/test_session_cli.py
+++ b/python/tests/cli/test_session_cli.py
@@ -13,7 +13,6 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from contextlib import contextmanager
-from unittest.mock import MagicMock
 
 from typer.testing import CliRunner
 
@@ -62,7 +61,10 @@ def test_session_create_passes_mount_flags():
     with _patched_client(fake):
         result = CliRunner().invoke(
             session_cli.app,
-            ["create", "demo", "--id", "agent", "-m", "/s3", "--mount", "/slack"],
+            [
+                "create", "demo", "--id", "agent", "-m", "/s3", "--mount",
+                "/slack"
+            ],
         )
     assert result.exit_code == 0, result.output
     assert fake.last_body == {

--- a/python/tests/cli/test_session_cli.py
+++ b/python/tests/cli/test_session_cli.py
@@ -12,11 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import re
 from contextlib import contextmanager
 
 from typer.testing import CliRunner
 
 from mirage.cli import session as session_cli
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
 class _FakeResponse:
@@ -95,4 +98,5 @@ def test_session_create_without_id_or_mount_sends_empty_body():
 def test_session_create_help_lists_mount_flag():
     result = CliRunner().invoke(session_cli.app, ["create", "--help"])
     assert result.exit_code == 0
-    assert "--mount" in result.output
+    plain = _ANSI_RE.sub("", result.output)
+    assert "--mount" in plain

--- a/python/tests/cli/test_session_cli.py
+++ b/python/tests/cli/test_session_cli.py
@@ -1,0 +1,96 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+from typer.testing import CliRunner
+
+from mirage.cli import session as session_cli
+
+
+class _FakeResponse:
+    status_code = 201
+    content = b'{"session_id": "agent", "cwd": "/"}'
+
+    def json(self) -> dict:
+        return {"session_id": "agent", "cwd": "/"}
+
+
+class _FakeClient:
+
+    def __init__(self) -> None:
+        self.last_body: dict | None = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def ensure_running(self, allow_spawn: bool = False) -> None:
+        return None
+
+    def request(self, method: str, path: str, json: dict | None = None):
+        self.last_body = json
+        return _FakeResponse()
+
+
+@contextmanager
+def _patched_client(fake: _FakeClient):
+    real = session_cli.make_client
+    session_cli.make_client = lambda: fake
+    try:
+        yield fake
+    finally:
+        session_cli.make_client = real
+
+
+def test_session_create_passes_mount_flags():
+    fake = _FakeClient()
+    with _patched_client(fake):
+        result = CliRunner().invoke(
+            session_cli.app,
+            ["create", "demo", "--id", "agent", "-m", "/s3", "--mount", "/slack"],
+        )
+    assert result.exit_code == 0, result.output
+    assert fake.last_body == {
+        "session_id": "agent",
+        "allowed_mounts": ["/s3", "/slack"],
+    }
+
+
+def test_session_create_no_mount_flag_omits_field():
+    fake = _FakeClient()
+    with _patched_client(fake):
+        result = CliRunner().invoke(
+            session_cli.app,
+            ["create", "demo", "--id", "agent"],
+        )
+    assert result.exit_code == 0, result.output
+    assert fake.last_body == {"session_id": "agent"}
+
+
+def test_session_create_without_id_or_mount_sends_empty_body():
+    fake = _FakeClient()
+    with _patched_client(fake):
+        result = CliRunner().invoke(session_cli.app, ["create", "demo"])
+    assert result.exit_code == 0, result.output
+    assert fake.last_body == {}
+
+
+def test_session_create_help_lists_mount_flag():
+    result = CliRunner().invoke(session_cli.app, ["create", "--help"])
+    assert result.exit_code == 0
+    assert "--mount" in result.output

--- a/python/tests/server/test_sessions_router.py
+++ b/python/tests/server/test_sessions_router.py
@@ -101,6 +101,28 @@ async def test_delete_unknown_session_404():
 
 
 @pytest.mark.asyncio
+async def test_create_session_with_allowed_mounts():
+    app = build_app(idle_grace_seconds=10.0)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport,
+                           base_url="http://test") as client:
+        wid = await _create_workspace(client)
+        r = await client.post(
+            f"/v1/workspaces/{wid}/sessions",
+            json={
+                "session_id": "agent_a",
+                "allowed_mounts": ["/"],
+            },
+        )
+        assert r.status_code == 201, r.text
+
+        registry = app.state.registry
+        sess = registry.get(wid).runner.ws.get_session("agent_a")
+        assert sess.allowed_mounts is not None
+        assert "/" in sess.allowed_mounts
+
+
+@pytest.mark.asyncio
 async def test_session_isolated_per_workspace():
     app = build_app(idle_grace_seconds=10.0)
     transport = ASGITransport(app=app)

--- a/python/tests/shell/test_syntax_errors.py
+++ b/python/tests/shell/test_syntax_errors.py
@@ -1,0 +1,62 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+import pytest
+
+from mirage.resource.ram import RAMResource
+from mirage.shell.parse import find_syntax_error, parse
+from mirage.workspace import Workspace
+
+
+@pytest.mark.parametrize("bad_cmd", [
+    "if then fi",
+    "echo (",
+    "for x do done",
+    "for",
+    "if",
+    "if; fi",
+    'echo "unterm',
+])
+def test_find_syntax_error_detects_error_nodes(bad_cmd):
+    ast = parse(bad_cmd)
+    snippet = find_syntax_error(ast)
+    assert snippet is not None, (
+        f"expected syntax error for {bad_cmd!r}, got None")
+
+
+@pytest.mark.parametrize("good_cmd", [
+    "echo hi",
+    "for x in a b; do echo $x; done",
+    "if true; then echo y; fi",
+    "cat /tmp/x | sort",
+])
+def test_find_syntax_error_returns_none_for_valid(good_cmd):
+    assert find_syntax_error(parse(good_cmd)) is None
+
+
+@pytest.mark.parametrize("bad_cmd", [
+    "if then fi",
+    "echo (",
+    "for x do done",
+])
+def test_execute_returns_clear_syntax_error(bad_cmd):
+    ws = Workspace({"/data": RAMResource()})
+    io = asyncio.run(ws.execute(bad_cmd))
+    assert io.exit_code == 2, (
+        f"expected exit 2 for {bad_cmd!r}, got {io.exit_code}")
+    stderr = io.stderr or b""
+    assert b"syntax error" in stderr, (
+        f"expected 'syntax error' in stderr for {bad_cmd!r}, got {stderr!r}")

--- a/python/tests/shell/test_unsupported_builtins.py
+++ b/python/tests/shell/test_unsupported_builtins.py
@@ -22,10 +22,7 @@ from mirage.workspace import Workspace
 
 
 @pytest.mark.parametrize("name", [
-    "fg",
     "bg",
-    "jobs",
-    "wait",
     "disown",
     "exec",
     "complete",

--- a/python/tests/shell/test_unsupported_builtins.py
+++ b/python/tests/shell/test_unsupported_builtins.py
@@ -17,6 +17,7 @@ import asyncio
 import pytest
 
 from mirage.resource.ram import RAMResource
+from mirage.types import MountMode
 from mirage.workspace import Workspace
 
 
@@ -39,3 +40,28 @@ def test_unsupported_builtin_returns_clear_error(name):
     stderr = io.stderr or b""
     assert f"unsupported builtin: {name}".encode() in stderr, (
         f"expected 'unsupported builtin: {name}' in stderr, got {stderr!r}")
+
+
+@pytest.mark.parametrize("cmd", [
+    "echo hi >(cat)",
+    "tee >(grep foo) /tmp/out",
+    "cat >(wc)",
+])
+def test_output_process_substitution_unsupported(cmd):
+    ws = Workspace({"/data": RAMResource()})
+    io = asyncio.run(ws.execute(cmd))
+    assert io.exit_code == 2, (
+        f"expected exit 2 for {cmd!r}, got {io.exit_code}")
+    stderr = io.stderr or b""
+    assert b"process substitution" in stderr, (
+        f"expected 'process substitution' in stderr, got {stderr!r}")
+    assert b"unsupported" in stderr
+
+
+def test_input_process_substitution_still_works():
+    ram = RAMResource()
+    ram._store.files["/a"] = b"line1\nline2\n"
+    ws = Workspace({"/data": (ram, MountMode.READ)})
+    io = asyncio.run(ws.execute("cat <(cat /data/a)"))
+    assert io.exit_code == 0, (
+        f"input process substitution should still work, got {io}")

--- a/python/tests/shell/test_unsupported_builtins.py
+++ b/python/tests/shell/test_unsupported_builtins.py
@@ -1,0 +1,41 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+import pytest
+
+from mirage.resource.ram import RAMResource
+from mirage.workspace import Workspace
+
+
+@pytest.mark.parametrize("name", [
+    "fg",
+    "bg",
+    "jobs",
+    "wait",
+    "disown",
+    "exec",
+    "complete",
+    "compgen",
+    "ulimit",
+])
+def test_unsupported_builtin_returns_clear_error(name):
+    ws = Workspace({"/data": RAMResource()})
+    io = asyncio.run(ws.execute(name))
+    assert io.exit_code == 2, (
+        f"expected exit 2 for {name!r}, got {io.exit_code}")
+    stderr = io.stderr or b""
+    assert f"unsupported builtin: {name}".encode() in stderr, (
+        f"expected 'unsupported builtin: {name}' in stderr, got {stderr!r}")

--- a/python/tests/workspace/session/test_manager.py
+++ b/python/tests/workspace/session/test_manager.py
@@ -122,3 +122,15 @@ def test_manager_lock_for():
     mgr.create("s1")
     lock2 = mgr.lock_for("s1")
     assert lock2 is not lock
+
+
+def test_manager_create_with_allowed_mounts():
+    mgr = SessionManager("default")
+    s = mgr.create("agent", allowed_mounts=frozenset({"/s3", "/slack"}))
+    assert s.allowed_mounts == frozenset({"/s3", "/slack"})
+
+
+def test_manager_create_default_unrestricted():
+    mgr = SessionManager("default")
+    s = mgr.create("worker")
+    assert s.allowed_mounts is None

--- a/python/tests/workspace/session/test_session.py
+++ b/python/tests/workspace/session/test_session.py
@@ -102,3 +102,13 @@ def test_session_independent_envs():
     s2 = Session(session_id="b")
     s1.env["X"] = "1"
     assert "X" not in s2.env
+
+
+def test_session_allowed_mounts_default_none():
+    s = Session(session_id="s")
+    assert s.allowed_mounts is None
+
+
+def test_session_allowed_mounts_set():
+    s = Session(session_id="s", allowed_mounts=frozenset({"/s3", "/slack"}))
+    assert s.allowed_mounts == frozenset({"/s3", "/slack"})

--- a/python/tests/workspace/test_index_writethrough.py
+++ b/python/tests/workspace/test_index_writethrough.py
@@ -1,0 +1,78 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+from mirage.resource.ram import RAMResource
+from mirage.types import MountMode, PathSpec
+from mirage.workspace import Workspace
+
+
+class _FakeRemote(RAMResource):
+    is_remote = True
+    _index_ttl = 600
+
+
+def _seed_remote() -> _FakeRemote:
+    remote = _FakeRemote()
+    remote._store.dirs.add("/data")
+    remote._store.files["/data/a.txt"] = b"a"
+    return remote
+
+
+def test_dispatch_write_invalidates_parent_dir_index():
+    remote = _seed_remote()
+    ws = Workspace({"/r": (remote, MountMode.WRITE)}, mode=MountMode.WRITE)
+
+    async def run():
+        before = await ws.readdir("/r/data")
+        scope = PathSpec(
+            original="/r/data/b.txt",
+            directory="/r/data",
+            prefix="/r",
+            resolved=True,
+        )
+        await ws.dispatch("write", scope, data=b"b")
+        after = await ws.readdir("/r/data")
+        return before, after
+
+    before, after = asyncio.run(run())
+    assert "/r/data/a.txt" in before
+    assert "/r/data/b.txt" in after, (
+        "after dispatch write, readdir should reflect b.txt; "
+        f"got {after!r}")
+
+
+def test_dispatch_unlink_invalidates_parent_dir_index():
+    remote = _seed_remote()
+    remote._store.files["/data/c.txt"] = b"c"
+    ws = Workspace({"/r": (remote, MountMode.WRITE)}, mode=MountMode.WRITE)
+
+    async def run():
+        before = await ws.readdir("/r/data")
+        scope = PathSpec(
+            original="/r/data/c.txt",
+            directory="/r/data",
+            prefix="/r",
+            resolved=True,
+        )
+        await ws.dispatch("unlink", scope)
+        after = await ws.readdir("/r/data")
+        return before, after
+
+    before, after = asyncio.run(run())
+    assert "/r/data/c.txt" in before
+    assert "/r/data/c.txt" not in after, (
+        "after dispatch unlink, readdir should drop c.txt; "
+        f"got {after!r}")

--- a/python/tests/workspace/test_session_capability.py
+++ b/python/tests/workspace/test_session_capability.py
@@ -1,0 +1,83 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+from mirage.resource.ram import RAMResource
+from mirage.workspace import Workspace
+
+
+def _seed(name: str, body: bytes) -> RAMResource:
+    r = RAMResource()
+    r._store.files[f"/{name}"] = body
+    return r
+
+
+def test_session_outside_allowlist_is_denied():
+    a = _seed("x.txt", b"public")
+    b = _seed("secret.txt", b"SECRET")
+    ws = Workspace({"/a": a, "/b": b})
+    ws.create_session("agent", allowed_mounts=frozenset({"/a"}))
+
+    async def run():
+        ok = await ws.execute("cat /a/x.txt", session_id="agent")
+        denied = await ws.execute("cat /b/secret.txt", session_id="agent")
+        return ok, denied
+
+    ok, denied = asyncio.run(run())
+    assert ok.exit_code == 0
+    assert b"public" in (ok.stdout or b"")
+    assert denied.exit_code != 0
+    stderr = denied.stderr or b""
+    assert b"not allowed" in stderr
+    assert b"/b" in stderr
+
+
+def test_default_session_unrestricted():
+    a = _seed("x.txt", b"hi")
+    ws = Workspace({"/a": a})
+
+    async def run():
+        return await ws.execute("cat /a/x.txt")
+
+    io = asyncio.run(run())
+    assert io.exit_code == 0
+    assert b"hi" in (io.stdout or b"")
+
+
+def test_allowed_session_can_write_to_its_mount():
+    a = _seed("x.txt", b"hi")
+    from mirage.types import MountMode
+    ws = Workspace({"/a": (a, MountMode.WRITE)}, mode=MountMode.WRITE)
+    ws.create_session("agent", allowed_mounts=frozenset({"/a"}))
+
+    async def run():
+        return await ws.execute("echo new > /a/y.txt", session_id="agent")
+
+    io = asyncio.run(run())
+    assert io.exit_code == 0, f"unexpected denial: {io}"
+    assert a._store.files.get("/y.txt") == b"new\n"
+
+
+def test_observer_prefix_always_allowed():
+    a = _seed("x.txt", b"hi")
+    ws = Workspace({"/a": a})
+    ws.create_session("agent", allowed_mounts=frozenset({"/a"}))
+
+    async def run():
+        return await ws.execute("ls /.sessions", session_id="agent")
+
+    io = asyncio.run(run())
+    assert io.exit_code == 0, (
+        f"observer prefix should always be readable, got {io}")

--- a/python/tests/workspace/test_session_capability.py
+++ b/python/tests/workspace/test_session_capability.py
@@ -81,3 +81,26 @@ def test_observer_prefix_always_allowed():
     io = asyncio.run(run())
     assert io.exit_code == 0, (
         f"observer prefix should always be readable, got {io}")
+
+
+def test_ops_blocks_programmatic_read_outside_allowlist():
+    import pytest
+
+    from mirage.workspace.session import (reset_current_session,
+                                          set_current_session)
+
+    a = _seed("x.txt", b"public")
+    b = _seed("secret.txt", b"SECRET")
+    ws = Workspace({"/a": a, "/b": b})
+    sess = ws.create_session("agent", allowed_mounts=frozenset({"/a"}))
+
+    async def run():
+        token = set_current_session(sess)
+        try:
+            assert await ws.ops.read("/a/x.txt") == b"public"
+            with pytest.raises(PermissionError, match="not allowed"):
+                await ws.ops.read("/b/secret.txt")
+        finally:
+            reset_current_session(token)
+
+    asyncio.run(run())

--- a/python/tests/workspace/test_session_capability.py
+++ b/python/tests/workspace/test_session_capability.py
@@ -104,3 +104,152 @@ def test_ops_blocks_programmatic_read_outside_allowlist():
             reset_current_session(token)
 
     asyncio.run(run())
+
+
+def _two_mounts_with_secret() -> Workspace:
+    from mirage.types import MountMode
+    a = _seed("x.txt", b"public-A\n")
+    a._store.files["/y.txt"] = b"public-B\n"
+    b = _seed("secret.txt", b"SECRET-FROM-B\n")
+    ws = Workspace({"/a": (a, MountMode.WRITE), "/b": (b, MountMode.WRITE)},
+                   mode=MountMode.WRITE)
+    ws.create_session("agent", allowed_mounts=frozenset({"/a"}))
+    return ws
+
+
+def test_pipe_across_mounts_blocks_forbidden_read():
+    ws = _two_mounts_with_secret()
+
+    async def run():
+        return await ws.execute("cat /b/secret.txt | wc -l",
+                                session_id="agent")
+
+    io = asyncio.run(run())
+    # Bash convention: a downstream success masks an upstream failure
+    # (no `pipefail`). Security guarantee: no leak + audit on stderr.
+    assert b"SECRET" not in (io.stdout or b""), (
+        f"forbidden read must not reach the pipe, got stdout={io.stdout!r}")
+    assert b"not allowed" in (io.stderr or b"")
+    assert b"/b" in (io.stderr or b"")
+
+
+def test_pipe_within_allowed_mount_succeeds():
+    ws = _two_mounts_with_secret()
+
+    async def run():
+        return await ws.execute("cat /a/x.txt | wc -c", session_id="agent")
+
+    io = asyncio.run(run())
+    assert io.exit_code == 0, f"in-allowlist pipe must succeed, got {io}"
+
+
+def test_command_substitution_into_forbidden_mount_is_denied():
+    ws = _two_mounts_with_secret()
+
+    async def run():
+        return await ws.execute("echo $(cat /b/secret.txt)",
+                                session_id="agent")
+
+    io = asyncio.run(run())
+    assert io.exit_code != 0 or b"SECRET" not in (io.stdout or b""), (
+        f"command substitution must not leak forbidden read, got {io}")
+
+
+def test_subshell_inherits_session_capability():
+    ws = _two_mounts_with_secret()
+
+    async def run():
+        return await ws.execute("(cat /b/secret.txt)", session_id="agent")
+
+    io = asyncio.run(run())
+    assert io.exit_code != 0
+    assert b"not allowed" in (io.stderr or b"")
+
+
+def test_and_chain_short_circuits_on_denial():
+    ws = _two_mounts_with_secret()
+
+    async def run():
+        return await ws.execute("cat /b/secret.txt && cat /a/x.txt",
+                                session_id="agent")
+
+    io = asyncio.run(run())
+    assert io.exit_code != 0
+    assert b"public-A" not in (io.stdout or b""), (
+        "denied left side should short-circuit the && chain")
+
+
+def test_or_chain_falls_through_to_allowed():
+    ws = _two_mounts_with_secret()
+
+    async def run():
+        return await ws.execute("cat /b/secret.txt || cat /a/x.txt",
+                                session_id="agent")
+
+    io = asyncio.run(run())
+    assert b"public-A" in (io.stdout or b""), (
+        f"|| should fall through to the allowed branch, got {io}")
+
+
+def test_redirect_to_forbidden_mount_is_denied():
+    ws = _two_mounts_with_secret()
+
+    async def run():
+        return await ws.execute("echo leaked > /b/leaked.txt",
+                                session_id="agent")
+
+    io = asyncio.run(run())
+    assert io.exit_code != 0
+    assert b"not allowed" in (io.stderr or b"")
+
+
+def test_cross_mount_copy_into_forbidden_mount_is_denied():
+    ws = _two_mounts_with_secret()
+
+    async def run():
+        return await ws.execute("cp /a/x.txt /b/leaked.txt",
+                                session_id="agent")
+
+    io = asyncio.run(run())
+    assert io.exit_code != 0
+    assert b"not allowed" in (io.stderr or b"")
+
+
+def test_concurrent_sessions_isolated():
+    a = _seed("x.txt", b"A-only\n")
+    b = _seed("y.txt", b"B-only\n")
+    ws = Workspace({"/a": a, "/b": b})
+    ws.create_session("agent_a", allowed_mounts=frozenset({"/a"}))
+    ws.create_session("agent_b", allowed_mounts=frozenset({"/b"}))
+
+    async def run():
+        results = await asyncio.gather(
+            ws.execute("cat /a/x.txt", session_id="agent_a"),
+            ws.execute("cat /b/y.txt", session_id="agent_b"),
+            ws.execute("cat /b/y.txt", session_id="agent_a"),
+            ws.execute("cat /a/x.txt", session_id="agent_b"),
+        )
+        return results
+
+    a_ok, b_ok, a_denied, b_denied = asyncio.run(run())
+    assert a_ok.exit_code == 0 and b"A-only" in (a_ok.stdout or b"")
+    assert b_ok.exit_code == 0 and b"B-only" in (b_ok.stdout or b"")
+    assert a_denied.exit_code != 0
+    assert b_denied.exit_code != 0
+
+
+def test_background_job_inherits_capability():
+    ws = _two_mounts_with_secret()
+
+    async def run():
+        # Background a forbidden read; the job runs in a Task that
+        # snapshots the contextvar. wait reaps it; jobs reports state.
+        return await ws.execute(
+            "cat /b/secret.txt &; wait",
+            session_id="agent",
+        )
+
+    io = asyncio.run(run())
+    out = (io.stdout or b"") + (io.stderr or b"")
+    assert b"SECRET" not in out, (
+        f"background job must not leak forbidden read, got {io}")

--- a/python/tests/workspace/test_session_capability.py
+++ b/python/tests/workspace/test_session_capability.py
@@ -14,8 +14,12 @@
 
 import asyncio
 
+import pytest
+
 from mirage.resource.ram import RAMResource
+from mirage.types import MountMode
 from mirage.workspace import Workspace
+from mirage.workspace.session import reset_current_session, set_current_session
 
 
 def _seed(name: str, body: bytes) -> RAMResource:
@@ -58,7 +62,6 @@ def test_default_session_unrestricted():
 
 def test_allowed_session_can_write_to_its_mount():
     a = _seed("x.txt", b"hi")
-    from mirage.types import MountMode
     ws = Workspace({"/a": (a, MountMode.WRITE)}, mode=MountMode.WRITE)
     ws.create_session("agent", allowed_mounts=frozenset({"/a"}))
 
@@ -84,11 +87,6 @@ def test_observer_prefix_always_allowed():
 
 
 def test_ops_blocks_programmatic_read_outside_allowlist():
-    import pytest
-
-    from mirage.workspace.session import (reset_current_session,
-                                          set_current_session)
-
     a = _seed("x.txt", b"public")
     b = _seed("secret.txt", b"SECRET")
     ws = Workspace({"/a": a, "/b": b})
@@ -107,11 +105,13 @@ def test_ops_blocks_programmatic_read_outside_allowlist():
 
 
 def _two_mounts_with_secret() -> Workspace:
-    from mirage.types import MountMode
     a = _seed("x.txt", b"public-A\n")
     a._store.files["/y.txt"] = b"public-B\n"
     b = _seed("secret.txt", b"SECRET-FROM-B\n")
-    ws = Workspace({"/a": (a, MountMode.WRITE), "/b": (b, MountMode.WRITE)},
+    ws = Workspace({
+        "/a": (a, MountMode.WRITE),
+        "/b": (b, MountMode.WRITE)
+    },
                    mode=MountMode.WRITE)
     ws.create_session("agent", allowed_mounts=frozenset({"/a"}))
     return ws

--- a/typescript/packages/cli/src/session.ts
+++ b/typescript/packages/cli/src/session.ts
@@ -28,11 +28,20 @@ export function registerSessionCommands(program: Command): void {
     .command('create')
     .argument('<wsId>')
     .option('--id <sessionId>')
-    .action(async (wsId: string, opts: { id?: string }) => {
+    .option(
+      '-m, --mount <prefix>',
+      'restrict session to this mount prefix; repeatable',
+      (value: string, prev: string[]) => prev.concat([value]),
+      [] as string[],
+    )
+    .action(async (wsId: string, opts: { id?: string; mount?: string[] }) => {
       const c = buildClient()
       await c.ensureRunning({ allowSpawn: false })
       const body: Record<string, unknown> = {}
       if (opts.id !== undefined) body.sessionId = opts.id
+      if (opts.mount !== undefined && opts.mount.length > 0) {
+        body.allowedMounts = opts.mount
+      }
       emit(
         await handleResponse(
           await c.request('POST', `/v1/workspaces/${wsId}/sessions`, {

--- a/typescript/packages/core/src/runtime/session_context.ts
+++ b/typescript/packages/core/src/runtime/session_context.ts
@@ -1,0 +1,47 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+import type { Session } from '../workspace/session/session.ts'
+
+const sessionStorage = new AsyncLocalStorage<Session>()
+
+export function runWithSession<T>(session: Session, fn: () => T): T {
+  return sessionStorage.run(session, fn)
+}
+
+export function getCurrentSession(): Session | null {
+  return sessionStorage.getStore() ?? null
+}
+
+export class MountNotAllowedError extends Error {
+  readonly sessionId: string
+  readonly mountPrefix: string
+  constructor(sessionId: string, mountPrefix: string) {
+    super(`session '${sessionId}' not allowed to access mount '${mountPrefix}'`)
+    this.name = 'MountNotAllowedError'
+    this.sessionId = sessionId
+    this.mountPrefix = mountPrefix
+  }
+}
+
+export function assertMountAllowed(mountPrefix: string): void {
+  const sess = getCurrentSession()
+  if (sess?.allowedMounts == null) return
+  const stripped = mountPrefix.replace(/^\/+|\/+$/g, '')
+  const norm = stripped === '' ? '/' : '/' + stripped
+  if (norm === '/' || sess.allowedMounts.has(norm)) return
+  throw new MountNotAllowedError(sess.sessionId, norm)
+}

--- a/typescript/packages/core/src/runtime/session_context.ts
+++ b/typescript/packages/core/src/runtime/session_context.ts
@@ -12,13 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { AsyncLocalStorage } from 'node:async_hooks'
-
+import { createAsyncContext } from '../utils/async_context.ts'
 import type { Session } from '../workspace/session/session.ts'
 
-const sessionStorage = new AsyncLocalStorage<Session>()
+const sessionStorage = createAsyncContext<Session>()
 
-export function runWithSession<T>(session: Session, fn: () => T): T {
+export function runWithSession<T>(session: Session, fn: () => T | Promise<T>): T | Promise<T> {
   return sessionStorage.run(session, fn)
 }
 

--- a/typescript/packages/core/src/shell/helpers.ts
+++ b/typescript/packages/core/src/shell/helpers.ts
@@ -352,6 +352,19 @@ export function getProcessSubCommand(node: TSNodeLike): TSNodeLike {
   return first
 }
 
+export const ProcessSubDirection = {
+  INPUT: 'input',
+  OUTPUT: 'output',
+} as const
+export type ProcessSubDirection = (typeof ProcessSubDirection)[keyof typeof ProcessSubDirection]
+
+export function getProcessSubDirection(node: TSNodeLike): ProcessSubDirection | null {
+  const open = node.children[0]?.type ?? ''
+  if (open === '<(') return ProcessSubDirection.INPUT
+  if (open === '>(') return ProcessSubDirection.OUTPUT
+  return null
+}
+
 export function getFunctionName(node: TSNodeLike): string {
   const first = node.namedChildren[0]
   return first !== undefined ? getText(first) : ''

--- a/typescript/packages/core/src/shell/parse.test.ts
+++ b/typescript/packages/core/src/shell/parse.test.ts
@@ -15,7 +15,7 @@
 import { readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { beforeAll, describe, expect, it } from 'vitest'
-import { createShellParser, type ShellParser } from './parse.ts'
+import { createShellParser, findSyntaxError, type ShellParser } from './parse.ts'
 
 const require = createRequire(import.meta.url)
 const engineWasm = readFileSync(require.resolve('web-tree-sitter/web-tree-sitter.wasm'))
@@ -128,5 +128,27 @@ describe('createShellParser — realistic multi-statement command', () => {
     const argTexts = args.map((n) => n.text)
     const pathArg = argTexts.find((t) => t === '/r2/Review')
     expect(pathArg).toBe('/r2/Review')
+  })
+})
+
+describe('findSyntaxError', () => {
+  it.each(['if then fi', 'echo (', 'for x do done', 'for', 'if', 'if; fi', 'echo "unterm'])(
+    'flags structural syntax error in %j',
+    (cmd) => {
+      const root = parser.parse(cmd)
+      expect(findSyntaxError(root)).not.toBeNull()
+    },
+  )
+
+  it.each([
+    'echo hi',
+    'for x in a b; do echo $x; done',
+    'if true; then echo y; fi',
+    'cat /tmp/x | sort',
+    'echo bg &; echo fg',
+    'for x in; do echo $x; done',
+  ])('returns null for valid / recoverable %j', (cmd) => {
+    const root = parser.parse(cmd)
+    expect(findSyntaxError(root)).toBeNull()
   })
 })

--- a/typescript/packages/core/src/shell/parse.ts
+++ b/typescript/packages/core/src/shell/parse.ts
@@ -49,3 +49,63 @@ function toArrayBuffer(bytes: Uint8Array | ArrayBuffer): ArrayBuffer {
 function toUint8(bytes: Uint8Array | ArrayBuffer): Uint8Array {
   return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)
 }
+
+const BASH_KEYWORDS: ReadonlySet<string> = new Set([
+  'if',
+  'then',
+  'else',
+  'elif',
+  'fi',
+  'for',
+  'while',
+  'until',
+  'do',
+  'done',
+  'case',
+  'esac',
+  'in',
+  'function',
+  'select',
+])
+
+const STRUCTURAL_TOKENS: ReadonlySet<string> = new Set([
+  '(',
+  ')',
+  '{',
+  '}',
+  '[',
+  ']',
+  '"',
+  "'",
+  '`',
+])
+
+function isStructuralError(node: Node): boolean {
+  for (const child of node.children) {
+    if (child.isNamed) return true
+    if (BASH_KEYWORDS.has(child.type)) return true
+    if (STRUCTURAL_TOKENS.has(child.type)) return true
+  }
+  return false
+}
+
+/**
+ * Locate a top-level structural syntax error in a parsed AST.
+ *
+ * Tree-sitter often recovers from minor anomalies (e.g. `for x in;`) by
+ * producing a valid statement with an internal ERROR token. Bash accepts
+ * those, so we only flag errors that surface as direct children of
+ * `program` AND contain a bash keyword, a bracket / quote, or a recovered
+ * named subtree. Stand-alone statement separators (`;`, `&`, `|`) inside an
+ * ERROR are deliberately not flagged because bash itself accepts e.g. `& ;`.
+ *
+ * Returns the offending region's text, or `null` if the AST is clean.
+ */
+export function findSyntaxError(node: Node): string | null {
+  if (!node.hasError) return null
+  for (const child of node.children) {
+    if (child.isMissing) return child.text
+    if (child.type === 'ERROR' && isStructuralError(child)) return child.text
+  }
+  return null
+}

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -18,6 +18,7 @@ import { OperandKind } from '../../commands/spec/types.ts'
 import type { ByteSource } from '../../io/types.ts'
 import { IOResult, materialize } from '../../io/types.ts'
 import type { Resource } from '../../resource/base.ts'
+import { assertMountAllowed, MountNotAllowedError } from '../../runtime/session_context.ts'
 import { CallStack } from '../../shell/call_stack.ts'
 import type { JobTable } from '../../shell/job_table.ts'
 import { ERREXIT_EXEMPT_TYPES } from '../../shell/types.ts'
@@ -149,6 +150,19 @@ export async function handleCommand(
       new IOResult({ exitCode: 127, stderr: err }),
       new ExecutionNode({ command: cmdStr, exitCode: 127 }),
     ]
+  }
+  try {
+    assertMountAllowed(mount.prefix)
+  } catch (err) {
+    if (err instanceof MountNotAllowedError) {
+      const errBytes = new TextEncoder().encode(`${cmdName}: ${err.message}\n`)
+      return [
+        null,
+        new IOResult({ exitCode: 1, stderr: errBytes }),
+        new ExecutionNode({ command: cmdStr, stderr: errBytes, exitCode: 1 }),
+      ]
+    }
+    throw err
   }
 
   const [paths, texts, flagKwargs] = parseFlags(parts.slice(1), mount, cmdName, session.cwd)

--- a/typescript/packages/core/src/workspace/executor/python/python.test.ts
+++ b/typescript/packages/core/src/workspace/executor/python/python.test.ts
@@ -241,24 +241,20 @@ describe('python3: TS-specific (Pyodide isolation + mechanics)', () => {
     await ws.close()
   })
 
-  it(
-    'cross-workspace isolation: different workspaces have different envs',
-    async () => {
-      const a = await makeWorkspace()
-      const b = await makeWorkspace()
-      await a.ws.execute('export NAME=alpha')
-      await b.ws.execute('export NAME=beta')
-      const [ra, rb] = await Promise.all([
-        a.ws.execute('python3 -c "import os; print(os.environ[\'NAME\'])"'),
-        b.ws.execute('python3 -c "import os; print(os.environ[\'NAME\'])"'),
-      ])
-      expect(stdoutStr(ra).trim()).toBe('alpha')
-      expect(stdoutStr(rb).trim()).toBe('beta')
-      await a.ws.close()
-      await b.ws.close()
-    },
-    30000,
-  )
+  it('cross-workspace isolation: different workspaces have different envs', async () => {
+    const a = await makeWorkspace()
+    const b = await makeWorkspace()
+    await a.ws.execute('export NAME=alpha')
+    await b.ws.execute('export NAME=beta')
+    const [ra, rb] = await Promise.all([
+      a.ws.execute('python3 -c "import os; print(os.environ[\'NAME\'])"'),
+      b.ws.execute('python3 -c "import os; print(os.environ[\'NAME\'])"'),
+    ])
+    expect(stdoutStr(ra).trim()).toBe('alpha')
+    expect(stdoutStr(rb).trim()).toBe('beta')
+    await a.ws.close()
+    await b.ws.close()
+  }, 30000)
 
   it('concurrent calls — each sees its own os.environ mutations atomically', async () => {
     const { ws } = await makeWorkspace()

--- a/typescript/packages/core/src/workspace/executor/python/python.test.ts
+++ b/typescript/packages/core/src/workspace/executor/python/python.test.ts
@@ -241,20 +241,24 @@ describe('python3: TS-specific (Pyodide isolation + mechanics)', () => {
     await ws.close()
   })
 
-  it('cross-workspace isolation: different workspaces have different envs', async () => {
-    const a = await makeWorkspace()
-    const b = await makeWorkspace()
-    await a.ws.execute('export NAME=alpha')
-    await b.ws.execute('export NAME=beta')
-    const [ra, rb] = await Promise.all([
-      a.ws.execute('python3 -c "import os; print(os.environ[\'NAME\'])"'),
-      b.ws.execute('python3 -c "import os; print(os.environ[\'NAME\'])"'),
-    ])
-    expect(stdoutStr(ra).trim()).toBe('alpha')
-    expect(stdoutStr(rb).trim()).toBe('beta')
-    await a.ws.close()
-    await b.ws.close()
-  })
+  it(
+    'cross-workspace isolation: different workspaces have different envs',
+    async () => {
+      const a = await makeWorkspace()
+      const b = await makeWorkspace()
+      await a.ws.execute('export NAME=alpha')
+      await b.ws.execute('export NAME=beta')
+      const [ra, rb] = await Promise.all([
+        a.ws.execute('python3 -c "import os; print(os.environ[\'NAME\'])"'),
+        b.ws.execute('python3 -c "import os; print(os.environ[\'NAME\'])"'),
+      ])
+      expect(stdoutStr(ra).trim()).toBe('alpha')
+      expect(stdoutStr(rb).trim()).toBe('beta')
+      await a.ws.close()
+      await b.ws.close()
+    },
+    30000,
+  )
 
   it('concurrent calls — each sees its own os.environ mutations atomically', async () => {
     const { ws } = await makeWorkspace()

--- a/typescript/packages/core/src/workspace/node/execute_node.ts
+++ b/typescript/packages/core/src/workspace/node/execute_node.ts
@@ -33,6 +33,8 @@ import {
   getNegatedCommand,
   getParts,
   getPipelineCommands,
+  getProcessSubDirection,
+  ProcessSubDirection,
   getRedirects,
   getSubshellBody,
   getText,
@@ -98,6 +100,15 @@ import { resolveGlobs } from './resolve_globs.ts'
 import { expandTestExpr } from './test_expr.ts'
 
 type Result = [ByteSource | null, IOResult, ExecutionNode]
+
+const UNSUPPORTED_BUILTINS: ReadonlySet<string> = new Set([
+  'bg',
+  'disown',
+  'exec',
+  'complete',
+  'compgen',
+  'ulimit',
+])
 
 export interface ExecuteNodeDeps {
   dispatch: DispatchFn
@@ -450,7 +461,15 @@ async function executeProgram(
       i += 1
       continue
     }
-    if (child.isNamed !== true || child.type === NT.ERROR || child.type === NT.COMMENT) {
+    if (child.isNamed !== true || child.type === NT.COMMENT) {
+      i += 1
+      continue
+    }
+    if (child.type === NT.ERROR) {
+      // ERROR nodes that contain only stray statement separators (`& ;`)
+      // are filtered out at parse-time by findSyntaxError, so anything
+      // reaching here is a recovered fragment we deliberately skip;
+      // structural errors would have raised before executeNode ran.
       i += 1
       continue
     }
@@ -648,6 +667,18 @@ async function runCommandBody(
   const cleanParts: TSNodeLike[] = []
   for (const p of parts) {
     if (p.type === NT.PROCESS_SUBSTITUTION) {
+      if (getProcessSubDirection(p) === ProcessSubDirection.OUTPUT) {
+        const err = new TextEncoder().encode('mirage: unsupported: process substitution >(...)\n')
+        return [
+          null,
+          new IOResult({ exitCode: 2, stderr: err }),
+          new ExecutionNode({
+            command: name === '' ? 'process_sub' : name,
+            exitCode: 2,
+            stderr: err,
+          }),
+        ]
+      }
       const innerCmds = p.namedChildren.filter((c) => c.type === NT.COMMAND)
       const innerFirst = innerCmds[0]
       if (innerFirst !== undefined) {
@@ -685,6 +716,18 @@ async function runCommandBody(
   const classified = classifyParts(expanded, registry, session.cwd, textArgs, pathArgs)
   const resolved = await resolveGlobs(classified, registry, textArgs)
   const finalExpanded = resolved.map((p) => (p instanceof PathSpec ? p.original : p))
+
+  // Unsupported bash builtins. Constructs the parser accepts but the
+  // executor cannot honor. Returning a clear error lets LLMs detect a
+  // capability gap instead of treating it as a missing binary.
+  if (UNSUPPORTED_BUILTINS.has(name)) {
+    const err = new TextEncoder().encode(`mirage: unsupported builtin: ${name}\n`)
+    return [
+      null,
+      new IOResult({ exitCode: 2, stderr: err }),
+      new ExecutionNode({ command: name, exitCode: 2, stderr: err }),
+    ]
+  }
 
   // Shell builtins
   if (name === SB.PWD) {

--- a/typescript/packages/core/src/workspace/session/manager.ts
+++ b/typescript/packages/core/src/workspace/session/manager.ts
@@ -39,11 +39,14 @@ export class SessionManager {
     this.defaultSession().env = value
   }
 
-  create(sessionId: string): Session {
+  create(sessionId: string, options: { allowedMounts?: ReadonlySet<string> | null } = {}): Session {
     if (this.sessions.has(sessionId)) {
       throw new Error(`Session ${sessionId} already exists`)
     }
-    const session = new Session({ sessionId })
+    const session = new Session({
+      sessionId,
+      allowedMounts: options.allowedMounts ?? null,
+    })
     this.sessions.set(sessionId, session)
     return session
   }

--- a/typescript/packages/core/src/workspace/session/session.ts
+++ b/typescript/packages/core/src/workspace/session/session.ts
@@ -25,6 +25,15 @@ export interface SessionInit {
   shellOptions?: Record<string, boolean>
   readonlyVars?: Set<string>
   arrays?: Record<string, string[]>
+  /**
+   * Mount prefixes this session is allowed to touch. `null` (the default)
+   * means no restriction — every mount in the workspace is reachable.
+   * When provided, dispatch / handle_command / Ops all reject paths that
+   * resolve to mounts outside this set with a capability error. The
+   * workspace always implicitly grants access to its own infrastructure
+   * mounts (cache root, observer, /dev) regardless of this allowlist.
+   */
+  allowedMounts?: ReadonlySet<string> | null
 }
 
 export class Session {
@@ -40,6 +49,7 @@ export class Session {
   arrays: Record<string, string[]>
   stdinBuffer: AsyncLineIterator | null = null
   localVars: Map<string, string | null> | null = null
+  readonly allowedMounts: ReadonlySet<string> | null
 
   constructor(init: SessionInit) {
     this.sessionId = init.sessionId
@@ -52,6 +62,7 @@ export class Session {
     this.shellOptions = init.shellOptions ?? {}
     this.readonlyVars = init.readonlyVars ?? new Set()
     this.arrays = init.arrays ?? {}
+    this.allowedMounts = init.allowedMounts ?? null
   }
 
   toJSON(): Record<string, unknown> {

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -708,8 +708,10 @@ export class Workspace {
         })
       : targetSession
     const [[stdout, io], opRecords] = await runWithRecording(() =>
-      runWithSession(effectiveSession, () =>
-        executeNode(deps, rootNode, effectiveSession, stdin, null),
+      Promise.resolve(
+        runWithSession(effectiveSession, () =>
+          executeNode(deps, rootNode, effectiveSession, stdin, null),
+        ),
       ),
     )
     const materialized = await applyBarrier(stdout, io, BarrierPolicy.VALUE)

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -23,12 +23,13 @@ import { runWithRecording } from '../observe/context.ts'
 import { Observer } from '../observe/observer.ts'
 import type { OpRecord } from '../observe/record.ts'
 import { type OpKwargs, OpsRegistry } from '../ops/registry.ts'
+import { assertMountAllowed, runWithSession } from '../runtime/session_context.ts'
 import type { Resource } from '../resource/base.ts'
 import { RAMResource, type RAMResourceState } from '../resource/ram/ram.ts'
 import { GENERAL_COMMANDS, HISTORY_COMMANDS } from '../commands/builtin/general/index.ts'
 import { applyBarrier, BarrierPolicy } from '../shell/barrier.ts'
 import { JobTable } from '../shell/job_table.ts'
-import type { ShellParser } from '../shell/parse.ts'
+import { findSyntaxError, type ShellParser } from '../shell/parse.ts'
 import {
   decodeSnapshot,
   encodeSnapshot,
@@ -351,8 +352,34 @@ export class Workspace {
     this.sessionManager.env = value
   }
 
-  createSession(sessionId: string): Session {
-    return this.sessionManager.create(sessionId)
+  createSession(
+    sessionId: string,
+    options: { allowedMounts?: ReadonlySet<string> | null } = {},
+  ): Session {
+    let allowed = options.allowedMounts ?? null
+    if (allowed !== null) {
+      const normalized = new Set<string>()
+      for (const m of allowed) normalized.add('/' + m.replace(/^\/+|\/+$/g, ''))
+      for (const p of this.infrastructureMountPrefixes()) normalized.add(p)
+      allowed = normalized
+    }
+    return this.sessionManager.create(sessionId, { allowedMounts: allowed })
+  }
+
+  /**
+   * Mount prefixes a session is always allowed to touch.
+   *
+   * The cache mount (where text-processing commands like `wc` without a
+   * path argument resolve), the device mount, and the observer log are
+   * infrastructure: they hold no user credentials, and rejecting them
+   * would break common shell idioms or audit logging.
+   */
+  private infrastructureMountPrefixes(): Set<string> {
+    const prefixes = new Set<string>(['/dev'])
+    const def = this.registry.defaultMount
+    if (def !== null) prefixes.add('/' + def.prefix.replace(/^\/+|\/+$/g, ''))
+    prefixes.add('/' + this.observer.prefix.replace(/^\/+|\/+$/g, ''))
+    return prefixes
   }
 
   getSession(sessionId: string): Session {
@@ -515,12 +542,39 @@ export class Workspace {
     }
     const result = this.registry.resolve(path)
     const [resource] = result
+    const mount = this.registry.mountFor(path)
+    if (mount !== null) assertMountAllowed(mount.prefix)
     if (!this.opened.has(resource)) {
       await resource.open()
       this.opened.add(resource)
       this.openOrder.push(resource)
     }
     return result
+  }
+
+  /**
+   * Drop file-cache + stale parent index after a write to `path`.
+   *
+   * Single source of truth for post-write invalidation. Called from the
+   * dispatch closure so a write through any code path (including direct
+   * Ops) sees the same invalidation rules: file cache is dropped only
+   * for remote-backed mounts, and the parent directory index is dirtied
+   * for any mount that maintains an index. No-op for paths that resolve
+   * to no known mount.
+   */
+  async invalidateAfterWriteByPath(path: string): Promise<void> {
+    const mount = this.registry.mountFor(path)
+    if (mount === null) return
+    if (mount.resource.isRemote === true) {
+      await this.cache.remove(path)
+    }
+    const idx = mount.resource.index
+    if (idx !== undefined) {
+      const slash = path.lastIndexOf('/')
+      const parent = slash <= 0 ? '/' : path.slice(0, slash)
+      await idx.invalidateDir(parent)
+      await idx.invalidateDir(parent + '/')
+    }
   }
 
   async provision(command: string): Promise<ProvisionResult> {
@@ -560,6 +614,16 @@ export class Workspace {
     const parser = await this.getShellParser()
     const opsRegistry = this.opsRegistry
     const root = parser.parse(command)
+    const offending = findSyntaxError(root)
+    if (offending !== null) {
+      const snippet = offending.trim().slice(0, 40)
+      const errMsg =
+        snippet.length > 0
+          ? `mirage: syntax error near '${snippet}'\n`
+          : 'mirage: syntax error in command\n'
+      const err = new TextEncoder().encode(errMsg)
+      return new ExecuteResult(new Uint8Array(), err, 2)
+    }
     const rootNode = root as unknown as TSNodeLike
 
     const cache = this.cache
@@ -587,8 +651,8 @@ export class Workspace {
         args ?? [],
         fullKwargs,
       )
-      if (cacheable && DISPATCH_WRITE_OPS.has(opName)) {
-        await cache.remove(path.original)
+      if (DISPATCH_WRITE_OPS.has(opName)) {
+        await this.invalidateAfterWriteByPath(path.original)
       }
       return [result, new IOResult()]
     }
@@ -640,10 +704,13 @@ export class Workspace {
           functions: { ...targetSession.functions },
           lastExitCode: targetSession.lastExitCode,
           positionalArgs: [...targetSession.positionalArgs],
+          allowedMounts: targetSession.allowedMounts,
         })
       : targetSession
     const [[stdout, io], opRecords] = await runWithRecording(() =>
-      executeNode(deps, rootNode, effectiveSession, stdin, null),
+      runWithSession(effectiveSession, () =>
+        executeNode(deps, rootNode, effectiveSession, stdin, null),
+      ),
     )
     const materialized = await applyBarrier(stdout, io, BarrierPolicy.VALUE)
     io.syncExitCode()

--- a/typescript/packages/server/src/routers/sessions.ts
+++ b/typescript/packages/server/src/routers/sessions.ts
@@ -31,6 +31,15 @@ interface WsSessionParams {
 
 interface CreateSessionBody {
   sessionId?: string
+  /**
+   * Optional list of mount prefixes this session is permitted to access.
+   * When omitted (or null), the session can reach every mount on the
+   * workspace. When provided, dispatch / commands / WorkspaceFS reject
+   * paths that resolve to mounts outside this set with a capability
+   * error. Infrastructure mounts (cache root, observer, /dev) are always
+   * implicitly allowed.
+   */
+  allowedMounts?: string[] | null
 }
 
 export function registerSessionsRoutes(app: FastifyInstance, deps: SessionsRoutesDeps): void {
@@ -46,7 +55,11 @@ export function registerSessionsRoutes(app: FastifyInstance, deps: SessionsRoute
       if (ws.listSessions().some((s) => s.sessionId === sid)) {
         return reply.status(409).send({ detail: `session id already exists: ${sid}` })
       }
-      const sess = ws.createSession(sid)
+      const allowed =
+        Array.isArray(req.body.allowedMounts) && req.body.allowedMounts.length > 0
+          ? new Set(req.body.allowedMounts)
+          : null
+      const sess = ws.createSession(sid, allowed !== null ? { allowedMounts: allowed } : {})
       return reply.status(201).send({ sessionId: sess.sessionId, cwd: sess.cwd })
     },
   )


### PR DESCRIPTION
Fixes #17, Fixes #18, Fixes #19.

## Summary

### #19 — Shell coverage (4 commits)
- Tree-sitter `ERROR` nodes that contain a bash keyword, a bracket / quote, or a recovered subtree now return exit 2 with `mirage: syntax error near '<token>'` instead of silently running whatever fragment did parse. Stray statement separators (`& ;`) are deliberately not flagged so the recovered behavior bash already accepts keeps working.
- `bg`, `disown`, `exec`, `complete`, `compgen`, `ulimit` return exit 2 with `mirage: unsupported builtin: <name>`. (`fg`, `jobs`, `wait`, `kill`, `ps` were already wired through `JobTable` and stay supported.)
- Output-direction process substitution `>(cmd)` returns `mirage: unsupported: process substitution >(...)`. Input direction `<(cmd)` is unchanged.
- `docs/home/shell.mdx` extended with a supported / unsupported syntax table and a note on the `&` vs `--background` distinction.

### #18 — Cache write-through (1 commit)
- `Workspace.dispatch()` now invalidates the file's parent directory index alongside the file cache after every write, closing the stale-readdir gap for cross-mount `cp`, `wget -O`, `curl -o`, and direct `ws.dispatch` writes. Redirects (`>`, `>>`) were already covered through `apply_io`.

### #17 — Per-session mount capability (7 commits + tests)
- New `Session.allowed_mounts: frozenset[str] | None`. `None` (default) preserves the unrestricted behavior; passing a set restricts the session to those mounts.
- Plumbed through `SessionManager.create`, `Workspace.create_session`, the server's `CreateSessionRequest` (`POST /v1/workspaces/{id}/sessions`), and `mirage session create --mount /a -m /b`.
- Enforcement at three chokepoints: `Workspace.dispatch` (redirects, cross-mount cp, `wget`/`curl`, `ws.readdir`/`ws.stat`, programmatic dispatch), `handle_command` (every shell command resolved through a mount), and `Ops._call` (programmatic `ws.ops.read/write/...`). All three call a shared `assert_mount_allowed(prefix)` helper that reads a `ContextVar[Session]` bound by `Workspace.execute()`.
- The infrastructure prefixes `/dev`, `/_default` (cache mount where `wc`/`sort`/etc. live), and the observer prefix (`/.sessions`) are added to the user's allowlist at `create_session` time so common shell idioms like `cat /a/x.txt | wc -c` work without the user needing to know about them.
- Documented in `docs/home/shell.mdx` with Python and CLI examples.

To break a `Workspace -> Ops -> workspace.session -> Workspace` import cycle, the contextvar + helper live in a new top-level `mirage.runtime` package. `mirage.workspace.session` re-exports them.

## Test plan
- [x] 1420 pytest cases pass (`workspace`, `cache`, `shell`, `server`, `cli/test_session_cli.py`)
- [x] Capability tests cover pipes (`cat /b/secret | wc -l`), command substitution (`echo $(cat /b/secret)`), subshells (`(cat /b/secret)`), `&&` short-circuit, `||` fall-through, redirects, cross-mount `cp`, two parallel sessions under `asyncio.gather`, background jobs (`cat /b/secret &; wait`)
- [x] No circular imports (`uv run python -c "import mirage; import mirage.ops.ops; import mirage.workspace.workspace; import mirage.runtime"`)
- [x] `pre-commit run --all-files` (Python hooks pass; pre-existing TS hook failures unchanged)

## Known follow-ups (will land as separate commits in this PR)
- `Workspace.create_session` hardcodes the cache prefix `"/_default"` instead of querying `self._registry.default_mount.prefix`. Brittle if the registry's synthetic prefix ever changes.
- Workspace.`_invalidate_after_write` and the inline invalidation block in `Ops._call` duplicate the same logic. Worth a single `(cache, index, path) -> None` helper.