### PR TITLE
fix(slack): ls no-args after cd; tolerate inaccessible channels in find

### DIFF
--- a/examples/python/slack/slack.py
+++ b/examples/python/slack/slack.py
@@ -248,33 +248,53 @@ async def main():
     r = await ws.execute("pwd")
     print(f"  {(await r.stdout_str()).strip()}")
 
-    print("\n=== ls (relative, in channel dir) ===")
+    # ── ls (no args) after cd — regression: bug where mount prefix
+    # was dropped, so readdir returned []. Now hard-asserts that ls
+    # surfaces cwd entries.
+    print("\n=== ls (no args, in channel dir) ===")
     r = await ws.execute("ls | tail -n 5")
     out = (await r.stdout_str()).strip()
-    if out:
-        for line in out.splitlines():
-            print(f"  {line}")
+    assert out, "regression: `ls` (no args) after cd returned empty"
+    for line in out.splitlines():
+        print(f"  {line}")
 
-    print(f"\n=== cat {target} (relative) | head -n 1 ===")
-    r = await ws.execute(f'cat {target} | head -n 1')
+    rel_chat = f"{date_dir.rsplit('/', 1)[-1]}/chat.jsonl"
+    print(f"\n=== cat {rel_chat} (relative) | head -n 1 ===")
+    r = await ws.execute(f'cat "{rel_chat}" | head -n 1')
     out = (await r.stdout_str()).strip()
-    if out:
-        print(f"  {out[:120]}")
-    else:
-        print("  (empty)")
+    assert out, "regression: relative `cat` after cd returned empty"
+    print(f"  {out[:120]}")
 
-    # ── glob expansion (exercises resolve_glob → readdir) ──
-    print(f"\n=== echo {base}/*/chat.jsonl (glob) ===")
+    # ── workspace-wide find — regression: would abort with
+    # `not_in_channel` if any channel was inaccessible. Now skips
+    # those channels and walks the rest.
+    print("\n=== find /slack/ -name 'chat.jsonl' (must not abort) ===")
+    r = await ws.execute('find /slack/ -name "chat.jsonl" | wc -l')
+    count = int((await r.stdout_str()).strip() or "0")
+    print(f"  matches: {count}")
+    assert r.exit_code == 0, ("regression: workspace-wide find aborted; "
+                              f"stderr={await r.stderr_str()}")
+    assert count > 0, "regression: workspace-wide find returned no matches"
+
+    # ── glob expansion (KNOWN LIMITATION: only single-segment globs
+    # are supported; multi-level patterns like `path/*/file` do not
+    # walk intermediate `*` segments). The next two probes document
+    # the limitation; if a future change makes them work, great.
+    print(
+        f"\n=== echo {base}/*/chat.jsonl (multi-level glob — limitation) ===")
     r = await ws.execute(f'echo "{base}/"*/chat.jsonl')
     out = (await r.stdout_str()).strip()
-    print(f"  {out[:200]}")
+    print(f"  out={out[:200]!r}  (multi-level globs are not expanded today)")
 
-    print(f"\n=== for f in {base}/*/chat.jsonl (glob loop) ===")
+    print(f"\n=== for f in {base}/*/chat.jsonl (glob loop — limitation) ===")
     r = await ws.execute(
         f'for f in "{base}/"*/chat.jsonl; do echo found:$f; done | head -n 3')
     out = (await r.stdout_str()).strip()
-    for line in out.splitlines():
-        print(f"  {line[:120]}")
+    if out:
+        for line in out.splitlines():
+            print(f"  {line[:120]}")
+    else:
+        print("  (no output — multi-level glob limitation)")
 
 
 if __name__ == "__main__":

--- a/python/mirage/commands/builtin/discord/ls.py
+++ b/python/mirage/commands/builtin/discord/ls.py
@@ -124,8 +124,9 @@ async def ls(
     results: list[str] = []
     if not paths:
         cwd = _extra.get("cwd", "/")
-        cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
-        paths = [PathSpec(original=cwd_str, directory=cwd_str, resolved=False)]
+        paths = [cwd] if isinstance(cwd, PathSpec) else [
+            PathSpec(original=cwd, directory=cwd, resolved=False)
+        ]
     paths = await resolve_glob(accessor, paths)
     for p in paths:
         try:

--- a/python/mirage/commands/builtin/email/ls.py
+++ b/python/mirage/commands/builtin/email/ls.py
@@ -125,8 +125,9 @@ async def ls(
     results: list[str] = []
     if not paths:
         cwd = _extra.get("cwd", "/")
-        cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
-        paths = [PathSpec(original=cwd_str, directory=cwd_str, resolved=False)]
+        paths = [cwd] if isinstance(cwd, PathSpec) else [
+            PathSpec(original=cwd, directory=cwd, resolved=False)
+        ]
     paths = await resolve_glob(accessor, paths, _extra.get("index"))
     for p in paths:
         try:

--- a/python/mirage/commands/builtin/gdrive/ls/ls.py
+++ b/python/mirage/commands/builtin/gdrive/ls/ls.py
@@ -127,8 +127,9 @@ async def ls(
     results: list[str] = []
     if not paths:
         cwd = _extra.get("cwd", "/")
-        cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
-        paths = [PathSpec(original=cwd_str, directory=cwd_str, resolved=False)]
+        paths = [cwd] if isinstance(cwd, PathSpec) else [
+            PathSpec(original=cwd, directory=cwd, resolved=False)
+        ]
     paths = await resolve_glob(accessor, paths, _extra.get("index"))
     for p in paths:
         try:

--- a/python/mirage/commands/builtin/github_ci/ls.py
+++ b/python/mirage/commands/builtin/github_ci/ls.py
@@ -124,8 +124,9 @@ async def ls(
     results: list[str] = []
     if not paths:
         cwd = _extra.get("cwd", "/")
-        cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
-        paths = [PathSpec(original=cwd_str, directory=cwd_str, resolved=False)]
+        paths = [cwd] if isinstance(cwd, PathSpec) else [
+            PathSpec(original=cwd, directory=cwd, resolved=False)
+        ]
     paths = await resolve_glob(accessor, paths)
     for p in paths:
         try:

--- a/python/mirage/commands/builtin/gmail/ls.py
+++ b/python/mirage/commands/builtin/gmail/ls.py
@@ -127,8 +127,9 @@ async def ls(
     results: list[str] = []
     if not paths:
         cwd = _extra.get("cwd", "/")
-        cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
-        paths = [PathSpec(original=cwd_str, directory=cwd_str, resolved=False)]
+        paths = [cwd] if isinstance(cwd, PathSpec) else [
+            PathSpec(original=cwd, directory=cwd, resolved=False)
+        ]
     paths = await resolve_glob(accessor, paths, _extra.get("index"))
     for p in paths:
         try:

--- a/python/mirage/commands/builtin/gsheets/ls.py
+++ b/python/mirage/commands/builtin/gsheets/ls.py
@@ -127,8 +127,9 @@ async def ls(
     results: list[str] = []
     if not paths:
         cwd = _extra.get("cwd", "/")
-        cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
-        paths = [PathSpec(original=cwd_str, directory=cwd_str, resolved=False)]
+        paths = [cwd] if isinstance(cwd, PathSpec) else [
+            PathSpec(original=cwd, directory=cwd, resolved=False)
+        ]
     paths = await resolve_glob(accessor, paths, _extra.get("index"))
     for p in paths:
         try:

--- a/python/mirage/commands/builtin/paperclip/ls.py
+++ b/python/mirage/commands/builtin/paperclip/ls.py
@@ -112,8 +112,9 @@ async def ls(
     results: list[str] = []
     if not paths:
         cwd = _extra.get("cwd", "/")
-        cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
-        paths = [PathSpec(original=cwd_str, directory=cwd_str, resolved=False)]
+        paths = [cwd] if isinstance(cwd, PathSpec) else [
+            PathSpec(original=cwd, directory=cwd, resolved=False)
+        ]
     paths = await resolve_glob(accessor, paths)
     for p in paths:
         try:

--- a/python/mirage/commands/builtin/slack/ls.py
+++ b/python/mirage/commands/builtin/slack/ls.py
@@ -125,8 +125,9 @@ async def ls(
     results: list[str] = []
     if not paths:
         cwd = _extra.get("cwd", "/")
-        cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
-        paths = [PathSpec(original=cwd_str, directory=cwd_str, resolved=False)]
+        paths = [cwd] if isinstance(cwd, PathSpec) else [
+            PathSpec(original=cwd, directory=cwd, resolved=False)
+        ]
     paths = await resolve_glob(accessor, paths, _extra.get("index"))
     for p in paths:
         try:

--- a/python/mirage/commands/builtin/telegram/ls.py
+++ b/python/mirage/commands/builtin/telegram/ls.py
@@ -124,8 +124,9 @@ async def ls(
     results: list[str] = []
     if not paths:
         cwd = _extra.get("cwd", "/")
-        cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
-        paths = [PathSpec(original=cwd_str, directory=cwd_str, resolved=False)]
+        paths = [cwd] if isinstance(cwd, PathSpec) else [
+            PathSpec(original=cwd, directory=cwd, resolved=False)
+        ]
     paths = await resolve_glob(accessor, paths)
     for p in paths:
         try:

--- a/python/mirage/core/slack/readdir.py
+++ b/python/mirage/core/slack/readdir.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import logging
 from datetime import datetime, timedelta, timezone
 
 from mirage.accessor.slack import SlackAccessor
@@ -26,7 +27,17 @@ from mirage.core.slack.scope import SlackScope, detect_scope
 from mirage.core.slack.users import list_users
 from mirage.types import PathSpec
 
+logger = logging.getLogger(__name__)
+
 VIRTUAL_ROOTS = ("channels", "dms", "users")
+
+_SOFT_HISTORY_ERRORS = (
+    "not_in_channel",
+    "channel_not_found",
+    "missing_scope",
+    "is_archived",
+    "not_authed",
+)
 
 
 def _date_range(latest_ts: float,
@@ -45,12 +56,20 @@ def _date_range(latest_ts: float,
 
 
 async def _latest_message_ts(config, channel_id: str) -> float | None:
-    data = await slack_get(config,
-                           "conversations.history",
-                           params={
-                               "channel": channel_id,
-                               "limit": 1,
-                           })
+    try:
+        data = await slack_get(config,
+                               "conversations.history",
+                               params={
+                                   "channel": channel_id,
+                                   "limit": 1,
+                               })
+    except RuntimeError as e:
+        if any(code in str(e) for code in _SOFT_HISTORY_ERRORS):
+            logger.debug(
+                "slack: history denied for %s (%s); treating as empty",
+                channel_id, e)
+            return None
+        raise
     messages = data.get("messages", [])
     if messages:
         return float(messages[0].get("ts", "0"))
@@ -313,8 +332,16 @@ async def _fetch_day(
     date_vkey: str,
     index: IndexCacheStore,
 ) -> None:
-    messages = await fetch_messages_for_day(accessor.config, channel_id,
-                                            date_str)
+    try:
+        messages = await fetch_messages_for_day(accessor.config, channel_id,
+                                                date_str)
+    except RuntimeError as e:
+        if any(code in str(e) for code in _SOFT_HISTORY_ERRORS):
+            logger.debug("slack: history denied for %s/%s (%s); empty day",
+                         channel_id, date_str, e)
+            await index.set_dir(date_vkey, [])
+            return
+        raise
     chat_entry = IndexEntry(
         id=f"{channel_id}:{date_str}:chat",
         name="chat.jsonl",

--- a/python/tests/commands/builtin/slack/test_ls_cwd.py
+++ b/python/tests/commands/builtin/slack/test_ls_cwd.py
@@ -1,0 +1,79 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import patch
+
+import pytest
+
+from mirage.resource.slack.config import SlackConfig
+from mirage.resource.slack.slack import SlackResource
+from mirage.types import MountMode
+from mirage.workspace.workspace import Workspace
+
+
+@pytest.fixture
+def config():
+    return SlackConfig(token="xoxb-test")
+
+
+@pytest.mark.asyncio
+async def test_ls_no_args_after_cd_returns_cwd_entries(config):
+    """Regression for bug: `ls` (no args) returned empty after `cd /slack/...`.
+
+    Root cause: `slack/ls.py` rebuilt a fresh `PathSpec` from `cwd.original`
+    without preserving the mount prefix, so readdir treated the mount prefix
+    segment as a container name and returned [].
+    """
+    resource = SlackResource(config)
+    ws = Workspace({"/slack": resource}, mode=MountMode.READ)
+    channels_page = {
+        "channels": [{
+            "id": "C001",
+            "name": "general",
+            "created": 1700000000
+        }],
+        "response_metadata": {
+            "next_cursor": ""
+        },
+    }
+    history_page = {
+        "messages": [{
+            "ts": "1700050000.0",
+            "text": "hi"
+        }],
+        "has_more": False,
+    }
+
+    async def fake_get(_cfg, method, params=None, token=None):
+        if method == "conversations.list":
+            return channels_page
+        if method == "conversations.history":
+            return history_page
+        raise AssertionError(f"unexpected method: {method}")
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get), \
+         patch("mirage.core.slack.readdir.slack_get", new=fake_get):
+        r = await ws.execute("cd /slack/channels/general__C001")
+        assert r.exit_code == 0
+        r = await ws.execute("pwd")
+        assert (await
+                r.stdout_str()).strip() == "/slack/channels/general__C001"
+
+        r = await ws.execute("ls")
+        out = (await r.stdout_str()).strip()
+    assert r.exit_code == 0
+    assert out != "", "ls no-args after cd returned empty"
+    first_line = out.splitlines()[0]
+    assert len(
+        first_line) == 10 and first_line[4] == "-" and first_line[7] == "-"

--- a/python/tests/core/slack/test_readdir_soft_errors.py
+++ b/python/tests/core/slack/test_readdir_soft_errors.py
@@ -1,0 +1,129 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mirage.accessor.slack import SlackAccessor
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.cache.index.config import IndexConfig
+from mirage.core.slack.readdir import _fetch_day, _latest_message_ts, readdir
+from mirage.resource.slack.config import SlackConfig
+from mirage.types import IndexType, PathSpec
+
+
+@pytest.fixture
+def config():
+    return SlackConfig(token="xoxb-test")
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore.from_config(
+        IndexConfig(type=IndexType.RAM, ttl=600))
+
+
+@pytest.mark.asyncio
+async def test_latest_message_ts_returns_none_on_not_in_channel(config):
+    err = RuntimeError(
+        "Slack API error (conversations.history): not_in_channel")
+    with patch("mirage.core.slack.readdir.slack_get",
+               new=AsyncMock(side_effect=err)):
+        result = await _latest_message_ts(config, "C_INACCESSIBLE")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_latest_message_ts_returns_none_on_missing_scope(config):
+    err = RuntimeError(
+        "Slack API error (conversations.history): missing_scope "
+        "(needed: channels:history; provided: channels:read)")
+    with patch("mirage.core.slack.readdir.slack_get",
+               new=AsyncMock(side_effect=err)):
+        result = await _latest_message_ts(config, "C_NO_SCOPE")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_latest_message_ts_reraises_unrelated_errors(config):
+    err = RuntimeError("Slack API error (conversations.history): rate_limited")
+    with patch("mirage.core.slack.readdir.slack_get",
+               new=AsyncMock(side_effect=err)):
+        with pytest.raises(RuntimeError, match="rate_limited"):
+            await _latest_message_ts(config, "C1")
+
+
+@pytest.mark.asyncio
+async def test_fetch_day_seals_empty_dir_on_not_in_channel(config, index):
+    err = RuntimeError(
+        "Slack API error (conversations.history): not_in_channel")
+    accessor = SlackAccessor(config=config)
+
+    async def fake_history(_cfg, channel_id, date_str):
+        raise err
+
+    with patch("mirage.core.slack.readdir.fetch_messages_for_day",
+               new=fake_history):
+        await _fetch_day(accessor, "C_INACCESSIBLE", "2026-05-10",
+                         "/slack/channels/foo__C_INACCESSIBLE/2026-05-10",
+                         index)
+    listing = await index.list_dir(
+        "/slack/channels/foo__C_INACCESSIBLE/2026-05-10")
+    assert listing.entries == []
+
+
+@pytest.mark.asyncio
+async def test_readdir_channel_inaccessible_yields_no_dates(config, index):
+    """Full integration: ls /slack/channels/inaccessible/ → no dates."""
+    accessor = SlackAccessor(config=config)
+    channels_page = {
+        "channels": [{
+            "id": "C_INACCESSIBLE",
+            "name": "private",
+            "created": 1
+        }],
+        "response_metadata": {
+            "next_cursor": ""
+        },
+    }
+    err = RuntimeError(
+        "Slack API error (conversations.history): not_in_channel")
+
+    async def fake_get(_cfg, method, params=None, token=None):
+        if method == "conversations.list":
+            return channels_page
+        if method == "conversations.history":
+            raise err
+        raise AssertionError(f"unexpected {method}")
+
+    with patch("mirage.core.slack.paginate.slack_get", new=fake_get), \
+         patch("mirage.core.slack.readdir.slack_get", new=fake_get):
+        await readdir(
+            accessor,
+            PathSpec(original="/slack/channels",
+                     directory="/slack/channels/",
+                     prefix="/slack"),
+            index,
+        )
+        dates = await readdir(
+            accessor,
+            PathSpec(
+                original="/slack/channels/private__C_INACCESSIBLE",
+                directory="/slack/channels/private__C_INACCESSIBLE/",
+                prefix="/slack",
+            ),
+            index,
+        )
+    assert dates == []


### PR DESCRIPTION
## Summary

Two pre-existing bugs surfaced during live testing of the slack example:

### Bug 1: `ls` (no args) returned empty after `cd /slack/...`

After `cd /slack/channels/general__C001`, `pwd` returned the correct path but `ls` (no args) returned empty. The fallback in `slack/ls.py:127-129` rebuilt a fresh `PathSpec` from `cwd.original` without preserving `cwd.prefix`, so `readdir` treated the mount-prefix segment as a container name and dispatched to nothing.

The **same broken pattern** lived in 9 backend `ls.py` files. All fixed by passing the incoming `cwd` PathSpec through verbatim instead of stripping and rebuilding.

### Bug 2: `find /slack/ ...` aborted with `not_in_channel`

Workspace-wide `find` walked into every channel; if the bot token didn't have history access to one of them, `_latest_message_ts` raised and find aborted with no output. Bot tokens not being in every channel is the *normal* case for Slack apps. Fix: `_latest_message_ts` and `_fetch_day` now catch soft Slack errors (`not_in_channel`, `channel_not_found`, `missing_scope`, `is_archived`, `not_authed`) and treat them as "no history", letting find walk past inaccessible channels.

### Known limitation (not fixed)

Multi-level globs (`path/*/file`) are not supported. `classify_word` only puts the last path segment in `pattern`; intermediate `*`s end up inside `directory` and don't expand. Single-level globs (`path/*`, `path/*.ext`) still work. The example documents this so a future fix is easy to detect.

## Test plan

- [x] 6 new regression tests added (1 for Bug 1, 5 for Bug 3 — soft errors at unit + integration levels).
- [x] Bug 1 regression test verified by reverting `slack/ls.py` → test fails as expected.
- [x] Slack example now hard-asserts both fixes (it crashes if either regresses).
- [x] Live run against real Slack: `find /slack/ -name 'chat.jsonl'` returns 91 matches; previously aborted on the first inaccessible channel.
- [x] Full pytest: **5596 passed, 221 skipped** (+6 vs. baseline).
- [x] `pre-commit run --all-files`: clean on touched files.