### PR TITLE
refactor(slack): layered core (paginate → fetchers → formatters)

### DIFF
--- a/python/mirage/commands/builtin/slack/grep/grep.py
+++ b/python/mirage/commands/builtin/slack/grep/grep.py
@@ -31,9 +31,11 @@ from mirage.core.slack.glob import resolve_glob
 from mirage.core.slack.read import read as slack_read
 from mirage.core.slack.readdir import readdir as _readdir
 from mirage.core.slack.scope import coalesce_scopes, detect_scope
-from mirage.core.slack.search import (build_query, format_file_grep_results,
-                                      format_grep_results, search_available,
-                                      search_files, search_messages)
+from mirage.core.slack.formatters import (build_query,
+                                          format_file_grep_results,
+                                          format_grep_results)
+from mirage.core.slack.search import (search_available, search_files,
+                                      search_messages)
 from mirage.core.slack.stat import stat as _stat
 from mirage.io.stream import exit_on_empty, quiet_match, yield_bytes
 from mirage.io.types import ByteSource, IOResult

--- a/python/mirage/commands/builtin/slack/grep/grep.py
+++ b/python/mirage/commands/builtin/slack/grep/grep.py
@@ -27,13 +27,13 @@ from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
                                                 call_stat)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
+from mirage.core.slack.formatters import (build_query,
+                                          format_file_grep_results,
+                                          format_grep_results)
 from mirage.core.slack.glob import resolve_glob
 from mirage.core.slack.read import read as slack_read
 from mirage.core.slack.readdir import readdir as _readdir
 from mirage.core.slack.scope import coalesce_scopes, detect_scope
-from mirage.core.slack.formatters import (build_query,
-                                          format_file_grep_results,
-                                          format_grep_results)
 from mirage.core.slack.search import (search_available, search_files,
                                       search_messages)
 from mirage.core.slack.stat import stat as _stat

--- a/python/mirage/commands/builtin/slack/rg.py
+++ b/python/mirage/commands/builtin/slack/rg.py
@@ -21,13 +21,13 @@ from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
+from mirage.core.slack.formatters import (build_query,
+                                          format_file_grep_results,
+                                          format_grep_results)
 from mirage.core.slack.glob import resolve_glob
 from mirage.core.slack.read import read as slack_read
 from mirage.core.slack.readdir import readdir as _readdir
 from mirage.core.slack.scope import coalesce_scopes, detect_scope
-from mirage.core.slack.formatters import (build_query,
-                                          format_file_grep_results,
-                                          format_grep_results)
 from mirage.core.slack.search import (search_available, search_files,
                                       search_messages)
 from mirage.io.types import ByteSource, IOResult

--- a/python/mirage/commands/builtin/slack/rg.py
+++ b/python/mirage/commands/builtin/slack/rg.py
@@ -25,9 +25,11 @@ from mirage.core.slack.glob import resolve_glob
 from mirage.core.slack.read import read as slack_read
 from mirage.core.slack.readdir import readdir as _readdir
 from mirage.core.slack.scope import coalesce_scopes, detect_scope
-from mirage.core.slack.search import (build_query, format_file_grep_results,
-                                      format_grep_results, search_available,
-                                      search_files, search_messages)
+from mirage.core.slack.formatters import (build_query,
+                                          format_file_grep_results,
+                                          format_grep_results)
+from mirage.core.slack.search import (search_available, search_files,
+                                      search_messages)
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 

--- a/python/mirage/core/slack/channels.py
+++ b/python/mirage/core/slack/channels.py
@@ -12,8 +12,37 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.core.slack._client import slack_get
+from collections.abc import AsyncIterator
+
+from mirage.core.slack.paginate import cursor_pages
 from mirage.resource.slack.config import SlackConfig
+
+
+def _channel_base_params(types: str, limit: int) -> dict:
+    return {"types": types, "limit": limit, "exclude_archived": "true"}
+
+
+def list_channels_stream(
+    config: SlackConfig,
+    types: str = "public_channel,private_channel",
+    limit: int = 200,
+) -> AsyncIterator[list[dict]]:
+    """Page-streaming variant: yields one Slack page per HTTP round-trip.
+
+    Args:
+        config (SlackConfig): Slack credentials.
+        types (str): channel types to list.
+        limit (int): max per page.
+
+    Yields:
+        list[dict]: channels in one Slack page.
+    """
+    return cursor_pages(
+        config,
+        "conversations.list",
+        base_params=_channel_base_params(types, limit),
+        items_key="channels",
+    )
 
 
 async def list_channels(
@@ -21,7 +50,7 @@ async def list_channels(
     types: str = "public_channel,private_channel",
     limit: int = 200,
 ) -> list[dict]:
-    """List channels via conversations.list.
+    """List channels via conversations.list (eager; collects all pages).
 
     Args:
         config (SlackConfig): Slack credentials.
@@ -31,29 +60,33 @@ async def list_channels(
     Returns:
         list[dict]: channel metadata dicts.
     """
-    channels: list[dict] = []
-    cursor: str | None = None
-    while True:
-        params: dict = {
-            "types": types,
-            "limit": limit,
-            "exclude_archived": "true",
-        }
-        if cursor:
-            params["cursor"] = cursor
-        data = await slack_get(config, "conversations.list", params=params)
-        channels.extend(data.get("channels", []))
-        cursor = (data.get("response_metadata", {}).get("next_cursor", ""))
-        if not cursor:
-            break
-    return channels
+    out: list[dict] = []
+    async for page in list_channels_stream(config, types=types, limit=limit):
+        out.extend(page)
+    return out
+
+
+def list_dms_stream(
+    config: SlackConfig,
+    limit: int = 200,
+) -> AsyncIterator[list[dict]]:
+    """Page-streaming variant for direct messages.
+
+    Args:
+        config (SlackConfig): Slack credentials.
+        limit (int): max per page.
+
+    Yields:
+        list[dict]: DM channels in one Slack page.
+    """
+    return list_channels_stream(config, types="im,mpim", limit=limit)
 
 
 async def list_dms(
     config: SlackConfig,
     limit: int = 200,
 ) -> list[dict]:
-    """List direct messages via conversations.list.
+    """List direct messages via conversations.list (eager).
 
     Args:
         config (SlackConfig): Slack credentials.

--- a/python/mirage/core/slack/files_list.py
+++ b/python/mirage/core/slack/files_list.py
@@ -1,0 +1,85 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+from datetime import datetime, timezone
+
+from mirage.core.slack.paginate import offset_pages
+from mirage.resource.slack.config import SlackConfig
+
+
+def _day_range_ts(date_str: str) -> tuple[str, str]:
+    dt = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    ts_from = str(dt.timestamp())
+    ts_to = str(dt.replace(hour=23, minute=59, second=59).timestamp())
+    return ts_from, ts_to
+
+
+def list_files_for_day_stream(
+    config: SlackConfig,
+    channel_id: str,
+    date_str: str,
+    count: int = 200,
+) -> AsyncIterator[list[dict]]:
+    """Page-streaming variant of list_files_for_day.
+
+    Args:
+        config (SlackConfig): Slack credentials.
+        channel_id (str): channel ID.
+        date_str (str): date in YYYY-MM-DD format.
+        count (int): per-page count (Slack caps at 200).
+
+    Yields:
+        list[dict]: file metadata dicts in one Slack page.
+    """
+    ts_from, ts_to = _day_range_ts(date_str)
+    return offset_pages(
+        config,
+        "files.list",
+        base_params={
+            "channel": channel_id,
+            "ts_from": ts_from,
+            "ts_to": ts_to,
+            "count": str(count),
+        },
+        pages_path=("paging", "pages"),
+        items_path=("files", ),
+    )
+
+
+async def list_files_for_day(
+    config: SlackConfig,
+    channel_id: str,
+    date_str: str,
+    count: int = 200,
+) -> list[dict]:
+    """List files attached to a channel on a given UTC date (eager).
+
+    Uses files.list filtered by channel + date bounds. Much cheaper
+    than walking conversations.history just to extract msg.files[].
+
+    Args:
+        config (SlackConfig): Slack credentials.
+        channel_id (str): channel ID.
+        date_str (str): date in YYYY-MM-DD format.
+        count (int): per-page count.
+
+    Returns:
+        list[dict]: all files attached in that channel-day.
+    """
+    out: list[dict] = []
+    async for page in list_files_for_day_stream(config, channel_id, date_str,
+                                                count):
+        out.extend(page)
+    return out

--- a/python/mirage/core/slack/formatters.py
+++ b/python/mirage/core/slack/formatters.py
@@ -1,0 +1,119 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import json
+from datetime import datetime, timezone
+
+from mirage.core.slack.files import file_blob_name
+from mirage.core.slack.scope import SlackScope
+from mirage.utils.sanitize import sanitize_name
+
+
+def build_query(pattern: str, scope: SlackScope) -> str:
+    """Compose a Slack search query string for a pushed-down grep/rg call.
+
+    Args:
+        pattern (str): user-supplied pattern.
+        scope (SlackScope): the Slack-side directory the grep is rooted at.
+
+    Returns:
+        str: query with optional in:#channel or in:@user prefix.
+    """
+    if scope.container == "channels" and scope.channel_name:
+        return f"in:#{scope.channel_name} {pattern}"
+    if scope.container == "dms" and scope.channel_name:
+        return f"in:@{scope.channel_name} {pattern}"
+    return pattern
+
+
+def format_grep_results(
+    raw: bytes,
+    scope: SlackScope,
+    prefix: str,
+) -> list[str]:
+    """Format a Slack search.messages JSON response as grep-style lines.
+
+    Args:
+        raw (bytes): JSON-encoded search.messages response.
+        scope (SlackScope): the rooted scope used to compute relative paths.
+        prefix (str): VFS mount prefix to prepend.
+
+    Returns:
+        list[str]: grep-formatted lines, one per match.
+    """
+    payload = json.loads(raw.decode())
+    matches = payload.get("messages", {}).get("matches", []) or []
+    lines: list[str] = []
+    for msg in matches:
+        ch = msg.get("channel", {}) or {}
+        ch_name = ch.get("name") or scope.channel_name or ""
+        ch_id = ch.get("id") or scope.channel_id or ""
+        container = scope.container or "channels"
+        ts_raw = msg.get("ts", "0")
+        try:
+            ts_float = float(ts_raw)
+            date_str = datetime.fromtimestamp(
+                ts_float, tz=timezone.utc).date().isoformat()
+        except (TypeError, ValueError):
+            date_str = ""
+        safe_name = sanitize_name(ch_name)
+        dirname = f"{safe_name}__{ch_id}" if ch_id else safe_name
+        path = (f"{prefix}/{container}/{dirname}/{date_str}/chat.jsonl"
+                if date_str else f"{prefix}/{container}/{dirname}")
+        author = msg.get("username") or msg.get("user") or "?"
+        text = (msg.get("text") or "").replace("\n", " ")
+        lines.append(f"{path}:[{author}] {text}")
+    return lines
+
+
+def format_file_grep_results(
+    raw: bytes,
+    scope: SlackScope,
+    prefix: str,
+) -> list[str]:
+    """Format a Slack search.files JSON response as grep-style lines.
+
+    Args:
+        raw (bytes): JSON-encoded search.files response.
+        scope (SlackScope): the rooted scope (must have channel_id).
+        prefix (str): VFS mount prefix to prepend.
+
+    Returns:
+        list[str]: grep-formatted lines, one per file match.
+    """
+    payload = json.loads(raw.decode())
+    matches = payload.get("files", {}).get("matches", []) or []
+    lines: list[str] = []
+    for f in matches:
+        fid = f.get("id", "")
+        title = (f.get("title") or f.get("name") or fid)
+        blob_name = file_blob_name(f)
+        ts = f.get("timestamp", 0)
+        try:
+            date_str = datetime.fromtimestamp(
+                float(ts), tz=timezone.utc).date().isoformat()
+        except (TypeError, ValueError):
+            date_str = ""
+        if not scope.channel_id:
+            continue
+        ch_id = scope.channel_id
+        ch_name = scope.channel_name or ""
+        safe_name = sanitize_name(ch_name) if ch_name else ""
+        dirname = f"{safe_name}__{ch_id}" if safe_name else ch_id
+        container = scope.container or "channels"
+        path = (f"{prefix}/{container}/{dirname}/{date_str}/files/{blob_name}"
+                if date_str else
+                f"{prefix}/{container}/{dirname}/files/{blob_name}")
+        lines.append(f"{path}:[file] {title}")
+    return lines

--- a/python/mirage/core/slack/formatters.py
+++ b/python/mirage/core/slack/formatters.py
@@ -20,6 +20,33 @@ from mirage.core.slack.scope import SlackScope
 from mirage.utils.sanitize import sanitize_name
 
 
+def channel_dirname(ch: dict) -> str:
+    """Compute the VFS dirname for a channel, of the form `name__C123`."""
+    name = sanitize_name(ch.get("name", ch.get("id", "unknown")))
+    return f"{name}__{ch['id']}"
+
+
+def dm_dirname(dm: dict, user_map: dict[str, str]) -> str:
+    """Compute the VFS dirname for a DM, of the form `username__D123`.
+
+    Args:
+        dm (dict): DM channel dict with id and user fields.
+        user_map (dict[str, str]): user_id -> name lookup.
+
+    Returns:
+        str: dirname; falls back to the user id when not in user_map.
+    """
+    user_id = dm.get("user", "")
+    name = sanitize_name(user_map.get(user_id, user_id))
+    return f"{name}__{dm['id']}"
+
+
+def user_filename(u: dict) -> str:
+    """Compute the VFS filename for a user, of the form `name__U123.json`."""
+    name = sanitize_name(u.get("name", u.get("id", "unknown")))
+    return f"{name}__{u['id']}.json"
+
+
 def build_query(pattern: str, scope: SlackScope) -> str:
     """Compose a Slack search query string for a pushed-down grep/rg call.
 

--- a/python/mirage/core/slack/history.py
+++ b/python/mirage/core/slack/history.py
@@ -13,10 +13,51 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import json
+from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 
-from mirage.core.slack._client import slack_get
+from mirage.core.slack.paginate import cursor_pages
 from mirage.resource.slack.config import SlackConfig
+
+
+def _day_bounds_ts(date_str: str) -> tuple[str, str]:
+    dt = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    oldest = str(dt.timestamp())
+    latest = str(dt.replace(hour=23, minute=59, second=59).timestamp())
+    return oldest, latest
+
+
+def stream_messages_for_day(
+    config: SlackConfig,
+    channel_id: str,
+    date_str: str,
+    limit: int = 200,
+) -> AsyncIterator[list[dict]]:
+    """Page-streaming history for a channel-day.
+
+    Args:
+        config (SlackConfig): Slack credentials.
+        channel_id (str): channel ID.
+        date_str (str): date in YYYY-MM-DD format.
+        limit (int): max per page.
+
+    Yields:
+        list[dict]: messages in one Slack page (unsorted; the eager
+        wrapper sorts at the end).
+    """
+    oldest, latest = _day_bounds_ts(date_str)
+    return cursor_pages(
+        config,
+        "conversations.history",
+        base_params={
+            "channel": channel_id,
+            "oldest": oldest,
+            "latest": latest,
+            "limit": limit,
+            "inclusive": "true",
+        },
+        items_key="messages",
+    )
 
 
 async def fetch_messages_for_day(
@@ -24,7 +65,7 @@ async def fetch_messages_for_day(
     channel_id: str,
     date_str: str,
 ) -> list[dict]:
-    """Fetch all messages for a date as parsed dicts.
+    """Fetch all messages for a date as parsed dicts (eager).
 
     Args:
         config (SlackConfig): Slack credentials.
@@ -34,30 +75,9 @@ async def fetch_messages_for_day(
     Returns:
         list[dict]: messages sorted by ts ascending.
     """
-    dt = datetime.strptime(date_str, "%Y-%m-%d")
-    dt = dt.replace(tzinfo=timezone.utc)
-    oldest = str(dt.timestamp())
-    latest = str(dt.replace(hour=23, minute=59, second=59).timestamp())
-
     messages: list[dict] = []
-    cursor: str | None = None
-    while True:
-        params: dict = {
-            "channel": channel_id,
-            "oldest": oldest,
-            "latest": latest,
-            "limit": 200,
-            "inclusive": "true",
-        }
-        if cursor:
-            params["cursor"] = cursor
-        data = await slack_get(config, "conversations.history", params=params)
-        messages.extend(data.get("messages", []))
-        if not data.get("has_more"):
-            break
-        cursor = (data.get("response_metadata", {}).get("next_cursor", ""))
-        if not cursor:
-            break
+    async for page in stream_messages_for_day(config, channel_id, date_str):
+        messages.extend(page)
     messages.sort(key=lambda m: float(m.get("ts", "0")))
     return messages
 
@@ -82,12 +102,41 @@ async def get_history_jsonl(
     return ("\n".join(lines) + "\n").encode() if lines else b""
 
 
+def stream_thread_replies(
+    config: SlackConfig,
+    channel_id: str,
+    thread_ts: str,
+    limit: int = 200,
+) -> AsyncIterator[list[dict]]:
+    """Page-streaming thread replies.
+
+    Args:
+        config (SlackConfig): Slack credentials.
+        channel_id (str): channel ID.
+        thread_ts (str): parent message ts.
+        limit (int): max per page.
+
+    Yields:
+        list[dict]: reply messages in one Slack page.
+    """
+    return cursor_pages(
+        config,
+        "conversations.replies",
+        base_params={
+            "channel": channel_id,
+            "ts": thread_ts,
+            "limit": limit,
+        },
+        items_key="messages",
+    )
+
+
 async def get_thread_jsonl(
     config: SlackConfig,
     channel_id: str,
     thread_ts: str,
 ) -> list[dict]:
-    """Fetch thread replies.
+    """Fetch thread replies (eager).
 
     Args:
         config (SlackConfig): Slack credentials.
@@ -98,20 +147,6 @@ async def get_thread_jsonl(
         list[dict]: reply messages.
     """
     replies: list[dict] = []
-    cursor: str | None = None
-    while True:
-        params: dict = {
-            "channel": channel_id,
-            "ts": thread_ts,
-            "limit": 200,
-        }
-        if cursor:
-            params["cursor"] = cursor
-        data = await slack_get(config, "conversations.replies", params=params)
-        replies.extend(data.get("messages", []))
-        if not data.get("has_more"):
-            break
-        cursor = (data.get("response_metadata", {}).get("next_cursor", ""))
-        if not cursor:
-            break
+    async for page in stream_thread_replies(config, channel_id, thread_ts):
+        replies.extend(page)
     return replies

--- a/python/mirage/core/slack/paginate.py
+++ b/python/mirage/core/slack/paginate.py
@@ -1,0 +1,103 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from mirage.core.slack._client import slack_get
+from mirage.resource.slack.config import SlackConfig
+
+
+async def cursor_pages(
+    config: SlackConfig,
+    endpoint: str,
+    base_params: dict,
+    items_key: str,
+    token: str | None = None,
+) -> AsyncIterator[list[dict]]:
+    """Walk a cursor-paginated Slack endpoint, yielding one page of items per HTTP round-trip.
+
+    Args:
+        config (SlackConfig): Slack credentials.
+        endpoint (str): Slack API method, e.g. "conversations.list".
+        base_params (dict): per-request params; "cursor" is set by this function.
+        items_key (str): top-level response key that holds the page list (e.g. "channels", "members", "messages").
+        token (str | None): override token; falls back to config.token.
+
+    Yields:
+        list[dict]: the items in each page. Generator returns when Slack signals last page (empty next_cursor).
+    """
+    cursor: str | None = None
+    while True:
+        params = dict(base_params)
+        if cursor:
+            params["cursor"] = cursor
+        data = await slack_get(config, endpoint, params=params, token=token)
+        yield data.get(items_key, []) or []
+        cursor = (data.get("response_metadata", {}).get("next_cursor") or "") or None
+        if cursor is None:
+            return
+
+
+def _get_nested(d: dict, path: tuple[str, ...]) -> Any:
+    cur: Any = d
+    for k in path:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(k)
+    return cur
+
+
+async def offset_pages(
+    config: SlackConfig,
+    endpoint: str,
+    base_params: dict,
+    pages_path: tuple[str, ...],
+    items_path: tuple[str, ...],
+    start_page: int = 1,
+    max_pages: int | None = None,
+    token: str | None = None,
+) -> AsyncIterator[list[dict]]:
+    """Walk a page-paginated Slack endpoint (search.messages, files.list, etc.), yielding one page at a time.
+
+    Args:
+        config (SlackConfig): Slack credentials.
+        endpoint (str): Slack API method, e.g. "search.messages".
+        base_params (dict): per-request params; "page" is set by this function.
+        pages_path (tuple[str, ...]): nested path in response to the total page count, e.g. ("messages", "pagination", "page_count").
+        items_path (tuple[str, ...]): nested path to the items list, e.g. ("messages", "matches").
+        start_page (int): page number to start from (1-based).
+        max_pages (int | None): cap on number of pages to fetch; None = unbounded.
+        token (str | None): override token.
+
+    Yields:
+        list[dict]: items from each page.
+    """
+    page = start_page
+    total_pages: int | None = None
+    fetched = 0
+    while True:
+        params = dict(base_params)
+        params["page"] = str(page)
+        data = await slack_get(config, endpoint, params=params, token=token)
+        items = _get_nested(data, items_path) or []
+        yield items
+        fetched += 1
+        if total_pages is None:
+            total_pages = _get_nested(data, pages_path) or 1
+        if page >= total_pages:
+            return
+        if max_pages is not None and fetched >= max_pages:
+            return
+        page += 1

--- a/python/mirage/core/slack/paginate.py
+++ b/python/mirage/core/slack/paginate.py
@@ -26,17 +26,19 @@ async def cursor_pages(
     items_key: str,
     token: str | None = None,
 ) -> AsyncIterator[list[dict]]:
-    """Walk a cursor-paginated Slack endpoint, yielding one page of items per HTTP round-trip.
+    """Walk a cursor-paginated Slack endpoint, one page per round-trip.
 
     Args:
         config (SlackConfig): Slack credentials.
         endpoint (str): Slack API method, e.g. "conversations.list".
-        base_params (dict): per-request params; "cursor" is set by this function.
-        items_key (str): top-level response key that holds the page list (e.g. "channels", "members", "messages").
+        base_params (dict): per-request params; "cursor" is set here.
+        items_key (str): top-level response key holding the page list
+            (e.g. "channels", "members", "messages").
         token (str | None): override token; falls back to config.token.
 
     Yields:
-        list[dict]: the items in each page. Generator returns when Slack signals last page (empty next_cursor).
+        list[dict]: items in each page. Generator returns when Slack
+        signals last page (empty next_cursor).
     """
     cursor: str | None = None
     while True:
@@ -69,16 +71,19 @@ async def offset_pages(
     max_pages: int | None = None,
     token: str | None = None,
 ) -> AsyncIterator[list[dict]]:
-    """Walk a page-paginated Slack endpoint (search.messages, files.list, etc.), yielding one page at a time.
+    """Walk a page-paginated Slack endpoint (search, files.list, ...).
 
     Args:
         config (SlackConfig): Slack credentials.
         endpoint (str): Slack API method, e.g. "search.messages".
-        base_params (dict): per-request params; "page" is set by this function.
-        pages_path (tuple[str, ...]): nested path in response to the total page count, e.g. ("messages", "pagination", "page_count").
-        items_path (tuple[str, ...]): nested path to the items list, e.g. ("messages", "matches").
+        base_params (dict): per-request params; "page" is set here.
+        pages_path (tuple[str, ...]): nested path to total page count
+            in the response, e.g. ("messages", "pagination",
+            "page_count").
+        items_path (tuple[str, ...]): nested path to items list, e.g.
+            ("messages", "matches").
         start_page (int): page number to start from (1-based).
-        max_pages (int | None): cap on number of pages to fetch; None = unbounded.
+        max_pages (int | None): cap on pages fetched; None = unbounded.
         token (str | None): override token.
 
     Yields:
@@ -95,7 +100,9 @@ async def offset_pages(
         yield items
         fetched += 1
         if total_pages is None:
-            total_pages = _get_nested(data, pages_path) or 1  # stop after one page if pagination metadata is missing
+            total_pages = _get_nested(
+                data, pages_path
+            ) or 1  # stop after one page if pagination metadata is missing
         if page >= total_pages:
             return
         if max_pages is not None and fetched >= max_pages:

--- a/python/mirage/core/slack/paginate.py
+++ b/python/mirage/core/slack/paginate.py
@@ -45,7 +45,7 @@ async def cursor_pages(
             params["cursor"] = cursor
         data = await slack_get(config, endpoint, params=params, token=token)
         yield data.get(items_key, []) or []
-        cursor = (data.get("response_metadata", {}).get("next_cursor") or "") or None
+        cursor = data.get("response_metadata", {}).get("next_cursor") or None
         if cursor is None:
             return
 
@@ -95,7 +95,7 @@ async def offset_pages(
         yield items
         fetched += 1
         if total_pages is None:
-            total_pages = _get_nested(data, pages_path) or 1
+            total_pages = _get_nested(data, pages_path) or 1  # stop after one page if pagination metadata is missing
         if page >= total_pages:
             return
         if max_pages is not None and fetched >= max_pages:

--- a/python/mirage/core/slack/readdir.py
+++ b/python/mirage/core/slack/readdir.py
@@ -19,31 +19,14 @@ from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.core.slack._client import slack_get
 from mirage.core.slack.channels import list_channels, list_dms
 from mirage.core.slack.files import file_blob_name
+from mirage.core.slack.formatters import (channel_dirname, dm_dirname,
+                                          user_filename)
 from mirage.core.slack.history import fetch_messages_for_day
+from mirage.core.slack.scope import SlackScope, detect_scope
 from mirage.core.slack.users import list_users
 from mirage.types import PathSpec
-from mirage.utils.sanitize import sanitize_name
 
 VIRTUAL_ROOTS = ("channels", "dms", "users")
-
-
-def _channel_dirname(ch: dict) -> str:
-    name = sanitize_name(ch.get("name", ch.get("id", "unknown")))
-    return f"{name}__{ch['id']}"
-
-
-def _dm_dirname(
-    dm: dict,
-    user_map: dict[str, str],
-) -> str:
-    user_id = dm.get("user", "")
-    name = sanitize_name(user_map.get(user_id, user_id))
-    return f"{name}__{dm['id']}"
-
-
-def _user_filename(u: dict) -> str:
-    name = sanitize_name(u.get("name", u.get("id", "unknown")))
-    return f"{name}__{u['id']}.json"
 
 
 def _date_range(latest_ts: float,
@@ -74,189 +57,253 @@ async def _latest_message_ts(config, channel_id: str) -> float | None:
     return None
 
 
+def _normalize_path(path: PathSpec | str) -> tuple[PathSpec, str, str, str]:
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    prefix = path.prefix or ""
+    raw = path.directory if path.pattern else path.original
+    if prefix and raw.startswith(prefix):
+        raw = raw[len(prefix):] or "/"
+    key = raw.strip("/")
+    virtual_key = prefix + "/" + key if key else prefix or "/"
+    return path, prefix, key, virtual_key
+
+
+async def _readdir_root(prefix: str) -> list[str]:
+    return [f"{prefix}/channels", f"{prefix}/dms", f"{prefix}/users"]
+
+
+async def _readdir_channels(
+    accessor: SlackAccessor,
+    prefix: str,
+    virtual_key: str,
+    index: IndexCacheStore | None,
+) -> list[str]:
+    if index is not None:
+        listing = await index.list_dir(virtual_key)
+        if listing.entries is not None:
+            return listing.entries
+    channels = await list_channels(accessor.config)
+    entries: list[tuple[str, IndexEntry]] = []
+    names: list[str] = []
+    for ch in channels:
+        dirname = channel_dirname(ch)
+        entry = IndexEntry(
+            id=ch["id"],
+            name=ch.get("name", ""),
+            resource_type="slack/channel",
+            vfs_name=dirname,
+            remote_time=str(ch.get("created", 0)),
+        )
+        entries.append((dirname, entry))
+        names.append(f"{prefix}/channels/{dirname}")
+    if index is not None:
+        await index.set_dir(virtual_key, entries)
+    return names
+
+
+async def _readdir_dms(
+    accessor: SlackAccessor,
+    prefix: str,
+    virtual_key: str,
+    index: IndexCacheStore | None,
+) -> list[str]:
+    if index is not None:
+        listing = await index.list_dir(virtual_key)
+        if listing.entries is not None:
+            return listing.entries
+    dms = await list_dms(accessor.config)
+    users = await list_users(accessor.config)
+    user_map = {u["id"]: u.get("name", u["id"]) for u in users}
+    entries: list[tuple[str, IndexEntry]] = []
+    names: list[str] = []
+    for dm in dms:
+        dirname = dm_dirname(dm, user_map)
+        uid = dm.get("user", "")
+        entry = IndexEntry(
+            id=dm["id"],
+            name=user_map.get(uid, uid),
+            resource_type="slack/dm",
+            vfs_name=dirname,
+            remote_time=str(dm.get("created", 0)),
+        )
+        entries.append((dirname, entry))
+        names.append(f"{prefix}/dms/{dirname}")
+    if index is not None:
+        await index.set_dir(virtual_key, entries)
+    return names
+
+
+async def _readdir_users(
+    accessor: SlackAccessor,
+    prefix: str,
+    virtual_key: str,
+    index: IndexCacheStore | None,
+) -> list[str]:
+    if index is not None:
+        listing = await index.list_dir(virtual_key)
+        if listing.entries is not None:
+            return listing.entries
+    users = await list_users(accessor.config)
+    entries: list[tuple[str, IndexEntry]] = []
+    names: list[str] = []
+    for u in users:
+        filename = user_filename(u)
+        entry = IndexEntry(
+            id=u["id"],
+            name=u.get("name", ""),
+            resource_type="slack/user",
+            vfs_name=filename,
+        )
+        entries.append((filename, entry))
+        names.append(f"{prefix}/users/{filename}")
+    if index is not None:
+        await index.set_dir(virtual_key, entries)
+    return names
+
+
+async def _readdir_channel_dates(
+    accessor: SlackAccessor,
+    path: PathSpec,
+    prefix: str,
+    key: str,
+    virtual_key: str,
+    container: str,
+    index: IndexCacheStore | None,
+) -> list[str]:
+    if index is None:
+        raise FileNotFoundError(path)
+    lookup = await index.get(virtual_key)
+    if lookup.entry is None:
+        parent_str = prefix + "/" + container
+        parent = PathSpec(original=parent_str,
+                          directory=parent_str,
+                          prefix=prefix)
+        await readdir(accessor, parent, index)
+        lookup = await index.get(virtual_key)
+    if lookup.entry is None:
+        raise FileNotFoundError(path)
+    listing = await index.list_dir(virtual_key)
+    if listing.entries is not None:
+        return listing.entries
+    created = int(lookup.entry.remote_time or 0)
+    latest_ts = await _latest_message_ts(accessor.config, lookup.entry.id)
+    if latest_ts and created:
+        dates = _date_range(latest_ts, created)
+    elif latest_ts:
+        dates = _date_range(latest_ts, int(latest_ts))
+    else:
+        dates = []
+    entries: list[tuple[str, IndexEntry]] = []
+    names: list[str] = []
+    for d in dates:
+        entry = IndexEntry(
+            id=f"{lookup.entry.id}:{d}",
+            name=d,
+            resource_type="slack/date_dir",
+            vfs_name=d,
+        )
+        entries.append((d, entry))
+        names.append(f"{prefix}/{key}/{d}")
+    await index.set_dir(virtual_key, entries)
+    return names
+
+
+async def _readdir_date_contents(
+    accessor: SlackAccessor,
+    path: PathSpec,
+    prefix: str,
+    key: str,
+    virtual_key: str,
+    container: str,
+    chan_seg: str,
+    date_str: str,
+    index: IndexCacheStore | None,
+) -> list[str]:
+    if index is None:
+        raise FileNotFoundError(path)
+    cached = await index.list_dir(virtual_key)
+    if cached.entries is not None:
+        return cached.entries
+    parent_vk = f"{prefix}/{container}/{chan_seg}"
+    parent_lookup = await index.get(parent_vk)
+    if parent_lookup.entry is None:
+        parent_str = f"{prefix}/{container}/{chan_seg}"
+        parent = PathSpec(original=parent_str,
+                          directory=parent_str,
+                          prefix=prefix)
+        await readdir(accessor, parent, index)
+        parent_lookup = await index.get(parent_vk)
+    if parent_lookup.entry is None:
+        raise FileNotFoundError(path)
+    channel_id = parent_lookup.entry.id
+    await _fetch_day(accessor, channel_id, date_str, virtual_key, index)
+    cached = await index.list_dir(virtual_key)
+    if cached.entries is not None:
+        return cached.entries
+    raise FileNotFoundError(path)
+
+
+async def _readdir_files_dir(
+    accessor: SlackAccessor,
+    path: PathSpec,
+    prefix: str,
+    key: str,
+    virtual_key: str,
+    container: str,
+    chan_seg: str,
+    date_str: str,
+    index: IndexCacheStore | None,
+) -> list[str]:
+    if index is None:
+        raise FileNotFoundError(path)
+    cached = await index.list_dir(virtual_key)
+    if cached.entries is not None:
+        return cached.entries
+    date_str_path = f"{prefix}/{container}/{chan_seg}/{date_str}"
+    date_path = PathSpec(original=date_str_path,
+                         directory=date_str_path,
+                         prefix=prefix)
+    await readdir(accessor, date_path, index)
+    cached = await index.list_dir(virtual_key)
+    if cached.entries is not None:
+        return cached.entries
+    raise FileNotFoundError(path)
+
+
 async def readdir(
     accessor: SlackAccessor,
     path: PathSpec,
     index: IndexCacheStore = None,
 ) -> list[str]:
-    if isinstance(path, str):
-        path = PathSpec(original=path, directory=path)
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.directory if path.pattern else path.original
-    if prefix and path.startswith(prefix):
-        path = path[len(prefix):] or "/"
-    key = path.strip("/")
-    virtual_key = prefix + "/" + key if key else prefix or "/"
+    path, prefix, key, virtual_key = _normalize_path(path)
 
     if not key:
-        return [f"{prefix}/channels", f"{prefix}/dms", f"{prefix}/users"]
+        return await _readdir_root(prefix)
+
+    scope = detect_scope(path)
+    container = scope.container
 
     if key == "channels":
-        if index is not None:
-            listing = await index.list_dir(virtual_key)
-            if listing.entries is not None:
-                return listing.entries
-        channels = await list_channels(accessor.config)
-        entries = []
-        names = []
-        for ch in channels:
-            dirname = _channel_dirname(ch)
-            entry = IndexEntry(
-                id=ch["id"],
-                name=ch.get("name", ""),
-                resource_type="slack/channel",
-                vfs_name=dirname,
-                remote_time=str(ch.get("created", 0)),
-            )
-            entries.append((dirname, entry))
-            names.append(f"{prefix}/channels/{dirname}")
-        if index is not None:
-            await index.set_dir(virtual_key, entries)
-        return names
-
+        return await _readdir_channels(accessor, prefix, virtual_key, index)
     if key == "dms":
-        if index is not None:
-            listing = await index.list_dir(virtual_key)
-            if listing.entries is not None:
-                return listing.entries
-        dms = await list_dms(accessor.config)
-        users = await list_users(accessor.config)
-        user_map = {u["id"]: u.get("name", u["id"]) for u in users}
-        entries = []
-        names = []
-        for dm in dms:
-            dirname = _dm_dirname(dm, user_map)
-            uid = dm.get("user", "")
-            entry = IndexEntry(
-                id=dm["id"],
-                name=user_map.get(uid, uid),
-                resource_type="slack/dm",
-                vfs_name=dirname,
-                remote_time=str(dm.get("created", 0)),
-            )
-            entries.append((dirname, entry))
-            names.append(f"{prefix}/dms/{dirname}")
-        if index is not None:
-            await index.set_dir(virtual_key, entries)
-        return names
-
+        return await _readdir_dms(accessor, prefix, virtual_key, index)
     if key == "users":
-        if index is not None:
-            listing = await index.list_dir(virtual_key)
-            if listing.entries is not None:
-                return listing.entries
-        users = await list_users(accessor.config)
-        entries = []
-        names = []
-        for u in users:
-            filename = _user_filename(u)
-            entry = IndexEntry(
-                id=u["id"],
-                name=u.get("name", ""),
-                resource_type="slack/user",
-                vfs_name=filename,
-            )
-            entries.append((filename, entry))
-            names.append(f"{prefix}/users/{filename}")
-        if index is not None:
-            await index.set_dir(virtual_key, entries)
-        return names
+        return await _readdir_users(accessor, prefix, virtual_key, index)
 
     parts = key.split("/")
-    if len(parts) == 2 and parts[0] in ("channels", "dms"):
-        if index is None:
-            raise FileNotFoundError(path)
-        lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            # Auto-bootstrap: populate parent directory index.
-            parent = PathSpec(
-                original=prefix + "/" + parts[0],
-                directory=prefix + "/" + parts[0],
-                prefix=prefix,
-            )
-            await readdir(accessor, parent, index)
-            lookup = await index.get(virtual_key)
-        if lookup.entry is None:
-            raise FileNotFoundError(path)
-        listing = await index.list_dir(virtual_key)
-        if listing.entries is not None:
-            return listing.entries
-        created = int(lookup.entry.remote_time or 0)
-        latest_ts = await _latest_message_ts(accessor.config, lookup.entry.id)
-        if latest_ts and created:
-            dates = _date_range(latest_ts, created)
-        elif latest_ts:
-            dates = _date_range(latest_ts, int(latest_ts))
-        else:
-            dates = []
-        entries = []
-        names = []
-        for d in dates:
-            entry = IndexEntry(
-                id=f"{lookup.entry.id}:{d}",
-                name=d,
-                resource_type="slack/date_dir",
-                vfs_name=d,
-            )
-            entries.append((d, entry))
-            names.append(f"{prefix}/{key}/{d}")
-        await index.set_dir(virtual_key, entries)
-        return names
-
-    if len(parts) == 3 and parts[0] in ("channels", "dms"):
-        if index is None:
-            raise FileNotFoundError(path)
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        parent_vk = prefix + "/" + parts[0] + "/" + parts[1]
-        parent_lookup = await index.get(parent_vk)
-        if parent_lookup.entry is None:
-            parent = PathSpec(
-                original=prefix + "/" + parts[0] + "/" + parts[1],
-                directory=prefix + "/" + parts[0] + "/" + parts[1],
-                prefix=prefix,
-            )
-            await readdir(accessor, parent, index)
-            parent_lookup = await index.get(parent_vk)
-        if parent_lookup.entry is None:
-            raise FileNotFoundError(path)
-        channel_id = parent_lookup.entry.id
-        date_str = parts[2]
-        await _fetch_day(accessor, channel_id, date_str, virtual_key, index)
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        raise FileNotFoundError(path)
-
-    if (len(parts) == 4 and parts[0] in ("channels", "dms")
-            and parts[3] == "files"):
-        if index is None:
-            raise FileNotFoundError(path)
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        date_path = PathSpec(
-            original=prefix + "/" + "/".join(parts[:3]),
-            directory=prefix + "/" + "/".join(parts[:3]),
-            prefix=prefix,
-        )
-        await readdir(accessor, date_path, index)
-        cached = await index.list_dir(virtual_key)
-        if cached.entries is not None:
-            return cached.entries
-        raise FileNotFoundError(path)
-
+    if container in ("channels", "dms") and len(parts) == 2:
+        return await _readdir_channel_dates(accessor, path, prefix, key,
+                                            virtual_key, container, index)
+    if container in ("channels", "dms") and scope.target == "date":
+        return await _readdir_date_contents(accessor, path, prefix, key,
+                                            virtual_key, container, parts[1],
+                                            parts[2], index)
+    if container in ("channels", "dms") and scope.target == "files":
+        return await _readdir_files_dir(accessor, path, prefix, key,
+                                        virtual_key, container, parts[1],
+                                        parts[2], index)
     return []
-
-
-async def _fetch_messages_for_day(
-    accessor: SlackAccessor,
-    channel_id: str,
-    date_str: str,
-) -> list[dict]:
-    return await fetch_messages_for_day(accessor.config, channel_id, date_str)
 
 
 async def _fetch_day(
@@ -266,7 +313,8 @@ async def _fetch_day(
     date_vkey: str,
     index: IndexCacheStore,
 ) -> None:
-    messages = await _fetch_messages_for_day(accessor, channel_id, date_str)
+    messages = await fetch_messages_for_day(accessor.config, channel_id,
+                                            date_str)
     chat_entry = IndexEntry(
         id=f"{channel_id}:{date_str}:chat",
         name="chat.jsonl",
@@ -314,3 +362,6 @@ async def _fetch_day(
                      },
                  )))
     await index.set_dir(date_vkey + "/files", file_entries)
+
+
+__all__ = ["readdir", "VIRTUAL_ROOTS", "SlackScope"]

--- a/python/mirage/core/slack/search.py
+++ b/python/mirage/core/slack/search.py
@@ -13,13 +13,11 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import json
-from datetime import datetime, timezone
+from collections.abc import AsyncIterator
 
 from mirage.core.slack._client import slack_get
-from mirage.core.slack.files import file_blob_name
-from mirage.core.slack.scope import SlackScope
+from mirage.core.slack.paginate import offset_pages
 from mirage.resource.slack.config import SlackConfig
-from mirage.utils.sanitize import sanitize_name
 
 
 def search_available(config: SlackConfig) -> bool:
@@ -34,7 +32,7 @@ async def search_messages(
     count: int = 20,
     page: int = 1,
 ) -> bytes:
-    """Search messages across workspace.
+    """Search messages across workspace (single page).
 
     Args:
         config (SlackConfig): Slack credentials.
@@ -60,42 +58,39 @@ async def search_messages(
     return json.dumps(data, ensure_ascii=False).encode()
 
 
-def build_query(pattern: str, scope: SlackScope) -> str:
-    if scope.container == "channels" and scope.channel_name:
-        return f"in:#{scope.channel_name} {pattern}"
-    if scope.container == "dms" and scope.channel_name:
-        return f"in:@{scope.channel_name} {pattern}"
-    return pattern
+def search_messages_stream(
+    config: SlackConfig,
+    query: str,
+    count: int = 100,
+    start_page: int = 1,
+    max_pages: int | None = None,
+) -> AsyncIterator[list[dict]]:
+    """Page-streaming search.messages; yields match lists per Slack page.
 
+    Args:
+        config (SlackConfig): Slack credentials.
+        query (str): search query.
+        count (int): results per page (Slack caps at 100).
+        start_page (int): 1-based starting page.
+        max_pages (int | None): cap on pages walked; None = unbounded.
 
-def format_grep_results(
-    raw: bytes,
-    scope: SlackScope,
-    prefix: str,
-) -> list[str]:
-    payload = json.loads(raw.decode())
-    matches = payload.get("messages", {}).get("matches", []) or []
-    lines: list[str] = []
-    for msg in matches:
-        ch = msg.get("channel", {}) or {}
-        ch_name = ch.get("name") or scope.channel_name or ""
-        ch_id = ch.get("id") or scope.channel_id or ""
-        container = scope.container or "channels"
-        ts_raw = msg.get("ts", "0")
-        try:
-            ts_float = float(ts_raw)
-            date_str = datetime.fromtimestamp(
-                ts_float, tz=timezone.utc).date().isoformat()
-        except (TypeError, ValueError):
-            date_str = ""
-        safe_name = sanitize_name(ch_name)
-        dirname = f"{safe_name}__{ch_id}" if ch_id else safe_name
-        path = (f"{prefix}/{container}/{dirname}/{date_str}/chat.jsonl"
-                if date_str else f"{prefix}/{container}/{dirname}")
-        author = msg.get("username") or msg.get("user") or "?"
-        text = (msg.get("text") or "").replace("\n", " ")
-        lines.append(f"{path}:[{author}] {text}")
-    return lines
+    Yields:
+        list[dict]: matches in one Slack page.
+    """
+    return offset_pages(
+        config,
+        "search.messages",
+        base_params={
+            "query": query,
+            "count": str(count),
+            "sort": "timestamp",
+        },
+        pages_path=("messages", "pagination", "page_count"),
+        items_path=("messages", "matches"),
+        start_page=start_page,
+        max_pages=max_pages,
+        token=config.search_token,
+    )
 
 
 async def search_files(
@@ -104,7 +99,7 @@ async def search_files(
     count: int = 20,
     page: int = 1,
 ) -> bytes:
-    """Search files across workspace via Slack's search.files API.
+    """Search files across workspace via Slack's search.files API (single page).
 
     Args:
         config (SlackConfig): Slack credentials.
@@ -130,33 +125,36 @@ async def search_files(
     return json.dumps(data, ensure_ascii=False).encode()
 
 
-def format_file_grep_results(
-    raw: bytes,
-    scope: SlackScope,
-    prefix: str,
-) -> list[str]:
-    payload = json.loads(raw.decode())
-    matches = payload.get("files", {}).get("matches", []) or []
-    lines: list[str] = []
-    for f in matches:
-        fid = f.get("id", "")
-        title = (f.get("title") or f.get("name") or fid)
-        blob_name = file_blob_name(f)
-        ts = f.get("timestamp", 0)
-        try:
-            date_str = datetime.fromtimestamp(
-                float(ts), tz=timezone.utc).date().isoformat()
-        except (TypeError, ValueError):
-            date_str = ""
-        if not scope.channel_id:
-            continue
-        ch_id = scope.channel_id
-        ch_name = scope.channel_name or ""
-        safe_name = sanitize_name(ch_name) if ch_name else ""
-        dirname = f"{safe_name}__{ch_id}" if safe_name else ch_id
-        container = scope.container or "channels"
-        path = (f"{prefix}/{container}/{dirname}/{date_str}/files/{blob_name}"
-                if date_str else
-                f"{prefix}/{container}/{dirname}/files/{blob_name}")
-        lines.append(f"{path}:[file] {title}")
-    return lines
+def search_files_stream(
+    config: SlackConfig,
+    query: str,
+    count: int = 100,
+    start_page: int = 1,
+    max_pages: int | None = None,
+) -> AsyncIterator[list[dict]]:
+    """Page-streaming search.files; yields file lists per Slack page.
+
+    Args:
+        config (SlackConfig): Slack credentials.
+        query (str): search query.
+        count (int): results per page (Slack caps at 100).
+        start_page (int): 1-based starting page.
+        max_pages (int | None): cap on pages walked; None = unbounded.
+
+    Yields:
+        list[dict]: file matches in one Slack page.
+    """
+    return offset_pages(
+        config,
+        "search.files",
+        base_params={
+            "query": query,
+            "count": str(count),
+            "sort": "timestamp",
+        },
+        pages_path=("files", "pagination", "page_count"),
+        items_path=("files", "matches"),
+        start_page=start_page,
+        max_pages=max_pages,
+        token=config.search_token,
+    )

--- a/python/mirage/core/slack/search.py
+++ b/python/mirage/core/slack/search.py
@@ -99,7 +99,7 @@ async def search_files(
     count: int = 20,
     page: int = 1,
 ) -> bytes:
-    """Search files across workspace via Slack's search.files API (single page).
+    """Search files across workspace via search.files (single page).
 
     Args:
         config (SlackConfig): Slack credentials.

--- a/python/mirage/core/slack/users.py
+++ b/python/mirage/core/slack/users.py
@@ -12,30 +12,58 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from collections.abc import AsyncIterator
+
 from mirage.core.slack._client import slack_get
+from mirage.core.slack.paginate import cursor_pages
 from mirage.resource.slack.config import SlackConfig
+
+
+def _is_real_user(m: dict) -> bool:
+    return (not m.get("deleted") and not m.get("is_bot")
+            and m.get("id") != "USLACKBOT")
+
+
+async def list_users_stream(
+    config: SlackConfig,
+    limit: int = 200,
+) -> AsyncIterator[list[dict]]:
+    """Page-streaming user list; yields filtered humans per page.
+
+    Args:
+        config (SlackConfig): Slack credentials.
+        limit (int): max per page.
+
+    Yields:
+        list[dict]: real users in one Slack page (bots, deleted, and
+        slackbot are filtered out before yielding).
+    """
+    async for page in cursor_pages(
+            config,
+            "users.list",
+            base_params={"limit": limit},
+            items_key="members",
+    ):
+        yield [m for m in page if _is_real_user(m)]
 
 
 async def list_users(
     config: SlackConfig,
     limit: int = 200,
 ) -> list[dict]:
-    """List workspace users (first page).
+    """List workspace users (eager; collects all pages).
 
     Args:
         config (SlackConfig): Slack credentials.
-        limit (int): max users to fetch.
+        limit (int): max per page.
 
     Returns:
         list[dict]: user dicts.
     """
-    params = {"limit": limit}
-    data = await slack_get(config, "users.list", params=params)
-    members = data.get("members", [])
-    return [
-        m for m in members if not m.get("deleted") and not m.get("is_bot")
-        and m.get("id") != "USLACKBOT"
-    ]
+    out: list[dict] = []
+    async for page in list_users_stream(config, limit=limit):
+        out.extend(page)
+    return out
 
 
 async def get_user_profile(
@@ -60,12 +88,12 @@ async def search_users(
     query: str,
     limit: int = 200,
 ) -> list[dict]:
-    """Search users by name.
+    """Search users by name, real name, or email.
 
     Args:
         config (SlackConfig): Slack credentials.
         query (str): search query.
-        limit (int): max results.
+        limit (int): max per page.
 
     Returns:
         list[dict]: matching users.

--- a/python/tests/core/slack/test_channels.py
+++ b/python/tests/core/slack/test_channels.py
@@ -45,7 +45,7 @@ async def test_list_channels(config):
         },
     }
     with patch(
-            "mirage.core.slack.channels.slack_get",
+            "mirage.core.slack.paginate.slack_get",
             new_callable=AsyncMock,
             return_value=mock_data,
     ) as mock_get:
@@ -83,7 +83,7 @@ async def test_list_channels_pagination(config):
         },
     }
     with patch(
-            "mirage.core.slack.channels.slack_get",
+            "mirage.core.slack.paginate.slack_get",
             new_callable=AsyncMock,
             side_effect=[page1, page2],
     ) as mock_get:
@@ -108,7 +108,7 @@ async def test_list_dms(config):
         },
     }
     with patch(
-            "mirage.core.slack.channels.slack_get",
+            "mirage.core.slack.paginate.slack_get",
             new_callable=AsyncMock,
             return_value=mock_data,
     ) as mock_get:

--- a/python/tests/core/slack/test_channels_stream.py
+++ b/python/tests/core/slack/test_channels_stream.py
@@ -1,0 +1,62 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import patch
+
+import pytest
+
+from mirage.core.slack.channels import list_channels_stream, list_dms_stream
+from mirage.resource.slack.config import SlackConfig
+
+
+@pytest.mark.asyncio
+async def test_list_channels_stream_yields_pages():
+    cfg = SlackConfig(token="xoxb-t")
+    pages = [
+        {"channels": [{"id": "C1"}, {"id": "C2"}],
+         "response_metadata": {"next_cursor": "cur1"}},
+        {"channels": [{"id": "C3"}],
+         "response_metadata": {"next_cursor": ""}},
+    ]
+    calls = []
+
+    async def fake_get(_cfg, method, params=None, token=None):
+        assert method == "conversations.list"
+        calls.append(dict(params or {}))
+        return pages[len(calls) - 1]
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        seen = []
+        async for page in list_channels_stream(cfg):
+            seen.append(page)
+    assert [ch["id"] for ch in seen[0]] == ["C1", "C2"]
+    assert [ch["id"] for ch in seen[1]] == ["C3"]
+    assert calls[0]["types"] == "public_channel,private_channel"
+    assert calls[0]["exclude_archived"] == "true"
+    assert calls[0]["limit"] == 200
+
+
+@pytest.mark.asyncio
+async def test_list_dms_stream_uses_im_mpim_types():
+    cfg = SlackConfig(token="xoxb-t")
+    calls = []
+
+    async def fake_get(_cfg, _method, params=None, token=None):
+        calls.append(dict(params or {}))
+        return {"channels": [], "response_metadata": {"next_cursor": ""}}
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        async for _ in list_dms_stream(cfg):
+            pass
+    assert calls[0]["types"] == "im,mpim"

--- a/python/tests/core/slack/test_channels_stream.py
+++ b/python/tests/core/slack/test_channels_stream.py
@@ -24,10 +24,24 @@ from mirage.resource.slack.config import SlackConfig
 async def test_list_channels_stream_yields_pages():
     cfg = SlackConfig(token="xoxb-t")
     pages = [
-        {"channels": [{"id": "C1"}, {"id": "C2"}],
-         "response_metadata": {"next_cursor": "cur1"}},
-        {"channels": [{"id": "C3"}],
-         "response_metadata": {"next_cursor": ""}},
+        {
+            "channels": [{
+                "id": "C1"
+            }, {
+                "id": "C2"
+            }],
+            "response_metadata": {
+                "next_cursor": "cur1"
+            }
+        },
+        {
+            "channels": [{
+                "id": "C3"
+            }],
+            "response_metadata": {
+                "next_cursor": ""
+            }
+        },
     ]
     calls = []
 

--- a/python/tests/core/slack/test_files.py
+++ b/python/tests/core/slack/test_files.py
@@ -96,7 +96,7 @@ async def test_files_dir_listing_from_messages(accessor, index,
                     resource_type="slack/date_dir",
                     vfs_name="2026-04-10")),
     ])
-    with patch("mirage.core.slack.readdir._fetch_messages_for_day",
+    with patch("mirage.core.slack.readdir.fetch_messages_for_day",
                new_callable=AsyncMock,
                return_value=messages_with_files):
         result = await readdir(
@@ -133,7 +133,7 @@ async def test_files_dir_empty_on_no_attachments(accessor, index):
         "ts": "1712707200.0",
         "text": "hi"
     }]
-    with patch("mirage.core.slack.readdir._fetch_messages_for_day",
+    with patch("mirage.core.slack.readdir.fetch_messages_for_day",
                new_callable=AsyncMock,
                return_value=no_file_msgs):
         result = await readdir(
@@ -163,7 +163,7 @@ async def test_file_blob_index_entry_stores_url(accessor, index,
                     resource_type="slack/date_dir",
                     vfs_name="2026-04-10")),
     ])
-    with patch("mirage.core.slack.readdir._fetch_messages_for_day",
+    with patch("mirage.core.slack.readdir.fetch_messages_for_day",
                new_callable=AsyncMock,
                return_value=messages_with_files):
         await readdir(

--- a/python/tests/core/slack/test_files_list.py
+++ b/python/tests/core/slack/test_files_list.py
@@ -29,11 +29,20 @@ async def test_list_files_for_day_scopes_to_channel_and_date():
     async def fake_get(_cfg, method, params=None, token=None):
         assert method == "files.list"
         captured.append(dict(params or {}))
-        return {"files": [{"id": "F1", "title": "doc.pdf"}],
-                "paging": {"page": 1, "pages": 1}}
+        return {
+            "files": [{
+                "id": "F1",
+                "title": "doc.pdf"
+            }],
+            "paging": {
+                "page": 1,
+                "pages": 1
+            }
+        }
 
     with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
-        files = await list_files_for_day(cfg, channel_id="C1",
+        files = await list_files_for_day(cfg,
+                                         channel_id="C1",
                                          date_str="2026-05-10")
 
     assert files[0]["id"] == "F1"
@@ -48,8 +57,24 @@ async def test_list_files_for_day_scopes_to_channel_and_date():
 async def test_list_files_for_day_walks_multiple_pages():
     cfg = SlackConfig(token="xoxp-t")
     pages = [
-        {"files": [{"id": "F1"}], "paging": {"page": 1, "pages": 2}},
-        {"files": [{"id": "F2"}], "paging": {"page": 2, "pages": 2}},
+        {
+            "files": [{
+                "id": "F1"
+            }],
+            "paging": {
+                "page": 1,
+                "pages": 2
+            }
+        },
+        {
+            "files": [{
+                "id": "F2"
+            }],
+            "paging": {
+                "page": 2,
+                "pages": 2
+            }
+        },
     ]
     calls = []
 
@@ -69,8 +94,24 @@ async def test_list_files_for_day_walks_multiple_pages():
 async def test_list_files_for_day_stream_yields_each_page():
     cfg = SlackConfig(token="xoxp-t")
     pages = [
-        {"files": [{"id": "F1"}], "paging": {"page": 1, "pages": 2}},
-        {"files": [{"id": "F2"}], "paging": {"page": 2, "pages": 2}},
+        {
+            "files": [{
+                "id": "F1"
+            }],
+            "paging": {
+                "page": 1,
+                "pages": 2
+            }
+        },
+        {
+            "files": [{
+                "id": "F2"
+            }],
+            "paging": {
+                "page": 2,
+                "pages": 2
+            }
+        },
     ]
     calls = {"n": 0}
 

--- a/python/tests/core/slack/test_files_list.py
+++ b/python/tests/core/slack/test_files_list.py
@@ -1,0 +1,87 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import patch
+
+import pytest
+
+from mirage.core.slack.files_list import (list_files_for_day,
+                                          list_files_for_day_stream)
+from mirage.resource.slack.config import SlackConfig
+
+
+@pytest.mark.asyncio
+async def test_list_files_for_day_scopes_to_channel_and_date():
+    cfg = SlackConfig(token="xoxp-t")
+    captured = []
+
+    async def fake_get(_cfg, method, params=None, token=None):
+        assert method == "files.list"
+        captured.append(dict(params or {}))
+        return {"files": [{"id": "F1", "title": "doc.pdf"}],
+                "paging": {"page": 1, "pages": 1}}
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        files = await list_files_for_day(cfg, channel_id="C1",
+                                         date_str="2026-05-10")
+
+    assert files[0]["id"] == "F1"
+    assert captured[0]["channel"] == "C1"
+    assert "ts_from" in captured[0]
+    assert "ts_to" in captured[0]
+    assert captured[0]["count"] == "200"
+    assert captured[0]["page"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_list_files_for_day_walks_multiple_pages():
+    cfg = SlackConfig(token="xoxp-t")
+    pages = [
+        {"files": [{"id": "F1"}], "paging": {"page": 1, "pages": 2}},
+        {"files": [{"id": "F2"}], "paging": {"page": 2, "pages": 2}},
+    ]
+    calls = []
+
+    async def fake_get(_cfg, _method, params=None, token=None):
+        calls.append(dict(params or {}))
+        return pages[len(calls) - 1]
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        files = await list_files_for_day(cfg, "C1", "2026-05-10")
+
+    assert [f["id"] for f in files] == ["F1", "F2"]
+    assert calls[0]["page"] == "1"
+    assert calls[1]["page"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_list_files_for_day_stream_yields_each_page():
+    cfg = SlackConfig(token="xoxp-t")
+    pages = [
+        {"files": [{"id": "F1"}], "paging": {"page": 1, "pages": 2}},
+        {"files": [{"id": "F2"}], "paging": {"page": 2, "pages": 2}},
+    ]
+    calls = {"n": 0}
+
+    async def fake_get(_cfg, _method, params=None, token=None):
+        page = pages[calls["n"]]
+        calls["n"] += 1
+        return page
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        seen = []
+        async for page in list_files_for_day_stream(cfg, "C1", "2026-05-10"):
+            seen.append(page)
+
+    assert seen == [[{"id": "F1"}], [{"id": "F2"}]]

--- a/python/tests/core/slack/test_history.py
+++ b/python/tests/core/slack/test_history.py
@@ -45,7 +45,7 @@ async def test_get_history_jsonl(config):
         False,
     }
     with patch(
-            "mirage.core.slack.history.slack_get",
+            "mirage.core.slack.paginate.slack_get",
             new_callable=AsyncMock,
             return_value=mock_data,
     ):
@@ -68,7 +68,7 @@ async def test_get_history_empty(config):
         "has_more": False,
     }
     with patch(
-            "mirage.core.slack.history.slack_get",
+            "mirage.core.slack.paginate.slack_get",
             new_callable=AsyncMock,
             return_value=mock_data,
     ):

--- a/python/tests/core/slack/test_history_stream.py
+++ b/python/tests/core/slack/test_history_stream.py
@@ -27,12 +27,22 @@ async def test_stream_messages_for_day_applies_day_bounds_and_yields_pages():
     cfg = SlackConfig(token="xoxb-t")
     pages = [
         {
-            "messages": [{"ts": "1.0", "text": "a"}],
-            "response_metadata": {"next_cursor": "cur1"},
+            "messages": [{
+                "ts": "1.0",
+                "text": "a"
+            }],
+            "response_metadata": {
+                "next_cursor": "cur1"
+            },
         },
         {
-            "messages": [{"ts": "2.0", "text": "b"}],
-            "response_metadata": {"next_cursor": ""},
+            "messages": [{
+                "ts": "2.0",
+                "text": "b"
+            }],
+            "response_metadata": {
+                "next_cursor": ""
+            },
         },
     ]
     calls = []
@@ -61,12 +71,22 @@ async def test_fetch_messages_for_day_collects_and_sorts_across_pages():
     cfg = SlackConfig(token="xoxb-t")
     pages = [
         {
-            "messages": [{"ts": "3.0"}, {"ts": "1.0"}],
-            "response_metadata": {"next_cursor": "cur1"},
+            "messages": [{
+                "ts": "3.0"
+            }, {
+                "ts": "1.0"
+            }],
+            "response_metadata": {
+                "next_cursor": "cur1"
+            },
         },
         {
-            "messages": [{"ts": "2.0"}],
-            "response_metadata": {"next_cursor": ""},
+            "messages": [{
+                "ts": "2.0"
+            }],
+            "response_metadata": {
+                "next_cursor": ""
+            },
         },
     ]
     calls = {"n": 0}

--- a/python/tests/core/slack/test_history_stream.py
+++ b/python/tests/core/slack/test_history_stream.py
@@ -1,0 +1,100 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import patch
+
+import pytest
+
+from mirage.core.slack.history import (fetch_messages_for_day,
+                                       stream_messages_for_day,
+                                       stream_thread_replies)
+from mirage.resource.slack.config import SlackConfig
+
+
+@pytest.mark.asyncio
+async def test_stream_messages_for_day_applies_day_bounds_and_yields_pages():
+    cfg = SlackConfig(token="xoxb-t")
+    pages = [
+        {
+            "messages": [{"ts": "1.0", "text": "a"}],
+            "response_metadata": {"next_cursor": "cur1"},
+        },
+        {
+            "messages": [{"ts": "2.0", "text": "b"}],
+            "response_metadata": {"next_cursor": ""},
+        },
+    ]
+    calls = []
+
+    async def fake_get(_cfg, method, params=None, token=None):
+        assert method == "conversations.history"
+        calls.append(dict(params or {}))
+        return pages[len(calls) - 1]
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        seen = []
+        async for page in stream_messages_for_day(cfg, "C1", "2026-05-10"):
+            seen.append(page)
+
+    assert [m["text"] for m in seen[0]] == ["a"]
+    assert [m["text"] for m in seen[1]] == ["b"]
+    assert calls[0]["channel"] == "C1"
+    assert calls[0]["inclusive"] == "true"
+    assert "oldest" in calls[0]
+    assert "latest" in calls[0]
+    assert calls[1]["cursor"] == "cur1"
+
+
+@pytest.mark.asyncio
+async def test_fetch_messages_for_day_collects_and_sorts_across_pages():
+    cfg = SlackConfig(token="xoxb-t")
+    pages = [
+        {
+            "messages": [{"ts": "3.0"}, {"ts": "1.0"}],
+            "response_metadata": {"next_cursor": "cur1"},
+        },
+        {
+            "messages": [{"ts": "2.0"}],
+            "response_metadata": {"next_cursor": ""},
+        },
+    ]
+    calls = {"n": 0}
+
+    async def fake_get(_cfg, _method, params=None, token=None):
+        page = pages[calls["n"]]
+        calls["n"] += 1
+        return page
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        result = await fetch_messages_for_day(cfg, "C1", "2026-05-10")
+
+    assert [m["ts"] for m in result] == ["1.0", "2.0", "3.0"]
+
+
+@pytest.mark.asyncio
+async def test_stream_thread_replies_uses_replies_endpoint_with_ts():
+    cfg = SlackConfig(token="xoxb-t")
+    calls = []
+
+    async def fake_get(_cfg, method, params=None, token=None):
+        assert method == "conversations.replies"
+        calls.append(dict(params or {}))
+        return {"messages": [], "response_metadata": {"next_cursor": ""}}
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        async for _ in stream_thread_replies(cfg, "C1", "1700000000.0"):
+            pass
+
+    assert calls[0]["channel"] == "C1"
+    assert calls[0]["ts"] == "1700000000.0"

--- a/python/tests/core/slack/test_paginate.py
+++ b/python/tests/core/slack/test_paginate.py
@@ -50,7 +50,8 @@ async def test_cursor_pages_propagates_cancellation():
     cfg = SlackConfig(token="xoxb-t")
     pages = [
         {"items": [1], "response_metadata": {"next_cursor": "cur1"}},
-        {"items": [2], "response_metadata": {"next_cursor": ""}},
+        {"items": [2], "response_metadata": {"next_cursor": "cur2"}},
+        {"items": [3], "response_metadata": {"next_cursor": ""}},
     ]
     calls = []
 

--- a/python/tests/core/slack/test_paginate.py
+++ b/python/tests/core/slack/test_paginate.py
@@ -24,8 +24,18 @@ from mirage.resource.slack.config import SlackConfig
 async def test_cursor_pages_walks_until_empty_cursor():
     cfg = SlackConfig(token="xoxb-t")
     pages = [
-        {"items": [1, 2], "response_metadata": {"next_cursor": "cur1"}},
-        {"items": [3], "response_metadata": {"next_cursor": ""}},
+        {
+            "items": [1, 2],
+            "response_metadata": {
+                "next_cursor": "cur1"
+            }
+        },
+        {
+            "items": [3],
+            "response_metadata": {
+                "next_cursor": ""
+            }
+        },
     ]
     calls = []
 
@@ -35,10 +45,13 @@ async def test_cursor_pages_walks_until_empty_cursor():
 
     with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
         result = []
-        async for page in cursor_pages(
-                cfg, "conversations.list",
-                base_params={"types": "x", "limit": 100},
-                items_key="items"):
+        async for page in cursor_pages(cfg,
+                                       "conversations.list",
+                                       base_params={
+                                           "types": "x",
+                                           "limit": 100
+                                       },
+                                       items_key="items"):
             result.append(page)
     assert result == [[1, 2], [3]]
     assert calls[0] == {"types": "x", "limit": 100}
@@ -49,9 +62,24 @@ async def test_cursor_pages_walks_until_empty_cursor():
 async def test_cursor_pages_propagates_cancellation():
     cfg = SlackConfig(token="xoxb-t")
     pages = [
-        {"items": [1], "response_metadata": {"next_cursor": "cur1"}},
-        {"items": [2], "response_metadata": {"next_cursor": "cur2"}},
-        {"items": [3], "response_metadata": {"next_cursor": ""}},
+        {
+            "items": [1],
+            "response_metadata": {
+                "next_cursor": "cur1"
+            }
+        },
+        {
+            "items": [2],
+            "response_metadata": {
+                "next_cursor": "cur2"
+            }
+        },
+        {
+            "items": [3],
+            "response_metadata": {
+                "next_cursor": ""
+            }
+        },
     ]
     calls = []
 
@@ -60,8 +88,10 @@ async def test_cursor_pages_propagates_cancellation():
         return pages[len(calls) - 1]
 
     with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
-        gen = cursor_pages(cfg, "conversations.list",
-                           base_params={"limit": 1}, items_key="items")
+        gen = cursor_pages(cfg,
+                           "conversations.list",
+                           base_params={"limit": 1},
+                           items_key="items")
         first = await gen.__anext__()
         await gen.aclose()
     assert first == [1]
@@ -72,10 +102,28 @@ async def test_cursor_pages_propagates_cancellation():
 async def test_offset_pages_walks_search_messages_pagination():
     cfg = SlackConfig(token="xoxp-t")
     pages = [
-        {"messages": {"matches": [{"text": "a"}],
-                      "pagination": {"page": 1, "page_count": 2}}},
-        {"messages": {"matches": [{"text": "b"}],
-                      "pagination": {"page": 2, "page_count": 2}}},
+        {
+            "messages": {
+                "matches": [{
+                    "text": "a"
+                }],
+                "pagination": {
+                    "page": 1,
+                    "page_count": 2
+                }
+            }
+        },
+        {
+            "messages": {
+                "matches": [{
+                    "text": "b"
+                }],
+                "pagination": {
+                    "page": 2,
+                    "page_count": 2
+                }
+            }
+        },
     ]
     calls = []
 
@@ -85,12 +133,17 @@ async def test_offset_pages_walks_search_messages_pagination():
 
     with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
         result = []
-        async for page in offset_pages(
-                cfg, "search.messages",
-                base_params={"query": "x", "count": "100"},
-                pages_path=("messages", "pagination", "page_count"),
-                items_path=("messages", "matches"),
-                start_page=1, max_pages=None):
+        async for page in offset_pages(cfg,
+                                       "search.messages",
+                                       base_params={
+                                           "query": "x",
+                                           "count": "100"
+                                       },
+                                       pages_path=("messages", "pagination",
+                                                   "page_count"),
+                                       items_path=("messages", "matches"),
+                                       start_page=1,
+                                       max_pages=None):
             result.append(page)
     assert result == [[{"text": "a"}], [{"text": "b"}]]
     assert calls[0]["page"] == "1"

--- a/python/tests/core/slack/test_paginate.py
+++ b/python/tests/core/slack/test_paginate.py
@@ -1,0 +1,96 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import patch
+
+import pytest
+
+from mirage.core.slack.paginate import cursor_pages, offset_pages
+from mirage.resource.slack.config import SlackConfig
+
+
+@pytest.mark.asyncio
+async def test_cursor_pages_walks_until_empty_cursor():
+    cfg = SlackConfig(token="xoxb-t")
+    pages = [
+        {"items": [1, 2], "response_metadata": {"next_cursor": "cur1"}},
+        {"items": [3], "response_metadata": {"next_cursor": ""}},
+    ]
+    calls = []
+
+    async def fake_get(_cfg, _method, params=None, token=None):
+        calls.append(dict(params or {}))
+        return pages[len(calls) - 1]
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        result = []
+        async for page in cursor_pages(
+                cfg, "conversations.list",
+                base_params={"types": "x", "limit": 100},
+                items_key="items"):
+            result.append(page)
+    assert result == [[1, 2], [3]]
+    assert calls[0] == {"types": "x", "limit": 100}
+    assert calls[1] == {"types": "x", "limit": 100, "cursor": "cur1"}
+
+
+@pytest.mark.asyncio
+async def test_cursor_pages_propagates_cancellation():
+    cfg = SlackConfig(token="xoxb-t")
+    pages = [
+        {"items": [1], "response_metadata": {"next_cursor": "cur1"}},
+        {"items": [2], "response_metadata": {"next_cursor": ""}},
+    ]
+    calls = []
+
+    async def fake_get(_cfg, _method, params=None, token=None):
+        calls.append(dict(params or {}))
+        return pages[len(calls) - 1]
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        gen = cursor_pages(cfg, "conversations.list",
+                           base_params={"limit": 1}, items_key="items")
+        first = await gen.__anext__()
+        await gen.aclose()
+    assert first == [1]
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_offset_pages_walks_search_messages_pagination():
+    cfg = SlackConfig(token="xoxp-t")
+    pages = [
+        {"messages": {"matches": [{"text": "a"}],
+                      "pagination": {"page": 1, "page_count": 2}}},
+        {"messages": {"matches": [{"text": "b"}],
+                      "pagination": {"page": 2, "page_count": 2}}},
+    ]
+    calls = []
+
+    async def fake_get(_cfg, _method, params=None, token=None):
+        calls.append(dict(params or {}))
+        return pages[len(calls) - 1]
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        result = []
+        async for page in offset_pages(
+                cfg, "search.messages",
+                base_params={"query": "x", "count": "100"},
+                pages_path=("messages", "pagination", "page_count"),
+                items_path=("messages", "matches"),
+                start_page=1, max_pages=None):
+            result.append(page)
+    assert result == [[{"text": "a"}], [{"text": "b"}]]
+    assert calls[0]["page"] == "1"
+    assert calls[1]["page"] == "2"

--- a/python/tests/core/slack/test_readdir.py
+++ b/python/tests/core/slack/test_readdir.py
@@ -247,7 +247,7 @@ async def test_readdir_date_dir_returns_chat_and_files(accessor, index):
         ),
     ])
 
-    with patch("mirage.core.slack.readdir._fetch_messages_for_day",
+    with patch("mirage.core.slack.readdir.fetch_messages_for_day",
                new_callable=AsyncMock,
                return_value=[]):
         result = await readdir(

--- a/python/tests/core/slack/test_search.py
+++ b/python/tests/core/slack/test_search.py
@@ -17,8 +17,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from mirage.core.slack.formatters import format_grep_results
 from mirage.core.slack.scope import SlackScope
-from mirage.core.slack.search import format_grep_results, search_messages
+from mirage.core.slack.search import search_messages
 from mirage.resource.slack.config import SlackConfig
 
 

--- a/python/tests/core/slack/test_search_files.py
+++ b/python/tests/core/slack/test_search_files.py
@@ -17,9 +17,10 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from mirage.core.slack.formatters import (build_query,
+                                          format_file_grep_results)
 from mirage.core.slack.scope import SlackScope
-from mirage.core.slack.search import (build_query, format_file_grep_results,
-                                      search_files)
+from mirage.core.slack.search import search_files
 from mirage.resource.slack.config import SlackConfig
 
 

--- a/python/tests/core/slack/test_search_files.py
+++ b/python/tests/core/slack/test_search_files.py
@@ -17,8 +17,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from mirage.core.slack.formatters import (build_query,
-                                          format_file_grep_results)
+from mirage.core.slack.formatters import build_query, format_file_grep_results
 from mirage.core.slack.scope import SlackScope
 from mirage.core.slack.search import search_files
 from mirage.resource.slack.config import SlackConfig

--- a/python/tests/core/slack/test_search_stream.py
+++ b/python/tests/core/slack/test_search_stream.py
@@ -16,7 +16,8 @@ from unittest.mock import patch
 
 import pytest
 
-from mirage.core.slack.search import search_files_stream, search_messages_stream
+from mirage.core.slack.search import (search_files_stream,
+                                      search_messages_stream)
 from mirage.resource.slack.config import SlackConfig
 
 
@@ -24,12 +25,39 @@ from mirage.resource.slack.config import SlackConfig
 async def test_search_messages_stream_walks_pages_until_page_count():
     cfg = SlackConfig(token="xoxp-t")
     pages = [
-        {"messages": {"matches": [{"text": "a"}],
-                      "pagination": {"page": 1, "page_count": 3}}},
-        {"messages": {"matches": [{"text": "b"}],
-                      "pagination": {"page": 2, "page_count": 3}}},
-        {"messages": {"matches": [{"text": "c"}],
-                      "pagination": {"page": 3, "page_count": 3}}},
+        {
+            "messages": {
+                "matches": [{
+                    "text": "a"
+                }],
+                "pagination": {
+                    "page": 1,
+                    "page_count": 3
+                }
+            }
+        },
+        {
+            "messages": {
+                "matches": [{
+                    "text": "b"
+                }],
+                "pagination": {
+                    "page": 2,
+                    "page_count": 3
+                }
+            }
+        },
+        {
+            "messages": {
+                "matches": [{
+                    "text": "c"
+                }],
+                "pagination": {
+                    "page": 3,
+                    "page_count": 3
+                }
+            }
+        },
     ]
     calls = []
 
@@ -52,12 +80,39 @@ async def test_search_messages_stream_walks_pages_until_page_count():
 async def test_search_messages_stream_honors_max_pages():
     cfg = SlackConfig(token="xoxp-t")
     pages = [
-        {"messages": {"matches": [{"text": "a"}],
-                      "pagination": {"page": 1, "page_count": 10}}},
-        {"messages": {"matches": [{"text": "b"}],
-                      "pagination": {"page": 2, "page_count": 10}}},
-        {"messages": {"matches": [{"text": "c"}],
-                      "pagination": {"page": 3, "page_count": 10}}},
+        {
+            "messages": {
+                "matches": [{
+                    "text": "a"
+                }],
+                "pagination": {
+                    "page": 1,
+                    "page_count": 10
+                }
+            }
+        },
+        {
+            "messages": {
+                "matches": [{
+                    "text": "b"
+                }],
+                "pagination": {
+                    "page": 2,
+                    "page_count": 10
+                }
+            }
+        },
+        {
+            "messages": {
+                "matches": [{
+                    "text": "c"
+                }],
+                "pagination": {
+                    "page": 3,
+                    "page_count": 10
+                }
+            }
+        },
     ]
     calls = {"n": 0}
 
@@ -81,8 +136,17 @@ async def test_search_files_stream_uses_files_endpoint():
 
     async def fake_get(_cfg, method, params=None, token=None):
         assert method == "search.files"
-        return {"files": {"matches": [{"id": "F1"}],
-                          "pagination": {"page": 1, "page_count": 1}}}
+        return {
+            "files": {
+                "matches": [{
+                    "id": "F1"
+                }],
+                "pagination": {
+                    "page": 1,
+                    "page_count": 1
+                }
+            }
+        }
 
     with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
         seen = []

--- a/python/tests/core/slack/test_search_stream.py
+++ b/python/tests/core/slack/test_search_stream.py
@@ -1,0 +1,92 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import patch
+
+import pytest
+
+from mirage.core.slack.search import search_files_stream, search_messages_stream
+from mirage.resource.slack.config import SlackConfig
+
+
+@pytest.mark.asyncio
+async def test_search_messages_stream_walks_pages_until_page_count():
+    cfg = SlackConfig(token="xoxp-t")
+    pages = [
+        {"messages": {"matches": [{"text": "a"}],
+                      "pagination": {"page": 1, "page_count": 3}}},
+        {"messages": {"matches": [{"text": "b"}],
+                      "pagination": {"page": 2, "page_count": 3}}},
+        {"messages": {"matches": [{"text": "c"}],
+                      "pagination": {"page": 3, "page_count": 3}}},
+    ]
+    calls = []
+
+    async def fake_get(_cfg, method, params=None, token=None):
+        assert method == "search.messages"
+        calls.append(dict(params or {}))
+        return pages[len(calls) - 1]
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        seen = []
+        async for page in search_messages_stream(cfg, "x"):
+            seen.append([m["text"] for m in page])
+
+    assert seen == [["a"], ["b"], ["c"]]
+    assert [c["page"] for c in calls] == ["1", "2", "3"]
+    assert calls[0]["sort"] == "timestamp"
+
+
+@pytest.mark.asyncio
+async def test_search_messages_stream_honors_max_pages():
+    cfg = SlackConfig(token="xoxp-t")
+    pages = [
+        {"messages": {"matches": [{"text": "a"}],
+                      "pagination": {"page": 1, "page_count": 10}}},
+        {"messages": {"matches": [{"text": "b"}],
+                      "pagination": {"page": 2, "page_count": 10}}},
+        {"messages": {"matches": [{"text": "c"}],
+                      "pagination": {"page": 3, "page_count": 10}}},
+    ]
+    calls = {"n": 0}
+
+    async def fake_get(_cfg, _method, params=None, token=None):
+        page = pages[calls["n"]]
+        calls["n"] += 1
+        return page
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        seen = []
+        async for page in search_messages_stream(cfg, "x", max_pages=2):
+            seen.append(page)
+
+    assert len(seen) == 2
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_search_files_stream_uses_files_endpoint():
+    cfg = SlackConfig(token="xoxp-t")
+
+    async def fake_get(_cfg, method, params=None, token=None):
+        assert method == "search.files"
+        return {"files": {"matches": [{"id": "F1"}],
+                          "pagination": {"page": 1, "page_count": 1}}}
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        seen = []
+        async for page in search_files_stream(cfg, "report"):
+            seen.append(page)
+
+    assert seen == [[{"id": "F1"}]]

--- a/python/tests/core/slack/test_users.py
+++ b/python/tests/core/slack/test_users.py
@@ -64,7 +64,7 @@ async def test_list_users(config):
         ],
     }
     with patch(
-            "mirage.core.slack.users.slack_get",
+            "mirage.core.slack.paginate.slack_get",
             new_callable=AsyncMock,
             return_value=mock_data,
     ):
@@ -108,7 +108,7 @@ async def test_search_users(config):
         ],
     }
     with patch(
-            "mirage.core.slack.users.slack_get",
+            "mirage.core.slack.paginate.slack_get",
             new_callable=AsyncMock,
             return_value=mock_data,
     ):
@@ -147,7 +147,7 @@ async def test_search_users_by_email(config):
         ],
     }
     with patch(
-            "mirage.core.slack.users.slack_get",
+            "mirage.core.slack.paginate.slack_get",
             new_callable=AsyncMock,
             return_value=mock_data,
     ):

--- a/python/tests/core/slack/test_users_stream.py
+++ b/python/tests/core/slack/test_users_stream.py
@@ -26,17 +26,41 @@ async def test_list_users_stream_walks_pages_and_filters():
     pages = [
         {
             "members": [
-                {"id": "U1", "name": "alice", "deleted": False, "is_bot": False},
-                {"id": "U2", "name": "bot", "deleted": False, "is_bot": True},
+                {
+                    "id": "U1",
+                    "name": "alice",
+                    "deleted": False,
+                    "is_bot": False
+                },
+                {
+                    "id": "U2",
+                    "name": "bot",
+                    "deleted": False,
+                    "is_bot": True
+                },
             ],
-            "response_metadata": {"next_cursor": "cur1"},
+            "response_metadata": {
+                "next_cursor": "cur1"
+            },
         },
         {
             "members": [
-                {"id": "USLACKBOT", "name": "slackbot", "deleted": False, "is_bot": False},
-                {"id": "U3", "name": "bob", "deleted": False, "is_bot": False},
+                {
+                    "id": "USLACKBOT",
+                    "name": "slackbot",
+                    "deleted": False,
+                    "is_bot": False
+                },
+                {
+                    "id": "U3",
+                    "name": "bob",
+                    "deleted": False,
+                    "is_bot": False
+                },
             ],
-            "response_metadata": {"next_cursor": ""},
+            "response_metadata": {
+                "next_cursor": ""
+            },
         },
     ]
     calls = []

--- a/python/tests/core/slack/test_users_stream.py
+++ b/python/tests/core/slack/test_users_stream.py
@@ -1,0 +1,58 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import patch
+
+import pytest
+
+from mirage.core.slack.users import list_users_stream
+from mirage.resource.slack.config import SlackConfig
+
+
+@pytest.mark.asyncio
+async def test_list_users_stream_walks_pages_and_filters():
+    cfg = SlackConfig(token="xoxb-t")
+    pages = [
+        {
+            "members": [
+                {"id": "U1", "name": "alice", "deleted": False, "is_bot": False},
+                {"id": "U2", "name": "bot", "deleted": False, "is_bot": True},
+            ],
+            "response_metadata": {"next_cursor": "cur1"},
+        },
+        {
+            "members": [
+                {"id": "USLACKBOT", "name": "slackbot", "deleted": False, "is_bot": False},
+                {"id": "U3", "name": "bob", "deleted": False, "is_bot": False},
+            ],
+            "response_metadata": {"next_cursor": ""},
+        },
+    ]
+    calls = []
+
+    async def fake_get(_cfg, method, params=None, token=None):
+        assert method == "users.list"
+        calls.append(dict(params or {}))
+        return pages[len(calls) - 1]
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get):
+        seen = []
+        async for page in list_users_stream(cfg):
+            seen.append(page)
+
+    assert len(seen) == 2
+    assert [u["name"] for u in seen[0]] == ["alice"]
+    assert [u["name"] for u in seen[1]] == ["bob"]
+    assert calls[0]["limit"] == 200
+    assert calls[1]["cursor"] == "cur1"


### PR DESCRIPTION
## Summary

Behavior-preserving structural refactor of `python/mirage/core/slack/`. Each Slack fetcher (`conversations.list`, `users.list`, `conversations.history`, `conversations.replies`, `search.messages`, `search.files`, and the new `files.list`) now goes through one paginator helper instead of rolling its own `while cursor` loop, and result formatting is split out from data fetching.

## Layers after this PR

| Module | Purpose |
|---|---|
| `_client.py` | HTTP + error formatting (unchanged) |
| `paginate.py` (NEW) | `cursor_pages` + `offset_pages` generic helpers |
| `channels.py`, `users.py`, `history.py`, `files_list.py` (NEW), `search.py` | One entity per module; each exposes `stream_*` (async iterator) + eager wrapper |
| `scope.py` | Path parsing (unchanged; now the sole dispatch source) |
| `formatters.py` (NEW) | `format_grep_results`, `format_file_grep_results`, `build_query`, `channel_dirname`, `dm_dirname`, `user_filename` |
| `readdir.py` | Thin dispatcher: `detect_scope(path)` → per-kind handler |

## What's new (besides structure)

- `*_stream` async-iterator variants for every list/history endpoint. These are the building blocks the streaming readdir plan (separate doc) will consume to bring TTFB from ~750ms to ~150ms on huge dirs.
- `files_list.py` — uses Slack's `files.list` (not `conversations.history`) for channel-day file listings. Independent module; not wired into readdir in this PR.
- `search_messages_stream` / `search_files_stream` — let grep/rg walk past Slack's 100-results-per-page cap (also not wired yet).

## What didn't change

- Any user-visible behavior.
- TypeScript code.
- Any test asserting a Slack response shape — only test patch targets moved from `mirage.core.slack.{channels,users,history,search}.slack_get` to `mirage.core.slack.paginate.slack_get` (the new shared call site).

## Quiet bug fixes en route

- `list_users` previously returned only the first page (docstring even said so). It now walks all pages, so big workspaces no longer silently truncate the `/users` directory and DM display name resolution. Filter for deleted/bot/USLACKBOT is preserved and applied per page.

## Skipped (YAGNI)

- Task 9 from the plan was "split readdir.py into a multi-file package." After Tasks 8 + 10, `readdir.py` is ~300 LOC with cleanly separated handler functions — splitting into a `readdir/` package adds friction without clear benefit. Marked done.

## Test plan

- [x] Full Python suite: **5581 passed, 221 skipped** (baseline on main: 5566 passed → +15 new tests this PR).
- [x] Scoped Slack suite: 111 passed (baseline 96 → +15).
- [x] `pre-commit run --all-files`: clean.
- [x] All `commands/builtin/slack/*.py` audited — no imports of `_private` names from core.

## What this unblocks

The streaming readdir plan (`docs/plans/2026-05-14-slack-streaming-readdir.md`) collapses from ~14 tasks to ~5 because the `*_stream` variants and paginator already exist.