### PR TITLE
test(py): assert listdir basenames (mirror TS contract)

### DIFF
--- a/python/tests/ops/test_os_patch.py
+++ b/python/tests/ops/test_os_patch.py
@@ -49,7 +49,7 @@ class TestPatchedOs:
         run(ops.write("/data/dir/b.txt", b"b"))
         patched = make_os_module(ops)
         entries = patched.listdir("/data/dir")
-        assert len(entries) == 2
+        assert sorted(entries) == ["a.txt", "b.txt"]
 
     def test_remove(self):
         ops, _ = make_ops_with_dir()
@@ -78,7 +78,7 @@ class TestPatchedOs:
         with ws:
             vos = sys.modules["os"]
             entries = vos.listdir("/mem/dir")
-            assert len(entries) == 2
+            assert sorted(entries) == ["a.txt", "b.txt"]
             assert vos.path.exists("/mem/dir/a.txt") is True
             assert vos.path.exists("/mem/dir/nope.txt") is False
         assert sys.modules["os"] is original_os


### PR DESCRIPTION
## Summary

Tighten `test_listdir` and `test_sys_modules_listdir` in `tests/ops/test_os_patch.py` to assert exact basenames, mirroring the TS contract in [fs_monkey.test.ts:76](https://github.com/strukto-ai/mirage/blob/main/typescript/packages/node/src/fs_monkey.test.ts#L76):

```typescript
expect((await fs.promises.readdir('/data')).sort()).toEqual(['a.txt', 'b.txt'])
```

The Python side previously asserted only `len(entries) == 2` — which passed whether `listdir` returned basenames or full paths. That's exactly why the basename-vs-full-path regression slept since v0.0.1-alpha.1 (fixed in #52). This locks the contract so the regression can't return.

## Test plan

- [x] `pytest tests/ops/test_os_patch.py` — 8/8 pass
- [x] Pre-commit on the file — all hooks pass