### PR TITLE
refactor(py+ts): python3 from shell builtin to overridable general command

### DIFF
--- a/.github/workflows/infra-example.yml
+++ b/.github/workflows/infra-example.yml
@@ -263,6 +263,113 @@ jobs:
           echo "$output" | grep -q "read: lazy demo" || (echo "FAIL: lazy-on-miss read failed" && exit 1)
           echo "$output" | grep -q "PNG magic: 89 50 4e 47" || (echo "FAIL: PIL save did not produce a PNG" && exit 1)
 
+  examples-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.32.1
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: typescript/pnpm-lock.yaml
+
+      - name: Install node-gyp
+        run: npm install -g node-gyp
+
+      - name: Install Python dependencies
+        working-directory: python
+        run: uv sync --all-extras --no-extra camel
+
+      - name: Install TypeScript dependencies
+        working-directory: typescript
+        run: pnpm install --frozen-lockfile
+
+      - name: Build TypeScript packages
+        working-directory: typescript
+        run: pnpm -r build
+
+      - name: Run python3 example (Python, RAM)
+        run: |
+          output=$(./python/.venv/bin/python examples/python/ram/ram_python.py 2>&1)
+          echo "$output"
+          # Regression guard: argv after -c must stay raw, not be path-resolved
+          echo "$output" | grep -q "argv after -c: \['alpha', 'beta'\]" || (echo "FAIL: argv after -c regression" && exit 1)
+          # Script + argv path
+          echo "$output" | grep -q "argv after script: \['one', 'two'\]" || (echo "FAIL: argv after script" && exit 1)
+          # Script dispatched through VFS
+          echo "$output" | grep -q "hello from vfs" || (echo "FAIL: script via dispatch" && exit 1)
+          # Session env passthrough
+          echo "$output" | grep -q "hello_mirage" || (echo "FAIL: env passthrough" && exit 1)
+
+      - name: Run python_basic example (TypeScript)
+        run: |
+          output=$(pnpm -C examples/typescript exec tsx python/python_basic.ts 2>&1)
+          echo "$output"
+          # Regression guard: argv after -c
+          echo "$output" | grep -q "\['alpha', 'beta'\]" || (echo "FAIL: argv after -c regression" && exit 1)
+          # SystemExit honored
+          echo "$output" | grep -q "exit: 3 (expect 3)" || (echo "FAIL: SystemExit code" && exit 1)
+          # Traceback propagates to stderr
+          echo "$output" | grep -q "RuntimeError: boom" || (echo "FAIL: traceback on stderr" && exit 1)
+
+      - name: Run python_env example (TypeScript)
+        run: |
+          output=$(pnpm -C examples/typescript exec tsx python/python_env.ts 2>&1)
+          echo "$output"
+          echo "$output" | grep -q "stdout: bar" || (echo "FAIL: env passthrough" && exit 1)
+          echo "$output" | grep -q "wsA:  alice" || (echo "FAIL: cross-workspace isolation wsA" && exit 1)
+          echo "$output" | grep -q "wsB:  bob" || (echo "FAIL: cross-workspace isolation wsB" && exit 1)
+
+      - name: Run python_heredoc example (TypeScript)
+        run: |
+          output=$(pnpm -C examples/typescript exec tsx python/python_heredoc.ts 2>&1)
+          echo "$output"
+          # quoted heredoc: $X literal (fixed-string match to avoid regex anchor)
+          echo "$output" | grep -qF 'stdout: $X' || (echo "FAIL: quoted heredoc" && exit 1)
+          # unquoted heredoc: $X expanded
+          echo "$output" | grep -q "stdout: shellval" || (echo "FAIL: unquoted heredoc" && exit 1)
+          # dash-strip
+          echo "$output" | grep -q "item-0" || (echo "FAIL: dash-strip heredoc" && exit 1)
+          # heredoc + pipe
+          echo "$output" | grep -q "^keep 1$" || (echo "FAIL: heredoc + pipe" && exit 1)
+          # heredoc in for-loop
+          echo "$output" | grep -q "hello, alice!" || (echo "FAIL: heredoc in for-loop" && exit 1)
+
+      - name: Run python_script example (TypeScript)
+        run: |
+          output=$(pnpm -C examples/typescript exec tsx python/python_script.ts 2>&1)
+          echo "$output"
+          echo "$output" | grep -q "count: 4" || (echo "FAIL: script + stdin pipeline" && exit 1)
+          echo "$output" | grep -q "alice -> login" || (echo "FAIL: inline -c pipeline" && exit 1)
+
+      - name: Run python_ram example (TypeScript)
+        run: |
+          output=$(pnpm -C examples/typescript exec tsx python/python_ram.ts 2>&1)
+          echo "$output"
+          echo "$output" | grep -q "hello, world!" || (echo "FAIL: bare script run" && exit 1)
+          echo "$output" | grep -q "sum(1..10): 55" || (echo "FAIL: script computation" && exit 1)
+          # Regression guard: argv after script
+          echo "$output" | grep -q "args: \['alice', 'bob'\]" || (echo "FAIL: argv after script" && exit 1)
+          echo "$output" | grep -q "alice: 2" || (echo "FAIL: cat | python pipeline" && exit 1)
+          echo "$output" | grep -q "python3: /ram/missing.py: No such file" || (echo "FAIL: missing script error" && exit 1)
+
   examples-custom-command:
     runs-on: ubuntu-latest
     steps:

--- a/examples/python/ram/ram_python.py
+++ b/examples/python/ram/ram_python.py
@@ -1,0 +1,69 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+from mirage import MountMode, Workspace
+from mirage.resource.ram import RAMResource
+
+
+async def main() -> None:
+    ws = Workspace({"/ram": RAMResource()}, mode=MountMode.EXEC)
+
+    print("=== python3 -c (basic) ===")
+    r = await ws.execute('python3 -c "print(42)"')
+    print(f"stdout: {(await r.stdout_str()).strip()}  (expected: 42)")
+
+    print("\n=== python3 -c with argv (flag-conditional) ===")
+    r = await ws.execute(
+        'python3 -c "import sys; print(sys.argv[1:])" alpha beta')
+    print(f"argv after -c: {(await r.stdout_str()).strip()}  "
+          f"(expected: ['alpha', 'beta'])")
+
+    print("\n=== python3 /ram/script.py (abs path → dispatch read) ===")
+    await ws.execute("echo 'print(\"hello from vfs\")' > /ram/h.py")
+    r = await ws.execute("python3 /ram/h.py")
+    print(f"stdout: {(await r.stdout_str()).strip()}  "
+          f"(expected: hello from vfs)")
+
+    print("\n=== python3 /abs/script.py arg1 arg2 (script + argv) ===")
+    await ws.execute("echo 'import sys; print(sys.argv[1:])' > /ram/argv.py")
+    r = await ws.execute("python3 /ram/argv.py one two")
+    print(f"argv after script: {(await r.stdout_str()).strip()}  "
+          f"(expected: ['one', 'two'])")
+
+    print("\n=== python3 bare-name script via cwd ===")
+    r = await ws.execute("cd /ram && python3 h.py")
+    print(f"stdout: {(await r.stdout_str()).strip()}  "
+          f"(expected: hello from vfs)")
+
+    print("\n=== echo code | python3 (stdin) ===")
+    r = await ws.execute('echo "print(7*6)" | python3')
+    print(f"stdout: {(await r.stdout_str()).strip()}  (expected: 42)")
+
+    print("\n=== heredoc ===")
+    r = await ws.execute("python3 <<PYEOF\nprint(1 + 2)\nPYEOF")
+    print(f"stdout: {(await r.stdout_str()).strip()}  (expected: 3)")
+
+    print("\n=== session env passthrough ===")
+    await ws.execute("export GREETING=hello_mirage")
+    r = await ws.execute(
+        "python3 -c \"import os; print(os.environ.get('GREETING','none'))\"")
+    print(
+        f"stdout: {(await r.stdout_str()).strip()}  (expected: hello_mirage)")
+
+    await ws.close()
+
+
+asyncio.run(main())

--- a/examples/typescript/python/python_basic.ts
+++ b/examples/typescript/python/python_basic.ts
@@ -32,7 +32,7 @@ async function runLabeled(ws: Workspace, label: string, cmd: string): Promise<vo
 
 async function main(): Promise<void> {
   const ram = new RAMResource()
-  const ws = new Workspace({ '/data': ram }, { mode: MountMode.WRITE })
+  const ws = new Workspace({ '/data': ram }, { mode: MountMode.EXEC })
 
   console.log('python3 in @mirage-ai — Pyodide-backed, three invocation modes')
   console.log('(first call takes ~1-2s to boot Pyodide; subsequent calls are instant)\n')

--- a/examples/typescript/python/python_env.ts
+++ b/examples/typescript/python/python_env.ts
@@ -15,7 +15,7 @@
 import { MountMode, RAMResource, Workspace } from '@struktoai/mirage-node'
 
 async function main(): Promise<void> {
-  const ws = new Workspace({ '/ram': new RAMResource() }, { mode: MountMode.WRITE })
+  const ws = new Workspace({ '/ram': new RAMResource() }, { mode: MountMode.EXEC })
 
   console.log('python3 + session env (os.environ passthrough)\n')
 
@@ -32,8 +32,8 @@ async function main(): Promise<void> {
   )
 
   console.log('=== isolation across workspaces — each has its own Pyodide ===')
-  const wsA = new Workspace({ '/ram': new RAMResource() }, { mode: MountMode.WRITE })
-  const wsB = new Workspace({ '/ram': new RAMResource() }, { mode: MountMode.WRITE })
+  const wsA = new Workspace({ '/ram': new RAMResource() }, { mode: MountMode.EXEC })
+  const wsB = new Workspace({ '/ram': new RAMResource() }, { mode: MountMode.EXEC })
   await wsA.execute('export NAME=alice')
   await wsB.execute('export NAME=bob')
 

--- a/examples/typescript/python/python_heredoc.ts
+++ b/examples/typescript/python/python_heredoc.ts
@@ -15,7 +15,7 @@
 import { MountMode, RAMResource, Workspace } from '@struktoai/mirage-node'
 
 async function main(): Promise<void> {
-  const ws = new Workspace({ '/ram': new RAMResource() }, { mode: MountMode.WRITE })
+  const ws = new Workspace({ '/ram': new RAMResource() }, { mode: MountMode.EXEC })
 
   console.log('python3 heredoc patterns (commonly emitted by AI agents)\n')
 

--- a/examples/typescript/python/python_ram.ts
+++ b/examples/typescript/python/python_ram.ts
@@ -16,7 +16,7 @@ import { MountMode, RAMResource, Workspace } from '@struktoai/mirage-node'
 
 async function main(): Promise<void> {
   const ram = new RAMResource()
-  const ws = new Workspace({ '/ram': ram }, { mode: MountMode.WRITE })
+  const ws = new Workspace({ '/ram': ram }, { mode: MountMode.EXEC })
 
   console.log('python3 reads a script file from ANY mount — demo: /ram/\n')
   console.log('Script path is dispatched through the workspace mount registry,')

--- a/examples/typescript/python/python_script.ts
+++ b/examples/typescript/python/python_script.ts
@@ -33,7 +33,7 @@ for r in records[:3]:
 
 async function main(): Promise<void> {
   const disk = new RAMResource()
-  const ws = new Workspace({ '/disk': disk }, { mode: MountMode.WRITE })
+  const ws = new Workspace({ '/disk': disk }, { mode: MountMode.EXEC })
 
   console.log('python3 script file (read from mount) + piped stdin\n')
 

--- a/python/mirage/commands/builtin/general/__init__.py
+++ b/python/mirage/commands/builtin/general/__init__.py
@@ -17,10 +17,11 @@ from mirage.commands.builtin.general.curl import curl
 from mirage.commands.builtin.general.date import date
 from mirage.commands.builtin.general.expr import expr
 from mirage.commands.builtin.general.history import history_cmd
+from mirage.commands.builtin.general.python import python3, python_cmd
 from mirage.commands.builtin.general.seq import seq
 from mirage.commands.builtin.general.wget import wget
 
-_FNS = [bc, curl, date, expr, seq, wget]
+_FNS = [bc, curl, date, expr, python3, python_cmd, seq, wget]
 HISTORY_FN = history_cmd
 HISTORY_COMMANDS = list(history_cmd._registered_commands)
 

--- a/python/mirage/commands/builtin/general/python.py
+++ b/python/mirage/commands/builtin/general/python.py
@@ -1,0 +1,124 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import os
+import posixpath
+import sys
+from typing import Callable
+
+from mirage.accessor.base import Accessor, NOOPAccessor
+from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+def _resolve_script(name: str, cwd: PathSpec | None) -> PathSpec:
+    if name.startswith("/"):
+        path = posixpath.normpath(name)
+    else:
+        base = cwd.original.rstrip("/") if cwd is not None else ""
+        path = posixpath.normpath((base + "/" + name) if base else "/" + name)
+    last_slash = path.rfind("/")
+    directory = path[:last_slash + 1] if last_slash >= 0 else "/"
+    return PathSpec(original=path, directory=directory, resolved=True)
+
+
+async def _run_python_subprocess(
+    code: str,
+    stdin_data: bytes | None,
+    args: list[str],
+    env: dict[str, str] | None,
+) -> tuple[bytes, bytes | None, int]:
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        code,
+        *args,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env={
+            **os.environ,
+            **(env or {})
+        },
+    )
+    stdout, stderr = await proc.communicate(input=stdin_data)
+    return stdout, stderr or None, proc.returncode
+
+
+async def _python3(
+    accessor: Accessor = NOOPAccessor(),
+    paths: list[PathSpec] | None = None,
+    *texts: str,
+    c: str | None = None,
+    stdin: ByteSource | None = None,
+    dispatch: Callable | None = None,
+    cwd: PathSpec | None = None,
+    env: dict[str, str] | None = None,
+    exec_allowed: bool = True,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not exec_allowed:
+        err = b"python3: root mount '/' is not in EXEC mode\n"
+        return None, IOResult(exit_code=126, stderr=err)
+
+    paths = paths or []
+    text_list = list(texts)
+    code: str | None = c
+    has_code = code is not None
+    script_path: PathSpec | None = None
+    arg_strs: list[str]
+    if has_code:
+        arg_strs = [p.original for p in paths] + text_list
+    elif paths:
+        script_path = paths[0]
+        arg_strs = [p.original for p in paths[1:]] + text_list
+    elif text_list:
+        script_path = _resolve_script(text_list[0], cwd)
+        arg_strs = text_list[1:]
+    else:
+        arg_strs = []
+
+    if code is None and script_path is not None:
+        if dispatch is None:
+            err = b"python3: no dispatch available to read script\n"
+            return None, IOResult(exit_code=1, stderr=err)
+        try:
+            data, _ = await dispatch("read", script_path)
+        except FileNotFoundError:
+            err = f"python3: {script_path.original}: No such file\n".encode()
+            return None, IOResult(exit_code=1, stderr=err)
+        code = data.decode(errors="replace") if isinstance(data, bytes) else ""
+
+    stdin_data = await _read_stdin_async(stdin)
+    if code is None:
+        if stdin_data:
+            code = stdin_data.decode(errors="replace")
+            stdin_data = None
+        else:
+            return None, IOResult(exit_code=1, stderr=b"python3: no input\n")
+
+    stdout, stderr, exit_code = await _run_python_subprocess(
+        code, stdin_data, arg_strs, env)
+    return stdout if stdout else None, IOResult(
+        exit_code=exit_code,
+        stderr=stderr,
+    )
+
+
+python3 = command("python3", resource=None, spec=SPECS["python3"])(_python3)
+python_cmd = command("python", resource=None, spec=SPECS["python"])(_python3)

--- a/python/mirage/commands/spec/builtin_specs.py
+++ b/python/mirage/commands/spec/builtin_specs.py
@@ -161,12 +161,12 @@ SPECS: dict[str, CommandSpec] = {
     "python":
     CommandSpec(
         options=(Option(short="-c", value_kind=OperandKind.TEXT), ),
-        rest=Operand(kind=OperandKind.PATH),
+        rest=Operand(kind=OperandKind.TEXT),
     ),
     "python3":
     CommandSpec(
         options=(Option(short="-c", value_kind=OperandKind.TEXT), ),
-        rest=Operand(kind=OperandKind.PATH),
+        rest=Operand(kind=OperandKind.TEXT),
     ),
     "nl":
     CommandSpec(

--- a/python/mirage/workspace/executor/builtins.py
+++ b/python/mirage/workspace/executor/builtins.py
@@ -13,12 +13,9 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
-import os
-import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.config import RegisteredCommand
 from mirage.commands.spec import SPECS, CommandSpec
 from mirage.io import IOResult
@@ -760,63 +757,3 @@ async def handle_sleep(
                                                          exit_code=1)
     await cancellable_sleep(seconds, cancel)
     return None, IOResult(), ExecutionNode(command="sleep", exit_code=0)
-
-
-async def _run_python(
-    code: str,
-    stdin_data: bytes | None = None,
-    args: list[str] | None = None,
-    env: dict[str, str] | None = None,
-) -> tuple[bytes, bytes | None, int]:
-    """Execute Python code in an async subprocess."""
-    proc = await asyncio.create_subprocess_exec(
-        sys.executable,
-        "-c",
-        code,
-        *(args or []),
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env={
-            **os.environ,
-            **(env or {})
-        },
-    )
-    stdout, stderr = await proc.communicate(input=stdin_data)
-    return stdout, stderr or None, proc.returncode
-
-
-async def handle_python(
-    dispatch: Callable,
-    path_scope: PathSpec | None,
-    args: list[str],
-    stdin: ByteSource | None = None,
-    env: dict[str, str] | None = None,
-    code: str | None = None,
-) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
-    """Execute Python code as an async subprocess.
-
-    Two modes:
-    - python3 -c "code": code param is set, path_scope is None
-    - python3 script.py: path_scope is set, reads file via dispatch
-    """
-    if code is None:
-        try:
-            data, _ = await dispatch("read", path_scope)
-        except FileNotFoundError:
-            err = f"python3: {path_scope.original}: No such file\n".encode()
-            return None, IOResult(exit_code=1, stderr=err), ExecutionNode(
-                command=f"python3 {path_scope.original}", exit_code=1)
-        code = data.decode(errors="replace") if isinstance(data, bytes) else ""
-
-    cmd_str = f"python3 {path_scope.original}" if path_scope else "python3 -c"
-    stdin_data = await _read_stdin_async(stdin)
-    stdout, stderr, exit_code = await _run_python(code,
-                                                  stdin_data,
-                                                  args=args,
-                                                  env=env)
-
-    return stdout, IOResult(
-        exit_code=exit_code,
-        stderr=stderr,
-    ), ExecutionNode(command=cmd_str, exit_code=exit_code)

--- a/python/mirage/workspace/executor/command.py
+++ b/python/mirage/workspace/executor/command.py
@@ -661,15 +661,19 @@ async def handle_command(
                                         stdin)
 
     try:
-        stdout, io = await mount.execute_cmd(cmd_name,
-                                             paths,
-                                             texts,
-                                             flag_kwargs,
-                                             stdin=stdin,
-                                             cwd=session.cwd,
-                                             dispatch=dispatch,
-                                             history=history,
-                                             session_id=session.session_id)
+        stdout, io = await mount.execute_cmd(
+            cmd_name,
+            paths,
+            texts,
+            flag_kwargs,
+            stdin=stdin,
+            cwd=session.cwd,
+            dispatch=dispatch,
+            history=history,
+            session_id=session.session_id,
+            env=session.env,
+            exec_allowed=registry.is_exec_allowed(),
+        )
     except (FileNotFoundError, NotADirectoryError, PermissionError) as exc:
         err = f"{cmd_name}: {exc}\n".encode()
         return None, IOResult(exit_code=1,

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -373,6 +373,8 @@ class Mount:
         dispatch: Callable | None = None,
         history: Any = None,
         session_id: str | None = None,
+        env: dict[str, str] | None = None,
+        exec_allowed: bool = True,
     ) -> tuple[ByteSource | None, IOResult]:
         """Execute a command on this mount's resource.
 
@@ -429,6 +431,9 @@ class Mount:
             kw["history"] = history
         if session_id is not None:
             kw["session_id"] = session_id
+        if env is not None:
+            kw["env"] = env
+        kw["exec_allowed"] = exec_allowed
 
         prev_prefix = push_mount_prefix(mount_prefix)
         revs_token = push_revisions(self.revisions or None)

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -54,10 +54,9 @@ from mirage.shell.helpers import (  # isort: skip
     get_subshell_body, get_text, get_unset_names, get_while_parts)
 from mirage.workspace.executor.builtins import (  # isort: skip
     handle_bash, handle_cd, handle_echo, handle_eval, handle_export,
-    handle_local, handle_man, handle_printenv, handle_printf, handle_python,
-    handle_read, handle_readonly, handle_return, handle_set, handle_shift,
-    handle_sleep, handle_source, handle_test, handle_trap, handle_unset,
-    handle_whoami)
+    handle_local, handle_man, handle_printenv, handle_printf, handle_read,
+    handle_readonly, handle_return, handle_set, handle_shift, handle_sleep,
+    handle_source, handle_test, handle_trap, handle_unset, handle_whoami)
 
 _UNSUPPORTED_BUILTINS = frozenset({
     "bg",
@@ -838,53 +837,6 @@ async def _dispatch_command_body(
 
     if name == SB.CONTINUE:
         raise ContinueSignal()
-
-    if name in (SB.PYTHON, SB.PYTHON3):
-        if not registry.is_exec_allowed():
-            err = f"{name}: root mount '/' is not in EXEC mode\n".encode()
-            return None, IOResult(
-                exit_code=126,
-                stderr=err,
-            ), ExecutionNode(command=name, exit_code=126)
-        # Both -c and script.py need session.env for the
-        # subprocess, so handle everything here.
-        has_c_flag = "-c" in expanded
-        if has_c_flag:
-            c_idx = expanded.index("-c")
-            code = expanded[c_idx + 1] if c_idx + 1 < len(expanded) else ""
-            extra_args = expanded[c_idx + 2:]
-            return await handle_python(dispatch,
-                                       None,
-                                       extra_args,
-                                       stdin=stdin,
-                                       env=session.env,
-                                       code=code)
-        path_scope = None
-        for p in classified[1:]:
-            if isinstance(p, PathSpec):
-                path_scope = p
-                break
-        if path_scope is not None:
-            extra_args = [e for e in expanded[1:] if e != path_scope.original]
-            return await handle_python(dispatch,
-                                       path_scope,
-                                       extra_args,
-                                       stdin=stdin,
-                                       env=session.env)
-        if stdin is not None:
-            stdin_data = await materialize(stdin)
-            if stdin_data:
-                code = stdin_data.decode(errors="replace")
-                extra_args = expanded[1:]
-                return await handle_python(dispatch,
-                                           None,
-                                           extra_args,
-                                           env=session.env,
-                                           code=code)
-        return None, IOResult(
-            exit_code=1,
-            stderr=b"python3: no input\n",
-        ), ExecutionNode(command="python3", exit_code=1)
 
     # ── mount command (default) ─────────────────
     return await handle_command(recurse,

--- a/python/tests/workspace/node/test_execute_node.py
+++ b/python/tests/workspace/node/test_execute_node.py
@@ -2466,47 +2466,22 @@ def test_nested_while_loops():
 
 
 # ═══════════════════════════════════════════════
-# Python command parsing + execution
+# Python command shell-parser routing
 # ═══════════════════════════════════════════════
+#
+# python3 is now a registered general command (see
+# mirage.commands.builtin.general.python). End-to-end behavior
+# (script read via dispatch, env passthrough, exit codes) is covered
+# by tests/workspace/test_workspace.py against a real workspace.
+# Tests here only verify the shell parser routes python3 like any
+# other command (heredocs, pipelines, redirects, fan-out).
 
 
-def test_python3_script_dispatches():
-    """python3 /data/script.py → reads via dispatch, executes."""
-    dispatch = _mock_dispatch()
-    dispatch.return_value = (b"print('hello')", IOResult())
-    stdout, io, _, _, _, _ = _exec("python3 /data/script.py",
-                                   dispatch=dispatch)
-    read_calls = [c for c in dispatch.call_args_list if c[0][0] == "read"]
-    assert len(read_calls) == 1
-    assert read_calls[0][0][1].original == "/data/script.py"
-
-
-def test_python3_c_flag():
-    """python3 -c 'print(1)' → runs code in subprocess."""
-    stdout, io, _, _, _, _ = _exec("python3 -c 'print(42)'")
-    assert io.exit_code == 0
-    assert stdout == b"42\n"
-
-
-def test_python_command():
-    """python script.py → reads via dispatch."""
-    dispatch = _mock_dispatch()
-    dispatch.return_value = (b"print('ok')", IOResult())
-    _, io, _, _, _, _ = _exec("python /data/script.py", dispatch=dispatch)
-    read_calls = [c for c in dispatch.call_args_list if c[0][0] == "read"]
-    assert len(read_calls) == 1
-
-
-def test_python3_with_var_arg():
-    """python3 $SCRIPT → expanded, reads via dispatch."""
-    dispatch = _mock_dispatch()
-    dispatch.return_value = (b"print('hi')", IOResult())
-    _, io, _, _, _, _ = _exec("python3 $SCRIPT",
-                              dispatch=dispatch,
-                              env={"SCRIPT": "/data/run.py"})
-    read_calls = [c for c in dispatch.call_args_list if c[0][0] == "read"]
-    assert len(read_calls) == 1
-    assert read_calls[0][0][1].original == "/data/run.py"
+def test_python3_dispatched_to_mount():
+    """python3 -c 'code' → dispatched as a command to mount."""
+    _, _, _, _, mount, _ = _exec("python3 -c 'print(42)'")
+    mount.execute_cmd.assert_called_once()
+    assert mount.execute_cmd.call_args[0][0] == "python3"
 
 
 def test_python3_heredoc_parsed():
@@ -2525,23 +2500,6 @@ def test_python3_heredoc_double_quoted():
     """python3 <<"EOF"\\ncode\\nEOF → parsed correctly."""
     _, io, _, _, _, _ = _exec('python3 <<"EOF"\nimport os\nEOF')
     assert io.exit_code is not None
-
-
-def test_python3_no_args():
-    """python3 with no args → error."""
-    _, io, _, _, _, _ = _exec("python3")
-    assert io.exit_code == 1
-    assert b"no input" in io.stderr
-
-
-def test_python3_in_for():
-    """python3 inside for loop — dispatches read per iteration."""
-    dispatch = _mock_dispatch()
-    dispatch.return_value = (b"print(1)", IOResult())
-    _, _, _, _, _, dispatch = _exec(
-        "for f in a b; do python3 /data/$f.py; done", dispatch=dispatch)
-    read_calls = [c for c in dispatch.call_args_list if c[0][0] == "read"]
-    assert len(read_calls) == 2
 
 
 def test_python3_in_pipeline():

--- a/python/tests/workspace/test_workspace.py
+++ b/python/tests/workspace/test_workspace.py
@@ -1437,6 +1437,50 @@ def test_python3_no_args():
     assert b"no input" in io.stderr
 
 
+def test_python3_c_with_argv():
+    """python3 -c "code" arg1 arg2 → arg1/arg2 reach sys.argv as bare text."""
+    ws = _ws()
+    io = _exec(ws, 'python3 -c "import sys; print(sys.argv[1:])" alpha beta')
+    assert io.exit_code == 0
+    assert _stdout(io) == b"['alpha', 'beta']\n"
+
+
+def test_python3_c_with_abs_path_argv():
+    """python3 -c "code" /abs/path → abs path stays text argv (not script)."""
+    ws = _ws()
+    io = _exec(ws,
+               'python3 -c "import sys; print(sys.argv[1:])" /disk/some_file')
+    assert io.exit_code == 0
+    assert _stdout(io) == b"['/disk/some_file']\n"
+
+
+def test_python3_script_with_argv():
+    """python3 /abs/script.py arg1 arg2 → script reads, argv passed through."""
+    ws = _ws()
+    _exec(ws, "echo 'import sys; print(sys.argv[1:])' > /disk/argv.py")
+    io = _exec(ws, "python3 /disk/argv.py alpha beta")
+    assert io.exit_code == 0
+    assert _stdout(io) == b"['alpha', 'beta']\n"
+
+
+def test_python3_bare_name_script_via_cwd():
+    """python3 script.py (bare name) → resolves against cwd, dispatched."""
+    ws = _ws()
+    _exec(ws, "echo 'print(123)' > /disk/bare.py")
+    io = _exec(ws, "cd /disk && python3 bare.py")
+    assert io.exit_code == 0
+    assert _stdout(io) == b"123\n"
+
+
+def test_python3_bare_name_script_with_argv():
+    """python3 script.py one two (bare + argv) → cwd-resolved + argv passes."""
+    ws = _ws()
+    _exec(ws, "echo 'import sys; print(sys.argv[1:])' > /disk/with_argv.py")
+    io = _exec(ws, "cd /disk && python3 with_argv.py one two")
+    assert io.exit_code == 0
+    assert _stdout(io) == b"['one', 'two']\n"
+
+
 # ── cross-mount commands ──────────────────────
 
 

--- a/typescript/packages/core/src/commands/builtin/general/index.ts
+++ b/typescript/packages/core/src/commands/builtin/general/index.ts
@@ -18,6 +18,7 @@ import { GENERAL_CURL } from './curl.ts'
 import { GENERAL_DATE } from './date.ts'
 import { GENERAL_EXPR } from './expr.ts'
 import { GENERAL_HISTORY } from './history.ts'
+import { GENERAL_PYTHON, GENERAL_PYTHON3 } from './python.ts'
 import { GENERAL_SEQ } from './seq.ts'
 import { GENERAL_SLEEP } from './sleep.ts'
 import { GENERAL_WGET } from './wget.ts'
@@ -27,6 +28,7 @@ export { GENERAL_CURL } from './curl.ts'
 export { GENERAL_DATE } from './date.ts'
 export { GENERAL_EXPR } from './expr.ts'
 export { GENERAL_HISTORY } from './history.ts'
+export { GENERAL_PYTHON, GENERAL_PYTHON3 } from './python.ts'
 export { GENERAL_SEQ } from './seq.ts'
 export { GENERAL_SLEEP } from './sleep.ts'
 export { GENERAL_WGET } from './wget.ts'
@@ -36,6 +38,8 @@ export const GENERAL_COMMANDS: readonly RegisteredCommand[] = [
   ...GENERAL_CURL,
   ...GENERAL_DATE,
   ...GENERAL_EXPR,
+  ...GENERAL_PYTHON,
+  ...GENERAL_PYTHON3,
   ...GENERAL_SEQ,
   ...GENERAL_SLEEP,
   ...GENERAL_WGET,

--- a/typescript/packages/core/src/commands/builtin/general/python.ts
+++ b/typescript/packages/core/src/commands/builtin/general/python.ts
@@ -1,0 +1,135 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { Accessor } from '../../../accessor/base.ts'
+import { IOResult, materialize } from '../../../io/types.ts'
+import { PathSpec } from '../../../types.ts'
+import { handlePython } from '../../../workspace/executor/python/handle.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder('utf-8', { fatal: false })
+
+function normalizePosix(p: string): string {
+  const parts: string[] = []
+  for (const seg of p.split('/')) {
+    if (seg === '' || seg === '.') continue
+    if (seg === '..') {
+      parts.pop()
+      continue
+    }
+    parts.push(seg)
+  }
+  return '/' + parts.join('/')
+}
+
+function resolveScript(name: string, cwd: string): PathSpec {
+  const joined = name.startsWith('/') ? name : `${cwd.replace(/\/+$/, '')}/${name}`
+  const path = normalizePosix(joined)
+  const lastSlash = path.lastIndexOf('/')
+  const directory = lastSlash >= 0 ? path.slice(0, lastSlash + 1) : '/'
+  return new PathSpec({ original: path, directory, resolved: true })
+}
+
+async function pythonCommand(
+  _accessor: Accessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  if (opts.execAllowed === false) {
+    return [
+      null,
+      new IOResult({
+        exitCode: 126,
+        stderr: ENC.encode("python3: root mount '/' is not in EXEC mode\n"),
+      }),
+    ]
+  }
+
+  if (opts.pythonRuntime === undefined) {
+    return [
+      null,
+      new IOResult({
+        exitCode: 127,
+        stderr: ENC.encode('python3: python runtime is not available\n'),
+      }),
+    ]
+  }
+
+  if (opts.dispatch === undefined) {
+    return [
+      null,
+      new IOResult({
+        exitCode: 1,
+        stderr: ENC.encode('python3: no dispatch available\n'),
+      }),
+    ]
+  }
+
+  const cFlag = opts.flags.c
+  const code = typeof cFlag === 'string' ? cFlag : null
+  const hasCode = code !== null
+  let scriptPath: PathSpec | null = null
+  let argStrs: string[]
+  if (hasCode) {
+    argStrs = [...paths.map((p) => p.original), ...texts]
+  } else if (paths.length > 0) {
+    scriptPath = paths[0] ?? null
+    argStrs = [...paths.slice(1).map((p) => p.original), ...texts]
+  } else if (texts.length > 0) {
+    scriptPath = resolveScript(texts[0] ?? '', opts.cwd)
+    argStrs = texts.slice(1)
+  } else {
+    argStrs = []
+  }
+
+  let resolvedCode: string | null = code
+  let stdinForRuntime = opts.stdin
+  if (resolvedCode === null && scriptPath === null && opts.stdin !== null) {
+    const bytes = await materialize(opts.stdin)
+    if (bytes.length > 0) {
+      resolvedCode = DEC.decode(bytes)
+      stdinForRuntime = null
+    }
+  }
+
+  const [stdout, io] = await handlePython(
+    opts.dispatch,
+    scriptPath,
+    argStrs,
+    {
+      stdin: stdinForRuntime,
+      env: opts.env ?? {},
+      code: resolvedCode,
+    },
+    { runtime: opts.pythonRuntime },
+  )
+  return [stdout, io]
+}
+
+export const GENERAL_PYTHON3 = command({
+  name: 'python3',
+  resource: null,
+  spec: specOf('python3'),
+  fn: pythonCommand,
+})
+
+export const GENERAL_PYTHON = command({
+  name: 'python',
+  resource: null,
+  spec: specOf('python'),
+  fn: pythonCommand,
+})

--- a/typescript/packages/core/src/commands/config.ts
+++ b/typescript/packages/core/src/commands/config.ts
@@ -17,6 +17,7 @@ import type { IndexCacheStore } from '../cache/index/index.ts'
 import { IOResult, type ByteSource } from '../io/types.ts'
 import type { Resource } from '../resource/base.ts'
 import type { PathSpec } from '../types.ts'
+import type { PyodideRuntime } from '../workspace/executor/python/runtime.ts'
 import type { AggregateResult } from './builtin/aggregators.ts'
 import { renderHelp } from './spec/help.ts'
 import { CommandSpec, OperandKind, Option } from './spec/types.ts'
@@ -55,6 +56,9 @@ export interface CommandOpts {
   dispatch?: CommandDispatch
   history?: CommandHistory
   sessionId?: string
+  env?: Record<string, string>
+  execAllowed?: boolean
+  pythonRuntime?: PyodideRuntime
 }
 
 export type CommandFnResult = [ByteSource | null, IOResult] | null

--- a/typescript/packages/core/src/commands/spec/builtins.ts
+++ b/typescript/packages/core/src/commands/spec/builtins.ts
@@ -142,11 +142,11 @@ export const BUILTIN_SPECS: Readonly<Record<string, CommandSpec>> = Object.freez
   }),
   python: new CommandSpec({
     options: [new Option({ short: '-c', valueKind: OperandKind.TEXT })],
-    rest: new Operand({ kind: OperandKind.PATH }),
+    rest: new Operand({ kind: OperandKind.TEXT }),
   }),
   python3: new CommandSpec({
     options: [new Option({ short: '-c', valueKind: OperandKind.TEXT })],
-    rest: new Operand({ kind: OperandKind.PATH }),
+    rest: new Operand({ kind: OperandKind.TEXT }),
   }),
   nl: new CommandSpec({
     options: [

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -25,6 +25,7 @@ import { ERREXIT_EXEMPT_TYPES } from '../../shell/types.ts'
 import { PathSpec } from '../../types.ts'
 import type { Mount } from '../mount/mount.ts'
 import type { MountRegistry } from '../mount/registry.ts'
+import type { PyodideRuntime } from './python/runtime.ts'
 import type { Session } from '../session/session.ts'
 import { ExecutionNode } from '../types.ts'
 import { asyncChain } from '../../io/stream.ts'
@@ -58,6 +59,7 @@ export async function handleCommand(
   ensureOpen?: (resource: Resource) => Promise<void>,
   unmount?: (prefix: string) => Promise<void>,
   history?: CommandHistory,
+  pythonRuntime?: PyodideRuntime,
 ): Promise<Result> {
   if (parts.length === 0) {
     return [null, new IOResult(), new ExecutionNode({ command: '', exitCode: 0 })]
@@ -193,6 +195,9 @@ export async function handleCommand(
       dispatch,
       ...(history !== undefined ? { history } : {}),
       sessionId: session.sessionId,
+      env: session.env,
+      execAllowed: registry.isExecAllowed(),
+      ...(pythonRuntime !== undefined ? { pythonRuntime } : {}),
     })
     let stdout = initialStdout
     if (cmdName === 'ls' && io.exitCode === 0) {

--- a/typescript/packages/core/src/workspace/executor/python/python.test.ts
+++ b/typescript/packages/core/src/workspace/executor/python/python.test.ts
@@ -117,6 +117,49 @@ describe('python3: core (ports of Python tests_workspace)', () => {
     await ws.close()
   })
 
+  // ── flag-conditional argv classification (no-c vs -c)
+  // These guard the spec/parser interaction: positional args after `-c "code"`
+  // must NOT be path-resolved (raw text → sys.argv); without -c, the first
+  // positional IS the script (PATH), and subsequent positionals are argv.
+
+  it('python3 -c "code" arg1 arg2 → argv stays bare (no path prefix)', async () => {
+    const { ws } = await makeWorkspace()
+    const io = await ws.execute('python3 -c "import sys; print(sys.argv[1:])" alpha beta')
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe("['alpha', 'beta']\n")
+    await ws.close()
+  })
+
+  it('python3 -c "code" /abs/path → abs path stays as text argv', async () => {
+    const { ws } = await makeWorkspace()
+    const io = await ws.execute('python3 -c "import sys; print(sys.argv[1:])" /disk/some_file')
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe("['/disk/some_file']\n")
+    await ws.close()
+  })
+
+  it('python3 /abs/script.py arg1 arg2 → script reads, argv passes through', async () => {
+    const { ws } = await makeWorkspace()
+    await ws.execute("echo 'import sys; print(sys.argv[1:])' > /disk/argv.py")
+    const io = await ws.execute('python3 /disk/argv.py alpha beta')
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe("['alpha', 'beta']\n")
+    await ws.close()
+  })
+
+  it('python3 script.py one two (bare name + argv via cwd)', async () => {
+    const { ws, disk } = await makeWorkspace()
+    disk.store.files.set(
+      '/with_argv.py',
+      new TextEncoder().encode('import sys; print(sys.argv[1:])\n'),
+    )
+    ws.getSession(DEFAULT_SESSION_ID).cwd = '/disk'
+    const io = await ws.execute('python3 with_argv.py one two')
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe("['one', 'two']\n")
+    await ws.close()
+  })
+
   it('test_python_pipe (L848): python3 -c ... | grep', async () => {
     const { ws } = await makeWorkspace()
     const io = await ws.execute("python3 -c 'print(42)' | grep 42")

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -31,6 +31,7 @@ import { runWithRevisions, setVirtualPrefix } from '../../observe/context.ts'
 import type { RegisteredOp } from '../../ops/registry.ts'
 import type { Resource } from '../../resource/base.ts'
 import { ConsistencyPolicy, MountMode, PathSpec } from '../../types.ts'
+import type { PyodideRuntime } from '../executor/python/runtime.ts'
 
 type CmdKey = string
 type OpKey = string
@@ -318,6 +319,9 @@ export class Mount {
       dispatch?: CommandDispatch
       history?: CommandHistory
       sessionId?: string
+      env?: Record<string, string>
+      execAllowed?: boolean
+      pythonRuntime?: PyodideRuntime
     } = {},
   ): Promise<[ByteSource | null, IOResult]> {
     const extension =
@@ -365,6 +369,9 @@ export class Mount {
       ...(opts.dispatch !== undefined ? { dispatch: opts.dispatch } : {}),
       ...(opts.history !== undefined ? { history: opts.history } : {}),
       ...(opts.sessionId !== undefined ? { sessionId: opts.sessionId } : {}),
+      ...(opts.env !== undefined ? { env: opts.env } : {}),
+      ...(opts.execAllowed !== undefined ? { execAllowed: opts.execAllowed } : {}),
+      ...(opts.pythonRuntime !== undefined ? { pythonRuntime: opts.pythonRuntime } : {}),
     }
 
     setVirtualPrefix(mountPrefix)

--- a/typescript/packages/core/src/workspace/node/execute_node.ts
+++ b/typescript/packages/core/src/workspace/node/execute_node.ts
@@ -828,87 +828,6 @@ async function runCommandBody(
     return [null, new IOResult(), new ExecutionNode({ command: 'timeout', exitCode: 0 })]
   }
 
-  if (name === SB.PYTHON || name === SB.PYTHON3) {
-    if (!registry.isExecAllowed()) {
-      const err = new TextEncoder().encode(`${name}: root mount '/' is not in EXEC mode\n`)
-      return [
-        null,
-        new IOResult({ exitCode: 126, stderr: err }),
-        new ExecutionNode({ command: name, exitCode: 126 }),
-      ]
-    }
-    // Reference: mirage/workspace/node/execute_node.py:639-678
-    const { handlePython } = await import('../executor/python/handle.ts')
-    if (pythonRuntime === undefined) {
-      const err = new TextEncoder().encode(`${name}: python runtime is not available\n`)
-      return [
-        null,
-        new IOResult({ exitCode: 127, stderr: err }),
-        new ExecutionNode({ command: name, exitCode: 127 }),
-      ]
-    }
-    const pythonDeps = { runtime: pythonRuntime }
-    const hasCFlag = finalExpanded.includes('-c')
-    if (hasCFlag) {
-      const cIdx = finalExpanded.indexOf('-c')
-      const code = finalExpanded[cIdx + 1] ?? ''
-      const extraArgs = finalExpanded.slice(cIdx + 2)
-      return handlePython(dispatch, null, extraArgs, { stdin, env: session.env, code }, pythonDeps)
-    }
-    let pathScope: PathSpec | null = null
-    for (let i = 1; i < classified.length; i++) {
-      const p = classified[i]
-      if (p instanceof PathSpec) {
-        pathScope = p
-        break
-      }
-    }
-    if (pathScope === null) {
-      for (let i = 1; i < finalExpanded.length; i++) {
-        const arg = finalExpanded[i]
-        if (arg === undefined || arg === '' || arg.startsWith('-')) continue
-        const resolvedBare = classifyBarePath(arg, registry, session.cwd)
-        if (resolvedBare instanceof PathSpec) {
-          pathScope = resolvedBare
-        }
-        break
-      }
-    }
-    if (pathScope !== null) {
-      const scope = pathScope
-      const extraArgs = finalExpanded.slice(1).filter((a) => a !== scope.original)
-      return handlePython(
-        dispatch,
-        pathScope,
-        extraArgs,
-        { stdin, env: session.env, code: null },
-        pythonDeps,
-      )
-    }
-    if (stdin !== null) {
-      const data = await materialize(stdin)
-      if (data.length > 0) {
-        const code = new TextDecoder().decode(data)
-        const extraArgs = finalExpanded.slice(1)
-        return handlePython(
-          dispatch,
-          null,
-          extraArgs,
-          { stdin: null, env: session.env, code },
-          pythonDeps,
-        )
-      }
-    }
-    return [
-      null,
-      new IOResult({
-        exitCode: 1,
-        stderr: new TextEncoder().encode('python3: no input\n'),
-      }),
-      new ExecutionNode({ command: 'python3', exitCode: 1 }),
-    ]
-  }
-
   // Default: mount-dispatched command
   return handleCommand(
     recurse,
@@ -922,6 +841,7 @@ async function runCommandBody(
     ensureOpen,
     unmount,
     history,
+    pythonRuntime,
   )
 }
 


### PR DESCRIPTION
## Summary
- Move `python3`/`python` out of the hard-branched shell builtin in `execute_node` (both Python and TypeScript) and register it as a general command in `commands/builtin/general/python.{py,ts}`. Users can now shadow it per workspace (e.g. route to E2B / Modal / Docker / a custom runtime) the same way they would `curl` or `grep`.
- Plumb `env`, `exec_allowed` (both langs), and `pythonRuntime` (TS only) through `mount.execute_cmd` / `CommandOpts` so the registered command body has what the old branch had. Python deletes `handle_python` / `_run_python` from `workspace/executor/builtins.py`; TS keeps `handlePython` since the registered command body still calls into it with the injected Pyodide runtime.
- Fix a regression introduced by the registered-command path: with the old spec (`rest=PATH`), the argv parser called `posixpath.join(cwd, arg)` on every bare positional, so `python3 -c "code" alpha beta` arrived as `['/alpha', '/beta']` instead of `['alpha', 'beta']`. Spec is now `rest=TEXT`; the command body handles script-path resolution itself (absolute paths classified upstream as `PathSpec`, bare names resolved against cwd inside the command), matching pre-refactor byte-for-byte.

## Tests
- 5 new Python tests in `test_workspace.py` and 4 in `python.test.ts` covering the four flag-conditional argv shapes that were missing: `-c` with argv, `-c` with abs-path argv, script + argv, bare-name script + argv.
- New `examples/python/ram/ram_python.py` exercises every invocation mode (RAM-only, no creds).
- 5 TS examples in `examples/typescript/python/*.ts` flipped from `MountMode.WRITE` to `MountMode.EXEC` so they actually run `python3` without tripping `is_exec_allowed()`.
- New `examples-python` job in `.github/workflows/infra-example.yml` runs 1 py + 5 ts examples and greps the regression-sensitive lines (`['alpha', 'beta']` is grepped from three independent examples for triple redundancy).

## Why the original regression slipped past unit tests
- `test_execute_node.py` is mock-based: `_mock_registry()` returns `(b"ok\n", IOResult())` regardless of input, so corrupted paths/texts never reached a subprocess where the bad value would have surfaced.
- `test_workspace.py` runs full real workspaces and could have caught it, but the existing `test_python3_*` block tested `-c` without trailing argv, or scripts without argv. The specific input shape that broke (`python3 -c "code" arg1 arg2`) was uncovered. The 5 new Python tests fill exactly that gap; the TS suite gets the same 4 ports.

## Test plan
- [x] `pre-commit run --all-files` clean (Python + TS lint, prettier, eslint, yapf, ruff)
- [x] `cd python && uv run pytest tests/` green
- [x] `pnpm test` in `typescript/packages/core` green (2637 tests, 319 files)
- [x] Local dry-run of every `grep` in the new `examples-python` CI job: all 21 patterns matched
- [x] `examples/python/ram/ram_python.py` runs end-to-end through the new general-command path; argv passthrough returns `['alpha', 'beta']`
- [x] `examples/typescript/python/python_basic.ts` runs end-to-end; `sys.argv[1:]` returns `['alpha', 'beta']`