### PR TITLE
fix(py): os.listdir patch returns basenames (stdlib parity)

### DIFF
--- a/examples/python/slack/slack_vfs.py
+++ b/examples/python/slack/slack_vfs.py
@@ -48,14 +48,15 @@ async def main():
 
         if channels:
             ch = next((c for c in channels if "general" in c), channels[0])
+            ch_dir = f"/slack/channels/{ch}"
             print("\n--- os.listdir() dates ---")
-            dates = vos.listdir(f"/slack{ch}")
+            dates = vos.listdir(ch_dir)
             for d in dates[-5:]:
                 print(f"  {d}")
 
             if dates:
                 for d in reversed(dates):
-                    path = f"/slack{d}"
+                    path = f"{ch_dir}/{d}/chat.jsonl"
                     with open(path) as f:
                         content = f.read()
                     lines = [
@@ -82,11 +83,12 @@ async def main():
 
         print("\n--- session observer ---")
         day_folders = vos.listdir("/.sessions")
-        log_entries = vos.listdir(day_folders[0]) if day_folders else []
+        day_dir = f"/.sessions/{day_folders[0]}" if day_folders else None
+        log_entries = vos.listdir(day_dir) if day_dir else []
         for e in log_entries:
-            print(f"  {e}")
-        if log_entries:
-            with open(log_entries[0]) as f:
+            print(f"  {day_dir}/{e}")
+        if log_entries and day_dir:
+            with open(f"{day_dir}/{log_entries[0]}") as f:
                 for i, line in enumerate(f):
                     if i >= 3:
                         break

--- a/python/mirage/ops/os_patch.py
+++ b/python/mirage/ops/os_patch.py
@@ -64,8 +64,10 @@ def make_os_module(ops: Ops, loop: asyncio.AbstractEventLoop | None = None):
     def _run(coro):
         return run_async_from_sync(coro, loop)
 
-    patched.listdir = (lambda p: _run(ops.readdir(p))
-                       if ops.is_mounted(p) else _real_os.listdir(p))
+    patched.listdir = (
+        lambda p:
+        [e.rstrip("/").rsplit("/", 1)[-1] for e in _run(ops.readdir(p))]
+        if ops.is_mounted(p) else _real_os.listdir(p))
     patched.remove = (lambda p: _run(ops.unlink(p))
                       if ops.is_mounted(p) else _real_os.remove(p))
     patched.rmdir = (lambda p: _run(ops.rmdir(p))


### PR DESCRIPTION
## Summary

- `os_patch.listdir` was passing `ops.readdir` output through verbatim, which is full paths by the Python convention (e.g. `/slack/channels/general__...`). Stdlib `os.listdir(path)` returns basenames — the patched module violated that contract and silently broke any caller doing `os.path.join(dir, name)`.
- Strip to basenames at the patch boundary, mirroring the existing FUSE adapter strip in [fuse/fs.py:161](https://github.com/strukto-ai/mirage/blob/main/python/mirage/fuse/fs.py#L161). Internal Ops/FUSE consumers are unaffected.
- Fix `examples/python/slack/slack_vfs.py` which assumed basenames — the dates listing was empty and session observer paths were corrupted (`/slack/slack/channels/...`).

Pre-existing since v0.0.1-alpha.1; not a regression.

## Test plan

- [x] `examples/python/slack/slack_vfs.py` runs end-to-end (73 ops / 15848 bytes, real message bodies rendered, `os.path.exists` returns True)
- [x] `pytest tests/ops/test_os_patch.py` — 8/8 pass
- [x] RAM probe confirms cross-resource basenames: `vos.listdir("/mem/dir")` → `['a.txt', 'b.txt']`
- [x] FUSE adapter strip remains a no-op on already-basename input (safe)
- [x] `pre-commit run --files <both>` — all hooks pass