### PR TITLE
feat(ts/slack/grep|rg): search push-down fallback with SLACK_USER_TOKEN hint

### DIFF
--- a/typescript/packages/core/src/commands/builtin/slack/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/grep.ts
@@ -17,9 +17,13 @@ import { resolveSlackGlob } from '../../../core/slack/glob.ts'
 import { read as slackRead } from '../../../core/slack/read.ts'
 import { readdir as slackReaddir } from '../../../core/slack/readdir.ts'
 import { stat as slackStat } from '../../../core/slack/stat.ts'
-import { buildQuery, formatGrepResults } from '../../../core/slack/formatters.ts'
+import {
+  buildQuery,
+  formatFileGrepResults,
+  formatGrepResults,
+} from '../../../core/slack/formatters.ts'
 import { detectScope } from '../../../core/slack/scope.ts'
-import { searchMessages } from '../../../core/slack/search.ts'
+import { searchFiles, searchMessages } from '../../../core/slack/search.ts'
 import { exitOnEmpty, quietMatch, yieldBytes } from '../../../io/stream.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { type FileStat, PathSpec, ResourceName } from '../../../types.ts'
@@ -95,6 +99,7 @@ async function grepCommand(
   }
   const f = parseFlags(opts.flags)
 
+  const pushdownWarnings: string[] = []
   if (paths.length > 0) {
     const firstPath = paths[0]
     if (firstPath !== undefined) {
@@ -103,14 +108,41 @@ async function grepCommand(
         const filePrefix = firstPath.prefix
         const query = buildQuery(pattern, scope)
         const count = f.maxCount ?? 100
-        const raw = await searchMessages(accessor, query, count)
-        const lines = formatGrepResults(raw, scope, filePrefix)
-        if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-        return [ENC.encode(lines.join('\n') + '\n'), new IOResult()]
+        const target = scope.target
+        const doMessages = target === undefined || target === 'date' || target === 'messages'
+        const doFiles = target === undefined || target === 'date' || target === 'files'
+        try {
+          const nativeLines: string[] = []
+          if (doMessages) {
+            const raw = await searchMessages(accessor, query, count)
+            nativeLines.push(...formatGrepResults(raw, scope, filePrefix))
+          }
+          if (doFiles) {
+            const rawF = await searchFiles(accessor, query, count)
+            nativeLines.push(...formatFileGrepResults(rawF, scope, filePrefix))
+          }
+          if (nativeLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
+          return [ENC.encode(nativeLines.join('\n') + '\n'), new IOResult()]
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          pushdownWarnings.push(
+            `slack: native search push-down failed (${msg}); falling back to per-file scan`,
+          )
+          if (msg.includes('not_allowed_token_type') || msg.includes('missing_scope')) {
+            pushdownWarnings.push(
+              'slack: hint - set SLACK_USER_TOKEN (xoxp-) with search:read scope to enable workspace search',
+            )
+          }
+        }
       }
     }
     const resolved = await resolveSlackGlob(accessor, paths, opts.index ?? undefined)
     const pat = compilePattern(pattern, f.ignoreCase, f.fixedString, f.wholeWord)
+
+    const stderrFromWarnings = (extra: string[] = []): Uint8Array | undefined => {
+      const all = [...pushdownWarnings, ...extra]
+      return all.length > 0 ? ENC.encode(all.join('\n') + '\n') : undefined
+    }
 
     if (f.filesOnly) {
       const filePrefix = resolved[0]?.prefix ?? ''
@@ -144,7 +176,7 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : undefined
+      const stderr = stderrFromWarnings(warnings)
       if (results.length === 0) {
         return [
           new Uint8Array(0),
@@ -156,6 +188,10 @@ async function grepCommand(
         new IOResult({ ...(stderr !== undefined ? { stderr } : {}) }),
       ]
     }
+
+    const stderr = stderrFromWarnings()
+    const ioWith = (init: { exitCode?: number } = {}): IOResult =>
+      new IOResult({ ...init, ...(stderr !== undefined ? { stderr } : {}) })
 
     if (resolved.length > 1) {
       const allResults: string[] = []
@@ -170,21 +206,21 @@ async function grepCommand(
           for (const h of hits) allResults.push(`${p.original}:${h}`)
         }
       }
-      if (allResults.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
+      if (allResults.length === 0) return [new Uint8Array(0), ioWith({ exitCode: 1 })]
       const out: ByteSource = ENC.encode(allResults.join('\n'))
-      return [out, new IOResult()]
+      return [out, ioWith()]
     }
 
     const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
+    if (first === undefined) return [null, ioWith()]
     const raw = await slackRead(accessor, first, opts.index ?? undefined)
     const source = yieldBytes(raw)
     const stream = grepStream(source, pat, f)
     if (f.quiet) {
-      const io = new IOResult({ exitCode: 1 })
+      const io = ioWith({ exitCode: 1 })
       return [quietMatch(stream, io), io]
     }
-    const io = new IOResult()
+    const io = ioWith()
     return [exitOnEmpty(stream, io), io]
   }
 

--- a/typescript/packages/core/src/commands/builtin/slack/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/rg.ts
@@ -17,9 +17,13 @@ import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { resolveSlackGlob } from '../../../core/slack/glob.ts'
 import { read as slackRead } from '../../../core/slack/read.ts'
 import { readdir as slackReaddir } from '../../../core/slack/readdir.ts'
-import { buildQuery, formatGrepResults } from '../../../core/slack/formatters.ts'
+import {
+  buildQuery,
+  formatFileGrepResults,
+  formatGrepResults,
+} from '../../../core/slack/formatters.ts'
 import { detectScope } from '../../../core/slack/scope.ts'
-import { searchMessages } from '../../../core/slack/search.ts'
+import { searchFiles, searchMessages } from '../../../core/slack/search.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
@@ -110,6 +114,7 @@ async function rgCommand(
   const f = parseRgFlags(opts.flags)
   const pat = compilePattern(exprText, f.ignoreCase, f.fixedString, f.wholeWord)
 
+  const pushdownWarnings: string[] = []
   if (paths.length > 0) {
     const firstPath = paths[0]
     if (firstPath !== undefined) {
@@ -118,10 +123,32 @@ async function rgCommand(
         const filePrefix = firstPath.prefix
         const query = buildQuery(exprText, scope)
         const count = f.maxCount ?? 100
-        const raw = await searchMessages(accessor, query, count)
-        const lines = formatGrepResults(raw, scope, filePrefix)
-        if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-        return [ENC.encode(lines.join('\n') + '\n'), new IOResult()]
+        const target = scope.target
+        const doMessages = target === undefined || target === 'date' || target === 'messages'
+        const doFiles = target === undefined || target === 'date' || target === 'files'
+        try {
+          const nativeLines: string[] = []
+          if (doMessages) {
+            const raw = await searchMessages(accessor, query, count)
+            nativeLines.push(...formatGrepResults(raw, scope, filePrefix))
+          }
+          if (doFiles) {
+            const rawF = await searchFiles(accessor, query, count)
+            nativeLines.push(...formatFileGrepResults(rawF, scope, filePrefix))
+          }
+          if (nativeLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
+          return [ENC.encode(nativeLines.join('\n') + '\n'), new IOResult()]
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          pushdownWarnings.push(
+            `slack: native search push-down failed (${msg}); falling back to per-file scan`,
+          )
+          if (msg.includes('not_allowed_token_type') || msg.includes('missing_scope')) {
+            pushdownWarnings.push(
+              'slack: hint - set SLACK_USER_TOKEN (xoxp-) with search:read scope to enable workspace search',
+            )
+          }
+        }
       }
     }
     const resolved = await resolveSlackGlob(accessor, paths, opts.index ?? undefined)
@@ -166,9 +193,16 @@ async function rgCommand(
         allResults.push(`${bp}:${line}`)
       }
     }
-    if (!anyMatch) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
+    const stderr =
+      pushdownWarnings.length > 0 ? ENC.encode(pushdownWarnings.join('\n') + '\n') : undefined
+    if (!anyMatch) {
+      return [
+        new Uint8Array(0),
+        new IOResult({ exitCode: 1, ...(stderr !== undefined ? { stderr } : {}) }),
+      ]
+    }
     const out: ByteSource = ENC.encode(allResults.join('\n'))
-    return [out, new IOResult()]
+    return [out, new IOResult({ ...(stderr !== undefined ? { stderr } : {}) })]
   }
 
   const raw = await readStdinAsync(opts.stdin)

--- a/typescript/packages/core/src/commands/builtin/slack/search_pushdown_fallback.test.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/search_pushdown_fallback.test.ts
@@ -1,0 +1,152 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { RAMIndexCacheStore } from '../../../cache/index/ram.ts'
+import { SlackApiError, type SlackResponse } from '../../../core/slack/_client.ts'
+import { materialize } from '../../../io/types.ts'
+import { PathSpec } from '../../../types.ts'
+import { FakeSlackTransport, makeFakeResource, seedChannel } from './_test_util.ts'
+import { SLACK_GREP } from './grep.ts'
+import { SLACK_RG } from './rg.ts'
+
+const DEC = new TextDecoder()
+
+async function runGrep(
+  paths: PathSpec[],
+  texts: string[],
+  options: { transport: FakeSlackTransport; index: RAMIndexCacheStore },
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const cmd = SLACK_GREP[0]
+  if (cmd === undefined) throw new Error('grep not registered')
+  const resource = makeFakeResource(options.transport)
+  const result = await cmd.fn(resource.accessor, paths, texts, {
+    stdin: null,
+    flags: { args_l: true },
+    filetypeFns: null,
+    cwd: '/',
+    resource,
+    index: options.index,
+  })
+  if (result === null) return { stdout: '', stderr: '', exitCode: 0 }
+  const [out, io] = result
+  const stdoutBytes =
+    out === null
+      ? new Uint8Array()
+      : out instanceof Uint8Array
+        ? out
+        : await materialize(out as AsyncIterable<Uint8Array>)
+  const stderrBytes = await io.materializeStderr()
+  return {
+    stdout: DEC.decode(stdoutBytes),
+    stderr: DEC.decode(stderrBytes),
+    exitCode: io.exitCode,
+  }
+}
+
+async function runRg(
+  paths: PathSpec[],
+  texts: string[],
+  options: { transport: FakeSlackTransport; index: RAMIndexCacheStore },
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const cmd = SLACK_RG[0]
+  if (cmd === undefined) throw new Error('rg not registered')
+  const resource = makeFakeResource(options.transport)
+  const result = await cmd.fn(resource.accessor, paths, texts, {
+    stdin: null,
+    flags: { args_l: true },
+    filetypeFns: null,
+    cwd: '/',
+    resource,
+    index: options.index,
+  })
+  if (result === null) return { stdout: '', stderr: '', exitCode: 0 }
+  const [out, io] = result
+  const stdoutBytes =
+    out === null
+      ? new Uint8Array()
+      : out instanceof Uint8Array
+        ? out
+        : await materialize(out as AsyncIterable<Uint8Array>)
+  const stderrBytes = await io.materializeStderr()
+  return {
+    stdout: DEC.decode(stdoutBytes),
+    stderr: DEC.decode(stderrBytes),
+    exitCode: io.exitCode,
+  }
+}
+
+describe('slack grep: search push-down fallback', () => {
+  it('emits SLACK_USER_TOKEN hint when search.messages returns not_allowed_token_type', async () => {
+    const idx = new RAMIndexCacheStore()
+    await seedChannel(idx, '/mnt/slack', 'general__C1', 'C1', { dates: ['2024-01-01'] })
+    let searchCalled = false
+    const transport = new FakeSlackTransport((endpoint): SlackResponse => {
+      if (endpoint === 'search.messages' || endpoint === 'search.files') {
+        searchCalled = true
+        throw new SlackApiError(endpoint, 'not_allowed_token_type')
+      }
+      if (endpoint === 'conversations.history') {
+        return { ok: true, messages: [{ ts: '1.0', text: 'hello world' }] }
+      }
+      return { ok: true }
+    })
+    const out = await runGrep(
+      [
+        new PathSpec({
+          original: '/mnt/slack/channels/general__C1',
+          directory: '/mnt/slack/channels/general__C1',
+          resolved: false,
+          prefix: '/mnt/slack',
+        }),
+      ],
+      ['hello'],
+      { transport, index: idx },
+    )
+    expect(searchCalled).toBe(true)
+    expect(out.stderr).toContain('native search push-down failed')
+    expect(out.stderr).toContain('SLACK_USER_TOKEN')
+    expect(out.stderr).toContain('search:read')
+  })
+})
+
+describe('slack rg: search push-down fallback', () => {
+  it('emits SLACK_USER_TOKEN hint when search.messages returns missing_scope', async () => {
+    const idx = new RAMIndexCacheStore()
+    await seedChannel(idx, '/mnt/slack', 'general__C1', 'C1', { dates: ['2024-01-01'] })
+    const transport = new FakeSlackTransport((endpoint): SlackResponse => {
+      if (endpoint === 'search.messages' || endpoint === 'search.files') {
+        throw new SlackApiError(endpoint, 'missing_scope', 'search:read', 'channels:read')
+      }
+      if (endpoint === 'conversations.history') {
+        return { ok: true, messages: [{ ts: '1.0', text: 'hi' }] }
+      }
+      return { ok: true }
+    })
+    const out = await runRg(
+      [
+        new PathSpec({
+          original: '/mnt/slack/channels/general__C1',
+          directory: '/mnt/slack/channels/general__C1',
+          resolved: false,
+          prefix: '/mnt/slack',
+        }),
+      ],
+      ['hi'],
+      { transport, index: idx },
+    )
+    expect(out.stderr).toContain('SLACK_USER_TOKEN')
+    expect(out.stderr).toContain('search:read')
+  })
+})


### PR DESCRIPTION
## Summary

When the native search push-down (`search.messages` / `search.files`) fails, slack `grep` / `rg` now emit a stderr hint and fall back to per-file scanning. The most common failure mode is bot tokens (`xoxb-`) hitting `not_allowed_token_type` because `search.*` requires a user token (`xoxp-`) with `search:read`. Previously the error propagated as an unhandled rejection. Now: clear hint, graceful fallback.

Mirrors Python's warn-and-fallback pattern in `python/mirage/commands/builtin/slack/grep/grep.py`.

## What changed

- `grep.ts`: wrap `searchMessages` + `searchFiles` in try/catch. On error, push a warning + (if `not_allowed_token_type` / `missing_scope`) a `SLACK_USER_TOKEN` hint to stderr, then drop through to the per-file scan.
- `rg.ts`: same pattern.
- Both also now invoke `searchFiles` when the scope's target is `files` or `date` (previously messages-only). Pulls in `formatFileGrepResults` from `formatters.ts`.

### Example stderr output (bot token attempting workspace search)

```
slack: native search push-down failed (Slack API error (search.messages): not_allowed_token_type); falling back to per-file scan
slack: hint - set SLACK_USER_TOKEN (xoxp-) with search:read scope to enable workspace search
```

## Test plan

- [x] pnpm --filter './packages/core' typecheck clean
- [x] pnpm lint clean
- [x] pnpm --filter './packages/core' test --run -> 2635 passed (+2 new)
- [x] pre-commit run --files <staged> clean

New regression tests: search_pushdown_fallback.test.ts (2 tests).