### PR TITLE
fix(cli): propagate inner exit code on execute and job wait/get

### DIFF
--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -1,0 +1,241 @@
+name: CLI exit codes
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    name: Python CLI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install Python dependencies
+        working-directory: python
+        run: uv sync --all-extras --no-extra camel
+
+      - name: Install mirage package
+        working-directory: python
+        run: uv pip install .
+
+      - name: Smoke test exit code propagation
+        working-directory: python
+        shell: bash
+        run: |
+          set -u
+          MIRAGE=".venv/bin/mirage"
+          cat > /tmp/ws.yaml <<'YAML'
+          mounts:
+            /:
+              resource: ram
+              mode: WRITE
+          YAML
+
+          $MIRAGE workspace delete smoke > /dev/null 2>&1 || true
+          $MIRAGE workspace create /tmp/ws.yaml --id smoke
+
+          fail=0
+          check() {
+            local desc="$1"
+            local expected_exit="$2"
+            local expected_field="$3"
+            shift 3
+            echo
+            echo "--- $desc"
+            echo "+ $*"
+            set +e
+            out=$("$@")
+            got_exit=$?
+            set -e
+            echo "stdout:"
+            echo "$out" | sed 's/^/  /'
+            echo "process exit: $got_exit (expected $expected_exit)"
+            if [ "$got_exit" != "$expected_exit" ]; then
+              echo "FAIL: process exit code mismatch"
+              fail=1
+              return
+            fi
+            if [ -n "$expected_field" ]; then
+              field_val=$(echo "$out" | jq -r '.exit_code // .result.exit_code // empty')
+              echo "json exit_code: $field_val (expected $expected_field)"
+              if [ "$field_val" != "$expected_field" ]; then
+                echo "FAIL: json exit_code mismatch"
+                fail=1
+                return
+              fi
+            fi
+            echo "PASS"
+          }
+
+          check "echo ok succeeds" 0 0 $MIRAGE execute -w smoke -c 'echo ok'
+          check "false exits 1" 1 1 $MIRAGE execute -w smoke -c 'false'
+          check "false | echo: pipefail off => last cmd wins" 0 0 \
+            $MIRAGE execute -w smoke -c 'false | echo done'
+          check "pipefail on => rightmost failure wins" 1 1 \
+            $MIRAGE execute -w smoke -c 'set -o pipefail; false | echo done'
+
+          echo
+          echo "--- background + job wait"
+          submit=$($MIRAGE execute -w smoke --bg -c 'false')
+          echo "submit response:"
+          echo "$submit" | sed 's/^/  /'
+          JID=$(echo "$submit" | jq -r .job_id)
+          echo "job id: $JID"
+          check "job wait on failing job" 1 1 $MIRAGE job wait "$JID"
+
+          echo
+          echo "--- shell composition (&& and ||)"
+          if $MIRAGE execute -w smoke -c 'false' > /dev/null && echo "should not print"; then
+            echo "FAIL: && short-circuit did not work"
+            fail=1
+          else
+            echo "PASS: && correctly short-circuited on inner failure"
+          fi
+          if $MIRAGE execute -w smoke -c 'echo ok' > /dev/null && echo "should print"; then
+            echo "PASS: && correctly proceeded on inner success"
+          else
+            echo "FAIL: && incorrectly short-circuited on success"
+            fail=1
+          fi
+
+          $MIRAGE workspace delete smoke
+          $MIRAGE daemon stop || true
+
+          if [ "$fail" != "0" ]; then
+            echo
+            echo "One or more exit-code propagation checks failed."
+            exit 1
+          fi
+
+  typescript:
+    name: TypeScript CLI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.32.1
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: typescript/pnpm-lock.yaml
+
+      - name: Install TypeScript dependencies
+        working-directory: typescript
+        run: pnpm install --frozen-lockfile
+
+      - name: Build TypeScript packages
+        working-directory: typescript
+        run: pnpm -r build
+
+      - name: Smoke test exit code propagation
+        working-directory: typescript
+        shell: bash
+        run: |
+          set -u
+          MIRAGE="node packages/cli/dist/bin/mirage.js"
+          cat > /tmp/ws.yaml <<'YAML'
+          mounts:
+            /:
+              resource: ram
+              mode: WRITE
+          YAML
+
+          $MIRAGE workspace delete smoke > /dev/null 2>&1 || true
+          $MIRAGE workspace create /tmp/ws.yaml --id smoke
+
+          fail=0
+          check() {
+            local desc="$1"
+            local expected_exit="$2"
+            local expected_field="$3"
+            shift 3
+            echo
+            echo "--- $desc"
+            echo "+ $*"
+            set +e
+            out=$("$@")
+            got_exit=$?
+            set -e
+            echo "stdout:"
+            echo "$out" | sed 's/^/  /'
+            echo "process exit: $got_exit (expected $expected_exit)"
+            if [ "$got_exit" != "$expected_exit" ]; then
+              echo "FAIL: process exit code mismatch"
+              fail=1
+              return
+            fi
+            if [ -n "$expected_field" ]; then
+              field_val=$(echo "$out" | jq -r '.exitCode // .result.exitCode // empty')
+              echo "json exitCode: $field_val (expected $expected_field)"
+              if [ "$field_val" != "$expected_field" ]; then
+                echo "FAIL: json exitCode mismatch"
+                fail=1
+                return
+              fi
+            fi
+            echo "PASS"
+          }
+
+          check "echo ok succeeds" 0 0 $MIRAGE execute -w smoke -c 'echo ok'
+          check "false exits 1" 1 1 $MIRAGE execute -w smoke -c 'false'
+          check "false | echo: pipefail off => last cmd wins" 0 0 \
+            $MIRAGE execute -w smoke -c 'false | echo done'
+          check "pipefail on => rightmost failure wins" 1 1 \
+            $MIRAGE execute -w smoke -c 'set -o pipefail; false | echo done'
+
+          echo
+          echo "--- background + job wait"
+          submit=$($MIRAGE execute -w smoke --bg -c 'false')
+          echo "submit response:"
+          echo "$submit" | sed 's/^/  /'
+          JID=$(echo "$submit" | jq -r .jobId)
+          echo "job id: $JID"
+          check "job wait on failing job" 1 1 $MIRAGE job wait "$JID"
+
+          echo
+          echo "--- shell composition (&& and ||)"
+          if $MIRAGE execute -w smoke -c 'false' > /dev/null && echo "should not print"; then
+            echo "FAIL: && short-circuit did not work"
+            fail=1
+          else
+            echo "PASS: && correctly short-circuited on inner failure"
+          fi
+          if $MIRAGE execute -w smoke -c 'echo ok' > /dev/null && echo "should print"; then
+            echo "PASS: && correctly proceeded on inner success"
+          else
+            echo "FAIL: && incorrectly short-circuited on success"
+            fail=1
+          fi
+
+          $MIRAGE workspace delete smoke
+          $MIRAGE daemon stop || true
+
+          if [ "$fail" != "0" ]; then
+            echo
+            echo "One or more exit-code propagation checks failed."
+            exit 1
+          fi

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -143,6 +143,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: typescript/pnpm-lock.yaml
 
+      - name: Install node-gyp
+        run: npm install -g node-gyp
+
       - name: Install TypeScript dependencies
         working-directory: typescript
         run: pnpm install --frozen-lockfile

--- a/python/mirage/cli/execute.py
+++ b/python/mirage/cli/execute.py
@@ -18,7 +18,7 @@ import sys
 import typer
 
 from mirage.cli.client import make_client
-from mirage.cli.output import emit, handle_response
+from mirage.cli.output import emit, exit_code_from_response, handle_response
 
 app = typer.Typer(invoke_without_command=True, help="Execute a command.")
 
@@ -70,4 +70,6 @@ def execute_cmd(
             r = client.request("POST", path, files=files)
         else:
             r = client.request("POST", path, json=payload)
-    emit(handle_response(r))
+    response = handle_response(r)
+    emit(response)
+    raise typer.Exit(code=exit_code_from_response(response))

--- a/python/mirage/cli/job.py
+++ b/python/mirage/cli/job.py
@@ -15,7 +15,7 @@
 import typer
 
 from mirage.cli.client import make_client
-from mirage.cli.output import emit, handle_response
+from mirage.cli.output import emit, exit_code_from_response, handle_response
 
 app = typer.Typer(no_args_is_help=True, help="Manage daemon jobs.")
 
@@ -44,7 +44,9 @@ def get_cmd(job_id: str = typer.Argument(...)) -> None:
     with make_client() as client:
         client.ensure_running(allow_spawn=False)
         r = client.request("GET", f"/v1/jobs/{job_id}")
-    emit(handle_response(r))
+    response = handle_response(r)
+    emit(response)
+    raise typer.Exit(code=exit_code_from_response(response))
 
 
 @app.command("wait")
@@ -62,7 +64,9 @@ def wait_cmd(
     with make_client() as client:
         client.ensure_running(allow_spawn=False)
         r = client.request("POST", f"/v1/jobs/{job_id}/wait", json=body)
-    emit(handle_response(r))
+    response = handle_response(r)
+    emit(response)
+    raise typer.Exit(code=exit_code_from_response(response))
 
 
 @app.command("cancel")

--- a/python/mirage/cli/output.py
+++ b/python/mirage/cli/output.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import json
+import math
 import sys
 import time
 from typing import Any, Callable
@@ -40,6 +41,27 @@ def emit(obj: Any, human: Callable[[Any], str] | None = None) -> None:
 def fail(message: str, exit_code: int = 1) -> None:
     typer.echo(message, err=True)
     raise typer.Exit(code=exit_code)
+
+
+def exit_code_from_response(r: Any) -> int:
+    if not isinstance(r, dict):
+        return 0
+    if r.get("kind") == "io":
+        inner: dict | None = r
+    else:
+        result = r.get("result")
+        inner = result if isinstance(result, dict) else None
+    if inner is not None and inner.get("kind") == "io":
+        code = inner.get("exit_code")
+        if isinstance(code, bool) or not isinstance(code, (int, float)):
+            return 0
+        if not math.isfinite(code):
+            return 0
+        return max(0, min(255, int(code)))
+    status = r.get("status")
+    if status in ("failed", "canceled"):
+        return 2
+    return 0
 
 
 def handle_response(r: httpx.Response) -> dict | list:

--- a/python/tests/cli/test_cli_end_to_end.py
+++ b/python/tests/cli/test_cli_end_to_end.py
@@ -235,6 +235,30 @@ def test_provision_returns_dry_run_result(daemon, tmp_path):
     _run_cli(daemon["env"], "workspace", "delete", "provision-test")
 
 
+def test_execute_propagates_inner_exit_code(daemon, tmp_path):
+    cfg = _write_config(tmp_path)
+    _run_cli(daemon["env"], "workspace", "create", str(cfg), "--id",
+             "exit-test")
+
+    ok = _run_cli(daemon["env"], "execute", "-w", "exit-test", "-c", "echo ok")
+    assert ok["exit_code"] == 0
+
+    _run_cli(daemon["env"],
+             "execute",
+             "-w",
+             "exit-test",
+             "-c",
+             "false",
+             expect_exit=1)
+
+    bg = _run_cli(daemon["env"], "execute", "-w", "exit-test", "-c", "false",
+                  "--background")
+    job_id = bg["job_id"]
+    _run_cli(daemon["env"], "job", "wait", job_id, expect_exit=1)
+
+    _run_cli(daemon["env"], "workspace", "delete", "exit-test")
+
+
 def test_execute_subshell_cwd_does_not_leak(daemon, tmp_path):
     cfg = _write_config(tmp_path)
     _run_cli(daemon["env"], "workspace", "create", str(cfg), "--id",
@@ -268,8 +292,8 @@ def test_execute_background_then_cancel(daemon, tmp_path):
                          "sleep 30", "--background")
     job_id = submitted["job_id"]
     _run_cli(daemon["env"], "job", "cancel", job_id)
-    waited = _run_cli(daemon["env"], "job", "wait", job_id)
-    assert waited["status"] in ("canceled", "cancelled", "done")
+    waited = _run_cli(daemon["env"], "job", "wait", job_id, expect_exit=2)
+    assert waited == {}
     _run_cli(daemon["env"], "workspace", "delete", "cancel-test")
 
 

--- a/python/tests/cli/test_output.py
+++ b/python/tests/cli/test_output.py
@@ -1,0 +1,160 @@
+from mirage.cli.output import exit_code_from_response
+
+
+def test_io_zero():
+    assert exit_code_from_response({
+        "kind": "io",
+        "exit_code": 0,
+        "stdout": "",
+        "stderr": ""
+    }) == 0
+
+
+def test_io_nonzero():
+    assert exit_code_from_response({
+        "kind": "io",
+        "exit_code": 1,
+        "stdout": "",
+        "stderr": ""
+    }) == 1
+    assert exit_code_from_response({
+        "kind": "io",
+        "exit_code": 42,
+        "stdout": "",
+        "stderr": ""
+    }) == 42
+    assert exit_code_from_response({
+        "kind": "io",
+        "exit_code": 127,
+        "stdout": "",
+        "stderr": ""
+    }) == 127
+
+
+def test_clamp_high():
+    assert exit_code_from_response({"kind": "io", "exit_code": 300}) == 255
+
+
+def test_clamp_negative():
+    assert exit_code_from_response({"kind": "io", "exit_code": -1}) == 0
+
+
+def test_truncate_float():
+    assert exit_code_from_response({"kind": "io", "exit_code": 1.9}) == 1
+
+
+def test_nan_returns_zero():
+    assert exit_code_from_response({
+        "kind": "io",
+        "exit_code": float("nan")
+    }) == 0
+
+
+def test_inf_returns_zero():
+    assert exit_code_from_response({
+        "kind": "io",
+        "exit_code": float("inf")
+    }) == 0
+
+
+def test_bool_returns_zero():
+    assert exit_code_from_response({"kind": "io", "exit_code": True}) == 0
+
+
+def test_bg_submission():
+    assert exit_code_from_response({
+        "job_id": "job_abc",
+        "workspace_id": "ws",
+        "submitted_at": 0,
+    }) == 0
+
+
+def test_provision_kind():
+    assert exit_code_from_response({"kind": "provision", "detail": "ok"}) == 0
+
+
+def test_raw_kind():
+    assert exit_code_from_response({"kind": "raw", "value": "hi"}) == 0
+
+
+def test_job_detail_done():
+    assert exit_code_from_response({
+        "job_id": "job_x",
+        "status": "done",
+        "result": {
+            "kind": "io",
+            "exit_code": 7,
+            "stdout": "",
+            "stderr": ""
+        },
+        "error": None,
+    }) == 7
+
+
+def test_job_pending_returns_zero():
+    assert exit_code_from_response({
+        "job_id": "job_x",
+        "status": "pending",
+        "result": None,
+        "error": None,
+    }) == 0
+
+
+def test_job_running_returns_zero():
+    assert exit_code_from_response({
+        "job_id": "job_x",
+        "status": "running",
+        "result": None,
+        "error": None,
+    }) == 0
+
+
+def test_job_failed_no_result_returns_two():
+    assert exit_code_from_response({
+        "job_id": "job_x",
+        "status": "failed",
+        "result": None,
+        "error": "boom",
+    }) == 2
+
+
+def test_job_canceled_no_result_returns_two():
+    assert exit_code_from_response({
+        "job_id": "job_x",
+        "status": "canceled",
+        "result": None,
+        "error": None,
+    }) == 2
+
+
+def test_job_failed_with_result_prefers_inner():
+    assert exit_code_from_response({
+        "job_id": "job_x",
+        "status": "failed",
+        "result": {
+            "kind": "io",
+            "exit_code": 9,
+            "stdout": "",
+            "stderr": ""
+        },
+        "error": None,
+    }) == 9
+
+
+def test_non_dict_inputs():
+    assert exit_code_from_response(None) == 0
+    assert exit_code_from_response("string") == 0
+    assert exit_code_from_response(42) == 0
+    assert exit_code_from_response([1, 2, 3]) == 0
+
+
+def test_io_missing_exit_code():
+    assert exit_code_from_response({
+        "kind": "io",
+        "stdout": "",
+        "stderr": ""
+    }) == 0
+
+
+def test_io_non_numeric_exit_code():
+    assert exit_code_from_response({"kind": "io", "exit_code": "one"}) == 0

--- a/typescript/packages/cli/src/e2e.test.ts
+++ b/typescript/packages/cli/src/e2e.test.ts
@@ -50,6 +50,31 @@ function runCli(env: Record<string, string>, args: string[]): unknown {
   return JSON.parse(trimmed) as unknown
 }
 
+interface CliResult {
+  status: number | null
+  stdout: string
+  stderr: string
+  parsed: unknown
+}
+
+function runCliRaw(env: Record<string, string>, args: string[]): CliResult {
+  const r = spawnSync(process.execPath, [cliBin, ...args], {
+    env,
+    encoding: 'utf-8',
+    timeout: 30000,
+  })
+  const trimmed = r.stdout.trim()
+  let parsed: unknown = {}
+  if (trimmed !== '') {
+    try {
+      parsed = JSON.parse(trimmed) as unknown
+    } catch {
+      parsed = trimmed
+    }
+  }
+  return { status: r.status, stdout: r.stdout, stderr: r.stderr, parsed }
+}
+
 describe('mirage CLI end-to-end', () => {
   let tmp: string
   let env: Record<string, string>
@@ -89,6 +114,43 @@ describe('mirage CLI end-to-end', () => {
 
     const deleted = runCli(env, ['workspace', 'delete', created.id]) as { id: string }
     expect(deleted.id).toBe(created.id)
+  }, 30000)
+
+  it('execute propagates inner exit code to process exit', () => {
+    const cfgPath = join(tmp, 'exit-cfg.yaml')
+    writeFileSync(cfgPath, 'mounts:\n  /:\n    resource: ram\n    mode: write\n')
+    const created = runCli(env, ['workspace', 'create', cfgPath]) as { id: string }
+
+    const ok = runCliRaw(env, ['execute', '-w', created.id, '-c', 'true'])
+    expect(ok.status).toBe(0)
+
+    const fail = runCliRaw(env, ['execute', '-w', created.id, '-c', 'false'])
+    expect(fail.status).toBe(1)
+    expect((fail.parsed as { exitCode: number }).exitCode).toBe(1)
+
+    const pipeNoFail = runCliRaw(env, ['execute', '-w', created.id, '-c', 'false | true'])
+    expect(pipeNoFail.status).toBe(0)
+
+    const pipeFail = runCliRaw(env, [
+      'execute',
+      '-w',
+      created.id,
+      '-c',
+      'set -o pipefail; false | true',
+    ])
+    expect(pipeFail.status).toBe(1)
+
+    const bg = runCliRaw(env, ['execute', '-w', created.id, '--bg', '-c', 'false'])
+    expect(bg.status).toBe(0)
+    const jobId = (bg.parsed as { jobId: string }).jobId
+    expect(jobId).toMatch(/^job_/)
+
+    const waited = runCliRaw(env, ['job', 'wait', jobId])
+    expect(waited.status).toBe(1)
+    const result = (waited.parsed as { result: { exitCode: number } }).result
+    expect(result.exitCode).toBe(1)
+
+    runCli(env, ['workspace', 'delete', created.id])
   }, 30000)
 
   it('workspace snapshot + load round-trips', () => {

--- a/typescript/packages/cli/src/execute.ts
+++ b/typescript/packages/cli/src/execute.ts
@@ -14,7 +14,7 @@
 
 import type { Command } from 'commander'
 import { makeClient } from './client.ts'
-import { emit, handleResponse } from './output.ts'
+import { emit, exitCodeFromResponse, handleResponse } from './output.ts'
 import { loadDaemonSettings } from './settings.ts'
 
 export function registerExecuteCommand(program: Command): void {
@@ -33,7 +33,11 @@ export function registerExecuteCommand(program: Command): void {
           `/v1/workspaces/${opts.workspace}/execute` + (opts.bg === true ? '?background=true' : '')
         const c = makeClient(loadDaemonSettings())
         await c.ensureRunning({ allowSpawn: false })
-        emit(await handleResponse(await c.request('POST', path, { body: JSON.stringify(body) })))
+        const response = await handleResponse(
+          await c.request('POST', path, { body: JSON.stringify(body) }),
+        )
+        emit(response)
+        process.exit(exitCodeFromResponse(response))
       },
     )
 }

--- a/typescript/packages/cli/src/job.ts
+++ b/typescript/packages/cli/src/job.ts
@@ -14,7 +14,7 @@
 
 import type { Command } from 'commander'
 import { makeClient } from './client.ts'
-import { emit, handleResponse } from './output.ts'
+import { emit, exitCodeFromResponse, handleResponse } from './output.ts'
 import { loadDaemonSettings } from './settings.ts'
 
 function buildClient() {
@@ -41,7 +41,9 @@ export function registerJobCommands(program: Command): void {
     .action(async (id: string) => {
       const c = buildClient()
       await c.ensureRunning({ allowSpawn: false })
-      emit(await handleResponse(await c.request('GET', `/v1/jobs/${id}`)))
+      const response = await handleResponse(await c.request('GET', `/v1/jobs/${id}`))
+      emit(response)
+      process.exit(exitCodeFromResponse(response))
     })
 
   job
@@ -53,11 +55,11 @@ export function registerJobCommands(program: Command): void {
       await c.ensureRunning({ allowSpawn: false })
       const body: Record<string, unknown> = {}
       if (opts.timeout !== undefined) body.timeoutS = Number(opts.timeout)
-      emit(
-        await handleResponse(
-          await c.request('POST', `/v1/jobs/${id}/wait`, { body: JSON.stringify(body) }),
-        ),
+      const response = await handleResponse(
+        await c.request('POST', `/v1/jobs/${id}/wait`, { body: JSON.stringify(body) }),
       )
+      emit(response)
+      process.exit(exitCodeFromResponse(response))
     })
 
   job

--- a/typescript/packages/cli/src/output.test.ts
+++ b/typescript/packages/cli/src/output.test.ts
@@ -1,0 +1,131 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { exitCodeFromResponse } from './output.ts'
+
+describe('exitCodeFromResponse', () => {
+  it('returns 0 for kind:io with exitCode 0', () => {
+    expect(exitCodeFromResponse({ kind: 'io', exitCode: 0, stdout: '', stderr: '' })).toBe(0)
+  })
+
+  it('returns the exit code for kind:io with non-zero exitCode', () => {
+    expect(exitCodeFromResponse({ kind: 'io', exitCode: 1, stdout: '', stderr: '' })).toBe(1)
+    expect(exitCodeFromResponse({ kind: 'io', exitCode: 42, stdout: '', stderr: '' })).toBe(42)
+    expect(exitCodeFromResponse({ kind: 'io', exitCode: 127, stdout: '', stderr: '' })).toBe(127)
+  })
+
+  it('clamps exit codes above 255', () => {
+    expect(exitCodeFromResponse({ kind: 'io', exitCode: 300, stdout: '', stderr: '' })).toBe(255)
+  })
+
+  it('clamps negative exit codes to 0', () => {
+    expect(exitCodeFromResponse({ kind: 'io', exitCode: -1, stdout: '', stderr: '' })).toBe(0)
+  })
+
+  it('truncates non-integer exit codes', () => {
+    expect(exitCodeFromResponse({ kind: 'io', exitCode: 1.9, stdout: '', stderr: '' })).toBe(1)
+  })
+
+  it('returns 0 for background submission envelope', () => {
+    expect(exitCodeFromResponse({ jobId: 'job_abc', workspaceId: 'ws', submittedAt: 0 })).toBe(0)
+  })
+
+  it('returns 0 for kind:provision', () => {
+    expect(exitCodeFromResponse({ kind: 'provision', detail: 'ok' })).toBe(0)
+  })
+
+  it('returns 0 for kind:raw', () => {
+    expect(exitCodeFromResponse({ kind: 'raw', value: 'hi' })).toBe(0)
+  })
+
+  it('reads exit code from job detail envelope', () => {
+    expect(
+      exitCodeFromResponse({
+        jobId: 'job_x',
+        status: 'done',
+        result: { kind: 'io', exitCode: 7, stdout: '', stderr: '' },
+        error: null,
+      }),
+    ).toBe(7)
+  })
+
+  it('returns 0 for pending job (no result yet)', () => {
+    expect(
+      exitCodeFromResponse({
+        jobId: 'job_x',
+        status: 'pending',
+        result: null,
+        error: null,
+      }),
+    ).toBe(0)
+  })
+
+  it('returns 0 for running job (no result yet)', () => {
+    expect(
+      exitCodeFromResponse({
+        jobId: 'job_x',
+        status: 'running',
+        result: null,
+        error: null,
+      }),
+    ).toBe(0)
+  })
+
+  it('returns 2 for daemon-side failed job with no result', () => {
+    expect(
+      exitCodeFromResponse({
+        jobId: 'job_x',
+        status: 'failed',
+        result: null,
+        error: 'boom',
+      }),
+    ).toBe(2)
+  })
+
+  it('returns 2 for canceled job with no result', () => {
+    expect(
+      exitCodeFromResponse({
+        jobId: 'job_x',
+        status: 'canceled',
+        result: null,
+        error: null,
+      }),
+    ).toBe(2)
+  })
+
+  it('prefers inner result exit code over status-based fallback', () => {
+    expect(
+      exitCodeFromResponse({
+        jobId: 'job_x',
+        status: 'failed',
+        result: { kind: 'io', exitCode: 9, stdout: '', stderr: '' },
+        error: null,
+      }),
+    ).toBe(9)
+  })
+
+  it('returns 0 for null, undefined, and non-object inputs', () => {
+    expect(exitCodeFromResponse(null)).toBe(0)
+    expect(exitCodeFromResponse(undefined)).toBe(0)
+    expect(exitCodeFromResponse('string')).toBe(0)
+    expect(exitCodeFromResponse(42)).toBe(0)
+  })
+
+  it('returns 0 when kind:io is present but exitCode is missing or non-numeric', () => {
+    expect(exitCodeFromResponse({ kind: 'io', stdout: '', stderr: '' })).toBe(0)
+    expect(exitCodeFromResponse({ kind: 'io', exitCode: 'one', stdout: '', stderr: '' })).toBe(0)
+    expect(exitCodeFromResponse({ kind: 'io', exitCode: NaN, stdout: '', stderr: '' })).toBe(0)
+  })
+})

--- a/typescript/packages/cli/src/output.ts
+++ b/typescript/packages/cli/src/output.ts
@@ -27,6 +27,25 @@ export function fail(message: string, exitCode = 1): never {
   process.exit(exitCode)
 }
 
+export function exitCodeFromResponse(r: unknown): number {
+  if (typeof r !== 'object' || r === null) return 0
+  const obj = r as Record<string, unknown>
+  const inner =
+    obj.kind === 'io' ? obj : ((obj.result as Record<string, unknown> | null | undefined) ?? null)
+  if (
+    inner !== null &&
+    inner.kind === 'io' &&
+    typeof inner.exitCode === 'number' &&
+    Number.isFinite(inner.exitCode)
+  ) {
+    return Math.min(255, Math.max(0, Math.trunc(inner.exitCode)))
+  }
+  if (typeof obj.status === 'string' && (obj.status === 'failed' || obj.status === 'canceled')) {
+    return 2
+  }
+  return 0
+}
+
 export async function handleResponse(r: Response): Promise<unknown> {
   if (r.status >= 400) {
     let detail = await r.text()


### PR DESCRIPTION
## Summary

Closes #29.

Both the Python and TypeScript CLIs were exiting 0 regardless of the wrapped command's exit code, so `set -e`, `&&`, `||`, and `$?` all silently succeeded on every `mirage execute` invocation. The daemon already returned the correct exit code in its JSON payload (`{kind: 'io', exit_code: ...}`); only the CLI layer was dropping it on the floor.

This adds a shared `exit_code_from_response` / `exitCodeFromResponse` helper in each runtime and threads it into `execute`, `job wait`, and `job get`.

## Behavior changes

- `mirage execute -c 'false'` now exits 1 (was 0). `&&` short-circuits, `$?` reflects the inner code.
- `mirage job wait <id>` exits with the inner result's exit code once the job is terminal.
- `mirage job get <id>` on a terminal job exits with the inner result's exit code. Pending/running jobs still exit 0 (the GET succeeded; the job hasn't decided).
- A daemon-side `failed` or `canceled` job (no inner result) exits 2, matching the existing `fail()` convention for daemon HTTP errors.
- Background submission (`--bg`) still exits 0; the wait command is where propagation lands for that path.
- One existing test (`test_execute_background_then_cancel`) was updated to expect exit 2 from `job wait` on a canceled job, which is the new correct semantic.

## Exit-code taxonomy

| Situation | Exit |
| --- | --- |
| Command exits N (0-255) | N |
| `--bg` submission accepted | 0 |
| `job get` while pending/running | 0 |
| `job wait`/`get` on `done` job | inner exit code |
| `job wait`/`get` on `failed` or `canceled` job (no result) | 2 |
| Daemon HTTP 4xx/5xx | 2 (unchanged) |
| Daemon unreachable | 2 (unchanged) |

The helper clamps to `[0, 255]` and defensively rejects NaN/Inf/booleans before calling `int()` (Python) so a malformed payload can't crash the CLI.

## Tests

- 16 TS unit tests in `typescript/packages/cli/src/output.test.ts`.
- 20 Python unit tests in `python/tests/cli/test_output.py`.
- One e2e test in each runtime exercising foreground, pipefail on/off, `--bg` + `job wait`, against a real daemon.
- New cross-runtime smoke workflow `.github/workflows/test_cli.yml` that builds each CLI, creates a RAM workspace, and asserts both the process exit code AND the printed JSON field for: `echo ok`, `false`, `false | echo done` (pipefail off vs on), `--bg` + `job wait`, and `&&` short-circuit composition.

## Test plan

- [x] `cd python && uv run pytest --no-cov` (5537 passed, 215 skipped)
- [x] `cd typescript && pnpm -r test` (4157 passed)
- [x] `pre-commit run --all-files` clean
- [x] Local smoke runs against both runtimes pass end-to-end
- [x] CI green on the new `test_cli.yml` workflow