### PR TITLE
refactor(snapshot): record fp/rev on OpRecord; pin via Mount.revisions

### DIFF
--- a/docs/home/snapshot.mdx
+++ b/docs/home/snapshot.mdx
@@ -13,14 +13,14 @@ When the backend exposes a stable per-object revision marker (S3 `VersionId`, Dr
 ```mermaid
 flowchart TD
     Load["Workspace.load(tar)"] --> Inject{Manifest carries<br/>revision for path?}
-    Inject -->|yes| Pin["Resource.pin_revision(path, rev)"]
-    Inject -->|no| Mark[Mark path for drift check]
+    Inject -->|yes| Pin["mount.revisions[path] = revision"]
+    Inject -->|no| Mark[Queue (mount, path, fingerprint)<br/>for drift check]
     Pin --> Ready[Workspace ready]
     Mark --> Ready
     Ready --> First[First dispatch / execute]
-    First --> Gather[asyncio.gather drift checks<br/>skip pinned paths]
+    First --> Gather[asyncio.gather drift checks<br/>pinned paths never queued]
     Gather --> Read[Read at path]
-    Read --> Pinned{Pinned?}
+    Read --> Pinned{revision_for path<br/>set?}
     Pinned -->|yes| Versioned[GET path with VersionId<br/>= original bytes]
     Pinned -->|no| Live[GET path live]
     Live --> Match{Fingerprint<br/>matches snapshot?}
@@ -135,7 +135,7 @@ Legend: ✅ = supported · 🟡 = adapter needed (no work in flight) · 📝 = p
 | --- | :---: | :---: | :---: | :---: | --- | --- |
 | S3 | ✅ | ✅ | 📝 | 📝 | `ETag` + `VersionId` | Pin requires bucket versioning. |
 | R2 | ✅ | ✅ | 📝 | 📝 | `ETag` + `VersionId` | Inherits S3 path; pin requires R2 versioning (GA 2024). |
-| GCS | ✅ | 🟡 | 📝 | 🟡 | `ETag` + `x-goog-generation` | TODO(snapshot-gcs): map generation → `Revision` in `core/s3/stat.py`. |
+| GCS | ✅ | 🟡 | 📝 | 🟡 | `ETag` + `x-goog-generation` | TODO(snapshot-gcs): map generation → `ContentVersion(kind="revision")` in `core/s3/stat.py`. |
 | OCI | ✅ | 🟡 | 📝 | 🟡 | `ETag` + `versionId` header | TODO(snapshot-oci): same shape as GCS adapter. |
 | Supabase | ✅ | ❌ | 📝 | ❌ | `ETag` only | Inherits `S3Resource`. Supabase's S3-compat endpoint does not surface object `VersionId`, so drift detection works but pinning is not available. |
 
@@ -154,8 +154,9 @@ Legend: ✅ = supported · 🟡 = adapter needed (no work in flight) · 📝 = p
 Three steps in Python:
 
 ```python
+from mirage.observe.context import record, revision_for
 from mirage.resource.base import BaseResource
-from mirage.types import FileStat, Fingerprint, Revision
+from mirage.types import FileStat
 
 
 class MyResource(BaseResource):
@@ -164,17 +165,31 @@ class MyResource(BaseResource):
     async def stat(self, ...) -> FileStat:
         return FileStat(
             ...,
-            fingerprint=Fingerprint(my_etag_equivalent),   # 2. for drift
-            revision=Revision(my_revision_marker),         # optional, for pin
+            fingerprint=my_etag_equivalent,        # 2. for drift
+            revision=my_revision_marker_or_None,   # 3. optional, for pin
         )
-
-    def pin_revision(self, path: str, revision: Revision) -> bool:
-        # 3. honor the pin on subsequent reads
-        self.accessor.revision_pins[path] = revision
-        return True
 ```
 
-If your backend has no stable revision, omit step 3 — drift detection still works.
+And in your read function, look up the active pin and pass both the
+fingerprint and the revision through to ``record`` so the snapshot
+captures whatever the backend served:
+
+```python
+async def read_bytes(accessor, virtual_path, ...):
+    pinned = revision_for(virtual_path)  # 4. None if no pin installed
+    response = backend_get(virtual_path, revision=pinned)
+    record(
+        "read", virtual_path, "my-backend", len(response.body), start_ms,
+        fingerprint=response.etag,        # 5. for drift detection
+        revision=response.revision,       # 6. for pinning on replay
+    )
+    return response.body
+```
+
+At load time the workspace writes each manifest entry straight into
+``mount.revisions`` — no per-resource hook required. If your backend
+has no stable revision, skip steps 3 and 6; drift detection still
+works on the fingerprint alone.
 
 ## Caveats
 

--- a/python/mirage/accessor/s3.py
+++ b/python/mirage/accessor/s3.py
@@ -13,11 +13,9 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.base import Accessor
-from mirage.types import Revision
 
 
 class S3Accessor(Accessor):
 
     def __init__(self, config) -> None:
         self.config = config
-        self.revision_pins: dict[str, Revision] = {}

--- a/python/mirage/core/s3/read.py
+++ b/python/mirage/core/s3/read.py
@@ -17,8 +17,27 @@ import time
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.s3._client import _client_kwargs, _key, async_session
-from mirage.observe.context import record
+from mirage.observe.context import record, revision_for
 from mirage.types import PathSpec
+
+
+def _fp_rev_from_response(resp: dict) -> tuple[str | None, str | None]:
+    """Extract ``(fingerprint, revision)`` from a boto GET response.
+
+    Args:
+        resp (dict): The raw response dict from ``client.get_object``.
+
+    Returns:
+        tuple[str | None, str | None]: ``(ETag-without-quotes,
+        VersionId)``. ``VersionId`` is None on non-versioned buckets
+        (boto returns the literal string ``"null"`` there, which we
+        normalize to None).
+    """
+    etag = resp.get("ETag", "").strip('"') or None
+    vid = resp.get("VersionId")
+    if vid == "null":
+        vid = None
+    return etag, vid
 
 
 async def read_bytes(accessor: S3Accessor,
@@ -32,7 +51,6 @@ async def read_bytes(accessor: S3Accessor,
         accessor (S3Accessor): S3 accessor.
         path (PathSpec | str): Object path.
         index: Index cache store.
-        prefix (str): Mount prefix.
         offset (int): Byte offset for range reads.
         size (int | None): Number of bytes for range reads.
     """
@@ -47,9 +65,9 @@ async def read_bytes(accessor: S3Accessor,
     config = accessor.config
     key = _key(path)
     kwargs = {"Bucket": config.bucket, "Key": key}
-    pin = accessor.revision_pins.get(virtual)
-    if pin:
-        kwargs["VersionId"] = pin
+    pinned_revision = revision_for(virtual)
+    if pinned_revision is not None:
+        kwargs["VersionId"] = pinned_revision
     if offset or size is not None:
         end = (offset + size - 1) if size is not None else ""
         kwargs["Range"] = f"bytes={offset}-{end}"
@@ -59,7 +77,14 @@ async def read_bytes(accessor: S3Accessor,
         async with session.client(**_client_kwargs(config)) as client:
             resp = await client.get_object(**kwargs)
             data = await resp["Body"].read()
-            record("read", path, "s3", len(data), start_ms)
+            fingerprint, revision = _fp_rev_from_response(resp)
+            record("read",
+                   path,
+                   "s3",
+                   len(data),
+                   start_ms,
+                   fingerprint=fingerprint,
+                   revision=revision)
             return data
     except Exception as exc:
         if (hasattr(exc, "response")

--- a/python/mirage/core/s3/stat.py
+++ b/python/mirage/core/s3/stat.py
@@ -17,7 +17,7 @@ from datetime import timezone
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.s3._client import _client_kwargs, _key, async_session
-from mirage.types import FileStat, FileType, Fingerprint, PathSpec, Revision
+from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.filetype import guess_type
 
 
@@ -92,8 +92,8 @@ async def stat(accessor: S3Accessor,
                 size=resp["ContentLength"],
                 modified=modified,
                 type=guess_type(path),
-                fingerprint=Fingerprint(etag_raw) if etag_raw else None,
-                revision=Revision(vid_raw) if vid_raw else None,
+                fingerprint=etag_raw or None,
+                revision=vid_raw or None,
                 extra={"etag": etag_raw},
             )
         except Exception as exc:

--- a/python/mirage/core/s3/stream.py
+++ b/python/mirage/core/s3/stream.py
@@ -18,7 +18,8 @@ from collections.abc import AsyncIterator
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.s3._client import _client_kwargs, _key, async_session
-from mirage.observe.context import record, record_stream
+from mirage.core.s3.read import _fp_rev_from_response
+from mirage.observe.context import record, record_stream, revision_for
 from mirage.types import PathSpec
 
 
@@ -44,15 +45,19 @@ async def read_stream(
         path = path.original
     if prefix and path.startswith(prefix):
         path = path[len(prefix):] or "/"
-    pin = accessor.revision_pins.get(virtual)
+    pinned_revision = revision_for(virtual)
     config = accessor.config
     rec = record_stream("read", path, "s3")
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:
         kwargs: dict = {"Bucket": config.bucket, "Key": _key(path)}
-        if pin:
-            kwargs["VersionId"] = pin
+        if pinned_revision is not None:
+            kwargs["VersionId"] = pinned_revision
         response = await client.get_object(**kwargs)
+        if rec is not None:
+            fingerprint, revision = _fp_rev_from_response(response)
+            rec.fingerprint = fingerprint
+            rec.revision = revision
         async for chunk in response["Body"].iter_chunks(chunk_size):
             if rec is not None:
                 rec.bytes += len(chunk)
@@ -83,10 +88,17 @@ async def range_read(accessor: S3Accessor, path: PathSpec, start: int,
             "Key": _key(path),
             "Range": f"bytes={start}-{end - 1}",
         }
-        pin = accessor.revision_pins.get(virtual)
-        if pin:
-            kwargs["VersionId"] = pin
+        pinned_revision = revision_for(virtual)
+        if pinned_revision is not None:
+            kwargs["VersionId"] = pinned_revision
         response = await client.get_object(**kwargs)
         data = await response["Body"].read()
-        record("read", path, "s3", len(data), start_ms)
+        fingerprint, revision = _fp_rev_from_response(response)
+        record("read",
+               path,
+               "s3",
+               len(data),
+               start_ms,
+               fingerprint=fingerprint,
+               revision=revision)
         return data

--- a/python/mirage/observe/context.py
+++ b/python/mirage/observe/context.py
@@ -122,8 +122,13 @@ def _virtual(path: str, prefix: str) -> str:
     return path
 
 
-def record(op: str, path: str, source: str, nbytes: int,
-           start_ms: int) -> None:
+def record(op: str,
+           path: str,
+           source: str,
+           nbytes: int,
+           start_ms: int,
+           fingerprint: str | None = None,
+           revision: str | None = None) -> None:
     """Record a byte transfer event. No-op if no recording context is active.
 
     Args:
@@ -132,6 +137,11 @@ def record(op: str, path: str, source: str, nbytes: int,
         source (str): Resource name ("s3", "ram", "disk").
         nbytes (int): Bytes transferred.
         start_ms (int): Monotonic start time in milliseconds.
+        fingerprint (str | None): Content-derived identifier returned by
+            the backend (ETag, md5). Used for drift detection at replay.
+        revision (str | None): Stable revision handle returned by the
+            backend (S3 ``VersionId``, Drive ``revisionId``, Git SHA).
+            Used to pin replay reads to the exact recorded version.
     """
     rec = _recorder.get()
     if rec is None:
@@ -147,22 +157,35 @@ def record(op: str, path: str, source: str, nbytes: int,
             timestamp=int(time.time() * 1000),
             duration_ms=elapsed,
             mount_prefix=prefix,
+            fingerprint=fingerprint,
+            revision=revision,
         ))
 
 
-def record_stream(op: str, path: str, source: str) -> OpRecord | None:
+def record_stream(op: str,
+                  path: str,
+                  source: str,
+                  fingerprint: str | None = None,
+                  revision: str | None = None) -> OpRecord | None:
     """Start recording a streaming transfer. Returns a mutable OpRecord.
 
-    The caller updates `rec.bytes` as chunks flow through. The record is
-    appended to the active recorder immediately so it captures partial
-    consumption (e.g., head stopping early).
+    The caller updates ``rec.bytes`` as chunks flow through. The record
+    is appended to the active recorder immediately so it captures
+    partial consumption (e.g., head stopping early). The caller may
+    also assign ``rec.fingerprint`` / ``rec.revision`` after the initial
+    GET response is available; passing them here is a shortcut for the
+    common case where the values are known up front.
 
-    Returns None if no recording context is active.
+    Returns ``None`` if no recording context is active.
 
     Args:
         op (str): Operation name ("read", "write").
         path (str): Resource-relative path.
         source (str): Resource name ("s3", "ram", "disk").
+        fingerprint (str | None): Initial fingerprint; the caller can
+            also set ``rec.fingerprint`` later.
+        revision (str | None): Initial revision; the caller can also set
+            ``rec.revision`` later.
 
     Returns:
         OpRecord | None: Mutable record, or None if not recording.
@@ -179,6 +202,89 @@ def record_stream(op: str, path: str, source: str) -> OpRecord | None:
         timestamp=int(time.time() * 1000),
         duration_ms=0,
         mount_prefix=prefix,
+        fingerprint=fingerprint,
+        revision=revision,
     )
     rec.sink.append(op_rec)
     return op_rec
+
+
+_revisions: ContextVar[dict[str, str] | None] = ContextVar("_revisions",
+                                                           default=None)
+
+
+def push_revisions(revisions: dict[str, str] | None):
+    """Set the active revision map for the current async context.
+
+    Read functions consult :func:`revision_for` to look up whether a
+    given virtual path should be pinned to a specific backend revision
+    on replay. Mount entry points push their ``revisions`` map here
+    before dispatching, so any read fired inside the mount's command or
+    op handler sees the pin without explicit threading.
+
+    Returns the token from ``ContextVar.set`` so callers can restore
+    the previous state via :func:`reset_revisions`. Task-isolated: the
+    ContextVar copy is per-task, so concurrent mounts don't see each
+    other's pins.
+
+    Args:
+        revisions (dict[str, str] | None): Mapping of virtual path to
+            backend revision. None clears the active map.
+
+    Returns:
+        Token: passable to ``reset_revisions``.
+    """
+    return _revisions.set(revisions)
+
+
+def reset_revisions(token) -> None:
+    """Restore the previous revisions map after a :func:`push_revisions`.
+
+    Args:
+        token: The token returned by ``push_revisions``.
+    """
+    _revisions.reset(token)
+
+
+def revision_for(path: str) -> str | None:
+    """Return the revision pin for ``path`` if one is active.
+
+    Args:
+        path (str): Virtual path (mount_prefix + rel_path).
+
+    Returns:
+        str | None: The pinned revision, or None if no revisions
+        context is active or the path has no pin.
+    """
+    revs = _revisions.get()
+    if revs is None:
+        return None
+    return revs.get(path)
+
+
+async def with_revisions(revisions: dict[str, str] | None,
+                         it: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
+    """Wrap an async iterator so the active revisions map is ``revisions``
+    during each ``__anext__`` of the underlying stream.
+
+    Mirrors :func:`with_mount_prefix`. A command handler can return an
+    async generator that defers its backend ``read_stream`` call to the
+    first chunk request; by the time the caller consumes it, the
+    dispatcher's ``revisions`` context would otherwise have been reset.
+    Wrapping with this restores the pins on every iteration.
+
+    Args:
+        revisions (dict[str, str] | None): Revisions to push during
+            iteration.
+        it (AsyncIterator[bytes]): The stream to wrap.
+    """
+    aiter = it.__aiter__()
+    while True:
+        token = push_revisions(revisions)
+        try:
+            chunk = await aiter.__anext__()
+        except StopAsyncIteration:
+            reset_revisions(token)
+            return
+        reset_revisions(token)
+        yield chunk

--- a/python/mirage/observe/record.py
+++ b/python/mirage/observe/record.py
@@ -30,6 +30,19 @@ class OpRecord:
             (e.g. "/s3"). Empty when recorded outside any mount frame.
             Stored explicitly so consumers don't have to re-derive it
             from the virtual path.
+        fingerprint (str | None): For read ops on a backend that supports
+            snapshot+replay, the content-derived identifier the backend
+            returned (e.g. S3 ``ETag``, md5). Used to detect drift at
+            replay time. Captured at read time so the snapshot reflects
+            what the agent actually saw. None for writes, metadata ops,
+            and backends without snapshot support.
+        revision (str | None): For read ops on a backend that exposes
+            stable revision handles (S3 ``VersionId``, Drive
+            ``revisionId``, Git commit SHA), the value the backend
+            returned. Used to pin reads at replay time so the original
+            bytes can be re-fetched even if the live object has moved on.
+            Strictly stronger than ``fingerprint`` — populated only by
+            backends that can guarantee revision durability.
     """
 
     op: str
@@ -39,6 +52,8 @@ class OpRecord:
     timestamp: int
     duration_ms: int
     mount_prefix: str = field(default="")
+    fingerprint: str | None = field(default=None)
+    revision: str | None = field(default=None)
 
     @property
     def is_cache(self) -> bool:

--- a/python/mirage/resource/base.py
+++ b/python/mirage/resource/base.py
@@ -18,7 +18,6 @@ from typing import Any, Callable
 from mirage.accessor.base import Accessor
 from mirage.cache.index import (IndexCacheStore, IndexConfig,
                                 RAMIndexCacheStore, RedisIndexConfig)
-from mirage.types import Revision
 
 try:
     from mirage.cache.index import RedisIndexCacheStore
@@ -92,34 +91,6 @@ class BaseResource:
             str | None: Fingerprint string, or None if always fresh.
         """
         return None
-
-    def pin_revision(self, path: str, revision: Revision) -> bool:
-        """Pin future reads at `path` to a specific revision.
-
-        Snapshot+replay hook. When the snapshot manifest carries a
-        ``revision`` for a recorded read, ``Workspace.load`` calls this
-        on the owning resource to install the pin. Subsequent reads at
-        that path then fetch the exact recorded version (e.g. S3
-        ``GetObject(VersionId=...)``) instead of the current head, and
-        the drift check skips the path because the bytes are guaranteed
-        to match by construction.
-
-        Default returns False: the backend does not support revision
-        pinning, so the load layer will fall back to drift detection
-        only. Override in subclasses that can honor a pin (S3 family
-        today; Google Drive, GitHub, Azure Blob in the future).
-
-        Args:
-            path (str): Virtual path whose reads should be pinned.
-            revision (Revision): Opaque per-backend revision marker
-                that was captured at snapshot time.
-
-        Returns:
-            bool: True if the pin was accepted and future reads will
-            honor it; False if the backend does not pin (caller falls
-            back to drift detection).
-        """
-        return False
 
     def register_op(self, fn) -> None:
         for ro in fn._registered_ops:

--- a/python/mirage/resource/s3/s3.py
+++ b/python/mirage/resource/s3/s3.py
@@ -39,7 +39,7 @@ from mirage.core.s3.write import write_bytes
 from mirage.ops.s3 import OPS as S3_OPS
 from mirage.resource.base import BaseResource
 from mirage.resource.s3.prompt import PROMPT
-from mirage.types import PathSpec, ResourceName, Revision
+from mirage.types import PathSpec, ResourceName
 
 _S3_OPS = {
     "read_bytes": read_bytes,
@@ -110,32 +110,6 @@ class S3Resource(BaseResource):
             return remote.extra.get("etag")
         except FileNotFoundError:
             return None
-
-    def pin_revision(self, path: str, revision: Revision) -> bool:
-        """Pin reads at `path` to an S3 ``VersionId``.
-
-        Subsequent ``GetObject`` calls from
-        :mod:`mirage.core.s3.read` /
-        :mod:`mirage.core.s3.stream` pick the pin out of
-        ``accessor.revision_pins`` and pass it as ``VersionId=``,
-        serving the exact recorded bytes even if the live object has
-        since been overwritten or deleted (subject to the bucket's
-        versioning retention).
-
-        Inherited unchanged by ``R2Resource``, ``GCSResource``, and
-        ``OCIResource`` because they all delegate to the same S3
-        client; bucket versioning must be enabled at the source for
-        the pin to actually resolve.
-
-        Args:
-            path (str): Virtual path whose reads should be pinned.
-            revision (Revision): S3 ``VersionId`` recorded at snapshot.
-
-        Returns:
-            bool: Always True.
-        """
-        self.accessor.revision_pins[path] = revision
-        return True
 
     def get_state(self) -> dict:
         redacted = [

--- a/python/mirage/server/clone.py
+++ b/python/mirage/server/clone.py
@@ -16,12 +16,8 @@ from typing import Any
 
 from mirage import Workspace
 from mirage.resource.registry import build_resource
+from mirage.workspace.snapshot import to_state_dict
 from mirage.workspace.snapshot.utils import norm_mount_prefix
-
-
-async def _to_state(ws: Workspace) -> dict:
-    from mirage.workspace.snapshot import to_state_dict
-    return await to_state_dict(ws)
 
 
 def _build_override_resources(override: dict[str, Any] | None) -> dict:
@@ -81,7 +77,7 @@ async def clone_workspace_with_override(src_ws: Workspace,
     Returns:
         Workspace: a new, independent workspace.
     """
-    state = await _to_state(src_ws)
+    state = to_state_dict(src_ws)
     override_resources = _build_override_resources(override)
     existing = _existing_needs_override_resources(src_ws,
                                                   skip=set(override_resources))

--- a/python/mirage/types.py
+++ b/python/mirage/types.py
@@ -14,12 +14,8 @@
 
 from dataclasses import dataclass
 from enum import Enum, StrEnum
-from typing import NewType
 
 from pydantic import BaseModel, ConfigDict, Field
-
-Fingerprint = NewType("Fingerprint", str)
-Revision = NewType("Revision", str)
 
 
 class FileType(str, Enum):
@@ -46,8 +42,8 @@ class FileStat(BaseModel):
     name: str
     size: int | None = None
     modified: str | None = None
-    fingerprint: Fingerprint | None = None
-    revision: Revision | None = None
+    fingerprint: str | None = None
+    revision: str | None = None
     type: FileType | None = None
     extra: dict = Field(default_factory=dict)
 

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -20,7 +20,9 @@ from mirage.commands.config import RegisteredCommand
 from mirage.commands.resolve import get_extension
 from mirage.commands.spec import CommandSpec
 from mirage.io.types import ByteSource, IOResult
-from mirage.observe.context import push_mount_prefix, with_mount_prefix
+from mirage.observe.context import (push_mount_prefix, push_revisions,
+                                    reset_revisions, with_mount_prefix,
+                                    with_revisions)
 from mirage.ops.registry import RegisteredOp
 from mirage.resource.base import BaseResource
 from mirage.types import ConsistencyPolicy, MountMode, PathSpec
@@ -29,10 +31,12 @@ from mirage.types import ConsistencyPolicy, MountMode, PathSpec
 def _wrap_cmd_streams(
     result: tuple[ByteSource | None, IOResult],
     mount_prefix: str,
+    revisions: dict[str, str] | None,
 ) -> tuple[ByteSource | None, IOResult]:
     """Wrap any async-iterator streams in ``result`` with the mount
-    prefix, so ``record_stream`` calls inside the lazy backend body
-    see the correct prefix when consumed after this frame exits.
+    prefix and active revisions, so ``record_stream`` and
+    ``revision_for`` calls inside the lazy backend body see the right
+    context when consumed after this frame exits.
 
     Mirrors the ``exit_on_empty`` pattern: thin async-gen wrapper that
     side-effects the recorder state as bytes flow through. Same object
@@ -42,6 +46,8 @@ def _wrap_cmd_streams(
     Args:
         result: ``(stream, io)`` as returned by a command handler.
         mount_prefix: prefix to push during stream consumption.
+        revisions: revisions map to push during stream consumption
+            (None when the mount has no pins installed).
     """
     stream, io = result
     seen: dict[int, ByteSource] = {}
@@ -53,6 +59,8 @@ def _wrap_cmd_streams(
         if oid in seen:
             return seen[oid]
         wrapped = with_mount_prefix(mount_prefix, obj)
+        if revisions:
+            wrapped = with_revisions(revisions, wrapped)
         seen[oid] = wrapped
         return wrapped
 
@@ -94,6 +102,13 @@ class Mount:
         self.resource = resource
         self.mode = mode
         self.consistency = consistency
+        # Per-path revision pins installed at Workspace.load time. Read
+        # functions consult these via the ``revision_for`` contextvar
+        # lookup; on a hit, the backend GET pins to the recorded
+        # revision so replay serves the exact bytes the agent saw.
+        # Empty during normal runs; populated only by the snapshot
+        # loader.
+        self.revisions: dict[str, str] = {}
         self._cmds: dict[tuple, RegisteredCommand] = {}
         self._general_cmds: dict[str, RegisteredCommand] = {}
         self._cmd_specs: dict[str, CommandSpec] = {}
@@ -416,6 +431,7 @@ class Mount:
             kw["session_id"] = session_id
 
         prev_prefix = push_mount_prefix(mount_prefix)
+        revs_token = push_revisions(self.revisions or None)
         try:
             for cmd in handlers:
                 if cmd.write and self.mode == MountMode.READ:
@@ -426,9 +442,11 @@ class Mount:
                 result = await cmd.fn(self.resource.accessor, paths, *texts,
                                       **kw)
                 if result is not None:
-                    return _wrap_cmd_streams(result, mount_prefix)
+                    return _wrap_cmd_streams(result, mount_prefix,
+                                             self.revisions or None)
             return None, IOResult()
         finally:
+            reset_revisions(revs_token)
             push_mount_prefix(prev_prefix)
 
     async def execute_op(
@@ -465,6 +483,7 @@ class Mount:
         )
         kwargs.setdefault("index", self.resource.index)
         prev_prefix = push_mount_prefix(mount_prefix)
+        revs_token = push_revisions(self.revisions or None)
         try:
             for op in levels:
                 result = op.fn(self.resource.accessor, scope, *args, **kwargs)
@@ -474,4 +493,5 @@ class Mount:
                     return result
             return None
         finally:
+            reset_revisions(revs_token)
             push_mount_prefix(prev_prefix)

--- a/python/mirage/workspace/snapshot/api.py
+++ b/python/mirage/workspace/snapshot/api.py
@@ -20,10 +20,10 @@ from mirage.workspace.snapshot.tar_io import write_tar
 async def snapshot(ws, target, *, compress: str | None = None) -> None:
     """Serialize a Workspace to a tar archive.
 
-    Async because fingerprint capture for SUPPORTS_SNAPSHOT mounts calls
-    each touched path's stat() to lock in the version markers (S3 ETag,
-    etc.) the agent saw. Without this, replay cannot detect upstream
-    drift.
+    Fingerprints come from ``ws._ops.records`` (each read carries the
+    backend's version marker captured at the moment of the read), so
+    no live network round-trips are needed at snapshot time. Kept as
+    ``async def`` for API stability and future-proofing.
 
     Workspace.load and Workspace.copy own the inverse direction
     (construction). Snapshot does not construct Workspace — that
@@ -35,6 +35,6 @@ async def snapshot(ws, target, *, compress: str | None = None) -> None:
             object (BytesIO, etc.).
         compress: None | "gz" | "bz2" | "xz".
     """
-    state = await to_state_dict(ws)
+    state = to_state_dict(ws)
     manifest, blobs = split_manifest_and_blobs(state)
     write_tar(target, manifest, blobs, compress=compress)

--- a/python/mirage/workspace/snapshot/drift.py
+++ b/python/mirage/workspace/snapshot/drift.py
@@ -46,55 +46,51 @@ class ContentDriftError(Exception):
             "since the snapshot was taken")
 
 
-async def capture_fingerprints(ws) -> list[dict]:
-    """Walk session ops and capture fingerprints for every distinct
-    remote read on a SUPPORTS_SNAPSHOT mount.
+def capture_fingerprints(ws) -> list[dict]:
+    """Walk session ops and emit one entry per distinct read on a
+    ``SUPPORTS_SNAPSHOT`` mount.
+
+    Pure aggregation over ``ws._ops.records``. Each read ``OpRecord``
+    carries the ``fingerprint`` and/or ``revision`` the backend
+    returned at the moment the agent read the bytes (populated from
+    the GET response, not a fresh stat at snapshot time). This avoids
+    the race where the upstream changes between read and snapshot.
 
     Skips paths whose owning mount has ``SUPPORTS_SNAPSHOT=False``
-    (live-only backends like Gmail/Slack/Linear) and paths the resource
-    cannot fingerprint (``stat()`` returned ``None``). The optional
-    ``revision`` (e.g. S3 ``VersionId``, Drive ``revisionId``) is
-    captured alongside the fingerprint when the backend exposes one;
-    load-time replay uses it to pin reads, bypassing drift detection.
+    (live-only backends like Gmail/Slack/Linear) and reads where the
+    backend returned neither marker.
 
     Args:
-        ws: Workspace whose ops history to walk.
+        ws: Workspace whose ops log to walk.
 
     Returns:
-        list[dict]: One entry per fingerprinted path, with ``PATH``,
-        ``MOUNT_PREFIX``, ``FINGERPRINT`` and optionally ``REVISION``.
+        list[dict]: One entry per (recorded, fingerprinted) path, with
+        ``PATH``, ``MOUNT_PREFIX`` and at least one of ``FINGERPRINT``
+        or ``REVISION``. Both may be present on versioned backends that
+        return ETag and VersionId on every GET.
     """
     seen: set[str] = set()
     out: list[dict] = []
     for rec in ws._ops.records:
-        if rec.op != "read":
+        if rec.op != "read" or rec.path in seen:
             continue
-        path = rec.path
-        if path in seen:
+        if rec.fingerprint is None and rec.revision is None:
             continue
-        seen.add(path)
+        seen.add(rec.path)
         try:
-            mount = ws._registry.mount_for(path)
+            mount = ws._registry.mount_for(rec.path)
         except ValueError:
             continue
         if not getattr(mount.resource, "SUPPORTS_SNAPSHOT", False):
             continue
-        try:
-            stat = await mount.execute_op("stat", path)
-        except Exception as exc:
-            logger.debug("fingerprint capture skipped %s: %s", path, exc)
-            continue
-        marker = getattr(stat, "fingerprint", None)
-        if marker is None:
-            continue
         entry: dict = {
-            FingerprintKey.PATH: path,
+            FingerprintKey.PATH: rec.path,
             FingerprintKey.MOUNT_PREFIX: mount.prefix,
-            FingerprintKey.FINGERPRINT: marker,
         }
-        rev = getattr(stat, "revision", None)
-        if rev:
-            entry[FingerprintKey.REVISION] = rev
+        if rec.fingerprint is not None:
+            entry[FingerprintKey.FINGERPRINT] = rec.fingerprint
+        if rec.revision is not None:
+            entry[FingerprintKey.REVISION] = rec.revision
         out.append(entry)
     return out
 

--- a/python/mirage/workspace/snapshot/state.py
+++ b/python/mirage/workspace/snapshot/state.py
@@ -34,7 +34,7 @@ def _mirage_version() -> str:
         return "unknown"
 
 
-async def to_state_dict(ws) -> dict:
+def to_state_dict(ws) -> dict:
     auto_prefixes = {"/dev/"}
     if ws.observer is not None:
         auto_prefixes.add(norm_mount_prefix(ws.observer.prefix))
@@ -70,7 +70,7 @@ async def to_state_dict(ws) -> dict:
         if j.status != JobStatus.RUNNING
     ]
 
-    fingerprints = await capture_fingerprints(ws)
+    fingerprints = capture_fingerprints(ws)
     live_only_mounts = live_only_mount_prefixes(ws)
 
     return {

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -43,8 +43,7 @@ from mirage.shell.job_table import JobTable
 from mirage.shell.parse import find_syntax_error, parse
 from mirage.types import (DEFAULT_AGENT_ID, DEFAULT_SESSION_ID,
                           ConsistencyPolicy, DriftPolicy, FileStat,
-                          FingerprintKey, MountMode, PathSpec, Revision,
-                          StateKey)
+                          FingerprintKey, MountMode, PathSpec, StateKey)
 from mirage.workspace.abort import MirageAbortError
 from mirage.workspace.fuse import FuseManager
 from mirage.workspace.history import ExecutionHistory
@@ -117,10 +116,11 @@ class Workspace:
         self._registry.set_default_mount(self._cache)
         self._locked_paths: set[str] = set()
         self._closed = False
-        self._fingerprints: dict[str, str] = {}
         self._drift_policy: DriftPolicy = DriftPolicy.OFF
         self._drift_check_pending: bool = False
-        self._pinned_paths: set[str] = set()
+        # Queued at Workspace.load: (mount, path, expected_fingerprint).
+        # First dispatch/execute drains via asyncio.gather, then clears.
+        self._pending_drift: list[tuple[Mount, str, str]] = []
         self.job_table = JobTable()
         self._current_agent_id: str = agent_id
         self._default_session_id = session_id
@@ -192,6 +192,21 @@ class Workspace:
 
     def mounts(self) -> list:
         return self._registry.mounts()
+
+    @property
+    def revisions(self) -> dict[str, str]:
+        """Flat view of every mount's installed revision pins.
+
+        Derived (read-only) — the source of truth lives per-mount on
+        ``mount.revisions``. Useful for tests, audit ("which paths got
+        pinned at load?"), and debugging. Empty until a snapshot is
+        loaded with revisions in its manifest.
+        """
+        out: dict[str, str] = {}
+        for m in self._registry.mounts():
+            if m.revisions:
+                out.update(m.revisions)
+        return out
 
     def mount(self, prefix: str):
         return self._registry.mount_for(prefix)
@@ -334,16 +349,19 @@ class Workspace:
              drift_policy: DriftPolicy = DriftPolicy.STRICT) -> "Workspace":
         """Reconstruct a Workspace from a tar.
 
-        Per recorded read:
-            1. Revision recorded + backend accepts the pin (e.g. S3
-               with bucket versioning): reads are pinned to that
-               revision via ``Resource.pin_revision``. Drift check
-               skipped (original bytes served even if the live object
-               moved on).
-            2. No revision (or backend rejected the pin): live
-               fingerprint compared against recorded. STRICT raises
-               ``ContentDriftError`` on mismatch. OFF evicts the
-               snapshot cache for the path so reads serve current.
+        For every recorded read:
+
+        1. If the manifest entry carries a ``revision`` (e.g. S3
+           ``VersionId``), the load installs it into the owning
+           ``mount.revisions``. Replay reads pin to that revision via
+           the ``revision_for`` contextvar lookup, so the original
+           bytes are served. Drift check is skipped for these paths —
+           the pin guarantees bytes match by construction.
+        2. If the entry carries only a ``fingerprint`` (no stable
+           revision), the load queues a drift check. STRICT raises
+           ``ContentDriftError`` on the first mismatch; OFF skips the
+           check entirely and evicts the snapshot cache so reads serve
+           current state.
 
         Drift check is eager (fires once on the first dispatch or
         execute), so downstream code can rely on consistent state.
@@ -359,27 +377,26 @@ class Workspace:
         state = read_tar(source)
         ws = cls._from_state(state, resources=resources)
         fingerprint_entries = state.get(StateKey.FINGERPRINTS) or []
-        ws._fingerprints = {
-            f[FingerprintKey.PATH]: f[FingerprintKey.FINGERPRINT]
-            for f in fingerprint_entries
-        }
         ws._drift_policy = drift_policy
-        ws._drift_check_pending = (drift_policy != DriftPolicy.OFF
-                                   and bool(ws._fingerprints))
-        if drift_policy != DriftPolicy.OFF:
+        if drift_policy == DriftPolicy.OFF:
+            if fingerprint_entries:
+                ws._cache.evict_paths(f[FingerprintKey.PATH]
+                                      for f in fingerprint_entries)
+        else:
             for f in fingerprint_entries:
-                rev = f.get(FingerprintKey.REVISION)
-                if not rev:
-                    continue
                 path = f[FingerprintKey.PATH]
                 try:
                     mount = ws._registry.mount_for(path)
                 except ValueError:
                     continue
-                if mount.resource.pin_revision(path, Revision(rev)):
-                    ws._pinned_paths.add(path)
-        if drift_policy == DriftPolicy.OFF and ws._fingerprints:
-            ws._cache.evict_paths(ws._fingerprints)
+                revision = f.get(FingerprintKey.REVISION)
+                if revision is not None:
+                    mount.revisions[path] = revision
+                    continue
+                fingerprint = f.get(FingerprintKey.FINGERPRINT)
+                if fingerprint is not None:
+                    ws._pending_drift.append((mount, path, fingerprint))
+            ws._drift_check_pending = bool(ws._pending_drift)
         live_only = state.get(StateKey.LIVE_ONLY_MOUNTS) or []
         if live_only:
             logger.warning(
@@ -397,7 +414,7 @@ class Workspace:
         # (S3, Redis, GDrive...). Local content resources (RAM, Disk)
         # are reconstructed fresh so the copy's writes don't clobber
         # the original's in-process data.
-        state = await to_state_dict(self)
+        state = to_state_dict(self)
         auto_prefixes = {"/dev/"}
         if self.observer is not None:
             auto_prefixes.add(norm_mount_prefix(self.observer.prefix))
@@ -517,28 +534,26 @@ class Workspace:
 
         Called once on the first async entry point (``dispatch`` or
         ``execute``) after ``Workspace.load`` with a non-OFF drift
-        policy. Stats every recorded fingerprint against the live
-        source in parallel and raises :class:`ContentDriftError` on the
-        first mismatch. Subsequent calls are no-ops.
+        policy. Stats every queued ``(mount, path, expected_fingerprint)``
+        triple against the live source in parallel and raises
+        :class:`ContentDriftError` on the first mismatch. Subsequent
+        calls are no-ops.
 
-        Paths that carry a revision pin are skipped: reads against them
-        will fetch the exact recorded version, so a live fingerprint
-        mismatch is expected and harmless.
+        Pinned paths (those whose manifest entry carried a stable
+        revision) are never enqueued, because the pin guarantees bytes
+        match by construction.
 
         Stats are issued with ``asyncio.gather`` so first-op latency
-        does not scale linearly with the number of recorded reads. The
-        order in which checks complete is irrelevant; the first
-        mismatch to surface cancels the rest via ``return_exceptions``
-        re-raise.
+        does not scale linearly with the number of recorded reads.
         """
         self._drift_check_pending = False
-        checks = [
-            check_drift(self, path, recorded)
-            for path, recorded in self._fingerprints.items()
-            if path not in self._pinned_paths
-        ]
-        if not checks:
+        if not self._pending_drift:
             return
+        checks = [
+            check_drift(self, path, fingerprint)
+            for _, path, fingerprint in self._pending_drift
+        ]
+        self._pending_drift.clear()
         results = await asyncio.gather(*checks, return_exceptions=True)
         for r in results:
             if isinstance(r, BaseException):

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -90,7 +90,7 @@ class AsyncMockS3Client:
         data = self.objects[Key]
         if Range is not None:
             data = _slice_range(data, Range)
-        return {"Body": AsyncMockBody(data)}
+        return {"Body": AsyncMockBody(data), "ETag": f'"{Key}"'}
 
     async def head_object(self, Bucket: str, Key: str) -> dict:
         del Bucket

--- a/python/tests/integration/s3_mock.py
+++ b/python/tests/integration/s3_mock.py
@@ -145,11 +145,12 @@ class MultiBucketS3Client:
                          Key: str,
                          Range: str | None = None,
                          VersionId: str | None = None) -> dict:
-        self._track(Bucket, Key)
+        vid_for_resp = self._track(Bucket, Key)
         if VersionId is not None:
             history = self._versions.get((Bucket, Key), [])
             for vid, data in history:
                 if vid == VersionId:
+                    vid_for_resp = vid
                     break
             else:
                 raise _mock_s3_error("NoSuchVersion")
@@ -158,9 +159,13 @@ class MultiBucketS3Client:
             if Key not in objects:
                 raise _mock_s3_error("NoSuchKey")
             data = objects[Key]
+        etag = hashlib.md5(data).hexdigest()
         if Range is not None:
             data = _slice_range(data, Range)
-        return {"Body": _AsyncMockBody(data)}
+        resp: dict = {"Body": _AsyncMockBody(data), "ETag": f'"{etag}"'}
+        if vid_for_resp is not None:
+            resp["VersionId"] = vid_for_resp
+        return resp
 
     async def head_object(self, Bucket: str, Key: str) -> dict:
         objects = self._objects(Bucket)

--- a/python/tests/integration/test_snapshot_drift_live.py
+++ b/python/tests/integration/test_snapshot_drift_live.py
@@ -163,6 +163,46 @@ def test_live_no_drift_passes(tmp_path):
         _cleanup_key(key)
 
 
+def test_live_pin_records_agent_version_not_snapshot_time_version(tmp_path):
+    """Race-fix regression test.
+
+    Agent reads V1 at T1. Between T1 and snapshot at T3, an external
+    actor mutates the object to V2. Old design (live stat at snapshot
+    time) would capture V2's VersionId and pin replay to V2, serving
+    bytes the agent never saw. New design records VersionId at READ
+    time (from the GET response headers), so the snapshot pins to V1
+    and serves V1 bytes on cache miss.
+
+    Skipped on non-versioned buckets (no revision = no pin).
+    """
+    if not _versioning_enabled():
+        pytest.skip("requires versioning")
+
+    key = _probe_key()
+    probe = f"/s3/{key}"
+    client = _boto_client()
+    client.put_object(Bucket=LIVE_BUCKET, Key=key, Body=b"v1\n")
+    try:
+        src = Workspace(_mount(), mode=MountMode.WRITE)
+        result = asyncio.run(src.execute(f"cat {probe}"))
+        assert b"v1" in result.stdout
+
+        # Race: upstream changes BEFORE snapshot fires
+        client.put_object(Bucket=LIVE_BUCKET, Key=key, Body=b"v2-racy\n")
+
+        snap = tmp_path / "racy.tar"
+        asyncio.run(src.snapshot(snap))
+
+        dst = Workspace.load(snap, resources=_override())
+        dst._cache.evict_paths([probe])
+        result = asyncio.run(dst.execute(f"cat {probe}"))
+        assert result.stdout == b"v1\n", (
+            f"snapshot pinned the wrong VersionId; served {result.stdout!r} "
+            "instead of the V1 the agent actually saw")
+    finally:
+        _cleanup_key(key)
+
+
 def test_live_version_pin_serves_original_on_versioned_bucket(tmp_path):
     """End-to-end pin: with bucket versioning enabled, snapshot captures
     the live VersionId. After the bucket head moves on, STRICT load
@@ -225,7 +265,7 @@ def test_live_off_policy_serves_current(tmp_path):
         dst = Workspace.load(snap,
                              resources=_override(),
                              drift_policy=DriftPolicy.OFF)
-        assert dst._pinned_paths == set()
+        assert dst.revisions == {}
         result = asyncio.run(dst.execute(f"cat {probe}"))
         assert b"mutated" in result.stdout
     finally:

--- a/python/tests/observe/test_context.py
+++ b/python/tests/observe/test_context.py
@@ -12,7 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.observe.context import (push_mount_prefix, record, start_recording,
+from mirage.observe.context import (push_mount_prefix, push_revisions, record,
+                                    record_stream, reset_revisions,
+                                    revision_for, start_recording,
                                     stop_recording)
 
 
@@ -84,3 +86,86 @@ def test_push_mount_prefix_returns_previous():
 
 def test_push_mount_prefix_no_recorder_is_noop():
     assert push_mount_prefix("/s3") == ""
+
+
+def test_record_carries_fingerprint_when_passed():
+    records = start_recording()
+    record("read", "/s3/x", "s3", 10, 0, fingerprint="abc")
+    stop_recording()
+    assert records[0].fingerprint == "abc"
+    assert records[0].revision is None
+
+
+def test_record_carries_revision_when_passed():
+    records = start_recording()
+    record("read", "/s3/x", "s3", 10, 0, revision="v1")
+    stop_recording()
+    assert records[0].revision == "v1"
+    assert records[0].fingerprint is None
+
+
+def test_record_carries_both_when_passed():
+    records = start_recording()
+    record("read", "/s3/x", "s3", 10, 0, fingerprint="abc", revision="v1")
+    stop_recording()
+    assert records[0].fingerprint == "abc"
+    assert records[0].revision == "v1"
+
+
+def test_record_fingerprint_default_is_none():
+    records = start_recording()
+    record("read", "/s3/x", "s3", 10, 0)
+    stop_recording()
+    assert records[0].fingerprint is None
+    assert records[0].revision is None
+
+
+def test_record_stream_carries_fingerprint_when_passed():
+    records = start_recording()
+    rec = record_stream("read", "/s3/x", "s3", fingerprint="abc")
+    stop_recording()
+    assert rec is not None
+    assert records[0].fingerprint == "abc"
+
+
+def test_record_stream_carries_revision_when_passed():
+    records = start_recording()
+    rec = record_stream("read", "/s3/x", "s3", revision="v1")
+    stop_recording()
+    assert rec is not None
+    assert records[0].revision == "v1"
+
+
+def test_record_stream_assignable_after_open():
+    records = start_recording()
+    rec = record_stream("read", "/s3/x", "s3")
+    assert rec.fingerprint is None
+    assert rec.revision is None
+    rec.fingerprint = "abc"
+    rec.revision = "v2"
+    stop_recording()
+    assert records[0].fingerprint == "abc"
+    assert records[0].revision == "v2"
+
+
+def test_revision_for_no_context():
+    assert revision_for("/s3/a") is None
+
+
+def test_revision_for_with_context():
+    token = push_revisions({"/s3/a": "v1", "/s3/b": "v2"})
+    try:
+        assert revision_for("/s3/a") == "v1"
+        assert revision_for("/s3/b") == "v2"
+        assert revision_for("/s3/c") is None
+    finally:
+        reset_revisions(token)
+    assert revision_for("/s3/a") is None
+
+
+def test_revision_for_with_none_context():
+    token = push_revisions(None)
+    try:
+        assert revision_for("/s3/a") is None
+    finally:
+        reset_revisions(token)

--- a/python/tests/observe/test_op_record.py
+++ b/python/tests/observe/test_op_record.py
@@ -31,6 +31,51 @@ def test_op_record_fields():
     assert r.bytes == 1024
     assert r.timestamp == 1711800000000
     assert r.duration_ms == 150
+    assert r.fingerprint is None
+    assert r.revision is None
+
+
+def test_op_record_with_fingerprint():
+    r = OpRecord(
+        op="read",
+        path="/s3/data/file.csv",
+        source="s3",
+        bytes=1024,
+        timestamp=1711800000000,
+        duration_ms=150,
+        fingerprint="abc123",
+    )
+    assert r.fingerprint == "abc123"
+    assert r.revision is None
+
+
+def test_op_record_with_revision():
+    r = OpRecord(
+        op="read",
+        path="/s3/data/file.csv",
+        source="s3",
+        bytes=1024,
+        timestamp=1711800000000,
+        duration_ms=150,
+        revision="vL5_raa...",
+    )
+    assert r.revision == "vL5_raa..."
+    assert r.fingerprint is None
+
+
+def test_op_record_with_both():
+    r = OpRecord(
+        op="read",
+        path="/s3/data/file.csv",
+        source="s3",
+        bytes=1024,
+        timestamp=1711800000000,
+        duration_ms=150,
+        fingerprint="abc123",
+        revision="vL5_raa...",
+    )
+    assert r.fingerprint == "abc123"
+    assert r.revision == "vL5_raa..."
 
 
 def test_op_record_zero_bytes():

--- a/python/tests/workspace/test_snapshot.py
+++ b/python/tests/workspace/test_snapshot.py
@@ -294,7 +294,7 @@ def test_workspace_copy_preserves_max_drain_bytes():
 def test_to_state_dict_shape():
     ws = Workspace({"/m": (RAMResource(), MountMode.WRITE)},
                    mode=MountMode.WRITE)
-    state = asyncio.run(to_state_dict(ws))
+    state = to_state_dict(ws)
     assert state["version"] == 2
     assert "mirage_version" in state
     assert isinstance(state["mounts"], list)


### PR DESCRIPTION
## Summary

Two related fixes against the snapshot+replay design landed in #32.

### 1. Record fingerprint and revision at **read time** (race fix)

The previous capture path did a live `stat()` per recorded read **at snapshot time**. That races concurrent upstream writes: if the object moved between the agent's read and the snapshot call, replay pinned to the newer version and served bytes the agent never saw.

Now each `OpRecord` carries flat `fingerprint: str | None` and `revision: str | None` fields, populated from the `GetObject` response at the moment of the read. `capture_fingerprints` became a pure aggregator over `ws._ops.records` — no live stats, no race.

### 2. Move pin state off the accessor, onto Mount

The accessor's job is backend transport (config, client kwargs); replay pins are a Mirage concept. Storage now lives at `Mount.revisions: dict[str, str]`. Read functions look up the active pin via a new `revision_for(path)` contextvar lookup, pushed by `Mount.execute_cmd` and `Mount.execute_op` around dispatch (and preserved across lazy stream consumption via `with_revisions`, mirroring `with_mount_prefix`).

## What dropped

| Removed | Why |
|---|---|
| `ContentVersion` tagged union | Two flat fields (`fingerprint`, `revision`) carry more information on versioned backends (you get **both**, not one) and don't need a `.pinnable` accessor. |
| `Resource.record_captured_version` | `Workspace.load` writes directly to `mount.revisions` for entries with a revision, and queues `(mount, path, fingerprint)` tuples for fingerprint-only entries. |
| `accessor.captured_versions` | `S3Accessor` is back to a thin config holder. |

## What renamed

- `Workspace.captured_versions` -> `Workspace.revisions` (derived view over `mount.revisions` for audit/debug).
- `Workspace._run_pending_drift_check` iterates the queued list instead of walking accessor state and filtering for non-pinnable entries.

## Test plan

- [x] `cd python && uv run pytest --no-cov` -- 5,558 passed, 221 skipped
- [x] Live S3 against `mirage-ai-test` (versioning ON): 5 passed, 1 skipped — including the race regression test `test_live_pin_records_agent_version_not_snapshot_time_version`
- [x] `pre-commit run --all-files`: all Python hooks pass (TS hooks fail due to local pnpm env; CI runs them)

## Docs

[docs/home/snapshot.mdx](docs/home/snapshot.mdx) updated:

- Mermaid label: `mount.revisions[path] = revision` (was `Resource.record_captured_version`)
- Drift queue node: `Queue (mount, path, fingerprint) for drift check`
- Pinned-read branch: `revision_for path set?`
- Extension recipe rewritten to show the `revision_for(...)` lookup in a backend read function plus `record(fingerprint=..., revision=...)`. No per-resource hook to implement anymore.