### PR TITLE
refactor: Session.fork() helper + tighten runWithSession typing

### DIFF
--- a/python/mirage/runtime/session_context.py
+++ b/python/mirage/runtime/session_context.py
@@ -58,7 +58,14 @@ def assert_mount_allowed(mount_prefix: str) -> None:
     if sess is None or sess.allowed_mounts is None:
         return
     norm = "/" + mount_prefix.strip("/") if mount_prefix.strip("/") else "/"
-    if norm == "/" or norm in sess.allowed_mounts:
+    # A user-defined root mount ({"/": resource}) currently bypasses
+    # the allowlist entirely. This is an undocumented escape hatch: a
+    # session restricted to /s3 but with a workspace mounted at root
+    # would still expose every path under /. Behaviour-changing fix is
+    # out of scope for this refactor, flagged for separate discussion.
+    if norm == "/":
         return
-    raise PermissionError(f"session {sess.session_id!r} not allowed to access "
-                          f"mount {norm!r}")
+    if norm in sess.allowed_mounts:
+        return
+    raise PermissionError(
+        f"session {sess.session_id!r} not allowed to access mount {norm!r}")

--- a/python/mirage/workspace/executor/jobs.py
+++ b/python/mirage/workspace/executor/jobs.py
@@ -35,11 +35,7 @@ async def handle_background(
     call_stack=None,
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
     """Run left side in background."""
-    bg_session = Session(
-        session_id=session.session_id,
-        cwd=session.cwd,
-        env=dict(session.env),
-    )
+    bg_session = session.fork()
 
     async def _run_bg():
         # Background jobs don't receive stdin, matching real shell

--- a/python/mirage/workspace/session/session.py
+++ b/python/mirage/workspace/session/session.py
@@ -65,7 +65,10 @@ class Session:
             "last_exit_code": self.last_exit_code,
             "shell_options": dict(self.shell_options),
             "readonly_vars": set(self.readonly_vars),
-            "arrays": {k: list(v) for k, v in self.arrays.items()},
+            "arrays": {
+                k: list(v)
+                for k, v in self.arrays.items()
+            },
             "allowed_mounts": self.allowed_mounts,
         }
         defaults.update(overrides)

--- a/python/mirage/workspace/session/session.py
+++ b/python/mirage/workspace/session/session.py
@@ -43,3 +43,30 @@ class Session:
     @classmethod
     def from_dict(cls, data: dict) -> "Session":
         return cls(**data)
+
+    def fork(self, **overrides) -> "Session":
+        """Return a copy of this session with overrides applied.
+
+        Mutable containers (env, functions, readonly_vars, arrays,
+        shell_options) are shallow-copied so mutations on the fork do
+        not leak back into the source. Every field, including
+        capability fields like ``allowed_mounts``, is propagated, so
+        callers cannot accidentally forget one when adding new fields.
+
+        Args:
+            **overrides: Field-name kwargs to override on the copy.
+        """
+        defaults = {
+            "session_id": self.session_id,
+            "cwd": self.cwd,
+            "env": dict(self.env),
+            "created_at": self.created_at,
+            "functions": dict(self.functions),
+            "last_exit_code": self.last_exit_code,
+            "shell_options": dict(self.shell_options),
+            "readonly_vars": set(self.readonly_vars),
+            "arrays": {k: list(v) for k, v in self.arrays.items()},
+            "allowed_mounts": self.allowed_mounts,
+        }
+        defaults.update(overrides)
+        return Session(**defaults)

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -18,7 +18,6 @@ import logging
 import sys
 import time
 from collections.abc import AsyncIterator
-from dataclasses import replace
 from typing import Any
 
 from mirage.cache.file import io as cache_io
@@ -579,15 +578,15 @@ class Workspace:
 
         session = self._session_mgr.get(session_id)
         use_override = cwd is not None or env is not None
-        effective_session = (replace(
-            session,
-            cwd=cwd if cwd is not None else session.cwd,
-            env={
-                **session.env,
-                **(env or {})
-            },
-            functions=dict(session.functions),
-        ) if use_override else session)
+        if use_override:
+            overrides: dict[str, Any] = {}
+            if cwd is not None:
+                overrides["cwd"] = cwd
+            if env is not None:
+                overrides["env"] = {**session.env, **env}
+            effective_session = session.fork(**overrides)
+        else:
+            effective_session = session
         self._current_agent_id = agent_id
         io = IOResult()
         exec_node = ExecutionNode(command=command, exit_code=0)

--- a/python/tests/workspace/session/test_session.py
+++ b/python/tests/workspace/session/test_session.py
@@ -147,8 +147,9 @@ def test_fork_overrides_apply_without_mutating_original():
 
 
 def test_fork_deep_copies_mutable_containers():
-    original = Session(
-        session_id="orig", env={"FOO": "bar"}, arrays={"A": ["1"]})
+    original = Session(session_id="orig",
+                       env={"FOO": "bar"},
+                       arrays={"A": ["1"]})
     forked = original.fork()
     forked.env["NEW"] = "leaked?"
     forked.arrays["A"].append("2")

--- a/python/tests/workspace/session/test_session.py
+++ b/python/tests/workspace/session/test_session.py
@@ -112,3 +112,45 @@ def test_session_allowed_mounts_default_none():
 def test_session_allowed_mounts_set():
     s = Session(session_id="s", allowed_mounts=frozenset({"/s3", "/slack"}))
     assert s.allowed_mounts == frozenset({"/s3", "/slack"})
+
+
+def test_fork_copies_every_field_including_allowed_mounts():
+    original = Session(
+        session_id="orig",
+        cwd="/disk",
+        env={"FOO": "bar"},
+        functions={"f": object()},
+        last_exit_code=7,
+        shell_options={"errexit": True},
+        readonly_vars={"HOME"},
+        arrays={"ARGV": ["a", "b"]},
+        allowed_mounts=frozenset({"/s3", "/dev", "/_default"}),
+    )
+    forked = original.fork()
+    assert forked.session_id == "orig"
+    assert forked.cwd == "/disk"
+    assert forked.env == {"FOO": "bar"}
+    assert forked.allowed_mounts == frozenset({"/s3", "/dev", "/_default"})
+    assert forked.shell_options == {"errexit": True}
+    assert "HOME" in forked.readonly_vars
+    assert forked.arrays == {"ARGV": ["a", "b"]}
+    assert forked.last_exit_code == 7
+
+
+def test_fork_overrides_apply_without_mutating_original():
+    original = Session(session_id="orig", cwd="/disk", env={"FOO": "bar"})
+    forked = original.fork(cwd="/ram", env={"BAZ": "qux"})
+    assert forked.cwd == "/ram"
+    assert forked.env == {"BAZ": "qux"}
+    assert original.cwd == "/disk"
+    assert original.env == {"FOO": "bar"}
+
+
+def test_fork_deep_copies_mutable_containers():
+    original = Session(
+        session_id="orig", env={"FOO": "bar"}, arrays={"A": ["1"]})
+    forked = original.fork()
+    forked.env["NEW"] = "leaked?"
+    forked.arrays["A"].append("2")
+    assert "NEW" not in original.env
+    assert original.arrays["A"] == ["1"]

--- a/typescript/packages/core/src/runtime/session_context.ts
+++ b/typescript/packages/core/src/runtime/session_context.ts
@@ -41,6 +41,12 @@ export function assertMountAllowed(mountPrefix: string): void {
   if (sess?.allowedMounts == null) return
   const stripped = mountPrefix.replace(/^\/+|\/+$/g, '')
   const norm = stripped === '' ? '/' : '/' + stripped
-  if (norm === '/' || sess.allowedMounts.has(norm)) return
+  // A user-defined root mount (`{"/": resource}`) currently bypasses the
+  // allowlist entirely. This is an undocumented escape hatch: a session
+  // restricted to `/s3` but with a workspace mounted at root would still
+  // expose every path under `/`. Behaviour-changing fix is out of scope
+  // for this refactor — flagged for separate discussion.
+  if (norm === '/') return
+  if (sess.allowedMounts.has(norm)) return
   throw new MountNotAllowedError(sess.sessionId, norm)
 }

--- a/typescript/packages/core/src/runtime/session_context.ts
+++ b/typescript/packages/core/src/runtime/session_context.ts
@@ -17,8 +17,8 @@ import type { Session } from '../workspace/session/session.ts'
 
 const sessionStorage = createAsyncContext<Session>()
 
-export function runWithSession<T>(session: Session, fn: () => T | Promise<T>): T | Promise<T> {
-  return sessionStorage.run(session, fn)
+export function runWithSession<T>(session: Session, fn: () => Promise<T>): Promise<T> {
+  return Promise.resolve(sessionStorage.run(session, fn))
 }
 
 export function getCurrentSession(): Session | null {

--- a/typescript/packages/core/src/workspace/executor/jobs.ts
+++ b/typescript/packages/core/src/workspace/executor/jobs.ts
@@ -16,7 +16,7 @@ import type { ByteSource } from '../../io/types.ts'
 import { IOResult, materialize } from '../../io/types.ts'
 import type { CallStack } from '../../shell/call_stack.ts'
 import type { JobTable } from '../../shell/job_table.ts'
-import { Session } from '../session/session.ts'
+import type { Session } from '../session/session.ts'
 import type { TSNodeLike } from '../expand/variable.ts'
 import { ExecutionNode } from '../types.ts'
 
@@ -39,11 +39,7 @@ export async function handleBackground(
   stdin: ByteSource | null = null,
   callStack: CallStack | null = null,
 ): Promise<JobHandlerResult> {
-  const bgSession = new Session({
-    sessionId: session.sessionId,
-    cwd: session.cwd,
-    env: { ...session.env },
-  })
+  const bgSession = session.fork()
 
   const abort = new AbortController()
   const task: Promise<[ByteSource | null, IOResult, ExecutionNode]> = (async () => {

--- a/typescript/packages/core/src/workspace/executor/jobs_capability.test.ts
+++ b/typescript/packages/core/src/workspace/executor/jobs_capability.test.ts
@@ -1,0 +1,40 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { makeWorkspace, stdoutStr } from '../fixtures/workspace_fixture.ts'
+
+describe('background jobs respect allowedMounts (regression)', () => {
+  // This passes both before and after the Session.fork() migration: the
+  // bg-job promise is created inside the parent's runWithSession() scope,
+  // so AsyncLocalStorage propagates the *parent* session to
+  // assertMountAllowed even though the bgSession object itself does not
+  // carry allowedMounts. Pinning this so a future change to ALS scoping
+  // (or a switch from ALS to per-session-object enforcement) cannot
+  // silently let `cmd &` escape an allowlist.
+  it('cmd & in a restricted session cannot escape the allowlist', async () => {
+    const { ws } = await makeWorkspace()
+    ws.createSession('restricted', { allowedMounts: new Set(['/disk']) })
+    await ws.execute('echo hello > /ram/leaked.txt &', {
+      sessionId: 'restricted',
+    })
+    await ws.execute('wait', { sessionId: 'restricted' })
+    // Read back from the DEFAULT (unrestricted) session so we measure
+    // whether the bg write actually landed, not whether the read is
+    // also blocked.
+    const probe = await ws.execute('cat /ram/leaked.txt')
+    expect(stdoutStr(probe).includes('hello')).toBe(false)
+    await ws.close()
+  }, 30_000)
+})

--- a/typescript/packages/core/src/workspace/per_call_override_capability.test.ts
+++ b/typescript/packages/core/src/workspace/per_call_override_capability.test.ts
@@ -1,0 +1,62 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { makeWorkspace, stdoutStr } from './fixtures/workspace_fixture.ts'
+
+// `Workspace.execute({cwd, env})` constructs a new Session via
+// `targetSession.fork({...})`. fork() must propagate allowedMounts so
+// the per-call override session cannot bypass the parent's allowlist.
+// Without fork() (or without manually copying allowedMounts in the old
+// inline `new Session({...})` ctor) this test would fail because the
+// override session would have allowedMounts === null and assertMountAllowed
+// would short-circuit on the `if (sess?.allowedMounts == null) return`
+// branch in runtime/session_context.ts.
+describe('per-call cwd/env override preserves allowedMounts', () => {
+  it('execute({cwd}) on a restricted session still rejects out-of-allowlist mounts', async () => {
+    const { ws } = await makeWorkspace()
+    ws.createSession('restricted', { allowedMounts: new Set(['/disk']) })
+    const io = await ws.execute('cat /ram/notes.txt', {
+      sessionId: 'restricted',
+      cwd: '/disk',
+    })
+    expect(io.exitCode).not.toBe(0)
+    expect(stdoutStr(io).includes('line1')).toBe(false)
+    await ws.close()
+  })
+
+  it('execute({env}) on a restricted session still rejects out-of-allowlist mounts', async () => {
+    const { ws } = await makeWorkspace()
+    ws.createSession('restricted', { allowedMounts: new Set(['/disk']) })
+    const io = await ws.execute('cat /ram/notes.txt', {
+      sessionId: 'restricted',
+      env: { EXTRA: '1' },
+    })
+    expect(io.exitCode).not.toBe(0)
+    expect(stdoutStr(io).includes('line1')).toBe(false)
+    await ws.close()
+  })
+
+  it('execute({cwd}) on a restricted session can still reach allowed mounts', async () => {
+    const { ws } = await makeWorkspace()
+    ws.createSession('restricted', { allowedMounts: new Set(['/disk']) })
+    const io = await ws.execute('cat /disk/readme.txt', {
+      sessionId: 'restricted',
+      cwd: '/disk',
+    })
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io).includes('disk readme')).toBe(true)
+    await ws.close()
+  })
+})

--- a/typescript/packages/core/src/workspace/session/session.test.ts
+++ b/typescript/packages/core/src/workspace/session/session.test.ts
@@ -60,3 +60,55 @@ describe('Session', () => {
     expect(restored.env).toEqual({ K: 'V' })
   })
 })
+
+describe('Session.fork', () => {
+  it('copies every field, including allowedMounts and shellOptions', () => {
+    const original = new Session({
+      sessionId: 'orig',
+      cwd: '/disk',
+      env: { FOO: 'bar' },
+      allowedMounts: new Set(['/s3', '/dev', '/_default']),
+      shellOptions: { errexit: true },
+      readonlyVars: new Set(['HOME']),
+      arrays: { ARGV: ['a', 'b'] },
+      positionalArgs: ['x'],
+      lastExitCode: 7,
+    })
+    const forked = original.fork({})
+    expect(forked.sessionId).toBe('orig')
+    expect(forked.cwd).toBe('/disk')
+    expect(forked.env).toEqual({ FOO: 'bar' })
+    expect(forked.allowedMounts).toBe(original.allowedMounts)
+    expect(forked.shellOptions).toEqual({ errexit: true })
+    expect(forked.readonlyVars.has('HOME')).toBe(true)
+    expect(forked.arrays).toEqual({ ARGV: ['a', 'b'] })
+    expect(forked.positionalArgs).toEqual(['x'])
+    expect(forked.lastExitCode).toBe(7)
+  })
+
+  it('applies overrides without mutating the original', () => {
+    const original = new Session({
+      sessionId: 'orig',
+      cwd: '/disk',
+      env: { FOO: 'bar' },
+    })
+    const forked = original.fork({ cwd: '/ram', env: { BAZ: 'qux' } })
+    expect(forked.cwd).toBe('/ram')
+    expect(forked.env).toEqual({ BAZ: 'qux' })
+    expect(original.cwd).toBe('/disk')
+    expect(original.env).toEqual({ FOO: 'bar' })
+  })
+
+  it('deep-copies mutable containers so mutations on the fork do not leak', () => {
+    const original = new Session({
+      sessionId: 'orig',
+      env: { FOO: 'bar' },
+      arrays: { A: ['1'] },
+    })
+    const forked = original.fork({})
+    forked.env.NEW = 'leaked?'
+    forked.arrays.A?.push('2')
+    expect('NEW' in original.env).toBe(false)
+    expect(original.arrays.A).toEqual(['1'])
+  })
+})

--- a/typescript/packages/core/src/workspace/session/session.ts
+++ b/typescript/packages/core/src/workspace/session/session.ts
@@ -65,6 +65,31 @@ export class Session {
     this.allowedMounts = init.allowedMounts ?? null
   }
 
+  /**
+   * Return a copy of this session with `overrides` applied. Mutable
+   * containers (env, functions, readonlyVars, arrays, positionalArgs)
+   * are shallow-copied so mutations on the fork do not leak back into
+   * the source. Every field — including capability fields like
+   * `allowedMounts` — is propagated, so callers cannot accidentally
+   * forget one when adding new fields.
+   */
+  fork(overrides: Partial<SessionInit> = {}): Session {
+    return new Session({
+      sessionId: overrides.sessionId ?? this.sessionId,
+      cwd: overrides.cwd ?? this.cwd,
+      env: overrides.env ?? { ...this.env },
+      createdAt: overrides.createdAt ?? this.createdAt,
+      functions: overrides.functions ?? { ...this.functions },
+      lastExitCode: overrides.lastExitCode ?? this.lastExitCode,
+      positionalArgs: overrides.positionalArgs ?? [...this.positionalArgs],
+      shellOptions: overrides.shellOptions ?? { ...this.shellOptions },
+      readonlyVars: overrides.readonlyVars ?? new Set(this.readonlyVars),
+      arrays:
+        overrides.arrays ?? Object.fromEntries(Object.entries(this.arrays).map(([k, v]) => [k, [...v]])),
+      allowedMounts: overrides.allowedMounts ?? this.allowedMounts,
+    })
+  }
+
   toJSON(): Record<string, unknown> {
     return {
       sessionId: this.sessionId,

--- a/typescript/packages/core/src/workspace/session/session.ts
+++ b/typescript/packages/core/src/workspace/session/session.ts
@@ -85,7 +85,8 @@ export class Session {
       shellOptions: overrides.shellOptions ?? { ...this.shellOptions },
       readonlyVars: overrides.readonlyVars ?? new Set(this.readonlyVars),
       arrays:
-        overrides.arrays ?? Object.fromEntries(Object.entries(this.arrays).map(([k, v]) => [k, [...v]])),
+        overrides.arrays ??
+        Object.fromEntries(Object.entries(this.arrays).map(([k, v]) => [k, [...v]])),
       allowedMounts: overrides.allowedMounts ?? this.allowedMounts,
     })
   }

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -60,7 +60,7 @@ import { makeAbortError } from './abort.ts'
 import { executeNode } from './node/execute_node.ts'
 import { provisionNode } from './node/provision_node.ts'
 import { SessionManager } from './session/manager.ts'
-import { Session } from './session/session.ts'
+import type { Session } from './session/session.ts'
 import { ExecutionHistory } from './history.ts'
 import { ExecutionNode, ExecutionRecord } from './types.ts'
 
@@ -698,9 +698,7 @@ export class Workspace {
     const effectiveSession = useOverride
       ? targetSession.fork({
           ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
-          ...(options.env !== undefined
-            ? { env: { ...targetSession.env, ...options.env } }
-            : {}),
+          ...(options.env !== undefined ? { env: { ...targetSession.env, ...options.env } } : {}),
         })
       : targetSession
     const [[stdout, io], opRecords] = await runWithRecording(() =>

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -704,10 +704,8 @@ export class Workspace {
         })
       : targetSession
     const [[stdout, io], opRecords] = await runWithRecording(() =>
-      Promise.resolve(
-        runWithSession(effectiveSession, () =>
-          executeNode(deps, rootNode, effectiveSession, stdin, null),
-        ),
+      runWithSession(effectiveSession, () =>
+        executeNode(deps, rootNode, effectiveSession, stdin, null),
       ),
     )
     const materialized = await applyBarrier(stdout, io, BarrierPolicy.VALUE)

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -696,15 +696,11 @@ export class Workspace {
     const targetSession = this.sessionManager.get(targetSessionId)
     const useOverride = options.cwd !== undefined || options.env !== undefined
     const effectiveSession = useOverride
-      ? new Session({
-          sessionId: targetSession.sessionId,
-          cwd: options.cwd ?? targetSession.cwd,
-          env: { ...targetSession.env, ...(options.env ?? {}) },
-          createdAt: targetSession.createdAt,
-          functions: { ...targetSession.functions },
-          lastExitCode: targetSession.lastExitCode,
-          positionalArgs: [...targetSession.positionalArgs],
-          allowedMounts: targetSession.allowedMounts,
+      ? targetSession.fork({
+          ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+          ...(options.env !== undefined
+            ? { env: { ...targetSession.env, ...options.env } }
+            : {}),
         })
       : targetSession
     const [[stdout, io], opRecords] = await runWithRecording(() =>


### PR DESCRIPTION
## Summary

Adds `Session.fork(overrides)` in both Python and TypeScript that copies *every* field — including capability fields like `allowedMounts` — so adding a new Session field can never silently leak past a fork site again.

**Honest framing on whether this fixes a bug:**

- The TS `Workspace.execute({cwd, env})` per-call override path *did* have the footgun: `effectiveSession` becomes the new ALS-bound session, so dropping `allowedMounts` would bypass the allowlist. PR #22 retrofitted that by hand. fork() is the structural fix that prevents the next miss.
- The bg-job site (`executor/jobs.{ts,py}` `cmd &` fork) also looked vulnerable — it manually constructed a new session and dropped `allowedMounts`. On investigation it's actually safe today: `assertMountAllowed`/`assert_mount_allowed` reads from AsyncLocalStorage / contextvar, which propagates the parent session across the bg promise / `asyncio.create_task` boundary. The new `bgSession` object's missing field doesn't matter for capability checks. Still migrating it because the same field-by-field shape is the footgun, and a future field that *isn't* read from ALS would break here.
- Python's per-call override was already using `dataclasses.replace(...)` which preserves all fields, so no bug there. fork() centralizes deep-copy semantics for mutable containers (today only `functions` is deep-copied at the override path; `arrays`, `readonly_vars` aren't).

## Other changes in this PR

- **TS `runWithSession` returns `Promise<T>`**: previously `T | Promise<T>`, forcing the only caller to wrap with `Promise.resolve(...)`. Tightening the signature drops the wrap.
- **Documents the `/` allowlist short-circuit**: a user-defined root mount (`{"/": resource}`) currently bypasses the allowlist entirely in both `assertMountAllowed` (TS) and `assert_mount_allowed` (Python). Comment-only — flagged for separate behaviour-change discussion since fixing it could break workspaces that intentionally rely on the bypass.

## Test plan

- [x] `Session.fork()` test confirms every field propagates and overrides don't mutate the source (TS + Python — 3 tests each)
- [x] New `per_call_override_capability.test.ts`: `execute({cwd|env})` on a restricted session still rejects out-of-allowlist mounts (this would fail without fork() copying `allowedMounts`)
- [x] New `jobs_capability.test.ts`: regression check that `cmd &` in a restricted session cannot escape the allowlist (passes both before and after — confirms ALS propagation continues to work)
- [x] Existing TS suite: 907 workspace tests passing
- [x] Existing Python suite: 5510 passing, 215 skipped
- [x] `examples/typescript/browser` build succeeds (the canary that caught the `node:async_hooks` regression in PR #22)
- [x] Pre-commit clean on all touched files (yapf / prettier / eslint)