### PR TITLE
fix(slack): paginate slack-search and surface missing scopes (#31)

### DIFF
--- a/python/mirage/commands/builtin/slack/slack_search.py
+++ b/python/mirage/commands/builtin/slack/slack_search.py
@@ -20,9 +20,23 @@ from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
 SPEC = CommandSpec(options=(
-    Option(long="--query", value_kind=OperandKind.TEXT),
-    Option(long="--count", value_kind=OperandKind.TEXT),
-    Option(long="--page", value_kind=OperandKind.TEXT),
+    Option(
+        long="--query",
+        value_kind=OperandKind.TEXT,
+        description=("Slack search query "
+                     "(supports operators like 'from:@user', "
+                     "'in:#channel')"),
+    ),
+    Option(
+        long="--count",
+        value_kind=OperandKind.TEXT,
+        description="Results per page (1-100, default 20)",
+    ),
+    Option(
+        long="--page",
+        value_kind=OperandKind.TEXT,
+        description="1-based page number (default 1)",
+    ),
 ), )
 
 

--- a/python/mirage/commands/builtin/slack/slack_search.py
+++ b/python/mirage/commands/builtin/slack/slack_search.py
@@ -19,8 +19,28 @@ from mirage.core.slack.search import search_messages
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
-SPEC = CommandSpec(options=(Option(long="--query",
-                                   value_kind=OperandKind.TEXT), ), )
+SPEC = CommandSpec(options=(
+    Option(long="--query", value_kind=OperandKind.TEXT),
+    Option(long="--count", value_kind=OperandKind.TEXT),
+    Option(long="--page", value_kind=OperandKind.TEXT),
+), )
+
+
+def _parse_int(raw: object, name: str, default: int, lo: int,
+               hi: int | None) -> int:
+    if raw is None or raw == "":
+        return default
+    if not isinstance(raw, str):
+        raise ValueError(f"--{name} must be an integer")
+    try:
+        value = int(raw)
+    except ValueError as e:
+        raise ValueError(f"--{name} must be an integer") from e
+    if value < lo:
+        raise ValueError(f"--{name} must be >= {lo}")
+    if hi is not None and value > hi:
+        raise ValueError(f"--{name} must be <= {hi}")
+    return value
 
 
 @command("slack-search", resource="slack", spec=SPEC)
@@ -33,5 +53,10 @@ async def slack_search(
     query = _extra.get("query", "")
     if not query or not isinstance(query, str):
         raise ValueError("--query is required")
-    result = await search_messages(accessor.config, query)
+    count = _parse_int(_extra.get("count"), "count", default=20, lo=1, hi=100)
+    page = _parse_int(_extra.get("page"), "page", default=1, lo=1, hi=None)
+    result = await search_messages(accessor.config,
+                                   query,
+                                   count=count,
+                                   page=page)
     return result, IOResult()

--- a/python/mirage/core/slack/_client.py
+++ b/python/mirage/core/slack/_client.py
@@ -27,6 +27,18 @@ def slack_headers(config: SlackConfig,
     }
 
 
+def _format_slack_error(method: str, data: dict) -> str:
+    err = data.get("error", "unknown_error")
+    base = f"Slack API error ({method}): {err}"
+    if err != "missing_scope":
+        return base
+    needed = data.get("needed") or ""
+    if not needed:
+        return base
+    provided = data.get("provided") or "(none)"
+    return f"{base} (needed: {needed}; provided: {provided})"
+
+
 async def slack_get(
     config: SlackConfig,
     method: str,
@@ -39,8 +51,7 @@ async def slack_get(
         async with session.get(url, headers=headers, params=params) as resp:
             data = await resp.json()
             if not data.get("ok"):
-                err = data.get("error", "unknown_error")
-                raise RuntimeError(f"Slack API error: {err}")
+                raise RuntimeError(_format_slack_error(method, data))
             return data
 
 
@@ -55,6 +66,5 @@ async def slack_post(
         async with session.post(url, headers=headers, json=body or {}) as resp:
             data = await resp.json()
             if not data.get("ok"):
-                err = data.get("error", "unknown_error")
-                raise RuntimeError(f"Slack API error: {err}")
+                raise RuntimeError(_format_slack_error(method, data))
             return data

--- a/python/mirage/core/slack/search.py
+++ b/python/mirage/core/slack/search.py
@@ -32,18 +32,25 @@ async def search_messages(
     config: SlackConfig,
     query: str,
     count: int = 20,
+    page: int = 1,
 ) -> bytes:
     """Search messages across workspace.
 
     Args:
         config (SlackConfig): Slack credentials.
         query (str): search query.
-        count (int): max results.
+        count (int): results per page (Slack caps at 100).
+        page (int): 1-based page number.
 
     Returns:
         bytes: JSON response.
     """
-    params = {"query": query, "count": count, "sort": "timestamp"}
+    params = {
+        "query": query,
+        "count": count,
+        "page": page,
+        "sort": "timestamp",
+    }
     data = await slack_get(
         config,
         "search.messages",
@@ -95,18 +102,25 @@ async def search_files(
     config: SlackConfig,
     query: str,
     count: int = 20,
+    page: int = 1,
 ) -> bytes:
     """Search files across workspace via Slack's search.files API.
 
     Args:
         config (SlackConfig): Slack credentials.
         query (str): search query.
-        count (int): max results.
+        count (int): results per page (Slack caps at 100).
+        page (int): 1-based page number.
 
     Returns:
         bytes: JSON response.
     """
-    params = {"query": query, "count": count, "sort": "timestamp"}
+    params = {
+        "query": query,
+        "count": count,
+        "page": page,
+        "sort": "timestamp",
+    }
     data = await slack_get(
         config,
         "search.files",

--- a/python/tests/commands/builtin/slack/test_write_commands.py
+++ b/python/tests/commands/builtin/slack/test_write_commands.py
@@ -94,9 +94,39 @@ async def test_search(accessor, config):
         stream, io_result = await slack_search(accessor, [],
                                                query="test query")
 
-    mock_search.assert_called_once_with(config, "test query")
+    mock_search.assert_called_once_with(config, "test query", count=20, page=1)
     out = json.loads(stream)
     assert out["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_search_forwards_count_and_page(accessor, config):
+    with patch(
+            "mirage.commands.builtin.slack.slack_search"
+            ".search_messages",
+            new_callable=AsyncMock,
+            return_value=b'{"ok":true}',
+    ) as mock_search:
+        await slack_search(accessor, [], query="q", count="50", page="3")
+    mock_search.assert_called_once_with(config, "q", count=50, page=3)
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_count_above_100(accessor):
+    with pytest.raises(ValueError, match="count"):
+        await slack_search(accessor, [], query="q", count="101")
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_page_below_1(accessor):
+    with pytest.raises(ValueError, match="page"):
+        await slack_search(accessor, [], query="q", page="0")
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_non_integer_count(accessor):
+    with pytest.raises(ValueError, match="count"):
+        await slack_search(accessor, [], query="q", count="abc")
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/slack/test_client.py
+++ b/python/tests/core/slack/test_client.py
@@ -72,8 +72,62 @@ async def test_slack_get_error(config):
         mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
         mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        with pytest.raises(RuntimeError, match="channel_not_found"):
+        with pytest.raises(
+                RuntimeError,
+                match=r"\(conversations\.info\): channel_not_found"):
             await slack_get(config, "conversations.info")
+
+
+@pytest.mark.asyncio
+async def test_slack_get_missing_scope_surfaces_scopes(config):
+    mock_resp = AsyncMock()
+    mock_resp.json = AsyncMock(
+        return_value={
+            "ok": False,
+            "error": "missing_scope",
+            "needed": "im:read,mpim:read",
+            "provided": "channels:read,users:read",
+        })
+    mock_session = AsyncMock()
+    mock_session.get = MagicMock(return_value=AsyncMock(
+        __aenter__=AsyncMock(return_value=mock_resp),
+        __aexit__=AsyncMock(return_value=False),
+    ))
+
+    with patch("mirage.core.slack._client.aiohttp.ClientSession") as mock_cs:
+        mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(
+                RuntimeError,
+                match=(r"\(conversations\.list\): missing_scope "
+                       r"\(needed: im:read,mpim:read; "
+                       r"provided: channels:read,users:read\)"),
+        ):
+            await slack_get(config, "conversations.list")
+
+
+@pytest.mark.asyncio
+async def test_slack_get_missing_scope_no_needed_falls_back(config):
+    mock_resp = AsyncMock()
+    mock_resp.json = AsyncMock(return_value={
+        "ok": False,
+        "error": "missing_scope",
+    })
+    mock_session = AsyncMock()
+    mock_session.get = MagicMock(return_value=AsyncMock(
+        __aenter__=AsyncMock(return_value=mock_resp),
+        __aexit__=AsyncMock(return_value=False),
+    ))
+
+    with patch("mirage.core.slack._client.aiohttp.ClientSession") as mock_cs:
+        mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(RuntimeError) as ei:
+            await slack_get(config, "conversations.list")
+        assert str(ei.value).endswith(
+            "Slack API error (conversations.list): missing_scope")
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/slack/test_search.py
+++ b/python/tests/core/slack/test_search.py
@@ -13,9 +13,41 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from mirage.core.slack.scope import SlackScope
-from mirage.core.slack.search import format_grep_results
+from mirage.core.slack.search import format_grep_results, search_messages
+from mirage.resource.slack.config import SlackConfig
+
+
+@pytest.mark.asyncio
+async def test_search_messages_defaults_include_page_1():
+    cfg = SlackConfig(token="xoxp-test")
+    with patch(
+            "mirage.core.slack.search.slack_get",
+            new=AsyncMock(return_value={"ok": True}),
+    ) as fake_get:
+        await search_messages(cfg, "hello")
+    params = fake_get.call_args.kwargs["params"]
+    assert params["query"] == "hello"
+    assert params["count"] == 20
+    assert params["page"] == 1
+    assert params["sort"] == "timestamp"
+
+
+@pytest.mark.asyncio
+async def test_search_messages_forwards_explicit_count_and_page():
+    cfg = SlackConfig(token="xoxp-test")
+    with patch(
+            "mirage.core.slack.search.slack_get",
+            new=AsyncMock(return_value={"ok": True}),
+    ) as fake_get:
+        await search_messages(cfg, "hello", count=50, page=3)
+    params = fake_get.call_args.kwargs["params"]
+    assert params["count"] == 50
+    assert params["page"] == 3
 
 
 def test_format_grep_results_path_uses_chat_jsonl():

--- a/typescript/packages/core/src/commands/builtin/slack/slack_search.test.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/slack_search.test.ts
@@ -43,12 +43,13 @@ async function runSearch(
 }
 
 describe('slack-search command', () => {
-  it('calls search.messages with query and default count=20', async () => {
+  it('calls search.messages with query, default count=20, page=1', async () => {
     const { transport } = await runSearch({ query: 'hello' })
     expect(transport.calls[0]?.endpoint).toBe('search.messages')
     expect(transport.calls[0]?.params).toMatchObject({
       query: 'hello',
       count: '20',
+      page: '1',
       sort: 'timestamp',
     })
   })
@@ -56,6 +57,11 @@ describe('slack-search command', () => {
   it('respects --count', async () => {
     const { transport } = await runSearch({ query: 'hello', count: '7' })
     expect(transport.calls[0]?.params).toMatchObject({ count: '7' })
+  })
+
+  it('respects --page', async () => {
+    const { transport } = await runSearch({ query: 'hello', count: '100', page: '3' })
+    expect(transport.calls[0]?.params).toMatchObject({ count: '100', page: '3' })
   })
 
   it('returns the JSON response bytes', async () => {
@@ -69,5 +75,17 @@ describe('slack-search command', () => {
 
   it('throws when --query missing', async () => {
     await expect(runSearch({})).rejects.toThrow(/query/)
+  })
+
+  it('rejects --count above 100', async () => {
+    await expect(runSearch({ query: 'q', count: '101' })).rejects.toThrow(/count/)
+  })
+
+  it('rejects --page below 1', async () => {
+    await expect(runSearch({ query: 'q', page: '0' })).rejects.toThrow(/page/)
+  })
+
+  it('rejects non-integer --count', async () => {
+    await expect(runSearch({ query: 'q', count: 'abc' })).rejects.toThrow(/count/)
   })
 })

--- a/typescript/packages/core/src/commands/builtin/slack/slack_search.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/slack_search.ts
@@ -23,8 +23,24 @@ const SPEC = new CommandSpec({
   options: [
     new Option({ long: '--query', valueKind: OperandKind.TEXT }),
     new Option({ long: '--count', valueKind: OperandKind.TEXT }),
+    new Option({ long: '--page', valueKind: OperandKind.TEXT }),
   ],
 })
+
+function parseIntFlag(
+  raw: string | boolean | undefined,
+  name: string,
+  fallback: number,
+  lo: number,
+  hi: number | null,
+): number {
+  if (raw === undefined || raw === '' || typeof raw !== 'string') return fallback
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed)) throw new Error(`--${name} must be an integer`)
+  if (parsed < lo) throw new Error(`--${name} must be >= ${String(lo)}`)
+  if (hi !== null && parsed > hi) throw new Error(`--${name} must be <= ${String(hi)}`)
+  return parsed
+}
 
 async function slackSearchCommand(
   accessor: SlackAccessor,
@@ -36,13 +52,9 @@ async function slackSearchCommand(
   if (typeof query !== 'string' || query === '') {
     throw new Error('--query is required')
   }
-  const countRaw = opts.flags.count
-  let count = 20
-  if (typeof countRaw === 'string' && countRaw !== '') {
-    const parsed = Number.parseInt(countRaw, 10)
-    if (Number.isFinite(parsed) && parsed > 0) count = parsed
-  }
-  const result = await searchMessages(accessor, query, count)
+  const count = parseIntFlag(opts.flags.count, 'count', 20, 1, 100)
+  const page = parseIntFlag(opts.flags.page, 'page', 1, 1, null)
+  const result = await searchMessages(accessor, query, count, page)
   return [result, new IOResult()]
 }
 

--- a/typescript/packages/core/src/commands/builtin/slack/slack_search.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/slack_search.ts
@@ -21,9 +21,21 @@ import { CommandSpec, OperandKind, Option } from '../../spec/types.ts'
 
 const SPEC = new CommandSpec({
   options: [
-    new Option({ long: '--query', valueKind: OperandKind.TEXT }),
-    new Option({ long: '--count', valueKind: OperandKind.TEXT }),
-    new Option({ long: '--page', valueKind: OperandKind.TEXT }),
+    new Option({
+      long: '--query',
+      valueKind: OperandKind.TEXT,
+      description: "Slack search query (supports operators like 'from:@user', 'in:#channel')",
+    }),
+    new Option({
+      long: '--count',
+      valueKind: OperandKind.TEXT,
+      description: 'Results per page (1-100, default 20)',
+    }),
+    new Option({
+      long: '--page',
+      valueKind: OperandKind.TEXT,
+      description: '1-based page number (default 1)',
+    }),
   ],
 })
 

--- a/typescript/packages/core/src/core/slack/_client.test.ts
+++ b/typescript/packages/core/src/core/slack/_client.test.ts
@@ -82,6 +82,54 @@ describe('HttpSlackTransport', () => {
     )
   })
 
+  it('missing_scope error surfaces needed and provided scopes', async () => {
+    const fakeFetch: typeof fetch = () =>
+      Promise.resolve(
+        jsonResponse({
+          ok: false,
+          error: 'missing_scope',
+          needed: 'im:read,mpim:read',
+          provided: 'channels:read,users:read',
+        }),
+      )
+    const t = new TestTransport('https://slack.com/api', {}, fakeFetch)
+    let caught: unknown = null
+    try {
+      await t.call('conversations.list')
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(SlackApiError)
+    const err = caught as SlackApiError
+    expect(err.needed).toBe('im:read,mpim:read')
+    expect(err.provided).toBe('channels:read,users:read')
+    expect(err.message).toMatch(/needed: im:read,mpim:read/)
+    expect(err.message).toMatch(/provided: channels:read,users:read/)
+  })
+
+  it('missing_scope without needed field falls back to base message', async () => {
+    const fakeFetch: typeof fetch = () =>
+      Promise.resolve(jsonResponse({ ok: false, error: 'missing_scope' }))
+    const t = new TestTransport('https://slack.com/api', {}, fakeFetch)
+    await expect(t.call('conversations.list')).rejects.toThrow(
+      /Slack API error \(conversations\.list\): missing_scope$/,
+    )
+  })
+
+  it('missing_scope with empty provided renders provided as (none)', async () => {
+    const fakeFetch: typeof fetch = () =>
+      Promise.resolve(
+        jsonResponse({
+          ok: false,
+          error: 'missing_scope',
+          needed: 'im:read',
+          provided: '',
+        }),
+      )
+    const t = new TestTransport('https://slack.com/api', {}, fakeFetch)
+    await expect(t.call('conversations.list')).rejects.toThrow(/provided: \(none\)/)
+  })
+
   it('attaches auth headers + Content-Type', async () => {
     let observedHeaders: HeadersInit | undefined
     const fakeFetch: typeof fetch = (_url, init) => {

--- a/typescript/packages/core/src/core/slack/_client.ts
+++ b/typescript/packages/core/src/core/slack/_client.ts
@@ -15,6 +15,8 @@
 export interface SlackResponse {
   ok: boolean
   error?: string
+  needed?: string
+  provided?: string
   [key: string]: unknown
 }
 
@@ -22,10 +24,24 @@ export class SlackApiError extends Error {
   constructor(
     public readonly endpoint: string,
     public readonly slackError: string,
+    public readonly needed: string | null = null,
+    public readonly provided: string | null = null,
   ) {
-    super(`Slack API error (${endpoint}): ${slackError}`)
+    super(formatSlackErrorMessage(endpoint, slackError, needed, provided))
     this.name = 'SlackApiError'
   }
+}
+
+function formatSlackErrorMessage(
+  endpoint: string,
+  slackError: string,
+  needed: string | null,
+  provided: string | null,
+): string {
+  const base = `Slack API error (${endpoint}): ${slackError}`
+  if (slackError !== 'missing_scope' || needed === null || needed === '') return base
+  const providedRepr = provided !== null && provided !== '' ? provided : '(none)'
+  return `${base} (needed: ${needed}; provided: ${providedRepr})`
 }
 
 export interface SlackTransport {
@@ -58,7 +74,12 @@ export abstract class HttpSlackTransport implements SlackTransport {
     const res = await this.fetch(url, init)
     const data = (await res.json()) as SlackResponse
     if (!data.ok) {
-      throw new SlackApiError(endpoint, data.error ?? 'unknown_error')
+      throw new SlackApiError(
+        endpoint,
+        data.error ?? 'unknown_error',
+        data.needed ?? null,
+        data.provided ?? null,
+      )
     }
     return data
   }

--- a/typescript/packages/core/src/core/slack/search.test.ts
+++ b/typescript/packages/core/src/core/slack/search.test.ts
@@ -31,19 +31,30 @@ class FakeTransport implements SlackTransport {
 }
 
 describe('searchMessages', () => {
-  it('calls search.messages with query, count, sort=timestamp', async () => {
+  it('calls search.messages with query, count, page, sort=timestamp', async () => {
     const t = new FakeTransport(() => ({ ok: true, messages: { matches: [] } }))
     const out = await searchMessages(new SlackAccessor(t), 'hello', 5)
     expect(t.calls[0]?.endpoint).toBe('search.messages')
-    expect(t.calls[0]?.params).toEqual({ query: 'hello', count: '5', sort: 'timestamp' })
+    expect(t.calls[0]?.params).toEqual({
+      query: 'hello',
+      count: '5',
+      page: '1',
+      sort: 'timestamp',
+    })
     const parsed = JSON.parse(DEC.decode(out)) as { ok: boolean }
     expect(parsed.ok).toBe(true)
   })
 
-  it('defaults count to 20', async () => {
+  it('defaults count to 20 and page to 1', async () => {
     const t = new FakeTransport(() => ({ ok: true }))
     await searchMessages(new SlackAccessor(t), 'q')
-    expect(t.calls[0]?.params).toMatchObject({ count: '20' })
+    expect(t.calls[0]?.params).toMatchObject({ count: '20', page: '1' })
+  })
+
+  it('forwards explicit page number', async () => {
+    const t = new FakeTransport(() => ({ ok: true }))
+    await searchMessages(new SlackAccessor(t), 'q', 50, 3)
+    expect(t.calls[0]?.params).toMatchObject({ count: '50', page: '3' })
   })
 
   it('returns bytes encoding the JSON response', async () => {

--- a/typescript/packages/core/src/core/slack/search.ts
+++ b/typescript/packages/core/src/core/slack/search.ts
@@ -36,10 +36,12 @@ export async function searchMessages(
   accessor: SlackAccessor,
   query: string,
   count = 20,
+  page = 1,
 ): Promise<Uint8Array> {
   const params: Record<string, string> = {
     query,
     count: String(count),
+    page: String(page),
     sort: 'timestamp',
   }
   let effective = accessor


### PR DESCRIPTION
## Summary

Fixes #31.

**slack-search pagination** — the command capped at 20 matches with no way to walk Slack's `pagination.page_count`. Adds:
- `--count` (1..100, default 20) — already existed on TS, now also on Python
- `--page` (>=1, default 1) — new on both sides

Callers can now iterate the response's `pagination.page_count` to reach matches 21..N without dropping to raw `curl`.

**missing_scope error UX** — adjacent friction the reporter mentioned: `ls /slack/dms` failed with a bare `missing_scope`, hiding which scopes the token actually lacked. The Slack API returns `needed` / `provided` fields; we now surface them.

Before:

```
ls: cannot access '/slack/dms': Slack API error (conversations.list): missing_scope
```

After:

```
ls: cannot access '/slack/dms': Slack API error (conversations.list): missing_scope (needed: im:read,mpim:read; provided: channels:read,users:read)
```

Python also now includes the endpoint name in error messages (parity with TS, which already did).

## Test plan

- [x] Python: new tests for `--count` / `--page` forwarding + validation (count>100, page<1, non-integer)
- [x] Python: new tests for `missing_scope` rich error + fallback when `needed` absent
- [x] TS: new tests mirroring all of the above (3 + 3)
- [x] Existing `test_search` updated for new positional kwargs; `test_slack_get_error` updated for endpoint-in-message format
- [x] Full Python suite: 5566 passed, 221 skipped
- [x] Scoped TS slack tests: 28 passed
- [x] `pre-commit run --all-files`: clean (ESLint + Prettier + yapf + ruff)