### PR TITLE
feat(ts): snapshot+replay drift detection and revision pinning for S3

### DIFF
--- a/examples/typescript/s3/s3_write.ts
+++ b/examples/typescript/s3/s3_write.ts
@@ -26,7 +26,17 @@
 // The example exercises the full S3Resource surface: writes (tee, cp, mv,
 // rm, mkdir), reads (cat, head, grep, wc), find, and the du/rmR helpers.
 // At the end it clears all keys it wrote so the demo is reproducible.
-import { MountMode, S3Resource, Workspace, type S3Config } from '@struktoai/mirage-node'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  ContentDriftError,
+  DriftPolicy,
+  MountMode,
+  S3Resource,
+  Workspace,
+  type S3Config,
+} from '@struktoai/mirage-node'
 
 const DEC = new TextDecoder()
 
@@ -61,6 +71,119 @@ async function ensureBucket(): Promise<void> {
     }
   } finally {
     client.destroy()
+  }
+}
+
+async function tryEnableVersioning(): Promise<boolean> {
+  const sdk = await import('@aws-sdk/client-s3')
+  const client = new sdk.S3Client({
+    region: config.region,
+    endpoint: config.endpoint,
+    forcePathStyle: true,
+    credentials: { accessKeyId: config.accessKeyId!, secretAccessKey: config.secretAccessKey! },
+  })
+  try {
+    await client.send(
+      new sdk.PutBucketVersioningCommand({
+        Bucket: config.bucket,
+        VersioningConfiguration: { Status: 'Enabled' },
+      }),
+    )
+    const resp = await client.send(
+      new sdk.GetBucketVersioningCommand({ Bucket: config.bucket }),
+    )
+    return resp.Status === 'Enabled'
+  } catch {
+    return false
+  } finally {
+    client.destroy()
+  }
+}
+
+async function putObjectViaSdk(key: string, body: string): Promise<void> {
+  const sdk = await import('@aws-sdk/client-s3')
+  const client = new sdk.S3Client({
+    region: config.region,
+    endpoint: config.endpoint,
+    forcePathStyle: true,
+    credentials: { accessKeyId: config.accessKeyId!, secretAccessKey: config.secretAccessKey! },
+  })
+  try {
+    await client.send(
+      new sdk.PutObjectCommand({ Bucket: config.bucket, Key: key, Body: body }),
+    )
+  } finally {
+    client.destroy()
+  }
+}
+
+async function deleteObjectViaSdk(key: string): Promise<void> {
+  const sdk = await import('@aws-sdk/client-s3')
+  const client = new sdk.S3Client({
+    region: config.region,
+    endpoint: config.endpoint,
+    forcePathStyle: true,
+    credentials: { accessKeyId: config.accessKeyId!, secretAccessKey: config.secretAccessKey! },
+  })
+  try {
+    await client.send(new sdk.DeleteObjectCommand({ Bucket: config.bucket, Key: key }))
+  } catch {
+    // Best-effort cleanup; ignore tombstone artifacts on versioned buckets.
+  } finally {
+    client.destroy()
+  }
+}
+
+async function driftAndPinDemo(): Promise<void> {
+  console.log('\n=== DRIFT + VERSION PIN ===\n')
+  const versioned = await tryEnableVersioning()
+  console.log(`  bucket versioning: ${versioned ? 'enabled' : 'unavailable (drift only)'}`)
+
+  const probeKey = `drift-probe-${Math.random().toString(36).slice(2, 10)}.txt`
+  const probeVirtual = `/s3/${probeKey}`
+  await putObjectViaSdk(probeKey, 'original\n')
+
+  const ws = new Workspace({ '/s3/': new S3Resource(config) }, { mode: MountMode.WRITE })
+  const tempDir = mkdtempSync(join(tmpdir(), 'mirage-drift-'))
+  const snap = join(tempDir, 'pin.json')
+  try {
+    const readRes = await ws.execute(`cat ${probeVirtual}`)
+    console.log(`  agent saw: ${JSON.stringify(readRes.stdoutText.trim())}`)
+    const size = await ws.snapshot(snap)
+    console.log(`  snapshot: ${snap} (${String(size)} bytes)`)
+
+    await putObjectViaSdk(probeKey, 'mutated\n')
+    console.log('  upstream mutated to "mutated"')
+
+    const loaded = await Workspace.load(
+      snap,
+      { mode: MountMode.WRITE, driftPolicy: DriftPolicy.STRICT },
+      { '/s3/': new S3Resource(config) },
+    )
+    const pinned = Object.keys(loaded.revisions)
+    console.log(`  installed pins: ${pinned.length === 0 ? '(none)' : pinned.join(', ')}`)
+    try {
+      const replay = await loaded.execute(`cat ${probeVirtual}`)
+      const served = replay.stdoutText.trim()
+      if (versioned && served === 'original') {
+        console.log(`  STRICT load -> served: ${JSON.stringify(served)} (OK pin served original)`)
+      } else if (!versioned) {
+        console.log(`  STRICT load -> served: ${JSON.stringify(served)} (no pin available)`)
+      } else {
+        console.log(`  STRICT load -> served: ${JSON.stringify(served)} (UNEXPECTED)`)
+      }
+    } catch (err) {
+      if (err instanceof ContentDriftError) {
+        console.log(`  STRICT load raised ContentDriftError as expected: ${err.path}`)
+      } else {
+        throw err
+      }
+    } finally {
+      await loaded.close()
+    }
+  } finally {
+    await ws.close()
+    await deleteObjectViaSdk(probeKey)
   }
 }
 
@@ -117,6 +240,8 @@ async function main(): Promise<void> {
   } finally {
     await ws.close()
   }
+
+  await driftAndPinDemo()
 }
 
 main().catch((err: unknown) => {

--- a/typescript/packages/browser/src/resource/s3/s3.ts
+++ b/typescript/packages/browser/src/resource/s3/s3.ts
@@ -61,6 +61,7 @@ export interface S3ResourceState {
 }
 
 export class S3Resource implements Resource {
+  readonly supportsSnapshot: boolean = true
   readonly kind: string = ResourceName.S3
   readonly isRemote: boolean = true
   readonly indexTtl: number = 600

--- a/typescript/packages/core/src/core/s3/read.ts
+++ b/typescript/packages/core/src/core/s3/read.ts
@@ -13,7 +13,8 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { IndexCacheStore } from '../../cache/index/store.ts'
-import type { PathSpec } from '../../types.ts'
+import { record, revisionFor } from '../../observe/context.ts'
+import { ResourceName, type PathSpec } from '../../types.ts'
 import type { S3Accessor } from '../../accessor/s3.ts'
 import { createS3Client, isNotFoundError, loadS3Module, s3Key, streamToBuffer } from './_client.ts'
 
@@ -22,33 +23,71 @@ export interface S3ReadOptions {
   size?: number
 }
 
+/**
+ * Extract `(fingerprint, revision)` from a GetObject / HeadObject response.
+ *
+ * VersionId is null on non-versioned buckets; the SDK can also return the
+ * literal string "null" there, which we normalize.
+ */
+export function fpRevFromS3Response(resp: { ETag?: string | null; VersionId?: string | null }): {
+  fingerprint: string | null
+  revision: string | null
+} {
+  const rawEtag = resp.ETag ?? ''
+  const fingerprint = rawEtag.replace(/^"|"$/g, '') || null
+  let vid = resp.VersionId ?? null
+  if (vid === 'null') vid = null
+  return { fingerprint, revision: vid }
+}
+
 export async function read(
   accessor: S3Accessor,
   path: PathSpec,
   _index?: IndexCacheStore,
   options: S3ReadOptions = {},
 ): Promise<Uint8Array> {
-  const original = path.original
+  const virtual = path.original
   const prefix = path.prefix
   const rawPath =
-    prefix !== '' && original.startsWith(prefix) ? original.slice(prefix.length) || '/' : original
+    prefix !== '' && virtual.startsWith(prefix) ? virtual.slice(prefix.length) || '/' : virtual
+  // `virtual` retains the mount prefix (e.g. /s3/foo) for snapshot records;
+  // `rawPath` is the backend-relative key used for the actual S3 call.
   const key = s3Key(rawPath)
   const { config } = accessor
   const { GetObjectCommand } = await loadS3Module(config)
   const client = await createS3Client(config)
   const input: Record<string, unknown> = { Bucket: config.bucket, Key: key }
+  const pinnedRevision = revisionFor(virtual)
+  if (pinnedRevision !== null) {
+    input.VersionId = pinnedRevision
+  }
   if (options.offset !== undefined || options.size !== undefined) {
     const start = options.offset ?? 0
     const end = options.size !== undefined ? start + options.size - 1 : ''
     input.Range = `bytes=${String(start)}-${String(end)}`
   }
+  const startMs = performance.now()
   try {
     const resp = (await (
       client as unknown as {
-        send: (cmd: unknown) => Promise<{ Body?: unknown }>
+        send: (cmd: unknown) => Promise<{ Body?: unknown; ETag?: string; VersionId?: string }>
       }
-    ).send(new GetObjectCommand(input))) as { Body?: unknown }
-    return await streamToBuffer(resp.Body)
+    ).send(new GetObjectCommand(input))) as {
+      Body?: unknown
+      ETag?: string
+      VersionId?: string
+    }
+    const bytes = await streamToBuffer(resp.Body)
+    const { fingerprint, revision } = fpRevFromS3Response(resp)
+    // Use the virtual (mount-prefixed) path here rather than rawPath +
+    // an applyPrefix lookup, because lazy stream consumption can outlive
+    // the mount's setVirtualPrefix scope. Passing virtual makes record's
+    // path independent of the active recording context state.
+    record('read', virtual, ResourceName.S3, bytes.byteLength, startMs, {
+      fingerprint,
+      revision,
+    })
+    return bytes
   } catch (err) {
     if (isNotFoundError(err)) {
       const e = new Error(`S3 object not found: ${rawPath}`) as Error & { code: string }

--- a/typescript/packages/core/src/core/s3/stat.ts
+++ b/typescript/packages/core/src/core/s3/stat.ts
@@ -109,14 +109,18 @@ export async function stat(
         ContentLength?: number
         LastModified?: Date
         ETag?: string
+        VersionId?: string
       }
       const modified = resp.LastModified?.toISOString() ?? null
       const etag = resp.ETag?.replace(/^"|"$/g, '') ?? ''
+      let revision = resp.VersionId ?? null
+      if (revision === 'null') revision = null
       return new FileStat({
         name: basename(rawPath),
         size: resp.ContentLength ?? null,
         modified,
         fingerprint: etag !== '' ? etag : null,
+        revision,
         type: guessType(rawPath),
         extra: etag !== '' ? { etag } : {},
       })

--- a/typescript/packages/core/src/core/s3/stream.ts
+++ b/typescript/packages/core/src/core/s3/stream.ts
@@ -12,37 +12,55 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { PathSpec } from '../../types.ts'
+import { recordStream, revisionFor } from '../../observe/context.ts'
+import { ResourceName, type PathSpec } from '../../types.ts'
 import type { S3Accessor } from '../../accessor/s3.ts'
 import { createS3Client, isNotFoundError, loadS3Module, s3Key } from './_client.ts'
+import { fpRevFromS3Response } from './read.ts'
 
 const DEFAULT_CHUNK_SIZE = 64 * 1024
 
 export async function* stream(accessor: S3Accessor, path: PathSpec): AsyncIterable<Uint8Array> {
-  const original = path.original
+  const virtual = path.original
   const prefix = path.prefix
   const rawPath =
-    prefix !== '' && original.startsWith(prefix) ? original.slice(prefix.length) || '/' : original
+    prefix !== '' && virtual.startsWith(prefix) ? virtual.slice(prefix.length) || '/' : virtual
 
   const { config } = accessor
   const { GetObjectCommand } = await loadS3Module(config)
   const client = await createS3Client(config)
   const send = (
     client as unknown as {
-      send: (cmd: unknown) => Promise<{ Body?: unknown }>
+      send: (cmd: unknown) => Promise<{ Body?: unknown; ETag?: string; VersionId?: string }>
     }
   ).send.bind(client)
 
+  const pinnedRevision = revisionFor(virtual)
+  const input: Record<string, unknown> = { Bucket: config.bucket, Key: s3Key(rawPath) }
+  if (pinnedRevision !== null) input.VersionId = pinnedRevision
+
+  // Use virtual (mount-prefixed) path so the record stays correct even
+  // when the stream body executes after setVirtualPrefix has been reset.
+  const rec = recordStream('read', virtual, ResourceName.S3)
+
   try {
-    const resp = (await send(
-      new GetObjectCommand({ Bucket: config.bucket, Key: s3Key(rawPath) }),
-    )) as { Body?: unknown }
+    const resp = (await send(new GetObjectCommand(input))) as {
+      Body?: unknown
+      ETag?: string
+      VersionId?: string
+    }
+    if (rec !== null) {
+      const { fingerprint, revision } = fpRevFromS3Response(resp)
+      rec.fingerprint = fingerprint
+      rec.revision = revision
+    }
     const body = resp.Body as
       | (AsyncIterable<Uint8Array> & { [Symbol.asyncIterator]?: () => AsyncIterator<Uint8Array> })
       | undefined
     if (body === undefined) return
     if (typeof body[Symbol.asyncIterator] === 'function') {
       for await (const chunk of body) {
+        if (rec !== null) rec.bytes += chunk.byteLength
         yield chunk
       }
     }

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export {
   ConsistencyPolicy,
   DEFAULT_AGENT_ID,
   DEFAULT_SESSION_ID,
+  DriftPolicy,
   FileStat,
   type FileStatInit,
   FileType,
@@ -25,6 +26,13 @@ export {
   type PathSpecInit,
   ResourceName,
 } from './types.ts'
+export {
+  captureFingerprints,
+  checkDrift,
+  ContentDriftError,
+  type FingerprintEntry,
+  liveOnlyMountPrefixes,
+} from './workspace/snapshot/drift.ts'
 export { type FindOptions, type Resource, throwUnsupported } from './resource/base.ts'
 export { RAMResource } from './resource/ram/ram.ts'
 export { RAMStore } from './resource/ram/store.ts'
@@ -186,7 +194,14 @@ export {
 export { OpRecord, type OpRecordInit } from './observe/record.ts'
 export { LogEntry, type LogEntryInit } from './observe/log_entry.ts'
 export { Observer } from './observe/observer.ts'
-export { record, recordStream, runWithRecording, setVirtualPrefix } from './observe/context.ts'
+export {
+  record,
+  recordStream,
+  revisionFor,
+  runWithRecording,
+  runWithRevisions,
+  setVirtualPrefix,
+} from './observe/context.ts'
 export { guessType } from './utils/filetype.ts'
 export { Accessor, NOOPAccessor, RAMAccessor } from './accessor/index.ts'
 export { cat as featherCat, describe as featherDescribe } from './core/filetype/feather.ts'
@@ -442,7 +457,7 @@ export { exists } from './core/s3/exists.ts'
 export { find } from './core/s3/find.ts'
 export { resolveGlob as resolveS3Glob } from './core/s3/glob.ts'
 export { mkdir } from './core/s3/mkdir.ts'
-export { read } from './core/s3/read.ts'
+export { fpRevFromS3Response, read } from './core/s3/read.ts'
 export { readdir } from './core/s3/readdir.ts'
 export { rename } from './core/s3/rename.ts'
 export { rmR } from './core/s3/rm.ts'

--- a/typescript/packages/core/src/observe/context.test.ts
+++ b/typescript/packages/core/src/observe/context.test.ts
@@ -14,7 +14,14 @@
 
 /* eslint-disable @typescript-eslint/require-await */
 import { describe, expect, it } from 'vitest'
-import { record, runWithRecording, setVirtualPrefix } from './context.ts'
+import {
+  record,
+  recordStream,
+  revisionFor,
+  runWithRecording,
+  runWithRevisions,
+  setVirtualPrefix,
+} from './context.ts'
 
 describe('runWithRecording / record / setVirtualPrefix', () => {
   it('record outside recording scope is a no-op', () => {
@@ -69,5 +76,82 @@ describe('runWithRecording / record / setVirtualPrefix', () => {
       record('read', '/s3/data/file.json', 's3', 100, 0)
     })
     expect(records[0]?.path).toBe('/s3/data/file.json')
+  })
+})
+
+describe('OpRecord: fingerprint + revision', () => {
+  it('record() persists fingerprint and revision on the OpRecord', async () => {
+    const [, records] = await runWithRecording(async () => {
+      record('read', '/a.txt', 's3', 100, performance.now(), {
+        fingerprint: 'abc',
+        revision: 'v1',
+      })
+    })
+    expect(records.length).toBe(1)
+    expect(records[0]?.fingerprint).toBe('abc')
+    expect(records[0]?.revision).toBe('v1')
+  })
+
+  it('record() defaults fingerprint and revision to null', async () => {
+    const [, records] = await runWithRecording(async () => {
+      record('read', '/a.txt', 's3', 100, performance.now())
+    })
+    expect(records[0]?.fingerprint).toBeNull()
+    expect(records[0]?.revision).toBeNull()
+  })
+
+  it('recordStream() persists fingerprint and revision', async () => {
+    let rec: ReturnType<typeof recordStream> = null
+    const [, records] = await runWithRecording(async () => {
+      rec = recordStream('read', '/a.txt', 's3', { fingerprint: 'abc', revision: 'v1' })
+    })
+    expect(rec).not.toBeNull()
+    expect(records[0]?.fingerprint).toBe('abc')
+    expect(records[0]?.revision).toBe('v1')
+  })
+
+  it('recordStream() allows late mutation of fp/rev on the returned record', async () => {
+    const [, records] = await runWithRecording(async () => {
+      const rec = recordStream('read', '/a.txt', 's3')
+      if (rec !== null) {
+        rec.fingerprint = 'late-fp'
+        rec.revision = 'late-rev'
+      }
+    })
+    expect(records[0]?.fingerprint).toBe('late-fp')
+    expect(records[0]?.revision).toBe('late-rev')
+  })
+})
+
+describe('revisions context', () => {
+  it('revisionFor returns null outside any revisions scope', () => {
+    expect(revisionFor('/s3/a')).toBeNull()
+  })
+
+  it('revisionFor returns null when null is passed as the map', async () => {
+    await runWithRevisions(null, async () => {
+      expect(revisionFor('/s3/a')).toBeNull()
+    })
+  })
+
+  it('runWithRevisions exposes the installed map; restores prior state after fn', async () => {
+    await runWithRevisions(
+      new Map([
+        ['/s3/a', 'v1'],
+        ['/s3/b', 'v2'],
+      ]),
+      async () => {
+        expect(revisionFor('/s3/a')).toBe('v1')
+        expect(revisionFor('/s3/b')).toBe('v2')
+        expect(revisionFor('/s3/c')).toBeNull()
+      },
+    )
+    expect(revisionFor('/s3/a')).toBeNull()
+  })
+
+  it('runWithRevisions works independently of runWithRecording', async () => {
+    await runWithRevisions(new Map([['/s3/a', 'v1']]), async () => {
+      expect(revisionFor('/s3/a')).toBe('v1')
+    })
   })
 })

--- a/typescript/packages/core/src/observe/context.ts
+++ b/typescript/packages/core/src/observe/context.ts
@@ -22,6 +22,17 @@ interface RecordingState {
 
 const storage = createAsyncContext<RecordingState>()
 
+/**
+ * Per-task revision pins. Independent of the recording context so that
+ * direct {@link Workspace.dispatch} calls (which run outside
+ * {@link runWithRecording}) still honour installed pins.
+ */
+interface RevisionsState {
+  map: Map<string, string> | null
+}
+
+const revisionsStorage = createAsyncContext<RevisionsState>()
+
 export async function runWithRecording<T>(fn: () => Promise<T>): Promise<[T, OpRecord[]]> {
   const state: RecordingState = { records: [], virtualPrefix: '' }
   const value = await storage.run(state, fn)
@@ -33,12 +44,18 @@ export function setVirtualPrefix(prefix: string): void {
   if (state !== undefined) state.virtualPrefix = prefix
 }
 
+export interface RecordOptions {
+  fingerprint?: string | null
+  revision?: string | null
+}
+
 export function record(
   op: string,
   path: string,
   source: string,
   nbytes: number,
   startMs: number,
+  options: RecordOptions = {},
 ): void {
   const state = storage.getStore()
   if (state === undefined) return
@@ -51,11 +68,18 @@ export function record(
       bytes: nbytes,
       timestamp: Date.now(),
       durationMs: elapsed,
+      fingerprint: options.fingerprint ?? null,
+      revision: options.revision ?? null,
     }),
   )
 }
 
-export function recordStream(op: string, path: string, source: string): OpRecord | null {
+export function recordStream(
+  op: string,
+  path: string,
+  source: string,
+  options: RecordOptions = {},
+): OpRecord | null {
   const state = storage.getStore()
   if (state === undefined) return null
   const rec = new OpRecord({
@@ -65,9 +89,38 @@ export function recordStream(op: string, path: string, source: string): OpRecord
     bytes: 0,
     timestamp: Date.now(),
     durationMs: 0,
+    fingerprint: options.fingerprint ?? null,
+    revision: options.revision ?? null,
   })
   state.records.push(rec)
   return rec
+}
+
+/**
+ * Run `fn` inside a revisions context. Backend read functions inside
+ * `fn` (or any async chain it starts) can consult {@link revisionFor}
+ * to look up a pin. Independent of {@link runWithRecording} so that
+ * direct {@link Workspace.dispatch} calls (which don't open a recording
+ * scope) still honour installed pins.
+ *
+ * Task-isolated via AsyncLocalStorage: concurrent runs on different
+ * mounts each see their own pin map.
+ */
+export function runWithRevisions<T>(
+  revisions: Map<string, string> | null,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return Promise.resolve(revisionsStorage.run({ map: revisions }, fn))
+}
+
+/**
+ * Look up the active revision pin for `path`, or null if no pin is
+ * installed (or no revisions context is active).
+ */
+export function revisionFor(path: string): string | null {
+  const state = revisionsStorage.getStore()
+  if (state === undefined || state.map === null) return null
+  return state.map.get(path) ?? null
 }
 
 function applyPrefix(prefix: string, path: string): string {

--- a/typescript/packages/core/src/observe/context.ts
+++ b/typescript/packages/core/src/observe/context.ts
@@ -118,9 +118,9 @@ export function runWithRevisions<T>(
  * installed (or no revisions context is active).
  */
 export function revisionFor(path: string): string | null {
-  const state = revisionsStorage.getStore()
-  if (state === undefined || state.map === null) return null
-  return state.map.get(path) ?? null
+  const map = revisionsStorage.getStore()?.map
+  if (!map) return null
+  return map.get(path) ?? null
 }
 
 function applyPrefix(prefix: string, path: string): string {

--- a/typescript/packages/core/src/observe/record.ts
+++ b/typescript/packages/core/src/observe/record.ts
@@ -21,6 +21,20 @@ export interface OpRecordInit {
   bytes: number
   timestamp: number
   durationMs: number
+  /**
+   * Content-derived identifier the backend returned for this read (ETag,
+   * md5). Captured at read time so the snapshot reflects what the agent
+   * actually saw. Null for writes, metadata ops, and backends without
+   * snapshot support.
+   */
+  fingerprint?: string | null
+  /**
+   * Stable revision handle the backend returned (S3 VersionId, Drive
+   * revisionId, Git SHA). Strictly stronger than fingerprint — populated
+   * only by backends that can guarantee revision durability. Used by
+   * replay to pin reads to the exact recorded version.
+   */
+  revision?: string | null
 }
 
 export class OpRecord {
@@ -30,6 +44,8 @@ export class OpRecord {
   bytes: number
   readonly timestamp: number
   durationMs: number
+  fingerprint: string | null
+  revision: string | null
 
   constructor(init: OpRecordInit) {
     this.op = init.op
@@ -38,6 +54,8 @@ export class OpRecord {
     this.bytes = init.bytes
     this.timestamp = init.timestamp
     this.durationMs = init.durationMs
+    this.fingerprint = init.fingerprint ?? null
+    this.revision = init.revision ?? null
   }
 
   get isCache(): boolean {
@@ -52,6 +70,8 @@ export class OpRecord {
       bytes: this.bytes,
       timestamp: this.timestamp,
       durationMs: this.durationMs,
+      fingerprint: this.fingerprint,
+      revision: this.revision,
     }
   }
 }

--- a/typescript/packages/core/src/resource/base.ts
+++ b/typescript/packages/core/src/resource/base.ts
@@ -39,6 +39,16 @@ export interface Resource {
   readonly writePrompt?: string
   readonly indexTtl?: number
   readonly isRemote?: boolean
+  /**
+   * Whether this resource carries enough version information for
+   * snapshot+replay drift detection. When true, the resource's
+   * {@link Resource.stat} must populate {@link FileStat.fingerprint}
+   * (and optionally {@link FileStat.revision}) with stable per-path
+   * markers. When false (the default), reads are treated as live-only
+   * at replay time: no fingerprint is captured at snapshot, no drift
+   * check fires at load.
+   */
+  readonly supportsSnapshot?: boolean
   readonly index?: IndexCacheStore
   readonly accessor?: Accessor
   readonly opsMap?: Record<string, unknown>

--- a/typescript/packages/core/src/snapshot/state.ts
+++ b/typescript/packages/core/src/snapshot/state.ts
@@ -64,9 +64,33 @@ export interface ExecutionRecordSnapshot {
   sessionId: string
 }
 
+/**
+ * One snapshot-time fingerprint entry per recorded read on a
+ * snapshot-capable mount. Carries the backend's identifier(s) for the
+ * bytes the agent actually saw, populated at read time from the GET
+ * response. At least one of `fingerprint` and `revision` is non-null.
+ */
+export interface FingerprintEntrySnapshot {
+  path: string
+  mountPrefix: string
+  fingerprint?: string | null
+  revision?: string | null
+}
+
 export interface WorkspaceStateDict {
   version: number
   mounts: MountSnapshot[]
   cache: CacheSnapshot
   history: ExecutionRecordSnapshot[]
+  /**
+   * Per-path fingerprint/revision pairs captured at snapshot time.
+   * Optional for backwards compatibility with v1 snapshots that
+   * predate drift detection.
+   */
+  fingerprints?: FingerprintEntrySnapshot[]
+  /**
+   * Mount prefixes whose resource opts out of snapshot replay
+   * (e.g. Gmail, Slack). Replay logs a warning naming these.
+   */
+  liveOnlyMounts?: string[]
 }

--- a/typescript/packages/core/src/types.ts
+++ b/typescript/packages/core/src/types.ts
@@ -27,6 +27,19 @@ export const ConsistencyPolicy = Object.freeze({
 
 export type ConsistencyPolicy = (typeof ConsistencyPolicy)[keyof typeof ConsistencyPolicy]
 
+/**
+ * Behaviour when a remote resource's live fingerprint differs from the
+ * value recorded at snapshot time.
+ */
+export const DriftPolicy = Object.freeze({
+  /** Raise ContentDriftError on first mismatch. */
+  STRICT: 'strict',
+  /** Skip drift checks entirely. */
+  OFF: 'off',
+} as const)
+
+export type DriftPolicy = (typeof DriftPolicy)[keyof typeof DriftPolicy]
+
 export const ResourceName = Object.freeze({
   DISK: 'disk',
   S3: 's3',
@@ -94,6 +107,7 @@ export interface FileStatInit {
   size?: number | null
   modified?: string | null
   fingerprint?: string | null
+  revision?: string | null
   type?: FileType | null
   extra?: Record<string, unknown>
 }
@@ -103,6 +117,7 @@ export class FileStat {
   readonly size: number | null
   readonly modified: string | null
   readonly fingerprint: string | null
+  readonly revision: string | null
   readonly type: FileType | null
   readonly extra: Record<string, unknown>
 
@@ -111,6 +126,7 @@ export class FileStat {
     this.size = init.size ?? null
     this.modified = init.modified ?? null
     this.fingerprint = init.fingerprint ?? null
+    this.revision = init.revision ?? null
     this.type = init.type ?? null
     this.extra = init.extra ?? {}
     Object.freeze(this)

--- a/typescript/packages/core/src/workspace/mount/mount.test.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.test.ts
@@ -17,6 +17,7 @@ import { command, type CommandFn, RegisteredCommand } from '../../commands/confi
 import { CommandSpec, Operand, OperandKind } from '../../commands/spec/types.ts'
 import { IOResult } from '../../io/types.ts'
 import type { Accessor } from '../../accessor/base.ts'
+import { revisionFor } from '../../observe/context.ts'
 import type { RegisteredOp } from '../../ops/registry.ts'
 import type { Resource } from '../../resource/base.ts'
 import { MountMode, PathSpec } from '../../types.ts'
@@ -232,6 +233,47 @@ describe('Mount.executeOp', () => {
     }
     m.registerOp(op)
     await expect(m.executeOp('write', '/x')).rejects.toThrow(/read-only/)
+  })
+})
+
+describe('Mount.revisions', () => {
+  it('starts empty and exposes the revisions map directly', () => {
+    const m = makeMount()
+    expect(m.revisions.size).toBe(0)
+  })
+
+  it('exposes installed pins to read functions via revisionFor during executeOp', async () => {
+    const m = makeMount()
+    m.revisions.set('/ram/x.txt', 'rev-1')
+    let observed: string | null = '<unset>'
+    const op: RegisteredOp = {
+      name: 'read',
+      resource: 'ram',
+      filetype: null,
+      write: false,
+      fn: (_accessor: Accessor, path: PathSpec) => {
+        observed = revisionFor(path.original)
+        return Promise.resolve(new Uint8Array())
+      },
+    }
+    m.registerOp(op)
+    await m.executeOp('read', '/ram/x.txt')
+    expect(observed).toBe('rev-1')
+  })
+
+  it('does not leak revisions outside the executeOp scope', async () => {
+    const m = makeMount()
+    m.revisions.set('/ram/x.txt', 'rev-1')
+    const op: RegisteredOp = {
+      name: 'read',
+      resource: 'ram',
+      filetype: null,
+      write: false,
+      fn: () => Promise.resolve(new Uint8Array()),
+    }
+    m.registerOp(op)
+    await m.executeOp('read', '/ram/x.txt')
+    expect(revisionFor('/ram/x.txt')).toBeNull()
   })
 })
 

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -27,7 +27,7 @@ import { getExtension } from '../../commands/resolve.ts'
 import type { CommandSpec } from '../../commands/spec/types.ts'
 import type { ByteSource } from '../../io/types.ts'
 import { IOResult } from '../../io/types.ts'
-import { setVirtualPrefix } from '../../observe/context.ts'
+import { runWithRevisions, setVirtualPrefix } from '../../observe/context.ts'
 import type { RegisteredOp } from '../../ops/registry.ts'
 import type { Resource } from '../../resource/base.ts'
 import { ConsistencyPolicy, MountMode, PathSpec } from '../../types.ts'
@@ -63,6 +63,15 @@ export class Mount {
   readonly resource: Resource
   readonly mode: MountMode
   readonly consistency: ConsistencyPolicy
+
+  /**
+   * Per-path revision pins installed at Workspace.load time. Read
+   * functions consult these via the {@link revisionFor} contextvar
+   * lookup; on a hit, the backend GET pins to the recorded revision so
+   * replay serves the exact bytes the agent saw. Empty during normal
+   * runs; populated only by the snapshot loader.
+   */
+  readonly revisions = new Map<string, string>()
 
   private readonly cmds = new Map<CmdKey, RegisteredCommand>()
   private readonly generalCmds = new Map<string, RegisteredCommand>()
@@ -360,22 +369,27 @@ export class Mount {
 
     setVirtualPrefix(mountPrefix)
     try {
-      for (const cmd of handlers) {
-        if (cmd.write && this.mode === MountMode.READ) {
-          return [
-            null,
-            new IOResult({
-              exitCode: 1,
-              stderr: new TextEncoder().encode(`${cmdName}: read-only mount at ${this.prefix}`),
-            }),
-          ]
-        }
-        const result = await cmd.fn(accessor, expandedPaths, texts, cmdOpts)
-        if (result !== null) {
-          return result
-        }
-      }
-      return [null, new IOResult()]
+      return await runWithRevisions(
+        this.revisions.size > 0 ? this.revisions : null,
+        async (): Promise<[ByteSource | null, IOResult]> => {
+          for (const cmd of handlers) {
+            if (cmd.write && this.mode === MountMode.READ) {
+              return [
+                null,
+                new IOResult({
+                  exitCode: 1,
+                  stderr: new TextEncoder().encode(`${cmdName}: read-only mount at ${this.prefix}`),
+                }),
+              ]
+            }
+            const result = await cmd.fn(accessor, expandedPaths, texts, cmdOpts)
+            if (result !== null) {
+              return result
+            }
+          }
+          return [null, new IOResult()]
+        },
+      )
     } finally {
       setVirtualPrefix('')
     }
@@ -410,11 +424,13 @@ export class Mount {
       ...(filetype !== null && kwargs.filetype === undefined ? { filetype } : {}),
     }
     const accessor = this.resource.accessor ?? NOOP_ACCESSOR
-    for (const op of levels) {
-      const result = await op.fn(accessor, scope, args, effectiveKwargs)
-      if (result !== null && result !== undefined) return result
-    }
-    return null
+    return runWithRevisions(this.revisions.size > 0 ? this.revisions : null, async () => {
+      for (const op of levels) {
+        const result = await op.fn(accessor, scope, args, effectiveKwargs)
+        if (result !== null && result !== undefined) return result
+      }
+      return null
+    })
   }
 }
 

--- a/typescript/packages/core/src/workspace/snapshot/drift.test.ts
+++ b/typescript/packages/core/src/workspace/snapshot/drift.test.ts
@@ -50,7 +50,8 @@ function makeMount(prefix: string, supportsSnapshot: boolean): Mount {
 
 function makeStatFn(stats?: Record<string, FileStat>): (path: string) => Promise<FileStat> {
   return (path) => {
-    if (stats !== undefined && path in stats) return Promise.resolve(stats[path]!)
+    const hit = stats?.[path]
+    if (hit !== undefined) return Promise.resolve(hit)
     const err = new Error(`not found: ${path}`) as Error & { code: string }
     err.code = 'ENOENT'
     return Promise.reject(err)

--- a/typescript/packages/core/src/workspace/snapshot/drift.test.ts
+++ b/typescript/packages/core/src/workspace/snapshot/drift.test.ts
@@ -1,0 +1,202 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { OpRecord } from '../../observe/record.ts'
+import type { Resource } from '../../resource/base.ts'
+import { FileStat } from '../../types.ts'
+import type { Mount } from '../mount/mount.ts'
+import {
+  captureFingerprints,
+  checkDrift,
+  ContentDriftError,
+  liveOnlyMountPrefixes,
+} from './drift.ts'
+
+interface RegistryLike {
+  mountFor(path: string): Mount | null
+  allMounts(): readonly Mount[]
+}
+
+function makeMount(prefix: string, supportsSnapshot: boolean): Mount {
+  const resource: Resource = {
+    kind: 's3',
+    supportsSnapshot,
+    open: () => Promise.resolve(),
+    close: () => Promise.resolve(),
+  }
+  const m: Partial<Mount> & {
+    prefix: string
+    resource: Resource
+    revisions: Map<string, string>
+  } = {
+    prefix,
+    resource,
+    revisions: new Map(),
+  }
+  return m as Mount
+}
+
+function makeStatFn(stats?: Record<string, FileStat>): (path: string) => Promise<FileStat> {
+  return (path) => {
+    if (stats !== undefined && path in stats) return Promise.resolve(stats[path]!)
+    const err = new Error(`not found: ${path}`) as Error & { code: string }
+    err.code = 'ENOENT'
+    return Promise.reject(err)
+  }
+}
+
+function makeRegistry(mounts: Mount[]): RegistryLike {
+  return {
+    mountFor: (path: string): Mount | null => {
+      for (const m of mounts) {
+        if (path.startsWith(m.prefix.replace(/\/$/, ''))) return m
+      }
+      return null
+    },
+    allMounts: () => mounts,
+  }
+}
+
+function makeRecord(
+  path: string,
+  fingerprint: string | null = null,
+  revision: string | null = null,
+): OpRecord {
+  return new OpRecord({
+    op: 'read',
+    path,
+    source: 's3',
+    bytes: 0,
+    timestamp: 0,
+    durationMs: 0,
+    fingerprint,
+    revision,
+  })
+}
+
+describe('captureFingerprints', () => {
+  it('emits one entry per distinct fingerprinted path on a snapshot-capable mount', () => {
+    const mount = makeMount('/s3/', true)
+    const registry = makeRegistry([mount])
+    const records = [makeRecord('/s3/a', 'fp-a'), makeRecord('/s3/b', 'fp-b', 'rev-b')]
+    const entries = captureFingerprints(records, registry)
+    expect(entries).toEqual([
+      { path: '/s3/a', mountPrefix: '/s3/', fingerprint: 'fp-a' },
+      { path: '/s3/b', mountPrefix: '/s3/', fingerprint: 'fp-b', revision: 'rev-b' },
+    ])
+  })
+
+  it('deduplicates by path; first read wins', () => {
+    const mount = makeMount('/s3/', true)
+    const registry = makeRegistry([mount])
+    const entries = captureFingerprints(
+      [makeRecord('/s3/a', 'fp-old'), makeRecord('/s3/a', 'fp-new')],
+      registry,
+    )
+    expect(entries.length).toBe(1)
+    expect(entries[0]?.fingerprint).toBe('fp-old')
+  })
+
+  it('skips reads with neither fingerprint nor revision', () => {
+    const mount = makeMount('/s3/', true)
+    const registry = makeRegistry([mount])
+    const entries = captureFingerprints([makeRecord('/s3/a')], registry)
+    expect(entries.length).toBe(0)
+  })
+
+  it('skips non-read ops', () => {
+    const mount = makeMount('/s3/', true)
+    const registry = makeRegistry([mount])
+    const writeRec = new OpRecord({
+      op: 'write',
+      path: '/s3/a',
+      source: 's3',
+      bytes: 1,
+      timestamp: 0,
+      durationMs: 0,
+      fingerprint: 'fp-a',
+    })
+    expect(captureFingerprints([writeRec], registry).length).toBe(0)
+  })
+
+  it('skips mounts that opt out of snapshot replay', () => {
+    const mount = makeMount('/gmail/', false)
+    const registry = makeRegistry([mount])
+    const entries = captureFingerprints([makeRecord('/gmail/inbox/1', 'fp-1')], registry)
+    expect(entries.length).toBe(0)
+  })
+})
+
+describe('liveOnlyMountPrefixes', () => {
+  it('returns prefixes of mounts that opt out of snapshot replay', () => {
+    const s3 = makeMount('/s3/', true)
+    const gmail = makeMount('/gmail/', false)
+    const registry = makeRegistry([s3, gmail])
+    expect(liveOnlyMountPrefixes(registry)).toEqual(['/gmail/'])
+  })
+
+  it('excludes infrastructure prefixes /dev/ and /.sessions/', () => {
+    const dev = makeMount('/dev/', false)
+    const sessions = makeMount('/.sessions/', false)
+    const registry = makeRegistry([dev, sessions])
+    expect(liveOnlyMountPrefixes(registry)).toEqual([])
+  })
+})
+
+describe('checkDrift', () => {
+  it('no-op when live fingerprint matches recorded', async () => {
+    const stats = { '/s3/a': new FileStat({ name: 'a', fingerprint: 'fp-a' }) }
+    const mount = makeMount('/s3/', true)
+    await expect(
+      checkDrift(makeRegistry([mount]), makeStatFn(stats), '/s3/a', 'fp-a'),
+    ).resolves.toBeUndefined()
+  })
+
+  it('throws ContentDriftError when live differs from recorded', async () => {
+    const stats = { '/s3/a': new FileStat({ name: 'a', fingerprint: 'fp-live' }) }
+    const mount = makeMount('/s3/', true)
+    await expect(
+      checkDrift(makeRegistry([mount]), makeStatFn(stats), '/s3/a', 'fp-snap'),
+    ).rejects.toBeInstanceOf(ContentDriftError)
+  })
+
+  it('throws ContentDriftError with live=null when the path is gone', async () => {
+    const mount = makeMount('/s3/', true)
+    let caught: unknown = null
+    try {
+      await checkDrift(makeRegistry([mount]), makeStatFn(), '/s3/missing', 'fp-snap')
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(ContentDriftError)
+    expect((caught as ContentDriftError).liveFingerprint).toBeNull()
+  })
+
+  it('no-op when live FileStat has null fingerprint (backend can not fingerprint)', async () => {
+    const stats = { '/s3/a': new FileStat({ name: 'a', fingerprint: null }) }
+    const mount = makeMount('/s3/', true)
+    await expect(
+      checkDrift(makeRegistry([mount]), makeStatFn(stats), '/s3/a', 'fp-snap'),
+    ).resolves.toBeUndefined()
+  })
+
+  it('no-op when mount opts out of snapshot replay', async () => {
+    const stats = { '/gmail/a': new FileStat({ name: 'a', fingerprint: 'fp-live' }) }
+    const mount = makeMount('/gmail/', false)
+    await expect(
+      checkDrift(makeRegistry([mount]), makeStatFn(stats), '/gmail/a', 'fp-snap'),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/typescript/packages/core/src/workspace/snapshot/drift.ts
+++ b/typescript/packages/core/src/workspace/snapshot/drift.ts
@@ -1,0 +1,138 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { OpRecord } from '../../observe/record.ts'
+import type { FileStat } from '../../types.ts'
+import type { Mount } from '../mount/mount.ts'
+
+/**
+ * Raised at load time when a remote resource's live fingerprint differs
+ * from what was recorded in the snapshot.
+ *
+ * Indicates the underlying source has been modified since the snapshot
+ * was taken, so reading current bytes would silently diverge from what
+ * the original agent saw. Surface to the caller rather than mask.
+ */
+export class ContentDriftError extends Error {
+  readonly path: string
+  readonly snapshotFingerprint: string
+  readonly liveFingerprint: string | null
+
+  constructor(path: string, snapshotFingerprint: string, liveFingerprint: string | null) {
+    const liveRepr = liveFingerprint === null ? '<missing>' : JSON.stringify(liveFingerprint)
+    super(
+      `${path}: snapshot fingerprint ${JSON.stringify(snapshotFingerprint)}, live ${liveRepr}; ` +
+        'data on the underlying source has changed since the snapshot was taken',
+    )
+    this.name = 'ContentDriftError'
+    this.path = path
+    this.snapshotFingerprint = snapshotFingerprint
+    this.liveFingerprint = liveFingerprint
+  }
+}
+
+export interface FingerprintEntry {
+  path: string
+  mountPrefix: string
+  fingerprint?: string | null
+  revision?: string | null
+}
+
+interface RegistryLike {
+  mountFor(path: string): Mount | null
+  allMounts(): readonly Mount[]
+}
+
+/**
+ * Walk recorded ops and emit one entry per distinct read on a
+ * snapshot-capable mount.
+ *
+ * Pure aggregation over `records`. Each read carries the `fingerprint`
+ * and/or `revision` the backend returned at the moment the agent read
+ * the bytes (populated from the GET response, not a fresh stat at
+ * snapshot time). This avoids the race where the upstream changes
+ * between read and snapshot.
+ *
+ * Skips paths whose owning mount has `supportsSnapshot=false` (live-only
+ * backends like Gmail/Slack/Linear) and reads where the backend returned
+ * neither marker.
+ */
+export function captureFingerprints(
+  records: readonly OpRecord[],
+  registry: RegistryLike,
+): FingerprintEntry[] {
+  const seen = new Set<string>()
+  const out: FingerprintEntry[] = []
+  for (const rec of records) {
+    if (rec.op !== 'read' || seen.has(rec.path)) continue
+    if (rec.fingerprint === null && rec.revision === null) continue
+    seen.add(rec.path)
+    const mount = registry.mountFor(rec.path)
+    if (mount === null) continue
+    if (mount.resource.supportsSnapshot !== true) continue
+    const entry: FingerprintEntry = { path: rec.path, mountPrefix: mount.prefix }
+    if (rec.fingerprint !== null) entry.fingerprint = rec.fingerprint
+    if (rec.revision !== null) entry.revision = rec.revision
+    out.push(entry)
+  }
+  return out
+}
+
+/**
+ * Return mount prefixes whose resource opts out of snapshot replay.
+ *
+ * These mounts will serve current state at load time with no drift
+ * detection. Surfaced in the snapshot manifest so the load layer can
+ * log them and so users can audit which paths are non-replayable.
+ */
+export function liveOnlyMountPrefixes(registry: RegistryLike): string[] {
+  const out: string[] = []
+  for (const m of registry.allMounts()) {
+    if (m.prefix === '/dev/' || m.prefix === '/.sessions/') continue
+    if (m.resource.supportsSnapshot !== true) out.push(m.prefix)
+  }
+  return out
+}
+
+/**
+ * Stat `path` and throw {@link ContentDriftError} if the live fingerprint
+ * does not match `recorded`. No-op if the mount cannot be resolved or the
+ * resource cannot fingerprint.
+ *
+ * The caller provides `statFn` (typically a thin wrapper over
+ * {@link Workspace.dispatch}) so that drift.ts stays decoupled from the
+ * workspace's op-resolution machinery.
+ */
+export async function checkDrift(
+  registry: RegistryLike,
+  statFn: (path: string) => Promise<unknown>,
+  path: string,
+  recorded: string,
+): Promise<void> {
+  const mount = registry.mountFor(path)
+  if (mount === null) return
+  if (mount.resource.supportsSnapshot !== true) return
+  let stat: FileStat
+  try {
+    stat = (await statFn(path)) as FileStat
+  } catch (err) {
+    if ((err as { code?: string } | null)?.code === 'ENOENT') {
+      throw new ContentDriftError(path, recorded, null)
+    }
+    throw err
+  }
+  const live = stat.fingerprint
+  if (live === null) return
+  if (live !== recorded) throw new ContentDriftError(path, recorded, live)
+}

--- a/typescript/packages/core/src/workspace/snapshot_drift.test.ts
+++ b/typescript/packages/core/src/workspace/snapshot_drift.test.ts
@@ -1,0 +1,277 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Accessor } from '../accessor/base.ts'
+import { record, revisionFor, runWithRecording } from '../observe/context.ts'
+import { type OpKwargs, OpsRegistry, type RegisteredOp } from '../ops/registry.ts'
+import type { Resource } from '../resource/base.ts'
+import { createShellParser, type ShellParser } from '../shell/parse.ts'
+import { DriftPolicy, FileStat, FileType, MountMode, type PathSpec } from '../types.ts'
+import { ContentDriftError } from './snapshot/drift.ts'
+import { Workspace } from './workspace.ts'
+
+const require = createRequire(import.meta.url)
+const engineWasm = readFileSync(require.resolve('web-tree-sitter/web-tree-sitter.wasm'))
+const grammarWasm = readFileSync(require.resolve('tree-sitter-bash/tree-sitter-bash.wasm'))
+
+let parser: ShellParser
+let tempDir: string
+
+beforeAll(async () => {
+  parser = await createShellParser({ engineWasm, grammarWasm })
+  tempDir = mkdtempSync(join(tmpdir(), 'mirage-drift-'))
+})
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true })
+})
+
+/**
+ * Minimal versioned blob store for drift tests: each `put` advances a
+ * revision counter; the read op records ETag + VersionId so the snapshot
+ * can recover them at load time.
+ */
+class FakeRemoteAccessor extends Accessor {
+  blobs = new Map<string, { bytes: Uint8Array; fingerprint: string; revision: string }>()
+  versionedHistory = new Map<string, Map<string, Uint8Array>>()
+  private counter = 0
+
+  put(path: string, bytes: Uint8Array): void {
+    this.counter += 1
+    const fingerprint = `fp-${path}-${String(this.counter)}`
+    const revision = `rev-${path}-${String(this.counter)}`
+    this.blobs.set(path, { bytes, fingerprint, revision })
+    let history = this.versionedHistory.get(path)
+    if (history === undefined) {
+      history = new Map()
+      this.versionedHistory.set(path, history)
+    }
+    history.set(revision, bytes)
+  }
+}
+
+class FakeRemoteResource implements Resource {
+  readonly kind = 'fake-remote'
+  readonly isRemote = true
+  readonly supportsSnapshot = true
+  readonly accessor: FakeRemoteAccessor
+
+  constructor(accessor: FakeRemoteAccessor) {
+    this.accessor = accessor
+  }
+
+  open(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  stat(p: PathSpec): Promise<FileStat> {
+    const entry = this.accessor.blobs.get(p.original)
+    if (entry === undefined) {
+      const err = new Error(`not found: ${p.original}`) as Error & { code: string }
+      err.code = 'ENOENT'
+      return Promise.reject(err)
+    }
+    return Promise.resolve(
+      new FileStat({
+        name: p.original.split('/').pop() ?? p.original,
+        size: entry.bytes.byteLength,
+        type: FileType.TEXT,
+        fingerprint: entry.fingerprint,
+        revision: entry.revision,
+      }),
+    )
+  }
+
+  getState(): { type: string; needsOverride: boolean } {
+    return { type: this.kind, needsOverride: true }
+  }
+}
+
+const readOp: RegisteredOp = {
+  name: 'read',
+  resource: 'fake-remote',
+  filetype: null,
+  write: false,
+  fn: (accessor: Accessor, scope: PathSpec, _args: readonly unknown[], _kwargs: OpKwargs) => {
+    const acc = accessor as unknown as FakeRemoteAccessor
+    const pinned = revisionFor(scope.original)
+    const entry = acc.blobs.get(scope.original)
+    if (entry === undefined) {
+      const err = new Error(`not found: ${scope.original}`) as Error & { code: string }
+      err.code = 'ENOENT'
+      throw err
+    }
+    if (pinned !== null) {
+      const history = acc.versionedHistory.get(scope.original)
+      const pinnedBytes = history?.get(pinned)
+      if (pinnedBytes !== undefined) {
+        record('read', scope.original, 'fake-remote', pinnedBytes.byteLength, performance.now(), {
+          fingerprint: entry.fingerprint,
+          revision: pinned,
+        })
+        return Promise.resolve(pinnedBytes)
+      }
+    }
+    record('read', scope.original, 'fake-remote', entry.bytes.byteLength, performance.now(), {
+      fingerprint: entry.fingerprint,
+      revision: entry.revision,
+    })
+    return Promise.resolve(entry.bytes)
+  },
+}
+
+const statOp: RegisteredOp = {
+  name: 'stat',
+  resource: 'fake-remote',
+  filetype: null,
+  write: false,
+  fn: (accessor: Accessor, scope: PathSpec) => {
+    const acc = accessor as unknown as FakeRemoteAccessor
+    const entry = acc.blobs.get(scope.original)
+    if (entry === undefined) {
+      const err = new Error(`not found: ${scope.original}`) as Error & { code: string }
+      err.code = 'ENOENT'
+      return Promise.reject(err)
+    }
+    return Promise.resolve(
+      new FileStat({
+        name: scope.original.split('/').pop() ?? scope.original,
+        size: entry.bytes.byteLength,
+        type: FileType.TEXT,
+        fingerprint: entry.fingerprint,
+        revision: entry.revision,
+      }),
+    )
+  },
+}
+
+function build(accessor: FakeRemoteAccessor): Workspace {
+  const ops = new OpsRegistry()
+  ops.register(readOp)
+  ops.register(statOp)
+  const res = new FakeRemoteResource(accessor)
+  return new Workspace({ '/remote': res }, { mode: MountMode.WRITE, ops, shellParser: parser })
+}
+
+// Wrap a dispatch call in runWithRecording so the captured OpRecord
+// reaches `ws.records`, mirroring what `Workspace.execute` does
+// implicitly via its `runWithRecording` setup.
+async function recordedDispatch(ws: Workspace, op: string, path: string): Promise<unknown> {
+  const [result, records] = await runWithRecording(async () => ws.dispatch(op, path))
+  ws.records.push(...records)
+  return result
+}
+
+describe('Workspace snapshot: capture and replay drift detection', () => {
+  it('toStateDict captures fingerprint + revision from read-time records', async () => {
+    const accessor = new FakeRemoteAccessor()
+    accessor.put('/remote/a.txt', new TextEncoder().encode('v1'))
+    const ws = build(accessor)
+    await recordedDispatch(ws, 'read', '/remote/a.txt')
+    const state = await ws.toStateDict()
+    expect(state.fingerprints?.length).toBe(1)
+    expect(state.fingerprints?.[0]?.path).toBe('/remote/a.txt')
+    expect(state.fingerprints?.[0]?.fingerprint).toContain('fp-')
+    expect(state.fingerprints?.[0]?.revision).toContain('rev-')
+    await ws.close()
+  })
+
+  it('STRICT load installs revisions; replay reads pin to the recorded revision', async () => {
+    const accessor = new FakeRemoteAccessor()
+    accessor.put('/remote/a.txt', new TextEncoder().encode('v1'))
+    const ws = build(accessor)
+    await recordedDispatch(ws, 'read', '/remote/a.txt')
+    const snap = join(tempDir, 'pin.json')
+    await ws.snapshot(snap)
+
+    accessor.put('/remote/a.txt', new TextEncoder().encode('v2-upstream'))
+
+    const ops = new OpsRegistry()
+    ops.register(readOp)
+    ops.register(statOp)
+    const loaded = await Workspace.load(
+      snap,
+      { mode: MountMode.WRITE, ops, shellParser: parser },
+      { '/remote/': new FakeRemoteResource(accessor) },
+    )
+    expect(Object.keys(loaded.revisions).length).toBe(1)
+    const bytes = (await loaded.dispatch('read', '/remote/a.txt')) as Uint8Array
+    expect(new TextDecoder().decode(bytes)).toBe('v1')
+    await ws.close()
+    await loaded.close()
+  })
+
+  it('STRICT load raises ContentDriftError when fingerprint drifts (no revision pin)', async () => {
+    const accessor = new FakeRemoteAccessor()
+    accessor.put('/remote/a.txt', new TextEncoder().encode('v1'))
+    const ws = build(accessor)
+    await recordedDispatch(ws, 'read', '/remote/a.txt')
+    const state = await ws.toStateDict()
+    // Strip revisions so the loader queues a drift check instead of pinning.
+    state.fingerprints = (state.fingerprints ?? []).map((e) => ({
+      path: e.path,
+      mountPrefix: e.mountPrefix,
+      fingerprint: e.fingerprint ?? null,
+    }))
+    const snap = join(tempDir, 'drift.json')
+    const { writeFileSync } = await import('node:fs')
+    writeFileSync(snap, JSON.stringify(state))
+
+    accessor.put('/remote/a.txt', new TextEncoder().encode('v2'))
+
+    const ops = new OpsRegistry()
+    ops.register(readOp)
+    ops.register(statOp)
+    const loaded = await Workspace.load(
+      snap,
+      { mode: MountMode.WRITE, ops, shellParser: parser, driftPolicy: DriftPolicy.STRICT },
+      { '/remote/': new FakeRemoteResource(accessor) },
+    )
+    await expect(loaded.dispatch('read', '/remote/a.txt')).rejects.toBeInstanceOf(ContentDriftError)
+    await ws.close()
+    await loaded.close()
+  })
+
+  it('OFF load skips drift check and leaves revision pins empty', async () => {
+    const accessor = new FakeRemoteAccessor()
+    accessor.put('/remote/a.txt', new TextEncoder().encode('v1'))
+    const ws = build(accessor)
+    await recordedDispatch(ws, 'read', '/remote/a.txt')
+    const snap = join(tempDir, 'off.json')
+    await ws.snapshot(snap)
+    accessor.put('/remote/a.txt', new TextEncoder().encode('v2-upstream'))
+
+    const ops = new OpsRegistry()
+    ops.register(readOp)
+    ops.register(statOp)
+    const loaded = await Workspace.load(
+      snap,
+      { mode: MountMode.WRITE, ops, shellParser: parser, driftPolicy: DriftPolicy.OFF },
+      { '/remote/': new FakeRemoteResource(accessor) },
+    )
+    expect(Object.keys(loaded.revisions).length).toBe(0)
+    const bytes = (await loaded.dispatch('read', '/remote/a.txt')) as Uint8Array
+    expect(new TextDecoder().decode(bytes)).toBe('v2-upstream')
+    await ws.close()
+    await loaded.close()
+  })
+})

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -19,7 +19,7 @@ import type { FileCache } from '../cache/file/mixin.ts'
 import { RAMFileCacheStore } from '../cache/file/ram.ts'
 import type { ByteSource } from '../io/types.ts'
 import { IOResult, materialize } from '../io/types.ts'
-import { runWithRecording } from '../observe/context.ts'
+import { runWithRecording, runWithRevisions } from '../observe/context.ts'
 import { Observer } from '../observe/observer.ts'
 import type { OpRecord } from '../observe/record.ts'
 import { type OpKwargs, OpsRegistry } from '../ops/registry.ts'
@@ -39,12 +39,19 @@ import {
 import {
   type ExecutionNodeSnapshot,
   type ExecutionRecordSnapshot,
+  type FingerprintEntrySnapshot,
   type MountSnapshot,
   type ResourceState,
   SNAPSHOT_FORMAT_VERSION,
   type WorkspaceStateDict,
 } from '../snapshot/state.ts'
-import { DEFAULT_AGENT_ID, FileType, MountMode, type PathSpec } from '../types.ts'
+import {
+  captureFingerprints,
+  checkDrift,
+  ContentDriftError,
+  liveOnlyMountPrefixes,
+} from './snapshot/drift.ts'
+import { DEFAULT_AGENT_ID, DriftPolicy, FileType, MountMode, type PathSpec } from '../types.ts'
 import type { TSNodeLike } from './expand/variable.ts'
 import type { ExecuteFn } from './expand/node.ts'
 import type { DispatchFn } from './executor/cross_mount.ts'
@@ -127,6 +134,18 @@ const VALID_MODES: readonly string[] = [MountMode.READ, MountMode.WRITE, MountMo
 export interface WorkspaceOptions {
   mode?: MountMode
   modeOverrides?: Record<string, MountMode>
+  /**
+   * Behaviour for the post-load drift check on fingerprinted reads. Only
+   * consulted by {@link Workspace.load} / {@link Workspace.fromState};
+   * fresh workspaces never have fingerprints to check.
+   *
+   * - `STRICT` (load default): raise {@link ContentDriftError} on the
+   *   first mismatch when the workspace's first `dispatch`/`execute`
+   *   runs.
+   * - `OFF`: skip drift checks entirely and evict the snapshot cache
+   *   for fingerprinted paths.
+   */
+  driftPolicy?: DriftPolicy
   ops?: OpsRegistry
   shellParser?: ShellParser
   shellParserFactory?: () => Promise<ShellParser>
@@ -225,6 +244,12 @@ export class Workspace {
   private readonly pythonRuntime: PyodideRuntime
   private fuseMountpointValue: string | null = null
   private fuseOwnedInProcess = false
+  // Drift check state populated by Workspace.load. Empty during normal
+  // runs. Drained on first dispatch/execute after load (see
+  // {@link runPendingDriftCheck}).
+  protected driftPolicy: DriftPolicy = DriftPolicy.OFF
+  protected driftCheckPending = false
+  protected pendingDrift: { mount: Mount; path: string; fingerprint: string }[] = []
 
   get fuseMountpoint(): string | null {
     return this.fuseMountpointValue
@@ -504,6 +529,92 @@ export class Workspace {
     return parts.join('\n\n')
   }
 
+  /**
+   * Drain the post-load drift check.
+   *
+   * Called once on the first async entry point (`dispatch` or `execute`)
+   * after {@link Workspace.load} with a non-OFF drift policy. Stats every
+   * queued `(mount, path, expected_fingerprint)` triple against the live
+   * source in parallel and throws {@link ContentDriftError} on the first
+   * mismatch. Subsequent calls are no-ops.
+   *
+   * Pinned paths (those whose manifest entry carried a stable revision)
+   * are never enqueued — the pin guarantees bytes match by construction.
+   */
+  protected async runPendingDriftCheck(): Promise<void> {
+    this.driftCheckPending = false
+    if (this.pendingDrift.length === 0) return
+    const pending = this.pendingDrift
+    this.pendingDrift = []
+    const statFn = async (p: string): Promise<unknown> => this.dispatch('stat', p)
+    const results = await Promise.allSettled(
+      pending.map((p) => checkDrift(this.registry, statFn, p.path, p.fingerprint)),
+    )
+    for (const r of results) {
+      if (r.status === 'rejected') throw r.reason
+    }
+  }
+
+  /**
+   * Walk a loaded snapshot's fingerprint manifest. For entries with a
+   * revision, install the pin on the owning mount so replay reads pin to
+   * that revision. For fingerprint-only entries, queue a `(mount, path,
+   * fingerprint)` tuple for the drift check.
+   *
+   * Idempotent: clearing existing state before installing. Called from
+   * {@link Workspace.load} / {@link Workspace.fromState}.
+   */
+  protected installDriftState(
+    state: WorkspaceStateDict,
+    policy: DriftPolicy = DriftPolicy.STRICT,
+  ): void {
+    this.driftPolicy = policy
+    this.pendingDrift = []
+    this.driftCheckPending = false
+    const entries = state.fingerprints ?? []
+    if (entries.length === 0) return
+    if (policy === DriftPolicy.OFF) {
+      // Evict snapshot cache for fingerprinted paths so reads serve live.
+      for (const e of entries) {
+        void this.cache.remove(e.path)
+      }
+      return
+    }
+    for (const e of entries) {
+      const mount = this.registry.mountFor(e.path)
+      if (mount === null) continue
+      if (e.revision !== undefined && e.revision !== null) {
+        mount.revisions.set(e.path, e.revision)
+        continue
+      }
+      if (e.fingerprint !== undefined && e.fingerprint !== null) {
+        this.pendingDrift.push({ mount, path: e.path, fingerprint: e.fingerprint })
+      }
+    }
+    this.driftCheckPending = this.pendingDrift.length > 0
+    const liveOnly = state.liveOnlyMounts ?? []
+    if (liveOnly.length > 0) {
+      console.warn(
+        `Workspace.load: ${String(liveOnly.length)} mount(s) opt out of snapshot replay; ` +
+          `reads against them will serve current state with no drift detection: ` +
+          liveOnly.join(', '),
+      )
+    }
+  }
+
+  /**
+   * Read-only view of every mount's installed revision pins. Useful for
+   * tests, audit, and debugging. Empty until a snapshot is loaded with
+   * revisions in its manifest.
+   */
+  get revisions(): Record<string, string> {
+    const out: Record<string, string> = {}
+    for (const m of this.registry.allMounts()) {
+      for (const [path, revision] of m.revisions) out[path] = revision
+    }
+    return out
+  }
+
   async stat(path: string): Promise<unknown> {
     return this.fs.stat(path)
   }
@@ -518,6 +629,9 @@ export class Workspace {
     args: readonly unknown[] = [],
     kwargs: OpKwargs = {},
   ): Promise<unknown> {
+    if (this.driftCheckPending) {
+      await this.runPendingDriftCheck()
+    }
     const [resource, spec, mode] = await this.resolve(path)
     if (mode === MountMode.READ && this.opsRegistry.find(opName, resource.kind)?.write === true) {
       throw new Error(`mount at '${path}' is read-only`)
@@ -526,13 +640,18 @@ export class Workspace {
       kwargs.index === undefined && resource.index !== undefined
         ? { ...kwargs, index: resource.index }
         : kwargs
-    return this.opsRegistry.call(
-      opName,
-      resource.kind,
-      resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
-      spec,
-      args,
-      fullKwargs,
+    const mount = this.registry.mountFor(path)
+    return runWithRevisions(
+      mount !== null && mount.revisions.size > 0 ? mount.revisions : null,
+      async () =>
+        this.opsRegistry.call(
+          opName,
+          resource.kind,
+          resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
+          spec,
+          args,
+          fullKwargs,
+        ),
     )
   }
 
@@ -609,6 +728,9 @@ export class Workspace {
     if (options.signal?.aborted === true) {
       throw makeAbortError()
     }
+    if (this.driftCheckPending) {
+      await this.runPendingDriftCheck()
+    }
     const stdin = options.stdin ?? null
     if (options.provision === true) return this.provision(command)
     const parser = await this.getShellParser()
@@ -643,13 +765,18 @@ export class Workspace {
         kwargs?.index === undefined && resource.index !== undefined
           ? { ...(kwargs ?? {}), index: resource.index }
           : (kwargs ?? {})
-      const result = await opsRegistry.call(
-        opName,
-        resource.kind,
-        resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
-        scope,
-        args ?? [],
-        fullKwargs,
+      const mount = this.registry.mountFor(path.original)
+      const result = await runWithRevisions(
+        mount !== null && mount.revisions.size > 0 ? mount.revisions : null,
+        async () =>
+          opsRegistry.call(
+            opName,
+            resource.kind,
+            resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
+            scope,
+            args ?? [],
+            fullKwargs,
+          ),
       )
       if (DISPATCH_WRITE_OPS.has(opName)) {
         await this.invalidateAfterWriteByPath(path.original)
@@ -779,11 +906,18 @@ export class Workspace {
           }))
         : []
     const historyRecords = this.history.entries().map((r) => recordToSnapshot(r))
+    const fingerprints: FingerprintEntrySnapshot[] = captureFingerprints(
+      this.records,
+      this.registry,
+    )
+    const liveOnly = liveOnlyMountPrefixes(this.registry)
     return {
       version: SNAPSHOT_FORMAT_VERSION,
       mounts: mountSnapshots,
       cache: { limit: this.cache.cacheLimit, entries: cacheEntries },
       history: historyRecords,
+      fingerprints,
+      liveOnlyMounts: liveOnly,
     }
   }
 
@@ -871,6 +1005,7 @@ export class Workspace {
     }
     const ws = new this(resources, mergedOptions) as InstanceType<T>
     await ws.restore({ ...state, mounts: needsRestore })
+    ws.installDriftState(state, options.driftPolicy ?? DriftPolicy.STRICT)
     return ws
   }
 

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -45,12 +45,7 @@ import {
   SNAPSHOT_FORMAT_VERSION,
   type WorkspaceStateDict,
 } from '../snapshot/state.ts'
-import {
-  captureFingerprints,
-  checkDrift,
-  ContentDriftError,
-  liveOnlyMountPrefixes,
-} from './snapshot/drift.ts'
+import { captureFingerprints, checkDrift, liveOnlyMountPrefixes } from './snapshot/drift.ts'
 import { DEFAULT_AGENT_ID, DriftPolicy, FileType, MountMode, type PathSpec } from '../types.ts'
 import type { TSNodeLike } from './expand/variable.ts'
 import type { ExecuteFn } from './expand/node.ts'

--- a/typescript/packages/node/src/resource/s3/s3.ts
+++ b/typescript/packages/node/src/resource/s3/s3.ts
@@ -58,6 +58,7 @@ export interface S3ResourceState {
 export class S3Resource implements Resource {
   readonly kind: string = ResourceName.S3
   readonly isRemote: boolean = true
+  readonly supportsSnapshot: boolean = true
   readonly indexTtl: number = 600
   readonly prompt: string = S3_PROMPT
   readonly config: S3Config


### PR DESCRIPTION
## Summary

Ports the Python design landed in #32 / #41 to TypeScript. Matches the architectural shape: pin state lives on `Mount`, drift state is a queued list of `(mount, path, expected_fingerprint)` tuples, fingerprint and revision are split fields on `OpRecord` captured at read time.

## Surface area

| File | Change |
|---|---|
| `types.ts` | Add `DriftPolicy` enum, `FileStat.revision`. |
| `observe/record.ts` | Add `OpRecord.fingerprint` and `OpRecord.revision`. |
| `observe/context.ts` | `record` / `recordStream` accept `{ fingerprint, revision }`. New `runWithRevisions` / `revisionFor` — independent of `runWithRecording` so direct `Workspace.dispatch` honours pins too. |
| `resource/base.ts` | `Resource.supportsSnapshot` opt-in flag. |
| `node` + `browser` S3Resource | `supportsSnapshot = true`. |
| `core/s3/read,stream,stat` | Extract ETag and VersionId from GET/HEAD response. GETs pin to `revisionFor(path)` when set. Record paths with the virtual prefix so lazy stream consumption is independent of active recording state. |
| `workspace/snapshot/drift.ts` (new) | `ContentDriftError`, `captureFingerprints`, `liveOnlyMountPrefixes`, `checkDrift` (caller supplies the stat function — keeps drift.ts decoupled from Workspace internals). |
| `snapshot/state.ts` | Optional `fingerprints` + `liveOnlyMounts` on `WorkspaceStateDict` (backwards-compatible with v1 snapshots). |
| `workspace/workspace.ts` | `toStateDict` captures fingerprints + lists live-only mounts. `load`/`fromState` install pins onto `mount.revisions` for entries with a revision and queue drift checks for the rest. First `dispatch`/`execute` drains the queue via `Promise.allSettled` and re-throws on the first mismatch. |
| `Mount.revisions: Map<string, string>` | `executeCmd` and `executeOp` wrap in `runWithRevisions` so backend reads see the pin via `revisionFor`. |
| `examples/typescript/s3/s3_write.ts` | DRIFT + VERSION PIN demo against MinIO, auto-enables bucket versioning. |

## End-to-end verification

Ran `s3_write.ts` against a local MinIO with versioning enabled:

```
=== DRIFT + VERSION PIN ===
  bucket versioning: enabled
  agent saw: "original"
  snapshot: /tmp/mirage-drift-.../pin.json (1671 bytes)
  upstream mutated to "mutated"
  installed pins: /s3/drift-probe-0nzs3rho.txt
  STRICT load -> served: "original" (OK pin served original)
```

## Test plan

- [x] `pnpm --filter @struktoai/mirage-core test`: 2,569 tests pass
- [x] New unit tests in `observe/context.test.ts`, `workspace/snapshot/drift.test.ts`, `workspace/mount/mount.test.ts`, `workspace/snapshot_drift.test.ts`
- [x] `pnpm --filter @struktoai/mirage-core build` + `--filter @struktoai/mirage-node build` clean
- [x] End-to-end MinIO drift+pin demo (above)