### PR TITLE
feat(mongodb): streaming reads, schema.json, nested layout, tail -f, elision

### DIFF
--- a/docs/python/resource/mongodb.mdx
+++ b/docs/python/resource/mongodb.mdx
@@ -20,29 +20,39 @@ config = MongoDBConfig(
     default_doc_limit=1000,
     default_search_limit=100,
     max_doc_limit=5000,
+    elide_fields={"sample_mflix.movies": ["plot_embedding"]},
 )
 resource = MongoDBResource(config=config)
 ws = Workspace({"/mongodb": resource}, mode=MountMode.READ)
 ```
 
-| Config field           | Required | Default | Description                                        |
-| ---------------------- | -------- | ------- | -------------------------------------------------- |
-| `uri`                  | yes      |         | MongoDB connection URI                             |
-| `databases`            | no       |         | List of database names to mount (omit for all)     |
-| `default_doc_limit`    | no       | 1000    | Default doc cap for `cat`, `jq`, file-level `grep` |
-| `default_search_limit` | no       | 100     | Default result cap for collection/db-level `grep`  |
-| `max_doc_limit`        | no       | 5000    | Hard cap for `head -n K` / `tail -n K`             |
+| Config field           | Required | Default | Description                                                                |
+| ---------------------- | -------- | ------- | -------------------------------------------------------------------------- |
+| `uri`                  | yes      |         | MongoDB connection URI                                                     |
+| `databases`            | no       |         | List of database names to mount (omit for all)                             |
+| `default_doc_limit`    | no       | 1000    | Default doc cap for one-shot reads (not used by streaming `cat`)           |
+| `default_search_limit` | no       | 100     | Default result cap for collection/db-level `grep`                          |
+| `max_doc_limit`        | no       | 5000    | Hard cap for `head -n K` / `tail -n K`                                     |
+| `elide_fields`         | no       | `{}`    | `{"<db>.<coll>": ["field", "nested.path"]}`; listed fields are dropped from `documents.jsonl` |
 
 ## Filesystem Layout
 
-### All databases (databases omitted)
+The mount mirrors MongoDB's `cluster → database → collection / view`
+model. The database directory always appears in the path, even when
+`databases` filters to a single entry.
 
 ```text
 /mongodb/
   <database>/
-    <collection>.jsonl
-    ...
-  ...
+    database.json                  # collections + views + counts
+    collections/
+      <collection>/
+        schema.json                # sampled types + indexes + validator
+        documents.jsonl            # streamed BSON Extended JSON
+    views/
+      <view>/
+        schema.json                # view-aware (no indexes / validator)
+        documents.jsonl            # streamed, same format as collections
 ```
 
 Example:
@@ -50,123 +60,138 @@ Example:
 ```text
 /mongodb/
   sample_mflix/
-    movies.jsonl
-    comments.jsonl
-    users.jsonl
-    theaters.jsonl
-  sample_analytics/
-    accounts.jsonl
-    transactions.jsonl
-    customers.jsonl
-  sample_airbnb/
-    listingsAndReviews.jsonl
+    database.json
+    collections/
+      movies/
+        schema.json
+        documents.jsonl
+      comments/
+        schema.json
+        documents.jsonl
+    views/
+      top_rated_movies/
+        schema.json
+        documents.jsonl
 ```
 
-### Filtered databases
+### documents.jsonl
+
+One JSON object per line, encoded with BSON
+[Relaxed Extended JSON](https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/).
+BSON-specific types round-trip through their canonical `$` wrappers:
+
+```json
+{"_id":{"$oid":"573a1390f29313caabcd4135"},"title":"Casablanca","released":{"$date":"1943-01-23T00:00:00Z"},"runtime":102}
+```
+
+`cat` / `head` / `tail` / `grep` / `jq` all stream from this file; nothing
+materializes the full collection in memory.
+
+### schema.json
+
+Generated from a 100-document `$sample`. Includes:
+
+- field path → observed BSON type frequencies (nested paths unioned across the sample)
+- indexes from `listIndexes` plus access counts from `$indexStats`
+- the `$jsonSchema` validator if one is registered
+
+Views skip the index and validator sections.
+
+### database.json
+
+Lists every collection and view under the database with their document
+counts. Useful for `cat /mongodb/<db>/database.json` to get an overview
+without recursing into each entity.
+
+### Elided fields
+
+Fields listed under `elide_fields` are dropped entirely from
+`documents.jsonl` output. The type stays documented in `schema.json`, so
+heavy fields (embeddings, large binary, raw text blobs) can be hidden
+from agent reads without losing the schema signal:
 
 ```python
 config = MongoDBConfig(
     uri=os.environ["MONGODB_URI"],
-    databases=["sample_mflix", "sample_analytics"],
+    elide_fields={
+        "sample_mflix.movies": ["plot_embedding"],
+        "rag.docs": ["metadata.embedding"],
+    },
 )
 ```
 
-```text
-/mongodb/
-  sample_mflix/
-    movies.jsonl
-    comments.jsonl
-    users.jsonl
-  sample_analytics/
-    accounts.jsonl
-    transactions.jsonl
-    customers.jsonl
-```
+Nested paths use dot notation. Elision applies to both `cat` (one-shot
+streaming reads) and `tail -f` (live change-stream follows).
 
-### Single database
+## Streaming and Limits
 
-When `databases` contains exactly one entry, the database directory
-layer is skipped:
+`cat`, `grep`, `head`, and `tail -f` consume documents lazily through a
+batched Motor cursor (or change stream); the consumer cancels to stop
+fetching. There is no truncation notice because nothing is forced into
+memory ahead of the consumer.
 
-```text
-/mongodb/
-  movies.jsonl
-  comments.jsonl
-  users.jsonl
-  theaters.jsonl
-```
-
-### Collections
-
-Each `.jsonl` file represents a collection. Each line is a JSON object
-representing one document. The `_id` field is serialized as a string.
-
-## Limits
-
-All document-reading commands enforce limits to prevent dumping huge
-collections:
-
-| Command                      | Limit behavior                                                  |
-| ---------------------------- | --------------------------------------------------------------- |
-| `cat`                        | Returns up to `default_doc_limit` docs, appends truncation note |
-| `head -n K` / `tail -n K`    | K is capped at `max_doc_limit`; server-side sort+limit          |
-| `grep` (file level)          | Inherits `default_doc_limit` when downloading                   |
-| `grep` (collection/db level) | Server-side query, capped at `default_search_limit`             |
-| `jq`                         | Inherits `default_doc_limit`                                    |
-| `wc`                         | Uses `countDocuments()` server-side - zero download             |
-| `stat`                       | Metadata only (doc count, indexes, size in extra dict)          |
-
-When a limit is hit, the output includes a truncation notice:
-
-```text
-[truncated: showing 1000/125000 documents]
-```
+| Command                      | Behavior                                                          |
+| ---------------------------- | ----------------------------------------------------------------- |
+| `cat`                        | Streams the whole collection sorted by `_id`; pipe to `head` to cap |
+| `head -n K` / `tail -n K`    | K is capped at `max_doc_limit`; server-side sort + limit          |
+| `tail -f`                    | Opens a change stream; yields each new insert as a JSONL line     |
+| `grep` (file level)          | Streams from `documents.jsonl`; supports `-m` for short-circuit   |
+| `grep` (collection/db level) | Server-side query, capped at `default_search_limit`               |
+| `jq`                         | Inherits the streaming `cat` source                               |
+| `wc`                         | Uses `countDocuments()` server-side; zero download                |
+| `stat`                       | Metadata only (doc count, indexes; views skip the index lookup)   |
 
 ## Smart Commands
 
 ### grep at different scopes
 
 `grep` uses MongoDB's query engine at directory scopes instead of
-downloading documents:
+streaming all documents through the regex pipeline:
 
 ```bash
-# FILE level - downloads docs (up to default_doc_limit), greps locally
-grep "Godfather" "/mongodb/sample_mflix/movies.jsonl"
+# FILE level - streams documents.jsonl, runs the regex locally
+grep "Godfather" "/mongodb/sample_mflix/collections/movies/documents.jsonl"
 
-# COLLECTION level - uses MongoDB query engine
+# COLLECTION level - server-side query against the collection
+grep "Godfather" "/mongodb/sample_mflix/collections/movies/"
+
+# DATABASE level - searches across every collection in sample_mflix
 grep "Godfather" "/mongodb/sample_mflix/"
 
-# DATABASE level - searches across all collections in sample_mflix
-grep "Godfather" "/mongodb/sample_mflix/"
-
-# ROOT level (all databases) - searches across all databases
+# ROOT level - fans out across every mounted database
 grep "Godfather" "/mongodb/"
 ```
 
-At collection or higher scope, the resource automatically picks the best
-server-side search strategy based on available indexes:
+At collection or higher scope the resource picks the best server-side
+strategy from the indexes available:
 
-1. **Text index exists** → uses `$text` query (fast, ranked by relevance)
-1. **Atlas Search index exists** → uses `$search` aggregation (fuzzy, Lucene-based)
-1. **Neither** → falls back to `$regex` on string fields (still server-side, no download)
+1. **Text index exists** → uses `$text` (ranked by relevance)
+1. **Atlas Search index exists** → uses `$search` (fuzzy, Lucene-based)
+1. **Neither** → falls back to `$regex` on sampled string fields
 
 Scope detection is handled by `mirage/core/mongodb/scope.py`.
 
-### head / tail
+### head / tail / tail -f
 
-`head` and `tail` use MongoDB's `sort` + `limit` instead of downloading
-documents. The requested count is capped at `max_doc_limit`:
+`head` and `tail` use server-side `sort` + `limit`; the requested count
+is capped at `max_doc_limit`. `tail -f` opens a Mongo change stream
+filtered to insert events and yields each new document as a JSONL line
+in the same format as `cat`:
 
 ```bash
-# Returns first 10 documents (sorted by _id ascending)
-head -n 10 "/mongodb/sample_mflix/movies.jsonl"
+# First 10 docs (sorted by _id ascending)
+head -n 10 "/mongodb/sample_mflix/collections/movies/documents.jsonl"
 
-# Returns last 10 documents (sorted by _id descending)
-tail -n 10 "/mongodb/sample_mflix/movies.jsonl"
+# Last 10 docs (sorted by _id descending)
+tail -n 10 "/mongodb/sample_mflix/collections/movies/documents.jsonl"
 
-# Requesting more than max_doc_limit gets capped silently
-head -n 100000 "/mongodb/sample_mflix/movies.jsonl"  # → returns max_doc_limit (5000)
+# Live-follow new inserts; consumer cancels to stop
+tail -f "/mongodb/sample_mflix/collections/movies/documents.jsonl"
 ```
+
+`tail -f` requires the cluster to be a replica set; Atlas already
+satisfies this. Views fall through to the non-streaming path because
+change streams aren't defined on views.
 
 ## Cache
 
@@ -199,21 +224,33 @@ async def main():
     r = await ws.execute("ls /mongodb/")
     print(await r.stdout_str())
 
-    # List collections in a database
+    # List the entities under a database (database.json, collections/, views/)
     r = await ws.execute("ls /mongodb/sample_mflix/")
     print(await r.stdout_str())
 
+    # List collections
+    r = await ws.execute("ls /mongodb/sample_mflix/collections/")
+    print(await r.stdout_str())
+
     # Read first 5 movies
-    r = await ws.execute('head -n 5 "/mongodb/sample_mflix/movies.jsonl"')
+    r = await ws.execute(
+        'head -n 5 "/mongodb/sample_mflix/collections/movies/documents.jsonl"')
     print(await r.stdout_str())
 
     # Read last 5 movies
-    r = await ws.execute('tail -n 5 "/mongodb/sample_mflix/movies.jsonl"')
+    r = await ws.execute(
+        'tail -n 5 "/mongodb/sample_mflix/collections/movies/documents.jsonl"')
+    print(await r.stdout_str())
+
+    # Inspect the sampled schema and indexes
+    r = await ws.execute(
+        'cat "/mongodb/sample_mflix/collections/movies/schema.json"')
     print(await r.stdout_str())
 
     # Extract titles with jq
     r = await ws.execute(
-        'jq -r ".[] | .title" "/mongodb/sample_mflix/movies.jsonl"')
+        'jq -r ".[] | .title" "/mongodb/sample_mflix/collections/movies/documents.jsonl"'
+    )
     print(await r.stdout_str())
 
     # Search across a database (uses MongoDB query engine)
@@ -221,11 +258,12 @@ async def main():
     print(await r.stdout_str())
 
     # Count documents (server-side, no download)
-    r = await ws.execute('wc -l "/mongodb/sample_mflix/movies.jsonl"')
+    r = await ws.execute(
+        'wc -l "/mongodb/sample_mflix/collections/movies/documents.jsonl"')
     print(await r.stdout_str())
 
-    # View all databases at a glance
-    r = await ws.execute("tree -L 1 /mongodb/")
+    # View the database overview without recursing
+    r = await ws.execute('cat "/mongodb/sample_mflix/database.json"')
     print(await r.stdout_str())
 
 
@@ -233,58 +271,70 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-See `examples/chat/mongodb.py` for the full working example.
+## Runnable examples
+
+Three working examples live under `examples/python/mongodb/`:
+
+- [`mongodb.py`](https://github.com/StruktoAI/mirage/blob/main/examples/python/mongodb/mongodb.py) — agent-shell workflow: `ls`, `tree`, `cat`, `head`, `tail`, `wc`, `stat`, `grep`/`rg` at every scope, `jq`, `find`, `cd` + relative paths.
+- [`mongodb_vfs.py`](https://github.com/StruktoAI/mirage/blob/main/examples/python/mongodb/mongodb_vfs.py) — in-process VFS: `os.listdir` and `open()` walk every readdir level (root, database, `collections/`, `views/`, entity) and read `database.json`, `schema.json`, `documents.jsonl` (collection + view).
+- [`mongodb_fuse.py`](https://github.com/StruktoAI/mirage/blob/main/examples/python/mongodb/mongodb_fuse.py) — same coverage as the VFS example, but the tree is mounted as a real filesystem so other processes can `cat`/`ls`/`head` the mountpoint directly.
+
+All three default to the `mirage_test` database seeded by `python/scripts/seed_mongodb_test.py`.
 
 ## Finding IDs
 
-MongoDB document `_id` fields are accessible in the JSONL output:
+`_id` is serialized as `{"$oid": "..."}` under Extended JSON:
 
 ```bash
-# List document IDs
-jq -r '.[] | ._id' "/mongodb/sample_mflix/movies.jsonl" | head -n 10
+# List the first 10 ObjectId values
+jq -r '.[] | ._id["$oid"]' \
+  "/mongodb/sample_mflix/collections/movies/documents.jsonl" | head -n 10
 
 # Find a specific document by ID
-grep "573a1390f29313caabcd4135" "/mongodb/sample_mflix/movies.jsonl"
+grep "573a1390f29313caabcd42e8" \
+  "/mongodb/sample_mflix/collections/movies/documents.jsonl"
 
-# Extract specific fields
-jq -r '.[] | "\(._id) \(.title) \(.year)"' "/mongodb/sample_mflix/movies.jsonl"
+# Extract a few fields together
+jq -r '.[] | "\(._id["$oid"]) \(.title) \(.year)"' \
+  "/mongodb/sample_mflix/collections/movies/documents.jsonl"
 ```
 
 ## Working with Large Collections
 
-Tips for efficient access on collections with many documents:
+Streaming is the default; reach for these patterns when you want to keep
+the round trip small:
 
 ```bash
-# Check document count (server-side, no download)
-wc -l "/mongodb/sample_mflix/comments.jsonl"
+# Document count (server-side, no download)
+wc -l "/mongodb/sample_mflix/collections/comments/documents.jsonl"
 
-# Read only recent documents (sorted by _id desc)
-tail -n 10 "/mongodb/sample_mflix/comments.jsonl"
+# Most recent documents (sorted by _id desc)
+tail -n 10 "/mongodb/sample_mflix/collections/comments/documents.jsonl"
 
-# Search uses MongoDB query engine at collection/database level (no download)
-grep "great movie" "/mongodb/sample_mflix/comments.jsonl"
+# Server-side query at collection scope avoids streaming the whole jsonl
+grep "love" "/mongodb/sample_mflix/collections/comments/"
 
-# Extract specific fields
-jq -r '.[] | "\(.name): \(.text)"' "/mongodb/sample_mflix/comments.jsonl" | head -n 20
-
+# Drop heavy fields via elide_fields, then take the slice you want
+head -n 20 "/mongodb/sample_mflix/collections/movies/documents.jsonl"
 ```
 
-Note: `grep`/`rg` at collection or database level uses MongoDB's query
-engine instead of downloading all documents, making it efficient even
-for large collections.
+Hide embeddings or large blobs from agent reads with `elide_fields`;
+`schema.json` still documents the original type so the agent can decide
+when to ask for the raw bytes through a different path.
 
 ## Shell Commands
 
 Standard commands available on the mounted MongoDB tree:
 
-| Command         | Notes                                                     |
-| --------------- | --------------------------------------------------------- |
-| `ls`            | List databases, collections                               |
-| `cat`           | Read collection docs (capped at `default_doc_limit`)      |
-| `head` / `tail` | Smart: server-side sort+limit (capped at `max_doc_limit`) |
-| `grep` / `rg`   | Smart: uses MongoDB query engine at collection/db scope   |
-| `jq`            | Query JSON; use `.[]` prefix for JSONL files              |
-| `wc`            | Smart: uses `countDocuments()` server-side                |
-| `stat`          | Metadata (doc count, indexes, size in extra dict)         |
-| `find`          | List databases/collections with `-name`, `-maxdepth`      |
-| `tree`          | Directory tree view                                       |
+| Command         | Notes                                                                   |
+| --------------- | ----------------------------------------------------------------------- |
+| `ls`            | List databases, collections, views, and per-entity files                |
+| `cat`           | Stream `documents.jsonl` (or read `schema.json` / `database.json`)      |
+| `head` / `tail` | Smart: server-side sort + limit (capped at `max_doc_limit`)             |
+| `tail -f`       | Live-follow new inserts via Mongo change stream                         |
+| `grep` / `rg`   | Smart: MongoDB query engine at collection/db scope, regex at file scope |
+| `jq`            | Query JSON; use `.[]` prefix when iterating JSONL files                 |
+| `wc`            | Smart: uses `countDocuments()` server-side                              |
+| `stat`          | Metadata (doc count, indexes; views skip the index lookup)              |
+| `find`          | List databases/collections/views with `-name`, `-maxdepth`              |
+| `tree`          | Directory tree view                                                     |

--- a/docs/python/setup/mongodb.mdx
+++ b/docs/python/setup/mongodb.mdx
@@ -39,16 +39,9 @@ resource = MongoDBResource(config=config)
 ws = Workspace({"/mongodb/": resource}, mode=MountMode.READ)
 ```
 
-### Mount a single database (flat layout)
-
-```python
-config = MongoDBConfig(
-    uri=os.environ["MONGODB_URI"],
-    databases=["sample_mflix"],
-)
-resource = MongoDBResource(config=config)
-ws = Workspace({"/mongodb/": resource}, mode=MountMode.READ)
-```
+The database directory always appears in the path, even when `databases`
+filters to a single entry. The full layout is documented under
+[MongoDB Resource](/python/resource/mongodb).
 
 ## Config Reference
 

--- a/docs/typescript/limitations.mdx
+++ b/docs/typescript/limitations.mdx
@@ -144,7 +144,7 @@ readFileSync('/data/x.txt')  // hits the real filesystem, throws ENOENT
 
 ### 3. FUSE files from API-backed resources cap at 100 MiB
 
-**The problem.** API-backed resources (Trello, Linear, Slack, etc.) return `stat.size = null` because the byte size isn't known until the API has been called. Python passes `direct_io=True` to libfuse at mount time so the kernel ignores reported size and issues `read()` until it returns 0 (Slack's daily history can be tens of MB and it just works).
+**The problem.** API-backed resources (Trello, Linear, Slack, MongoDB, etc.) return `stat.size = null` because the byte size isn't known until the API has been called. Python passes `direct_io=True` to libfuse at mount time so the kernel ignores reported size and issues `read()` until it returns 0 (Slack's daily history can be tens of MB and it just works).
 
 `@zkochan/fuse-native` doesn't expose `direct_io`. There's no per-file flag (the `open` C bridge can only return `fh`, not modify `fuse_file_info.direct_io`), and the `-o direct_io` mount option is rejected by macFUSE/libosxfuse and crashes the channel. So when Mirage's FUSE layer hits a `size=null` file, it has to report **some** non-zero size to make the kernel issue reads, otherwise `cat board.json` would print empty.
 
@@ -164,6 +164,8 @@ await readFile(`${ws.fuseMountpoint}/slack/channels/super-busy-channel/2026-04-1
 `ls -l` shows `100M` for any unfetched API-backed file. Once a file has been opened, the real size is cached and subsequent `ls -l` shows the actual byte count.
 
 The cap exists because Node's `fs/promises.readFile` allocates a Buffer of the reported size and decodes it as utf-8 at the end; V8's string length limit is ~512 MiB, so a larger sentinel throws `RangeError: Invalid string length` (which is what you'd hit before any real read).
+
+**Knock-on effect for JSON files.** Because the kernel zero-pads the unread tail of the 100 MiB buffer, `JSON.parse(readFile(...))` on a FUSE-mounted JSON file fails at the first ` ` byte right after the real payload with `SyntaxError: Unexpected non-whitespace character after JSON`. Streaming tools (`cat`, `grep`, `head`, `wc -c`, `jq`) stop at EOF and are unaffected; only consumers that decode the full buffer as UTF-8 and then parse it choke on the padding. MongoDB's FUSE-exposed `schema.json`, `database.json`, and `documents.jsonl` are the most visible cases, see [TS MongoDB → FUSE caveat](/typescript/setup/mongodb#fuse-caveat-padded-reads-of-schemajson-documentsjsonl) for workarounds.
 
 **Why Python doesn't hit this.** Python's `mfusepy` accepts `direct_io=True` and passes it to libfuse2 as a mount option. macFUSE supports it through that path even though it rejects the same option from `@zkochan/fuse-native`'s option string. With direct_io enabled, the kernel doesn't care what size getattr reports.
 

--- a/examples/python/mongodb/mongodb.py
+++ b/examples/python/mongodb/mongodb.py
@@ -22,7 +22,17 @@ from mirage.resource.mongodb import MongoDBConfig, MongoDBResource
 
 load_dotenv(".env.development")
 
-config = MongoDBConfig(uri=os.environ["MONGODB_URI"])
+DB = "mirage_test"
+COLL_HET = "heterogeneous"
+COLL_EMB = "embeddings"
+COLL_TXT = "text_indexed"
+VIEW = "high_rated_films"
+
+config = MongoDBConfig(
+    uri=os.environ["MONGODB_URI"],
+    databases=[DB],
+    elide_fields={f"{DB}.{COLL_EMB}": ["vector"]},
+)
 resource = MongoDBResource(config=config)
 
 
@@ -32,13 +42,13 @@ async def _run(ws, cmd):
     out = (await r.stdout_str()).strip()
     err = await r.stderr_str()
     if out:
-        for line in out.splitlines()[:10]:
-            print(f"  {line[:120]}")
+        for line in out.splitlines()[:8]:
+            print(f"  {line[:160]}")
         total = len(out.splitlines())
-        if total > 10:
+        if total > 8:
             print(f"  ... ({total} lines total)")
     if err:
-        print(f"  [stderr] {err.strip()[:120]}")
+        print(f"  [stderr] {err.strip()[:160]}")
     if not out and not err:
         print(f"  (empty, exit={r.exit_code})")
     return r
@@ -47,89 +57,84 @@ async def _run(ws, cmd):
 async def main():
     ws = Workspace({"/mongodb": resource}, mode=MountMode.READ)
 
+    coll_doc = f"/mongodb/{DB}/collections/{COLL_HET}/documents.jsonl"
+    coll_schema = f"/mongodb/{DB}/collections/{COLL_HET}/schema.json"
+    emb_doc = f"/mongodb/{DB}/collections/{COLL_EMB}/documents.jsonl"
+    text_doc = f"/mongodb/{DB}/collections/{COLL_TXT}/documents.jsonl"
+    view_doc = f"/mongodb/{DB}/views/{VIEW}/documents.jsonl"
+    view_schema = f"/mongodb/{DB}/views/{VIEW}/schema.json"
+    db_json = f"/mongodb/{DB}/database.json"
+
+    print("=" * 60)
+    print("DIRECTORY LISTING")
+    print("=" * 60)
     await _run(ws, "ls /mongodb/")
-    await _run(ws, "ls /mongodb/sample_mflix/")
-    await _run(ws, "tree -L 1 /mongodb/")
-
-    fp = "/mongodb/sample_mflix/movies.jsonl"
-
-    await _run(ws, f'head -n 3 "{fp}"')
-    await _run(ws, f'tail -n 3 "{fp}"')
-    await _run(ws, f'wc -l "{fp}"')
-    await _run(ws, f'stat "{fp}"')
+    await _run(ws, f"ls /mongodb/{DB}/")
+    await _run(ws, f"ls /mongodb/{DB}/collections/")
+    await _run(ws, f"ls /mongodb/{DB}/views/")
+    await _run(ws, f"ls /mongodb/{DB}/collections/{COLL_HET}/")
+    await _run(ws, f"tree -L 3 /mongodb/{DB}/")
 
     print("\n" + "=" * 60)
-    print("GREP at different scopes")
+    print("CAT (database.json, schema.json, documents.jsonl)")
     print("=" * 60)
-
-    await _run(ws, f'grep Godfather "{fp}"')
-
-    await _run(ws, f'grep -c Godfather "{fp}"')
-
-    await _run(ws, 'grep Godfather "/mongodb/sample_mflix/"')
-
-    await _run(ws, 'grep Godfather "/mongodb/"')
+    await _run(ws, f'cat "{db_json}"')
+    await _run(ws, f'cat "{coll_schema}"')
+    await _run(ws, f'cat "{view_schema}"')
 
     print("\n" + "=" * 60)
-    print("RG at database scope")
+    print("HEAD / TAIL / WC / STAT")
     print("=" * 60)
-
-    await _run(ws, 'rg Godfather "/mongodb/sample_mflix/"')
-
-    print("\n>>> native search across all dbs:")
-    await _run(ws, 'rg Godfather /mongodb/')
+    await _run(ws, f'head -n 3 "{coll_doc}"')
+    await _run(ws, f'tail -n 3 "{coll_doc}"')
+    await _run(ws, f'wc -l "{coll_doc}"')
+    await _run(ws, f'stat "{coll_doc}"')
+    await _run(ws, f'head -n 2 "{view_doc}"')
 
     print("\n" + "=" * 60)
-    print("JQ at different granularities")
+    print("ELIDE_FIELDS in action (embedding dropped from output)")
     print("=" * 60)
-
-    await _run(ws, f'jq ".[] | .title" "{fp}" | head -n 5')
-
-    await _run(ws, f'jq -r ".[] | .title" "{fp}" | head -n 5')
-
-    await _run(
-        ws,
-        f'jq -r ".[] | select(.year > 2000) | .title" "{fp}"'
-        " | head -n 5",
-    )
-
-    await _run(
-        ws,
-        f'jq -r ".[] | select(.year > 1990) | .title"'
-        f' "{fp}" | head -n 5',
-    )
-
-    await _run(
-        ws,
-        f'jq -r ".[] | ._id"'
-        f' "{fp}" | head -n 5',
-    )
-
-    await _run(
-        ws,
-        'jq -r ".[] | .name" '
-        '"/mongodb/sample_mflix/users.jsonl" | head -n 5',
-    )
-
-    await _run(
-        ws,
-        'jq -r ".[] | .cuisine" '
-        '"/mongodb/sample_restaurants/restaurants.jsonl"'
-        " | sort | uniq -c | sort -rn | head -n 10",
-    )
+    await _run(ws, f'head -n 1 "{emb_doc}"')
 
     print("\n" + "=" * 60)
-    print("FIND and CD")
+    print("GREP at every scope")
     print("=" * 60)
+    await _run(ws, f'grep -c title "{coll_doc}"')
+    await _run(ws, f'grep -m 3 title "{coll_doc}"')
+    await _run(ws, f'grep mongodb "/mongodb/{DB}/collections/{COLL_TXT}/"')
+    await _run(ws, f'grep mongodb "/mongodb/{DB}/"')
+    await _run(ws, 'grep mongodb "/mongodb/"')
 
+    print("\n" + "=" * 60)
+    print("RG at db / root scope")
+    print("=" * 60)
+    await _run(ws, f'rg database "/mongodb/{DB}/"')
+    await _run(ws, 'rg database "/mongodb/"')
+
+    print("\n" + "=" * 60)
+    print("JQ on documents.jsonl")
+    print("=" * 60)
+    await _run(ws, f'jq -r ".[] | .title" "{coll_doc}" | head -n 5')
+    await _run(ws, f'jq -r \'.[] | ._id["$oid"]\' "{coll_doc}" | head -n 5')
     await _run(
-        ws,
-        'find "/mongodb/sample_mflix/" -name "*.jsonl"',
-    )
+        ws, f'jq -r ".[] | select(.year >= 2024) | .title" "{coll_doc}"'
+        " | head -n 5")
+    await _run(ws, f'jq -r ".[] | .body" "{text_doc}" | head -n 3')
 
-    await ws.execute('cd "/mongodb/sample_mflix"')
+    print("\n" + "=" * 60)
+    print("FIND")
+    print("=" * 60)
+    await _run(ws, f'find "/mongodb/{DB}/" -name "schema.json"')
+    await _run(ws, f'find "/mongodb/{DB}/" -name "documents.jsonl"')
+    await _run(ws, f'find "/mongodb/{DB}/" -maxdepth 2')
+
+    print("\n" + "=" * 60)
+    print("CD + pwd + ls + relative path read")
+    print("=" * 60)
+    await ws.execute(f'cd "/mongodb/{DB}/collections/{COLL_HET}"')
     await _run(ws, "pwd")
     await _run(ws, "ls")
+    await _run(ws, 'head -n 1 documents.jsonl')
 
 
 if __name__ == "__main__":

--- a/examples/python/mongodb/mongodb_fuse.py
+++ b/examples/python/mongodb/mongodb_fuse.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+import sys
 import time
 
 from dotenv import load_dotenv
@@ -23,7 +24,11 @@ from mirage.resource.mongodb import MongoDBConfig, MongoDBResource
 
 load_dotenv(".env.development")
 
-config = MongoDBConfig(uri=os.environ["MONGODB_URI"])
+DB = "mirage_test"
+COLL = "heterogeneous"
+VIEW = "high_rated_films"
+
+config = MongoDBConfig(uri=os.environ["MONGODB_URI"], databases=[DB])
 resource = MongoDBResource(config=config)
 
 with Workspace(
@@ -36,56 +41,70 @@ with Workspace(
 
     print(f"=== FUSE MODE: mounted at {mp} ===\n")
 
-    print("--- os.listdir() databases ---")
-    databases = os.listdir(f"{mp}/mongodb")
-    for db in databases:
+    print("--- listdir() root (databases) ---")
+    for db in os.listdir(f"{mp}/mongodb"):
         print(f"  {db}")
 
-    if not databases:
-        print("no databases found")
-    else:
-        db = "sample_mflix"
-        if db not in databases:
-            db = databases[0]
+    print(f"\n--- listdir() /mongodb/{DB} (entities) ---")
+    for entry in os.listdir(f"{mp}/mongodb/{DB}"):
+        print(f"  {entry}")
 
-        print(f"\n--- os.listdir() {db} collections ---")
-        collections = os.listdir(f"{mp}/mongodb/{db}")
-        for col in collections:
-            print(f"  {col}")
+    print(f"\n--- listdir() /mongodb/{DB}/collections ---")
+    for col in os.listdir(f"{mp}/mongodb/{DB}/collections"):
+        print(f"  {col}")
 
-        if collections:
-            target = None
-            for col in collections:
-                if "movies" in col:
-                    target = col
-                    break
-            if not target:
-                target = collections[0]
+    print(f"\n--- listdir() /mongodb/{DB}/views ---")
+    for v in os.listdir(f"{mp}/mongodb/{DB}/views"):
+        print(f"  {v}")
 
-            path = f"{mp}/mongodb/{db}/{target}"
-            print(f"\n--- open() + read {target} ---")
-            with open(path) as f:
-                text = f.read().strip()
-            if text:
-                lines = text.splitlines()
-                print(f"  documents: {len(lines)}")
-                for line in lines[:5]:
-                    try:
-                        doc = json.loads(line)
-                        title = doc.get("title", doc.get("name", "?"))
-                        print(f"  {title}")
-                    except json.JSONDecodeError:
-                        print(f"  {line[:80]}")
-            else:
-                print("  (empty)")
+    print(f"\n--- listdir() /mongodb/{DB}/collections/{COLL} (entity) ---")
+    for entry in os.listdir(f"{mp}/mongodb/{DB}/collections/{COLL}"):
+        print(f"  {entry}")
+
+    print("\n--- open() database.json ---")
+    with open(f"{mp}/mongodb/{DB}/database.json") as f:
+        db_meta = json.loads(f.read())
+    print(f"  collections: {len(db_meta.get('collections', []))}")
+    print(f"  views: {len(db_meta.get('views', []))}")
+
+    print(f"\n--- open() schema.json for {COLL} ---")
+    with open(f"{mp}/mongodb/{DB}/collections/{COLL}/schema.json") as f:
+        schema = json.loads(f.read())
+    print(f"  kind: {schema.get('kind')}")
+    print(f"  fields: {len(schema.get('fields', []))}")
+    print(f"  indexes: {len(schema.get('indexes', []))}")
+
+    print(f"\n--- open() + read documents.jsonl for {COLL} ---")
+    path = f"{mp}/mongodb/{DB}/collections/{COLL}/documents.jsonl"
+    with open(path) as f:
+        text = f.read().strip()
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    print(f"  documents: {len(lines)}")
+    for line in lines[:3]:
+        doc = json.loads(line)
+        print(f"  {doc.get('title', '?')}")
+
+    print(f"\n--- open() + read view documents for {VIEW} ---")
+    view_path = f"{mp}/mongodb/{DB}/views/{VIEW}/documents.jsonl"
+    with open(view_path) as f:
+        view_text = f.read().strip()
+    view_lines = [ln for ln in view_text.splitlines() if ln.strip()]
+    print(f"  documents: {len(view_lines)}")
+    for line in view_lines[:3]:
+        doc = json.loads(line)
+        print(f"  {doc.get('title', '?')} (rating={doc.get('rating', '?')})")
 
     print(f"\n>>> FUSE mounted at: {mp}")
-    print(">>> Open another terminal and run:")
-    print(f">>>   ls {mp}/mongodb/")
-    print(f">>>   cat {mp}/mongodb/sample_mflix/movies.jsonl"
-          " | head -n 5")
-    print(">>> Press Enter to unmount and exit...")
-    input()
+    print(">>> Open another terminal and try:")
+    print(f">>>   ls {mp}/mongodb/{DB}/collections/")
+    print(
+        f">>>   head -n 3 {mp}/mongodb/{DB}/collections/{COLL}/documents.jsonl"
+    )
+    if sys.stdin.isatty():
+        print(">>> Press Enter to unmount and exit...")
+        input()
+    else:
+        print(">>> (non-interactive: unmounting now)")
 
     records = ws.ops.records
     total = sum(r.bytes for r in records)

--- a/examples/python/mongodb/mongodb_vfs.py
+++ b/examples/python/mongodb/mongodb_vfs.py
@@ -24,7 +24,11 @@ from mirage.resource.mongodb import MongoDBConfig, MongoDBResource
 
 load_dotenv(".env.development")
 
-config = MongoDBConfig(uri=os.environ["MONGODB_URI"])
+DB = "mirage_test"
+COLL = "heterogeneous"
+VIEW = "high_rated_films"
+
+config = MongoDBConfig(uri=os.environ["MONGODB_URI"], databases=[DB])
 resource = MongoDBResource(config=config)
 
 
@@ -33,62 +37,70 @@ async def main():
         vos = sys.modules["os"]
         print("=== VFS MODE: open() reads from MongoDB ===\n")
 
-        print("--- os.listdir() databases ---")
-        databases = vos.listdir("/mongodb")
-        for db in databases:
+        print("--- listdir() root (databases) ---")
+        for db in vos.listdir("/mongodb"):
             print(f"  {db}")
 
-        if not databases:
-            print("no databases found")
-            return
+        print(f"\n--- listdir() /mongodb/{DB} (entities) ---")
+        for entry in vos.listdir(f"/mongodb/{DB}"):
+            print(f"  {entry}")
 
-        db = "sample_mflix"
-        if db not in [d.split("/")[-1] for d in databases]:
-            db = databases[0].split("/")[-1]
-
-        print(f"\n--- os.listdir() {db} collections ---")
-        collections = vos.listdir(f"/mongodb/{db}")
+        print(f"\n--- listdir() /mongodb/{DB}/collections ---")
+        collections = vos.listdir(f"/mongodb/{DB}/collections")
         for col in collections:
             print(f"  {col}")
 
-        if not collections:
-            print("no collections found")
-            return
+        print(f"\n--- listdir() /mongodb/{DB}/views ---")
+        views = vos.listdir(f"/mongodb/{DB}/views")
+        for v in views:
+            print(f"  {v}")
 
-        target = None
-        for col in collections:
-            if "movies" in col:
-                target = col
-                break
-        if not target:
-            target = collections[0]
+        print(f"\n--- listdir() /mongodb/{DB}/collections/{COLL} (entity) ---")
+        for entry in vos.listdir(f"/mongodb/{DB}/collections/{COLL}"):
+            print(f"  {entry}")
 
-        path = f"/mongodb/{db}/{target}"
-        print(f"\n--- open() + read {target} ---")
+        print("\n--- open() database.json ---")
+        with open(f"/mongodb/{DB}/database.json") as f:
+            db_meta = json.loads(f.read())
+        print(f"  collections: {len(db_meta.get('collections', []))}")
+        print(f"  views: {len(db_meta.get('views', []))}")
+
+        print(f"\n--- open() schema.json for {COLL} ---")
+        with open(f"/mongodb/{DB}/collections/{COLL}/schema.json") as f:
+            schema = json.loads(f.read())
+        print(f"  kind: {schema.get('kind')}")
+        print(f"  fields: {len(schema.get('fields', []))}")
+        print(f"  indexes: {len(schema.get('indexes', []))}")
+
+        print(f"\n--- open() + read documents.jsonl for {COLL} ---")
+        path = f"/mongodb/{DB}/collections/{COLL}/documents.jsonl"
         with open(path) as f:
             content = f.read()
         lines = [ln for ln in content.strip().split("\n") if ln.strip()]
         print(f"  documents: {len(lines)}")
         for line in lines[:3]:
-            try:
-                doc = json.loads(line)
-                title = doc.get("title", doc.get("name", "?"))
-                doc_id = doc.get("_id", "?")
-                print(f"  [{doc_id}] {title}")
-            except json.JSONDecodeError:
-                print(f"  {line[:80]}")
+            doc = json.loads(line)
+            print(f"  [{doc['_id']['$oid']}] {doc.get('title', '?')}")
+
+        print(f"\n--- open() + read view documents for {VIEW} ---")
+        view_path = f"/mongodb/{DB}/views/{VIEW}/documents.jsonl"
+        with open(view_path) as f:
+            view_content = f.read()
+        view_lines = [
+            ln for ln in view_content.strip().split("\n") if ln.strip()
+        ]
+        print(f"  documents: {len(view_lines)}")
+        for line in view_lines[:3]:
+            doc = json.loads(line)
+            title = doc.get("title", "?")
+            rating = doc.get("rating", "?")
+            print(f"  {title} (rating={rating})")
 
         print("\n--- session observer ---")
         day_folders = vos.listdir("/.sessions")
         log_entries = vos.listdir(day_folders[0]) if day_folders else []
-        for e in log_entries:
+        for e in log_entries[:3]:
             print(f"  {e}")
-        if log_entries:
-            with open(log_entries[0]) as f:
-                for i, line in enumerate(f):
-                    if i >= 3:
-                        break
-                    print(f"  [{i}] {line.strip()[:120]}")
 
         records = ws.ops.records
         total = sum(r.bytes for r in records)

--- a/examples/typescript/mongodb/mongodb.ts
+++ b/examples/typescript/mongodb/mongodb.ts
@@ -13,11 +13,14 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { setServers } from 'node:dns'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import dotenv from 'dotenv'
 import { MongoDBResource, MountMode, Workspace } from '@struktoai/mirage-node'
 
+const __HERE = fileURLToPath(new URL('.', import.meta.url))
 setServers(['8.8.8.8', '1.1.1.1'])
-dotenv.config({ path: '.env.development' })
+dotenv.config({ path: resolve(__HERE, '../../../.env.development') })
 
 const uri = process.env.MONGODB_URI
 if (uri === undefined) {
@@ -26,15 +29,17 @@ if (uri === undefined) {
 }
 
 const DB = 'mirage_test'
-const COLL = 'heterogeneous'
+const COLL_HET = 'heterogeneous'
+const COLL_EMB = 'embeddings'
+const COLL_TXT = 'text_indexed'
 const VIEW = 'high_rated_films'
 
 const resource = new MongoDBResource({
   uri,
   databases: [DB],
-  elideFields: { [`${DB}.embeddings`]: ['vector'] },
+  elideFields: { [`${DB}.${COLL_EMB}`]: ['vector'] },
 })
-const ws = new Workspace({ '/mongodb/': resource }, { mode: MountMode.READ })
+const ws = new Workspace({ '/mongodb': resource }, { mode: MountMode.READ })
 
 const DEC = new TextDecoder()
 
@@ -44,72 +49,91 @@ async function run(cmd: string): Promise<void> {
   const out = DEC.decode(r.stdout).trimEnd()
   const err = DEC.decode(r.stderr).trimEnd()
   if (out !== '') {
-    const lines = out.split('\n').slice(0, 8)
-    for (const ln of lines) console.log(`  ${ln.slice(0, 160)}`)
-    const total = out.split('\n').length
-    if (total > 8) console.log(`  ... (${String(total)} lines total)`)
+    const lines = out.split('\n')
+    for (const ln of lines.slice(0, 8)) console.log(`  ${ln.slice(0, 160)}`)
+    if (lines.length > 8) console.log(`  ... (${String(lines.length)} lines total)`)
   }
   if (err !== '') console.log(`  [stderr] ${err.slice(0, 160)}`)
   if (out === '' && err === '') console.log(`  (empty, exit=${String(r.exitCode)})`)
 }
 
-const base = `/mongodb/${DB}`
-const collDoc = `${base}/collections/${COLL}/documents.jsonl`
-const collSchema = `${base}/collections/${COLL}/schema.json`
-const emb = `${base}/collections/embeddings/documents.jsonl`
-const viewDoc = `${base}/views/${VIEW}/documents.jsonl`
-const dbJson = `${base}/database.json`
+const collDoc = `/mongodb/${DB}/collections/${COLL_HET}/documents.jsonl`
+const collSchema = `/mongodb/${DB}/collections/${COLL_HET}/schema.json`
+const embDoc = `/mongodb/${DB}/collections/${COLL_EMB}/documents.jsonl`
+const textDoc = `/mongodb/${DB}/collections/${COLL_TXT}/documents.jsonl`
+const viewDoc = `/mongodb/${DB}/views/${VIEW}/documents.jsonl`
+const viewSchema = `/mongodb/${DB}/views/${VIEW}/schema.json`
+const dbJson = `/mongodb/${DB}/database.json`
 
 try {
-  console.log('============================================================')
+  console.log('='.repeat(60))
   console.log('DIRECTORY LISTING')
-  console.log('============================================================')
+  console.log('='.repeat(60))
   await run('ls /mongodb/')
-  await run(`ls ${base}/`)
-  await run(`ls ${base}/collections/`)
-  await run(`ls ${base}/views/`)
-  await run(`ls ${base}/collections/${COLL}/`)
-  await run(`tree -L 3 ${base}/`)
+  await run(`ls /mongodb/${DB}/`)
+  await run(`ls /mongodb/${DB}/collections/`)
+  await run(`ls /mongodb/${DB}/views/`)
+  await run(`ls /mongodb/${DB}/collections/${COLL_HET}/`)
+  await run(`tree -L 3 /mongodb/${DB}/`)
 
-  console.log('\n============================================================')
+  console.log('\n' + '='.repeat(60))
   console.log('CAT (database.json, schema.json, documents.jsonl)')
-  console.log('============================================================')
-  await run(`cat ${dbJson}`)
-  await run(`cat ${collSchema}`)
+  console.log('='.repeat(60))
+  await run(`cat "${dbJson}"`)
+  await run(`cat "${collSchema}"`)
+  await run(`cat "${viewSchema}"`)
 
-  console.log('\n============================================================')
+  console.log('\n' + '='.repeat(60))
   console.log('HEAD / TAIL / WC / STAT')
-  console.log('============================================================')
-  await run(`head -n 3 ${collDoc}`)
-  await run(`tail -n 3 ${collDoc}`)
-  await run(`wc -l ${collDoc}`)
-  await run(`stat ${collDoc}`)
-  await run(`head -n 2 ${viewDoc}`)
+  console.log('='.repeat(60))
+  await run(`head -n 3 "${collDoc}"`)
+  await run(`tail -n 3 "${collDoc}"`)
+  await run(`wc -l "${collDoc}"`)
+  await run(`stat "${collDoc}"`)
+  await run(`head -n 2 "${viewDoc}"`)
 
-  console.log('\n============================================================')
-  console.log('ELIDE_FIELDS in action (vector dropped from embeddings)')
-  console.log('============================================================')
-  await run(`head -n 1 ${emb}`)
+  console.log('\n' + '='.repeat(60))
+  console.log('ELIDE_FIELDS in action (embedding dropped from output)')
+  console.log('='.repeat(60))
+  await run(`head -n 1 "${embDoc}"`)
 
-  console.log('\n============================================================')
-  console.log('GREP / RG at every scope')
-  console.log('============================================================')
-  await run(`grep -c title ${collDoc}`)
-  await run(`grep mongodb ${base}/collections/text_indexed/`)
-  await run(`grep mongodb ${base}/`)
-  await run('grep mongodb /mongodb/')
-  await run(`rg database ${base}/`)
+  console.log('\n' + '='.repeat(60))
+  console.log('GREP at every scope')
+  console.log('='.repeat(60))
+  await run(`grep -c title "${collDoc}"`)
+  await run(`grep -m 3 title "${collDoc}"`)
+  await run(`grep mongodb "/mongodb/${DB}/collections/${COLL_TXT}/"`)
+  await run(`grep mongodb "/mongodb/${DB}/"`)
+  await run('grep mongodb "/mongodb/"')
 
-  console.log('\n============================================================')
+  console.log('\n' + '='.repeat(60))
+  console.log('RG at db / root scope')
+  console.log('='.repeat(60))
+  await run(`rg database "/mongodb/${DB}/"`)
+  await run('rg database "/mongodb/"')
+
+  console.log('\n' + '='.repeat(60))
   console.log('JQ on documents.jsonl')
-  console.log('============================================================')
-  await run(`jq -r ".[] | .title" ${collDoc} | head -n 5`)
+  console.log('='.repeat(60))
+  await run(`jq -r ".[] | .title" "${collDoc}" | head -n 5`)
+  await run(`jq -r '.[] | ._id["$oid"]' "${collDoc}" | head -n 5`)
+  await run(`jq -r ".[] | select(.year >= 2024) | .title" "${collDoc}" | head -n 5`)
+  await run(`jq -r ".[] | .body" "${textDoc}" | head -n 3`)
 
-  console.log('\n============================================================')
+  console.log('\n' + '='.repeat(60))
   console.log('FIND')
-  console.log('============================================================')
-  await run(`find ${base}/ -name "schema.json"`)
-  await run(`find ${base}/ -name "documents.jsonl"`)
+  console.log('='.repeat(60))
+  await run(`find "/mongodb/${DB}/" -name "schema.json"`)
+  await run(`find "/mongodb/${DB}/" -name "documents.jsonl"`)
+  await run(`find "/mongodb/${DB}/" -maxdepth 2`)
+
+  console.log('\n' + '='.repeat(60))
+  console.log('CD + pwd + ls + relative path read')
+  console.log('='.repeat(60))
+  await ws.execute(`cd "/mongodb/${DB}/collections/${COLL_HET}"`)
+  await run('pwd')
+  await run('ls')
+  await run('head -n 1 documents.jsonl')
 } finally {
   await ws.close()
   await resource.close()

--- a/examples/typescript/mongodb/mongodb.ts
+++ b/examples/typescript/mongodb/mongodb.ts
@@ -25,53 +25,91 @@ if (uri === undefined) {
   process.exit(1)
 }
 
-const resource = new MongoDBResource({ uri })
+const DB = 'mirage_test'
+const COLL = 'heterogeneous'
+const VIEW = 'high_rated_films'
+
+const resource = new MongoDBResource({
+  uri,
+  databases: [DB],
+  elideFields: { [`${DB}.embeddings`]: ['vector'] },
+})
 const ws = new Workspace({ '/mongodb/': resource }, { mode: MountMode.READ })
 
 const DEC = new TextDecoder()
 
-async function run(label: string, cmd: string): Promise<void> {
-  console.log(`\n=== ${label} ===`)
+async function run(cmd: string): Promise<void> {
+  console.log(`\n>>> ${cmd}`)
   const r = await ws.execute(cmd)
-  if (r.exitCode !== 0) {
-    console.log(`(exit=${String(r.exitCode)})`)
-    if (r.stderr.byteLength > 0) console.log(DEC.decode(r.stderr))
-    if (r.stdout.byteLength > 0) console.log(DEC.decode(r.stdout))
-    return
+  const out = DEC.decode(r.stdout).trimEnd()
+  const err = DEC.decode(r.stderr).trimEnd()
+  if (out !== '') {
+    const lines = out.split('\n').slice(0, 8)
+    for (const ln of lines) console.log(`  ${ln.slice(0, 160)}`)
+    const total = out.split('\n').length
+    if (total > 8) console.log(`  ... (${String(total)} lines total)`)
   }
-  process.stdout.write(DEC.decode(r.stdout))
-  if (!DEC.decode(r.stdout).endsWith('\n')) process.stdout.write('\n')
+  if (err !== '') console.log(`  [stderr] ${err.slice(0, 160)}`)
+  if (out === '' && err === '') console.log(`  (empty, exit=${String(r.exitCode)})`)
 }
 
+const base = `/mongodb/${DB}`
+const collDoc = `${base}/collections/${COLL}/documents.jsonl`
+const collSchema = `${base}/collections/${COLL}/schema.json`
+const emb = `${base}/collections/embeddings/documents.jsonl`
+const viewDoc = `${base}/views/${VIEW}/documents.jsonl`
+const dbJson = `${base}/database.json`
+
 try {
-  await run('ls /mongodb', 'ls /mongodb')
+  console.log('============================================================')
+  console.log('DIRECTORY LISTING')
+  console.log('============================================================')
+  await run('ls /mongodb/')
+  await run(`ls ${base}/`)
+  await run(`ls ${base}/collections/`)
+  await run(`ls ${base}/views/`)
+  await run(`ls ${base}/collections/${COLL}/`)
+  await run(`tree -L 3 ${base}/`)
 
-  const dbsOut = await ws.execute('ls /mongodb')
-  const dbs = DEC.decode(dbsOut.stdout).split('\n').filter((s) => s.length > 0)
-  if (dbs.length === 0) {
-    console.log('\nno databases visible; stopping')
-    process.exit(0)
-  }
-  const target = dbs[0]!
-  await run(`ls /mongodb/${target}`, `ls /mongodb/${target}`)
+  console.log('\n============================================================')
+  console.log('CAT (database.json, schema.json, documents.jsonl)')
+  console.log('============================================================')
+  await run(`cat ${dbJson}`)
+  await run(`cat ${collSchema}`)
 
-  const colsOut = await ws.execute(`ls /mongodb/${target}`)
-  const cols = DEC.decode(colsOut.stdout).split('\n').filter((s) => s.endsWith('.jsonl'))
-  if (cols.length === 0) {
-    console.log(`\nno collections in ${target}; stopping`)
-    process.exit(0)
-  }
-  const col = cols[0]!
-  const path = `/mongodb/${target}/${col}`
+  console.log('\n============================================================')
+  console.log('HEAD / TAIL / WC / STAT')
+  console.log('============================================================')
+  await run(`head -n 3 ${collDoc}`)
+  await run(`tail -n 3 ${collDoc}`)
+  await run(`wc -l ${collDoc}`)
+  await run(`stat ${collDoc}`)
+  await run(`head -n 2 ${viewDoc}`)
 
-  await run(`stat ${path}`, `stat ${path}`)
-  await run(`head -n 3 ${path}`, `head -n 3 ${path}`)
-  await run(`tail -n 2 ${path}`, `tail -n 2 ${path}`)
-  await run(`wc -l ${path}`, `wc -l ${path}`)
-  await run(`cat ${path} | head -n 1`, `cat ${path} | head -n 1`)
-  await run(`jq -s ".[0]" ${path}`, `jq -s ".[0]" ${path}`)
-  await run(`find /mongodb/${target} -maxdepth 1`, `find /mongodb/${target} -maxdepth 1`)
-  await run(`tree -L 2 /mongodb/${target}`, `tree -L 2 /mongodb/${target}`)
+  console.log('\n============================================================')
+  console.log('ELIDE_FIELDS in action (vector dropped from embeddings)')
+  console.log('============================================================')
+  await run(`head -n 1 ${emb}`)
+
+  console.log('\n============================================================')
+  console.log('GREP / RG at every scope')
+  console.log('============================================================')
+  await run(`grep -c title ${collDoc}`)
+  await run(`grep mongodb ${base}/collections/text_indexed/`)
+  await run(`grep mongodb ${base}/`)
+  await run('grep mongodb /mongodb/')
+  await run(`rg database ${base}/`)
+
+  console.log('\n============================================================')
+  console.log('JQ on documents.jsonl')
+  console.log('============================================================')
+  await run(`jq -r ".[] | .title" ${collDoc} | head -n 5`)
+
+  console.log('\n============================================================')
+  console.log('FIND')
+  console.log('============================================================')
+  await run(`find ${base}/ -name "schema.json"`)
+  await run(`find ${base}/ -name "documents.jsonl"`)
 } finally {
   await ws.close()
   await resource.close()

--- a/examples/typescript/mongodb/mongodb_fuse.ts
+++ b/examples/typescript/mongodb/mongodb_fuse.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { setServers } from 'node:dns'
-import { readdir, stat } from 'node:fs/promises'
+import { readdir, readFile } from 'node:fs/promises'
 import dotenv from 'dotenv'
 import { FuseManager, MongoDBResource, MountMode, Workspace } from '@struktoai/mirage-node'
 
@@ -26,13 +26,14 @@ if (uri === undefined) {
   process.exit(1)
 }
 
-const DEC = new TextDecoder()
+const DB = 'mirage_test'
+const COLL = 'heterogeneous'
+const VIEW = 'high_rated_films'
 
 async function main(): Promise<void> {
   const resource = new MongoDBResource({
     uri,
-    defaultDocLimit: 1000,
-    maxDocLimit: 100_000,
+    databases: [DB],
   })
   const ws = new Workspace({ '/mongodb/': resource }, { mode: MountMode.READ })
   const fm = new FuseManager()
@@ -58,37 +59,65 @@ async function main(): Promise<void> {
   try {
     console.log(`\n=== FUSE MODE: mounted at ${mp} ===\n`)
 
-    console.log('--- fs.readdir() root ---')
-    const dbs = (await readdir(`${mp}/mongodb`)).sort()
-    for (const e of dbs) console.log(`  ${e}`)
+    const base = `${mp}/mongodb/${DB}`
 
-    if (dbs.length === 0) return
-    const target = dbs[0]!
+    console.log('--- readdir root ---')
+    for (const e of (await readdir(`${mp}/mongodb`)).sort()) console.log(`  ${e}`)
 
-    console.log(`\n--- fs.readdir(${mp}/mongodb/${target}) ---`)
-    const cols = (await readdir(`${mp}/mongodb/${target}`)).sort()
-    for (const c of cols.slice(0, 5)) console.log(`  ${c}`)
+    console.log(`\n--- readdir ${base} ---`)
+    for (const e of (await readdir(base)).sort()) console.log(`  ${e}`)
 
-    if (cols.length === 0) return
-    const colPath = `/mongodb/${target}/${cols[0]!}`
+    console.log(`\n--- readdir ${base}/collections ---`)
+    for (const e of (await readdir(`${base}/collections`)).sort()) console.log(`  ${e}`)
 
-    console.log(`\n--- fs.stat(${mp}${colPath}) ---`)
-    const st = await stat(`${mp}${colPath}`)
-    console.log(`  size=${String(st.size)} type=${st.isFile() ? 'file' : 'dir'}`)
+    console.log(`\n--- readdir ${base}/views ---`)
+    for (const e of (await readdir(`${base}/views`)).sort()) console.log(`  ${e}`)
 
-    console.log(`\n--- ws.execute(head -n 1 ${colPath}) ---`)
-    const r = await ws.execute(`head -n 1 ${colPath}`)
-    process.stdout.write(DEC.decode(r.stdout).slice(0, 200))
-    console.log('...')
+    console.log(`\n--- readdir ${base}/collections/${COLL} (entity) ---`)
+    for (const e of (await readdir(`${base}/collections/${COLL}`)).sort()) console.log(`  ${e}`)
 
-    console.log(`\n--- ws.execute(wc -l ${colPath}) ---`)
-    const w = await ws.execute(`wc -l ${colPath}`)
-    process.stdout.write(DEC.decode(w.stdout))
+    console.log(`\n--- readFile database.json ---`)
+    const dbMeta = JSON.parse(await readFile(`${base}/database.json`, 'utf8')) as {
+      collections: unknown[]
+      views: unknown[]
+    }
+    console.log(`  collections: ${String(dbMeta.collections.length)}`)
+    console.log(`  views: ${String(dbMeta.views.length)}`)
+
+    console.log(`\n--- readFile schema.json for ${COLL} ---`)
+    const schema = JSON.parse(
+      await readFile(`${base}/collections/${COLL}/schema.json`, 'utf8'),
+    ) as { kind: string; fields: unknown[]; indexes: unknown[] }
+    console.log(`  kind: ${schema.kind}`)
+    console.log(`  fields: ${String(schema.fields.length)}`)
+    console.log(`  indexes: ${String(schema.indexes.length)}`)
+
+    console.log(`\n--- readFile documents.jsonl for ${COLL} (first 3 lines) ---`)
+    const docsText = (
+      await readFile(`${base}/collections/${COLL}/documents.jsonl`, 'utf8')
+    ).trim()
+    const lines = docsText.split('\n')
+    console.log(`  documents: ${String(lines.length)}`)
+    for (const ln of lines.slice(0, 3)) {
+      const doc = JSON.parse(ln) as { title?: string }
+      console.log(`  ${doc.title ?? '?'}`)
+    }
+
+    console.log(`\n--- readFile view documents for ${VIEW} (first 3 lines) ---`)
+    const viewText = (
+      await readFile(`${base}/views/${VIEW}/documents.jsonl`, 'utf8')
+    ).trim()
+    const viewLines = viewText.split('\n')
+    console.log(`  documents: ${String(viewLines.length)}`)
+    for (const ln of viewLines.slice(0, 3)) {
+      const doc = JSON.parse(ln) as { title?: string; rating?: number }
+      console.log(`  ${doc.title ?? '?'} (rating=${String(doc.rating ?? '?')})`)
+    }
 
     console.log(`\n>>> FUSE mounted at: ${mp}`)
-    console.log('>>> You could open another terminal and try:')
-    console.log(`>>>   ls ${mp}/mongodb/`)
-    console.log(`>>>   head -n 3 ${mp}${colPath}`)
+    console.log('>>> Open another terminal and try:')
+    console.log(`>>>   ls ${base}/collections/`)
+    console.log(`>>>   head -n 3 ${base}/collections/${COLL}/documents.jsonl`)
     console.log('>>> Auto-unmounting now (run interactively for manual exploration).')
   } finally {
     await fm.close()

--- a/examples/typescript/mongodb/mongodb_fuse.ts
+++ b/examples/typescript/mongodb/mongodb_fuse.ts
@@ -14,27 +14,26 @@
 
 import { setServers } from 'node:dns'
 import { readdir, readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import dotenv from 'dotenv'
 import { FuseManager, MongoDBResource, MountMode, Workspace } from '@struktoai/mirage-node'
 
+const __HERE = fileURLToPath(new URL('.', import.meta.url))
 setServers(['8.8.8.8', '1.1.1.1'])
-dotenv.config({ path: '.env.development' })
-
-const uri = process.env.MONGODB_URI
-if (uri === undefined) {
-  console.error('MONGODB_URI missing in .env.development')
-  process.exit(1)
-}
+dotenv.config({ path: resolve(__HERE, '../../../.env.development') })
 
 const DB = 'mirage_test'
 const COLL = 'heterogeneous'
 const VIEW = 'high_rated_films'
 
 async function main(): Promise<void> {
-  const resource = new MongoDBResource({
-    uri,
-    databases: [DB],
-  })
+  const uri = process.env.MONGODB_URI
+  if (uri === undefined) {
+    console.error('MONGODB_URI missing in .env.development')
+    process.exit(1)
+  }
+  const resource = new MongoDBResource({ uri, databases: [DB] })
   const ws = new Workspace({ '/mongodb/': resource }, { mode: MountMode.READ })
   const fm = new FuseManager()
   const mp = await fm.setup(ws)
@@ -57,57 +56,56 @@ async function main(): Promise<void> {
   process.on('SIGTERM', handler)
 
   try {
-    console.log(`\n=== FUSE MODE: mounted at ${mp} ===\n`)
+    console.log(`=== FUSE MODE: mounted at ${mp} ===\n`)
 
-    const base = `${mp}/mongodb/${DB}`
+    console.log('--- listdir() root (databases) ---')
+    for (const db of (await readdir(`${mp}/mongodb`)).sort()) console.log(`  ${db}`)
 
-    console.log('--- readdir root ---')
-    for (const e of (await readdir(`${mp}/mongodb`)).sort()) console.log(`  ${e}`)
+    console.log(`\n--- listdir() /mongodb/${DB} (entities) ---`)
+    for (const e of (await readdir(`${mp}/mongodb/${DB}`)).sort()) console.log(`  ${e}`)
 
-    console.log(`\n--- readdir ${base} ---`)
-    for (const e of (await readdir(base)).sort()) console.log(`  ${e}`)
+    console.log(`\n--- listdir() /mongodb/${DB}/collections ---`)
+    for (const c of (await readdir(`${mp}/mongodb/${DB}/collections`)).sort()) console.log(`  ${c}`)
 
-    console.log(`\n--- readdir ${base}/collections ---`)
-    for (const e of (await readdir(`${base}/collections`)).sort()) console.log(`  ${e}`)
+    console.log(`\n--- listdir() /mongodb/${DB}/views ---`)
+    for (const v of (await readdir(`${mp}/mongodb/${DB}/views`)).sort()) console.log(`  ${v}`)
 
-    console.log(`\n--- readdir ${base}/views ---`)
-    for (const e of (await readdir(`${base}/views`)).sort()) console.log(`  ${e}`)
+    console.log(`\n--- listdir() /mongodb/${DB}/collections/${COLL} (entity) ---`)
+    for (const e of (await readdir(`${mp}/mongodb/${DB}/collections/${COLL}`)).sort())
+      console.log(`  ${e}`)
 
-    console.log(`\n--- readdir ${base}/collections/${COLL} (entity) ---`)
-    for (const e of (await readdir(`${base}/collections/${COLL}`)).sort()) console.log(`  ${e}`)
-
-    console.log(`\n--- readFile database.json ---`)
-    const dbMeta = JSON.parse(await readFile(`${base}/database.json`, 'utf8')) as {
+    console.log('\n--- open() database.json ---')
+    const dbMeta = JSON.parse(await readFile(`${mp}/mongodb/${DB}/database.json`, 'utf8')) as {
       collections: unknown[]
       views: unknown[]
     }
     console.log(`  collections: ${String(dbMeta.collections.length)}`)
     console.log(`  views: ${String(dbMeta.views.length)}`)
 
-    console.log(`\n--- readFile schema.json for ${COLL} ---`)
+    console.log(`\n--- open() schema.json for ${COLL} ---`)
     const schema = JSON.parse(
-      await readFile(`${base}/collections/${COLL}/schema.json`, 'utf8'),
+      await readFile(`${mp}/mongodb/${DB}/collections/${COLL}/schema.json`, 'utf8'),
     ) as { kind: string; fields: unknown[]; indexes: unknown[] }
     console.log(`  kind: ${schema.kind}`)
     console.log(`  fields: ${String(schema.fields.length)}`)
     console.log(`  indexes: ${String(schema.indexes.length)}`)
 
-    console.log(`\n--- readFile documents.jsonl for ${COLL} (first 3 lines) ---`)
-    const docsText = (
-      await readFile(`${base}/collections/${COLL}/documents.jsonl`, 'utf8')
+    console.log(`\n--- open() + read documents.jsonl for ${COLL} ---`)
+    const text = (
+      await readFile(`${mp}/mongodb/${DB}/collections/${COLL}/documents.jsonl`, 'utf8')
     ).trim()
-    const lines = docsText.split('\n')
+    const lines = text.split('\n').filter((ln) => ln.trim() !== '')
     console.log(`  documents: ${String(lines.length)}`)
     for (const ln of lines.slice(0, 3)) {
       const doc = JSON.parse(ln) as { title?: string }
       console.log(`  ${doc.title ?? '?'}`)
     }
 
-    console.log(`\n--- readFile view documents for ${VIEW} (first 3 lines) ---`)
+    console.log(`\n--- open() + read view documents for ${VIEW} ---`)
     const viewText = (
-      await readFile(`${base}/views/${VIEW}/documents.jsonl`, 'utf8')
+      await readFile(`${mp}/mongodb/${DB}/views/${VIEW}/documents.jsonl`, 'utf8')
     ).trim()
-    const viewLines = viewText.split('\n')
+    const viewLines = viewText.split('\n').filter((ln) => ln.trim() !== '')
     console.log(`  documents: ${String(viewLines.length)}`)
     for (const ln of viewLines.slice(0, 3)) {
       const doc = JSON.parse(ln) as { title?: string; rating?: number }
@@ -116,9 +114,16 @@ async function main(): Promise<void> {
 
     console.log(`\n>>> FUSE mounted at: ${mp}`)
     console.log('>>> Open another terminal and try:')
-    console.log(`>>>   ls ${base}/collections/`)
-    console.log(`>>>   head -n 3 ${base}/collections/${COLL}/documents.jsonl`)
-    console.log('>>> Auto-unmounting now (run interactively for manual exploration).')
+    console.log(`>>>   ls ${mp}/mongodb/${DB}/collections/`)
+    console.log(`>>>   head -n 3 ${mp}/mongodb/${DB}/collections/${COLL}/documents.jsonl`)
+    if (process.stdin.isTTY) {
+      console.log('>>> Press Enter to unmount and exit...')
+      await new Promise<void>((resolve) => {
+        process.stdin.once('data', () => resolve())
+      })
+    } else {
+      console.log('>>> (non-interactive: unmounting now)')
+    }
   } finally {
     await fm.close()
     await ws.close()

--- a/examples/typescript/mongodb/mongodb_vfs.ts
+++ b/examples/typescript/mongodb/mongodb_vfs.ts
@@ -25,6 +25,10 @@ if (uri === undefined) {
   process.exit(1)
 }
 
+const DB = 'mirage_test'
+const COLL = 'heterogeneous'
+const VIEW = 'high_rated_films'
+
 const DEC = new TextDecoder()
 
 async function dump(ws: Workspace, label: string, cmd: string): Promise<void> {
@@ -34,44 +38,41 @@ async function dump(ws: Workspace, label: string, cmd: string): Promise<void> {
     console.log(`(exit=${String(r.exitCode)}) ${DEC.decode(r.stderr)}`)
     return
   }
-  process.stdout.write(DEC.decode(r.stdout))
-  if (!DEC.decode(r.stdout).endsWith('\n')) process.stdout.write('\n')
+  const out = DEC.decode(r.stdout)
+  for (const ln of out.trimEnd().split('\n').slice(0, 8)) console.log(`  ${ln.slice(0, 160)}`)
 }
 
 async function main(): Promise<void> {
   const resource = new MongoDBResource({
     uri,
-    defaultDocLimit: 50,
+    databases: [DB],
   })
   const ws = new Workspace({ '/mongodb/': resource }, { mode: MountMode.READ })
 
   try {
     console.log('=== VFS MODE: shell pipelines transparently read MongoDB ===')
 
-    await dump(ws, 'ls /mongodb — databases', 'ls /mongodb')
+    const base = `/mongodb/${DB}`
+    const collDoc = `${base}/collections/${COLL}/documents.jsonl`
+    const collSchema = `${base}/collections/${COLL}/schema.json`
+    const viewDoc = `${base}/views/${VIEW}/documents.jsonl`
 
-    const dbsOut = await ws.execute('ls /mongodb')
-    const dbs = DEC.decode(dbsOut.stdout).split('\n').filter((s) => s.length > 0)
-    if (dbs.length === 0) {
-      console.log('\nno databases')
-      return
-    }
-    const target = dbs[0]!
+    await dump(ws, 'listdir root', 'ls /mongodb/')
+    await dump(ws, `listdir ${base}/`, `ls ${base}/`)
+    await dump(ws, `listdir ${base}/collections/`, `ls ${base}/collections/`)
+    await dump(ws, `listdir ${base}/views/`, `ls ${base}/views/`)
+    await dump(
+      ws,
+      `listdir ${base}/collections/${COLL}/ (entity)`,
+      `ls ${base}/collections/${COLL}/`,
+    )
 
-    await dump(ws, `ls /mongodb/${target}`, `ls /mongodb/${target} | head -n 5`)
-
-    const colsOut = await ws.execute(`ls /mongodb/${target}`)
-    const cols = DEC.decode(colsOut.stdout).split('\n').filter((s) => s.endsWith('.jsonl'))
-    if (cols.length === 0) {
-      console.log(`\nno collections in ${target}`)
-      return
-    }
-    const path = `/mongodb/${target}/${cols[0]!}`
-
-    await dump(ws, `head -n 1 ${path}`, `head -n 1 ${path}`)
-    await dump(ws, `wc -l ${path}`, `wc -l ${path}`)
-    await dump(ws, `cat ${path} | wc -l`, `cat ${path} | wc -l`)
-    await dump(ws, `jq -s ".[0]" ${path}`, `jq -s ".[0]" ${path}`)
+    await dump(ws, `cat ${base}/database.json`, `cat ${base}/database.json`)
+    await dump(ws, `cat schema.json for ${COLL}`, `cat ${collSchema}`)
+    await dump(ws, `head -n 3 documents.jsonl`, `head -n 3 ${collDoc}`)
+    await dump(ws, `wc -l documents.jsonl`, `wc -l ${collDoc}`)
+    await dump(ws, `head -n 2 view documents`, `head -n 2 ${viewDoc}`)
+    await dump(ws, `jq titles`, `jq -r ".[] | .title" ${collDoc} | head -n 5`)
   } finally {
     await ws.close()
     await resource.close()

--- a/examples/typescript/mongodb/mongodb_vfs.ts
+++ b/examples/typescript/mongodb/mongodb_vfs.ts
@@ -13,66 +13,84 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { setServers } from 'node:dns'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import dotenv from 'dotenv'
 import { MongoDBResource, MountMode, Workspace } from '@struktoai/mirage-node'
 
+const __HERE = fileURLToPath(new URL('.', import.meta.url))
 setServers(['8.8.8.8', '1.1.1.1'])
-dotenv.config({ path: '.env.development' })
-
-const uri = process.env.MONGODB_URI
-if (uri === undefined) {
-  console.error('MONGODB_URI missing in .env.development')
-  process.exit(1)
-}
+dotenv.config({ path: resolve(__HERE, '../../../.env.development') })
 
 const DB = 'mirage_test'
 const COLL = 'heterogeneous'
 const VIEW = 'high_rated_films'
 
-const DEC = new TextDecoder()
-
-async function dump(ws: Workspace, label: string, cmd: string): Promise<void> {
-  console.log(`\n--- ${label} ---`)
-  const r = await ws.execute(cmd)
-  if (r.exitCode !== 0) {
-    console.log(`(exit=${String(r.exitCode)}) ${DEC.decode(r.stderr)}`)
-    return
-  }
-  const out = DEC.decode(r.stdout)
-  for (const ln of out.trimEnd().split('\n').slice(0, 8)) console.log(`  ${ln.slice(0, 160)}`)
-}
-
 async function main(): Promise<void> {
-  const resource = new MongoDBResource({
-    uri,
-    databases: [DB],
-  })
+  const uri = process.env.MONGODB_URI
+  if (uri === undefined) {
+    console.error('MONGODB_URI missing in .env.development')
+    process.exit(1)
+  }
+  const resource = new MongoDBResource({ uri, databases: [DB] })
   const ws = new Workspace({ '/mongodb/': resource }, { mode: MountMode.READ })
 
   try {
-    console.log('=== VFS MODE: shell pipelines transparently read MongoDB ===')
+    console.log('=== VFS MODE: open() reads from MongoDB ===\n')
 
-    const base = `/mongodb/${DB}`
-    const collDoc = `${base}/collections/${COLL}/documents.jsonl`
-    const collSchema = `${base}/collections/${COLL}/schema.json`
-    const viewDoc = `${base}/views/${VIEW}/documents.jsonl`
+    console.log('--- listdir() root (databases) ---')
+    for (const db of await ws.fs.readdir('/mongodb')) console.log(`  ${db}`)
 
-    await dump(ws, 'listdir root', 'ls /mongodb/')
-    await dump(ws, `listdir ${base}/`, `ls ${base}/`)
-    await dump(ws, `listdir ${base}/collections/`, `ls ${base}/collections/`)
-    await dump(ws, `listdir ${base}/views/`, `ls ${base}/views/`)
-    await dump(
-      ws,
-      `listdir ${base}/collections/${COLL}/ (entity)`,
-      `ls ${base}/collections/${COLL}/`,
+    console.log(`\n--- listdir() /mongodb/${DB} (entities) ---`)
+    for (const e of await ws.fs.readdir(`/mongodb/${DB}`)) console.log(`  ${e}`)
+
+    console.log(`\n--- listdir() /mongodb/${DB}/collections ---`)
+    for (const c of await ws.fs.readdir(`/mongodb/${DB}/collections`)) console.log(`  ${c}`)
+
+    console.log(`\n--- listdir() /mongodb/${DB}/views ---`)
+    for (const v of await ws.fs.readdir(`/mongodb/${DB}/views`)) console.log(`  ${v}`)
+
+    console.log(`\n--- listdir() /mongodb/${DB}/collections/${COLL} (entity) ---`)
+    for (const e of await ws.fs.readdir(`/mongodb/${DB}/collections/${COLL}`)) console.log(`  ${e}`)
+
+    console.log('\n--- open() database.json ---')
+    const dbMeta = JSON.parse(await ws.fs.readFileText(`/mongodb/${DB}/database.json`)) as {
+      collections: unknown[]
+      views: unknown[]
+    }
+    console.log(`  collections: ${String(dbMeta.collections.length)}`)
+    console.log(`  views: ${String(dbMeta.views.length)}`)
+
+    console.log(`\n--- open() schema.json for ${COLL} ---`)
+    const schema = JSON.parse(
+      await ws.fs.readFileText(`/mongodb/${DB}/collections/${COLL}/schema.json`),
+    ) as { kind: string; fields: unknown[]; indexes: unknown[] }
+    console.log(`  kind: ${schema.kind}`)
+    console.log(`  fields: ${String(schema.fields.length)}`)
+    console.log(`  indexes: ${String(schema.indexes.length)}`)
+
+    console.log(`\n--- open() + read documents.jsonl for ${COLL} ---`)
+    const content = await ws.fs.readFileText(
+      `/mongodb/${DB}/collections/${COLL}/documents.jsonl`,
     )
+    const lines = content.trim().split('\n').filter((ln) => ln.trim() !== '')
+    console.log(`  documents: ${String(lines.length)}`)
+    for (const ln of lines.slice(0, 3)) {
+      const doc = JSON.parse(ln) as { _id: { $oid?: string }; title?: string }
+      console.log(`  [${doc._id.$oid ?? '?'}] ${doc.title ?? '?'}`)
+    }
 
-    await dump(ws, `cat ${base}/database.json`, `cat ${base}/database.json`)
-    await dump(ws, `cat schema.json for ${COLL}`, `cat ${collSchema}`)
-    await dump(ws, `head -n 3 documents.jsonl`, `head -n 3 ${collDoc}`)
-    await dump(ws, `wc -l documents.jsonl`, `wc -l ${collDoc}`)
-    await dump(ws, `head -n 2 view documents`, `head -n 2 ${viewDoc}`)
-    await dump(ws, `jq titles`, `jq -r ".[] | .title" ${collDoc} | head -n 5`)
+    console.log(`\n--- open() + read view documents for ${VIEW} ---`)
+    const viewContent = await ws.fs.readFileText(
+      `/mongodb/${DB}/views/${VIEW}/documents.jsonl`,
+    )
+    const viewLines = viewContent.trim().split('\n').filter((ln) => ln.trim() !== '')
+    console.log(`  documents: ${String(viewLines.length)}`)
+    for (const ln of viewLines.slice(0, 3)) {
+      const doc = JSON.parse(ln) as { title?: string; rating?: number }
+      console.log(`  ${doc.title ?? '?'} (rating=${String(doc.rating ?? '?')})`)
+    }
+
   } finally {
     await ws.close()
     await resource.close()

--- a/python/mirage/accessor/mongodb.py
+++ b/python/mirage/accessor/mongodb.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
+
 from motor.motor_asyncio import AsyncIOMotorClient
 
 from mirage.accessor.base import Accessor
@@ -22,4 +24,22 @@ class MongoDBAccessor(Accessor):
 
     def __init__(self, config: MongoDBConfig) -> None:
         self.config = config
-        self.client = AsyncIOMotorClient(config.uri)
+        self._clients: dict[int, AsyncIOMotorClient] = {}
+
+    @property
+    def client(self) -> AsyncIOMotorClient:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return self._for_loop(None)
+        return self._for_loop(loop)
+
+    def _for_loop(
+            self,
+            loop: asyncio.AbstractEventLoop | None) -> AsyncIOMotorClient:
+        key = id(loop) if loop is not None else 0
+        client = self._clients.get(key)
+        if client is None:
+            client = AsyncIOMotorClient(self.config.uri)
+            self._clients[key] = client
+        return client

--- a/python/mirage/accessor/mongodb.py
+++ b/python/mirage/accessor/mongodb.py
@@ -13,6 +13,9 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from motor.motor_asyncio import AsyncIOMotorClient
 
@@ -22,9 +25,13 @@ from mirage.resource.mongodb.config import MongoDBConfig
 
 class MongoDBAccessor(Accessor):
 
-    def __init__(self, config: MongoDBConfig) -> None:
+    def __init__(self,
+                 config: MongoDBConfig,
+                 listing_cache_ttl: float = 5.0) -> None:
         self.config = config
+        self.listing_cache_ttl = listing_cache_ttl
         self._clients: dict[int, AsyncIOMotorClient] = {}
+        self._cache: dict[str, tuple[float, Any]] = {}
 
     @property
     def client(self) -> AsyncIOMotorClient:
@@ -43,3 +50,18 @@ class MongoDBAccessor(Accessor):
             client = AsyncIOMotorClient(self.config.uri)
             self._clients[key] = client
         return client
+
+    async def cached_list(self, key: str,
+                          fetch: Callable[[], Awaitable[Any]]) -> Any:
+        if self.listing_cache_ttl <= 0:
+            return await fetch()
+        now = time.monotonic()
+        hit = self._cache.get(key)
+        if hit is not None and hit[0] > now:
+            return hit[1]
+        value = await fetch()
+        self._cache[key] = (now + self.listing_cache_ttl, value)
+        return value
+
+    def invalidate_listings(self) -> None:
+        self._cache.clear()

--- a/python/mirage/commands/builtin/mongodb/cat.py
+++ b/python/mirage/commands/builtin/mongodb/cat.py
@@ -24,6 +24,7 @@ from mirage.core.mongodb.glob import resolve_glob
 from mirage.core.mongodb.read import read as mongodb_read
 from mirage.core.mongodb.scope import detect_scope
 from mirage.core.mongodb.stream import read_stream
+from mirage.core.mongodb.types import ScopeLevel
 from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
@@ -68,7 +69,7 @@ async def cat(
         paths = await resolve_glob(accessor, paths)
         p = paths[0]
         scope = detect_scope(p)
-        if scope.level == "documents":
+        if scope.level == ScopeLevel.DOCUMENTS:
             source = read_stream(accessor, p, index)
             io = IOResult(reads={p.strip_prefix: source},
                           cache=[p.strip_prefix])

--- a/python/mirage/commands/builtin/mongodb/cat.py
+++ b/python/mirage/commands/builtin/mongodb/cat.py
@@ -21,6 +21,8 @@ from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.mongodb.glob import resolve_glob
+from mirage.core.mongodb.read import read as mongodb_read
+from mirage.core.mongodb.scope import detect_scope
 from mirage.core.mongodb.stream import read_stream
 from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.types import ByteSource, IOResult
@@ -48,6 +50,10 @@ async def _number_lines_stream(
         num += 1
 
 
+async def _bytes_to_stream(data: bytes) -> AsyncIterator[bytes]:
+    yield data
+
+
 @command("cat", resource="mongodb", spec=SPECS["cat"], provision=cat_provision)
 async def cat(
     accessor: MongoDBAccessor,
@@ -61,11 +67,19 @@ async def cat(
     if paths:
         paths = await resolve_glob(accessor, paths)
         p = paths[0]
-        source = read_stream(accessor, p, index)
-        io = IOResult(reads={p.strip_prefix: source}, cache=[p.strip_prefix])
+        scope = detect_scope(p)
+        if scope.level == "documents":
+            source = read_stream(accessor, p, index)
+            io = IOResult(reads={p.strip_prefix: source},
+                          cache=[p.strip_prefix])
+            if n:
+                return _number_lines_stream(source), io
+            return source, io
+        data = await mongodb_read(accessor, p, index)
+        io = IOResult(reads={p.strip_prefix: data}, cache=[p.strip_prefix])
         if n:
-            return _number_lines_stream(source), io
-        return source, io
+            return _number_lines_stream(_bytes_to_stream(data)), io
+        return data, io
     source = _resolve_source(stdin, "cat: missing operand")
     if n:
         return _number_lines_stream(source), IOResult()

--- a/python/mirage/commands/builtin/mongodb/cat.py
+++ b/python/mirage/commands/builtin/mongodb/cat.py
@@ -15,12 +15,14 @@
 from collections.abc import AsyncIterator
 
 from mirage.accessor.mongodb import MongoDBAccessor
+from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.mongodb._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.mongodb.glob import resolve_glob
-from mirage.core.mongodb.read import read as mongodb_read
+from mirage.core.mongodb.stream import read_stream
+from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -38,10 +40,12 @@ async def cat_provision(
                           for p in paths))
 
 
-async def _number_lines(data: bytes) -> AsyncIterator[bytes]:
-    lines = data.decode(errors="replace").splitlines()
-    for i, line in enumerate(lines, 1):
-        yield f"     {i}\t{line}\n".encode()
+async def _number_lines_stream(
+        source: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
+    num = 1
+    async for line in AsyncLineIterator(source):
+        yield f"     {num}\t".encode() + line + b"\n"
+        num += 1
 
 
 @command("cat", resource="mongodb", spec=SPECS["cat"], provision=cat_provision)
@@ -51,20 +55,18 @@ async def cat(
     *texts: str,
     stdin: AsyncIterator[bytes] | bytes | None = None,
     n: bool = False,
+    index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     if paths:
         paths = await resolve_glob(accessor, paths)
         p = paths[0]
-        data = await mongodb_read(accessor, p, _extra.get("index"))
-        io = IOResult(reads={p.strip_prefix: data}, cache=[p.strip_prefix])
+        source = read_stream(accessor, p, index)
+        io = IOResult(reads={p.strip_prefix: source}, cache=[p.strip_prefix])
         if n:
-            return _number_lines(data), io
-        return data, io
+            return _number_lines_stream(source), io
+        return source, io
     source = _resolve_source(stdin, "cat: missing operand")
     if n:
-        raw = b""
-        async for chunk in source:
-            raw += chunk
-        return _number_lines(raw), IOResult()
+        return _number_lines_stream(source), IOResult()
     return source, IOResult()

--- a/python/mirage/commands/builtin/mongodb/grep/grep.py
+++ b/python/mirage/commands/builtin/mongodb/grep/grep.py
@@ -30,11 +30,13 @@ from mirage.commands.spec import SPECS
 from mirage.core.mongodb._client import list_databases
 from mirage.core.mongodb.glob import resolve_glob
 from mirage.core.mongodb.read import read as mongodb_read
-from mirage.core.mongodb.stream import read_stream
 from mirage.core.mongodb.readdir import readdir as _readdir
 from mirage.core.mongodb.scope import detect_scope
-from mirage.core.mongodb.search import format_grep_results, search_database
+from mirage.core.mongodb.search import (format_grep_results, search_collection,
+                                        search_database)
 from mirage.core.mongodb.stat import stat as _stat
+from mirage.core.mongodb.stream import read_stream
+from mirage.core.mongodb.types import ScopeLevel
 from mirage.io.stream import exit_on_empty, quiet_match
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
@@ -100,8 +102,20 @@ async def grep(
     if paths:
         scope = detect_scope(paths[0])
 
-        if scope.level in ("database", "root"):
-            if scope.level == "database" and scope.database:
+        if scope.level in (ScopeLevel.ENTITY, ScopeLevel.DATABASE,
+                           ScopeLevel.ROOT):
+            entity_match = (scope.level == ScopeLevel.ENTITY and scope.database
+                            and scope.name)
+            if entity_match:
+                docs = await search_collection(
+                    accessor.client,
+                    scope.database,
+                    scope.name,
+                    pattern,
+                    limit=limit,
+                )
+                results = [(scope.database, scope.name, docs)] if docs else []
+            elif scope.level == ScopeLevel.DATABASE and scope.database:
                 results = await search_database(
                     accessor.client,
                     scope.database,

--- a/python/mirage/commands/builtin/mongodb/grep/grep.py
+++ b/python/mirage/commands/builtin/mongodb/grep/grep.py
@@ -95,14 +95,10 @@ async def grep(
     before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
 
     config = accessor.config
-    single_db = config.databases is not None and len(config.databases) == 1
-    single_db_name = config.databases[0] if single_db else None
     limit = config.default_search_limit
 
     if paths:
-        scope = detect_scope(paths[0],
-                             single_db=single_db,
-                             single_db_name=single_db_name)
+        scope = detect_scope(paths[0])
 
         if scope.level in ("database", "root"):
             if scope.level == "database" and scope.database:

--- a/python/mirage/commands/builtin/mongodb/grep/grep.py
+++ b/python/mirage/commands/builtin/mongodb/grep/grep.py
@@ -30,11 +30,12 @@ from mirage.commands.spec import SPECS
 from mirage.core.mongodb._client import list_databases
 from mirage.core.mongodb.glob import resolve_glob
 from mirage.core.mongodb.read import read as mongodb_read
+from mirage.core.mongodb.stream import read_stream
 from mirage.core.mongodb.readdir import readdir as _readdir
 from mirage.core.mongodb.scope import detect_scope
 from mirage.core.mongodb.search import format_grep_results, search_database
 from mirage.core.mongodb.stat import stat as _stat
-from mirage.io.stream import exit_on_empty, quiet_match, yield_bytes
+from mirage.io.stream import exit_on_empty, quiet_match
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -196,8 +197,7 @@ async def grep(
                 return b"", IOResult(exit_code=1)
             return "\n".join(all_results).encode(), IOResult()
 
-        data = await rb(paths[0].original)
-        source = yield_bytes(data)
+        source = read_stream(accessor, paths[0], index)
         stream = grep_stream(
             source,
             pat,

--- a/python/mirage/commands/builtin/mongodb/head.py
+++ b/python/mirage/commands/builtin/mongodb/head.py
@@ -65,7 +65,7 @@ async def _head_stream(source: AsyncIterator[bytes], lines: int,
 
 
 async def _head_bytes_static(data: bytes, lines: int,
-                              bytes_mode: int | None) -> AsyncIterator[bytes]:
+                             bytes_mode: int | None) -> AsyncIterator[bytes]:
     if bytes_mode is not None:
         yield data[:bytes_mode]
         return

--- a/python/mirage/commands/builtin/mongodb/head.py
+++ b/python/mirage/commands/builtin/mongodb/head.py
@@ -12,10 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import json
 from collections.abc import AsyncIterator
-
-from bson.json_util import default
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
@@ -23,10 +20,9 @@ from mirage.commands.builtin.mongodb._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
-from mirage.core.mongodb._client import find_documents
 from mirage.core.mongodb.glob import resolve_glob
-from mirage.core.mongodb.read import read as mongodb_read
-from mirage.core.mongodb.scope import detect_scope
+from mirage.core.mongodb.stream import read_stream
+from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -44,23 +40,37 @@ async def head_provision(
                            for p in paths))
 
 
-async def _head_bytes(data: bytes, lines: int,
-                      bytes_mode: int | None) -> AsyncIterator[bytes]:
+async def _head_stream(source: AsyncIterator[bytes], lines: int,
+                       bytes_mode: int | None) -> AsyncIterator[bytes]:
+    if bytes_mode is not None:
+        total = 0
+        async for chunk in source:
+            remaining = bytes_mode - total
+            if remaining <= 0:
+                return
+            if len(chunk) <= remaining:
+                yield chunk
+                total += len(chunk)
+            else:
+                yield chunk[:remaining]
+                return
+        return
+    line_iter = AsyncLineIterator(source)
+    count = 0
+    async for line in line_iter:
+        if count >= lines:
+            return
+        yield line + b"\n"
+        count += 1
+
+
+async def _head_bytes_static(data: bytes, lines: int,
+                              bytes_mode: int | None) -> AsyncIterator[bytes]:
     if bytes_mode is not None:
         yield data[:bytes_mode]
         return
     parts = data.split(b"\n", lines)
     yield b"\n".join(parts[:lines])
-
-
-def _is_single_db(config) -> bool:
-    return config.databases is not None and len(config.databases) == 1
-
-
-def _parse_collection_from_scope(scope, config) -> tuple[str, str] | None:
-    if scope.level == "file" and scope.database and scope.collection:
-        return scope.database, scope.collection
-    return None
 
 
 @command("head",
@@ -80,35 +90,11 @@ async def head(
     lines = int(n) if n is not None else 10
     bytes_mode = int(c) if c is not None else None
     if paths:
-        single_db = _is_single_db(accessor.config)
-        single_db_name = accessor.config.databases[0] if single_db else None
-        scope = detect_scope(paths[0],
-                             single_db=single_db,
-                             single_db_name=single_db_name)
-
-        is_file = (scope.level == "file" and scope.database
-                   and scope.collection)
-        if is_file and not bytes_mode:
-            limit = min(lines, accessor.config.max_doc_limit)
-            docs = await find_documents(
-                accessor.client,
-                scope.database,
-                scope.collection,
-                sort=[("_id", 1)],
-                limit=limit,
-            )
-            for doc in docs:
-                doc["_id"] = str(doc["_id"])
-            jsonl = "\n".join(
-                json.dumps(doc, ensure_ascii=False, default=default)
-                for doc in docs) + "\n"
-            return _head_bytes(jsonl.encode(), lines, None), IOResult()
-
         paths = await resolve_glob(accessor, paths, index=index)
         p = paths[0]
-        data = await mongodb_read(accessor, p, index)
-        return _head_bytes(data, lines, bytes_mode), IOResult()
+        source = read_stream(accessor, p, index)
+        return _head_stream(source, lines, bytes_mode), IOResult()
     raw = await _read_stdin_async(stdin)
     if raw is None:
         raise ValueError("head: missing operand")
-    return _head_bytes(raw, lines, bytes_mode), IOResult()
+    return _head_bytes_static(raw, lines, bytes_mode), IOResult()

--- a/python/mirage/commands/builtin/mongodb/ls.py
+++ b/python/mirage/commands/builtin/mongodb/ls.py
@@ -129,6 +129,7 @@ async def ls(
                 PathSpec(
                     original=cwd.original,
                     directory=cwd.directory,
+                    prefix=cwd.prefix,
                     resolved=False,
                 )
             ]

--- a/python/mirage/commands/builtin/mongodb/rg.py
+++ b/python/mirage/commands/builtin/mongodb/rg.py
@@ -25,7 +25,9 @@ from mirage.core.mongodb.glob import resolve_glob
 from mirage.core.mongodb.read import read as mongodb_read
 from mirage.core.mongodb.readdir import readdir as _readdir
 from mirage.core.mongodb.scope import detect_scope
-from mirage.core.mongodb.search import format_grep_results, search_database
+from mirage.core.mongodb.search import (format_grep_results, search_collection,
+                                        search_database)
+from mirage.core.mongodb.types import ScopeLevel
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -89,8 +91,20 @@ async def rg(
     if paths:
         scope = detect_scope(paths[0])
 
-        if scope.level in ("database", "root"):
-            if scope.level == "database" and scope.database:
+        if scope.level in (ScopeLevel.ENTITY, ScopeLevel.DATABASE,
+                           ScopeLevel.ROOT):
+            entity_match = (scope.level == ScopeLevel.ENTITY and scope.database
+                            and scope.name)
+            if entity_match:
+                docs = await search_collection(
+                    accessor.client,
+                    scope.database,
+                    scope.name,
+                    pattern_str,
+                    limit=limit,
+                )
+                results = [(scope.database, scope.name, docs)] if docs else []
+            elif scope.level == ScopeLevel.DATABASE and scope.database:
                 results = await search_database(
                     accessor.client,
                     scope.database,

--- a/python/mirage/commands/builtin/mongodb/rg.py
+++ b/python/mirage/commands/builtin/mongodb/rg.py
@@ -84,14 +84,10 @@ async def rg(
     pat = compile_pattern(pattern_str, i, F, w)
 
     config = accessor.config
-    single_db = config.databases is not None and len(config.databases) == 1
-    single_db_name = config.databases[0] if single_db else None
     limit = config.default_search_limit
 
     if paths:
-        scope = detect_scope(paths[0],
-                             single_db=single_db,
-                             single_db_name=single_db_name)
+        scope = detect_scope(paths[0])
 
         if scope.level in ("database", "root"):
             if scope.level == "database" and scope.database:

--- a/python/mirage/commands/builtin/mongodb/tail.py
+++ b/python/mirage/commands/builtin/mongodb/tail.py
@@ -12,10 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import json
 from collections.abc import AsyncIterator
-
-from bson.json_util import default
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
@@ -24,10 +21,8 @@ from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
-from mirage.core.mongodb._client import find_documents
 from mirage.core.mongodb.glob import resolve_glob
 from mirage.core.mongodb.read import read as mongodb_read
-from mirage.core.mongodb.scope import detect_scope
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -53,10 +48,6 @@ async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
     yield tail_bytes(raw, lines, plus_mode=plus_mode)
 
 
-def _is_single_db(config) -> bool:
-    return config.databases is not None and len(config.databases) == 1
-
-
 @command("tail",
          resource="mongodb",
          spec=SPECS["tail"],
@@ -76,32 +67,6 @@ async def tail(
     lines, plus_mode = _parse_n(n)
     bytes_mode = int(c) if c is not None else None
     if paths:
-        single_db = _is_single_db(accessor.config)
-        single_db_name = accessor.config.databases[0] if single_db else None
-        scope = detect_scope(paths[0],
-                             single_db=single_db,
-                             single_db_name=single_db_name)
-
-        is_file = (scope.level == "file" and scope.database
-                   and scope.collection)
-        if is_file and not bytes_mode:
-            limit = min(lines, accessor.config.max_doc_limit)
-            docs = await find_documents(
-                accessor.client,
-                scope.database,
-                scope.collection,
-                sort=[("_id", -1)],
-                limit=limit,
-            )
-            docs.reverse()
-            for doc in docs:
-                doc["_id"] = str(doc["_id"])
-            jsonl = "\n".join(
-                json.dumps(doc, ensure_ascii=False, default=default)
-                for doc in docs) + "\n"
-            return _tail_result(jsonl.encode(), lines, plus_mode,
-                                None), IOResult()
-
         paths = await resolve_glob(accessor, paths, index=index)
         p = paths[0]
         raw = await mongodb_read(accessor, p, index)

--- a/python/mirage/commands/builtin/mongodb/tail.py
+++ b/python/mirage/commands/builtin/mongodb/tail.py
@@ -23,6 +23,8 @@ from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.mongodb.glob import resolve_glob
 from mirage.core.mongodb.read import read as mongodb_read
+from mirage.core.mongodb.scope import detect_scope
+from mirage.core.mongodb.stream import watch_stream
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -61,6 +63,7 @@ async def tail(
     c: str | None = None,
     q: bool = False,
     v: bool = False,
+    f: bool = False,
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
@@ -69,6 +72,8 @@ async def tail(
     if paths:
         paths = await resolve_glob(accessor, paths, index=index)
         p = paths[0]
+        if f and detect_scope(p).level == "documents":
+            return watch_stream(accessor, p, index), IOResult()
         raw = await mongodb_read(accessor, p, index)
         return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
     raw = await _read_stdin_async(stdin)

--- a/python/mirage/commands/builtin/mongodb/tail.py
+++ b/python/mirage/commands/builtin/mongodb/tail.py
@@ -25,6 +25,7 @@ from mirage.core.mongodb.glob import resolve_glob
 from mirage.core.mongodb.read import read as mongodb_read
 from mirage.core.mongodb.scope import detect_scope
 from mirage.core.mongodb.stream import watch_stream
+from mirage.core.mongodb.types import ScopeLevel
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -72,7 +73,7 @@ async def tail(
     if paths:
         paths = await resolve_glob(accessor, paths, index=index)
         p = paths[0]
-        if f and detect_scope(p).level == "documents":
+        if f and detect_scope(p).level == ScopeLevel.DOCUMENTS:
             return watch_stream(accessor, p, index), IOResult()
         raw = await mongodb_read(accessor, p, index)
         return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()

--- a/python/mirage/commands/builtin/mongodb/wc.py
+++ b/python/mirage/commands/builtin/mongodb/wc.py
@@ -20,6 +20,7 @@ from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.mongodb._client import count_documents
 from mirage.core.mongodb.glob import resolve_glob
+from mirage.core.mongodb.read import read as mongodb_read
 from mirage.core.mongodb.scope import detect_scope
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
@@ -36,10 +37,6 @@ async def wc_provision(
         accessor, paths,
         "wc " + " ".join(p.original if isinstance(p, PathSpec) else p
                          for p in paths))
-
-
-def _is_single_db(config) -> bool:
-    return (config.databases is not None and len(config.databases) == 1)
 
 
 @command("wc", resource="mongodb", spec=SPECS["wc"], provision=wc_provision)
@@ -65,30 +62,22 @@ async def wc(
     if not paths:
         raise ValueError("wc: missing operand")
 
-    single_db = _is_single_db(accessor.config)
-    dbs = accessor.config.databases
-    single_db_name = dbs[0] if single_db else None
-    scope = detect_scope(
-        paths[0],
-        single_db=single_db,
-        single_db_name=single_db_name,
-    )
+    scope = detect_scope(paths[0])
 
-    if scope.level == "file" and scope.database and scope.collection:
-        count = await count_documents(
-            accessor.client,
-            scope.database,
-            scope.collection,
-        )
+    if scope.level == "documents" and scope.database and scope.name:
         if c:
             paths = await resolve_glob(accessor, paths)
-            from mirage.core.mongodb.read import read
-            data = await read(
+            data = await mongodb_read(
                 accessor,
-                paths[0].original,
+                paths[0],
                 _extra.get("index"),
             )
             return str(len(data)).encode(), IOResult()
+        count = await count_documents(
+            accessor.client,
+            scope.database,
+            scope.name,
+        )
         return str(count).encode(), IOResult()
 
-    raise ValueError("wc: path must target a collection file")
+    raise ValueError("wc: path must target documents.jsonl")

--- a/python/mirage/commands/builtin/mongodb/wc.py
+++ b/python/mirage/commands/builtin/mongodb/wc.py
@@ -22,6 +22,7 @@ from mirage.core.mongodb._client import count_documents
 from mirage.core.mongodb.glob import resolve_glob
 from mirage.core.mongodb.read import read as mongodb_read
 from mirage.core.mongodb.scope import detect_scope
+from mirage.core.mongodb.types import ScopeLevel
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -64,7 +65,7 @@ async def wc(
 
     scope = detect_scope(paths[0])
 
-    if scope.level == "documents" and scope.database and scope.name:
+    if scope.level == ScopeLevel.DOCUMENTS and scope.database and scope.name:
         if c:
             paths = await resolve_glob(accessor, paths)
             data = await mongodb_read(

--- a/python/mirage/commands/spec/builtin_specs.py
+++ b/python/mirage/commands/spec/builtin_specs.py
@@ -121,6 +121,7 @@ SPECS: dict[str, CommandSpec] = {
             Option(short="-c", value_kind=OperandKind.TEXT),
             Option(short="-q"),
             Option(short="-v"),
+            Option(short="-f", long="--follow"),
         ),
         rest=Operand(kind=OperandKind.PATH),
     ),

--- a/python/mirage/core/mongodb/_client.py
+++ b/python/mirage/core/mongodb/_client.py
@@ -69,7 +69,8 @@ async def entity_exists(
     if not await database_exists(client, config, database, accessor):
         return False
     if accessor is not None:
-        key = f"list_collections:{database}:{kind.value if kind is not None else ''}"
+        suffix = kind.value if kind is not None else ""
+        key = f"list_collections:{database}:{suffix}"
         names = await accessor.cached_list(
             key,
             lambda: list_collections(client, database, kind),

--- a/python/mirage/core/mongodb/_client.py
+++ b/python/mirage/core/mongodb/_client.py
@@ -91,6 +91,20 @@ async def count_documents(
     return await col.count_documents(filter or {})
 
 
+async def iter_inserts(
+    client: AsyncIOMotorClient,
+    database: str,
+    collection: str,
+) -> AsyncIterator[dict]:
+    col = client[database][collection]
+    pipeline = [{"$match": {"operationType": "insert"}}]
+    async with col.watch(pipeline) as stream:
+        async for change in stream:
+            doc = change.get("fullDocument")
+            if doc is not None:
+                yield doc
+
+
 async def is_view(
     client: AsyncIOMotorClient,
     database: str,

--- a/python/mirage/core/mongodb/_client.py
+++ b/python/mirage/core/mongodb/_client.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from collections.abc import AsyncIterator
+
 from motor.motor_asyncio import AsyncIOMotorClient
 
 from mirage.resource.mongodb.config import MongoDBConfig
@@ -49,6 +51,25 @@ async def find_documents(
         cursor = cursor.sort(sort)
     cursor = cursor.limit(limit)
     return await cursor.to_list(length=limit)
+
+
+async def iter_documents(
+    client: AsyncIOMotorClient,
+    database: str,
+    collection: str,
+    filter: dict | None = None,
+    projection: dict | None = None,
+    sort: list[tuple[str, int]] | None = None,
+    batch_size: int = 100,
+) -> AsyncIterator[dict]:
+    db = client[database]
+    col = db[collection]
+    cursor = col.find(filter or {}, projection)
+    if sort:
+        cursor = cursor.sort(sort)
+    cursor = cursor.batch_size(batch_size)
+    async for doc in cursor:
+        yield doc
 
 
 async def count_documents(

--- a/python/mirage/core/mongodb/_client.py
+++ b/python/mirage/core/mongodb/_client.py
@@ -83,13 +83,26 @@ async def count_documents(
     return await col.count_documents(filter or {})
 
 
+async def is_view(
+    client: AsyncIOMotorClient,
+    database: str,
+    collection: str,
+) -> bool:
+    db = client[database]
+    cursor = await db.list_collections(filter={"name": collection})
+    async for spec in cursor:
+        return spec.get("type") == "view"
+    return False
+
+
 async def get_indexes(
     client: AsyncIOMotorClient,
     database: str,
     collection: str,
 ) -> list[dict]:
-    db = client[database]
-    col = db[collection]
+    if await is_view(client, database, collection):
+        return []
+    col = client[database][collection]
     indexes = []
     async for idx in col.list_indexes():
         indexes.append(idx)

--- a/python/mirage/core/mongodb/_client.py
+++ b/python/mirage/core/mongodb/_client.py
@@ -107,3 +107,28 @@ async def get_indexes(
     async for idx in col.list_indexes():
         indexes.append(idx)
     return indexes
+
+
+async def get_validator(
+    client: AsyncIOMotorClient,
+    database: str,
+    collection: str,
+) -> dict | None:
+    db = client[database]
+    cursor = await db.list_collections(filter={"name": collection})
+    async for spec in cursor:
+        validator = spec.get("options", {}).get("validator", {})
+        return validator.get("$jsonSchema")
+    return None
+
+
+async def get_index_stats(
+    client: AsyncIOMotorClient,
+    database: str,
+    collection: str,
+) -> dict[str, dict]:
+    col = client[database][collection]
+    out: dict[str, dict] = {}
+    async for doc in col.aggregate([{"$indexStats": {}}]):
+        out[doc["name"]] = doc.get("accesses", {})
+    return out

--- a/python/mirage/core/mongodb/_client.py
+++ b/python/mirage/core/mongodb/_client.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncIterator
 
 from motor.motor_asyncio import AsyncIOMotorClient
 
+from mirage.core.mongodb.types import EntityKind
 from mirage.resource.mongodb.config import MongoDBConfig
 
 
@@ -32,14 +33,12 @@ async def list_databases(client: AsyncIOMotorClient,
 async def list_collections(
     client: AsyncIOMotorClient,
     database: str,
-    kind: str | None = None,
+    kind: EntityKind | None = None,
 ) -> list[str]:
     db = client[database]
     filter_arg: dict | None = None
-    if kind == "collection":
-        filter_arg = {"type": "collection"}
-    elif kind == "view":
-        filter_arg = {"type": "view"}
+    if kind is not None:
+        filter_arg = {"type": kind.value}
     return sorted(await db.list_collection_names(filter=filter_arg))
 
 
@@ -113,7 +112,7 @@ async def is_view(
     db = client[database]
     cursor = await db.list_collections(filter={"name": collection})
     async for spec in cursor:
-        return spec.get("type") == "view"
+        return spec.get("type") == EntityKind.VIEW
     return False
 
 

--- a/python/mirage/core/mongodb/_client.py
+++ b/python/mirage/core/mongodb/_client.py
@@ -29,10 +29,18 @@ async def list_databases(client: AsyncIOMotorClient,
     return sorted(dbs)
 
 
-async def list_collections(client: AsyncIOMotorClient,
-                           database: str) -> list[str]:
+async def list_collections(
+    client: AsyncIOMotorClient,
+    database: str,
+    kind: str | None = None,
+) -> list[str]:
     db = client[database]
-    return sorted(await db.list_collection_names())
+    filter_arg: dict | None = None
+    if kind == "collection":
+        filter_arg = {"type": "collection"}
+    elif kind == "view":
+        filter_arg = {"type": "view"}
+    return sorted(await db.list_collection_names(filter=filter_arg))
 
 
 async def find_documents(

--- a/python/mirage/core/mongodb/_client.py
+++ b/python/mirage/core/mongodb/_client.py
@@ -42,6 +42,43 @@ async def list_collections(
     return sorted(await db.list_collection_names(filter=filter_arg))
 
 
+async def database_exists(
+    client: AsyncIOMotorClient,
+    config: MongoDBConfig,
+    database: str,
+    accessor: object | None = None,
+) -> bool:
+    if accessor is not None:
+        dbs = await accessor.cached_list(
+            "list_databases",
+            lambda: list_databases(client, config),
+        )
+    else:
+        dbs = await list_databases(client, config)
+    return database in dbs
+
+
+async def entity_exists(
+    client: AsyncIOMotorClient,
+    config: MongoDBConfig,
+    database: str,
+    name: str,
+    kind: EntityKind | None = None,
+    accessor: object | None = None,
+) -> bool:
+    if not await database_exists(client, config, database, accessor):
+        return False
+    if accessor is not None:
+        key = f"list_collections:{database}:{kind.value if kind is not None else ''}"
+        names = await accessor.cached_list(
+            key,
+            lambda: list_collections(client, database, kind),
+        )
+    else:
+        names = await list_collections(client, database, kind)
+    return name in names
+
+
 async def find_documents(
     client: AsyncIOMotorClient,
     database: str,

--- a/python/mirage/core/mongodb/_sampler.py
+++ b/python/mirage/core/mongodb/_sampler.py
@@ -1,0 +1,100 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import datetime as dt
+from collections.abc import Iterable
+
+from bson import Binary, Decimal128, Int64, ObjectId, Regex, Timestamp
+
+
+def _bump(counts: dict[str, dict[str, int]], path: str, tag: str) -> None:
+    counts.setdefault(path, {})
+    counts[path][tag] = counts[path].get(tag, 0) + 1
+
+
+def _scalar_tag(v) -> str:
+    if isinstance(v, bool):
+        return "bool"
+    if isinstance(v, Int64):
+        return "long"
+    if isinstance(v, int):
+        return "int"
+    if isinstance(v, float):
+        return "double"
+    if isinstance(v, str):
+        return "string"
+    if isinstance(v, ObjectId):
+        return "objectId"
+    if isinstance(v, Decimal128):
+        return "decimal"
+    if isinstance(v, dt.datetime):
+        return "date"
+    if isinstance(v, Timestamp):
+        return "timestamp"
+    if isinstance(v, Binary):
+        return "binary"
+    if isinstance(v, Regex):
+        return "regex"
+    if v is None:
+        return "null"
+    return type(v).__name__
+
+
+def _array_tag(items: Iterable) -> str:
+    items = list(items)
+    if not items:
+        return "array"
+    if all(
+            isinstance(x, (int, float)) and not isinstance(x, bool)
+            for x in items):
+        return f"array<double>({len(items)})"
+    if all(isinstance(x, str) for x in items):
+        return "array<string>"
+    return "array"
+
+
+def _walk(value, prefix: str, counts: dict[str, dict[str, int]]) -> None:
+    if isinstance(value, dict):
+        if prefix:
+            _bump(counts, prefix, "object")
+        for k, v in value.items():
+            _walk(v, f"{prefix}.{k}" if prefix else k, counts)
+        return
+    if isinstance(value, list):
+        _bump(counts, prefix, _array_tag(value))
+        return
+    if prefix:
+        _bump(counts, prefix, _scalar_tag(value))
+
+
+async def sample_field_types(col, sample_size: int = 100) -> list[dict]:
+    counts: dict[str, dict[str, int]] = {}
+    total = 0
+    async for doc in col.aggregate([{"$sample": {"size": sample_size}}]):
+        total += 1
+        _walk(doc, "", counts)
+    if total == 0:
+        return []
+    fields: list[dict] = []
+    for path, type_counts in sorted(counts.items()):
+        if path == "_id":
+            continue
+        presence_count = sum(type_counts.values())
+        fields.append({
+            "path": path,
+            "presence": presence_count / total,
+            "types": {t: c / total
+                      for t, c in type_counts.items()},
+        })
+    return fields

--- a/python/mirage/core/mongodb/_sampler.py
+++ b/python/mirage/core/mongodb/_sampler.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable
 
 from bson import Binary, Decimal128, Int64, ObjectId, Regex, Timestamp
 
-from mirage.core.mongodb.types import PRIMARY_KEY
+from mirage.core.mongodb.types import PRIMARY_KEY, BsonTypeTag
 
 
 def _bump(counts: dict[str, dict[str, int]], path: str, tag: str) -> None:
@@ -27,49 +27,49 @@ def _bump(counts: dict[str, dict[str, int]], path: str, tag: str) -> None:
 
 def _scalar_tag(v) -> str:
     if isinstance(v, bool):
-        return "bool"
+        return BsonTypeTag.BOOL
     if isinstance(v, Int64):
-        return "long"
+        return BsonTypeTag.LONG
     if isinstance(v, int):
-        return "int"
+        return BsonTypeTag.INT
     if isinstance(v, float):
-        return "double"
+        return BsonTypeTag.DOUBLE
     if isinstance(v, str):
-        return "string"
+        return BsonTypeTag.STRING
     if isinstance(v, ObjectId):
-        return "objectId"
+        return BsonTypeTag.OBJECT_ID
     if isinstance(v, Decimal128):
-        return "decimal"
+        return BsonTypeTag.DECIMAL
     if isinstance(v, dt.datetime):
-        return "date"
+        return BsonTypeTag.DATE
     if isinstance(v, Timestamp):
-        return "timestamp"
+        return BsonTypeTag.TIMESTAMP
     if isinstance(v, Binary):
-        return "binary"
+        return BsonTypeTag.BINARY
     if isinstance(v, Regex):
-        return "regex"
+        return BsonTypeTag.REGEX
     if v is None:
-        return "null"
+        return BsonTypeTag.NULL
     return type(v).__name__
 
 
 def _array_tag(items: Iterable) -> str:
     items = list(items)
     if not items:
-        return "array"
+        return BsonTypeTag.ARRAY
     if all(
             isinstance(x, (int, float)) and not isinstance(x, bool)
             for x in items):
-        return f"array<double>({len(items)})"
+        return f"array<{BsonTypeTag.DOUBLE}>({len(items)})"
     if all(isinstance(x, str) for x in items):
-        return "array<string>"
-    return "array"
+        return f"array<{BsonTypeTag.STRING}>"
+    return BsonTypeTag.ARRAY
 
 
 def _walk(value, prefix: str, counts: dict[str, dict[str, int]]) -> None:
     if isinstance(value, dict):
         if prefix:
-            _bump(counts, prefix, "object")
+            _bump(counts, prefix, BsonTypeTag.OBJECT)
         for k, v in value.items():
             _walk(v, f"{prefix}.{k}" if prefix else k, counts)
         return

--- a/python/mirage/core/mongodb/_sampler.py
+++ b/python/mirage/core/mongodb/_sampler.py
@@ -94,7 +94,9 @@ async def sample_field_types(col, sample_size: int = 100) -> list[dict]:
         fields.append({
             "path": path,
             "presence": presence_count / total,
-            "types": {t: c / total
-                      for t, c in type_counts.items()},
+            "types": {
+                t: c / total
+                for t, c in type_counts.items()
+            },
         })
     return fields

--- a/python/mirage/core/mongodb/_sampler.py
+++ b/python/mirage/core/mongodb/_sampler.py
@@ -17,6 +17,8 @@ from collections.abc import Iterable
 
 from bson import Binary, Decimal128, Int64, ObjectId, Regex, Timestamp
 
+from mirage.core.mongodb.types import PRIMARY_KEY
+
 
 def _bump(counts: dict[str, dict[str, int]], path: str, tag: str) -> None:
     counts.setdefault(path, {})
@@ -88,7 +90,7 @@ async def sample_field_types(col, sample_size: int = 100) -> list[dict]:
         return []
     fields: list[dict] = []
     for path, type_counts in sorted(counts.items()):
-        if path == "_id":
+        if path == PRIMARY_KEY:
             continue
         presence_count = sum(type_counts.values())
         fields.append({

--- a/python/mirage/core/mongodb/_schema_json.py
+++ b/python/mirage/core/mongodb/_schema_json.py
@@ -1,0 +1,59 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.mongodb import MongoDBAccessor
+from mirage.core.mongodb._client import (count_documents, get_index_stats,
+                                          get_indexes, get_validator, is_view)
+from mirage.core.mongodb._sampler import sample_field_types
+
+
+def _index_type(idx: dict) -> str:
+    if "textIndexVersion" in idx:
+        return "text"
+    return "btree"
+
+
+async def build_collection_schema_json(
+    accessor: MongoDBAccessor,
+    database: str,
+    collection: str,
+    sample_size: int = 100,
+) -> dict:
+    col = accessor.client[database][collection]
+    view = await is_view(accessor.client, database, collection)
+    validator = await get_validator(accessor.client, database, collection)
+    fields = await sample_field_types(col, sample_size=sample_size)
+    doc_count = await count_documents(accessor.client, database, collection)
+    if view:
+        enriched_indexes: list[dict] = []
+    else:
+        indexes = await get_indexes(accessor.client, database, collection)
+        stats = await get_index_stats(accessor.client, database, collection)
+        enriched_indexes = [{
+            "name": idx.get("name"),
+            "keys": dict(idx.get("key", {})),
+            "type": _index_type(idx),
+            "stats": stats.get(idx.get("name"), {}),
+        } for idx in indexes]
+    return {
+        "database": database,
+        "name": collection,
+        "kind": "view" if view else "collection",
+        "validator": validator,
+        "fields": fields,
+        "primary_key": "_id",
+        "indexes": enriched_indexes,
+        "document_count": doc_count,
+        "sampled": sample_size,
+    }

--- a/python/mirage/core/mongodb/_schema_json.py
+++ b/python/mirage/core/mongodb/_schema_json.py
@@ -14,7 +14,8 @@
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.core.mongodb._client import (count_documents, get_index_stats,
-                                          get_indexes, get_validator, is_view)
+                                          get_indexes, get_validator, is_view,
+                                          list_collections)
 from mirage.core.mongodb._sampler import sample_field_types
 
 
@@ -22,6 +23,29 @@ def _index_type(idx: dict) -> str:
     if "textIndexVersion" in idx:
         return "text"
     return "btree"
+
+
+async def build_database_json(
+    accessor: MongoDBAccessor,
+    database: str,
+) -> dict:
+    all_names = await list_collections(accessor.client, database)
+    collections: list[dict] = []
+    views: list[dict] = []
+    for name in all_names:
+        if await is_view(accessor.client, database, name):
+            views.append({"name": name})
+        else:
+            doc_count = await count_documents(accessor.client, database, name)
+            collections.append({
+                "name": name,
+                "document_count": doc_count,
+            })
+    return {
+        "database": database,
+        "collections": collections,
+        "views": views,
+    }
 
 
 async def build_collection_schema_json(

--- a/python/mirage/core/mongodb/_schema_json.py
+++ b/python/mirage/core/mongodb/_schema_json.py
@@ -17,13 +17,13 @@ from mirage.core.mongodb._client import (count_documents, get_index_stats,
                                          get_indexes, get_validator, is_view,
                                          list_collections)
 from mirage.core.mongodb._sampler import sample_field_types
-from mirage.core.mongodb.types import PRIMARY_KEY, EntityKind
+from mirage.core.mongodb.types import PRIMARY_KEY, EntityKind, IndexType
 
 
 def _index_type(idx: dict) -> str:
     if "textIndexVersion" in idx:
-        return "text"
-    return "btree"
+        return IndexType.TEXT
+    return IndexType.BTREE
 
 
 async def build_database_json(

--- a/python/mirage/core/mongodb/_schema_json.py
+++ b/python/mirage/core/mongodb/_schema_json.py
@@ -17,6 +17,7 @@ from mirage.core.mongodb._client import (count_documents, get_index_stats,
                                          get_indexes, get_validator, is_view,
                                          list_collections)
 from mirage.core.mongodb._sampler import sample_field_types
+from mirage.core.mongodb.types import PRIMARY_KEY, EntityKind
 
 
 def _index_type(idx: dict) -> str:
@@ -73,10 +74,10 @@ async def build_collection_schema_json(
     return {
         "database": database,
         "name": collection,
-        "kind": "view" if view else "collection",
+        "kind": EntityKind.VIEW if view else EntityKind.COLLECTION,
         "validator": validator,
         "fields": fields,
-        "primary_key": "_id",
+        "primary_key": PRIMARY_KEY,
         "indexes": enriched_indexes,
         "document_count": doc_count,
         "sampled": sample_size,

--- a/python/mirage/core/mongodb/_schema_json.py
+++ b/python/mirage/core/mongodb/_schema_json.py
@@ -14,8 +14,8 @@
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.core.mongodb._client import (count_documents, get_index_stats,
-                                          get_indexes, get_validator, is_view,
-                                          list_collections)
+                                         get_indexes, get_validator, is_view,
+                                         list_collections)
 from mirage.core.mongodb._sampler import sample_field_types
 
 

--- a/python/mirage/core/mongodb/read.py
+++ b/python/mirage/core/mongodb/read.py
@@ -12,8 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from bson.json_util import RELAXED_JSON_OPTIONS, dumps
+
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.core.mongodb._schema_json import (build_collection_schema_json,
+                                                build_database_json)
+from mirage.core.mongodb.scope import detect_scope
 from mirage.core.mongodb.stream import read_stream
 from mirage.types import PathSpec
 
@@ -23,7 +28,21 @@ async def read(
     path: PathSpec,
     index: IndexCacheStore = None,
 ) -> bytes:
-    chunks: list[bytes] = []
-    async for chunk in read_stream(accessor, path, index):
-        chunks.append(chunk)
-    return b"".join(chunks)
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    scope = detect_scope(path)
+    if scope.level == "documents":
+        chunks: list[bytes] = []
+        async for chunk in read_stream(accessor, path, index):
+            chunks.append(chunk)
+        return b"".join(chunks)
+    if scope.level == "schema_json":
+        payload = await build_collection_schema_json(accessor, scope.database,
+                                                      scope.name)
+        return (dumps(payload, json_options=RELAXED_JSON_OPTIONS) +
+                "\n").encode()
+    if scope.level == "database_json":
+        payload = await build_database_json(accessor, scope.database)
+        return (dumps(payload, json_options=RELAXED_JSON_OPTIONS) +
+                "\n").encode()
+    raise FileNotFoundError(path.original)

--- a/python/mirage/core/mongodb/read.py
+++ b/python/mirage/core/mongodb/read.py
@@ -16,6 +16,7 @@ from bson.json_util import RELAXED_JSON_OPTIONS, dumps
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.core.mongodb._client import database_exists, entity_exists
 from mirage.core.mongodb._schema_json import (build_collection_schema_json,
                                               build_database_json)
 from mirage.core.mongodb.scope import detect_scope
@@ -33,16 +34,27 @@ async def read(
         path = PathSpec(original=path, directory=path)
     scope = detect_scope(path)
     if scope.level == ScopeLevel.DOCUMENTS:
+        if not await entity_exists(accessor.client, accessor.config,
+                                   scope.database, scope.name, scope.kind,
+                                   accessor):
+            raise FileNotFoundError(path.original)
         chunks: list[bytes] = []
         async for chunk in read_stream(accessor, path, index):
             chunks.append(chunk)
         return b"".join(chunks)
     if scope.level == ScopeLevel.SCHEMA_JSON:
+        if not await entity_exists(accessor.client, accessor.config,
+                                   scope.database, scope.name, scope.kind,
+                                   accessor):
+            raise FileNotFoundError(path.original)
         payload = await build_collection_schema_json(accessor, scope.database,
                                                      scope.name)
         return (dumps(payload, json_options=RELAXED_JSON_OPTIONS) +
                 "\n").encode()
     if scope.level == ScopeLevel.DATABASE_JSON:
+        if not await database_exists(accessor.client, accessor.config,
+                                     scope.database, accessor):
+            raise FileNotFoundError(path.original)
         payload = await build_database_json(accessor, scope.database)
         return (dumps(payload, json_options=RELAXED_JSON_OPTIONS) +
                 "\n").encode()

--- a/python/mirage/core/mongodb/read.py
+++ b/python/mirage/core/mongodb/read.py
@@ -17,9 +17,10 @@ from bson.json_util import RELAXED_JSON_OPTIONS, dumps
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.mongodb._schema_json import (build_collection_schema_json,
-                                                build_database_json)
+                                              build_database_json)
 from mirage.core.mongodb.scope import detect_scope
 from mirage.core.mongodb.stream import read_stream
+from mirage.core.mongodb.types import ScopeLevel
 from mirage.types import PathSpec
 
 
@@ -31,17 +32,17 @@ async def read(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     scope = detect_scope(path)
-    if scope.level == "documents":
+    if scope.level == ScopeLevel.DOCUMENTS:
         chunks: list[bytes] = []
         async for chunk in read_stream(accessor, path, index):
             chunks.append(chunk)
         return b"".join(chunks)
-    if scope.level == "schema_json":
+    if scope.level == ScopeLevel.SCHEMA_JSON:
         payload = await build_collection_schema_json(accessor, scope.database,
-                                                      scope.name)
+                                                     scope.name)
         return (dumps(payload, json_options=RELAXED_JSON_OPTIONS) +
                 "\n").encode()
-    if scope.level == "database_json":
+    if scope.level == ScopeLevel.DATABASE_JSON:
         payload = await build_database_json(accessor, scope.database)
         return (dumps(payload, json_options=RELAXED_JSON_OPTIONS) +
                 "\n").encode()

--- a/python/mirage/core/mongodb/read.py
+++ b/python/mirage/core/mongodb/read.py
@@ -12,24 +12,10 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import json
-
-from bson.json_util import default
-
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.core.mongodb._client import find_documents
+from mirage.core.mongodb.stream import read_stream
 from mirage.types import PathSpec
-
-
-def _parse_collection_path(key: str, config) -> tuple[str, str]:
-    single_db = config.databases is not None and len(config.databases) == 1
-    parts = key.split("/")
-    if single_db and len(parts) == 1 and parts[0].endswith(".jsonl"):
-        return config.databases[0], parts[0].removesuffix(".jsonl")
-    if len(parts) == 2 and parts[1].endswith(".jsonl"):
-        return parts[0], parts[1].removesuffix(".jsonl")
-    raise FileNotFoundError(key)
 
 
 async def read(
@@ -37,40 +23,7 @@ async def read(
     path: PathSpec,
     index: IndexCacheStore = None,
 ) -> bytes:
-    """Read a collection as JSONL.
-
-    Args:
-        accessor (MongoDBAccessor): mongodb accessor.
-        path (str): resource-relative path.
-        index (IndexCacheStore | None): index cache.
-        prefix (str): mount prefix for virtual index keys.
-    """
-    if isinstance(path, str):
-        path = PathSpec(original=path, directory=path)
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        path = path[len(prefix):] or "/"
-    key = path.strip("/")
-
-    if any(p.startswith(".") for p in key.split("/")):
-        raise FileNotFoundError(path)
-
-    db_name, col_name = _parse_collection_path(key, accessor.config)
-    limit = accessor.config.default_doc_limit
-    docs = await find_documents(
-        accessor.client,
-        db_name,
-        col_name,
-        sort=[("_id", 1)],
-        limit=limit,
-    )
-    lines = []
-    for doc in docs:
-        doc["_id"] = str(doc["_id"])
-        lines.append(json.dumps(doc, ensure_ascii=False, default=default))
-    if not lines:
-        return b""
-    return ("\n".join(lines) + "\n").encode()
+    chunks: list[bytes] = []
+    async for chunk in read_stream(accessor, path, index):
+        chunks.append(chunk)
+    return b"".join(chunks)

--- a/python/mirage/core/mongodb/readdir.py
+++ b/python/mirage/core/mongodb/readdir.py
@@ -14,7 +14,8 @@
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore, IndexEntry
-from mirage.core.mongodb._client import list_collections, list_databases
+from mirage.core.mongodb._client import (database_exists, entity_exists,
+                                         list_collections, list_databases)
 from mirage.core.mongodb.scope import detect_scope
 from mirage.core.mongodb.types import (KIND_TO_DIR, KIND_TO_RESOURCE_TYPE,
                                        RESOURCE_TYPE_DATABASE, EntityKind,
@@ -37,6 +38,9 @@ async def readdir(
         return await _list_root(accessor, virtual_key, index, prefix)
 
     if scope.level == ScopeLevel.DATABASE:
+        if not await database_exists(accessor.client, accessor.config,
+                                     scope.database, accessor):
+            raise FileNotFoundError(path.original)
         base = f"{prefix}/{scope.database}"
         return [
             f"{base}/database.json",
@@ -45,10 +49,17 @@ async def readdir(
         ]
 
     if scope.level == ScopeLevel.KIND_DIR:
+        if not await database_exists(accessor.client, accessor.config,
+                                     scope.database, accessor):
+            raise FileNotFoundError(path.original)
         return await _list_kind_dir(accessor, scope.database, scope.kind,
                                     virtual_key, index, prefix)
 
     if scope.level == ScopeLevel.ENTITY:
+        if not await entity_exists(accessor.client, accessor.config,
+                                   scope.database, scope.name, scope.kind,
+                                   accessor):
+            raise FileNotFoundError(path.original)
         base = (f"{prefix}/{scope.database}/"
                 f"{KIND_TO_DIR[scope.kind]}/{scope.name}")
         return [

--- a/python/mirage/core/mongodb/readdir.py
+++ b/python/mirage/core/mongodb/readdir.py
@@ -15,16 +15,17 @@
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.core.mongodb._client import list_collections, list_databases
-from mirage.core.mongodb.scope import MongoEntityKind, detect_scope
+from mirage.core.mongodb.scope import detect_scope
+from mirage.core.mongodb.types import EntityKind, ScopeLevel
 from mirage.types import PathSpec
 
-_KIND_TO_DIR: dict[MongoEntityKind, str] = {
-    "collection": "collections",
-    "view": "views",
+_KIND_TO_DIR: dict[EntityKind, str] = {
+    EntityKind.COLLECTION: "collections",
+    EntityKind.VIEW: "views",
 }
-_KIND_RESOURCE_TYPE: dict[MongoEntityKind, str] = {
-    "collection": "mongodb/collection",
-    "view": "mongodb/view",
+_KIND_RESOURCE_TYPE: dict[EntityKind, str] = {
+    EntityKind.COLLECTION: "mongodb/collection",
+    EntityKind.VIEW: "mongodb/view",
 }
 
 
@@ -39,10 +40,10 @@ async def readdir(
     scope = detect_scope(path)
     virtual_key = (prefix + scope.resource_path).rstrip("/") or "/"
 
-    if scope.level == "root":
+    if scope.level == ScopeLevel.ROOT:
         return await _list_root(accessor, virtual_key, index, prefix)
 
-    if scope.level == "database":
+    if scope.level == ScopeLevel.DATABASE:
         base = f"{prefix}/{scope.database}"
         return [
             f"{base}/database.json",
@@ -50,11 +51,11 @@ async def readdir(
             f"{base}/views",
         ]
 
-    if scope.level == "kind_dir":
+    if scope.level == ScopeLevel.KIND_DIR:
         return await _list_kind_dir(accessor, scope.database, scope.kind,
-                                     virtual_key, index, prefix)
+                                    virtual_key, index, prefix)
 
-    if scope.level == "entity":
+    if scope.level == ScopeLevel.ENTITY:
         base = (f"{prefix}/{scope.database}/"
                 f"{_KIND_TO_DIR[scope.kind]}/{scope.name}")
         return [
@@ -95,7 +96,7 @@ async def _list_root(
 async def _list_kind_dir(
     accessor: MongoDBAccessor,
     database: str,
-    kind: MongoEntityKind,
+    kind: EntityKind,
     virtual_key: str,
     index: IndexCacheStore | None,
     prefix: str,

--- a/python/mirage/core/mongodb/readdir.py
+++ b/python/mirage/core/mongodb/readdir.py
@@ -16,17 +16,10 @@ from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.core.mongodb._client import list_collections, list_databases
 from mirage.core.mongodb.scope import detect_scope
-from mirage.core.mongodb.types import EntityKind, ScopeLevel
+from mirage.core.mongodb.types import (KIND_TO_DIR, KIND_TO_RESOURCE_TYPE,
+                                       RESOURCE_TYPE_DATABASE, EntityKind,
+                                       ScopeLevel)
 from mirage.types import PathSpec
-
-_KIND_TO_DIR: dict[EntityKind, str] = {
-    EntityKind.COLLECTION: "collections",
-    EntityKind.VIEW: "views",
-}
-_KIND_RESOURCE_TYPE: dict[EntityKind, str] = {
-    EntityKind.COLLECTION: "mongodb/collection",
-    EntityKind.VIEW: "mongodb/view",
-}
 
 
 async def readdir(
@@ -57,7 +50,7 @@ async def readdir(
 
     if scope.level == ScopeLevel.ENTITY:
         base = (f"{prefix}/{scope.database}/"
-                f"{_KIND_TO_DIR[scope.kind]}/{scope.name}")
+                f"{KIND_TO_DIR[scope.kind]}/{scope.name}")
         return [
             f"{base}/schema.json",
             f"{base}/documents.jsonl",
@@ -83,7 +76,7 @@ async def _list_root(
         entry = IndexEntry(
             id=db_name,
             name=db_name,
-            resource_type="mongodb/database",
+            resource_type=RESOURCE_TYPE_DATABASE,
             vfs_name=db_name,
         )
         entries.append((db_name, entry))
@@ -106,14 +99,14 @@ async def _list_kind_dir(
         if listing.entries is not None:
             return listing.entries
     names = await list_collections(accessor.client, database, kind=kind)
-    base = f"{prefix}/{database}/{_KIND_TO_DIR[kind]}"
+    base = f"{prefix}/{database}/{KIND_TO_DIR[kind]}"
     entries: list[tuple[str, IndexEntry]] = []
     out: list[str] = []
     for name in names:
         entry = IndexEntry(
             id=name,
             name=name,
-            resource_type=_KIND_RESOURCE_TYPE[kind],
+            resource_type=KIND_TO_RESOURCE_TYPE[kind],
             vfs_name=name,
         )
         entries.append((name, entry))

--- a/python/mirage/core/mongodb/readdir.py
+++ b/python/mirage/core/mongodb/readdir.py
@@ -15,11 +15,17 @@
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.core.mongodb._client import list_collections, list_databases
+from mirage.core.mongodb.scope import MongoEntityKind, detect_scope
 from mirage.types import PathSpec
 
-
-def _is_single_db(config) -> bool:
-    return config.databases is not None and len(config.databases) == 1
+_KIND_TO_DIR: dict[MongoEntityKind, str] = {
+    "collection": "collections",
+    "view": "views",
+}
+_KIND_RESOURCE_TYPE: dict[MongoEntityKind, str] = {
+    "collection": "mongodb/collection",
+    "view": "mongodb/view",
+}
 
 
 async def readdir(
@@ -27,74 +33,40 @@ async def readdir(
     path: PathSpec,
     index: IndexCacheStore = None,
 ) -> list[str]:
-    """List directory contents.
-
-    Args:
-        accessor (MongoDBAccessor): mongodb accessor.
-        path (PathSpec | str): resource-relative path.
-        index (IndexCacheStore | None): index cache.
-        prefix (str): mount prefix for virtual index keys.
-    """
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.directory if path.pattern else path.original
-    if prefix and path.startswith(prefix):
-        path = path[len(prefix):] or "/"
-    key = path.strip("/")
+    prefix = path.prefix or ""
+    scope = detect_scope(path)
+    virtual_key = (prefix + scope.resource_path).rstrip("/") or "/"
 
-    if key and any(p.startswith(".") for p in key.split("/")):
-        raise FileNotFoundError(path)
+    if scope.level == "root":
+        return await _list_root(accessor, virtual_key, index, prefix)
 
-    virtual_key = prefix + "/" + key if key else prefix or "/"
+    if scope.level == "database":
+        base = f"{prefix}/{scope.database}"
+        return [
+            f"{base}/database.json",
+            f"{base}/collections",
+            f"{base}/views",
+        ]
 
-    if not key:
-        if _is_single_db(accessor.config):
-            return await _readdir_collections(
-                accessor,
-                accessor.config.databases[0],
-                virtual_key,
-                index,
-                prefix,
-            )
-        if index is not None:
-            listing = await index.list_dir(virtual_key)
-            if listing.entries is not None:
-                return listing.entries
-        dbs = await list_databases(accessor.client, accessor.config)
-        entries = []
-        names = []
-        for db_name in dbs:
-            entry = IndexEntry(
-                id=db_name,
-                name=db_name,
-                resource_type="mongodb/database",
-                vfs_name=db_name,
-            )
-            entries.append((db_name, entry))
-            names.append(f"{prefix}/{db_name}")
-        if index is not None:
-            await index.set_dir(virtual_key, entries)
-        return names
+    if scope.level == "kind_dir":
+        return await _list_kind_dir(accessor, scope.database, scope.kind,
+                                     virtual_key, index, prefix)
 
-    parts = key.split("/")
+    if scope.level == "entity":
+        base = (f"{prefix}/{scope.database}/"
+                f"{_KIND_TO_DIR[scope.kind]}/{scope.name}")
+        return [
+            f"{base}/schema.json",
+            f"{base}/documents.jsonl",
+        ]
 
-    if len(parts) == 1:
-        return await _readdir_collections(
-            accessor,
-            parts[0],
-            virtual_key,
-            index,
-            prefix,
-        )
-
-    raise FileNotFoundError(path)
+    raise FileNotFoundError(path.original)
 
 
-async def _readdir_collections(
+async def _list_root(
     accessor: MongoDBAccessor,
-    db_name: str,
     virtual_key: str,
     index: IndexCacheStore | None,
     prefix: str,
@@ -103,22 +75,48 @@ async def _readdir_collections(
         listing = await index.list_dir(virtual_key)
         if listing.entries is not None:
             return listing.entries
-    collections = await list_collections(accessor.client, db_name)
-    entries = []
-    names = []
-    for col_name in collections:
-        filename = f"{col_name}.jsonl"
+    dbs = await list_databases(accessor.client, accessor.config)
+    entries: list[tuple[str, IndexEntry]] = []
+    names: list[str] = []
+    for db_name in dbs:
         entry = IndexEntry(
-            id=col_name,
-            name=col_name,
-            resource_type="mongodb/collection",
-            vfs_name=filename,
+            id=db_name,
+            name=db_name,
+            resource_type="mongodb/database",
+            vfs_name=db_name,
         )
-        entries.append((filename, entry))
-        full_path = f"{prefix}/{db_name}/{filename}"
-        if _is_single_db(accessor.config):
-            full_path = f"{prefix}/{filename}"
-        names.append(full_path)
+        entries.append((db_name, entry))
+        names.append(f"{prefix}/{db_name}")
     if index is not None:
         await index.set_dir(virtual_key, entries)
     return names
+
+
+async def _list_kind_dir(
+    accessor: MongoDBAccessor,
+    database: str,
+    kind: MongoEntityKind,
+    virtual_key: str,
+    index: IndexCacheStore | None,
+    prefix: str,
+) -> list[str]:
+    if index is not None:
+        listing = await index.list_dir(virtual_key)
+        if listing.entries is not None:
+            return listing.entries
+    names = await list_collections(accessor.client, database, kind=kind)
+    base = f"{prefix}/{database}/{_KIND_TO_DIR[kind]}"
+    entries: list[tuple[str, IndexEntry]] = []
+    out: list[str] = []
+    for name in names:
+        entry = IndexEntry(
+            id=name,
+            name=name,
+            resource_type=_KIND_RESOURCE_TYPE[kind],
+            vfs_name=name,
+        )
+        entries.append((name, entry))
+        out.append(f"{base}/{name}")
+    if index is not None:
+        await index.set_dir(virtual_key, entries)
+    return out

--- a/python/mirage/core/mongodb/scope.py
+++ b/python/mirage/core/mongodb/scope.py
@@ -13,60 +13,80 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from dataclasses import dataclass
+from typing import Literal
 
 from mirage.types import PathSpec
+
+MongoEntityKind = Literal["collection", "view"]
+
+KIND_DIR_NAMES: dict[str, MongoEntityKind] = {
+    "collections": "collection",
+    "views": "view",
+}
 
 
 @dataclass
 class MongoDBScope:
     level: str
     database: str | None = None
-    collection: str | None = None
+    kind: MongoEntityKind | None = None
+    name: str | None = None
     resource_path: str = "/"
 
 
-def detect_scope(
-    path: PathSpec,
-    single_db: bool = False,
-    single_db_name: str | None = None,
-) -> MongoDBScope:
+def detect_scope(path) -> MongoDBScope:
     raw = path.strip_prefix if isinstance(path, PathSpec) else path
     key = raw.strip("/")
 
     if not key:
-        if single_db:
-            return MongoDBScope(level="database",
-                                database=single_db_name,
-                                resource_path="/")
         return MongoDBScope(level="root", resource_path="/")
 
     parts = key.split("/")
 
-    if single_db:
-        if key.endswith(".jsonl"):
-            col = key.removesuffix(".jsonl")
-            return MongoDBScope(level="file",
-                                database=single_db_name,
-                                collection=col,
-                                resource_path=raw)
-        return MongoDBScope(level="database",
-                            database=single_db_name,
-                            resource_path=raw)
-
     if len(parts) == 1:
-        if parts[0].endswith(".jsonl"):
-            return MongoDBScope(level="file",
-                                database=None,
-                                collection=parts[0].removesuffix(".jsonl"),
-                                resource_path=raw)
         return MongoDBScope(level="database",
                             database=parts[0],
                             resource_path=raw)
 
-    if len(parts) == 2 and parts[1].endswith(".jsonl"):
-        return MongoDBScope(level="file",
-                            database=parts[0],
-                            collection=parts[1].removesuffix(".jsonl"),
-                            resource_path=raw)
+    if len(parts) == 2:
+        db, leaf = parts
+        if leaf == "database.json":
+            return MongoDBScope(level="database_json",
+                                database=db,
+                                resource_path=raw)
+        if leaf in KIND_DIR_NAMES:
+            return MongoDBScope(level="kind_dir",
+                                database=db,
+                                kind=KIND_DIR_NAMES[leaf],
+                                resource_path=raw)
+        return MongoDBScope(level="unknown", resource_path=raw)
 
-    return MongoDBScope(level="root", resource_path=raw)
+    if len(parts) == 3:
+        db, kind_seg, name = parts
+        if kind_seg in KIND_DIR_NAMES:
+            return MongoDBScope(level="entity",
+                                database=db,
+                                kind=KIND_DIR_NAMES[kind_seg],
+                                name=name,
+                                resource_path=raw)
+        return MongoDBScope(level="unknown", resource_path=raw)
+
+    if len(parts) == 4:
+        db, kind_seg, name, leaf = parts
+        if kind_seg in KIND_DIR_NAMES:
+            kind = KIND_DIR_NAMES[kind_seg]
+            if leaf == "schema.json":
+                return MongoDBScope(level="schema_json",
+                                    database=db,
+                                    kind=kind,
+                                    name=name,
+                                    resource_path=raw)
+            if leaf == "documents.jsonl":
+                return MongoDBScope(level="documents",
+                                    database=db,
+                                    kind=kind,
+                                    name=name,
+                                    resource_path=raw)
+        return MongoDBScope(level="unknown", resource_path=raw)
+
+    return MongoDBScope(level="unknown", resource_path=raw)

--- a/python/mirage/core/mongodb/scope.py
+++ b/python/mirage/core/mongodb/scope.py
@@ -13,23 +13,16 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from dataclasses import dataclass
-from typing import Literal
 
+from mirage.core.mongodb.types import KIND_DIR_NAMES, EntityKind, ScopeLevel
 from mirage.types import PathSpec
-
-MongoEntityKind = Literal["collection", "view"]
-
-KIND_DIR_NAMES: dict[str, MongoEntityKind] = {
-    "collections": "collection",
-    "views": "view",
-}
 
 
 @dataclass
 class MongoDBScope:
-    level: str
+    level: ScopeLevel
     database: str | None = None
-    kind: MongoEntityKind | None = None
+    kind: EntityKind | None = None
     name: str | None = None
     resource_path: str = "/"
 
@@ -39,54 +32,54 @@ def detect_scope(path) -> MongoDBScope:
     key = raw.strip("/")
 
     if not key:
-        return MongoDBScope(level="root", resource_path="/")
+        return MongoDBScope(level=ScopeLevel.ROOT, resource_path="/")
 
     parts = key.split("/")
 
     if len(parts) == 1:
-        return MongoDBScope(level="database",
+        return MongoDBScope(level=ScopeLevel.DATABASE,
                             database=parts[0],
                             resource_path=raw)
 
     if len(parts) == 2:
         db, leaf = parts
         if leaf == "database.json":
-            return MongoDBScope(level="database_json",
+            return MongoDBScope(level=ScopeLevel.DATABASE_JSON,
                                 database=db,
                                 resource_path=raw)
         if leaf in KIND_DIR_NAMES:
-            return MongoDBScope(level="kind_dir",
+            return MongoDBScope(level=ScopeLevel.KIND_DIR,
                                 database=db,
                                 kind=KIND_DIR_NAMES[leaf],
                                 resource_path=raw)
-        return MongoDBScope(level="unknown", resource_path=raw)
+        return MongoDBScope(level=ScopeLevel.UNKNOWN, resource_path=raw)
 
     if len(parts) == 3:
         db, kind_seg, name = parts
         if kind_seg in KIND_DIR_NAMES:
-            return MongoDBScope(level="entity",
+            return MongoDBScope(level=ScopeLevel.ENTITY,
                                 database=db,
                                 kind=KIND_DIR_NAMES[kind_seg],
                                 name=name,
                                 resource_path=raw)
-        return MongoDBScope(level="unknown", resource_path=raw)
+        return MongoDBScope(level=ScopeLevel.UNKNOWN, resource_path=raw)
 
     if len(parts) == 4:
         db, kind_seg, name, leaf = parts
         if kind_seg in KIND_DIR_NAMES:
             kind = KIND_DIR_NAMES[kind_seg]
             if leaf == "schema.json":
-                return MongoDBScope(level="schema_json",
+                return MongoDBScope(level=ScopeLevel.SCHEMA_JSON,
                                     database=db,
                                     kind=kind,
                                     name=name,
                                     resource_path=raw)
             if leaf == "documents.jsonl":
-                return MongoDBScope(level="documents",
+                return MongoDBScope(level=ScopeLevel.DOCUMENTS,
                                     database=db,
                                     kind=kind,
                                     name=name,
                                     resource_path=raw)
-        return MongoDBScope(level="unknown", resource_path=raw)
+        return MongoDBScope(level=ScopeLevel.UNKNOWN, resource_path=raw)
 
-    return MongoDBScope(level="unknown", resource_path=raw)
+    return MongoDBScope(level=ScopeLevel.UNKNOWN, resource_path=raw)

--- a/python/mirage/core/mongodb/search.py
+++ b/python/mirage/core/mongodb/search.py
@@ -12,24 +12,33 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import json
+import asyncio
 
-from bson.json_util import default
+from bson.json_util import RELAXED_JSON_OPTIONS, dumps
 from motor.motor_asyncio import AsyncIOMotorClient
 
 from mirage.core.mongodb._client import get_indexes, list_collections
 
 
-async def _regex_filter(col, pattern: str) -> list[dict]:
-    sample = await col.find_one()
-    if not sample:
-        return [{}]
-    string_fields = [
-        k for k, v in sample.items() if isinstance(v, str) and k != "_id"
-    ]
-    if not string_fields:
-        return [{}]
-    return [{f: {"$regex": pattern, "$options": "i"}} for f in string_fields]
+def _collect_string_paths(value, prefix: str, out: set[str]) -> None:
+    if isinstance(value, dict):
+        for k, v in value.items():
+            sub = f"{prefix}.{k}" if prefix else k
+            _collect_string_paths(v, sub, out)
+        return
+    if isinstance(value, str) and prefix and prefix != "_id":
+        out.add(prefix)
+
+
+async def _sampled_string_paths(col, sample_size: int = 100) -> list[str]:
+    paths: set[str] = set()
+    async for doc in col.aggregate([{"$sample": {"size": sample_size}}]):
+        _collect_string_paths(doc, "", paths)
+    return sorted(paths)
+
+
+def _has_text_index(indexes: list[dict]) -> bool:
+    return any("textIndexVersion" in idx for idx in indexes)
 
 
 async def search_collection(
@@ -42,15 +51,20 @@ async def search_collection(
     db = client[database]
     col = db[collection]
     indexes = await get_indexes(client, database, collection)
-    has_text_index = any(
-        any(v == "text" for v in idx.get("key", {}).values())
-        for idx in indexes)
-    if has_text_index:
-        cursor = col.find({"$text": {"$search": pattern}}).limit(limit)
+    if _has_text_index(indexes):
+        filter_expr: dict = {"$text": {"$search": pattern}}
     else:
-        cursor = col.find({
-            "$or": await _regex_filter(col, pattern)
-        }).limit(limit)
+        paths = await _sampled_string_paths(col)
+        if not paths:
+            filter_expr = {}
+        else:
+            filter_expr = {
+                "$or": [{p: {
+                    "$regex": pattern,
+                    "$options": "i"
+                }} for p in paths]
+            }
+    cursor = col.find(filter_expr).limit(limit)
     return await cursor.to_list(length=limit)
 
 
@@ -61,16 +75,13 @@ async def search_database(
     limit: int,
 ) -> list[tuple[str, str, list[dict]]]:
     collections = await list_collections(client, database)
-    results: list[tuple[str, str, list[dict]]] = []
-    for col in collections:
-        docs = await search_collection(client,
-                                       database,
-                                       col,
-                                       pattern,
-                                       limit=limit)
-        if docs:
-            results.append((database, col, docs))
-    return results
+    tasks = [
+        search_collection(client, database, col, pattern, limit=limit)
+        for col in collections
+    ]
+    results_per_col = await asyncio.gather(*tasks)
+    return [(database, col, docs)
+            for col, docs in zip(collections, results_per_col) if docs]
 
 
 def format_grep_results(
@@ -78,7 +89,6 @@ def format_grep_results(
     lines: list[str] = []
     for db_name, col_name, docs in results:
         for doc in docs:
-            doc["_id"] = str(doc.get("_id", ""))
-            line_json = json.dumps(doc, ensure_ascii=False, default=default)
+            line_json = dumps(doc, json_options=RELAXED_JSON_OPTIONS)
             lines.append(f"{db_name}/{col_name}.jsonl:{line_json}")
     return lines

--- a/python/mirage/core/mongodb/search.py
+++ b/python/mirage/core/mongodb/search.py
@@ -18,6 +18,7 @@ from bson.json_util import RELAXED_JSON_OPTIONS, dumps
 from motor.motor_asyncio import AsyncIOMotorClient
 
 from mirage.core.mongodb._client import get_indexes, list_collections
+from mirage.core.mongodb.types import PRIMARY_KEY, EntityKind
 
 
 def _collect_string_paths(value, prefix: str, out: set[str]) -> None:
@@ -26,7 +27,7 @@ def _collect_string_paths(value, prefix: str, out: set[str]) -> None:
             sub = f"{prefix}.{k}" if prefix else k
             _collect_string_paths(v, sub, out)
         return
-    if isinstance(value, str) and prefix and prefix != "_id":
+    if isinstance(value, str) and prefix and prefix != PRIMARY_KEY:
         out.add(prefix)
 
 
@@ -75,7 +76,9 @@ async def search_database(
     pattern: str,
     limit: int,
 ) -> list[tuple[str, str, list[dict]]]:
-    collections = await list_collections(client, database, kind="collection")
+    collections = await list_collections(client,
+                                         database,
+                                         kind=EntityKind.COLLECTION)
     tasks = [
         search_collection(client, database, col, pattern, limit=limit)
         for col in collections

--- a/python/mirage/core/mongodb/search.py
+++ b/python/mirage/core/mongodb/search.py
@@ -56,14 +56,15 @@ async def search_collection(
     else:
         paths = await _sampled_string_paths(col)
         if not paths:
-            filter_expr = {}
-        else:
-            filter_expr = {
-                "$or": [{p: {
+            return []
+        filter_expr = {
+            "$or": [{
+                p: {
                     "$regex": pattern,
                     "$options": "i"
-                }} for p in paths]
-            }
+                }
+            } for p in paths]
+        }
     cursor = col.find(filter_expr).limit(limit)
     return await cursor.to_list(length=limit)
 
@@ -74,7 +75,7 @@ async def search_database(
     pattern: str,
     limit: int,
 ) -> list[tuple[str, str, list[dict]]]:
-    collections = await list_collections(client, database)
+    collections = await list_collections(client, database, kind="collection")
     tasks = [
         search_collection(client, database, col, pattern, limit=limit)
         for col in collections
@@ -88,7 +89,8 @@ def format_grep_results(
         results: list[tuple[str, str, list[dict]]]) -> list[str]:  # noqa: E125
     lines: list[str] = []
     for db_name, col_name, docs in results:
+        path = f"{db_name}/collections/{col_name}/documents.jsonl"
         for doc in docs:
             line_json = dumps(doc, json_options=RELAXED_JSON_OPTIONS)
-            lines.append(f"{db_name}/{col_name}.jsonl:{line_json}")
+            lines.append(f"{path}:{line_json}")
     return lines

--- a/python/mirage/core/mongodb/stat.py
+++ b/python/mirage/core/mongodb/stat.py
@@ -15,7 +15,8 @@
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.mongodb._client import count_documents, get_indexes, is_view
-from mirage.core.mongodb.scope import MongoEntityKind, detect_scope
+from mirage.core.mongodb.scope import detect_scope
+from mirage.core.mongodb.types import EntityKind, ScopeLevel
 from mirage.types import FileStat, FileType, PathSpec
 
 
@@ -28,26 +29,29 @@ async def stat(
         path = PathSpec(original=path, directory=path)
     scope = detect_scope(path)
 
-    if scope.level == "root":
+    if scope.level == ScopeLevel.ROOT:
         return FileStat(name="/", type=FileType.DIRECTORY)
 
-    if scope.level == "database":
+    if scope.level == ScopeLevel.DATABASE:
         return FileStat(
             name=scope.database,
             type=FileType.DIRECTORY,
             extra={"database": scope.database},
         )
 
-    if scope.level == "kind_dir":
+    if scope.level == ScopeLevel.KIND_DIR:
         return FileStat(
             name=_kind_dir_name(scope.kind),
             type=FileType.DIRECTORY,
-            extra={"database": scope.database, "kind": scope.kind},
+            extra={
+                "database": scope.database,
+                "kind": scope.kind
+            },
         )
 
-    if scope.level == "entity":
+    if scope.level == ScopeLevel.ENTITY:
         doc_count = await count_documents(accessor.client, scope.database,
-                                           scope.name)
+                                          scope.name)
         return FileStat(
             name=scope.name,
             type=FileType.DIRECTORY,
@@ -59,11 +63,11 @@ async def stat(
             },
         )
 
-    if scope.level == "documents":
+    if scope.level == ScopeLevel.DOCUMENTS:
         return await _documents_stat(accessor, scope.database, scope.kind,
-                                      scope.name)
+                                     scope.name)
 
-    if scope.level == "schema_json":
+    if scope.level == ScopeLevel.SCHEMA_JSON:
         return FileStat(
             name="schema.json",
             type=FileType.TEXT,
@@ -74,7 +78,7 @@ async def stat(
             },
         )
 
-    if scope.level == "database_json":
+    if scope.level == ScopeLevel.DATABASE_JSON:
         return FileStat(
             name="database.json",
             type=FileType.TEXT,
@@ -84,17 +88,18 @@ async def stat(
     raise FileNotFoundError(path.original)
 
 
-def _kind_dir_name(kind: MongoEntityKind) -> str:
-    return "collections" if kind == "collection" else "views"
+def _kind_dir_name(kind: EntityKind) -> str:
+    return "collections" if kind == EntityKind.COLLECTION else "views"
 
 
 async def _documents_stat(
     accessor: MongoDBAccessor,
     database: str,
-    kind: MongoEntityKind,
+    kind: EntityKind,
     name: str,
 ) -> FileStat:
-    view = kind == "view" or await is_view(accessor.client, database, name)
+    view = (kind == EntityKind.VIEW
+            or await is_view(accessor.client, database, name))
     doc_count = await count_documents(accessor.client, database, name)
     if view:
         index_info: list[dict] = []

--- a/python/mirage/core/mongodb/stat.py
+++ b/python/mirage/core/mongodb/stat.py
@@ -14,7 +14,8 @@
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.core.mongodb._client import count_documents, get_indexes, is_view
+from mirage.core.mongodb._client import (count_documents, database_exists,
+                                         entity_exists, get_indexes, is_view)
 from mirage.core.mongodb.scope import detect_scope
 from mirage.core.mongodb.types import KIND_TO_DIR, EntityKind, ScopeLevel
 from mirage.types import FileStat, FileType, PathSpec
@@ -33,6 +34,9 @@ async def stat(
         return FileStat(name="/", type=FileType.DIRECTORY)
 
     if scope.level == ScopeLevel.DATABASE:
+        if not await database_exists(accessor.client, accessor.config,
+                                     scope.database, accessor):
+            raise FileNotFoundError(path.original)
         return FileStat(
             name=scope.database,
             type=FileType.DIRECTORY,
@@ -40,6 +44,9 @@ async def stat(
         )
 
     if scope.level == ScopeLevel.KIND_DIR:
+        if not await database_exists(accessor.client, accessor.config,
+                                     scope.database, accessor):
+            raise FileNotFoundError(path.original)
         return FileStat(
             name=_kind_dir_name(scope.kind),
             type=FileType.DIRECTORY,
@@ -50,6 +57,10 @@ async def stat(
         )
 
     if scope.level == ScopeLevel.ENTITY:
+        if not await entity_exists(accessor.client, accessor.config,
+                                   scope.database, scope.name, scope.kind,
+                                   accessor):
+            raise FileNotFoundError(path.original)
         doc_count = await count_documents(accessor.client, scope.database,
                                           scope.name)
         return FileStat(
@@ -64,10 +75,18 @@ async def stat(
         )
 
     if scope.level == ScopeLevel.DOCUMENTS:
+        if not await entity_exists(accessor.client, accessor.config,
+                                   scope.database, scope.name, scope.kind,
+                                   accessor):
+            raise FileNotFoundError(path.original)
         return await _documents_stat(accessor, scope.database, scope.kind,
                                      scope.name)
 
     if scope.level == ScopeLevel.SCHEMA_JSON:
+        if not await entity_exists(accessor.client, accessor.config,
+                                   scope.database, scope.name, scope.kind,
+                                   accessor):
+            raise FileNotFoundError(path.original)
         return FileStat(
             name="schema.json",
             type=FileType.TEXT,
@@ -79,6 +98,9 @@ async def stat(
         )
 
     if scope.level == ScopeLevel.DATABASE_JSON:
+        if not await database_exists(accessor.client, accessor.config,
+                                     scope.database, accessor):
+            raise FileNotFoundError(path.original)
         return FileStat(
             name="database.json",
             type=FileType.TEXT,

--- a/python/mirage/core/mongodb/stat.py
+++ b/python/mirage/core/mongodb/stat.py
@@ -16,7 +16,7 @@ from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.mongodb._client import count_documents, get_indexes, is_view
 from mirage.core.mongodb.scope import detect_scope
-from mirage.core.mongodb.types import EntityKind, ScopeLevel
+from mirage.core.mongodb.types import KIND_TO_DIR, EntityKind, ScopeLevel
 from mirage.types import FileStat, FileType, PathSpec
 
 
@@ -89,7 +89,7 @@ async def stat(
 
 
 def _kind_dir_name(kind: EntityKind) -> str:
-    return "collections" if kind == EntityKind.COLLECTION else "views"
+    return KIND_TO_DIR[kind]
 
 
 async def _documents_stat(
@@ -115,7 +115,7 @@ async def _documents_stat(
         extra={
             "database": database,
             "name": name,
-            "kind": "view" if view else "collection",
+            "kind": EntityKind.VIEW if view else EntityKind.COLLECTION,
             "document_count": doc_count,
             "indexes": index_info,
         },

--- a/python/mirage/core/mongodb/stat.py
+++ b/python/mirage/core/mongodb/stat.py
@@ -14,7 +14,8 @@
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.core.mongodb._client import count_documents, get_indexes
+from mirage.core.mongodb._client import (count_documents, get_indexes,
+                                          is_view)
 from mirage.types import FileStat, FileType, PathSpec
 
 
@@ -80,18 +81,23 @@ async def _collection_stat(
     col_name: str,
     filename: str,
 ) -> FileStat:
+    view = await is_view(accessor.client, db_name, col_name)
     doc_count = await count_documents(accessor.client, db_name, col_name)
-    indexes = await get_indexes(accessor.client, db_name, col_name)
-    index_info = [{
-        "name": idx.get("name"),
-        "keys": dict(idx.get("key", {}))
-    } for idx in indexes]
+    if view:
+        index_info: list[dict] = []
+    else:
+        indexes = await get_indexes(accessor.client, db_name, col_name)
+        index_info = [{
+            "name": idx.get("name"),
+            "keys": dict(idx.get("key", {}))
+        } for idx in indexes]
     return FileStat(
         name=filename,
         type=FileType.TEXT,
         extra={
             "database": db_name,
             "collection": col_name,
+            "kind": "view" if view else "collection",
             "document_count": doc_count,
             "indexes": index_info,
         },

--- a/python/mirage/core/mongodb/stat.py
+++ b/python/mirage/core/mongodb/stat.py
@@ -14,13 +14,9 @@
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.core.mongodb._client import (count_documents, get_indexes,
-                                          is_view)
+from mirage.core.mongodb._client import count_documents, get_indexes, is_view
+from mirage.core.mongodb.scope import MongoEntityKind, detect_scope
 from mirage.types import FileStat, FileType, PathSpec
-
-
-def _is_single_db(config) -> bool:
-    return config.databases is not None and len(config.databases) == 1
 
 
 async def stat(
@@ -28,75 +24,92 @@ async def stat(
     path: PathSpec,
     index: IndexCacheStore = None,
 ) -> FileStat:
-    """Get file stat for a path.
-
-    Args:
-        accessor (MongoDBAccessor): mongodb accessor.
-        path (str): resource-relative path.
-        index (IndexCacheStore | None): index cache.
-        prefix (str): mount prefix for virtual index keys.
-    """
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
+    scope = detect_scope(path)
 
-    if prefix and path.startswith(prefix):
-        path = path[len(prefix):] or "/"
-    key = path.strip("/")
-
-    if not key:
+    if scope.level == "root":
         return FileStat(name="/", type=FileType.DIRECTORY)
 
-    parts = key.split("/")
-
-    if any(p.startswith(".") for p in parts):
-        raise FileNotFoundError(path)
-
-    if _is_single_db(accessor.config) and len(
-            parts) == 1 and parts[0].endswith(".jsonl"):
-        db_name = accessor.config.databases[0]
-        col_name = parts[0].removesuffix(".jsonl")
-        return await _collection_stat(accessor, db_name, col_name, parts[0])
-
-    if len(parts) == 1 and not parts[0].endswith(".jsonl"):
+    if scope.level == "database":
         return FileStat(
-            name=parts[0],
+            name=scope.database,
             type=FileType.DIRECTORY,
-            extra={"database": parts[0]},
+            extra={"database": scope.database},
         )
 
-    if len(parts) == 2 and parts[1].endswith(".jsonl"):
-        db_name = parts[0]
-        col_name = parts[1].removesuffix(".jsonl")
-        return await _collection_stat(accessor, db_name, col_name, parts[1])
+    if scope.level == "kind_dir":
+        return FileStat(
+            name=_kind_dir_name(scope.kind),
+            type=FileType.DIRECTORY,
+            extra={"database": scope.database, "kind": scope.kind},
+        )
 
-    raise FileNotFoundError(path)
+    if scope.level == "entity":
+        doc_count = await count_documents(accessor.client, scope.database,
+                                           scope.name)
+        return FileStat(
+            name=scope.name,
+            type=FileType.DIRECTORY,
+            extra={
+                "database": scope.database,
+                "kind": scope.kind,
+                "name": scope.name,
+                "document_count": doc_count,
+            },
+        )
+
+    if scope.level == "documents":
+        return await _documents_stat(accessor, scope.database, scope.kind,
+                                      scope.name)
+
+    if scope.level == "schema_json":
+        return FileStat(
+            name="schema.json",
+            type=FileType.TEXT,
+            extra={
+                "database": scope.database,
+                "kind": scope.kind,
+                "name": scope.name,
+            },
+        )
+
+    if scope.level == "database_json":
+        return FileStat(
+            name="database.json",
+            type=FileType.TEXT,
+            extra={"database": scope.database},
+        )
+
+    raise FileNotFoundError(path.original)
 
 
-async def _collection_stat(
+def _kind_dir_name(kind: MongoEntityKind) -> str:
+    return "collections" if kind == "collection" else "views"
+
+
+async def _documents_stat(
     accessor: MongoDBAccessor,
-    db_name: str,
-    col_name: str,
-    filename: str,
+    database: str,
+    kind: MongoEntityKind,
+    name: str,
 ) -> FileStat:
-    view = await is_view(accessor.client, db_name, col_name)
-    doc_count = await count_documents(accessor.client, db_name, col_name)
+    view = kind == "view" or await is_view(accessor.client, database, name)
+    doc_count = await count_documents(accessor.client, database, name)
     if view:
         index_info: list[dict] = []
     else:
-        indexes = await get_indexes(accessor.client, db_name, col_name)
+        indexes = await get_indexes(accessor.client, database, name)
         index_info = [{
             "name": idx.get("name"),
             "keys": dict(idx.get("key", {}))
         } for idx in indexes]
     return FileStat(
-        name=filename,
+        name="documents.jsonl",
         type=FileType.TEXT,
         extra={
-            "database": db_name,
-            "collection": col_name,
+            "database": database,
+            "name": name,
             "kind": "view" if view else "collection",
             "document_count": doc_count,
             "indexes": index_info,

--- a/python/mirage/core/mongodb/stream.py
+++ b/python/mirage/core/mongodb/stream.py
@@ -1,0 +1,49 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from bson.json_util import RELAXED_JSON_OPTIONS, dumps
+
+from mirage.accessor.mongodb import MongoDBAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.mongodb._client import iter_documents
+from mirage.core.mongodb.scope import detect_scope
+from mirage.types import PathSpec
+
+
+async def read_stream(
+    accessor: MongoDBAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+    batch_size: int = 100,
+) -> AsyncIterator[bytes]:
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    config = accessor.config
+    single = config.databases is not None and len(config.databases) == 1
+    single_name = config.databases[0] if single else None
+    scope = detect_scope(path,
+                         single_db=single,
+                         single_db_name=single_name)
+    if scope.level != "file":
+        raise FileNotFoundError(path.original)
+    async for doc in iter_documents(
+            accessor.client,
+            scope.database,
+            scope.collection,
+            sort=[("_id", 1)],
+            batch_size=batch_size,
+    ):
+        yield (dumps(doc, json_options=RELAXED_JSON_OPTIONS) + "\n").encode()

--- a/python/mirage/core/mongodb/stream.py
+++ b/python/mirage/core/mongodb/stream.py
@@ -19,8 +19,42 @@ from bson.json_util import RELAXED_JSON_OPTIONS, dumps
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.mongodb._client import iter_documents
+from mirage.core.mongodb._sampler import _array_tag, _scalar_tag
 from mirage.core.mongodb.scope import detect_scope
 from mirage.types import PathSpec
+
+
+def _stub_for(value: object) -> dict:
+    if isinstance(value, list):
+        tag = _array_tag(value)
+    else:
+        tag = _scalar_tag(value)
+    return {"$elided": tag}
+
+
+def _apply_elision(value: dict, paths: set[str]) -> dict:
+    grouped: dict[str, set[str]] = {}
+    leaves: set[str] = set()
+    for p in paths:
+        head, _, tail = p.partition(".")
+        if tail:
+            grouped.setdefault(head, set()).add(tail)
+        else:
+            leaves.add(head)
+    out: dict = {}
+    for k, v in value.items():
+        if k in leaves:
+            out[k] = _stub_for(v)
+        elif k in grouped and isinstance(v, dict):
+            out[k] = _apply_elision(v, grouped[k])
+        else:
+            out[k] = v
+    return out
+
+
+def _elision_paths(config, database: str, name: str) -> set[str]:
+    key = f"{database}.{name}"
+    return set(config.elide_fields.get(key, []))
 
 
 async def read_stream(
@@ -34,6 +68,7 @@ async def read_stream(
     scope = detect_scope(path)
     if scope.level != "documents":
         raise FileNotFoundError(path.original)
+    elide = _elision_paths(accessor.config, scope.database, scope.name)
     async for doc in iter_documents(
             accessor.client,
             scope.database,
@@ -41,4 +76,6 @@ async def read_stream(
             sort=[("_id", 1)],
             batch_size=batch_size,
     ):
+        if elide:
+            doc = _apply_elision(doc, elide)
         yield (dumps(doc, json_options=RELAXED_JSON_OPTIONS) + "\n").encode()

--- a/python/mirage/core/mongodb/stream.py
+++ b/python/mirage/core/mongodb/stream.py
@@ -20,6 +20,7 @@ from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.mongodb._client import iter_documents, iter_inserts
 from mirage.core.mongodb.scope import detect_scope
+from mirage.core.mongodb.types import ScopeLevel
 from mirage.types import PathSpec
 
 
@@ -57,7 +58,7 @@ async def read_stream(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     scope = detect_scope(path)
-    if scope.level != "documents":
+    if scope.level != ScopeLevel.DOCUMENTS:
         raise FileNotFoundError(path.original)
     elide = _elision_paths(accessor.config, scope.database, scope.name)
     async for doc in iter_documents(
@@ -80,7 +81,7 @@ async def watch_stream(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     scope = detect_scope(path)
-    if scope.level != "documents":
+    if scope.level != ScopeLevel.DOCUMENTS:
         raise FileNotFoundError(path.original)
     elide = _elision_paths(accessor.config, scope.database, scope.name)
     async for doc in iter_inserts(accessor.client, scope.database, scope.name):

--- a/python/mirage/core/mongodb/stream.py
+++ b/python/mirage/core/mongodb/stream.py
@@ -18,7 +18,7 @@ from bson.json_util import RELAXED_JSON_OPTIONS, dumps
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.core.mongodb._client import iter_documents
+from mirage.core.mongodb._client import iter_documents, iter_inserts
 from mirage.core.mongodb.scope import detect_scope
 from mirage.types import PathSpec
 
@@ -67,6 +67,23 @@ async def read_stream(
             sort=[("_id", 1)],
             batch_size=batch_size,
     ):
+        if elide:
+            doc = _apply_elision(doc, elide)
+        yield (dumps(doc, json_options=RELAXED_JSON_OPTIONS) + "\n").encode()
+
+
+async def watch_stream(
+    accessor: MongoDBAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> AsyncIterator[bytes]:
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    scope = detect_scope(path)
+    if scope.level != "documents":
+        raise FileNotFoundError(path.original)
+    elide = _elision_paths(accessor.config, scope.database, scope.name)
+    async for doc in iter_inserts(accessor.client, scope.database, scope.name):
         if elide:
             doc = _apply_elision(doc, elide)
         yield (dumps(doc, json_options=RELAXED_JSON_OPTIONS) + "\n").encode()

--- a/python/mirage/core/mongodb/stream.py
+++ b/python/mirage/core/mongodb/stream.py
@@ -20,7 +20,7 @@ from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.mongodb._client import iter_documents, iter_inserts
 from mirage.core.mongodb.scope import detect_scope
-from mirage.core.mongodb.types import ScopeLevel
+from mirage.core.mongodb.types import PRIMARY_KEY, ScopeLevel
 from mirage.types import PathSpec
 
 
@@ -65,7 +65,7 @@ async def read_stream(
             accessor.client,
             scope.database,
             scope.name,
-            sort=[("_id", 1)],
+            sort=[(PRIMARY_KEY, 1)],
             batch_size=batch_size,
     ):
         if elide:

--- a/python/mirage/core/mongodb/stream.py
+++ b/python/mirage/core/mongodb/stream.py
@@ -19,17 +19,8 @@ from bson.json_util import RELAXED_JSON_OPTIONS, dumps
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.mongodb._client import iter_documents
-from mirage.core.mongodb._sampler import _array_tag, _scalar_tag
 from mirage.core.mongodb.scope import detect_scope
 from mirage.types import PathSpec
-
-
-def _stub_for(value: object) -> dict:
-    if isinstance(value, list):
-        tag = _array_tag(value)
-    else:
-        tag = _scalar_tag(value)
-    return {"$elided": tag}
 
 
 def _apply_elision(value: dict, paths: set[str]) -> dict:
@@ -44,8 +35,8 @@ def _apply_elision(value: dict, paths: set[str]) -> dict:
     out: dict = {}
     for k, v in value.items():
         if k in leaves:
-            out[k] = _stub_for(v)
-        elif k in grouped and isinstance(v, dict):
+            continue
+        if k in grouped and isinstance(v, dict):
             out[k] = _apply_elision(v, grouped[k])
         else:
             out[k] = v

--- a/python/mirage/core/mongodb/stream.py
+++ b/python/mirage/core/mongodb/stream.py
@@ -31,18 +31,13 @@ async def read_stream(
 ) -> AsyncIterator[bytes]:
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
-    config = accessor.config
-    single = config.databases is not None and len(config.databases) == 1
-    single_name = config.databases[0] if single else None
-    scope = detect_scope(path,
-                         single_db=single,
-                         single_db_name=single_name)
-    if scope.level != "file":
+    scope = detect_scope(path)
+    if scope.level != "documents":
         raise FileNotFoundError(path.original)
     async for doc in iter_documents(
             accessor.client,
             scope.database,
-            scope.collection,
+            scope.name,
             sort=[("_id", 1)],
             batch_size=batch_size,
     ):

--- a/python/mirage/core/mongodb/types.py
+++ b/python/mirage/core/mongodb/types.py
@@ -1,0 +1,37 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from enum import StrEnum
+
+
+class ScopeLevel(StrEnum):
+    ROOT = "root"
+    DATABASE = "database"
+    DATABASE_JSON = "database_json"
+    KIND_DIR = "kind_dir"
+    ENTITY = "entity"
+    SCHEMA_JSON = "schema_json"
+    DOCUMENTS = "documents"
+    UNKNOWN = "unknown"
+
+
+class EntityKind(StrEnum):
+    COLLECTION = "collection"
+    VIEW = "view"
+
+
+KIND_DIR_NAMES: dict[str, EntityKind] = {
+    "collections": EntityKind.COLLECTION,
+    "views": EntityKind.VIEW,
+}

--- a/python/mirage/core/mongodb/types.py
+++ b/python/mirage/core/mongodb/types.py
@@ -31,6 +31,24 @@ class EntityKind(StrEnum):
     VIEW = "view"
 
 
+class BsonTypeTag(StrEnum):
+    BOOL = "bool"
+    INT = "int"
+    LONG = "long"
+    DOUBLE = "double"
+    STRING = "string"
+    OBJECT_ID = "objectId"
+    DECIMAL = "decimal"
+    DATE = "date"
+    TIMESTAMP = "timestamp"
+    BINARY = "binary"
+    REGEX = "regex"
+    NULL = "null"
+    OBJECT = "object"
+    ARRAY = "array"
+    UNKNOWN = "unknown"
+
+
 PRIMARY_KEY = "_id"
 
 RESOURCE_TYPE_DATABASE = "mongodb/database"

--- a/python/mirage/core/mongodb/types.py
+++ b/python/mirage/core/mongodb/types.py
@@ -31,7 +31,20 @@ class EntityKind(StrEnum):
     VIEW = "view"
 
 
-KIND_DIR_NAMES: dict[str, EntityKind] = {
-    "collections": EntityKind.COLLECTION,
-    "views": EntityKind.VIEW,
+PRIMARY_KEY = "_id"
+
+RESOURCE_TYPE_DATABASE = "mongodb/database"
+RESOURCE_TYPE_COLLECTION = "mongodb/collection"
+RESOURCE_TYPE_VIEW = "mongodb/view"
+
+KIND_TO_DIR: dict[EntityKind, str] = {
+    EntityKind.COLLECTION: "collections",
+    EntityKind.VIEW: "views",
 }
+
+KIND_TO_RESOURCE_TYPE: dict[EntityKind, str] = {
+    EntityKind.COLLECTION: RESOURCE_TYPE_COLLECTION,
+    EntityKind.VIEW: RESOURCE_TYPE_VIEW,
+}
+
+KIND_DIR_NAMES: dict[str, EntityKind] = {v: k for k, v in KIND_TO_DIR.items()}

--- a/python/mirage/core/mongodb/types.py
+++ b/python/mirage/core/mongodb/types.py
@@ -49,6 +49,15 @@ class BsonTypeTag(StrEnum):
     UNKNOWN = "unknown"
 
 
+class IndexType(StrEnum):
+    BTREE = "btree"
+    TEXT = "text"
+    HASHED = "hashed"
+    GEO_2D = "2d"
+    GEO_2DSPHERE = "2dsphere"
+    WILDCARD = "wildcard"
+
+
 PRIMARY_KEY = "_id"
 
 RESOURCE_TYPE_DATABASE = "mongodb/database"

--- a/python/mirage/resource/mongodb/config.py
+++ b/python/mirage/resource/mongodb/config.py
@@ -21,3 +21,4 @@ class MongoDBConfig(BaseModel):
     default_doc_limit: int = 1000
     default_search_limit: int = 100
     max_doc_limit: int = 5000
+    elide_fields: dict[str, list[str]] = {}

--- a/python/tests/commands/builtin/mongodb/test_cat.py
+++ b/python/tests/commands/builtin/mongodb/test_cat.py
@@ -1,0 +1,89 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from bson import ObjectId
+
+from mirage.accessor.mongodb import MongoDBAccessor
+from mirage.commands.builtin.mongodb.cat import cat
+from mirage.resource.mongodb.config import MongoDBConfig
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def accessor():
+    return MongoDBAccessor(
+        config=MongoDBConfig(uri="mongodb://localhost:27017"))
+
+
+def _path(s: str = "/db1/coll1.jsonl") -> PathSpec:
+    return PathSpec(original=s, directory=s)
+
+
+async def _drain(source) -> bytes:
+    if source is None:
+        return b""
+    if isinstance(source, (bytes, bytearray)):
+        return bytes(source)
+    chunks: list[bytes] = []
+    async for chunk in source:
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+@pytest.mark.asyncio
+async def test_cat_streams_all_docs_as_extended_json(accessor):
+    docs = [{"_id": ObjectId(), "i": i} for i in range(7)]
+
+    async def _fake(*_args, **_kwargs):
+        for d in docs:
+            yield d
+
+    with patch("mirage.core.mongodb.stream.iter_documents",
+               new=_fake), patch(
+                   "mirage.commands.builtin.mongodb.cat.resolve_glob",
+                   new=AsyncMock(return_value=[_path()])):
+        source, _ = await cat(accessor, [_path()])
+        data = await _drain(source)
+    lines = [line for line in data.decode().split("\n") if line]
+    assert len(lines) == 7
+    for line in lines:
+        parsed = json.loads(line)
+        assert isinstance(parsed["_id"], dict)
+        assert "$oid" in parsed["_id"]
+
+
+@pytest.mark.asyncio
+async def test_cat_n_prepends_line_numbers(accessor):
+    docs = [{"_id": ObjectId(), "i": 0}, {"_id": ObjectId(), "i": 1}]
+
+    async def _fake(*_args, **_kwargs):
+        for d in docs:
+            yield d
+
+    with patch("mirage.core.mongodb.stream.iter_documents",
+               new=_fake), patch(
+                   "mirage.commands.builtin.mongodb.cat.resolve_glob",
+                   new=AsyncMock(return_value=[_path()])):
+        source, _ = await cat(accessor, [_path()], n=True)
+        data = await _drain(source)
+    lines = data.decode().splitlines()
+    assert lines[0].lstrip().startswith("1\t")
+    assert lines[1].lstrip().startswith("2\t")
+    payload = lines[0].split("\t", 1)[1]
+    parsed = json.loads(payload)
+    assert "$oid" in parsed["_id"]

--- a/python/tests/commands/builtin/mongodb/test_cat.py
+++ b/python/tests/commands/builtin/mongodb/test_cat.py
@@ -26,8 +26,8 @@ from mirage.types import PathSpec
 
 @pytest.fixture
 def accessor():
-    return MongoDBAccessor(
-        config=MongoDBConfig(uri="mongodb://localhost:27017"))
+    return MongoDBAccessor(config=MongoDBConfig(
+        uri="mongodb://localhost:27017"))
 
 
 def _path(s: str = "/db1/collections/coll1/documents.jsonl") -> PathSpec:
@@ -53,10 +53,9 @@ async def test_cat_streams_all_docs_as_extended_json(accessor):
         for d in docs:
             yield d
 
-    with patch("mirage.core.mongodb.stream.iter_documents",
-               new=_fake), patch(
-                   "mirage.commands.builtin.mongodb.cat.resolve_glob",
-                   new=AsyncMock(return_value=[_path()])):
+    with patch("mirage.core.mongodb.stream.iter_documents", new=_fake), patch(
+            "mirage.commands.builtin.mongodb.cat.resolve_glob",
+            new=AsyncMock(return_value=[_path()])):
         source, _ = await cat(accessor, [_path()])
         data = await _drain(source)
     lines = [line for line in data.decode().split("\n") if line]
@@ -75,10 +74,9 @@ async def test_cat_n_prepends_line_numbers(accessor):
         for d in docs:
             yield d
 
-    with patch("mirage.core.mongodb.stream.iter_documents",
-               new=_fake), patch(
-                   "mirage.commands.builtin.mongodb.cat.resolve_glob",
-                   new=AsyncMock(return_value=[_path()])):
+    with patch("mirage.core.mongodb.stream.iter_documents", new=_fake), patch(
+            "mirage.commands.builtin.mongodb.cat.resolve_glob",
+            new=AsyncMock(return_value=[_path()])):
         source, _ = await cat(accessor, [_path()], n=True)
         data = await _drain(source)
     lines = data.decode().splitlines()

--- a/python/tests/commands/builtin/mongodb/test_cat.py
+++ b/python/tests/commands/builtin/mongodb/test_cat.py
@@ -30,7 +30,7 @@ def accessor():
         config=MongoDBConfig(uri="mongodb://localhost:27017"))
 
 
-def _path(s: str = "/db1/coll1.jsonl") -> PathSpec:
+def _path(s: str = "/db1/collections/coll1/documents.jsonl") -> PathSpec:
     return PathSpec(original=s, directory=s)
 
 

--- a/python/tests/commands/builtin/mongodb/test_grep.py
+++ b/python/tests/commands/builtin/mongodb/test_grep.py
@@ -29,7 +29,7 @@ def accessor():
         config=MongoDBConfig(uri="mongodb://localhost:27017"))
 
 
-def _path(s: str = "/db1/coll1.jsonl") -> PathSpec:
+def _path(s: str = "/db1/collections/coll1/documents.jsonl") -> PathSpec:
     return PathSpec(original=s, directory=s)
 
 

--- a/python/tests/commands/builtin/mongodb/test_grep.py
+++ b/python/tests/commands/builtin/mongodb/test_grep.py
@@ -25,8 +25,8 @@ from mirage.types import PathSpec
 
 @pytest.fixture
 def accessor():
-    return MongoDBAccessor(
-        config=MongoDBConfig(uri="mongodb://localhost:27017"))
+    return MongoDBAccessor(config=MongoDBConfig(
+        uri="mongodb://localhost:27017"))
 
 
 def _path(s: str = "/db1/collections/coll1/documents.jsonl") -> PathSpec:
@@ -53,10 +53,9 @@ async def test_grep_streams_and_finds_match(accessor):
         for d in docs:
             yield d
 
-    with patch("mirage.core.mongodb.stream.iter_documents",
-               new=_fake), patch(
-                   "mirage.commands.builtin.mongodb.grep.grep.resolve_glob",
-                   new=AsyncMock(return_value=[_path()])):
+    with patch("mirage.core.mongodb.stream.iter_documents", new=_fake), patch(
+            "mirage.commands.builtin.mongodb.grep.grep.resolve_glob",
+            new=AsyncMock(return_value=[_path()])):
         source, io = await grep(accessor, [_path()], "target")
         data = await _drain(source)
     text = data.decode()
@@ -74,10 +73,9 @@ async def test_grep_m1_short_circuits_after_first_match(accessor):
             tag = "FOUND" if i == 3 else "skip"
             yield {"_id": ObjectId(), "i": i, "tag": tag}
 
-    with patch("mirage.core.mongodb.stream.iter_documents",
-               new=_fake), patch(
-                   "mirage.commands.builtin.mongodb.grep.grep.resolve_glob",
-                   new=AsyncMock(return_value=[_path()])):
+    with patch("mirage.core.mongodb.stream.iter_documents", new=_fake), patch(
+            "mirage.commands.builtin.mongodb.grep.grep.resolve_glob",
+            new=AsyncMock(return_value=[_path()])):
         source, _ = await grep(accessor, [_path()], "FOUND", m="1")
         data = await _drain(source)
     assert b"FOUND" in data
@@ -92,10 +90,9 @@ async def test_grep_no_match_returns_exit_code_1(accessor):
         for d in docs:
             yield d
 
-    with patch("mirage.core.mongodb.stream.iter_documents",
-               new=_fake), patch(
-                   "mirage.commands.builtin.mongodb.grep.grep.resolve_glob",
-                   new=AsyncMock(return_value=[_path()])):
+    with patch("mirage.core.mongodb.stream.iter_documents", new=_fake), patch(
+            "mirage.commands.builtin.mongodb.grep.grep.resolve_glob",
+            new=AsyncMock(return_value=[_path()])):
         source, io = await grep(accessor, [_path()], "absent_pattern_xyz")
         _ = await _drain(source)
     assert io.exit_code == 1

--- a/python/tests/commands/builtin/mongodb/test_grep.py
+++ b/python/tests/commands/builtin/mongodb/test_grep.py
@@ -1,0 +1,101 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from bson import ObjectId
+
+from mirage.accessor.mongodb import MongoDBAccessor
+from mirage.commands.builtin.mongodb.grep.grep import grep
+from mirage.resource.mongodb.config import MongoDBConfig
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def accessor():
+    return MongoDBAccessor(
+        config=MongoDBConfig(uri="mongodb://localhost:27017"))
+
+
+def _path(s: str = "/db1/coll1.jsonl") -> PathSpec:
+    return PathSpec(original=s, directory=s)
+
+
+async def _drain(source) -> bytes:
+    if source is None:
+        return b""
+    if isinstance(source, (bytes, bytearray)):
+        return bytes(source)
+    chunks: list[bytes] = []
+    async for chunk in source:
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+@pytest.mark.asyncio
+async def test_grep_streams_and_finds_match(accessor):
+    docs = [{"_id": ObjectId(), "i": i, "name": f"item-{i}"} for i in range(5)]
+    docs[2]["name"] = "target-2"
+
+    async def _fake(*_args, **_kwargs):
+        for d in docs:
+            yield d
+
+    with patch("mirage.core.mongodb.stream.iter_documents",
+               new=_fake), patch(
+                   "mirage.commands.builtin.mongodb.grep.grep.resolve_glob",
+                   new=AsyncMock(return_value=[_path()])):
+        source, io = await grep(accessor, [_path()], "target")
+        data = await _drain(source)
+    text = data.decode()
+    assert "target-2" in text
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_grep_m1_short_circuits_after_first_match(accessor):
+    consumed: list[int] = []
+
+    async def _fake(*_args, **_kwargs):
+        for i in range(1000):
+            consumed.append(i)
+            tag = "FOUND" if i == 3 else "skip"
+            yield {"_id": ObjectId(), "i": i, "tag": tag}
+
+    with patch("mirage.core.mongodb.stream.iter_documents",
+               new=_fake), patch(
+                   "mirage.commands.builtin.mongodb.grep.grep.resolve_glob",
+                   new=AsyncMock(return_value=[_path()])):
+        source, _ = await grep(accessor, [_path()], "FOUND", m="1")
+        data = await _drain(source)
+    assert b"FOUND" in data
+    assert len(consumed) < 100
+
+
+@pytest.mark.asyncio
+async def test_grep_no_match_returns_exit_code_1(accessor):
+    docs = [{"_id": ObjectId(), "name": f"item-{i}"} for i in range(3)]
+
+    async def _fake(*_args, **_kwargs):
+        for d in docs:
+            yield d
+
+    with patch("mirage.core.mongodb.stream.iter_documents",
+               new=_fake), patch(
+                   "mirage.commands.builtin.mongodb.grep.grep.resolve_glob",
+                   new=AsyncMock(return_value=[_path()])):
+        source, io = await grep(accessor, [_path()], "absent_pattern_xyz")
+        _ = await _drain(source)
+    assert io.exit_code == 1

--- a/python/tests/commands/builtin/mongodb/test_head.py
+++ b/python/tests/commands/builtin/mongodb/test_head.py
@@ -1,0 +1,124 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from bson import ObjectId
+
+from mirage.accessor.mongodb import MongoDBAccessor
+from mirage.commands.builtin.mongodb.head import head
+from mirage.resource.mongodb.config import MongoDBConfig
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def accessor():
+    return MongoDBAccessor(
+        config=MongoDBConfig(uri="mongodb://localhost:27017"))
+
+
+def _path(s: str = "/db1/coll1.jsonl") -> PathSpec:
+    return PathSpec(original=s, directory=s)
+
+
+async def _drain(source) -> bytes:
+    if source is None:
+        return b""
+    if isinstance(source, (bytes, bytearray)):
+        return bytes(source)
+    chunks: list[bytes] = []
+    async for chunk in source:
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+@pytest.mark.asyncio
+async def test_head_default_returns_first_10_lines(accessor):
+    consumed: list[int] = []
+
+    async def _fake(*_args, **_kwargs):
+        for i in range(1000):
+            consumed.append(i)
+            yield {"_id": ObjectId(), "i": i}
+
+    with patch("mirage.core.mongodb.stream.iter_documents",
+               new=_fake), patch(
+                   "mirage.commands.builtin.mongodb.head.resolve_glob",
+                   new=AsyncMock(return_value=[_path()])):
+        source, _ = await head(accessor, [_path()])
+        data = await _drain(source)
+    lines = [line for line in data.decode().split("\n") if line]
+    assert len(lines) == 10
+    assert len(consumed) <= 11
+
+
+@pytest.mark.asyncio
+async def test_head_n5_short_circuits_after_5_docs(accessor):
+    consumed: list[int] = []
+
+    async def _fake(*_args, **_kwargs):
+        for i in range(1000):
+            consumed.append(i)
+            yield {"_id": ObjectId(), "i": i}
+
+    with patch("mirage.core.mongodb.stream.iter_documents",
+               new=_fake), patch(
+                   "mirage.commands.builtin.mongodb.head.resolve_glob",
+                   new=AsyncMock(return_value=[_path()])):
+        source, _ = await head(accessor, [_path()], n="5")
+        data = await _drain(source)
+    lines = [line for line in data.decode().split("\n") if line]
+    assert len(lines) == 5
+    assert len(consumed) <= 6
+
+
+@pytest.mark.asyncio
+async def test_head_output_uses_extended_json_for_oid(accessor):
+    oid = ObjectId()
+    docs = [{"_id": oid, "title": "first"}]
+
+    async def _fake(*_args, **_kwargs):
+        for d in docs:
+            yield d
+
+    with patch("mirage.core.mongodb.stream.iter_documents",
+               new=_fake), patch(
+                   "mirage.commands.builtin.mongodb.head.resolve_glob",
+                   new=AsyncMock(return_value=[_path()])):
+        source, _ = await head(accessor, [_path()], n="1")
+        data = await _drain(source)
+    parsed = json.loads(data.decode().strip())
+    assert parsed["_id"] == {"$oid": str(oid)}
+    assert parsed["title"] == "first"
+
+
+@pytest.mark.asyncio
+async def test_head_c_bytes_mode_short_circuits(accessor):
+    consumed: list[int] = []
+
+    async def _fake(*_args, **_kwargs):
+        for i in range(1000):
+            consumed.append(i)
+            yield {"_id": ObjectId(), "i": i, "filler": "x" * 100}
+
+    with patch("mirage.core.mongodb.stream.iter_documents",
+               new=_fake), patch(
+                   "mirage.commands.builtin.mongodb.head.resolve_glob",
+                   new=AsyncMock(return_value=[_path()])):
+        source, _ = await head(accessor, [_path()], c="50")
+        data = await _drain(source)
+    assert len(data) == 50
+    assert len(consumed) <= 2

--- a/python/tests/commands/builtin/mongodb/test_head.py
+++ b/python/tests/commands/builtin/mongodb/test_head.py
@@ -30,7 +30,7 @@ def accessor():
         config=MongoDBConfig(uri="mongodb://localhost:27017"))
 
 
-def _path(s: str = "/db1/coll1.jsonl") -> PathSpec:
+def _path(s: str = "/db1/collections/coll1/documents.jsonl") -> PathSpec:
     return PathSpec(original=s, directory=s)
 
 

--- a/python/tests/commands/builtin/mongodb/test_head.py
+++ b/python/tests/commands/builtin/mongodb/test_head.py
@@ -26,8 +26,8 @@ from mirage.types import PathSpec
 
 @pytest.fixture
 def accessor():
-    return MongoDBAccessor(
-        config=MongoDBConfig(uri="mongodb://localhost:27017"))
+    return MongoDBAccessor(config=MongoDBConfig(
+        uri="mongodb://localhost:27017"))
 
 
 def _path(s: str = "/db1/collections/coll1/documents.jsonl") -> PathSpec:
@@ -54,10 +54,9 @@ async def test_head_default_returns_first_10_lines(accessor):
             consumed.append(i)
             yield {"_id": ObjectId(), "i": i}
 
-    with patch("mirage.core.mongodb.stream.iter_documents",
-               new=_fake), patch(
-                   "mirage.commands.builtin.mongodb.head.resolve_glob",
-                   new=AsyncMock(return_value=[_path()])):
+    with patch("mirage.core.mongodb.stream.iter_documents", new=_fake), patch(
+            "mirage.commands.builtin.mongodb.head.resolve_glob",
+            new=AsyncMock(return_value=[_path()])):
         source, _ = await head(accessor, [_path()])
         data = await _drain(source)
     lines = [line for line in data.decode().split("\n") if line]
@@ -74,10 +73,9 @@ async def test_head_n5_short_circuits_after_5_docs(accessor):
             consumed.append(i)
             yield {"_id": ObjectId(), "i": i}
 
-    with patch("mirage.core.mongodb.stream.iter_documents",
-               new=_fake), patch(
-                   "mirage.commands.builtin.mongodb.head.resolve_glob",
-                   new=AsyncMock(return_value=[_path()])):
+    with patch("mirage.core.mongodb.stream.iter_documents", new=_fake), patch(
+            "mirage.commands.builtin.mongodb.head.resolve_glob",
+            new=AsyncMock(return_value=[_path()])):
         source, _ = await head(accessor, [_path()], n="5")
         data = await _drain(source)
     lines = [line for line in data.decode().split("\n") if line]
@@ -94,10 +92,9 @@ async def test_head_output_uses_extended_json_for_oid(accessor):
         for d in docs:
             yield d
 
-    with patch("mirage.core.mongodb.stream.iter_documents",
-               new=_fake), patch(
-                   "mirage.commands.builtin.mongodb.head.resolve_glob",
-                   new=AsyncMock(return_value=[_path()])):
+    with patch("mirage.core.mongodb.stream.iter_documents", new=_fake), patch(
+            "mirage.commands.builtin.mongodb.head.resolve_glob",
+            new=AsyncMock(return_value=[_path()])):
         source, _ = await head(accessor, [_path()], n="1")
         data = await _drain(source)
     parsed = json.loads(data.decode().strip())
@@ -114,10 +111,9 @@ async def test_head_c_bytes_mode_short_circuits(accessor):
             consumed.append(i)
             yield {"_id": ObjectId(), "i": i, "filler": "x" * 100}
 
-    with patch("mirage.core.mongodb.stream.iter_documents",
-               new=_fake), patch(
-                   "mirage.commands.builtin.mongodb.head.resolve_glob",
-                   new=AsyncMock(return_value=[_path()])):
+    with patch("mirage.core.mongodb.stream.iter_documents", new=_fake), patch(
+            "mirage.commands.builtin.mongodb.head.resolve_glob",
+            new=AsyncMock(return_value=[_path()])):
         source, _ = await head(accessor, [_path()], c="50")
         data = await _drain(source)
     assert len(data) == 50

--- a/python/tests/core/mongodb/test_client.py
+++ b/python/tests/core/mongodb/test_client.py
@@ -13,9 +13,9 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
-from mirage.core.mongodb._client import iter_documents
+from mirage.core.mongodb._client import get_indexes, is_view, iter_documents
 
 
 class _AsyncIter:
@@ -85,3 +85,69 @@ async def test_iter_documents_empty_yields_nothing():
     async for doc in iter_documents(client, "db1", "coll1"):
         out.append(doc)
     assert out == []
+
+
+def _build_indexes_client(spec, indexes):
+    spec_cursor = MagicMock()
+    spec_cursor.__aiter__ = lambda self: _AsyncIter([spec] if spec else []
+                                                    ).__aiter__()
+    idx_cursor = MagicMock()
+    idx_cursor.__aiter__ = lambda self: _AsyncIter(indexes).__aiter__()
+    col = MagicMock()
+    col.list_indexes = MagicMock(return_value=idx_cursor)
+    db = MagicMock()
+    db.list_collections = AsyncMock(return_value=spec_cursor)
+    db.__getitem__.return_value = col
+    client = MagicMock()
+    client.__getitem__.return_value = db
+    return client, col, db
+
+
+@pytest.mark.asyncio
+async def test_is_view_true_when_spec_type_view():
+    client, _, db = _build_indexes_client(
+        spec={"name": "myview", "type": "view"},
+        indexes=[],
+    )
+    assert await is_view(client, "db1", "myview") is True
+    db.list_collections.assert_awaited_once_with(filter={"name": "myview"})
+
+
+@pytest.mark.asyncio
+async def test_is_view_false_for_regular_collection():
+    client, _, _ = _build_indexes_client(
+        spec={"name": "coll1", "type": "collection"},
+        indexes=[],
+    )
+    assert await is_view(client, "db1", "coll1") is False
+
+
+@pytest.mark.asyncio
+async def test_is_view_false_when_collection_absent():
+    client, _, _ = _build_indexes_client(spec=None, indexes=[])
+    assert await is_view(client, "db1", "missing") is False
+
+
+@pytest.mark.asyncio
+async def test_get_indexes_returns_indexes_for_collection():
+    indexes = [{"name": "_id_", "key": {"_id": 1}}]
+    client, col, db = _build_indexes_client(
+        spec={"name": "coll1", "type": "collection"},
+        indexes=indexes,
+    )
+    out = await get_indexes(client, "db1", "coll1")
+    assert out == indexes
+    db.list_collections.assert_awaited_once_with(filter={"name": "coll1"})
+    col.list_indexes.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_get_indexes_returns_empty_for_view_without_listing():
+    client, col, db = _build_indexes_client(
+        spec={"name": "myview", "type": "view"},
+        indexes=[],
+    )
+    out = await get_indexes(client, "db1", "myview")
+    assert out == []
+    db.list_collections.assert_awaited_once_with(filter={"name": "myview"})
+    col.list_indexes.assert_not_called()

--- a/python/tests/core/mongodb/test_client.py
+++ b/python/tests/core/mongodb/test_client.py
@@ -12,12 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from mirage.core.mongodb._client import (get_index_stats, get_indexes,
-                                          get_validator, is_view,
-                                          iter_documents)
+                                         get_validator, is_view,
+                                         iter_documents)
 
 
 class _AsyncIter:
@@ -69,7 +70,9 @@ async def test_iter_documents_applies_filter_projection_and_sort():
     async for doc in iter_documents(client,
                                     "db1",
                                     "coll1",
-                                    filter={"x": {"$gt": 0}},
+                                    filter={"x": {
+                                        "$gt": 0
+                                    }},
                                     projection={"x": 1},
                                     sort=[("_id", -1)],
                                     batch_size=50):
@@ -91,8 +94,9 @@ async def test_iter_documents_empty_yields_nothing():
 
 def _build_indexes_client(spec, indexes):
     spec_cursor = MagicMock()
-    spec_cursor.__aiter__ = lambda self: _AsyncIter([spec] if spec else []
-                                                    ).__aiter__()
+    spec_cursor.__aiter__ = lambda self: _AsyncIter([spec]
+                                                    if spec else []).__aiter__(
+                                                    )
     idx_cursor = MagicMock()
     idx_cursor.__aiter__ = lambda self: _AsyncIter(indexes).__aiter__()
     col = MagicMock()
@@ -108,7 +112,10 @@ def _build_indexes_client(spec, indexes):
 @pytest.mark.asyncio
 async def test_is_view_true_when_spec_type_view():
     client, _, db = _build_indexes_client(
-        spec={"name": "myview", "type": "view"},
+        spec={
+            "name": "myview",
+            "type": "view"
+        },
         indexes=[],
     )
     assert await is_view(client, "db1", "myview") is True
@@ -118,7 +125,10 @@ async def test_is_view_true_when_spec_type_view():
 @pytest.mark.asyncio
 async def test_is_view_false_for_regular_collection():
     client, _, _ = _build_indexes_client(
-        spec={"name": "coll1", "type": "collection"},
+        spec={
+            "name": "coll1",
+            "type": "collection"
+        },
         indexes=[],
     )
     assert await is_view(client, "db1", "coll1") is False
@@ -134,7 +144,10 @@ async def test_is_view_false_when_collection_absent():
 async def test_get_indexes_returns_indexes_for_collection():
     indexes = [{"name": "_id_", "key": {"_id": 1}}]
     client, col, db = _build_indexes_client(
-        spec={"name": "coll1", "type": "collection"},
+        spec={
+            "name": "coll1",
+            "type": "collection"
+        },
         indexes=indexes,
     )
     out = await get_indexes(client, "db1", "coll1")
@@ -145,8 +158,9 @@ async def test_get_indexes_returns_indexes_for_collection():
 
 def _build_validator_client(spec):
     spec_cursor = MagicMock()
-    spec_cursor.__aiter__ = lambda self: _AsyncIter([spec] if spec else []
-                                                    ).__aiter__()
+    spec_cursor.__aiter__ = lambda self: _AsyncIter([spec]
+                                                    if spec else []).__aiter__(
+                                                    )
     db = MagicMock()
     db.list_collections = AsyncMock(return_value=spec_cursor)
     client = MagicMock()
@@ -200,9 +214,20 @@ def _build_indexstats_client(rows):
 @pytest.mark.asyncio
 async def test_get_index_stats_returns_map_keyed_by_name():
     rows = [
-        {"name": "_id_", "accesses": {"ops": 1234, "since": "2026-01-01"}},
-        {"name": "title_text",
-         "accesses": {"ops": 5678, "since": "2026-02-01"}},
+        {
+            "name": "_id_",
+            "accesses": {
+                "ops": 1234,
+                "since": "2026-01-01"
+            }
+        },
+        {
+            "name": "title_text",
+            "accesses": {
+                "ops": 5678,
+                "since": "2026-02-01"
+            }
+        },
     ]
     client, col = _build_indexstats_client(rows)
     out = await get_index_stats(client, "db1", "coll1")
@@ -221,7 +246,10 @@ async def test_get_index_stats_empty_when_view():
 @pytest.mark.asyncio
 async def test_get_indexes_returns_empty_for_view_without_listing():
     client, col, db = _build_indexes_client(
-        spec={"name": "myview", "type": "view"},
+        spec={
+            "name": "myview",
+            "type": "view"
+        },
         indexes=[],
     )
     out = await get_indexes(client, "db1", "myview")

--- a/python/tests/core/mongodb/test_client.py
+++ b/python/tests/core/mongodb/test_client.py
@@ -15,7 +15,9 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
-from mirage.core.mongodb._client import get_indexes, is_view, iter_documents
+from mirage.core.mongodb._client import (get_index_stats, get_indexes,
+                                          get_validator, is_view,
+                                          iter_documents)
 
 
 class _AsyncIter:
@@ -139,6 +141,81 @@ async def test_get_indexes_returns_indexes_for_collection():
     assert out == indexes
     db.list_collections.assert_awaited_once_with(filter={"name": "coll1"})
     col.list_indexes.assert_called_once_with()
+
+
+def _build_validator_client(spec):
+    spec_cursor = MagicMock()
+    spec_cursor.__aiter__ = lambda self: _AsyncIter([spec] if spec else []
+                                                    ).__aiter__()
+    db = MagicMock()
+    db.list_collections = AsyncMock(return_value=spec_cursor)
+    client = MagicMock()
+    client.__getitem__.return_value = db
+    return client, db
+
+
+@pytest.mark.asyncio
+async def test_get_validator_returns_json_schema_when_present():
+    spec = {
+        "name": "movies",
+        "options": {
+            "validator": {
+                "$jsonSchema": {
+                    "bsonType": "object",
+                    "required": ["title"]
+                }
+            }
+        }
+    }
+    client, db = _build_validator_client(spec)
+    out = await get_validator(client, "db1", "movies")
+    assert out == {"bsonType": "object", "required": ["title"]}
+    db.list_collections.assert_awaited_once_with(filter={"name": "movies"})
+
+
+@pytest.mark.asyncio
+async def test_get_validator_returns_none_without_validator():
+    client, _ = _build_validator_client({"name": "movies", "options": {}})
+    assert await get_validator(client, "db1", "movies") is None
+
+
+@pytest.mark.asyncio
+async def test_get_validator_returns_none_when_collection_missing():
+    client, _ = _build_validator_client(None)
+    assert await get_validator(client, "db1", "ghost") is None
+
+
+def _build_indexstats_client(rows):
+    cursor = MagicMock()
+    cursor.__aiter__ = lambda self: _AsyncIter(rows).__aiter__()
+    col = MagicMock()
+    col.aggregate = MagicMock(return_value=cursor)
+    db = MagicMock()
+    db.__getitem__.return_value = col
+    client = MagicMock()
+    client.__getitem__.return_value = db
+    return client, col
+
+
+@pytest.mark.asyncio
+async def test_get_index_stats_returns_map_keyed_by_name():
+    rows = [
+        {"name": "_id_", "accesses": {"ops": 1234, "since": "2026-01-01"}},
+        {"name": "title_text",
+         "accesses": {"ops": 5678, "since": "2026-02-01"}},
+    ]
+    client, col = _build_indexstats_client(rows)
+    out = await get_index_stats(client, "db1", "coll1")
+    assert out["title_text"] == {"ops": 5678, "since": "2026-02-01"}
+    assert out["_id_"] == {"ops": 1234, "since": "2026-01-01"}
+    col.aggregate.assert_called_once_with([{"$indexStats": {}}])
+
+
+@pytest.mark.asyncio
+async def test_get_index_stats_empty_when_view():
+    client, _ = _build_indexstats_client([])
+    out = await get_index_stats(client, "db1", "myview")
+    assert out == {}
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/mongodb/test_client.py
+++ b/python/tests/core/mongodb/test_client.py
@@ -1,0 +1,87 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+from unittest.mock import MagicMock
+
+from mirage.core.mongodb._client import iter_documents
+
+
+class _AsyncIter:
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+def _build_mock_client(docs):
+    cursor = MagicMock()
+    cursor.sort = MagicMock(return_value=cursor)
+    cursor.batch_size = MagicMock(return_value=cursor)
+    cursor.__aiter__ = lambda self: _AsyncIter(docs).__aiter__()
+    col = MagicMock()
+    col.find = MagicMock(return_value=cursor)
+    db = MagicMock()
+    db.__getitem__.return_value = col
+    client = MagicMock()
+    client.__getitem__.return_value = db
+    return client, col, cursor
+
+
+@pytest.mark.asyncio
+async def test_iter_documents_yields_each_doc_in_order():
+    docs = [{"_id": i, "v": i * 10} for i in range(3)]
+    client, col, cursor = _build_mock_client(docs)
+    out = []
+    async for doc in iter_documents(client, "db1", "coll1", batch_size=100):
+        out.append(doc)
+    assert out == docs
+    col.find.assert_called_once_with({}, None)
+    cursor.batch_size.assert_called_once_with(100)
+    cursor.sort.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_iter_documents_applies_filter_projection_and_sort():
+    docs = [{"_id": 1, "x": 5}]
+    client, col, cursor = _build_mock_client(docs)
+    out = []
+    async for doc in iter_documents(client,
+                                    "db1",
+                                    "coll1",
+                                    filter={"x": {"$gt": 0}},
+                                    projection={"x": 1},
+                                    sort=[("_id", -1)],
+                                    batch_size=50):
+        out.append(doc)
+    assert out == docs
+    col.find.assert_called_once_with({"x": {"$gt": 0}}, {"x": 1})
+    cursor.sort.assert_called_once_with([("_id", -1)])
+    cursor.batch_size.assert_called_once_with(50)
+
+
+@pytest.mark.asyncio
+async def test_iter_documents_empty_yields_nothing():
+    client, _, _ = _build_mock_client([])
+    out = []
+    async for doc in iter_documents(client, "db1", "coll1"):
+        out.append(doc)
+    assert out == []

--- a/python/tests/core/mongodb/test_read.py
+++ b/python/tests/core/mongodb/test_read.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from bson import ObjectId
@@ -23,6 +23,10 @@ from mirage.cache.index.ram import RAMIndexCacheStore
 from mirage.core.mongodb.read import read
 from mirage.resource.mongodb.config import MongoDBConfig
 from mirage.types import PathSpec
+
+DOCS_PATH = "/sample_mflix/collections/movies/documents.jsonl"
+SCHEMA_PATH = "/sample_mflix/collections/movies/schema.json"
+DBJSON_PATH = "/sample_mflix/database.json"
 
 
 async def _gen(items):
@@ -46,18 +50,19 @@ def _patched_iter(docs):
                  new=lambda *args, **kwargs: _gen(docs))
 
 
+def _path(s: str) -> PathSpec:
+    return PathSpec(original=s, directory=s)
+
+
 @pytest.mark.asyncio
-async def test_read_collection_returns_jsonl_extended_json(accessor, index):
+async def test_read_documents_returns_extended_json_jsonl(accessor, index):
     oid = ObjectId()
     docs = [
         {"_id": oid, "title": "Movie 1"},
         {"_id": ObjectId(), "title": "Movie 2"},
     ]
     with _patched_iter(docs):
-        result = await read(
-            accessor,
-            PathSpec(original="/sample_mflix/movies.jsonl",
-                     directory="/sample_mflix/movies.jsonl"), index)
+        result = await read(accessor, _path(DOCS_PATH), index)
     lines = result.decode().strip().split("\n")
     assert len(lines) == 2
     first = json.loads(lines[0])
@@ -66,36 +71,62 @@ async def test_read_collection_returns_jsonl_extended_json(accessor, index):
 
 
 @pytest.mark.asyncio
-async def test_read_returns_all_streamed_docs_no_cap(accessor, index):
-    docs = [{"_id": ObjectId(), "x": i} for i in range(10)]
+async def test_read_documents_no_doc_cap(accessor, index):
+    docs = [{"_id": ObjectId(), "x": i} for i in range(50)]
     with _patched_iter(docs):
-        result = await read(
-            accessor,
-            PathSpec(original="/sample_mflix/movies.jsonl",
-                     directory="/sample_mflix/movies.jsonl"), index)
+        result = await read(accessor, _path(DOCS_PATH), index)
     lines = result.decode().strip().split("\n")
-    assert len(lines) == 10
-    for line in lines:
-        parsed = json.loads(line)
-        assert isinstance(parsed["_id"], dict)
-        assert "$oid" in parsed["_id"]
+    assert len(lines) == 50
 
 
 @pytest.mark.asyncio
-async def test_read_empty_collection(accessor, index):
+async def test_read_documents_empty(accessor, index):
     with _patched_iter([]):
-        result = await read(
-            accessor,
-            PathSpec(original="/sample_mflix/movies.jsonl",
-                     directory="/sample_mflix/movies.jsonl"), index)
+        result = await read(accessor, _path(DOCS_PATH), index)
     assert result == b""
 
 
 @pytest.mark.asyncio
-async def test_read_invalid_path_raises(accessor, index):
-    with _patched_iter([]):
-        with pytest.raises(FileNotFoundError):
-            await read(
-                accessor,
-                PathSpec(original="/not_a_jsonl_file",
-                         directory="/not_a_jsonl_file"), index)
+async def test_read_schema_json_returns_jsonschema_payload(accessor, index):
+    payload = {
+        "database": "sample_mflix",
+        "name": "movies",
+        "kind": "collection",
+        "validator": None,
+        "fields": [],
+        "primary_key": "_id",
+        "indexes": [],
+        "document_count": 0,
+        "sampled": 100,
+    }
+    with patch("mirage.core.mongodb.read.build_collection_schema_json",
+               new=AsyncMock(return_value=payload)):
+        result = await read(accessor, _path(SCHEMA_PATH), index)
+    parsed = json.loads(result.decode())
+    assert parsed == payload
+
+
+@pytest.mark.asyncio
+async def test_read_database_json_returns_payload(accessor, index):
+    payload = {
+        "database": "sample_mflix",
+        "collections": [{"name": "movies", "document_count": 100}],
+        "views": [{"name": "top_rated"}],
+    }
+    with patch("mirage.core.mongodb.read.build_database_json",
+               new=AsyncMock(return_value=payload)):
+        result = await read(accessor, _path(DBJSON_PATH), index)
+    parsed = json.loads(result.decode())
+    assert parsed == payload
+
+
+@pytest.mark.asyncio
+async def test_read_unknown_path_raises(accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await read(accessor, _path("/garbage/path"), index)
+
+
+@pytest.mark.asyncio
+async def test_read_kind_dir_path_raises(accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await read(accessor, _path("/sample_mflix/collections"), index)

--- a/python/tests/core/mongodb/test_read.py
+++ b/python/tests/core/mongodb/test_read.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 from bson import ObjectId
@@ -25,6 +25,11 @@ from mirage.resource.mongodb.config import MongoDBConfig
 from mirage.types import PathSpec
 
 
+async def _gen(items):
+    for item in items:
+        yield item
+
+
 @pytest.fixture
 def index():
     return RAMIndexCacheStore()
@@ -32,99 +37,65 @@ def index():
 
 @pytest.fixture
 def accessor():
-    config = MongoDBConfig(uri="mongodb://localhost:27017",
-                           default_doc_limit=10)
-    return MongoDBAccessor(config=config)
+    return MongoDBAccessor(
+        config=MongoDBConfig(uri="mongodb://localhost:27017"))
+
+
+def _patched_iter(docs):
+    return patch("mirage.core.mongodb.stream.iter_documents",
+                 new=lambda *args, **kwargs: _gen(docs))
 
 
 @pytest.mark.asyncio
-async def test_read_collection_returns_jsonl(accessor, index):
+async def test_read_collection_returns_jsonl_extended_json(accessor, index):
     oid = ObjectId()
     docs = [
-        {
-            "_id": oid,
-            "title": "Movie 1"
-        },
-        {
-            "_id": ObjectId(),
-            "title": "Movie 2"
-        },
+        {"_id": oid, "title": "Movie 1"},
+        {"_id": ObjectId(), "title": "Movie 2"},
     ]
-    with patch(
-            "mirage.core.mongodb.read.find_documents",
-            new_callable=AsyncMock,
-            return_value=docs,
-    ):
+    with _patched_iter(docs):
         result = await read(
             accessor,
             PathSpec(original="/sample_mflix/movies.jsonl",
                      directory="/sample_mflix/movies.jsonl"), index)
-
     lines = result.decode().strip().split("\n")
     assert len(lines) == 2
     first = json.loads(lines[0])
     assert first["title"] == "Movie 1"
-    assert first["_id"] == str(oid)
+    assert first["_id"] == {"$oid": str(oid)}
 
 
 @pytest.mark.asyncio
-async def test_read_returns_limited_docs(accessor, index):
+async def test_read_returns_all_streamed_docs_no_cap(accessor, index):
     docs = [{"_id": ObjectId(), "x": i} for i in range(10)]
-    with patch(
-            "mirage.core.mongodb.read.find_documents",
-            new_callable=AsyncMock,
-            return_value=docs,
-    ):
+    with _patched_iter(docs):
         result = await read(
             accessor,
             PathSpec(original="/sample_mflix/movies.jsonl",
                      directory="/sample_mflix/movies.jsonl"), index)
-
     lines = result.decode().strip().split("\n")
     assert len(lines) == 10
     for line in lines:
         parsed = json.loads(line)
-        assert isinstance(parsed["_id"], str)
-
-
-@pytest.mark.asyncio
-async def test_read_id_converted_to_string(accessor, index):
-    oid = ObjectId()
-    docs = [{"_id": oid, "name": "test"}]
-    with patch(
-            "mirage.core.mongodb.read.find_documents",
-            new_callable=AsyncMock,
-            return_value=docs,
-    ):
-        result = await read(
-            accessor,
-            PathSpec(original="/sample_mflix/movies.jsonl",
-                     directory="/sample_mflix/movies.jsonl"), index)
-
-    line = json.loads(result.decode().strip())
-    assert isinstance(line["_id"], str)
-    assert line["_id"] == str(oid)
+        assert isinstance(parsed["_id"], dict)
+        assert "$oid" in parsed["_id"]
 
 
 @pytest.mark.asyncio
 async def test_read_empty_collection(accessor, index):
-    with patch(
-            "mirage.core.mongodb.read.find_documents",
-            new_callable=AsyncMock,
-            return_value=[],
-    ):
+    with _patched_iter([]):
         result = await read(
             accessor,
             PathSpec(original="/sample_mflix/movies.jsonl",
                      directory="/sample_mflix/movies.jsonl"), index)
-
     assert result == b""
 
 
 @pytest.mark.asyncio
 async def test_read_invalid_path_raises(accessor, index):
-    with pytest.raises(FileNotFoundError):
-        await read(
-            accessor,
-            PathSpec(original="/not_a_jsonl_file",
-                     directory="/not_a_jsonl_file"), index)
+    with _patched_iter([]):
+        with pytest.raises(FileNotFoundError):
+            await read(
+                accessor,
+                PathSpec(original="/not_a_jsonl_file",
+                         directory="/not_a_jsonl_file"), index)

--- a/python/tests/core/mongodb/test_read.py
+++ b/python/tests/core/mongodb/test_read.py
@@ -41,8 +41,8 @@ def index():
 
 @pytest.fixture
 def accessor():
-    return MongoDBAccessor(
-        config=MongoDBConfig(uri="mongodb://localhost:27017"))
+    return MongoDBAccessor(config=MongoDBConfig(
+        uri="mongodb://localhost:27017"))
 
 
 def _patched_iter(docs):
@@ -58,8 +58,14 @@ def _path(s: str) -> PathSpec:
 async def test_read_documents_returns_extended_json_jsonl(accessor, index):
     oid = ObjectId()
     docs = [
-        {"_id": oid, "title": "Movie 1"},
-        {"_id": ObjectId(), "title": "Movie 2"},
+        {
+            "_id": oid,
+            "title": "Movie 1"
+        },
+        {
+            "_id": ObjectId(),
+            "title": "Movie 2"
+        },
     ]
     with _patched_iter(docs):
         result = await read(accessor, _path(DOCS_PATH), index)
@@ -110,8 +116,13 @@ async def test_read_schema_json_returns_jsonschema_payload(accessor, index):
 async def test_read_database_json_returns_payload(accessor, index):
     payload = {
         "database": "sample_mflix",
-        "collections": [{"name": "movies", "document_count": 100}],
-        "views": [{"name": "top_rated"}],
+        "collections": [{
+            "name": "movies",
+            "document_count": 100
+        }],
+        "views": [{
+            "name": "top_rated"
+        }],
     }
     with patch("mirage.core.mongodb.read.build_database_json",
                new=AsyncMock(return_value=payload)):

--- a/python/tests/core/mongodb/test_read.py
+++ b/python/tests/core/mongodb/test_read.py
@@ -54,6 +54,20 @@ def _path(s: str) -> PathSpec:
     return PathSpec(original=s, directory=s)
 
 
+@pytest.fixture(autouse=True)
+def _stub_existence_checks():
+    with patch(
+            "mirage.core.mongodb.read.database_exists",
+            new_callable=AsyncMock,
+            return_value=True,
+    ), patch(
+            "mirage.core.mongodb.read.entity_exists",
+            new_callable=AsyncMock,
+            return_value=True,
+    ):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_read_documents_returns_extended_json_jsonl(accessor, index):
     oid = ObjectId()
@@ -141,3 +155,28 @@ async def test_read_unknown_path_raises(accessor, index):
 async def test_read_kind_dir_path_raises(accessor, index):
     with pytest.raises(FileNotFoundError):
         await read(accessor, _path("/sample_mflix/collections"), index)
+
+
+@pytest.mark.asyncio
+async def test_read_documents_missing_collection_raises(accessor, index):
+    with patch(
+            "mirage.core.mongodb.read.entity_exists",
+            new_callable=AsyncMock,
+            return_value=False,
+    ):
+        with pytest.raises(FileNotFoundError):
+            await read(
+                accessor,
+                _path("/sample_mflix/collections/ghost/documents.jsonl"),
+                index)
+
+
+@pytest.mark.asyncio
+async def test_read_database_json_missing_db_raises(accessor, index):
+    with patch(
+            "mirage.core.mongodb.read.database_exists",
+            new_callable=AsyncMock,
+            return_value=False,
+    ):
+        with pytest.raises(FileNotFoundError):
+            await read(accessor, _path("/ghost/database.json"), index)

--- a/python/tests/core/mongodb/test_readdir.py
+++ b/python/tests/core/mongodb/test_readdir.py
@@ -30,8 +30,8 @@ def index():
 
 @pytest.fixture
 def accessor():
-    return MongoDBAccessor(
-        config=MongoDBConfig(uri="mongodb://localhost:27017"))
+    return MongoDBAccessor(config=MongoDBConfig(
+        uri="mongodb://localhost:27017"))
 
 
 def _path(s: str) -> PathSpec:
@@ -67,13 +67,13 @@ async def test_readdir_collections_dir_lists_collections_only(accessor, index):
             new_callable=AsyncMock,
             return_value=["movies", "users"],
     ) as mock_list:
-        result = await readdir(accessor,
-                               _path("/sample_mflix/collections"), index)
+        result = await readdir(accessor, _path("/sample_mflix/collections"),
+                               index)
     assert "/sample_mflix/collections/movies" in result
     assert "/sample_mflix/collections/users" in result
     mock_list.assert_awaited_once_with(accessor.client,
-                                        "sample_mflix",
-                                        kind="collection")
+                                       "sample_mflix",
+                                       kind="collection")
 
 
 @pytest.mark.asyncio
@@ -83,19 +83,18 @@ async def test_readdir_views_dir_lists_views_only(accessor, index):
             new_callable=AsyncMock,
             return_value=["top_rated"],
     ) as mock_list:
-        result = await readdir(accessor, _path("/sample_mflix/views"),
-                               index)
+        result = await readdir(accessor, _path("/sample_mflix/views"), index)
     assert result == ["/sample_mflix/views/top_rated"]
     mock_list.assert_awaited_once_with(accessor.client,
-                                        "sample_mflix",
-                                        kind="view")
+                                       "sample_mflix",
+                                       kind="view")
 
 
 @pytest.mark.asyncio
 async def test_readdir_collection_entity_lists_schema_and_documents(
         accessor, index):
-    result = await readdir(accessor,
-                           _path("/sample_mflix/collections/movies"), index)
+    result = await readdir(accessor, _path("/sample_mflix/collections/movies"),
+                           index)
     assert result == [
         "/sample_mflix/collections/movies/schema.json",
         "/sample_mflix/collections/movies/documents.jsonl",
@@ -103,10 +102,9 @@ async def test_readdir_collection_entity_lists_schema_and_documents(
 
 
 @pytest.mark.asyncio
-async def test_readdir_view_entity_lists_schema_and_documents(
-        accessor, index):
-    result = await readdir(accessor,
-                           _path("/sample_mflix/views/top_rated"), index)
+async def test_readdir_view_entity_lists_schema_and_documents(accessor, index):
+    result = await readdir(accessor, _path("/sample_mflix/views/top_rated"),
+                           index)
     assert result == [
         "/sample_mflix/views/top_rated/schema.json",
         "/sample_mflix/views/top_rated/documents.jsonl",
@@ -122,8 +120,7 @@ async def test_readdir_unknown_path_raises(accessor, index):
 @pytest.mark.asyncio
 async def test_readdir_root_index_caches_databases(accessor, index):
     mock_list = AsyncMock(return_value=["db1"])
-    with patch("mirage.core.mongodb.readdir.list_databases",
-               new=mock_list):
+    with patch("mirage.core.mongodb.readdir.list_databases", new=mock_list):
         first = await readdir(accessor, _path("/"), index)
         second = await readdir(accessor, _path("/"), index)
     assert first == second

--- a/python/tests/core/mongodb/test_readdir.py
+++ b/python/tests/core/mongodb/test_readdir.py
@@ -30,14 +30,12 @@ def index():
 
 @pytest.fixture
 def accessor():
-    config = MongoDBConfig(uri="mongodb://localhost:27017")
-    return MongoDBAccessor(config=config)
+    return MongoDBAccessor(
+        config=MongoDBConfig(uri="mongodb://localhost:27017"))
 
 
-@pytest.fixture
-def single_db_accessor():
-    config = MongoDBConfig(uri="mongodb://localhost:27017", databases=["mydb"])
-    return MongoDBAccessor(config=config)
+def _path(s: str) -> PathSpec:
+    return PathSpec(original=s, directory=s)
 
 
 @pytest.mark.asyncio
@@ -47,64 +45,99 @@ async def test_readdir_root_lists_databases(accessor, index):
             new_callable=AsyncMock,
             return_value=["db1", "db2"],
     ):
-        result = await readdir(accessor, PathSpec(original="/", directory="/"),
-                               index)
-
+        result = await readdir(accessor, _path("/"), index)
     assert "/db1" in result
     assert "/db2" in result
 
 
 @pytest.mark.asyncio
-async def test_readdir_database_lists_collections(accessor, index):
+async def test_readdir_database_returns_fixed_children(accessor, index):
+    result = await readdir(accessor, _path("/sample_mflix"), index)
+    assert result == [
+        "/sample_mflix/database.json",
+        "/sample_mflix/collections",
+        "/sample_mflix/views",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_readdir_collections_dir_lists_collections_only(accessor, index):
     with patch(
             "mirage.core.mongodb.readdir.list_collections",
             new_callable=AsyncMock,
             return_value=["movies", "users"],
-    ):
-        result = await readdir(
-            accessor,
-            PathSpec(original="/sample_mflix", directory="/sample_mflix"),
-            index)
-
-    assert "/sample_mflix/movies.jsonl" in result
-    assert "/sample_mflix/users.jsonl" in result
+    ) as mock_list:
+        result = await readdir(accessor,
+                               _path("/sample_mflix/collections"), index)
+    assert "/sample_mflix/collections/movies" in result
+    assert "/sample_mflix/collections/users" in result
+    mock_list.assert_awaited_once_with(accessor.client,
+                                        "sample_mflix",
+                                        kind="collection")
 
 
 @pytest.mark.asyncio
-async def test_readdir_single_db_mode(single_db_accessor, index):
+async def test_readdir_views_dir_lists_views_only(accessor, index):
     with patch(
             "mirage.core.mongodb.readdir.list_collections",
             new_callable=AsyncMock,
-            return_value=["movies", "users"],
-    ):
-        result = await readdir(single_db_accessor,
-                               PathSpec(original="/", directory="/"), index)
-
-    assert "/movies.jsonl" in result
-    assert "/users.jsonl" in result
-
-
-@pytest.mark.asyncio
-async def test_readdir_index_caching(accessor, index):
-    mock_list_db = AsyncMock(return_value=["db1", "db2"])
-    with patch(
-            "mirage.core.mongodb.readdir.list_databases",
-            new_callable=AsyncMock,
-            side_effect=mock_list_db,
-    ):
-        first = await readdir(accessor, PathSpec(original="/", directory="/"),
-                              index)
-    second = await readdir(accessor, PathSpec(original="/", directory="/"),
-                           index)
-
-    assert first == second
-    assert mock_list_db.call_count == 1
+            return_value=["top_rated"],
+    ) as mock_list:
+        result = await readdir(accessor, _path("/sample_mflix/views"),
+                               index)
+    assert result == ["/sample_mflix/views/top_rated"]
+    mock_list.assert_awaited_once_with(accessor.client,
+                                        "sample_mflix",
+                                        kind="view")
 
 
 @pytest.mark.asyncio
-async def test_readdir_nested_path_raises(accessor, index):
+async def test_readdir_collection_entity_lists_schema_and_documents(
+        accessor, index):
+    result = await readdir(accessor,
+                           _path("/sample_mflix/collections/movies"), index)
+    assert result == [
+        "/sample_mflix/collections/movies/schema.json",
+        "/sample_mflix/collections/movies/documents.jsonl",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_readdir_view_entity_lists_schema_and_documents(
+        accessor, index):
+    result = await readdir(accessor,
+                           _path("/sample_mflix/views/top_rated"), index)
+    assert result == [
+        "/sample_mflix/views/top_rated/schema.json",
+        "/sample_mflix/views/top_rated/documents.jsonl",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_readdir_unknown_path_raises(accessor, index):
     with pytest.raises(FileNotFoundError):
-        await readdir(
-            accessor,
-            PathSpec(original="/db/col/extra", directory="/db/col/extra"),
-            index)
+        await readdir(accessor, _path("/db/something/extra"), index)
+
+
+@pytest.mark.asyncio
+async def test_readdir_root_index_caches_databases(accessor, index):
+    mock_list = AsyncMock(return_value=["db1"])
+    with patch("mirage.core.mongodb.readdir.list_databases",
+               new=mock_list):
+        first = await readdir(accessor, _path("/"), index)
+        second = await readdir(accessor, _path("/"), index)
+    assert first == second
+    assert mock_list.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_readdir_prefix_carries_through(accessor, index):
+    p = PathSpec(original="/mongo/sample_mflix",
+                 directory="/mongo/sample_mflix",
+                 prefix="/mongo")
+    result = await readdir(accessor, p, index)
+    assert result == [
+        "/mongo/sample_mflix/database.json",
+        "/mongo/sample_mflix/collections",
+        "/mongo/sample_mflix/views",
+    ]

--- a/python/tests/core/mongodb/test_readdir.py
+++ b/python/tests/core/mongodb/test_readdir.py
@@ -38,6 +38,20 @@ def _path(s: str) -> PathSpec:
     return PathSpec(original=s, directory=s)
 
 
+@pytest.fixture(autouse=True)
+def _stub_existence_checks():
+    with patch(
+            "mirage.core.mongodb.readdir.database_exists",
+            new_callable=AsyncMock,
+            return_value=True,
+    ), patch(
+            "mirage.core.mongodb.readdir.entity_exists",
+            new_callable=AsyncMock,
+            return_value=True,
+    ):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_readdir_root_lists_databases(accessor, index):
     with patch(
@@ -125,6 +139,29 @@ async def test_readdir_root_index_caches_databases(accessor, index):
         second = await readdir(accessor, _path("/"), index)
     assert first == second
     assert mock_list.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_readdir_database_raises_when_db_missing(accessor, index):
+    with patch(
+            "mirage.core.mongodb.readdir.database_exists",
+            new_callable=AsyncMock,
+            return_value=False,
+    ):
+        with pytest.raises(FileNotFoundError):
+            await readdir(accessor, _path("/ghost"), index)
+
+
+@pytest.mark.asyncio
+async def test_readdir_entity_raises_when_collection_missing(accessor, index):
+    with patch(
+            "mirage.core.mongodb.readdir.entity_exists",
+            new_callable=AsyncMock,
+            return_value=False,
+    ):
+        with pytest.raises(FileNotFoundError):
+            await readdir(accessor, _path("/sample_mflix/collections/ghost"),
+                          index)
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/mongodb/test_sampler.py
+++ b/python/tests/core/mongodb/test_sampler.py
@@ -43,9 +43,22 @@ def _col(docs):
 @pytest.mark.asyncio
 async def test_sample_field_types_tallies_types_and_presence():
     docs = [
-        {"_id": 1, "title": "Hi", "year": 2020, "tags": ["a", "b"]},
-        {"_id": 2, "title": "Bye", "year": "2021", "tags": ["c"]},
-        {"_id": 3, "title": "Yo"},
+        {
+            "_id": 1,
+            "title": "Hi",
+            "year": 2020,
+            "tags": ["a", "b"]
+        },
+        {
+            "_id": 2,
+            "title": "Bye",
+            "year": "2021",
+            "tags": ["c"]
+        },
+        {
+            "_id": 3,
+            "title": "Yo"
+        },
     ]
     out = await sample_field_types(_col(docs), sample_size=3)
     by_path = {f["path"]: f for f in out}
@@ -68,8 +81,20 @@ async def test_sample_field_types_recognizes_fixed_numeric_arrays():
 @pytest.mark.asyncio
 async def test_sample_field_types_walks_nested_objects():
     docs = [
-        {"_id": 1, "metadata": {"tag": "a", "ratings": [1.0, 2.0]}},
-        {"_id": 2, "metadata": {"tag": "b", "extra": ObjectId()}},
+        {
+            "_id": 1,
+            "metadata": {
+                "tag": "a",
+                "ratings": [1.0, 2.0]
+            }
+        },
+        {
+            "_id": 2,
+            "metadata": {
+                "tag": "b",
+                "extra": ObjectId()
+            }
+        },
     ]
     out = await sample_field_types(_col(docs), sample_size=2)
     paths = {f["path"] for f in out}

--- a/python/tests/core/mongodb/test_sampler.py
+++ b/python/tests/core/mongodb/test_sampler.py
@@ -1,0 +1,97 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import MagicMock
+
+import pytest
+from bson import Decimal128, ObjectId
+
+from mirage.core.mongodb._sampler import sample_field_types
+
+
+class _AsyncIter:
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+def _col(docs):
+    col = MagicMock()
+    col.aggregate = MagicMock(return_value=_AsyncIter(docs))
+    return col
+
+
+@pytest.mark.asyncio
+async def test_sample_field_types_tallies_types_and_presence():
+    docs = [
+        {"_id": 1, "title": "Hi", "year": 2020, "tags": ["a", "b"]},
+        {"_id": 2, "title": "Bye", "year": "2021", "tags": ["c"]},
+        {"_id": 3, "title": "Yo"},
+    ]
+    out = await sample_field_types(_col(docs), sample_size=3)
+    by_path = {f["path"]: f for f in out}
+    assert "_id" not in by_path
+    assert by_path["title"]["presence"] == 1.0
+    assert by_path["title"]["types"] == {"string": 1.0}
+    assert by_path["year"]["presence"] == pytest.approx(2 / 3)
+    assert set(by_path["year"]["types"].keys()) == {"int", "string"}
+    assert by_path["tags"]["types"] == {"array<string>": pytest.approx(2 / 3)}
+
+
+@pytest.mark.asyncio
+async def test_sample_field_types_recognizes_fixed_numeric_arrays():
+    docs = [{"_id": i, "embedding": [0.1] * 1024} for i in range(5)]
+    out = await sample_field_types(_col(docs), sample_size=5)
+    by_path = {f["path"]: f for f in out}
+    assert by_path["embedding"]["types"] == {"array<double>(1024)": 1.0}
+
+
+@pytest.mark.asyncio
+async def test_sample_field_types_walks_nested_objects():
+    docs = [
+        {"_id": 1, "metadata": {"tag": "a", "ratings": [1.0, 2.0]}},
+        {"_id": 2, "metadata": {"tag": "b", "extra": ObjectId()}},
+    ]
+    out = await sample_field_types(_col(docs), sample_size=2)
+    paths = {f["path"] for f in out}
+    assert "metadata.tag" in paths
+    assert "metadata.ratings" in paths
+    assert "metadata.extra" in paths
+
+
+@pytest.mark.asyncio
+async def test_sample_field_types_handles_bson_scalars():
+    docs = [{
+        "_id": 1,
+        "dec": Decimal128("1.23"),
+        "oid": ObjectId("65f0000000000000000000a1")
+    }]
+    out = await sample_field_types(_col(docs), sample_size=1)
+    by_path = {f["path"]: f for f in out}
+    assert by_path["dec"]["types"] == {"decimal": 1.0}
+    assert by_path["oid"]["types"] == {"objectId": 1.0}
+
+
+@pytest.mark.asyncio
+async def test_sample_field_types_empty_sample_returns_empty_list():
+    out = await sample_field_types(_col([]), sample_size=5)
+    assert out == []

--- a/python/tests/core/mongodb/test_schema_json.py
+++ b/python/tests/core/mongodb/test_schema_json.py
@@ -1,0 +1,118 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mirage.accessor.mongodb import MongoDBAccessor
+from mirage.core.mongodb._schema_json import build_collection_schema_json
+from mirage.resource.mongodb.config import MongoDBConfig
+
+
+@pytest.fixture
+def accessor():
+    return MongoDBAccessor(
+        config=MongoDBConfig(uri="mongodb://localhost:27017"))
+
+
+@pytest.mark.asyncio
+async def test_build_collection_schema_json_assembles_all_sections(accessor):
+    fields = [{"path": "title", "presence": 1.0, "types": {"string": 1.0}}]
+    indexes = [{"name": "_id_", "key": {"_id": 1}}]
+    stats = {"_id_": {"ops": 42, "since": "2026-03-01T00:00:00Z"}}
+    with (
+            patch("mirage.core.mongodb._schema_json.get_validator",
+                  new=AsyncMock(return_value={"bsonType": "object"})),
+            patch("mirage.core.mongodb._schema_json.sample_field_types",
+                  new=AsyncMock(return_value=fields)),
+            patch("mirage.core.mongodb._schema_json.get_indexes",
+                  new=AsyncMock(return_value=indexes)),
+            patch("mirage.core.mongodb._schema_json.get_index_stats",
+                  new=AsyncMock(return_value=stats)),
+            patch("mirage.core.mongodb._schema_json.count_documents",
+                  new=AsyncMock(return_value=999)),
+            patch("mirage.core.mongodb._schema_json.is_view",
+                  new=AsyncMock(return_value=False)),
+    ):
+        out = await build_collection_schema_json(accessor, "db1", "movies")
+    assert out["database"] == "db1"
+    assert out["name"] == "movies"
+    assert out["kind"] == "collection"
+    assert out["validator"] == {"bsonType": "object"}
+    assert out["fields"] == fields
+    assert out["primary_key"] == "_id"
+    assert out["document_count"] == 999
+    assert out["sampled"] == 100
+    assert len(out["indexes"]) == 1
+    enriched = out["indexes"][0]
+    assert enriched["name"] == "_id_"
+    assert enriched["keys"] == {"_id": 1}
+    assert enriched["type"] == "btree"
+    assert enriched["stats"] == {"ops": 42, "since": "2026-03-01T00:00:00Z"}
+
+
+@pytest.mark.asyncio
+async def test_build_collection_schema_json_text_index_tagged(accessor):
+    indexes = [{
+        "name": "title_text",
+        "key": {"_fts": "text", "_ftsx": 1},
+        "textIndexVersion": 3,
+    }]
+    with (
+            patch("mirage.core.mongodb._schema_json.get_validator",
+                  new=AsyncMock(return_value=None)),
+            patch("mirage.core.mongodb._schema_json.sample_field_types",
+                  new=AsyncMock(return_value=[])),
+            patch("mirage.core.mongodb._schema_json.get_indexes",
+                  new=AsyncMock(return_value=indexes)),
+            patch("mirage.core.mongodb._schema_json.get_index_stats",
+                  new=AsyncMock(return_value={})),
+            patch("mirage.core.mongodb._schema_json.count_documents",
+                  new=AsyncMock(return_value=0)),
+            patch("mirage.core.mongodb._schema_json.is_view",
+                  new=AsyncMock(return_value=False)),
+    ):
+        out = await build_collection_schema_json(accessor, "db1", "articles")
+    assert out["indexes"][0]["type"] == "text"
+    assert out["indexes"][0]["stats"] == {}
+
+
+@pytest.mark.asyncio
+async def test_build_collection_schema_json_view_skips_indexes(accessor):
+    fields = [{"path": "title", "presence": 1.0, "types": {"string": 1.0}}]
+    with (
+            patch("mirage.core.mongodb._schema_json.get_validator",
+                  new=AsyncMock(return_value=None)),
+            patch("mirage.core.mongodb._schema_json.sample_field_types",
+                  new=AsyncMock(return_value=fields)),
+            patch("mirage.core.mongodb._schema_json.get_indexes",
+                  new=AsyncMock(
+                      side_effect=AssertionError(
+                          "get_indexes must not be called for views"))),
+            patch("mirage.core.mongodb._schema_json.get_index_stats",
+                  new=AsyncMock(
+                      side_effect=AssertionError(
+                          "get_index_stats must not be called for views"))),
+            patch("mirage.core.mongodb._schema_json.count_documents",
+                  new=AsyncMock(return_value=40)),
+            patch("mirage.core.mongodb._schema_json.is_view",
+                  new=AsyncMock(return_value=True)),
+    ):
+        out = await build_collection_schema_json(accessor, "db1", "myview")
+    assert out["kind"] == "view"
+    assert out["indexes"] == []
+    assert out["validator"] is None
+    assert out["document_count"] == 40
+    assert out["fields"] == fields

--- a/python/tests/core/mongodb/test_schema_json.py
+++ b/python/tests/core/mongodb/test_schema_json.py
@@ -23,8 +23,8 @@ from mirage.resource.mongodb.config import MongoDBConfig
 
 @pytest.fixture
 def accessor():
-    return MongoDBAccessor(
-        config=MongoDBConfig(uri="mongodb://localhost:27017"))
+    return MongoDBAccessor(config=MongoDBConfig(
+        uri="mongodb://localhost:27017"))
 
 
 @pytest.mark.asyncio
@@ -67,7 +67,10 @@ async def test_build_collection_schema_json_assembles_all_sections(accessor):
 async def test_build_collection_schema_json_text_index_tagged(accessor):
     indexes = [{
         "name": "title_text",
-        "key": {"_fts": "text", "_ftsx": 1},
+        "key": {
+            "_fts": "text",
+            "_ftsx": 1
+        },
         "textIndexVersion": 3,
     }]
     with (
@@ -98,13 +101,11 @@ async def test_build_collection_schema_json_view_skips_indexes(accessor):
             patch("mirage.core.mongodb._schema_json.sample_field_types",
                   new=AsyncMock(return_value=fields)),
             patch("mirage.core.mongodb._schema_json.get_indexes",
-                  new=AsyncMock(
-                      side_effect=AssertionError(
-                          "get_indexes must not be called for views"))),
+                  new=AsyncMock(side_effect=AssertionError(
+                      "get_indexes must not be called for views"))),
             patch("mirage.core.mongodb._schema_json.get_index_stats",
-                  new=AsyncMock(
-                      side_effect=AssertionError(
-                          "get_index_stats must not be called for views"))),
+                  new=AsyncMock(side_effect=AssertionError(
+                      "get_index_stats must not be called for views"))),
             patch("mirage.core.mongodb._schema_json.count_documents",
                   new=AsyncMock(return_value=40)),
             patch("mirage.core.mongodb._schema_json.is_view",

--- a/python/tests/core/mongodb/test_schema_json_integration.py
+++ b/python/tests/core/mongodb/test_schema_json_integration.py
@@ -45,7 +45,7 @@ def accessor():
 @pytest.mark.asyncio
 async def test_schema_captures_jsonschema_validator(accessor):
     s = await build_collection_schema_json(accessor, "mirage_test",
-                                            "with_validator")
+                                           "with_validator")
     assert s["kind"] == "collection"
     assert s["validator"]["bsonType"] == "object"
     assert "title" in s["validator"]["required"]
@@ -55,7 +55,7 @@ async def test_schema_captures_jsonschema_validator(accessor):
 @pytest.mark.asyncio
 async def test_schema_recognizes_fixed_length_embedding_array(accessor):
     s = await build_collection_schema_json(accessor, "mirage_test",
-                                            "embeddings")
+                                           "embeddings")
     vec = next(f for f in s["fields"] if f["path"] == "vector")
     assert vec["types"] == {"array<double>(1024)": 1.0}
 
@@ -63,7 +63,7 @@ async def test_schema_recognizes_fixed_length_embedding_array(accessor):
 @pytest.mark.asyncio
 async def test_schema_tags_text_index_and_returns_indexstats(accessor):
     s = await build_collection_schema_json(accessor, "mirage_test",
-                                            "text_indexed")
+                                           "text_indexed")
     by_name = {idx["name"]: idx for idx in s["indexes"]}
     assert by_name["title_body_text"]["type"] == "text"
     assert "ops" in by_name["title_body_text"]["stats"]
@@ -73,7 +73,7 @@ async def test_schema_tags_text_index_and_returns_indexstats(accessor):
 @pytest.mark.asyncio
 async def test_schema_view_marks_kind_and_skips_indexes(accessor):
     s = await build_collection_schema_json(accessor, "mirage_test",
-                                            "high_rated_films")
+                                           "high_rated_films")
     assert s["kind"] == "view"
     assert s["indexes"] == []
     assert s["document_count"] == 40
@@ -82,9 +82,9 @@ async def test_schema_view_marks_kind_and_skips_indexes(accessor):
 @pytest.mark.asyncio
 async def test_schema_heterogeneous_collection_surfaces_mixed_types(accessor):
     s = await build_collection_schema_json(accessor,
-                                            "mirage_test",
-                                            "heterogeneous",
-                                            sample_size=200)
+                                           "mirage_test",
+                                           "heterogeneous",
+                                           sample_size=200)
     by_path = {f["path"]: f for f in s["fields"]}
     assert "metadata.tag" in by_path
     score = by_path["score"]

--- a/python/tests/core/mongodb/test_schema_json_integration.py
+++ b/python/tests/core/mongodb/test_schema_json_integration.py
@@ -1,0 +1,92 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import os
+from pathlib import Path
+
+import pytest
+from dotenv import load_dotenv
+
+from mirage.accessor.mongodb import MongoDBAccessor
+from mirage.core.mongodb._schema_json import build_collection_schema_json
+from mirage.resource.mongodb.config import MongoDBConfig
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("MIRAGE_RUN_INTEGRATION_MONGO") != "1",
+    reason="integration test (set MIRAGE_RUN_INTEGRATION_MONGO=1 to enable)",
+)
+
+
+def _load_env() -> str:
+    repo_root = Path(__file__).resolve().parents[4]
+    load_dotenv(repo_root / ".env.development")
+    uri = os.environ.get("MONGODB_URI")
+    if not uri:
+        pytest.skip("MONGODB_URI not set in .env.development")
+    return uri
+
+
+@pytest.fixture
+def accessor():
+    return MongoDBAccessor(config=MongoDBConfig(uri=_load_env()))
+
+
+@pytest.mark.asyncio
+async def test_schema_captures_jsonschema_validator(accessor):
+    s = await build_collection_schema_json(accessor, "mirage_test",
+                                            "with_validator")
+    assert s["kind"] == "collection"
+    assert s["validator"]["bsonType"] == "object"
+    assert "title" in s["validator"]["required"]
+    assert "year" in s["validator"]["required"]
+
+
+@pytest.mark.asyncio
+async def test_schema_recognizes_fixed_length_embedding_array(accessor):
+    s = await build_collection_schema_json(accessor, "mirage_test",
+                                            "embeddings")
+    vec = next(f for f in s["fields"] if f["path"] == "vector")
+    assert vec["types"] == {"array<double>(1024)": 1.0}
+
+
+@pytest.mark.asyncio
+async def test_schema_tags_text_index_and_returns_indexstats(accessor):
+    s = await build_collection_schema_json(accessor, "mirage_test",
+                                            "text_indexed")
+    by_name = {idx["name"]: idx for idx in s["indexes"]}
+    assert by_name["title_body_text"]["type"] == "text"
+    assert "ops" in by_name["title_body_text"]["stats"]
+    assert by_name["_id_"]["type"] == "btree"
+
+
+@pytest.mark.asyncio
+async def test_schema_view_marks_kind_and_skips_indexes(accessor):
+    s = await build_collection_schema_json(accessor, "mirage_test",
+                                            "high_rated_films")
+    assert s["kind"] == "view"
+    assert s["indexes"] == []
+    assert s["document_count"] == 40
+
+
+@pytest.mark.asyncio
+async def test_schema_heterogeneous_collection_surfaces_mixed_types(accessor):
+    s = await build_collection_schema_json(accessor,
+                                            "mirage_test",
+                                            "heterogeneous",
+                                            sample_size=200)
+    by_path = {f["path"]: f for f in s["fields"]}
+    assert "metadata.tag" in by_path
+    score = by_path["score"]
+    assert set(score["types"].keys()).issubset({"string", "int", "null"})
+    assert sum(score["types"].values()) == pytest.approx(score["presence"])

--- a/python/tests/core/mongodb/test_scope.py
+++ b/python/tests/core/mongodb/test_scope.py
@@ -16,76 +16,120 @@ from mirage.core.mongodb.scope import detect_scope
 from mirage.types import PathSpec
 
 
-def test_root_path():
+def test_root():
     scope = detect_scope("/")
     assert scope.level == "root"
     assert scope.database is None
-    assert scope.collection is None
+    assert scope.kind is None
+    assert scope.name is None
 
 
-def test_database_path():
+def test_database():
     scope = detect_scope("/sample_mflix")
     assert scope.level == "database"
     assert scope.database == "sample_mflix"
-    assert scope.collection is None
+    assert scope.kind is None
+    assert scope.name is None
 
 
-def test_file_path():
-    scope = detect_scope("/sample_mflix/movies.jsonl")
-    assert scope.level == "file"
+def test_database_json():
+    scope = detect_scope("/sample_mflix/database.json")
+    assert scope.level == "database_json"
     assert scope.database == "sample_mflix"
-    assert scope.collection == "movies"
 
 
-def test_single_db_root():
-    scope = detect_scope("/", single_db=True, single_db_name="mydb")
-    assert scope.level == "database"
-    assert scope.database == "mydb"
+def test_collections_kind_dir():
+    scope = detect_scope("/sample_mflix/collections")
+    assert scope.level == "kind_dir"
+    assert scope.database == "sample_mflix"
+    assert scope.kind == "collection"
 
 
-def test_single_db_file():
-    scope = detect_scope("/movies.jsonl",
-                         single_db=True,
-                         single_db_name="mydb")
-    assert scope.level == "file"
-    assert scope.database == "mydb"
-    assert scope.collection == "movies"
+def test_views_kind_dir():
+    scope = detect_scope("/sample_mflix/views")
+    assert scope.level == "kind_dir"
+    assert scope.database == "sample_mflix"
+    assert scope.kind == "view"
 
 
-def test_glob_scope_root():
-    gs = PathSpec(
+def test_collection_entity_dir():
+    scope = detect_scope("/sample_mflix/collections/movies")
+    assert scope.level == "entity"
+    assert scope.database == "sample_mflix"
+    assert scope.kind == "collection"
+    assert scope.name == "movies"
+
+
+def test_view_entity_dir():
+    scope = detect_scope("/sample_mflix/views/top_rated")
+    assert scope.level == "entity"
+    assert scope.database == "sample_mflix"
+    assert scope.kind == "view"
+    assert scope.name == "top_rated"
+
+
+def test_collection_schema_json():
+    scope = detect_scope("/sample_mflix/collections/movies/schema.json")
+    assert scope.level == "schema_json"
+    assert scope.database == "sample_mflix"
+    assert scope.kind == "collection"
+    assert scope.name == "movies"
+
+
+def test_collection_documents_jsonl():
+    scope = detect_scope("/sample_mflix/collections/movies/documents.jsonl")
+    assert scope.level == "documents"
+    assert scope.database == "sample_mflix"
+    assert scope.kind == "collection"
+    assert scope.name == "movies"
+
+
+def test_view_documents_jsonl():
+    scope = detect_scope("/sample_mflix/views/top_rated/documents.jsonl")
+    assert scope.level == "documents"
+    assert scope.kind == "view"
+    assert scope.name == "top_rated"
+
+
+def test_unknown_leaf_under_entity():
+    scope = detect_scope("/sample_mflix/collections/movies/weird.txt")
+    assert scope.level == "unknown"
+
+
+def test_unknown_top_segment_under_db():
+    scope = detect_scope("/sample_mflix/randomdir")
+    assert scope.level == "unknown"
+
+
+def test_pathspec_with_prefix_root():
+    p = PathSpec(
         original="/mongo/",
         directory="/mongo/",
-        pattern=None,
-        resolved=False,
         prefix="/mongo",
     )
-    scope = detect_scope(gs)
+    scope = detect_scope(p)
     assert scope.level == "root"
 
 
-def test_glob_scope_database():
-    gs = PathSpec(
+def test_pathspec_with_prefix_database():
+    p = PathSpec(
         original="/mongo/sample_mflix",
         directory="/mongo/",
-        pattern=None,
-        resolved=False,
         prefix="/mongo",
     )
-    scope = detect_scope(gs)
+    scope = detect_scope(p)
     assert scope.level == "database"
     assert scope.database == "sample_mflix"
 
 
-def test_glob_scope_file():
-    gs = PathSpec(
-        original="/mongo/sample_mflix/movies.jsonl",
-        directory="/mongo/sample_mflix/",
-        pattern="*.jsonl",
-        resolved=True,
+def test_pathspec_with_prefix_documents():
+    p = PathSpec(
+        original="/mongo/sample_mflix/collections/movies/documents.jsonl",
+        directory="/mongo/sample_mflix/collections/movies/",
         prefix="/mongo",
     )
-    scope = detect_scope(gs)
-    assert scope.level == "file"
+    scope = detect_scope(p)
+    assert scope.level == "documents"
     assert scope.database == "sample_mflix"
-    assert scope.collection == "movies"
+    assert scope.kind == "collection"
+    assert scope.name == "movies"

--- a/python/tests/core/mongodb/test_search.py
+++ b/python/tests/core/mongodb/test_search.py
@@ -1,0 +1,116 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mirage.core.mongodb.search import (search_collection, search_database)
+
+
+class _AsyncIter:
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+def _agg_iter(items):
+    return _AsyncIter(items)
+
+
+def _build_search_client(sampled_docs, matched_docs):
+    col = MagicMock()
+    col.aggregate = MagicMock(return_value=_agg_iter(sampled_docs))
+    cursor = MagicMock()
+    cursor.limit = MagicMock(return_value=cursor)
+    cursor.to_list = AsyncMock(return_value=matched_docs)
+    col.find = MagicMock(return_value=cursor)
+    db = MagicMock()
+    db.__getitem__.return_value = col
+    client = MagicMock()
+    client.__getitem__.return_value = db
+    return client, col
+
+
+@pytest.mark.asyncio
+async def test_search_collection_unions_string_fields_across_sampled_docs():
+    sampled = [
+        {"_id": 1, "title": "Hello"},
+        {"_id": 2, "body": "World"},
+        {"_id": 3, "metadata": {"tag": "x"}},
+    ]
+    matched = [{"_id": 2, "body": "World matches"}]
+    client, col = _build_search_client(sampled, matched)
+    with patch("mirage.core.mongodb.search.get_indexes",
+               new=AsyncMock(return_value=[])):
+        out = await search_collection(client, "db1", "coll1", "World",
+                                      limit=10)
+    assert out == matched
+    filter_arg = col.find.call_args[0][0]
+    or_fields = {list(clause.keys())[0] for clause in filter_arg["$or"]}
+    assert {"title", "body", "metadata.tag"}.issubset(or_fields)
+
+
+@pytest.mark.asyncio
+async def test_search_collection_uses_text_when_textIndexVersion_present():
+    indexes = [{
+        "name": "title_text",
+        "key": {"_fts": "text", "_ftsx": 1},
+        "weights": {"title": 1},
+        "textIndexVersion": 3,
+    }]
+    client, col = _build_search_client([], [{"_id": 1}])
+    with patch("mirage.core.mongodb.search.get_indexes",
+               new=AsyncMock(return_value=indexes)):
+        await search_collection(client, "db1", "coll1", "query", limit=10)
+    assert col.find.call_args[0][0] == {"$text": {"$search": "query"}}
+
+
+@pytest.mark.asyncio
+async def test_search_collection_no_string_fields_uses_empty_filter():
+    sampled = [{"_id": 1, "n": 42}, {"_id": 2, "n": 7}]
+    client, col = _build_search_client(sampled, [])
+    with patch("mirage.core.mongodb.search.get_indexes",
+               new=AsyncMock(return_value=[])):
+        await search_collection(client, "db1", "coll1", "anything", limit=10)
+    filter_arg = col.find.call_args[0][0]
+    assert filter_arg == {}
+
+
+@pytest.mark.asyncio
+async def test_search_database_runs_collections_concurrently():
+    barrier = asyncio.Barrier(3)
+
+    async def slow_search(client, database, col, pattern, limit):
+        await barrier.wait()
+        return [{"_id": col, "v": col}]
+
+    with patch("mirage.core.mongodb.search.list_collections",
+               new=AsyncMock(return_value=["a", "b", "c"])):
+        with patch("mirage.core.mongodb.search.search_collection",
+                   new=slow_search):
+            out = await asyncio.wait_for(
+                search_database(None, "db", "p", 10),
+                timeout=2.0,
+            )
+    assert {col for _, col, _ in out} == {"a", "b", "c"}

--- a/python/tests/core/mongodb/test_search.py
+++ b/python/tests/core/mongodb/test_search.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from mirage.core.mongodb.search import (search_collection, search_database)
+from mirage.core.mongodb.search import search_collection, search_database
 
 
 class _AsyncIter:
@@ -55,15 +55,29 @@ def _build_search_client(sampled_docs, matched_docs):
 @pytest.mark.asyncio
 async def test_search_collection_unions_string_fields_across_sampled_docs():
     sampled = [
-        {"_id": 1, "title": "Hello"},
-        {"_id": 2, "body": "World"},
-        {"_id": 3, "metadata": {"tag": "x"}},
+        {
+            "_id": 1,
+            "title": "Hello"
+        },
+        {
+            "_id": 2,
+            "body": "World"
+        },
+        {
+            "_id": 3,
+            "metadata": {
+                "tag": "x"
+            }
+        },
     ]
     matched = [{"_id": 2, "body": "World matches"}]
     client, col = _build_search_client(sampled, matched)
     with patch("mirage.core.mongodb.search.get_indexes",
                new=AsyncMock(return_value=[])):
-        out = await search_collection(client, "db1", "coll1", "World",
+        out = await search_collection(client,
+                                      "db1",
+                                      "coll1",
+                                      "World",
                                       limit=10)
     assert out == matched
     filter_arg = col.find.call_args[0][0]
@@ -75,8 +89,13 @@ async def test_search_collection_unions_string_fields_across_sampled_docs():
 async def test_search_collection_uses_text_when_textIndexVersion_present():
     indexes = [{
         "name": "title_text",
-        "key": {"_fts": "text", "_ftsx": 1},
-        "weights": {"title": 1},
+        "key": {
+            "_fts": "text",
+            "_ftsx": 1
+        },
+        "weights": {
+            "title": 1
+        },
         "textIndexVersion": 3,
     }]
     client, col = _build_search_client([], [{"_id": 1}])
@@ -87,14 +106,18 @@ async def test_search_collection_uses_text_when_textIndexVersion_present():
 
 
 @pytest.mark.asyncio
-async def test_search_collection_no_string_fields_uses_empty_filter():
+async def test_search_collection_no_string_fields_returns_no_results():
     sampled = [{"_id": 1, "n": 42}, {"_id": 2, "n": 7}]
     client, col = _build_search_client(sampled, [])
     with patch("mirage.core.mongodb.search.get_indexes",
                new=AsyncMock(return_value=[])):
-        await search_collection(client, "db1", "coll1", "anything", limit=10)
-    filter_arg = col.find.call_args[0][0]
-    assert filter_arg == {}
+        out = await search_collection(client,
+                                      "db1",
+                                      "coll1",
+                                      "anything",
+                                      limit=10)
+    assert out == []
+    assert col.find.call_args is None
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/mongodb/test_stat.py
+++ b/python/tests/core/mongodb/test_stat.py
@@ -30,159 +30,122 @@ def index():
 
 @pytest.fixture
 def accessor():
-    config = MongoDBConfig(uri="mongodb://localhost:27017")
-    return MongoDBAccessor(config=config)
+    return MongoDBAccessor(
+        config=MongoDBConfig(uri="mongodb://localhost:27017"))
 
 
-@pytest.fixture
-def single_db_accessor():
-    config = MongoDBConfig(uri="mongodb://localhost:27017", databases=["mydb"])
-    return MongoDBAccessor(config=config)
+def _path(s: str) -> PathSpec:
+    return PathSpec(original=s, directory=s)
 
 
 @pytest.mark.asyncio
 async def test_stat_root(accessor, index):
-    result = await stat(accessor, PathSpec(original="/", directory="/"), index)
+    result = await stat(accessor, _path("/"), index)
     assert result.type == FileType.DIRECTORY
     assert result.name == "/"
 
 
 @pytest.mark.asyncio
 async def test_stat_database(accessor, index):
-    result = await stat(
-        accessor, PathSpec(original="/sample_mflix",
-                           directory="/sample_mflix"), index)
+    result = await stat(accessor, _path("/sample_mflix"), index)
     assert result.type == FileType.DIRECTORY
+    assert result.name == "sample_mflix"
     assert result.extra["database"] == "sample_mflix"
 
 
 @pytest.mark.asyncio
-async def test_stat_collection_file(accessor, index):
+async def test_stat_collections_kind_dir(accessor, index):
+    result = await stat(accessor, _path("/sample_mflix/collections"), index)
+    assert result.type == FileType.DIRECTORY
+    assert result.name == "collections"
+    assert result.extra["kind"] == "collection"
+
+
+@pytest.mark.asyncio
+async def test_stat_views_kind_dir(accessor, index):
+    result = await stat(accessor, _path("/sample_mflix/views"), index)
+    assert result.type == FileType.DIRECTORY
+    assert result.name == "views"
+    assert result.extra["kind"] == "view"
+
+
+@pytest.mark.asyncio
+async def test_stat_entity_collection(accessor, index):
+    with patch("mirage.core.mongodb.stat.count_documents",
+               new=AsyncMock(return_value=23519)):
+        result = await stat(accessor,
+                            _path("/sample_mflix/collections/movies"), index)
+    assert result.type == FileType.DIRECTORY
+    assert result.name == "movies"
+    assert result.extra["kind"] == "collection"
+    assert result.extra["document_count"] == 23519
+
+
+@pytest.mark.asyncio
+async def test_stat_documents_collection_full_metadata(accessor, index):
     fake_indexes = [{"name": "_id_", "key": {"_id": 1}}]
     with (
-            patch(
-                "mirage.core.mongodb.stat.is_view",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch(
-                "mirage.core.mongodb.stat.count_documents",
-                new_callable=AsyncMock,
-                return_value=42,
-            ),
-            patch(
-                "mirage.core.mongodb.stat.get_indexes",
-                new_callable=AsyncMock,
-                return_value=fake_indexes,
-            ),
+            patch("mirage.core.mongodb.stat.is_view",
+                  new=AsyncMock(return_value=False)),
+            patch("mirage.core.mongodb.stat.count_documents",
+                  new=AsyncMock(return_value=42)),
+            patch("mirage.core.mongodb.stat.get_indexes",
+                  new=AsyncMock(return_value=fake_indexes)),
     ):
         result = await stat(
             accessor,
-            PathSpec(original="/sample_mflix/movies.jsonl",
-                     directory="/sample_mflix/movies.jsonl"), index)
-
+            _path("/sample_mflix/collections/movies/documents.jsonl"), index)
     assert result.type == FileType.TEXT
-    assert result.name == "movies.jsonl"
-    assert result.extra["database"] == "sample_mflix"
-    assert result.extra["collection"] == "movies"
+    assert result.name == "documents.jsonl"
+    assert result.extra["kind"] == "collection"
     assert result.extra["document_count"] == 42
     assert result.extra["indexes"] == [{"name": "_id_", "keys": {"_id": 1}}]
 
 
 @pytest.mark.asyncio
-async def test_stat_single_db_collection(single_db_accessor, index):
+async def test_stat_documents_view_skips_indexes(accessor, index):
     with (
             patch(
-                "mirage.core.mongodb.stat.is_view",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch(
                 "mirage.core.mongodb.stat.count_documents",
-                new_callable=AsyncMock,
-                return_value=10,
+                new=AsyncMock(return_value=17),
             ),
             patch(
                 "mirage.core.mongodb.stat.get_indexes",
-                new_callable=AsyncMock,
-                return_value=[],
-            ),
-    ):
-        result = await stat(
-            single_db_accessor,
-            PathSpec(original="/movies.jsonl", directory="/movies.jsonl"),
-            index)
-
-    assert result.type == FileType.TEXT
-    assert result.extra["database"] == "mydb"
-    assert result.extra["collection"] == "movies"
-
-
-@pytest.mark.asyncio
-async def test_stat_view_skips_indexes(accessor, index):
-    with (
-            patch(
-                "mirage.core.mongodb.stat.is_view",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
-            patch(
-                "mirage.core.mongodb.stat.count_documents",
-                new_callable=AsyncMock,
-                return_value=17,
-            ),
-            patch(
-                "mirage.core.mongodb.stat.get_indexes",
-                new_callable=AsyncMock,
-                side_effect=AssertionError(
-                    "get_indexes should not be called on a view"),
+                new=AsyncMock(
+                    side_effect=AssertionError(
+                        "get_indexes must not be called for views")),
             ),
     ):
         result = await stat(
             accessor,
-            PathSpec(original="/sample_mflix/my_view.jsonl",
-                     directory="/sample_mflix/my_view.jsonl"), index)
+            _path("/sample_mflix/views/my_view/documents.jsonl"), index)
     assert result.type == FileType.TEXT
-    assert result.name == "my_view.jsonl"
-    assert result.extra["database"] == "sample_mflix"
-    assert result.extra["collection"] == "my_view"
-    assert result.extra["document_count"] == 17
-    assert result.extra["indexes"] == []
     assert result.extra["kind"] == "view"
+    assert result.extra["indexes"] == []
+    assert result.extra["document_count"] == 17
 
 
 @pytest.mark.asyncio
-async def test_stat_collection_marks_kind(accessor, index):
-    fake_indexes = [{"name": "_id_", "key": {"_id": 1}}]
-    with (
-            patch(
-                "mirage.core.mongodb.stat.is_view",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch(
-                "mirage.core.mongodb.stat.count_documents",
-                new_callable=AsyncMock,
-                return_value=5,
-            ),
-            patch(
-                "mirage.core.mongodb.stat.get_indexes",
-                new_callable=AsyncMock,
-                return_value=fake_indexes,
-            ),
-    ):
-        result = await stat(
-            accessor,
-            PathSpec(original="/sample_mflix/movies.jsonl",
-                     directory="/sample_mflix/movies.jsonl"), index)
+async def test_stat_schema_json(accessor, index):
+    result = await stat(
+        accessor, _path("/sample_mflix/collections/movies/schema.json"),
+        index)
+    assert result.type == FileType.TEXT
+    assert result.name == "schema.json"
     assert result.extra["kind"] == "collection"
-    assert result.extra["indexes"] == [{"name": "_id_", "keys": {"_id": 1}}]
+    assert result.extra["name"] == "movies"
 
 
 @pytest.mark.asyncio
-async def test_stat_not_found(accessor, index):
+async def test_stat_database_json(accessor, index):
+    result = await stat(accessor, _path("/sample_mflix/database.json"),
+                        index)
+    assert result.type == FileType.TEXT
+    assert result.name == "database.json"
+    assert result.extra["database"] == "sample_mflix"
+
+
+@pytest.mark.asyncio
+async def test_stat_unknown_path_raises(accessor, index):
     with pytest.raises(FileNotFoundError):
-        await stat(
-            accessor,
-            PathSpec(original="/db/col/extra/path",
-                     directory="/db/col/extra/path"), index)
+        await stat(accessor, _path("/db/something/extra/leaf"), index)

--- a/python/tests/core/mongodb/test_stat.py
+++ b/python/tests/core/mongodb/test_stat.py
@@ -61,6 +61,11 @@ async def test_stat_collection_file(accessor, index):
     fake_indexes = [{"name": "_id_", "key": {"_id": 1}}]
     with (
             patch(
+                "mirage.core.mongodb.stat.is_view",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
                 "mirage.core.mongodb.stat.count_documents",
                 new_callable=AsyncMock,
                 return_value=42,
@@ -88,6 +93,11 @@ async def test_stat_collection_file(accessor, index):
 async def test_stat_single_db_collection(single_db_accessor, index):
     with (
             patch(
+                "mirage.core.mongodb.stat.is_view",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
                 "mirage.core.mongodb.stat.count_documents",
                 new_callable=AsyncMock,
                 return_value=10,
@@ -106,6 +116,67 @@ async def test_stat_single_db_collection(single_db_accessor, index):
     assert result.type == FileType.TEXT
     assert result.extra["database"] == "mydb"
     assert result.extra["collection"] == "movies"
+
+
+@pytest.mark.asyncio
+async def test_stat_view_skips_indexes(accessor, index):
+    with (
+            patch(
+                "mirage.core.mongodb.stat.is_view",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "mirage.core.mongodb.stat.count_documents",
+                new_callable=AsyncMock,
+                return_value=17,
+            ),
+            patch(
+                "mirage.core.mongodb.stat.get_indexes",
+                new_callable=AsyncMock,
+                side_effect=AssertionError(
+                    "get_indexes should not be called on a view"),
+            ),
+    ):
+        result = await stat(
+            accessor,
+            PathSpec(original="/sample_mflix/my_view.jsonl",
+                     directory="/sample_mflix/my_view.jsonl"), index)
+    assert result.type == FileType.TEXT
+    assert result.name == "my_view.jsonl"
+    assert result.extra["database"] == "sample_mflix"
+    assert result.extra["collection"] == "my_view"
+    assert result.extra["document_count"] == 17
+    assert result.extra["indexes"] == []
+    assert result.extra["kind"] == "view"
+
+
+@pytest.mark.asyncio
+async def test_stat_collection_marks_kind(accessor, index):
+    fake_indexes = [{"name": "_id_", "key": {"_id": 1}}]
+    with (
+            patch(
+                "mirage.core.mongodb.stat.is_view",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "mirage.core.mongodb.stat.count_documents",
+                new_callable=AsyncMock,
+                return_value=5,
+            ),
+            patch(
+                "mirage.core.mongodb.stat.get_indexes",
+                new_callable=AsyncMock,
+                return_value=fake_indexes,
+            ),
+    ):
+        result = await stat(
+            accessor,
+            PathSpec(original="/sample_mflix/movies.jsonl",
+                     directory="/sample_mflix/movies.jsonl"), index)
+    assert result.extra["kind"] == "collection"
+    assert result.extra["indexes"] == [{"name": "_id_", "keys": {"_id": 1}}]
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/mongodb/test_stat.py
+++ b/python/tests/core/mongodb/test_stat.py
@@ -38,6 +38,20 @@ def _path(s: str) -> PathSpec:
     return PathSpec(original=s, directory=s)
 
 
+@pytest.fixture(autouse=True)
+def _stub_existence_checks():
+    with patch(
+            "mirage.core.mongodb.stat.database_exists",
+            new_callable=AsyncMock,
+            return_value=True,
+    ), patch(
+            "mirage.core.mongodb.stat.entity_exists",
+            new_callable=AsyncMock,
+            return_value=True,
+    ):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_stat_root(accessor, index):
     result = await stat(accessor, _path("/"), index)
@@ -147,3 +161,40 @@ async def test_stat_database_json(accessor, index):
 async def test_stat_unknown_path_raises(accessor, index):
     with pytest.raises(FileNotFoundError):
         await stat(accessor, _path("/db/something/extra/leaf"), index)
+
+
+@pytest.mark.asyncio
+async def test_stat_database_missing_raises(accessor, index):
+    with patch(
+            "mirage.core.mongodb.stat.database_exists",
+            new_callable=AsyncMock,
+            return_value=False,
+    ):
+        with pytest.raises(FileNotFoundError):
+            await stat(accessor, _path("/ghost"), index)
+
+
+@pytest.mark.asyncio
+async def test_stat_collection_missing_raises(accessor, index):
+    with patch(
+            "mirage.core.mongodb.stat.entity_exists",
+            new_callable=AsyncMock,
+            return_value=False,
+    ):
+        with pytest.raises(FileNotFoundError):
+            await stat(accessor, _path("/sample_mflix/collections/ghost"),
+                       index)
+
+
+@pytest.mark.asyncio
+async def test_stat_documents_under_missing_collection_raises(accessor, index):
+    with patch(
+            "mirage.core.mongodb.stat.entity_exists",
+            new_callable=AsyncMock,
+            return_value=False,
+    ):
+        with pytest.raises(FileNotFoundError):
+            await stat(
+                accessor,
+                _path("/sample_mflix/collections/ghost/documents.jsonl"),
+                index)

--- a/python/tests/core/mongodb/test_stat.py
+++ b/python/tests/core/mongodb/test_stat.py
@@ -30,8 +30,8 @@ def index():
 
 @pytest.fixture
 def accessor():
-    return MongoDBAccessor(
-        config=MongoDBConfig(uri="mongodb://localhost:27017"))
+    return MongoDBAccessor(config=MongoDBConfig(
+        uri="mongodb://localhost:27017"))
 
 
 def _path(s: str) -> PathSpec:
@@ -111,14 +111,13 @@ async def test_stat_documents_view_skips_indexes(accessor, index):
             ),
             patch(
                 "mirage.core.mongodb.stat.get_indexes",
-                new=AsyncMock(
-                    side_effect=AssertionError(
-                        "get_indexes must not be called for views")),
+                new=AsyncMock(side_effect=AssertionError(
+                    "get_indexes must not be called for views")),
             ),
     ):
         result = await stat(
-            accessor,
-            _path("/sample_mflix/views/my_view/documents.jsonl"), index)
+            accessor, _path("/sample_mflix/views/my_view/documents.jsonl"),
+            index)
     assert result.type == FileType.TEXT
     assert result.extra["kind"] == "view"
     assert result.extra["indexes"] == []
@@ -127,9 +126,9 @@ async def test_stat_documents_view_skips_indexes(accessor, index):
 
 @pytest.mark.asyncio
 async def test_stat_schema_json(accessor, index):
-    result = await stat(
-        accessor, _path("/sample_mflix/collections/movies/schema.json"),
-        index)
+    result = await stat(accessor,
+                        _path("/sample_mflix/collections/movies/schema.json"),
+                        index)
     assert result.type == FileType.TEXT
     assert result.name == "schema.json"
     assert result.extra["kind"] == "collection"
@@ -138,8 +137,7 @@ async def test_stat_schema_json(accessor, index):
 
 @pytest.mark.asyncio
 async def test_stat_database_json(accessor, index):
-    result = await stat(accessor, _path("/sample_mflix/database.json"),
-                        index)
+    result = await stat(accessor, _path("/sample_mflix/database.json"), index)
     assert result.type == FileType.TEXT
     assert result.name == "database.json"
     assert result.extra["database"] == "sample_mflix"

--- a/python/tests/core/mongodb/test_stream.py
+++ b/python/tests/core/mongodb/test_stream.py
@@ -1,0 +1,146 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import datetime as dt
+import json
+from unittest.mock import patch
+
+import pytest
+from bson import Decimal128, ObjectId
+
+from mirage.accessor.mongodb import MongoDBAccessor
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.core.mongodb.stream import read_stream
+from mirage.resource.mongodb.config import MongoDBConfig
+from mirage.types import PathSpec
+
+
+async def _gen(items):
+    for item in items:
+        yield item
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+@pytest.fixture
+def accessor():
+    return MongoDBAccessor(
+        config=MongoDBConfig(uri="mongodb://localhost:27017"))
+
+
+@pytest.fixture
+def single_db_accessor():
+    return MongoDBAccessor(config=MongoDBConfig(
+        uri="mongodb://localhost:27017", databases=["db1"]))
+
+
+def _patched_iter(docs):
+    return patch("mirage.core.mongodb.stream.iter_documents",
+                 new=lambda *args, **kwargs: _gen(docs))
+
+
+async def _collect(gen):
+    chunks = []
+    async for chunk in gen:
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+@pytest.mark.asyncio
+async def test_read_stream_yields_one_jsonl_line_per_doc(accessor, index):
+    oid_a, oid_b = ObjectId(), ObjectId()
+    docs = [{"_id": oid_a, "title": "A"}, {"_id": oid_b, "title": "B"}]
+    path = PathSpec(original="/db1/coll1.jsonl",
+                    directory="/db1/coll1.jsonl")
+    with _patched_iter(docs):
+        data = await _collect(read_stream(accessor, path, index))
+    lines = [line for line in data.decode().split("\n") if line]
+    assert len(lines) == 2
+    first = json.loads(lines[0])
+    assert first["title"] == "A"
+    assert first["_id"] == {"$oid": str(oid_a)}
+
+
+@pytest.mark.asyncio
+async def test_read_stream_preserves_bson_types_via_extended_json(
+        accessor, index):
+    docs = [{
+        "_id": ObjectId("65f0000000000000000000a1"),
+        "date": dt.datetime(2026, 5, 15, 12, 30, 45,
+                            tzinfo=dt.timezone.utc),
+        "decimal": Decimal128("123.456"),
+    }]
+    path = PathSpec(original="/db1/coll1.jsonl",
+                    directory="/db1/coll1.jsonl")
+    with _patched_iter(docs):
+        data = await _collect(read_stream(accessor, path, index))
+    parsed = json.loads(data.decode().strip())
+    assert parsed["_id"] == {"$oid": "65f0000000000000000000a1"}
+    assert "$date" in parsed["date"]
+    assert parsed["decimal"] == {"$numberDecimal": "123.456"}
+
+
+@pytest.mark.asyncio
+async def test_read_stream_empty_yields_nothing(accessor, index):
+    path = PathSpec(original="/db1/coll1.jsonl",
+                    directory="/db1/coll1.jsonl")
+    with _patched_iter([]):
+        chunks = []
+        async for chunk in read_stream(accessor, path, index):
+            chunks.append(chunk)
+    assert chunks == []
+
+
+@pytest.mark.asyncio
+async def test_read_stream_short_circuits_when_consumer_closes(
+        accessor, index):
+    consumed: list[int] = []
+
+    async def _instrumented(*_args, **_kwargs):
+        for i in range(1000):
+            consumed.append(i)
+            yield {"_id": ObjectId(), "i": i}
+
+    path = PathSpec(original="/db1/coll1.jsonl",
+                    directory="/db1/coll1.jsonl")
+    with patch("mirage.core.mongodb.stream.iter_documents",
+               new=_instrumented):
+        gen = read_stream(accessor, path, index)
+        await gen.__anext__()
+        await gen.aclose()
+    assert len(consumed) <= 2
+
+
+@pytest.mark.asyncio
+async def test_read_stream_single_db_mode_collapses_path(
+        single_db_accessor, index):
+    docs = [{"_id": ObjectId(), "v": 1}]
+    path = PathSpec(original="/coll1.jsonl", directory="/coll1.jsonl")
+    with _patched_iter(docs):
+        data = await _collect(read_stream(single_db_accessor, path, index))
+    assert data
+    parsed = json.loads(data.decode().strip())
+    assert parsed["v"] == 1
+
+
+@pytest.mark.asyncio
+async def test_read_stream_directory_path_raises(accessor, index):
+    path = PathSpec(original="/db1", directory="/db1")
+    with _patched_iter([]):
+        with pytest.raises(FileNotFoundError):
+            async for _ in read_stream(accessor, path, index):
+                pass

--- a/python/tests/core/mongodb/test_stream.py
+++ b/python/tests/core/mongodb/test_stream.py
@@ -41,8 +41,8 @@ def index():
 
 @pytest.fixture
 def accessor():
-    return MongoDBAccessor(
-        config=MongoDBConfig(uri="mongodb://localhost:27017"))
+    return MongoDBAccessor(config=MongoDBConfig(
+        uri="mongodb://localhost:27017"))
 
 
 def _patched_iter(docs):
@@ -78,10 +78,12 @@ async def test_read_stream_yields_one_jsonl_line_per_doc(accessor, index):
 async def test_read_stream_preserves_bson_types_via_extended_json(
         accessor, index):
     docs = [{
-        "_id": ObjectId("65f0000000000000000000a1"),
-        "date": dt.datetime(2026, 5, 15, 12, 30, 45,
-                            tzinfo=dt.timezone.utc),
-        "decimal": Decimal128("123.456"),
+        "_id":
+        ObjectId("65f0000000000000000000a1"),
+        "date":
+        dt.datetime(2026, 5, 15, 12, 30, 45, tzinfo=dt.timezone.utc),
+        "decimal":
+        Decimal128("123.456"),
     }]
     with _patched_iter(docs):
         data = await _collect(read_stream(accessor, _path(DOCS_PATH), index))
@@ -110,8 +112,7 @@ async def test_read_stream_short_circuits_when_consumer_closes(
             consumed.append(i)
             yield {"_id": ObjectId(), "i": i}
 
-    with patch("mirage.core.mongodb.stream.iter_documents",
-               new=_instrumented):
+    with patch("mirage.core.mongodb.stream.iter_documents", new=_instrumented):
         gen = read_stream(accessor, _path(DOCS_PATH), index)
         await gen.__anext__()
         await gen.aclose()
@@ -143,8 +144,8 @@ async def test_read_stream_schema_json_path_raises(accessor, index):
     with _patched_iter([]):
         with pytest.raises(FileNotFoundError):
             async for _ in read_stream(
-                    accessor,
-                    _path("/db1/collections/coll1/schema.json"), index):
+                    accessor, _path("/db1/collections/coll1/schema.json"),
+                    index):
                 pass
 
 
@@ -156,16 +157,12 @@ async def test_read_stream_elides_configured_top_level_field(index):
     )
     acc = MongoDBAccessor(config=cfg)
     oid = ObjectId()
-    docs = [{
-        "_id": oid,
-        "title": "hi",
-        "vector": [0.1, 0.2, 0.3, 0.4, 0.5]
-    }]
+    docs = [{"_id": oid, "title": "hi", "vector": [0.1, 0.2, 0.3, 0.4, 0.5]}]
     with _patched_iter(docs):
         data = await _collect(read_stream(acc, _path(DOCS_PATH), index))
     parsed = json.loads(data.decode().strip())
     assert parsed["title"] == "hi"
-    assert parsed["vector"] == {"$elided": "array<double>(5)"}
+    assert "vector" not in parsed
     assert parsed["_id"] == {"$oid": str(oid)}
 
 
@@ -187,9 +184,7 @@ async def test_read_stream_elides_configured_nested_path(index):
         data = await _collect(read_stream(acc, _path(DOCS_PATH), index))
     parsed = json.loads(data.decode().strip())
     assert parsed["metadata"]["tag"] == "alpha"
-    assert parsed["metadata"]["embedding"] == {
-        "$elided": "array<double>(1024)"
-    }
+    assert "embedding" not in parsed["metadata"]
 
 
 @pytest.mark.asyncio
@@ -204,17 +199,3 @@ async def test_read_stream_elision_isolated_to_configured_collection(index):
         data = await _collect(read_stream(acc, _path(DOCS_PATH), index))
     parsed = json.loads(data.decode().strip())
     assert parsed["vector"] == [1.0, 2.0]
-
-
-@pytest.mark.asyncio
-async def test_read_stream_elision_stub_uses_array_string_tag(index):
-    cfg = MongoDBConfig(
-        uri="mongodb://localhost:27017",
-        elide_fields={"db1.coll1": ["tags"]},
-    )
-    acc = MongoDBAccessor(config=cfg)
-    docs = [{"_id": ObjectId(), "tags": ["a", "b", "c"]}]
-    with _patched_iter(docs):
-        data = await _collect(read_stream(acc, _path(DOCS_PATH), index))
-    parsed = json.loads(data.decode().strip())
-    assert parsed["tags"] == {"$elided": "array<string>"}

--- a/python/tests/core/mongodb/test_stream.py
+++ b/python/tests/core/mongodb/test_stream.py
@@ -21,7 +21,7 @@ from bson import Decimal128, ObjectId
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index.ram import RAMIndexCacheStore
-from mirage.core.mongodb.stream import read_stream
+from mirage.core.mongodb.stream import read_stream, watch_stream
 from mirage.resource.mongodb.config import MongoDBConfig
 from mirage.types import PathSpec
 
@@ -47,6 +47,11 @@ def accessor():
 
 def _patched_iter(docs):
     return patch("mirage.core.mongodb.stream.iter_documents",
+                 new=lambda *args, **kwargs: _gen(docs))
+
+
+def _patched_watch(docs):
+    return patch("mirage.core.mongodb.stream.iter_inserts",
                  new=lambda *args, **kwargs: _gen(docs))
 
 
@@ -199,3 +204,84 @@ async def test_read_stream_elision_isolated_to_configured_collection(index):
         data = await _collect(read_stream(acc, _path(DOCS_PATH), index))
     parsed = json.loads(data.decode().strip())
     assert parsed["vector"] == [1.0, 2.0]
+
+
+@pytest.mark.asyncio
+async def test_watch_stream_yields_one_jsonl_line_per_insert(accessor, index):
+    oid_a, oid_b = ObjectId(), ObjectId()
+    docs = [{"_id": oid_a, "title": "A"}, {"_id": oid_b, "title": "B"}]
+    with _patched_watch(docs):
+        data = await _collect(watch_stream(accessor, _path(DOCS_PATH), index))
+    lines = [line for line in data.decode().split("\n") if line]
+    assert len(lines) == 2
+    assert json.loads(lines[0])["_id"] == {"$oid": str(oid_a)}
+    assert json.loads(lines[1])["title"] == "B"
+
+
+@pytest.mark.asyncio
+async def test_watch_stream_preserves_bson_types(accessor, index):
+    docs = [{
+        "_id":
+        ObjectId("65f0000000000000000000a1"),
+        "date":
+        dt.datetime(2026, 5, 15, 12, 30, 45, tzinfo=dt.timezone.utc),
+        "decimal":
+        Decimal128("123.456"),
+    }]
+    with _patched_watch(docs):
+        data = await _collect(watch_stream(accessor, _path(DOCS_PATH), index))
+    parsed = json.loads(data.decode().strip())
+    assert parsed["_id"] == {"$oid": "65f0000000000000000000a1"}
+    assert "$date" in parsed["date"]
+    assert parsed["decimal"] == {"$numberDecimal": "123.456"}
+
+
+@pytest.mark.asyncio
+async def test_watch_stream_empty_yields_nothing(accessor, index):
+    with _patched_watch([]):
+        chunks = []
+        async for chunk in watch_stream(accessor, _path(DOCS_PATH), index):
+            chunks.append(chunk)
+    assert chunks == []
+
+
+@pytest.mark.asyncio
+async def test_watch_stream_short_circuits_when_consumer_closes(
+        accessor, index):
+    consumed: list[int] = []
+
+    async def _instrumented(*_args, **_kwargs):
+        for i in range(1000):
+            consumed.append(i)
+            yield {"_id": ObjectId(), "i": i}
+
+    with patch("mirage.core.mongodb.stream.iter_inserts", new=_instrumented):
+        gen = watch_stream(accessor, _path(DOCS_PATH), index)
+        await gen.__anext__()
+        await gen.aclose()
+    assert len(consumed) <= 2
+
+
+@pytest.mark.asyncio
+async def test_watch_stream_directory_path_raises(accessor, index):
+    with _patched_watch([]):
+        with pytest.raises(FileNotFoundError):
+            async for _ in watch_stream(accessor, _path("/db1"), index):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_watch_stream_applies_elision(index):
+    cfg = MongoDBConfig(
+        uri="mongodb://localhost:27017",
+        elide_fields={"db1.coll1": ["vector"]},
+    )
+    acc = MongoDBAccessor(config=cfg)
+    oid = ObjectId()
+    docs = [{"_id": oid, "title": "live", "vector": [0.1, 0.2, 0.3]}]
+    with _patched_watch(docs):
+        data = await _collect(watch_stream(acc, _path(DOCS_PATH), index))
+    parsed = json.loads(data.decode().strip())
+    assert parsed["title"] == "live"
+    assert "vector" not in parsed
+    assert parsed["_id"] == {"$oid": str(oid)}

--- a/python/tests/core/mongodb/test_stream.py
+++ b/python/tests/core/mongodb/test_stream.py
@@ -146,3 +146,75 @@ async def test_read_stream_schema_json_path_raises(accessor, index):
                     accessor,
                     _path("/db1/collections/coll1/schema.json"), index):
                 pass
+
+
+@pytest.mark.asyncio
+async def test_read_stream_elides_configured_top_level_field(index):
+    cfg = MongoDBConfig(
+        uri="mongodb://localhost:27017",
+        elide_fields={"db1.coll1": ["vector"]},
+    )
+    acc = MongoDBAccessor(config=cfg)
+    oid = ObjectId()
+    docs = [{
+        "_id": oid,
+        "title": "hi",
+        "vector": [0.1, 0.2, 0.3, 0.4, 0.5]
+    }]
+    with _patched_iter(docs):
+        data = await _collect(read_stream(acc, _path(DOCS_PATH), index))
+    parsed = json.loads(data.decode().strip())
+    assert parsed["title"] == "hi"
+    assert parsed["vector"] == {"$elided": "array<double>(5)"}
+    assert parsed["_id"] == {"$oid": str(oid)}
+
+
+@pytest.mark.asyncio
+async def test_read_stream_elides_configured_nested_path(index):
+    cfg = MongoDBConfig(
+        uri="mongodb://localhost:27017",
+        elide_fields={"db1.coll1": ["metadata.embedding"]},
+    )
+    acc = MongoDBAccessor(config=cfg)
+    docs = [{
+        "_id": ObjectId(),
+        "metadata": {
+            "tag": "alpha",
+            "embedding": [0.1] * 1024,
+        },
+    }]
+    with _patched_iter(docs):
+        data = await _collect(read_stream(acc, _path(DOCS_PATH), index))
+    parsed = json.loads(data.decode().strip())
+    assert parsed["metadata"]["tag"] == "alpha"
+    assert parsed["metadata"]["embedding"] == {
+        "$elided": "array<double>(1024)"
+    }
+
+
+@pytest.mark.asyncio
+async def test_read_stream_elision_isolated_to_configured_collection(index):
+    cfg = MongoDBConfig(
+        uri="mongodb://localhost:27017",
+        elide_fields={"db1.other_coll": ["vector"]},
+    )
+    acc = MongoDBAccessor(config=cfg)
+    docs = [{"_id": ObjectId(), "vector": [1.0, 2.0]}]
+    with _patched_iter(docs):
+        data = await _collect(read_stream(acc, _path(DOCS_PATH), index))
+    parsed = json.loads(data.decode().strip())
+    assert parsed["vector"] == [1.0, 2.0]
+
+
+@pytest.mark.asyncio
+async def test_read_stream_elision_stub_uses_array_string_tag(index):
+    cfg = MongoDBConfig(
+        uri="mongodb://localhost:27017",
+        elide_fields={"db1.coll1": ["tags"]},
+    )
+    acc = MongoDBAccessor(config=cfg)
+    docs = [{"_id": ObjectId(), "tags": ["a", "b", "c"]}]
+    with _patched_iter(docs):
+        data = await _collect(read_stream(acc, _path(DOCS_PATH), index))
+    parsed = json.loads(data.decode().strip())
+    assert parsed["tags"] == {"$elided": "array<string>"}

--- a/python/tests/core/mongodb/test_stream.py
+++ b/python/tests/core/mongodb/test_stream.py
@@ -25,6 +25,9 @@ from mirage.core.mongodb.stream import read_stream
 from mirage.resource.mongodb.config import MongoDBConfig
 from mirage.types import PathSpec
 
+DOCS_PATH = "/db1/collections/coll1/documents.jsonl"
+VIEW_DOCS_PATH = "/db1/views/myview/documents.jsonl"
+
 
 async def _gen(items):
     for item in items:
@@ -42,15 +45,13 @@ def accessor():
         config=MongoDBConfig(uri="mongodb://localhost:27017"))
 
 
-@pytest.fixture
-def single_db_accessor():
-    return MongoDBAccessor(config=MongoDBConfig(
-        uri="mongodb://localhost:27017", databases=["db1"]))
-
-
 def _patched_iter(docs):
     return patch("mirage.core.mongodb.stream.iter_documents",
                  new=lambda *args, **kwargs: _gen(docs))
+
+
+def _path(s: str) -> PathSpec:
+    return PathSpec(original=s, directory=s)
 
 
 async def _collect(gen):
@@ -64,10 +65,8 @@ async def _collect(gen):
 async def test_read_stream_yields_one_jsonl_line_per_doc(accessor, index):
     oid_a, oid_b = ObjectId(), ObjectId()
     docs = [{"_id": oid_a, "title": "A"}, {"_id": oid_b, "title": "B"}]
-    path = PathSpec(original="/db1/coll1.jsonl",
-                    directory="/db1/coll1.jsonl")
     with _patched_iter(docs):
-        data = await _collect(read_stream(accessor, path, index))
+        data = await _collect(read_stream(accessor, _path(DOCS_PATH), index))
     lines = [line for line in data.decode().split("\n") if line]
     assert len(lines) == 2
     first = json.loads(lines[0])
@@ -84,10 +83,8 @@ async def test_read_stream_preserves_bson_types_via_extended_json(
                             tzinfo=dt.timezone.utc),
         "decimal": Decimal128("123.456"),
     }]
-    path = PathSpec(original="/db1/coll1.jsonl",
-                    directory="/db1/coll1.jsonl")
     with _patched_iter(docs):
-        data = await _collect(read_stream(accessor, path, index))
+        data = await _collect(read_stream(accessor, _path(DOCS_PATH), index))
     parsed = json.loads(data.decode().strip())
     assert parsed["_id"] == {"$oid": "65f0000000000000000000a1"}
     assert "$date" in parsed["date"]
@@ -96,11 +93,9 @@ async def test_read_stream_preserves_bson_types_via_extended_json(
 
 @pytest.mark.asyncio
 async def test_read_stream_empty_yields_nothing(accessor, index):
-    path = PathSpec(original="/db1/coll1.jsonl",
-                    directory="/db1/coll1.jsonl")
     with _patched_iter([]):
         chunks = []
-        async for chunk in read_stream(accessor, path, index):
+        async for chunk in read_stream(accessor, _path(DOCS_PATH), index):
             chunks.append(chunk)
     assert chunks == []
 
@@ -115,32 +110,39 @@ async def test_read_stream_short_circuits_when_consumer_closes(
             consumed.append(i)
             yield {"_id": ObjectId(), "i": i}
 
-    path = PathSpec(original="/db1/coll1.jsonl",
-                    directory="/db1/coll1.jsonl")
     with patch("mirage.core.mongodb.stream.iter_documents",
                new=_instrumented):
-        gen = read_stream(accessor, path, index)
+        gen = read_stream(accessor, _path(DOCS_PATH), index)
         await gen.__anext__()
         await gen.aclose()
     assert len(consumed) <= 2
 
 
 @pytest.mark.asyncio
-async def test_read_stream_single_db_mode_collapses_path(
-        single_db_accessor, index):
-    docs = [{"_id": ObjectId(), "v": 1}]
-    path = PathSpec(original="/coll1.jsonl", directory="/coll1.jsonl")
+async def test_read_stream_works_on_view_documents_path(accessor, index):
+    oid = ObjectId()
+    docs = [{"_id": oid, "v": 1}]
     with _patched_iter(docs):
-        data = await _collect(read_stream(single_db_accessor, path, index))
-    assert data
+        data = await _collect(
+            read_stream(accessor, _path(VIEW_DOCS_PATH), index))
     parsed = json.loads(data.decode().strip())
     assert parsed["v"] == 1
+    assert parsed["_id"] == {"$oid": str(oid)}
 
 
 @pytest.mark.asyncio
 async def test_read_stream_directory_path_raises(accessor, index):
-    path = PathSpec(original="/db1", directory="/db1")
     with _patched_iter([]):
         with pytest.raises(FileNotFoundError):
-            async for _ in read_stream(accessor, path, index):
+            async for _ in read_stream(accessor, _path("/db1"), index):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_read_stream_schema_json_path_raises(accessor, index):
+    with _patched_iter([]):
+        with pytest.raises(FileNotFoundError):
+            async for _ in read_stream(
+                    accessor,
+                    _path("/db1/collections/coll1/schema.json"), index):
                 pass

--- a/python/tests/core/mongodb/test_stream_integration.py
+++ b/python/tests/core/mongodb/test_stream_integration.py
@@ -1,0 +1,99 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+from dotenv import load_dotenv
+
+from mirage.accessor.mongodb import MongoDBAccessor
+from mirage.core.mongodb.stream import read_stream
+from mirage.resource.mongodb.config import MongoDBConfig
+from mirage.types import PathSpec
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("MIRAGE_RUN_INTEGRATION_MONGO") != "1",
+    reason="integration test (set MIRAGE_RUN_INTEGRATION_MONGO=1 to enable)",
+)
+
+
+def _load_env() -> str:
+    repo_root = Path(__file__).resolve().parents[4]
+    load_dotenv(repo_root / ".env.development")
+    uri = os.environ.get("MONGODB_URI")
+    if not uri:
+        pytest.skip("MONGODB_URI not set in .env.development")
+    return uri
+
+
+@pytest.fixture
+def accessor():
+    uri = _load_env()
+    return MongoDBAccessor(config=MongoDBConfig(uri=uri))
+
+
+async def _collect_lines(gen) -> list[str]:
+    chunks = []
+    async for chunk in gen:
+        chunks.append(chunk)
+    text = b"".join(chunks).decode()
+    return [line for line in text.split("\n") if line]
+
+
+@pytest.mark.asyncio
+async def test_extended_json_for_bson_types(accessor):
+    path = PathSpec(original="/mirage_test/bson_types.jsonl",
+                    directory="/mirage_test/bson_types.jsonl")
+    lines = await _collect_lines(read_stream(accessor, path))
+    assert len(lines) == 5
+    by_label = {json.loads(line)["label"]: json.loads(line) for line in lines}
+    scalars = by_label["scalars"]
+    assert scalars["_id"] == {"$oid": "65f0000000000000000000a1"}
+    assert scalars["decimal"] == {"$numberDecimal": "123456789.987654321"}
+    assert scalars["int64"] == 1099511627776
+    assert scalars["null"] is None
+    temporal = by_label["temporal"]
+    assert "$date" in temporal["date_utc"]
+    binary_and_regex = by_label["binary_and_regex"]
+    assert "$binary" in binary_and_regex["binary"]
+    nested = by_label["nested"]
+    assert nested["metadata"]["nested"]["leaf"] == {
+        "$oid": "65f0000000000000000000b1"
+    }
+
+
+@pytest.mark.asyncio
+async def test_streams_full_5000_docs_without_cap(accessor):
+    path = PathSpec(original="/mirage_test/streaming_large.jsonl",
+                    directory="/mirage_test/streaming_large.jsonl")
+    count = 0
+    async for chunk in read_stream(accessor, path, batch_size=500):
+        count += chunk.count(b"\n")
+    assert count == 5000
+
+
+@pytest.mark.asyncio
+async def test_short_circuit_when_only_first_doc_consumed(accessor):
+    path = PathSpec(original="/mirage_test/streaming_large.jsonl",
+                    directory="/mirage_test/streaming_large.jsonl")
+    start = time.monotonic()
+    gen = read_stream(accessor, path, batch_size=100)
+    first = await gen.__anext__()
+    await gen.aclose()
+    elapsed = time.monotonic() - start
+    assert first
+    assert elapsed < 5.0

--- a/scripts/seed_mongodb_test.py
+++ b/scripts/seed_mongodb_test.py
@@ -1,0 +1,223 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import datetime as dt
+import os
+import re
+
+from bson import Binary, Decimal128, Int64, ObjectId, Regex, Timestamp
+from dotenv import load_dotenv
+from motor.motor_asyncio import AsyncIOMotorClient
+
+DB_NAME = "mirage_test"
+
+BSON_TYPE_DOCS = [
+    {
+        "_id": ObjectId("65f0000000000000000000a1"),
+        "label": "scalars",
+        "string": "hello",
+        "int32": 42,
+        "int64": Int64(2**40),
+        "double": 3.14159,
+        "bool": True,
+        "null": None,
+        "decimal": Decimal128("123456789.987654321"),
+    },
+    {
+        "_id": ObjectId("65f0000000000000000000a2"),
+        "label": "temporal",
+        "date_utc": dt.datetime(2026, 5, 15, 12, 30, 45,
+                                tzinfo=dt.timezone.utc),
+        "timestamp": Timestamp(1715774400, 1),
+    },
+    {
+        "_id": ObjectId("65f0000000000000000000a3"),
+        "label": "binary_and_regex",
+        "binary": Binary(b"\x00\x01\x02\x03\x04\xff\xfe"),
+        "regex": Regex(r"^foo.*bar$", "i"),
+    },
+    {
+        "_id": ObjectId("65f0000000000000000000a4"),
+        "label": "nested",
+        "metadata": {
+            "tag": "alpha",
+            "ratings": [4.5, 3.7, Decimal128("4.85")],
+            "nested": {"depth": 2, "leaf": ObjectId("65f0000000000000000000b1")},
+        },
+    },
+    {
+        "_id": ObjectId("65f0000000000000000000a5"),
+        "label": "arrays",
+        "mixed_array": [1, "two", 3.0, True, None,
+                        {"inner": "value"}, [10, 20]],
+        "string_array": ["alpha", "beta", "gamma"],
+    },
+]
+
+
+def _heterogeneous_doc(i: int) -> dict:
+    doc: dict = {"_id": ObjectId(), "i": i, "title": f"item-{i}"}
+    if i % 3 == 0:
+        doc["category"] = "alpha"
+    if i % 5 == 0:
+        doc["score"] = 100 + (i % 7)
+    elif i % 5 == 1:
+        doc["score"] = f"{100 + (i % 7)}"
+    if i % 7 == 0:
+        doc["metadata"] = {"tag": f"t{i % 4}", "active": i % 2 == 0}
+    if i % 11 == 0:
+        doc["tags"] = [f"tag-{j}" for j in range(i % 4)]
+    return doc
+
+
+def _embedding_doc(i: int, dim: int) -> dict:
+    base = (i % 17) / 17.0
+    vector = [round(base + (j % 13) / 1000.0, 6) for j in range(dim)]
+    return {
+        "_id": ObjectId(),
+        "i": i,
+        "title": f"embed-{i}",
+        "vector": vector,
+    }
+
+
+def _text_doc(i: int) -> dict:
+    topics = ["mongodb streaming", "vector database",
+              "filesystem mount", "agent search", "BSON encoding"]
+    return {
+        "_id": ObjectId(),
+        "i": i,
+        "title": f"article-{i}",
+        "body": f"This is article {i} about {topics[i % len(topics)]}. "
+                "It explores the topic in depth and provides examples.",
+    }
+
+
+def _view_source_doc(i: int) -> dict:
+    return {
+        "_id": ObjectId(),
+        "year": 2000 + (i % 25),
+        "title": f"film-{i}",
+        "genre": ["drama", "comedy", "thriller", "scifi"][i % 4],
+        "rating": round(5.0 + (i % 50) / 10.0, 1),
+    }
+
+
+async def seed_bson_types(db) -> int:
+    await db.bson_types.insert_many(BSON_TYPE_DOCS)
+    return len(BSON_TYPE_DOCS)
+
+
+async def seed_heterogeneous(db, n: int = 500) -> int:
+    docs = [_heterogeneous_doc(i) for i in range(n)]
+    await db.heterogeneous.insert_many(docs)
+    return len(docs)
+
+
+async def seed_embeddings(db, n: int = 100, dim: int = 1024) -> int:
+    docs = [_embedding_doc(i, dim) for i in range(n)]
+    await db.embeddings.insert_many(docs)
+    return len(docs)
+
+
+async def seed_with_validator(db) -> int:
+    await db.create_collection(
+        "with_validator",
+        validator={
+            "$jsonSchema": {
+                "bsonType": "object",
+                "required": ["title", "year"],
+                "properties": {
+                    "title": {"bsonType": "string"},
+                    "year": {"bsonType": "int", "minimum": 1900},
+                },
+            }
+        },
+        validationLevel="moderate",
+    )
+    docs = [{"_id": ObjectId(), "title": f"book-{i}", "year": 2000 + i}
+            for i in range(10)]
+    await db.with_validator.insert_many(docs)
+    return len(docs)
+
+
+async def seed_text_indexed(db, n: int = 200) -> int:
+    docs = [_text_doc(i) for i in range(n)]
+    await db.text_indexed.insert_many(docs)
+    await db.text_indexed.create_index([("title", "text"), ("body", "text")],
+                                       name="title_body_text")
+    return len(docs)
+
+
+async def seed_view_source_and_view(db, n: int = 100) -> int:
+    docs = [_view_source_doc(i) for i in range(n)]
+    await db.view_source.insert_many(docs)
+    await db.command({
+        "create": "high_rated_films",
+        "viewOn": "view_source",
+        "pipeline": [
+            {"$match": {"rating": {"$gte": 8.0}}},
+            {"$project": {"title": 1, "year": 1, "rating": 1, "_id": 1}},
+        ],
+    })
+    return len(docs)
+
+
+async def seed_streaming_large(db, n: int = 5000) -> int:
+    batch_size = 1000
+    total = 0
+    for start in range(0, n, batch_size):
+        end = min(start + batch_size, n)
+        docs = [{"_id": ObjectId(), "i": i, "v": i * 2} for i in range(start, end)]
+        await db.streaming_large.insert_many(docs)
+        total += len(docs)
+    return total
+
+
+async def main() -> None:
+    load_dotenv(".env.development")
+    uri = os.environ.get("MONGODB_URI")
+    if not uri:
+        raise SystemExit("MONGODB_URI not set. Check .env.development.")
+    client = AsyncIOMotorClient(uri)
+    db = client[DB_NAME]
+    print(f"Dropping {DB_NAME}...")
+    await client.drop_database(DB_NAME)
+    print(f"Seeding {DB_NAME}...")
+    n = await seed_bson_types(db)
+    print(f"  bson_types: {n} docs")
+    n = await seed_heterogeneous(db)
+    print(f"  heterogeneous: {n} docs")
+    n = await seed_embeddings(db)
+    print(f"  embeddings: {n} docs")
+    n = await seed_with_validator(db)
+    print(f"  with_validator: {n} docs (with $jsonSchema)")
+    n = await seed_text_indexed(db)
+    print(f"  text_indexed: {n} docs (text index)")
+    n = await seed_view_source_and_view(db)
+    print(f"  view_source: {n} docs + high_rated_films view")
+    n = await seed_streaming_large(db)
+    print(f"  streaming_large: {n} docs")
+    result = await db.command({"listCollections": 1})
+    coll_info = result["cursor"]["firstBatch"]
+    summary = sorted([(c["name"], c.get("type", "collection")) for c in coll_info])
+    print(f"\nFinal collections in {DB_NAME}:")
+    for name, kind in summary:
+        print(f"  {name:<22} ({kind})")
+    client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/seed_mongodb_test.py
+++ b/scripts/seed_mongodb_test.py
@@ -15,7 +15,6 @@
 import asyncio
 import datetime as dt
 import os
-import re
 
 from bson import Binary, Decimal128, Int64, ObjectId, Regex, Timestamp
 from dotenv import load_dotenv
@@ -38,7 +37,12 @@ BSON_TYPE_DOCS = [
     {
         "_id": ObjectId("65f0000000000000000000a2"),
         "label": "temporal",
-        "date_utc": dt.datetime(2026, 5, 15, 12, 30, 45,
+        "date_utc": dt.datetime(2026,
+                                5,
+                                15,
+                                12,
+                                30,
+                                45,
                                 tzinfo=dt.timezone.utc),
         "timestamp": Timestamp(1715774400, 1),
     },
@@ -54,14 +58,19 @@ BSON_TYPE_DOCS = [
         "metadata": {
             "tag": "alpha",
             "ratings": [4.5, 3.7, Decimal128("4.85")],
-            "nested": {"depth": 2, "leaf": ObjectId("65f0000000000000000000b1")},
+            "nested": {
+                "depth": 2,
+                "leaf": ObjectId("65f0000000000000000000b1")
+            },
         },
     },
     {
         "_id": ObjectId("65f0000000000000000000a5"),
         "label": "arrays",
-        "mixed_array": [1, "two", 3.0, True, None,
-                        {"inner": "value"}, [10, 20]],
+        "mixed_array":
+        [1, "two", 3.0, True, None, {
+            "inner": "value"
+        }, [10, 20]],
         "string_array": ["alpha", "beta", "gamma"],
     },
 ]
@@ -94,14 +103,20 @@ def _embedding_doc(i: int, dim: int) -> dict:
 
 
 def _text_doc(i: int) -> dict:
-    topics = ["mongodb streaming", "vector database",
-              "filesystem mount", "agent search", "BSON encoding"]
+    topics = [
+        "mongodb streaming", "vector database", "filesystem mount",
+        "agent search", "BSON encoding"
+    ]
     return {
-        "_id": ObjectId(),
-        "i": i,
-        "title": f"article-{i}",
-        "body": f"This is article {i} about {topics[i % len(topics)]}. "
-                "It explores the topic in depth and provides examples.",
+        "_id":
+        ObjectId(),
+        "i":
+        i,
+        "title":
+        f"article-{i}",
+        "body":
+        f"This is article {i} about {topics[i % len(topics)]}. "
+        "It explores the topic in depth and provides examples.",
     }
 
 
@@ -140,15 +155,23 @@ async def seed_with_validator(db) -> int:
                 "bsonType": "object",
                 "required": ["title", "year"],
                 "properties": {
-                    "title": {"bsonType": "string"},
-                    "year": {"bsonType": "int", "minimum": 1900},
+                    "title": {
+                        "bsonType": "string"
+                    },
+                    "year": {
+                        "bsonType": "int",
+                        "minimum": 1900
+                    },
                 },
             }
         },
         validationLevel="moderate",
     )
-    docs = [{"_id": ObjectId(), "title": f"book-{i}", "year": 2000 + i}
-            for i in range(10)]
+    docs = [{
+        "_id": ObjectId(),
+        "title": f"book-{i}",
+        "year": 2000 + i
+    } for i in range(10)]
     await db.with_validator.insert_many(docs)
     return len(docs)
 
@@ -165,11 +188,26 @@ async def seed_view_source_and_view(db, n: int = 100) -> int:
     docs = [_view_source_doc(i) for i in range(n)]
     await db.view_source.insert_many(docs)
     await db.command({
-        "create": "high_rated_films",
-        "viewOn": "view_source",
+        "create":
+        "high_rated_films",
+        "viewOn":
+        "view_source",
         "pipeline": [
-            {"$match": {"rating": {"$gte": 8.0}}},
-            {"$project": {"title": 1, "year": 1, "rating": 1, "_id": 1}},
+            {
+                "$match": {
+                    "rating": {
+                        "$gte": 8.0
+                    }
+                }
+            },
+            {
+                "$project": {
+                    "title": 1,
+                    "year": 1,
+                    "rating": 1,
+                    "_id": 1
+                }
+            },
         ],
     })
     return len(docs)
@@ -180,7 +218,11 @@ async def seed_streaming_large(db, n: int = 5000) -> int:
     total = 0
     for start in range(0, n, batch_size):
         end = min(start + batch_size, n)
-        docs = [{"_id": ObjectId(), "i": i, "v": i * 2} for i in range(start, end)]
+        docs = [{
+            "_id": ObjectId(),
+            "i": i,
+            "v": i * 2
+        } for i in range(start, end)]
         await db.streaming_large.insert_many(docs)
         total += len(docs)
     return total
@@ -212,7 +254,8 @@ async def main() -> None:
     print(f"  streaming_large: {n} docs")
     result = await db.command({"listCollections": 1})
     coll_info = result["cursor"]["firstBatch"]
-    summary = sorted([(c["name"], c.get("type", "collection")) for c in coll_info])
+    summary = sorted([(c["name"], c.get("type", "collection"))
+                      for c in coll_info])
     print(f"\nFinal collections in {DB_NAME}:")
     for name, kind in summary:
         print(f"  {name:<22} ({kind})")

--- a/typescript/packages/browser/src/resource/mongodb/http_driver.ts
+++ b/typescript/packages/browser/src/resource/mongodb/http_driver.ts
@@ -140,10 +140,7 @@ export class HttpMongoDriver implements MongoDriver {
     })
   }
 
-  getIndexStats(
-    database: string,
-    collection: string,
-  ): Promise<Record<string, MongoIndexAccess>> {
+  getIndexStats(database: string, collection: string): Promise<Record<string, MongoIndexAccess>> {
     return this.post<Record<string, MongoIndexAccess>>({
       op: 'getIndexStats',
       database,

--- a/typescript/packages/browser/src/resource/mongodb/http_driver.ts
+++ b/typescript/packages/browser/src/resource/mongodb/http_driver.ts
@@ -12,7 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { MongoDriver, MongoFindOptions } from '@struktoai/mirage-core'
+import type {
+  EntityKind,
+  MongoCollectionSpec,
+  MongoDriver,
+  MongoFindOptions,
+  MongoIndexAccess,
+  MongoIterOptions,
+} from '@struktoai/mirage-core'
 
 export interface HttpMongoDriverOptions {
   endpoint: string
@@ -21,11 +28,21 @@ export interface HttpMongoDriverOptions {
 }
 
 interface MongoProxyRequest {
-  op: 'listDatabases' | 'listCollections' | 'findDocuments' | 'countDocuments' | 'listIndexes'
+  op:
+    | 'listDatabases'
+    | 'listCollections'
+    | 'listCollectionsDetailed'
+    | 'findDocuments'
+    | 'iterDocuments'
+    | 'countDocuments'
+    | 'listIndexes'
+    | 'getIndexStats'
   database?: string
   collection?: string
+  kind?: EntityKind | null
+  nameFilter?: { name?: string }
   filter?: Record<string, unknown>
-  options?: MongoFindOptions
+  options?: MongoFindOptions | MongoIterOptions
 }
 
 export class HttpMongoDriver implements MongoDriver {
@@ -56,8 +73,19 @@ export class HttpMongoDriver implements MongoDriver {
     return this.post<string[]>({ op: 'listDatabases' })
   }
 
-  listCollections(database: string): Promise<string[]> {
-    return this.post<string[]>({ op: 'listCollections', database })
+  listCollections(database: string, kind: EntityKind | null = null): Promise<string[]> {
+    return this.post<string[]>({ op: 'listCollections', database, kind })
+  }
+
+  listCollectionsDetailed(
+    database: string,
+    filter: { name?: string } = {},
+  ): Promise<MongoCollectionSpec[]> {
+    return this.post<MongoCollectionSpec[]>({
+      op: 'listCollectionsDetailed',
+      database,
+      nameFilter: filter,
+    })
   }
 
   async findDocuments<T = Record<string, unknown>>(
@@ -75,6 +103,27 @@ export class HttpMongoDriver implements MongoDriver {
     })
   }
 
+  async *iterDocuments<T = Record<string, unknown>>(
+    database: string,
+    collection: string,
+    options: MongoIterOptions = {},
+  ): AsyncIterableIterator<T> {
+    const docs = await this.post<T[]>({
+      op: 'iterDocuments',
+      database,
+      collection,
+      options,
+    })
+    for (const d of docs) yield d
+  }
+
+  async *iterInserts<T = Record<string, unknown>>(
+    _database: string,
+    _collection: string,
+  ): AsyncIterableIterator<T> {
+    throw new Error('iterInserts (tail -f) is not supported by HttpMongoDriver')
+  }
+
   countDocuments(
     database: string,
     collection: string,
@@ -86,6 +135,17 @@ export class HttpMongoDriver implements MongoDriver {
   listIndexes(database: string, collection: string): Promise<Record<string, unknown>[]> {
     return this.post<Record<string, unknown>[]>({
       op: 'listIndexes',
+      database,
+      collection,
+    })
+  }
+
+  getIndexStats(
+    database: string,
+    collection: string,
+  ): Promise<Record<string, MongoIndexAccess>> {
+    return this.post<Record<string, MongoIndexAccess>>({
+      op: 'getIndexStats',
       database,
       collection,
     })

--- a/typescript/packages/browser/src/resource/mongodb/http_driver.ts
+++ b/typescript/packages/browser/src/resource/mongodb/http_driver.ts
@@ -117,11 +117,17 @@ export class HttpMongoDriver implements MongoDriver {
     for (const d of docs) yield d
   }
 
-  async *iterInserts<T = Record<string, unknown>>(
+  iterInserts<T = Record<string, unknown>>(
     _database: string,
     _collection: string,
   ): AsyncIterableIterator<T> {
-    throw new Error('iterInserts (tail -f) is not supported by HttpMongoDriver')
+    return {
+      next: () =>
+        Promise.reject(new Error('iterInserts (tail -f) is not supported by HttpMongoDriver')),
+      [Symbol.asyncIterator]() {
+        return this
+      },
+    }
   }
 
   countDocuments(

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -61,6 +61,7 @@
     "@aws-sdk/client-s3": "^3.0.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "apache-arrow": "^21.1.0",
+    "bson": "^6.10.4",
     "h5wasm": "^0.10.1",
     "hyparquet": "^1.25.6",
     "jq-wasm": "1.1.0-jq-1.8.1",

--- a/typescript/packages/core/src/accessor/mongodb.test.ts
+++ b/typescript/packages/core/src/accessor/mongodb.test.ts
@@ -13,18 +13,11 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import type { MongoDriver } from '../core/mongodb/_driver.ts'
+import { stubMongoDriver } from '../core/mongodb/_test_util.ts'
 import { resolveMongoDBConfig } from '../resource/mongodb/config.ts'
 import { MongoDBAccessor } from './mongodb.ts'
 
-const STUB_DRIVER: MongoDriver = {
-  listDatabases: () => Promise.resolve([]),
-  listCollections: () => Promise.resolve([]),
-  findDocuments: () => Promise.resolve([]),
-  countDocuments: () => Promise.resolve(0),
-  listIndexes: () => Promise.resolve([]),
-  close: () => Promise.resolve(),
-}
+const STUB_DRIVER = stubMongoDriver()
 
 describe('MongoDBAccessor', () => {
   it('holds the driver and resolved config', () => {

--- a/typescript/packages/core/src/accessor/mongodb.ts
+++ b/typescript/packages/core/src/accessor/mongodb.ts
@@ -16,13 +16,39 @@ import { Accessor } from './base.ts'
 import type { MongoDriver } from '../core/mongodb/_driver.ts'
 import type { MongoDBConfigResolved } from '../resource/mongodb/config.ts'
 
+interface CacheEntry<T> {
+  value: T
+  expires: number
+}
+
 export class MongoDBAccessor extends Accessor {
   readonly driver: MongoDriver
   readonly config: MongoDBConfigResolved
+  readonly listingCacheTtlMs: number
+  private readonly cache = new Map<string, CacheEntry<unknown>>()
 
-  constructor(driver: MongoDriver, config: MongoDBConfigResolved) {
+  constructor(
+    driver: MongoDriver,
+    config: MongoDBConfigResolved,
+    options: { listingCacheTtlMs?: number } = {},
+  ) {
     super()
     this.driver = driver
     this.config = config
+    this.listingCacheTtlMs = options.listingCacheTtlMs ?? 5000
+  }
+
+  async cachedList<T>(key: string, fetch: () => Promise<T>): Promise<T> {
+    if (this.listingCacheTtlMs <= 0) return fetch()
+    const now = Date.now()
+    const hit = this.cache.get(key)
+    if (hit !== undefined && hit.expires > now) return hit.value as T
+    const value = await fetch()
+    this.cache.set(key, { value, expires: now + this.listingCacheTtlMs })
+    return value
+  }
+
+  invalidateListings(): void {
+    this.cache.clear()
   }
 }

--- a/typescript/packages/core/src/commands/builtin/mongodb/cat.test.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/cat.test.ts
@@ -19,7 +19,7 @@ vi.mock('../../../core/mongodb/read.ts', () => ({
 }))
 
 import { MongoDBAccessor } from '../../../accessor/mongodb.ts'
-import type { MongoDriver } from '../../../core/mongodb/_driver.ts'
+import { stubMongoDriver } from '../../../core/mongodb/_test_util.ts'
 import * as readModule from '../../../core/mongodb/read.ts'
 import { resolveMongoDBConfig } from '../../../resource/mongodb/config.ts'
 import { materialize } from '../../../io/types.ts'
@@ -28,14 +28,7 @@ import { MONGODB_CAT } from './cat.ts'
 
 const DEC = new TextDecoder()
 
-const STUB_DRIVER: MongoDriver = {
-  listDatabases: () => Promise.resolve([]),
-  listCollections: () => Promise.resolve([]),
-  findDocuments: () => Promise.resolve([]),
-  countDocuments: () => Promise.resolve(0),
-  listIndexes: () => Promise.resolve([]),
-  close: () => Promise.resolve(),
-}
+const STUB_DRIVER = stubMongoDriver()
 
 function makeAccessor(): MongoDBAccessor {
   return new MongoDBAccessor(STUB_DRIVER, resolveMongoDBConfig({ uri: 'mongodb://h' }))

--- a/typescript/packages/core/src/commands/builtin/mongodb/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/grep.ts
@@ -176,18 +176,6 @@ async function grepCommand(
 
     const pat = compilePattern(pattern, f.ignoreCase, f.fixedString, f.wholeWord)
 
-    if (
-      scope.level === ScopeLevel.DOCUMENTS &&
-      scope.database !== null &&
-      scope.name !== null
-    ) {
-      const docs = await searchCollection(accessor, scope.database, scope.name, pattern, limit)
-      if (docs.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      const results = [{ database: scope.database, collection: scope.name, docs }]
-      const allLines = formatGrepResults(results)
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
-    }
-
     let fileStat: FileStat
     try {
       fileStat = await st(target.original)

--- a/typescript/packages/core/src/commands/builtin/mongodb/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/grep.ts
@@ -18,6 +18,7 @@ import { resolveGlob } from '../../../core/mongodb/glob.ts'
 import { read as mongoRead } from '../../../core/mongodb/read.ts'
 import { readdir as mongoReaddir } from '../../../core/mongodb/readdir.ts'
 import { detectScope } from '../../../core/mongodb/scope.ts'
+import { ScopeLevel } from '../../../core/mongodb/types.ts'
 import { stat as mongoStat } from '../../../core/mongodb/stat.ts'
 import {
   formatGrepResults,
@@ -93,16 +94,13 @@ async function grepCommand(
   }
   const f = parseFlags(opts.flags)
   const limit = accessor.config.defaultSearchLimit
-  const cfg = accessor.config
-  const singleDb = cfg.databases !== null && cfg.databases.length === 1
-  const singleDbName = singleDb ? (cfg.databases?.[0] ?? null) : null
 
   if (paths.length > 0) {
     const first = paths[0]
     if (first === undefined) return [null, new IOResult()]
-    const scope = detectScope(first, { singleDb, singleDbName })
+    const scope = detectScope(first)
 
-    if (scope.level === 'root') {
+    if (scope.level === ScopeLevel.ROOT) {
       const dbs = await listDatabases(accessor)
       const results: Awaited<ReturnType<typeof searchDatabase>> = []
       for (const db of dbs) {
@@ -113,10 +111,18 @@ async function grepCommand(
       return [ENC.encode(allLines.join('\n')), new IOResult()]
     }
 
-    if (scope.level === 'database' && scope.database !== null) {
+    if (scope.level === ScopeLevel.DATABASE && scope.database !== null) {
       const results = await searchDatabase(accessor, scope.database, pattern, limit)
       const allLines = formatGrepResults(results)
       if (allLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
+      return [ENC.encode(allLines.join('\n')), new IOResult()]
+    }
+
+    if (scope.level === ScopeLevel.ENTITY && scope.database !== null && scope.name !== null) {
+      const docs = await searchCollection(accessor, scope.database, scope.name, pattern, limit)
+      if (docs.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
+      const results = [{ database: scope.database, collection: scope.name, docs }]
+      const allLines = formatGrepResults(results)
       return [ENC.encode(allLines.join('\n')), new IOResult()]
     }
 
@@ -170,16 +176,14 @@ async function grepCommand(
 
     const pat = compilePattern(pattern, f.ignoreCase, f.fixedString, f.wholeWord)
 
-    if (scope.level === 'file' && scope.database !== null && scope.collection !== null) {
-      const docs = await searchCollection(
-        accessor,
-        scope.database,
-        scope.collection,
-        pattern,
-        limit,
-      )
+    if (
+      scope.level === ScopeLevel.DOCUMENTS &&
+      scope.database !== null &&
+      scope.name !== null
+    ) {
+      const docs = await searchCollection(accessor, scope.database, scope.name, pattern, limit)
       if (docs.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      const results = [{ database: scope.database, collection: scope.collection, docs }]
+      const results = [{ database: scope.database, collection: scope.name, docs }]
       const allLines = formatGrepResults(results)
       return [ENC.encode(allLines.join('\n')), new IOResult()]
     }

--- a/typescript/packages/core/src/commands/builtin/mongodb/head.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/head.ts
@@ -17,6 +17,7 @@ import { findDocuments } from '../../../core/mongodb/_client.ts'
 import { resolveGlob } from '../../../core/mongodb/glob.ts'
 import { read as mongoRead } from '../../../core/mongodb/read.ts'
 import { detectScope } from '../../../core/mongodb/scope.ts'
+import { ScopeLevel } from '../../../core/mongodb/types.ts'
 import { type ByteSource, IOResult } from '../../../io/types.ts'
 import { type PathSpec, ResourceName } from '../../../types.ts'
 import { encodeBase64 } from '../../../utils/base64.ts'
@@ -104,21 +105,19 @@ async function headCommand(
   if (paths.length > 0) {
     const first = paths[0]
     if (first === undefined) return [null, new IOResult()]
-    const singleDb = accessor.config.databases !== null && accessor.config.databases.length === 1
-    const singleDbName = singleDb ? (accessor.config.databases?.[0] ?? null) : null
-    const scope = detectScope(first, { singleDb, singleDbName })
+    const scope = detectScope(first)
 
     if (
-      scope.level === 'file' &&
+      scope.level === ScopeLevel.DOCUMENTS &&
       scope.database !== null &&
-      scope.collection !== null &&
+      scope.name !== null &&
       bytesMode === null
     ) {
       const limit = Math.min(lines, accessor.config.maxDocLimit)
       const docs = await findDocuments(
         accessor,
         scope.database,
-        scope.collection,
+        scope.name,
         {},
         { limit, sort: { _id: 1 } },
       )

--- a/typescript/packages/core/src/commands/builtin/mongodb/head.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/head.ts
@@ -17,61 +17,16 @@ import { findDocuments } from '../../../core/mongodb/_client.ts'
 import { resolveGlob } from '../../../core/mongodb/glob.ts'
 import { read as mongoRead } from '../../../core/mongodb/read.ts'
 import { detectScope } from '../../../core/mongodb/scope.ts'
+import { applyElision, elisionPaths, stringifyDoc } from '../../../core/mongodb/stream.ts'
 import { ScopeLevel } from '../../../core/mongodb/types.ts'
 import { type ByteSource, IOResult } from '../../../io/types.ts'
 import { type PathSpec, ResourceName } from '../../../types.ts'
-import { encodeBase64 } from '../../../utils/base64.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { readStdinAsync } from '../utils/stream.ts'
 import { fileReadProvision } from './_provision.ts'
 
 const ENC = new TextEncoder()
-
-function safeToString(value: unknown): string {
-  if (value === null || value === undefined) return ''
-  if (typeof value === 'string') return value
-  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
-    return String(value)
-  }
-  if (typeof value === 'object' && 'toString' in value) {
-    try {
-      return (value as { toString: () => string }).toString()
-    } catch {
-      return Object.prototype.toString.call(value)
-    }
-  }
-  return Object.prototype.toString.call(value)
-}
-
-function bsonReplacer(_key: string, value: unknown): unknown {
-  if (value instanceof Date) return value.toISOString()
-  if (typeof value === 'bigint') return value.toString()
-  if (value instanceof Uint8Array) return encodeBase64(value)
-  if (typeof value === 'object' && value !== null && 'toJSON' in value) {
-    try {
-      return (value as { toJSON: () => unknown }).toJSON()
-    } catch {
-      return safeToString(value)
-    }
-  }
-  return value
-}
-
-function stringifyId(value: unknown): unknown {
-  if (typeof value === 'string') return value
-  if (typeof value === 'number') return value
-  if (value === null || value === undefined) return value
-  if (typeof value === 'object' && 'toString' in value) {
-    try {
-      const s = (value as { toString: () => string }).toString()
-      if (s !== '[object Object]') return s
-    } catch {
-      return safeToString(value)
-    }
-  }
-  return safeToString(value)
-}
 
 function headBytes(data: Uint8Array, lines: number, bytesMode: number | null): Uint8Array {
   if (bytesMode !== null) {
@@ -122,14 +77,13 @@ async function headCommand(
         { limit, sort: { _id: 1 } },
       )
       if (docs.length === 0) return [headBytes(new Uint8Array(0), lines, null), new IOResult()]
+      const elide = elisionPaths(accessor, scope.database, scope.name)
       const jsonl =
         docs
           .map((d) => {
-            const copy: Record<string, unknown> = { ...d }
-            if (copy._id !== undefined && copy._id !== null) {
-              copy._id = stringifyId(copy._id)
-            }
-            return JSON.stringify(copy, bsonReplacer)
+            const doc = d
+            const final = elide.size > 0 ? applyElision(doc, elide) : doc
+            return stringifyDoc(final)
           })
           .join('\n') + '\n'
       return [headBytes(ENC.encode(jsonl), lines, null), new IOResult()]

--- a/typescript/packages/core/src/commands/builtin/mongodb/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/rg.ts
@@ -19,6 +19,7 @@ import { resolveGlob } from '../../../core/mongodb/glob.ts'
 import { read as mongoRead } from '../../../core/mongodb/read.ts'
 import { readdir as mongoReaddir } from '../../../core/mongodb/readdir.ts'
 import { detectScope } from '../../../core/mongodb/scope.ts'
+import { ScopeLevel } from '../../../core/mongodb/types.ts'
 import {
   formatGrepResults,
   searchCollection,
@@ -114,16 +115,13 @@ async function rgCommand(
   const f = parseRgFlags(opts.flags)
   const pat = compilePattern(exprText, f.ignoreCase, f.fixedString, f.wholeWord)
   const limit = accessor.config.defaultSearchLimit
-  const cfg = accessor.config
-  const singleDb = cfg.databases !== null && cfg.databases.length === 1
-  const singleDbName = singleDb ? (cfg.databases?.[0] ?? null) : null
 
   if (paths.length > 0) {
     const first = paths[0]
     if (first === undefined) return [null, new IOResult()]
-    const scope = detectScope(first, { singleDb, singleDbName })
+    const scope = detectScope(first)
 
-    if (scope.level === 'root') {
+    if (scope.level === ScopeLevel.ROOT) {
       const dbs = await listDatabases(accessor)
       const results: Awaited<ReturnType<typeof searchDatabase>> = []
       for (const db of dbs) {
@@ -133,22 +131,20 @@ async function rgCommand(
       if (allLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
       return [ENC.encode(allLines.join('\n')), new IOResult()]
     }
-    if (scope.level === 'database' && scope.database !== null) {
+    if (scope.level === ScopeLevel.DATABASE && scope.database !== null) {
       const results = await searchDatabase(accessor, scope.database, exprText, limit)
       const allLines = formatGrepResults(results)
       if (allLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
       return [ENC.encode(allLines.join('\n')), new IOResult()]
     }
-    if (scope.level === 'file' && scope.database !== null && scope.collection !== null) {
-      const docs = await searchCollection(
-        accessor,
-        scope.database,
-        scope.collection,
-        exprText,
-        limit,
-      )
+    if (
+      (scope.level === ScopeLevel.ENTITY || scope.level === ScopeLevel.DOCUMENTS) &&
+      scope.database !== null &&
+      scope.name !== null
+    ) {
+      const docs = await searchCollection(accessor, scope.database, scope.name, exprText, limit)
       if (docs.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      const results = [{ database: scope.database, collection: scope.collection, docs }]
+      const results = [{ database: scope.database, collection: scope.name, docs }]
       const allLines = formatGrepResults(results)
       return [ENC.encode(allLines.join('\n')), new IOResult()]
     }

--- a/typescript/packages/core/src/commands/builtin/mongodb/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/rg.ts
@@ -137,11 +137,7 @@ async function rgCommand(
       if (allLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
       return [ENC.encode(allLines.join('\n')), new IOResult()]
     }
-    if (
-      (scope.level === ScopeLevel.ENTITY || scope.level === ScopeLevel.DOCUMENTS) &&
-      scope.database !== null &&
-      scope.name !== null
-    ) {
+    if (scope.level === ScopeLevel.ENTITY && scope.database !== null && scope.name !== null) {
       const docs = await searchCollection(accessor, scope.database, scope.name, exprText, limit)
       if (docs.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
       const results = [{ database: scope.database, collection: scope.name, docs }]

--- a/typescript/packages/core/src/commands/builtin/mongodb/tail.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/tail.ts
@@ -17,10 +17,10 @@ import { findDocuments } from '../../../core/mongodb/_client.ts'
 import { resolveGlob } from '../../../core/mongodb/glob.ts'
 import { read as mongoRead } from '../../../core/mongodb/read.ts'
 import { detectScope } from '../../../core/mongodb/scope.ts'
+import { applyElision, elisionPaths, stringifyDoc } from '../../../core/mongodb/stream.ts'
 import { ScopeLevel } from '../../../core/mongodb/types.ts'
 import { type ByteSource, IOResult } from '../../../io/types.ts'
 import { type PathSpec, ResourceName } from '../../../types.ts'
-import { encodeBase64 } from '../../../utils/base64.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { parseN, tailBytes } from '../tail_helper.ts'
@@ -28,51 +28,6 @@ import { readStdinAsync } from '../utils/stream.ts'
 import { fileReadProvision } from './_provision.ts'
 
 const ENC = new TextEncoder()
-
-function safeToString(value: unknown): string {
-  if (value === null || value === undefined) return ''
-  if (typeof value === 'string') return value
-  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
-    return String(value)
-  }
-  if (typeof value === 'object' && 'toString' in value) {
-    try {
-      return (value as { toString: () => string }).toString()
-    } catch {
-      return Object.prototype.toString.call(value)
-    }
-  }
-  return Object.prototype.toString.call(value)
-}
-
-function bsonReplacer(_key: string, value: unknown): unknown {
-  if (value instanceof Date) return value.toISOString()
-  if (typeof value === 'bigint') return value.toString()
-  if (value instanceof Uint8Array) return encodeBase64(value)
-  if (typeof value === 'object' && value !== null && 'toJSON' in value) {
-    try {
-      return (value as { toJSON: () => unknown }).toJSON()
-    } catch {
-      return safeToString(value)
-    }
-  }
-  return value
-}
-
-function stringifyId(value: unknown): unknown {
-  if (typeof value === 'string') return value
-  if (typeof value === 'number') return value
-  if (value === null || value === undefined) return value
-  if (typeof value === 'object' && 'toString' in value) {
-    try {
-      const s = (value as { toString: () => string }).toString()
-      if (s !== '[object Object]') return s
-    } catch {
-      return safeToString(value)
-    }
-  }
-  return safeToString(value)
-}
 
 function tailResult(
   raw: Uint8Array,
@@ -120,14 +75,13 @@ async function tailCommand(
       if (docs.length === 0) {
         return [tailResult(new Uint8Array(0), lines, plusMode, null), new IOResult()]
       }
+      const elide = elisionPaths(accessor, scope.database, scope.name)
       const jsonl =
         docs
           .map((d) => {
-            const copy: Record<string, unknown> = { ...d }
-            if (copy._id !== undefined && copy._id !== null) {
-              copy._id = stringifyId(copy._id)
-            }
-            return JSON.stringify(copy, bsonReplacer)
+            const doc = d
+            const final = elide.size > 0 ? applyElision(doc, elide) : doc
+            return stringifyDoc(final)
           })
           .join('\n') + '\n'
       return [tailResult(ENC.encode(jsonl), lines, plusMode, null), new IOResult()]

--- a/typescript/packages/core/src/commands/builtin/mongodb/tail.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/tail.ts
@@ -17,6 +17,7 @@ import { findDocuments } from '../../../core/mongodb/_client.ts'
 import { resolveGlob } from '../../../core/mongodb/glob.ts'
 import { read as mongoRead } from '../../../core/mongodb/read.ts'
 import { detectScope } from '../../../core/mongodb/scope.ts'
+import { ScopeLevel } from '../../../core/mongodb/types.ts'
 import { type ByteSource, IOResult } from '../../../io/types.ts'
 import { type PathSpec, ResourceName } from '../../../types.ts'
 import { encodeBase64 } from '../../../utils/base64.ts'
@@ -99,21 +100,19 @@ async function tailCommand(
   if (paths.length > 0) {
     const first = paths[0]
     if (first === undefined) return [null, new IOResult()]
-    const singleDb = accessor.config.databases !== null && accessor.config.databases.length === 1
-    const singleDbName = singleDb ? (accessor.config.databases?.[0] ?? null) : null
-    const scope = detectScope(first, { singleDb, singleDbName })
+    const scope = detectScope(first)
 
     if (
-      scope.level === 'file' &&
+      scope.level === ScopeLevel.DOCUMENTS &&
       scope.database !== null &&
-      scope.collection !== null &&
+      scope.name !== null &&
       bytesMode === null
     ) {
       const limit = Math.min(lines, accessor.config.maxDocLimit)
       const docs = await findDocuments(
         accessor,
         scope.database,
-        scope.collection,
+        scope.name,
         {},
         { limit, sort: { _id: -1 } },
       )

--- a/typescript/packages/core/src/commands/builtin/mongodb/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/wc.ts
@@ -17,6 +17,7 @@ import { countDocuments } from '../../../core/mongodb/_client.ts'
 import { resolveGlob } from '../../../core/mongodb/glob.ts'
 import { read as mongoRead } from '../../../core/mongodb/read.ts'
 import { detectScope } from '../../../core/mongodb/scope.ts'
+import { ScopeLevel } from '../../../core/mongodb/types.ts'
 import { type ByteSource, IOResult } from '../../../io/types.ts'
 import { type PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
@@ -54,11 +55,13 @@ async function wcCommand(
 
   const first = paths[0]
   if (first === undefined) return [null, new IOResult()]
-  const singleDb = accessor.config.databases !== null && accessor.config.databases.length === 1
-  const singleDbName = singleDb ? (accessor.config.databases?.[0] ?? null) : null
-  const scope = detectScope(first, { singleDb, singleDbName })
+  const scope = detectScope(first)
 
-  if (scope.level === 'file' && scope.database !== null && scope.collection !== null) {
+  if (
+    scope.level === ScopeLevel.DOCUMENTS &&
+    scope.database !== null &&
+    scope.name !== null
+  ) {
     if (cFlag) {
       const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
       const target = resolved[0]
@@ -68,10 +71,10 @@ async function wcCommand(
       return [out, new IOResult()]
     }
     if (lFlag) {
-      const count = await countDocuments(accessor, scope.database, scope.collection)
+      const count = await countDocuments(accessor, scope.database, scope.name)
       return [ENC.encode(String(count)), new IOResult()]
     }
-    const count = await countDocuments(accessor, scope.database, scope.collection)
+    const count = await countDocuments(accessor, scope.database, scope.name)
     return [ENC.encode(String(count)), new IOResult()]
   }
 

--- a/typescript/packages/core/src/commands/builtin/mongodb/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/wc.ts
@@ -57,11 +57,7 @@ async function wcCommand(
   if (first === undefined) return [null, new IOResult()]
   const scope = detectScope(first)
 
-  if (
-    scope.level === ScopeLevel.DOCUMENTS &&
-    scope.database !== null &&
-    scope.name !== null
-  ) {
+  if (scope.level === ScopeLevel.DOCUMENTS && scope.database !== null && scope.name !== null) {
     if (cFlag) {
       const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
       const target = resolved[0]

--- a/typescript/packages/core/src/core/mongodb/_client.test.ts
+++ b/typescript/packages/core/src/core/mongodb/_client.test.ts
@@ -23,9 +23,10 @@ import {
   listIndexes,
 } from './_client.ts'
 import type { MongoDriver } from './_driver.ts'
+import { stubMongoDriver } from './_test_util.ts'
 
 function makeDriver(overrides: Partial<MongoDriver> = {}): MongoDriver {
-  return {
+  return stubMongoDriver({
     listDatabases: vi.fn(() => Promise.resolve([])),
     listCollections: vi.fn(() => Promise.resolve([])),
     findDocuments: vi.fn(() => Promise.resolve([])),
@@ -33,7 +34,7 @@ function makeDriver(overrides: Partial<MongoDriver> = {}): MongoDriver {
     listIndexes: vi.fn(() => Promise.resolve([])),
     close: vi.fn(() => Promise.resolve()),
     ...overrides,
-  }
+  })
 }
 
 function makeAccessor(

--- a/typescript/packages/core/src/core/mongodb/_client.ts
+++ b/typescript/packages/core/src/core/mongodb/_client.ts
@@ -19,14 +19,16 @@ import { EntityKind } from './types.ts'
 const SYSTEM_DBS: ReadonlySet<string> = new Set(['admin', 'local', 'config'])
 
 export async function listDatabases(accessor: MongoDBAccessor): Promise<string[]> {
-  const all = await accessor.driver.listDatabases()
-  let dbs = all.filter((d) => !SYSTEM_DBS.has(d))
-  const allow = accessor.config.databases
-  if (allow !== null) {
-    const allowSet = new Set(allow)
-    dbs = dbs.filter((d) => allowSet.has(d))
-  }
-  return [...dbs].sort()
+  return accessor.cachedList('listDatabases', async () => {
+    const all = await accessor.driver.listDatabases()
+    let dbs = all.filter((d) => !SYSTEM_DBS.has(d))
+    const allow = accessor.config.databases
+    if (allow !== null) {
+      const allowSet = new Set(allow)
+      dbs = dbs.filter((d) => allowSet.has(d))
+    }
+    return [...dbs].sort()
+  })
 }
 
 export async function listCollections(
@@ -34,8 +36,30 @@ export async function listCollections(
   database: string,
   kind: EntityKind | null = null,
 ): Promise<string[]> {
-  const cols = await accessor.driver.listCollections(database, kind)
-  return [...cols].sort()
+  const key = `listCollections:${database}:${kind ?? ''}`
+  return accessor.cachedList(key, async () => {
+    const cols = await accessor.driver.listCollections(database, kind)
+    return [...cols].sort()
+  })
+}
+
+export async function databaseExists(
+  accessor: MongoDBAccessor,
+  database: string,
+): Promise<boolean> {
+  const dbs = await listDatabases(accessor)
+  return dbs.includes(database)
+}
+
+export async function entityExists(
+  accessor: MongoDBAccessor,
+  database: string,
+  name: string,
+  kind: EntityKind | null = null,
+): Promise<boolean> {
+  if (!(await databaseExists(accessor, database))) return false
+  const names = await listCollections(accessor, database, kind)
+  return names.includes(name)
 }
 
 export async function findDocuments<T = Record<string, unknown>>(

--- a/typescript/packages/core/src/core/mongodb/_client.ts
+++ b/typescript/packages/core/src/core/mongodb/_client.ts
@@ -13,7 +13,8 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { MongoDBAccessor } from '../../accessor/mongodb.ts'
-import type { MongoFindOptions } from './_driver.ts'
+import type { MongoFindOptions, MongoIndexAccess, MongoIterOptions } from './_driver.ts'
+import { EntityKind } from './types.ts'
 
 const SYSTEM_DBS: ReadonlySet<string> = new Set(['admin', 'local', 'config'])
 
@@ -31,8 +32,9 @@ export async function listDatabases(accessor: MongoDBAccessor): Promise<string[]
 export async function listCollections(
   accessor: MongoDBAccessor,
   database: string,
+  kind: EntityKind | null = null,
 ): Promise<string[]> {
-  const cols = await accessor.driver.listCollections(database)
+  const cols = await accessor.driver.listCollections(database, kind)
   return [...cols].sort()
 }
 
@@ -52,6 +54,23 @@ export async function findDocuments<T = Record<string, unknown>>(
   })
 }
 
+export function iterDocuments<T = Record<string, unknown>>(
+  accessor: MongoDBAccessor,
+  database: string,
+  collection: string,
+  options: MongoIterOptions = {},
+): AsyncIterableIterator<T> {
+  return accessor.driver.iterDocuments<T>(database, collection, options)
+}
+
+export function iterInserts<T = Record<string, unknown>>(
+  accessor: MongoDBAccessor,
+  database: string,
+  collection: string,
+): AsyncIterableIterator<T> {
+  return accessor.driver.iterInserts<T>(database, collection)
+}
+
 export async function countDocuments(
   accessor: MongoDBAccessor,
   database: string,
@@ -61,10 +80,46 @@ export async function countDocuments(
   return accessor.driver.countDocuments(database, collection, filter)
 }
 
+export async function isView(
+  accessor: MongoDBAccessor,
+  database: string,
+  collection: string,
+): Promise<boolean> {
+  const specs = await accessor.driver.listCollectionsDetailed(database, {
+    name: collection,
+  })
+  for (const spec of specs) return spec.type === EntityKind.VIEW
+  return false
+}
+
 export async function listIndexes(
   accessor: MongoDBAccessor,
   database: string,
   collection: string,
 ): Promise<Record<string, unknown>[]> {
+  if (await isView(accessor, database, collection)) return []
   return accessor.driver.listIndexes(database, collection)
+}
+
+export async function getValidator(
+  accessor: MongoDBAccessor,
+  database: string,
+  collection: string,
+): Promise<unknown> {
+  const specs = await accessor.driver.listCollectionsDetailed(database, {
+    name: collection,
+  })
+  for (const spec of specs) {
+    const validator = spec.options?.validator as { $jsonSchema?: unknown } | undefined
+    return validator?.$jsonSchema ?? null
+  }
+  return null
+}
+
+export async function getIndexStats(
+  accessor: MongoDBAccessor,
+  database: string,
+  collection: string,
+): Promise<Record<string, MongoIndexAccess>> {
+  return accessor.driver.getIndexStats(database, collection)
 }

--- a/typescript/packages/core/src/core/mongodb/_driver.ts
+++ b/typescript/packages/core/src/core/mongodb/_driver.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { EntityKind } from './types.ts'
+
 export interface MongoFindOptions {
   limit?: number
   sort?: Record<string, 1 | -1>
@@ -19,20 +21,55 @@ export interface MongoFindOptions {
   skip?: number
 }
 
+export interface MongoIterOptions {
+  filter?: Record<string, unknown>
+  sort?: Record<string, 1 | -1>
+  projection?: Record<string, unknown>
+  batchSize?: number
+}
+
+export interface MongoCollectionSpec {
+  name: string
+  type?: EntityKind | string
+  options?: { validator?: { $jsonSchema?: unknown } | Record<string, unknown> }
+}
+
+export interface MongoIndexAccess {
+  ops?: number
+  since?: string
+}
+
 export interface MongoDriver {
   listDatabases(): Promise<string[]>
-  listCollections(database: string): Promise<string[]>
+  listCollections(database: string, kind?: EntityKind | null): Promise<string[]>
+  listCollectionsDetailed(
+    database: string,
+    filter?: { name?: string },
+  ): Promise<MongoCollectionSpec[]>
   findDocuments<T = Record<string, unknown>>(
     database: string,
     collection: string,
     filter?: Record<string, unknown>,
     options?: MongoFindOptions,
   ): Promise<T[]>
+  iterDocuments<T = Record<string, unknown>>(
+    database: string,
+    collection: string,
+    options?: MongoIterOptions,
+  ): AsyncIterableIterator<T>
+  iterInserts<T = Record<string, unknown>>(
+    database: string,
+    collection: string,
+  ): AsyncIterableIterator<T>
   countDocuments(
     database: string,
     collection: string,
     filter?: Record<string, unknown>,
   ): Promise<number>
   listIndexes(database: string, collection: string): Promise<Record<string, unknown>[]>
+  getIndexStats(
+    database: string,
+    collection: string,
+  ): Promise<Record<string, MongoIndexAccess>>
   close(): Promise<void>
 }

--- a/typescript/packages/core/src/core/mongodb/_driver.ts
+++ b/typescript/packages/core/src/core/mongodb/_driver.ts
@@ -30,7 +30,7 @@ export interface MongoIterOptions {
 
 export interface MongoCollectionSpec {
   name: string
-  type?: EntityKind | string
+  type?: string
   options?: { validator?: { $jsonSchema?: unknown } | Record<string, unknown> }
 }
 
@@ -67,9 +67,6 @@ export interface MongoDriver {
     filter?: Record<string, unknown>,
   ): Promise<number>
   listIndexes(database: string, collection: string): Promise<Record<string, unknown>[]>
-  getIndexStats(
-    database: string,
-    collection: string,
-  ): Promise<Record<string, MongoIndexAccess>>
+  getIndexStats(database: string, collection: string): Promise<Record<string, MongoIndexAccess>>
   close(): Promise<void>
 }

--- a/typescript/packages/core/src/core/mongodb/_sampler.ts
+++ b/typescript/packages/core/src/core/mongodb/_sampler.ts
@@ -128,7 +128,7 @@ export async function sampleFieldTypes(
   const fields: SampledField[] = []
   for (const path of [...counts.keys()].sort()) {
     if (path === PRIMARY_KEY) continue
-    const inner = counts.get(path) ?? new Map()
+    const inner = counts.get(path) ?? new Map<string, number>()
     const presenceCount = [...inner.values()].reduce((a, b) => a + b, 0)
     const types: Record<string, number> = {}
     for (const [t, c] of inner) types[t] = c / total

--- a/typescript/packages/core/src/core/mongodb/_sampler.ts
+++ b/typescript/packages/core/src/core/mongodb/_sampler.ts
@@ -1,0 +1,142 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { MongoDBAccessor } from '../../accessor/mongodb.ts'
+import { BsonTypeTag, PRIMARY_KEY } from './types.ts'
+
+export interface SampledField {
+  path: string
+  presence: number
+  types: Record<string, number>
+}
+
+function bump(counts: Map<string, Map<string, number>>, path: string, tag: string): void {
+  let inner = counts.get(path)
+  if (inner === undefined) {
+    inner = new Map()
+    counts.set(path, inner)
+  }
+  inner.set(tag, (inner.get(tag) ?? 0) + 1)
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v) && v.constructor === Object
+}
+
+function isObjectIdLike(v: unknown): boolean {
+  if (typeof v !== 'object' || v === null) return false
+  const proto = (v as { _bsontype?: string })._bsontype
+  return proto === 'ObjectId' || proto === 'ObjectID'
+}
+
+function isDecimalLike(v: unknown): boolean {
+  if (typeof v !== 'object' || v === null) return false
+  return (v as { _bsontype?: string })._bsontype === 'Decimal128'
+}
+
+function isBinaryLike(v: unknown): boolean {
+  if (typeof v !== 'object' || v === null) return false
+  return (v as { _bsontype?: string })._bsontype === 'Binary'
+}
+
+function isLongLike(v: unknown): boolean {
+  if (typeof v !== 'object' || v === null) return false
+  return (v as { _bsontype?: string })._bsontype === 'Long'
+}
+
+function isTimestampLike(v: unknown): boolean {
+  if (typeof v !== 'object' || v === null) return false
+  return (v as { _bsontype?: string })._bsontype === 'Timestamp'
+}
+
+function isRegexLike(v: unknown): boolean {
+  if (v instanceof RegExp) return true
+  if (typeof v !== 'object' || v === null) return false
+  return (v as { _bsontype?: string })._bsontype === 'BSONRegExp'
+}
+
+export function scalarTag(v: unknown): string {
+  if (typeof v === 'boolean') return BsonTypeTag.BOOL
+  if (isLongLike(v)) return BsonTypeTag.LONG
+  if (typeof v === 'number') return Number.isInteger(v) ? BsonTypeTag.INT : BsonTypeTag.DOUBLE
+  if (typeof v === 'string') return BsonTypeTag.STRING
+  if (isObjectIdLike(v)) return BsonTypeTag.OBJECT_ID
+  if (isDecimalLike(v)) return BsonTypeTag.DECIMAL
+  if (v instanceof Date) return BsonTypeTag.DATE
+  if (isTimestampLike(v)) return BsonTypeTag.TIMESTAMP
+  if (isBinaryLike(v)) return BsonTypeTag.BINARY
+  if (isRegexLike(v)) return BsonTypeTag.REGEX
+  if (v === null) return BsonTypeTag.NULL
+  return BsonTypeTag.UNKNOWN
+}
+
+export function arrayTag(items: readonly unknown[]): string {
+  if (items.length === 0) return BsonTypeTag.ARRAY
+  if (items.every((x) => typeof x === 'number' && Number.isFinite(x))) {
+    return `array<${BsonTypeTag.DOUBLE}>(${String(items.length)})`
+  }
+  if (items.every((x) => typeof x === 'string')) {
+    return `array<${BsonTypeTag.STRING}>`
+  }
+  return BsonTypeTag.ARRAY
+}
+
+function walk(value: unknown, prefix: string, counts: Map<string, Map<string, number>>): void {
+  if (isPlainObject(value)) {
+    if (prefix !== '') bump(counts, prefix, BsonTypeTag.OBJECT)
+    for (const [k, v] of Object.entries(value)) {
+      const next = prefix === '' ? k : `${prefix}.${k}`
+      walk(v, next, counts)
+    }
+    return
+  }
+  if (Array.isArray(value)) {
+    if (prefix !== '') bump(counts, prefix, arrayTag(value))
+    return
+  }
+  if (prefix !== '') bump(counts, prefix, scalarTag(value))
+}
+
+export async function sampleFieldTypes(
+  accessor: MongoDBAccessor,
+  database: string,
+  collection: string,
+  sampleSize = 100,
+): Promise<SampledField[]> {
+  const counts = new Map<string, Map<string, number>>()
+  let total = 0
+  for await (const doc of accessor.driver.iterDocuments(database, collection, {
+    batchSize: sampleSize,
+    sort: { _id: 1 },
+  })) {
+    total++
+    walk(doc, '', counts)
+    if (total >= sampleSize) break
+  }
+  if (total === 0) return []
+  const fields: SampledField[] = []
+  for (const path of [...counts.keys()].sort()) {
+    if (path === PRIMARY_KEY) continue
+    const inner = counts.get(path) ?? new Map()
+    const presenceCount = [...inner.values()].reduce((a, b) => a + b, 0)
+    const types: Record<string, number> = {}
+    for (const [t, c] of inner) types[t] = c / total
+    fields.push({
+      path,
+      presence: presenceCount / total,
+      types,
+    })
+  }
+  return fields
+}

--- a/typescript/packages/core/src/core/mongodb/_schema_json.ts
+++ b/typescript/packages/core/src/core/mongodb/_schema_json.ts
@@ -1,0 +1,116 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { MongoDBAccessor } from '../../accessor/mongodb.ts'
+import {
+  countDocuments,
+  getIndexStats,
+  getValidator,
+  isView,
+  listCollections,
+  listIndexes,
+} from './_client.ts'
+import { sampleFieldTypes, type SampledField } from './_sampler.ts'
+import { EntityKind, IndexType, PRIMARY_KEY } from './types.ts'
+
+function indexType(idx: Record<string, unknown>): string {
+  if ('textIndexVersion' in idx) return IndexType.TEXT
+  return IndexType.BTREE
+}
+
+export interface DatabaseJsonCollection {
+  name: string
+  document_count: number
+}
+
+export interface DatabaseJsonView {
+  name: string
+}
+
+export interface DatabaseJson {
+  database: string
+  collections: DatabaseJsonCollection[]
+  views: DatabaseJsonView[]
+}
+
+export async function buildDatabaseJson(
+  accessor: MongoDBAccessor,
+  database: string,
+): Promise<DatabaseJson> {
+  const allNames = await listCollections(accessor, database)
+  const collections: DatabaseJsonCollection[] = []
+  const views: DatabaseJsonView[] = []
+  for (const name of allNames) {
+    if (await isView(accessor, database, name)) {
+      views.push({ name })
+    } else {
+      const doc_count = await countDocuments(accessor, database, name)
+      collections.push({ name, document_count: doc_count })
+    }
+  }
+  return { database, collections, views }
+}
+
+export interface CollectionSchemaIndex {
+  name: string | undefined
+  keys: Record<string, unknown>
+  type: string
+  stats: Record<string, unknown>
+}
+
+export interface CollectionSchemaJson {
+  database: string
+  name: string
+  kind: EntityKind
+  validator: unknown
+  fields: SampledField[]
+  primary_key: string
+  indexes: CollectionSchemaIndex[]
+  document_count: number
+  sampled: number
+}
+
+export async function buildCollectionSchemaJson(
+  accessor: MongoDBAccessor,
+  database: string,
+  collection: string,
+  sampleSize = 100,
+): Promise<CollectionSchemaJson> {
+  const view = await isView(accessor, database, collection)
+  const validator = await getValidator(accessor, database, collection)
+  const fields = await sampleFieldTypes(accessor, database, collection, sampleSize)
+  const docCount = await countDocuments(accessor, database, collection)
+  let enrichedIndexes: CollectionSchemaIndex[] = []
+  if (!view) {
+    const indexes = await listIndexes(accessor, database, collection)
+    const stats = await getIndexStats(accessor, database, collection)
+    enrichedIndexes = indexes.map((idx) => ({
+      name: idx.name as string | undefined,
+      keys: (idx.key as Record<string, unknown> | undefined) ?? {},
+      type: indexType(idx),
+      stats: (stats[idx.name as string] as Record<string, unknown> | undefined) ?? {},
+    }))
+  }
+  return {
+    database,
+    name: collection,
+    kind: view ? EntityKind.VIEW : EntityKind.COLLECTION,
+    validator,
+    fields,
+    primary_key: PRIMARY_KEY,
+    indexes: enrichedIndexes,
+    document_count: docCount,
+    sampled: sampleSize,
+  }
+}

--- a/typescript/packages/core/src/core/mongodb/_test_util.ts
+++ b/typescript/packages/core/src/core/mongodb/_test_util.ts
@@ -34,8 +34,10 @@ export function stubMongoDriver(overrides: Partial<MongoDriver> = {}): MongoDriv
   }
 }
 
-export function arrayIter<T>(items: readonly T[]): () => AsyncIterableIterator<T> {
-  return async function* () {
-    for (const i of items) yield i
+export function arrayIter(
+  items: readonly Record<string, unknown>[],
+): <T = Record<string, unknown>>() => AsyncIterableIterator<T> {
+  return async function* <T = Record<string, unknown>>() {
+    for (const i of items) yield i as T
   }
 }

--- a/typescript/packages/core/src/core/mongodb/_test_util.ts
+++ b/typescript/packages/core/src/core/mongodb/_test_util.ts
@@ -14,8 +14,13 @@
 
 import type { MongoDriver } from './_driver.ts'
 
-async function* emptyAsyncIter<T>(): AsyncIterableIterator<T> {
-  // no docs
+function emptyAsyncIter<T>(): AsyncIterableIterator<T> {
+  return {
+    next: () => Promise.resolve({ value: undefined as T, done: true }),
+    [Symbol.asyncIterator]() {
+      return this
+    },
+  }
 }
 
 export function stubMongoDriver(overrides: Partial<MongoDriver> = {}): MongoDriver {
@@ -37,7 +42,18 @@ export function stubMongoDriver(overrides: Partial<MongoDriver> = {}): MongoDriv
 export function arrayIter(
   items: readonly Record<string, unknown>[],
 ): <T = Record<string, unknown>>() => AsyncIterableIterator<T> {
-  return async function* <T = Record<string, unknown>>() {
-    for (const i of items) yield i as T
+  return <T = Record<string, unknown>>(): AsyncIterableIterator<T> => {
+    let i = 0
+    return {
+      next: () =>
+        Promise.resolve(
+          i < items.length
+            ? { value: items[i++] as T, done: false }
+            : { value: undefined as T, done: true },
+        ),
+      [Symbol.asyncIterator]() {
+        return this
+      },
+    }
   }
 }

--- a/typescript/packages/core/src/core/mongodb/_test_util.ts
+++ b/typescript/packages/core/src/core/mongodb/_test_util.ts
@@ -1,0 +1,41 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { MongoDriver } from './_driver.ts'
+
+async function* emptyAsyncIter<T>(): AsyncIterableIterator<T> {
+  // no docs
+}
+
+export function stubMongoDriver(overrides: Partial<MongoDriver> = {}): MongoDriver {
+  return {
+    listDatabases: () => Promise.resolve([]),
+    listCollections: () => Promise.resolve([]),
+    listCollectionsDetailed: () => Promise.resolve([]),
+    findDocuments: () => Promise.resolve([]),
+    iterDocuments: () => emptyAsyncIter(),
+    iterInserts: () => emptyAsyncIter(),
+    countDocuments: () => Promise.resolve(0),
+    listIndexes: () => Promise.resolve([]),
+    getIndexStats: () => Promise.resolve({}),
+    close: () => Promise.resolve(),
+    ...overrides,
+  }
+}
+
+export function arrayIter<T>(items: readonly T[]): () => AsyncIterableIterator<T> {
+  return async function* () {
+    for (const i of items) yield i
+  }
+}

--- a/typescript/packages/core/src/core/mongodb/glob.test.ts
+++ b/typescript/packages/core/src/core/mongodb/glob.test.ts
@@ -21,18 +21,11 @@ vi.mock('./readdir.ts', () => ({
 import { MongoDBAccessor } from '../../accessor/mongodb.ts'
 import { resolveMongoDBConfig } from '../../resource/mongodb/config.ts'
 import { PathSpec } from '../../types.ts'
-import type { MongoDriver } from './_driver.ts'
+import { stubMongoDriver } from './_test_util.ts'
 import { resolveGlob } from './glob.ts'
 import { readdir } from './readdir.ts'
 
-const STUB_DRIVER: MongoDriver = {
-  listDatabases: () => Promise.resolve([]),
-  listCollections: () => Promise.resolve([]),
-  findDocuments: () => Promise.resolve([]),
-  countDocuments: () => Promise.resolve(0),
-  listIndexes: () => Promise.resolve([]),
-  close: () => Promise.resolve(),
-}
+const STUB_DRIVER = stubMongoDriver()
 
 function makeAccessor(): MongoDBAccessor {
   return new MongoDBAccessor(STUB_DRIVER, resolveMongoDBConfig({ uri: 'mongodb://h' }))

--- a/typescript/packages/core/src/core/mongodb/read.test.ts
+++ b/typescript/packages/core/src/core/mongodb/read.test.ts
@@ -12,31 +12,15 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-vi.mock('./_client.ts', () => ({
-  findDocuments: vi.fn(),
-}))
-
+import { describe, expect, it } from 'vitest'
 import { MongoDBAccessor } from '../../accessor/mongodb.ts'
-import { resolveMongoDBConfig, type MongoDBConfig } from '../../resource/mongodb/config.ts'
+import { resolveMongoDBConfig } from '../../resource/mongodb/config.ts'
 import { PathSpec } from '../../types.ts'
-import * as _client from './_client.ts'
-import type { MongoDriver } from './_driver.ts'
 import { read } from './read.ts'
+import { arrayIter, stubMongoDriver } from './_test_util.ts'
 
-const STUB_DRIVER: MongoDriver = {
-  listDatabases: () => Promise.resolve([]),
-  listCollections: () => Promise.resolve([]),
-  findDocuments: () => Promise.resolve([]),
-  countDocuments: () => Promise.resolve(0),
-  listIndexes: () => Promise.resolve([]),
-  close: () => Promise.resolve(),
-}
-
-function makeAccessor(cfgOverrides: Partial<MongoDBConfig> = {}): MongoDBAccessor {
-  const cfg = resolveMongoDBConfig({ uri: 'mongodb://h', ...cfgOverrides })
-  return new MongoDBAccessor(STUB_DRIVER, cfg)
+function ps(p: string): PathSpec {
+  return new PathSpec({ original: p, directory: p, prefix: '/mongo' })
 }
 
 function decode(b: Uint8Array): string {
@@ -44,82 +28,37 @@ function decode(b: Uint8Array): string {
 }
 
 describe('read', () => {
-  beforeEach(() => {
-    vi.mocked(_client.findDocuments).mockReset()
+  it('streams documents.jsonl as one JSON line per doc', async () => {
+    const driver = stubMongoDriver({
+      iterDocuments: arrayIter([
+        { _id: 'a', x: 1 },
+        { _id: 'b', x: 2 },
+      ]),
+    })
+    const accessor = new MongoDBAccessor(driver, resolveMongoDBConfig({ uri: 'mongodb://h' }))
+    const out = await read(accessor, ps('/mongo/app/collections/users/documents.jsonl'))
+    const lines = decode(out).trim().split('\n')
+    expect(lines).toHaveLength(2)
+    expect(JSON.parse(lines[0] ?? '')).toEqual({ _id: 'a', x: 1 })
   })
 
-  it('returns empty bytes when no docs', async () => {
-    vi.mocked(_client.findDocuments).mockResolvedValue([])
-    const out = await read(
-      makeAccessor(),
-      new PathSpec({
-        original: '/mongo/app/users.jsonl',
-        directory: '/mongo/app/',
-        prefix: '/mongo',
-      }),
-    )
-    expect(out.byteLength).toBe(0)
+  it('throws ENOENT for an unknown path', async () => {
+    const driver = stubMongoDriver()
+    const accessor = new MongoDBAccessor(driver, resolveMongoDBConfig({ uri: 'mongodb://h' }))
+    await expect(read(accessor, ps('/mongo/app/something'))).rejects.toThrow()
   })
 
-  it('uses defaultDocLimit when no explicit limit', async () => {
-    vi.mocked(_client.findDocuments).mockResolvedValue([{ _id: 'a', x: 1 }])
-    await read(
-      makeAccessor({ defaultDocLimit: 7 }),
-      new PathSpec({
-        original: '/mongo/app/users.jsonl',
-        directory: '/mongo/app/',
-        prefix: '/mongo',
-      }),
-    )
-    const call = vi.mocked(_client.findDocuments).mock.calls[0]
-    expect(call?.[4]?.limit).toBe(7)
-    expect(call?.[4]?.sort).toEqual({ _id: 1 })
-  })
-
-  it('honors explicit limit/offset (skip)', async () => {
-    vi.mocked(_client.findDocuments).mockResolvedValue([])
-    await read(
-      makeAccessor(),
-      new PathSpec({
-        original: '/mongo/app/users.jsonl',
-        directory: '/mongo/app/',
-        prefix: '/mongo',
-      }),
-      undefined,
-      { limit: 10, offset: 5 },
-    )
-    const call = vi.mocked(_client.findDocuments).mock.calls[0]
-    expect(call?.[4]?.limit).toBe(10)
-    expect(call?.[4]?.skip).toBe(5)
-  })
-
-  it('serializes Date as ISO and stringifies _id', async () => {
-    vi.mocked(_client.findDocuments).mockResolvedValue([
-      { _id: { toString: () => 'abc123' }, ts: new Date('2026-04-30T00:00:00.000Z') },
-    ])
-    const out = await read(
-      makeAccessor(),
-      new PathSpec({
-        original: '/mongo/app/users.jsonl',
-        directory: '/mongo/app/',
-        prefix: '/mongo',
-      }),
-    )
-    expect(decode(out)).toBe('{"_id":"abc123","ts":"2026-04-30T00:00:00.000Z"}\n')
-  })
-
-  it('single-db mode resolves /<col>.jsonl', async () => {
-    vi.mocked(_client.findDocuments).mockResolvedValue([{ _id: '1' }])
-    await read(
-      makeAccessor({ databases: ['app'] }),
-      new PathSpec({
-        original: '/mongo/users.jsonl',
-        directory: '/mongo/',
-        prefix: '/mongo',
-      }),
-    )
-    const call = vi.mocked(_client.findDocuments).mock.calls[0]
-    expect(call?.[1]).toBe('app')
-    expect(call?.[2]).toBe('users')
+  it('returns database.json payload at database_json scope', async () => {
+    const driver = stubMongoDriver({
+      listCollections: () => Promise.resolve(['users', 'orders']),
+      listCollectionsDetailed: (_db, filter = {}) =>
+        Promise.resolve([{ name: filter.name ?? 'users', type: 'collection' }]),
+      countDocuments: () => Promise.resolve(7),
+    })
+    const accessor = new MongoDBAccessor(driver, resolveMongoDBConfig({ uri: 'mongodb://h' }))
+    const out = await read(accessor, ps('/mongo/app/database.json'))
+    const parsed = JSON.parse(decode(out)) as { database: string; collections: unknown[] }
+    expect(parsed.database).toBe('app')
+    expect(parsed.collections).toHaveLength(2)
   })
 })

--- a/typescript/packages/core/src/core/mongodb/read.test.ts
+++ b/typescript/packages/core/src/core/mongodb/read.test.ts
@@ -30,6 +30,8 @@ function decode(b: Uint8Array): string {
 describe('read', () => {
   it('streams documents.jsonl as one JSON line per doc', async () => {
     const driver = stubMongoDriver({
+      listDatabases: () => Promise.resolve(['app']),
+      listCollections: () => Promise.resolve(['users']),
       iterDocuments: arrayIter([
         { _id: 'a', x: 1 },
         { _id: 'b', x: 2 },
@@ -50,6 +52,7 @@ describe('read', () => {
 
   it('returns database.json payload at database_json scope', async () => {
     const driver = stubMongoDriver({
+      listDatabases: () => Promise.resolve(['app']),
       listCollections: () => Promise.resolve(['users', 'orders']),
       listCollectionsDetailed: (_db, filter = {}) =>
         Promise.resolve([{ name: filter.name ?? 'users', type: 'collection' }]),
@@ -60,5 +63,24 @@ describe('read', () => {
     const parsed = JSON.parse(decode(out)) as { database: string; collections: unknown[] }
     expect(parsed.database).toBe('app')
     expect(parsed.collections).toHaveLength(2)
+  })
+
+  it('throws ENOENT when DOCUMENTS path references a missing collection', async () => {
+    const driver = stubMongoDriver({
+      listDatabases: () => Promise.resolve(['app']),
+      listCollections: () => Promise.resolve([]),
+    })
+    const accessor = new MongoDBAccessor(driver, resolveMongoDBConfig({ uri: 'mongodb://h' }))
+    await expect(
+      read(accessor, ps('/mongo/app/collections/ghost/documents.jsonl')),
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('throws ENOENT when DATABASE_JSON path references a missing database', async () => {
+    const driver = stubMongoDriver({ listDatabases: () => Promise.resolve([]) })
+    const accessor = new MongoDBAccessor(driver, resolveMongoDBConfig({ uri: 'mongodb://h' }))
+    await expect(read(accessor, ps('/mongo/ghost/database.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
   })
 })

--- a/typescript/packages/core/src/core/mongodb/read.ts
+++ b/typescript/packages/core/src/core/mongodb/read.ts
@@ -14,39 +14,11 @@
 
 import type { MongoDBAccessor } from '../../accessor/mongodb.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
-import type { MongoDBConfigResolved } from '../../resource/mongodb/config.ts'
 import { PathSpec } from '../../types.ts'
-import { encodeBase64 } from '../../utils/base64.ts'
-import { findDocuments } from './_client.ts'
-
-export interface ReadOptions {
-  limit?: number | null
-  offset?: number | null
-}
-
-function isSingleDb(config: MongoDBConfigResolved): boolean {
-  return config.databases !== null && config.databases.length === 1
-}
-
-function singleDbName(config: MongoDBConfigResolved): string | null {
-  if (config.databases !== null && config.databases.length === 1) {
-    return config.databases[0] ?? null
-  }
-  return null
-}
-
-function parseCollectionPath(key: string, config: MongoDBConfigResolved): [string, string] {
-  const parts = key.split('/')
-  if (isSingleDb(config) && parts.length === 1 && (parts[0] ?? '').endsWith('.jsonl')) {
-    const db = singleDbName(config)
-    if (db === null) throw notFound(key)
-    return [db, (parts[0] ?? '').slice(0, -'.jsonl'.length)]
-  }
-  if (parts.length === 2 && (parts[1] ?? '').endsWith('.jsonl')) {
-    return [parts[0] ?? '', (parts[1] ?? '').slice(0, -'.jsonl'.length)]
-  }
-  throw notFound(key)
-}
+import { buildCollectionSchemaJson, buildDatabaseJson } from './_schema_json.ts'
+import { detectScope } from './scope.ts'
+import { readStream } from './stream.ts'
+import { ScopeLevel } from './types.ts'
 
 function notFound(p: string): Error {
   const err = new Error(p) as Error & { code?: string }
@@ -54,91 +26,43 @@ function notFound(p: string): Error {
   return err
 }
 
-function safeToString(value: unknown): string {
-  if (value === null || value === undefined) return ''
-  if (typeof value === 'string') return value
-  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
-    return String(value)
-  }
-  if (typeof value === 'object' && 'toString' in value) {
-    try {
-      return (value as { toString: () => string }).toString()
-    } catch {
-      return Object.prototype.toString.call(value)
-    }
-  }
-  return Object.prototype.toString.call(value)
-}
-
-function bsonReplacer(_key: string, value: unknown): unknown {
-  if (value instanceof Date) return value.toISOString()
-  if (typeof value === 'bigint') return value.toString()
-  if (value instanceof Uint8Array) return encodeBase64(value)
-  if (typeof value === 'object' && value !== null && 'toJSON' in value) {
-    try {
-      return (value as { toJSON: () => unknown }).toJSON()
-    } catch {
-      return safeToString(value)
-    }
-  }
-  return value
-}
-
 export async function read(
   accessor: MongoDBAccessor,
   path: PathSpec | string,
   _index?: IndexCacheStore,
-  options: ReadOptions = {},
 ): Promise<Uint8Array> {
   const spec = typeof path === 'string' ? PathSpec.fromStrPath(path) : path
-  const prefix = spec.prefix
-  let raw = spec.original
-  if (prefix !== '' && raw.startsWith(prefix)) {
-    raw = raw.slice(prefix.length) || '/'
-  }
-  const key = raw.replace(/^\/+|\/+$/g, '')
+  const scope = detectScope(spec)
 
-  if (key !== '' && key.split('/').some((p) => p.startsWith('.'))) {
-    throw notFound(raw)
-  }
-
-  const [dbName, colName] = parseCollectionPath(key, accessor.config)
-
-  const limit = options.limit ?? null
-  const offset = options.offset ?? null
-  const effectiveLimit =
-    limit !== null ? Math.min(limit, accessor.config.maxDocLimit) : accessor.config.defaultDocLimit
-  const findOptions: { limit: number; sort: Record<string, 1 | -1>; skip?: number } = {
-    limit: effectiveLimit,
-    sort: { _id: 1 },
-  }
-  if (offset !== null && offset > 0) findOptions.skip = offset
-
-  const docs = await findDocuments(accessor, dbName, colName, {}, findOptions)
-  if (docs.length === 0) return new Uint8Array()
-
-  const lines: string[] = []
-  for (const doc of docs) {
-    const copy: Record<string, unknown> = { ...doc }
-    if (copy._id !== undefined && copy._id !== null) {
-      copy._id = stringifyId(copy._id)
+  if (scope.level === ScopeLevel.DOCUMENTS) {
+    const chunks: Uint8Array[] = []
+    let total = 0
+    for await (const chunk of readStream(accessor, spec)) {
+      chunks.push(chunk)
+      total += chunk.byteLength
     }
-    lines.push(JSON.stringify(copy, bsonReplacer))
-  }
-  return new TextEncoder().encode(lines.join('\n') + '\n')
-}
-
-function stringifyId(value: unknown): unknown {
-  if (typeof value === 'string') return value
-  if (typeof value === 'number') return value
-  if (value === null || value === undefined) return value
-  if (typeof value === 'object' && 'toString' in value) {
-    try {
-      const s = (value as { toString: () => string }).toString()
-      if (s !== '[object Object]') return s
-    } catch {
-      return safeToString(value)
+    const buf = new Uint8Array(total)
+    let off = 0
+    for (const c of chunks) {
+      buf.set(c, off)
+      off += c.byteLength
     }
+    return buf
   }
-  return safeToString(value)
+
+  if (
+    scope.level === ScopeLevel.SCHEMA_JSON &&
+    scope.database !== null &&
+    scope.name !== null
+  ) {
+    const payload = await buildCollectionSchemaJson(accessor, scope.database, scope.name)
+    return new TextEncoder().encode(JSON.stringify(payload) + '\n')
+  }
+
+  if (scope.level === ScopeLevel.DATABASE_JSON && scope.database !== null) {
+    const payload = await buildDatabaseJson(accessor, scope.database)
+    return new TextEncoder().encode(JSON.stringify(payload) + '\n')
+  }
+
+  throw notFound(spec.original)
 }

--- a/typescript/packages/core/src/core/mongodb/read.ts
+++ b/typescript/packages/core/src/core/mongodb/read.ts
@@ -15,6 +15,7 @@
 import type { MongoDBAccessor } from '../../accessor/mongodb.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
+import { databaseExists, entityExists } from './_client.ts'
 import { buildCollectionSchemaJson, buildDatabaseJson } from './_schema_json.ts'
 import { detectScope } from './scope.ts'
 import { readStream } from './stream.ts'
@@ -34,7 +35,10 @@ export async function read(
   const spec = typeof path === 'string' ? PathSpec.fromStrPath(path) : path
   const scope = detectScope(spec)
 
-  if (scope.level === ScopeLevel.DOCUMENTS) {
+  if (scope.level === ScopeLevel.DOCUMENTS && scope.database !== null && scope.name !== null) {
+    if (!(await entityExists(accessor, scope.database, scope.name, scope.kind))) {
+      throw notFound(spec.original)
+    }
     const chunks: Uint8Array[] = []
     let total = 0
     for await (const chunk of readStream(accessor, spec)) {
@@ -50,16 +54,16 @@ export async function read(
     return buf
   }
 
-  if (
-    scope.level === ScopeLevel.SCHEMA_JSON &&
-    scope.database !== null &&
-    scope.name !== null
-  ) {
+  if (scope.level === ScopeLevel.SCHEMA_JSON && scope.database !== null && scope.name !== null) {
+    if (!(await entityExists(accessor, scope.database, scope.name, scope.kind))) {
+      throw notFound(spec.original)
+    }
     const payload = await buildCollectionSchemaJson(accessor, scope.database, scope.name)
     return new TextEncoder().encode(JSON.stringify(payload) + '\n')
   }
 
   if (scope.level === ScopeLevel.DATABASE_JSON && scope.database !== null) {
+    if (!(await databaseExists(accessor, scope.database))) throw notFound(spec.original)
     const payload = await buildDatabaseJson(accessor, scope.database)
     return new TextEncoder().encode(JSON.stringify(payload) + '\n')
   }

--- a/typescript/packages/core/src/core/mongodb/readdir.test.ts
+++ b/typescript/packages/core/src/core/mongodb/readdir.test.ts
@@ -12,11 +12,13 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('./_client.ts', () => ({
   listDatabases: vi.fn(),
   listCollections: vi.fn(),
+  databaseExists: vi.fn(),
+  entityExists: vi.fn(),
 }))
 
 import { MongoDBAccessor } from '../../accessor/mongodb.ts'
@@ -38,6 +40,11 @@ function ps(p: string): PathSpec {
 }
 
 describe('readdir', () => {
+  beforeEach(() => {
+    vi.mocked(_client.databaseExists).mockResolvedValue(true)
+    vi.mocked(_client.entityExists).mockResolvedValue(true)
+  })
+
   it('lists root: databases', async () => {
     vi.mocked(_client.listDatabases).mockResolvedValue(['app', 'analytics'])
     const out = await readdir(makeAccessor(), ps('/mongo/'))
@@ -46,11 +53,7 @@ describe('readdir', () => {
 
   it('lists database: fixed [database.json, collections, views]', async () => {
     const out = await readdir(makeAccessor(), ps('/mongo/app'))
-    expect(out).toEqual([
-      '/mongo/app/database.json',
-      '/mongo/app/collections',
-      '/mongo/app/views',
-    ])
+    expect(out).toEqual(['/mongo/app/database.json', '/mongo/app/collections', '/mongo/app/views'])
   })
 
   it('lists kind_dir (collections): collection names', async () => {
@@ -87,5 +90,19 @@ describe('readdir', () => {
     await expect(
       readdir(makeAccessor(), ps('/mongo/app/collections/users/documents.jsonl')),
     ).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('throws ENOENT when database does not exist', async () => {
+    vi.mocked(_client.databaseExists).mockResolvedValue(false)
+    await expect(readdir(makeAccessor(), ps('/mongo/ghost'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
+  })
+
+  it('throws ENOENT when collection does not exist', async () => {
+    vi.mocked(_client.entityExists).mockResolvedValue(false)
+    await expect(readdir(makeAccessor(), ps('/mongo/app/collections/ghost'))).rejects.toMatchObject(
+      { code: 'ENOENT' },
+    )
   })
 })

--- a/typescript/packages/core/src/core/mongodb/readdir.test.ts
+++ b/typescript/packages/core/src/core/mongodb/readdir.test.ts
@@ -21,74 +21,71 @@ vi.mock('./_client.ts', () => ({
 
 import { MongoDBAccessor } from '../../accessor/mongodb.ts'
 import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
-import { resolveMongoDBConfig, type MongoDBConfig } from '../../resource/mongodb/config.ts'
+import { resolveMongoDBConfig } from '../../resource/mongodb/config.ts'
 import { PathSpec } from '../../types.ts'
 import * as _client from './_client.ts'
-import type { MongoDriver } from './_driver.ts'
+import { stubMongoDriver } from './_test_util.ts'
 import { readdir } from './readdir.ts'
 
-const STUB_DRIVER: MongoDriver = {
-  listDatabases: () => Promise.resolve([]),
-  listCollections: () => Promise.resolve([]),
-  findDocuments: () => Promise.resolve([]),
-  countDocuments: () => Promise.resolve(0),
-  listIndexes: () => Promise.resolve([]),
-  close: () => Promise.resolve(),
+const STUB_DRIVER = stubMongoDriver()
+
+function makeAccessor(): MongoDBAccessor {
+  return new MongoDBAccessor(STUB_DRIVER, resolveMongoDBConfig({ uri: 'mongodb://h' }))
 }
 
-function makeAccessor(cfgOverrides: Partial<MongoDBConfig> = {}): MongoDBAccessor {
-  const cfg = resolveMongoDBConfig({ uri: 'mongodb://h', ...cfgOverrides })
-  return new MongoDBAccessor(STUB_DRIVER, cfg)
+function ps(p: string): PathSpec {
+  return new PathSpec({ original: p, directory: p, prefix: '/mongo' })
 }
 
 describe('readdir', () => {
-  it('lists root: databases with mount prefix', async () => {
+  it('lists root: databases', async () => {
     vi.mocked(_client.listDatabases).mockResolvedValue(['app', 'analytics'])
-    const accessor = makeAccessor()
-    const path = new PathSpec({ original: '/mongo/', directory: '/mongo/', prefix: '/mongo' })
-    const out = await readdir(accessor, path)
+    const out = await readdir(makeAccessor(), ps('/mongo/'))
     expect(out).toEqual(['/mongo/app', '/mongo/analytics'])
   })
 
-  it('lists database level: <col>.jsonl files', async () => {
-    vi.mocked(_client.listCollections).mockResolvedValue(['users', 'orders'])
-    const out = await readdir(
-      makeAccessor(),
-      new PathSpec({ original: '/mongo/app', directory: '/mongo/app', prefix: '/mongo' }),
-    )
-    expect(out).toEqual(['/mongo/app/users.jsonl', '/mongo/app/orders.jsonl'])
+  it('lists database: fixed [database.json, collections, views]', async () => {
+    const out = await readdir(makeAccessor(), ps('/mongo/app'))
+    expect(out).toEqual([
+      '/mongo/app/database.json',
+      '/mongo/app/collections',
+      '/mongo/app/views',
+    ])
   })
 
-  it('single-db mode collapses root to collections', async () => {
-    vi.mocked(_client.listCollections).mockResolvedValue(['users'])
-    const out = await readdir(
-      makeAccessor({ databases: ['app'] }),
-      new PathSpec({ original: '/mongo/', directory: '/mongo/', prefix: '/mongo' }),
-    )
-    expect(out).toEqual(['/mongo/users.jsonl'])
+  it('lists kind_dir (collections): collection names', async () => {
+    vi.mocked(_client.listCollections).mockResolvedValue(['users', 'orders'])
+    const out = await readdir(makeAccessor(), ps('/mongo/app/collections'))
+    expect(out).toEqual(['/mongo/app/collections/users', '/mongo/app/collections/orders'])
+  })
+
+  it('lists kind_dir (views): view names', async () => {
+    vi.mocked(_client.listCollections).mockResolvedValue(['recent'])
+    const out = await readdir(makeAccessor(), ps('/mongo/app/views'))
+    expect(out).toEqual(['/mongo/app/views/recent'])
+  })
+
+  it('lists entity (collection): [schema.json, documents.jsonl]', async () => {
+    const out = await readdir(makeAccessor(), ps('/mongo/app/collections/users'))
+    expect(out).toEqual([
+      '/mongo/app/collections/users/schema.json',
+      '/mongo/app/collections/users/documents.jsonl',
+    ])
   })
 
   it('caches root listing in index when provided', async () => {
     vi.mocked(_client.listDatabases).mockResolvedValue(['app'])
     const index = new RAMIndexCacheStore()
     const accessor = makeAccessor()
-    const path = new PathSpec({ original: '/mongo/', directory: '/mongo/', prefix: '/mongo' })
-    await readdir(accessor, path, index)
+    await readdir(accessor, ps('/mongo/'), index)
     vi.mocked(_client.listDatabases).mockClear()
-    await readdir(accessor, path, index)
+    await readdir(accessor, ps('/mongo/'), index)
     expect(_client.listDatabases).not.toHaveBeenCalled()
   })
 
-  it('throws ENOENT for file-level paths', async () => {
+  it('throws ENOENT for documents-leaf paths', async () => {
     await expect(
-      readdir(
-        makeAccessor(),
-        new PathSpec({
-          original: '/mongo/app/users.jsonl',
-          directory: '/mongo/app/',
-          prefix: '/mongo',
-        }),
-      ),
+      readdir(makeAccessor(), ps('/mongo/app/collections/users/documents.jsonl')),
     ).rejects.toMatchObject({ code: 'ENOENT' })
   })
 })

--- a/typescript/packages/core/src/core/mongodb/readdir.ts
+++ b/typescript/packages/core/src/core/mongodb/readdir.ts
@@ -16,15 +16,10 @@ import type { MongoDBAccessor } from '../../accessor/mongodb.ts'
 import { IndexEntry } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
-import { listCollections, listDatabases } from './_client.ts'
+import { databaseExists, entityExists, listCollections, listDatabases } from './_client.ts'
 import { detectScope } from './scope.ts'
-import {
-  EntityKind,
-  KIND_TO_DIR,
-  KIND_TO_RESOURCE_TYPE,
-  RESOURCE_TYPE_DATABASE,
-  ScopeLevel,
-} from './types.ts'
+import type { EntityKind } from './types.ts'
+import { KIND_TO_DIR, KIND_TO_RESOURCE_TYPE, RESOURCE_TYPE_DATABASE, ScopeLevel } from './types.ts'
 
 function notFound(p: string): Error {
   const err = new Error(p) as Error & { code?: string }
@@ -47,15 +42,13 @@ export async function readdir(
   }
 
   if (scope.level === ScopeLevel.DATABASE && scope.database !== null) {
+    if (!(await databaseExists(accessor, scope.database))) throw notFound(spec.original)
     const base = `${prefix}/${scope.database}`
     return [`${base}/database.json`, `${base}/collections`, `${base}/views`]
   }
 
-  if (
-    scope.level === ScopeLevel.KIND_DIR &&
-    scope.database !== null &&
-    scope.kind !== null
-  ) {
+  if (scope.level === ScopeLevel.KIND_DIR && scope.database !== null && scope.kind !== null) {
+    if (!(await databaseExists(accessor, scope.database))) throw notFound(spec.original)
     return listKindDir(accessor, scope.database, scope.kind, virtualKey, index, prefix)
   }
 
@@ -65,6 +58,9 @@ export async function readdir(
     scope.kind !== null &&
     scope.name !== null
   ) {
+    if (!(await entityExists(accessor, scope.database, scope.name, scope.kind))) {
+      throw notFound(spec.original)
+    }
     const base = `${prefix}/${scope.database}/${KIND_TO_DIR[scope.kind]}/${scope.name}`
     return [`${base}/schema.json`, `${base}/documents.jsonl`]
   }

--- a/typescript/packages/core/src/core/mongodb/readdir.ts
+++ b/typescript/packages/core/src/core/mongodb/readdir.ts
@@ -15,19 +15,21 @@
 import type { MongoDBAccessor } from '../../accessor/mongodb.ts'
 import { IndexEntry } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
-import type { MongoDBConfigResolved } from '../../resource/mongodb/config.ts'
 import { PathSpec } from '../../types.ts'
 import { listCollections, listDatabases } from './_client.ts'
+import { detectScope } from './scope.ts'
+import {
+  EntityKind,
+  KIND_TO_DIR,
+  KIND_TO_RESOURCE_TYPE,
+  RESOURCE_TYPE_DATABASE,
+  ScopeLevel,
+} from './types.ts'
 
-function isSingleDb(config: MongoDBConfigResolved): boolean {
-  return config.databases !== null && config.databases.length === 1
-}
-
-function singleDbName(config: MongoDBConfigResolved): string | null {
-  if (config.databases !== null && config.databases.length === 1) {
-    return config.databases[0] ?? null
-  }
-  return null
+function notFound(p: string): Error {
+  const err = new Error(p) as Error & { code?: string }
+  err.code = 'ENOENT'
+  return err
 }
 
 export async function readdir(
@@ -37,93 +39,96 @@ export async function readdir(
 ): Promise<string[]> {
   const spec = typeof path === 'string' ? PathSpec.fromStrPath(path) : path
   const prefix = spec.prefix
-  let raw = spec.pattern !== null ? spec.directory : spec.original
-  if (prefix !== '' && raw.startsWith(prefix)) {
-    raw = raw.slice(prefix.length) || '/'
-  }
-  const key = raw.replace(/^\/+|\/+$/g, '')
+  const scope = detectScope(spec)
+  const virtualKey = `${prefix}${scope.resourcePath}`.replace(/\/+$/, '') || '/'
 
-  if (key !== '' && key.split('/').some((p) => p.startsWith('.'))) {
-    const err = new Error(raw) as Error & { code?: string }
-    err.code = 'ENOENT'
-    throw err
+  if (scope.level === ScopeLevel.ROOT) {
+    return listRoot(accessor, virtualKey, index, prefix)
   }
 
-  const virtualKey = key !== '' ? `${prefix}/${key}` : prefix !== '' ? prefix : '/'
-
-  if (key === '') {
-    if (isSingleDb(accessor.config)) {
-      const db = singleDbName(accessor.config)
-      if (db === null) {
-        const err = new Error(raw) as Error & { code?: string }
-        err.code = 'ENOENT'
-        throw err
-      }
-      return readdirCollections(accessor, db, virtualKey, index, prefix, true)
-    }
-    if (index !== undefined) {
-      const cached = await index.listDir(virtualKey)
-      if (cached.entries !== null && cached.entries !== undefined) return cached.entries
-    }
-    const dbs = await listDatabases(accessor)
-    const entries: [string, IndexEntry][] = []
-    const names: string[] = []
-    for (const db of dbs) {
-      entries.push([
-        db,
-        new IndexEntry({
-          id: db,
-          name: db,
-          resourceType: 'mongodb/database',
-          vfsName: db,
-        }),
-      ])
-      names.push(`${prefix}/${db}`)
-    }
-    if (index !== undefined) await index.setDir(virtualKey, entries)
-    return names
+  if (scope.level === ScopeLevel.DATABASE && scope.database !== null) {
+    const base = `${prefix}/${scope.database}`
+    return [`${base}/database.json`, `${base}/collections`, `${base}/views`]
   }
 
-  const parts = key.split('/')
-  if (parts.length === 1) {
-    const dbName = parts[0] ?? ''
-    return readdirCollections(accessor, dbName, virtualKey, index, prefix, false)
+  if (
+    scope.level === ScopeLevel.KIND_DIR &&
+    scope.database !== null &&
+    scope.kind !== null
+  ) {
+    return listKindDir(accessor, scope.database, scope.kind, virtualKey, index, prefix)
   }
 
-  const err = new Error(raw) as Error & { code?: string }
-  err.code = 'ENOENT'
-  throw err
+  if (
+    scope.level === ScopeLevel.ENTITY &&
+    scope.database !== null &&
+    scope.kind !== null &&
+    scope.name !== null
+  ) {
+    const base = `${prefix}/${scope.database}/${KIND_TO_DIR[scope.kind]}/${scope.name}`
+    return [`${base}/schema.json`, `${base}/documents.jsonl`]
+  }
+
+  throw notFound(spec.original)
 }
 
-async function readdirCollections(
+async function listRoot(
   accessor: MongoDBAccessor,
-  dbName: string,
   virtualKey: string,
   index: IndexCacheStore | undefined,
   prefix: string,
-  collapsed: boolean,
 ): Promise<string[]> {
   if (index !== undefined) {
     const cached = await index.listDir(virtualKey)
     if (cached.entries !== null && cached.entries !== undefined) return cached.entries
   }
-  const collections = await listCollections(accessor, dbName)
+  const dbs = await listDatabases(accessor)
   const entries: [string, IndexEntry][] = []
   const names: string[] = []
-  for (const col of collections) {
-    const filename = `${col}.jsonl`
+  for (const db of dbs) {
     entries.push([
-      filename,
+      db,
       new IndexEntry({
-        id: col,
-        name: col,
-        resourceType: 'mongodb/collection',
-        vfsName: filename,
+        id: db,
+        name: db,
+        resourceType: RESOURCE_TYPE_DATABASE,
+        vfsName: db,
       }),
     ])
-    const fullPath = collapsed ? `${prefix}/${filename}` : `${prefix}/${dbName}/${filename}`
-    names.push(fullPath)
+    names.push(`${prefix}/${db}`)
   }
   if (index !== undefined) await index.setDir(virtualKey, entries)
   return names
+}
+
+async function listKindDir(
+  accessor: MongoDBAccessor,
+  database: string,
+  kind: EntityKind,
+  virtualKey: string,
+  index: IndexCacheStore | undefined,
+  prefix: string,
+): Promise<string[]> {
+  if (index !== undefined) {
+    const cached = await index.listDir(virtualKey)
+    if (cached.entries !== null && cached.entries !== undefined) return cached.entries
+  }
+  const names = await listCollections(accessor, database, kind)
+  const base = `${prefix}/${database}/${KIND_TO_DIR[kind]}`
+  const entries: [string, IndexEntry][] = []
+  const out: string[] = []
+  for (const name of names) {
+    entries.push([
+      name,
+      new IndexEntry({
+        id: name,
+        name,
+        resourceType: KIND_TO_RESOURCE_TYPE[kind],
+        vfsName: name,
+      }),
+    ])
+    out.push(`${base}/${name}`)
+  }
+  if (index !== undefined) await index.setDir(virtualKey, entries)
+  return out
 }

--- a/typescript/packages/core/src/core/mongodb/scope.test.ts
+++ b/typescript/packages/core/src/core/mongodb/scope.test.ts
@@ -103,9 +103,7 @@ describe('detectScope', () => {
   })
 
   it('returns unknown for too-deep paths', () => {
-    expect(detectScope(ps('/a/collections/b/documents.jsonl/extra')).level).toBe(
-      ScopeLevel.UNKNOWN,
-    )
+    expect(detectScope(ps('/a/collections/b/documents.jsonl/extra')).level).toBe(ScopeLevel.UNKNOWN)
   })
 })
 

--- a/typescript/packages/core/src/core/mongodb/scope.test.ts
+++ b/typescript/packages/core/src/core/mongodb/scope.test.ts
@@ -15,77 +15,111 @@
 import { describe, expect, it } from 'vitest'
 import { PathSpec } from '../../types.ts'
 import { detectScope } from './scope.ts'
+import { EntityKind, ScopeLevel } from './types.ts'
 
 function ps(p: string): PathSpec {
   return new PathSpec({ original: p, directory: p })
 }
 
-describe('detectScope (multi-db)', () => {
-  it('detects root from "/"', () => {
+describe('detectScope', () => {
+  it('returns root for "/"', () => {
     const s = detectScope(ps('/'))
-    expect(s.level).toBe('root')
+    expect(s.level).toBe(ScopeLevel.ROOT)
     expect(s.resourcePath).toBe('/')
   })
 
-  it('detects root from empty string', () => {
-    expect(detectScope(ps('')).level).toBe('root')
+  it('returns root for empty string', () => {
+    expect(detectScope(ps('')).level).toBe(ScopeLevel.ROOT)
   })
 
-  it('detects database level for /<db>', () => {
+  it('returns database level for /<db>', () => {
     const s = detectScope(ps('/app'))
-    expect(s.level).toBe('database')
+    expect(s.level).toBe(ScopeLevel.DATABASE)
     expect(s.database).toBe('app')
   })
 
-  it('detects database level with trailing slash', () => {
+  it('handles trailing slash on database path', () => {
     const s = detectScope(ps('/app/'))
-    expect(s.level).toBe('database')
+    expect(s.level).toBe(ScopeLevel.DATABASE)
     expect(s.database).toBe('app')
   })
 
-  it('detects file level for /<db>/<col>.jsonl', () => {
-    const s = detectScope(ps('/app/users.jsonl'))
-    expect(s.level).toBe('file')
-    expect(s.database).toBe('app')
-    expect(s.collection).toBe('users')
-  })
-
-  it('returns root for too-deep paths', () => {
-    expect(detectScope(ps('/app/users/extra')).level).toBe('root')
-  })
-})
-
-describe('detectScope (single-db mode)', () => {
-  it('treats "/" as the database', () => {
-    const s = detectScope(ps('/'), { singleDb: true, singleDbName: 'app' })
-    expect(s.level).toBe('database')
+  it('returns database_json for /<db>/database.json', () => {
+    const s = detectScope(ps('/app/database.json'))
+    expect(s.level).toBe(ScopeLevel.DATABASE_JSON)
     expect(s.database).toBe('app')
   })
 
-  it('treats /<col>.jsonl as a file', () => {
-    const s = detectScope(ps('/users.jsonl'), { singleDb: true, singleDbName: 'app' })
-    expect(s.level).toBe('file')
+  it('returns kind_dir for /<db>/collections', () => {
+    const s = detectScope(ps('/app/collections'))
+    expect(s.level).toBe(ScopeLevel.KIND_DIR)
     expect(s.database).toBe('app')
-    expect(s.collection).toBe('users')
+    expect(s.kind).toBe(EntityKind.COLLECTION)
   })
 
-  it('treats /<x> as still the database', () => {
-    const s = detectScope(ps('/sub'), { singleDb: true, singleDbName: 'app' })
-    expect(s.level).toBe('database')
+  it('returns kind_dir for /<db>/views', () => {
+    const s = detectScope(ps('/app/views'))
+    expect(s.level).toBe(ScopeLevel.KIND_DIR)
+    expect(s.kind).toBe(EntityKind.VIEW)
+  })
+
+  it('returns entity for /<db>/collections/<name>', () => {
+    const s = detectScope(ps('/app/collections/users'))
+    expect(s.level).toBe(ScopeLevel.ENTITY)
     expect(s.database).toBe('app')
+    expect(s.kind).toBe(EntityKind.COLLECTION)
+    expect(s.name).toBe('users')
+  })
+
+  it('returns entity for /<db>/views/<name>', () => {
+    const s = detectScope(ps('/app/views/active_users'))
+    expect(s.level).toBe(ScopeLevel.ENTITY)
+    expect(s.kind).toBe(EntityKind.VIEW)
+    expect(s.name).toBe('active_users')
+  })
+
+  it('returns schema_json for documents-deep schema.json', () => {
+    const s = detectScope(ps('/app/collections/users/schema.json'))
+    expect(s.level).toBe(ScopeLevel.SCHEMA_JSON)
+    expect(s.kind).toBe(EntityKind.COLLECTION)
+    expect(s.name).toBe('users')
+  })
+
+  it('returns documents for documents-deep documents.jsonl', () => {
+    const s = detectScope(ps('/app/collections/users/documents.jsonl'))
+    expect(s.level).toBe(ScopeLevel.DOCUMENTS)
+    expect(s.kind).toBe(EntityKind.COLLECTION)
+    expect(s.name).toBe('users')
+  })
+
+  it('returns documents for a view documents.jsonl', () => {
+    const s = detectScope(ps('/app/views/active_users/documents.jsonl'))
+    expect(s.level).toBe(ScopeLevel.DOCUMENTS)
+    expect(s.kind).toBe(EntityKind.VIEW)
+  })
+
+  it('returns unknown for unrecognized 2-part paths', () => {
+    expect(detectScope(ps('/app/something')).level).toBe(ScopeLevel.UNKNOWN)
+  })
+
+  it('returns unknown for too-deep paths', () => {
+    expect(detectScope(ps('/a/collections/b/documents.jsonl/extra')).level).toBe(
+      ScopeLevel.UNKNOWN,
+    )
   })
 })
 
 describe('detectScope (path prefix)', () => {
   it('strips mount prefix before detection', () => {
     const path = new PathSpec({
-      original: '/mongo/app/users.jsonl',
-      directory: '/mongo/app/',
+      original: '/mongo/app/collections/users/documents.jsonl',
+      directory: '/mongo/app/collections/users/',
       prefix: '/mongo',
     })
     const s = detectScope(path)
-    expect(s.level).toBe('file')
+    expect(s.level).toBe(ScopeLevel.DOCUMENTS)
     expect(s.database).toBe('app')
-    expect(s.collection).toBe('users')
+    expect(s.kind).toBe(EntityKind.COLLECTION)
+    expect(s.name).toBe('users')
   })
 })

--- a/typescript/packages/core/src/core/mongodb/scope.ts
+++ b/typescript/packages/core/src/core/mongodb/scope.ts
@@ -48,33 +48,41 @@ export function detectScope(path: PathSpec | string): MongoDBScope {
   }
 
   if (parts.length === 2) {
-    const [db, leaf] = parts
+    const db = parts[0] ?? ''
+    const leaf = parts[1] ?? ''
     if (leaf === 'database.json') {
       return scope(ScopeLevel.DATABASE_JSON, raw, db)
     }
-    if (leaf in KIND_DIR_NAMES) {
-      return scope(ScopeLevel.KIND_DIR, raw, db, KIND_DIR_NAMES[leaf])
+    const dirKind = KIND_DIR_NAMES[leaf]
+    if (dirKind !== undefined) {
+      return scope(ScopeLevel.KIND_DIR, raw, db, dirKind)
     }
     return scope(ScopeLevel.UNKNOWN, raw)
   }
 
   if (parts.length === 3) {
-    const [db, kindSeg, name] = parts
-    if (kindSeg in KIND_DIR_NAMES) {
-      return scope(ScopeLevel.ENTITY, raw, db, KIND_DIR_NAMES[kindSeg], name)
+    const db = parts[0] ?? ''
+    const kindSeg = parts[1] ?? ''
+    const name = parts[2] ?? ''
+    const dirKind = KIND_DIR_NAMES[kindSeg]
+    if (dirKind !== undefined) {
+      return scope(ScopeLevel.ENTITY, raw, db, dirKind, name)
     }
     return scope(ScopeLevel.UNKNOWN, raw)
   }
 
   if (parts.length === 4) {
-    const [db, kindSeg, name, leaf] = parts
-    if (kindSeg in KIND_DIR_NAMES) {
-      const kind = KIND_DIR_NAMES[kindSeg]
+    const db = parts[0] ?? ''
+    const kindSeg = parts[1] ?? ''
+    const name = parts[2] ?? ''
+    const leaf = parts[3] ?? ''
+    const dirKind = KIND_DIR_NAMES[kindSeg]
+    if (dirKind !== undefined) {
       if (leaf === 'schema.json') {
-        return scope(ScopeLevel.SCHEMA_JSON, raw, db, kind, name)
+        return scope(ScopeLevel.SCHEMA_JSON, raw, db, dirKind, name)
       }
       if (leaf === 'documents.jsonl') {
-        return scope(ScopeLevel.DOCUMENTS, raw, db, kind, name)
+        return scope(ScopeLevel.DOCUMENTS, raw, db, dirKind, name)
       }
     }
     return scope(ScopeLevel.UNKNOWN, raw)

--- a/typescript/packages/core/src/core/mongodb/scope.ts
+++ b/typescript/packages/core/src/core/mongodb/scope.ts
@@ -13,89 +13,72 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { PathSpec } from '../../types.ts'
+import { EntityKind, KIND_DIR_NAMES, ScopeLevel } from './types.ts'
 
 export interface MongoDBScope {
-  level: 'root' | 'database' | 'file' | 'invalid'
+  level: ScopeLevel
   database: string | null
-  collection: string | null
+  kind: EntityKind | null
+  name: string | null
   resourcePath: string
 }
 
-export interface DetectScopeOptions {
-  singleDb?: boolean
-  singleDbName?: string | null
+function scope(
+  level: ScopeLevel,
+  resourcePath: string,
+  database: string | null = null,
+  kind: EntityKind | null = null,
+  name: string | null = null,
+): MongoDBScope {
+  return { level, database, kind, name, resourcePath }
 }
 
-export function detectScope(
-  path: PathSpec | string,
-  options: DetectScopeOptions = {},
-): MongoDBScope {
-  const singleDb = options.singleDb === true
-  const singleDbName = options.singleDbName ?? null
+export function detectScope(path: PathSpec | string): MongoDBScope {
   const raw = path instanceof PathSpec ? path.stripPrefix : path
   const key = raw.replace(/^\/+|\/+$/g, '')
 
   if (key === '') {
-    if (singleDb) {
-      return {
-        level: 'database',
-        database: singleDbName,
-        collection: null,
-        resourcePath: '/',
-      }
-    }
-    return { level: 'root', database: null, collection: null, resourcePath: '/' }
+    return scope(ScopeLevel.ROOT, '/')
   }
 
   const parts = key.split('/')
 
-  if (singleDb) {
-    if (key.endsWith('.jsonl')) {
-      const col = key.slice(0, -'.jsonl'.length)
-      return {
-        level: 'file',
-        database: singleDbName,
-        collection: col,
-        resourcePath: raw,
-      }
-    }
-    return {
-      level: 'database',
-      database: singleDbName,
-      collection: null,
-      resourcePath: raw,
-    }
-  }
-
   if (parts.length === 1) {
-    const part = parts[0] ?? ''
-    if (part.endsWith('.jsonl')) {
-      return {
-        level: 'file',
-        database: null,
-        collection: part.slice(0, -'.jsonl'.length),
-        resourcePath: raw,
-      }
-    }
-    return {
-      level: 'database',
-      database: part,
-      collection: null,
-      resourcePath: raw,
-    }
+    return scope(ScopeLevel.DATABASE, raw, parts[0])
   }
 
   if (parts.length === 2) {
-    const second = parts[1] ?? ''
-    if (second.endsWith('.jsonl')) {
-      return {
-        level: 'file',
-        database: parts[0] ?? null,
-        collection: second.slice(0, -'.jsonl'.length),
-        resourcePath: raw,
-      }
+    const [db, leaf] = parts
+    if (leaf === 'database.json') {
+      return scope(ScopeLevel.DATABASE_JSON, raw, db)
     }
+    if (leaf in KIND_DIR_NAMES) {
+      return scope(ScopeLevel.KIND_DIR, raw, db, KIND_DIR_NAMES[leaf])
+    }
+    return scope(ScopeLevel.UNKNOWN, raw)
   }
 
-  return { level: 'root', database: null, collection: null, resourcePath: raw }
+  if (parts.length === 3) {
+    const [db, kindSeg, name] = parts
+    if (kindSeg in KIND_DIR_NAMES) {
+      return scope(ScopeLevel.ENTITY, raw, db, KIND_DIR_NAMES[kindSeg], name)
+    }
+    return scope(ScopeLevel.UNKNOWN, raw)
+  }
+
+  if (parts.length === 4) {
+    const [db, kindSeg, name, leaf] = parts
+    if (kindSeg in KIND_DIR_NAMES) {
+      const kind = KIND_DIR_NAMES[kindSeg]
+      if (leaf === 'schema.json') {
+        return scope(ScopeLevel.SCHEMA_JSON, raw, db, kind, name)
+      }
+      if (leaf === 'documents.jsonl') {
+        return scope(ScopeLevel.DOCUMENTS, raw, db, kind, name)
+      }
+    }
+    return scope(ScopeLevel.UNKNOWN, raw)
+  }
+
+  return scope(ScopeLevel.UNKNOWN, raw)
 }

--- a/typescript/packages/core/src/core/mongodb/scope.ts
+++ b/typescript/packages/core/src/core/mongodb/scope.ts
@@ -13,7 +13,8 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { PathSpec } from '../../types.ts'
-import { EntityKind, KIND_DIR_NAMES, ScopeLevel } from './types.ts'
+import type { EntityKind } from './types.ts'
+import { KIND_DIR_NAMES, ScopeLevel } from './types.ts'
 
 export interface MongoDBScope {
   level: ScopeLevel

--- a/typescript/packages/core/src/core/mongodb/search.test.ts
+++ b/typescript/packages/core/src/core/mongodb/search.test.ts
@@ -23,17 +23,10 @@ vi.mock('./_client.ts', () => ({
 import { MongoDBAccessor } from '../../accessor/mongodb.ts'
 import { resolveMongoDBConfig } from '../../resource/mongodb/config.ts'
 import * as _client from './_client.ts'
-import type { MongoDriver } from './_driver.ts'
+import { stubMongoDriver } from './_test_util.ts'
 import { formatGrepResults, searchCollection, searchDatabase } from './search.ts'
 
-const STUB_DRIVER: MongoDriver = {
-  listDatabases: () => Promise.resolve([]),
-  listCollections: () => Promise.resolve([]),
-  findDocuments: () => Promise.resolve([]),
-  countDocuments: () => Promise.resolve(0),
-  listIndexes: () => Promise.resolve([]),
-  close: () => Promise.resolve(),
-}
+const STUB_DRIVER = stubMongoDriver()
 
 function makeAccessor(): MongoDBAccessor {
   return new MongoDBAccessor(STUB_DRIVER, resolveMongoDBConfig({ uri: 'mongodb://h' }))

--- a/typescript/packages/core/src/core/mongodb/search.test.ts
+++ b/typescript/packages/core/src/core/mongodb/search.test.ts
@@ -23,13 +23,14 @@ vi.mock('./_client.ts', () => ({
 import { MongoDBAccessor } from '../../accessor/mongodb.ts'
 import { resolveMongoDBConfig } from '../../resource/mongodb/config.ts'
 import * as _client from './_client.ts'
-import { stubMongoDriver } from './_test_util.ts'
+import { arrayIter, stubMongoDriver } from './_test_util.ts'
 import { formatGrepResults, searchCollection, searchDatabase } from './search.ts'
 
-const STUB_DRIVER = stubMongoDriver()
-
-function makeAccessor(): MongoDBAccessor {
-  return new MongoDBAccessor(STUB_DRIVER, resolveMongoDBConfig({ uri: 'mongodb://h' }))
+function accessorWith(iterDocs: readonly Record<string, unknown>[] = []): MongoDBAccessor {
+  return new MongoDBAccessor(
+    stubMongoDriver({ iterDocuments: arrayIter(iterDocs) }),
+    resolveMongoDBConfig({ uri: 'mongodb://h' }),
+  )
 }
 
 beforeEach(() => {
@@ -40,48 +41,61 @@ beforeEach(() => {
 
 describe('searchCollection', () => {
   it('uses $text when a text index exists', async () => {
-    vi.mocked(_client.listIndexes).mockResolvedValue([{ key: { name: 'text' } }])
+    vi.mocked(_client.listIndexes).mockResolvedValue([
+      { name: 'body_text', textIndexVersion: 3 },
+    ])
     vi.mocked(_client.findDocuments).mockResolvedValue([{ _id: '1', name: 'a' }])
-    const out = await searchCollection(makeAccessor(), 'app', 'users', 'foo', 5)
+    const out = await searchCollection(accessorWith(), 'app', 'users', 'foo', 5)
     expect(out).toEqual([{ _id: '1', name: 'a' }])
     const call = vi.mocked(_client.findDocuments).mock.calls[0]
     expect(call?.[3]).toEqual({ $text: { $search: 'foo' } })
   })
 
   it('falls back to $or of $regex over sampled string fields', async () => {
-    vi.mocked(_client.listIndexes).mockResolvedValue([{ key: { _id: 1 } }])
-    vi.mocked(_client.findDocuments)
-      .mockResolvedValueOnce([{ _id: '1', name: 'x', email: 'y', age: 7 }])
-      .mockResolvedValueOnce([{ _id: '1', name: 'foobar' }])
-    const out = await searchCollection(makeAccessor(), 'app', 'users', 'foo', 5)
+    vi.mocked(_client.listIndexes).mockResolvedValue([{ name: '_id_', key: { _id: 1 } }])
+    vi.mocked(_client.findDocuments).mockResolvedValue([{ _id: '1', name: 'foobar' }])
+    const acc = accessorWith([{ _id: '1', name: 'x', email: 'y', age: 7 }])
+    const out = await searchCollection(acc, 'app', 'users', 'foo', 5)
     expect(out).toEqual([{ _id: '1', name: 'foobar' }])
-    const call = vi.mocked(_client.findDocuments).mock.calls[1]
+    const call = vi.mocked(_client.findDocuments).mock.calls[0]
     expect(call?.[3]).toEqual({
       $or: [
-        { name: { $regex: 'foo', $options: 'i' } },
         { email: { $regex: 'foo', $options: 'i' } },
+        { name: { $regex: 'foo', $options: 'i' } },
       ],
     })
+  })
+
+  it('returns no results when sampled docs have no string fields', async () => {
+    vi.mocked(_client.listIndexes).mockResolvedValue([{ name: '_id_', key: { _id: 1 } }])
+    const acc = accessorWith([{ _id: '1', i: 0, v: 0 }])
+    const out = await searchCollection(acc, 'app', 'numbers', 'foo', 5)
+    expect(out).toEqual([])
+    expect(_client.findDocuments).not.toHaveBeenCalled()
   })
 })
 
 describe('searchDatabase', () => {
   it('walks collections and emits matches', async () => {
     vi.mocked(_client.listCollections).mockResolvedValue(['users', 'orders'])
-    vi.mocked(_client.listIndexes).mockResolvedValue([{ key: { name: 'text' } }])
+    vi.mocked(_client.listIndexes).mockResolvedValue([
+      { name: 'body_text', textIndexVersion: 3 },
+    ])
     vi.mocked(_client.findDocuments)
       .mockResolvedValueOnce([{ _id: '1' }])
       .mockResolvedValueOnce([])
-    const out = await searchDatabase(makeAccessor(), 'app', 'foo', 5)
+    const out = await searchDatabase(accessorWith(), 'app', 'foo', 5)
     expect(out).toEqual([{ database: 'app', collection: 'users', docs: [{ _id: '1' }] }])
   })
 })
 
 describe('formatGrepResults', () => {
-  it('emits one line per matching doc with path-prefix', () => {
+  it('emits one line per matching doc with nested-path prefix', () => {
     const lines = formatGrepResults([
       { database: 'app', collection: 'users', docs: [{ _id: '1', name: 'a' }] },
     ])
-    expect(lines).toEqual(['app/users.jsonl:{"_id":"1","name":"a"}'])
+    expect(lines).toEqual([
+      'app/collections/users/documents.jsonl:{"_id":"1","name":"a"}',
+    ])
   })
 })

--- a/typescript/packages/core/src/core/mongodb/search.test.ts
+++ b/typescript/packages/core/src/core/mongodb/search.test.ts
@@ -41,9 +41,7 @@ beforeEach(() => {
 
 describe('searchCollection', () => {
   it('uses $text when a text index exists', async () => {
-    vi.mocked(_client.listIndexes).mockResolvedValue([
-      { name: 'body_text', textIndexVersion: 3 },
-    ])
+    vi.mocked(_client.listIndexes).mockResolvedValue([{ name: 'body_text', textIndexVersion: 3 }])
     vi.mocked(_client.findDocuments).mockResolvedValue([{ _id: '1', name: 'a' }])
     const out = await searchCollection(accessorWith(), 'app', 'users', 'foo', 5)
     expect(out).toEqual([{ _id: '1', name: 'a' }])
@@ -78,9 +76,7 @@ describe('searchCollection', () => {
 describe('searchDatabase', () => {
   it('walks collections and emits matches', async () => {
     vi.mocked(_client.listCollections).mockResolvedValue(['users', 'orders'])
-    vi.mocked(_client.listIndexes).mockResolvedValue([
-      { name: 'body_text', textIndexVersion: 3 },
-    ])
+    vi.mocked(_client.listIndexes).mockResolvedValue([{ name: 'body_text', textIndexVersion: 3 }])
     vi.mocked(_client.findDocuments)
       .mockResolvedValueOnce([{ _id: '1' }])
       .mockResolvedValueOnce([])
@@ -94,8 +90,6 @@ describe('formatGrepResults', () => {
     const lines = formatGrepResults([
       { database: 'app', collection: 'users', docs: [{ _id: '1', name: 'a' }] },
     ])
-    expect(lines).toEqual([
-      'app/collections/users/documents.jsonl:{"_id":"1","name":"a"}',
-    ])
+    expect(lines).toEqual(['app/collections/users/documents.jsonl:{"_id":"1","name":"a"}'])
   })
 })

--- a/typescript/packages/core/src/core/mongodb/search.ts
+++ b/typescript/packages/core/src/core/mongodb/search.ts
@@ -14,6 +14,7 @@
 
 import type { MongoDBAccessor } from '../../accessor/mongodb.ts'
 import { findDocuments, listCollections, listIndexes } from './_client.ts'
+import { stringifyDoc } from './stream.ts'
 import { EntityKind, PRIMARY_KEY } from './types.ts'
 
 export interface CollectionMatches {
@@ -22,11 +23,7 @@ export interface CollectionMatches {
   docs: Record<string, unknown>[]
 }
 
-function collectStringPaths(
-  value: unknown,
-  prefix: string,
-  out: Set<string>,
-): void {
+function collectStringPaths(value: unknown, prefix: string, out: Set<string>): void {
   if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
       const sub = prefix === '' ? k : `${prefix}.${k}`
@@ -83,9 +80,7 @@ export async function searchDatabase(
 ): Promise<CollectionMatches[]> {
   const collections = await listCollections(accessor, database, EntityKind.COLLECTION)
   const tasks = collections.map((col) =>
-    searchCollection(accessor, database, col, pattern, limit).then(
-      (docs) => [col, docs] as const,
-    ),
+    searchCollection(accessor, database, col, pattern, limit).then((docs) => [col, docs] as const),
   )
   const settled = await Promise.all(tasks)
   const out: CollectionMatches[] = []
@@ -100,56 +95,8 @@ export function formatGrepResults(results: readonly CollectionMatches[]): string
   for (const { database, collection, docs } of results) {
     const path = `${database}/collections/${collection}/documents.jsonl`
     for (const doc of docs) {
-      const copy: Record<string, unknown> = { ...doc }
-      if (copy._id !== undefined && copy._id !== null) {
-        copy._id = stringifyId(copy._id)
-      }
-      lines.push(`${path}:${JSON.stringify(copy, bsonReplacer)}`)
+      lines.push(`${path}:${stringifyDoc(doc)}`)
     }
   }
   return lines
-}
-
-function bsonReplacer(_key: string, value: unknown): unknown {
-  if (value instanceof Date) return value.toISOString()
-  if (typeof value === 'bigint') return value.toString()
-  if (typeof value === 'object' && value !== null && 'toJSON' in value) {
-    try {
-      return (value as { toJSON: () => unknown }).toJSON()
-    } catch {
-      return safeToString(value)
-    }
-  }
-  return value
-}
-
-function safeToString(value: unknown): string {
-  if (value === null || value === undefined) return ''
-  if (typeof value === 'string') return value
-  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
-    return String(value)
-  }
-  if (typeof value === 'object' && 'toString' in value) {
-    try {
-      return (value as { toString: () => string }).toString()
-    } catch {
-      return Object.prototype.toString.call(value)
-    }
-  }
-  return Object.prototype.toString.call(value)
-}
-
-function stringifyId(value: unknown): unknown {
-  if (typeof value === 'string') return value
-  if (typeof value === 'number') return value
-  if (value === null || value === undefined) return value
-  if (typeof value === 'object' && 'toString' in value) {
-    try {
-      const s = (value as { toString: () => string }).toString()
-      if (s !== '[object Object]') return s
-    } catch {
-      return safeToString(value)
-    }
-  }
-  return safeToString(value)
 }

--- a/typescript/packages/core/src/core/mongodb/search.ts
+++ b/typescript/packages/core/src/core/mongodb/search.ts
@@ -14,6 +14,7 @@
 
 import type { MongoDBAccessor } from '../../accessor/mongodb.ts'
 import { findDocuments, listCollections, listIndexes } from './_client.ts'
+import { EntityKind, PRIMARY_KEY } from './types.ts'
 
 export interface CollectionMatches {
   database: string
@@ -21,21 +22,39 @@ export interface CollectionMatches {
   docs: Record<string, unknown>[]
 }
 
-async function regexFilter(
+function collectStringPaths(
+  value: unknown,
+  prefix: string,
+  out: Set<string>,
+): void {
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      const sub = prefix === '' ? k : `${prefix}.${k}`
+      collectStringPaths(v, sub, out)
+    }
+    return
+  }
+  if (typeof value === 'string' && prefix !== '' && prefix !== PRIMARY_KEY) {
+    out.add(prefix)
+  }
+}
+
+async function sampledStringPaths(
   accessor: MongoDBAccessor,
   database: string,
   collection: string,
-  pattern: string,
-): Promise<Record<string, unknown>[]> {
-  const sample = await findDocuments(accessor, database, collection, {}, { limit: 1 })
-  const first = sample[0]
-  if (first === undefined) return [{}]
-  const stringFields: string[] = []
-  for (const [k, v] of Object.entries(first)) {
-    if (k !== '_id' && typeof v === 'string') stringFields.push(k)
+  sampleSize = 100,
+): Promise<string[]> {
+  const paths = new Set<string>()
+  let n = 0
+  for await (const doc of accessor.driver.iterDocuments(database, collection, {
+    batchSize: sampleSize,
+  })) {
+    collectStringPaths(doc, '', paths)
+    n++
+    if (n >= sampleSize) break
   }
-  if (stringFields.length === 0) return [{}]
-  return stringFields.map((f) => ({ [f]: { $regex: pattern, $options: 'i' } }))
+  return [...paths].sort()
 }
 
 export async function searchCollection(
@@ -46,15 +65,13 @@ export async function searchCollection(
   limit: number,
 ): Promise<Record<string, unknown>[]> {
   const indexes = await listIndexes(accessor, database, collection)
-  const hasTextIndex = indexes.some((idx) => {
-    const key = idx.key as Record<string, unknown> | undefined
-    if (key === undefined) return false
-    return Object.values(key).some((v) => v === 'text')
-  })
+  const hasTextIndex = indexes.some((idx) => 'textIndexVersion' in idx)
   if (hasTextIndex) {
     return findDocuments(accessor, database, collection, { $text: { $search: pattern } }, { limit })
   }
-  const orFilters = await regexFilter(accessor, database, collection, pattern)
+  const paths = await sampledStringPaths(accessor, database, collection)
+  if (paths.length === 0) return []
+  const orFilters = paths.map((f) => ({ [f]: { $regex: pattern, $options: 'i' } }))
   return findDocuments(accessor, database, collection, { $or: orFilters }, { limit })
 }
 
@@ -64,10 +81,15 @@ export async function searchDatabase(
   pattern: string,
   limit: number,
 ): Promise<CollectionMatches[]> {
-  const collections = await listCollections(accessor, database)
+  const collections = await listCollections(accessor, database, EntityKind.COLLECTION)
+  const tasks = collections.map((col) =>
+    searchCollection(accessor, database, col, pattern, limit).then(
+      (docs) => [col, docs] as const,
+    ),
+  )
+  const settled = await Promise.all(tasks)
   const out: CollectionMatches[] = []
-  for (const col of collections) {
-    const docs = await searchCollection(accessor, database, col, pattern, limit)
+  for (const [col, docs] of settled) {
     if (docs.length > 0) out.push({ database, collection: col, docs })
   }
   return out
@@ -76,12 +98,13 @@ export async function searchDatabase(
 export function formatGrepResults(results: readonly CollectionMatches[]): string[] {
   const lines: string[] = []
   for (const { database, collection, docs } of results) {
+    const path = `${database}/collections/${collection}/documents.jsonl`
     for (const doc of docs) {
       const copy: Record<string, unknown> = { ...doc }
       if (copy._id !== undefined && copy._id !== null) {
         copy._id = stringifyId(copy._id)
       }
-      lines.push(`${database}/${collection}.jsonl:${JSON.stringify(copy, bsonReplacer)}`)
+      lines.push(`${path}:${JSON.stringify(copy, bsonReplacer)}`)
     }
   }
   return lines

--- a/typescript/packages/core/src/core/mongodb/stat.test.ts
+++ b/typescript/packages/core/src/core/mongodb/stat.test.ts
@@ -25,7 +25,11 @@ function ps(p: string): PathSpec {
 
 function accessor(overrides: Partial<Parameters<typeof stubMongoDriver>[0]> = {}) {
   return new MongoDBAccessor(
-    stubMongoDriver(overrides),
+    stubMongoDriver({
+      listDatabases: () => Promise.resolve(['app']),
+      listCollections: (_db, kind) => Promise.resolve(kind === 'view' ? ['recent'] : ['users']),
+      ...overrides,
+    }),
     resolveMongoDBConfig({ uri: 'mongodb://h' }),
   )
 }
@@ -69,8 +73,7 @@ describe('stat', () => {
     const r = await stat(
       accessor({
         countDocuments: () => Promise.resolve(42),
-        listCollectionsDetailed: () =>
-          Promise.resolve([{ name: 'users', type: 'collection' }]),
+        listCollectionsDetailed: () => Promise.resolve([{ name: 'users', type: 'collection' }]),
         listIndexes: () => Promise.resolve([{ name: '_id_', key: { _id: 1 } }]),
       }),
       ps('/mongo/app/collections/users/documents.jsonl'),
@@ -85,8 +88,7 @@ describe('stat', () => {
     const r = await stat(
       accessor({
         countDocuments: () => Promise.resolve(10),
-        listCollectionsDetailed: () =>
-          Promise.resolve([{ name: 'recent', type: 'view' }]),
+        listCollectionsDetailed: () => Promise.resolve([{ name: 'recent', type: 'view' }]),
       }),
       ps('/mongo/app/views/recent/documents.jsonl'),
     )
@@ -96,10 +98,7 @@ describe('stat', () => {
   })
 
   it('marks schema.json as TEXT', async () => {
-    const r = await stat(
-      accessor(),
-      ps('/mongo/app/collections/users/schema.json'),
-    )
+    const r = await stat(accessor(), ps('/mongo/app/collections/users/schema.json'))
     expect(r.type).toBe(FileType.TEXT)
     expect(r.name).toBe('schema.json')
   })
@@ -114,5 +113,23 @@ describe('stat', () => {
     await expect(stat(accessor(), ps('/mongo/app/foo'))).rejects.toMatchObject({
       code: 'ENOENT',
     })
+  })
+
+  it('throws ENOENT for a nonexistent database', async () => {
+    await expect(stat(accessor(), ps('/mongo/ghost'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
+  })
+
+  it('throws ENOENT for a nonexistent collection under a real database', async () => {
+    await expect(stat(accessor(), ps('/mongo/app/collections/ghost'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
+  })
+
+  it('throws ENOENT for documents.jsonl under a nonexistent collection', async () => {
+    await expect(
+      stat(accessor(), ps('/mongo/app/collections/ghost/documents.jsonl')),
+    ).rejects.toMatchObject({ code: 'ENOENT' })
   })
 })

--- a/typescript/packages/core/src/core/mongodb/stat.test.ts
+++ b/typescript/packages/core/src/core/mongodb/stat.test.ts
@@ -12,63 +12,68 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it, vi } from 'vitest'
-
-vi.mock('./_client.ts', () => ({
-  countDocuments: vi.fn(),
-  listIndexes: vi.fn(),
-}))
-
+import { describe, expect, it } from 'vitest'
 import { MongoDBAccessor } from '../../accessor/mongodb.ts'
-import { resolveMongoDBConfig, type MongoDBConfig } from '../../resource/mongodb/config.ts'
+import { resolveMongoDBConfig } from '../../resource/mongodb/config.ts'
 import { FileType, PathSpec } from '../../types.ts'
-import * as _client from './_client.ts'
-import type { MongoDriver } from './_driver.ts'
 import { stat } from './stat.ts'
+import { stubMongoDriver } from './_test_util.ts'
 
-const STUB_DRIVER: MongoDriver = {
-  listDatabases: () => Promise.resolve([]),
-  listCollections: () => Promise.resolve([]),
-  findDocuments: () => Promise.resolve([]),
-  countDocuments: () => Promise.resolve(0),
-  listIndexes: () => Promise.resolve([]),
-  close: () => Promise.resolve(),
+function ps(p: string): PathSpec {
+  return new PathSpec({ original: p, directory: p, prefix: '/mongo' })
 }
 
-function makeAccessor(cfgOverrides: Partial<MongoDBConfig> = {}): MongoDBAccessor {
-  const cfg = resolveMongoDBConfig({ uri: 'mongodb://h', ...cfgOverrides })
-  return new MongoDBAccessor(STUB_DRIVER, cfg)
+function accessor(overrides: Partial<Parameters<typeof stubMongoDriver>[0]> = {}) {
+  return new MongoDBAccessor(
+    stubMongoDriver(overrides),
+    resolveMongoDBConfig({ uri: 'mongodb://h' }),
+  )
 }
 
 describe('stat', () => {
   it('marks root as DIRECTORY', async () => {
-    const r = await stat(
-      makeAccessor(),
-      new PathSpec({ original: '/mongo/', directory: '/mongo/', prefix: '/mongo' }),
-    )
+    const r = await stat(accessor(), ps('/mongo/'))
     expect(r.name).toBe('/')
     expect(r.type).toBe(FileType.DIRECTORY)
   })
 
   it('marks database level as DIRECTORY with extras', async () => {
-    const r = await stat(
-      makeAccessor(),
-      new PathSpec({ original: '/mongo/app', directory: '/mongo/', prefix: '/mongo' }),
-    )
+    const r = await stat(accessor(), ps('/mongo/app'))
     expect(r.type).toBe(FileType.DIRECTORY)
     expect(r.extra).toEqual({ database: 'app' })
   })
 
-  it('marks collection file as TEXT with size=null and extras', async () => {
-    vi.mocked(_client.countDocuments).mockResolvedValue(42)
-    vi.mocked(_client.listIndexes).mockResolvedValue([{ name: '_id_', key: { _id: 1 } }])
+  it('marks kind_dir as DIRECTORY with kind extra', async () => {
+    const r = await stat(accessor(), ps('/mongo/app/collections'))
+    expect(r.type).toBe(FileType.DIRECTORY)
+    expect(r.name).toBe('collections')
+    expect(r.extra).toMatchObject({ database: 'app', kind: 'collection' })
+  })
+
+  it('marks entity (collection dir) as DIRECTORY with document_count', async () => {
     const r = await stat(
-      makeAccessor(),
-      new PathSpec({
-        original: '/mongo/app/users.jsonl',
-        directory: '/mongo/app/',
-        prefix: '/mongo',
+      accessor({ countDocuments: () => Promise.resolve(42) }),
+      ps('/mongo/app/collections/users'),
+    )
+    expect(r.type).toBe(FileType.DIRECTORY)
+    expect(r.name).toBe('users')
+    expect(r.extra).toMatchObject({
+      database: 'app',
+      kind: 'collection',
+      name: 'users',
+      document_count: 42,
+    })
+  })
+
+  it('marks documents.jsonl as TEXT with indexes for a collection', async () => {
+    const r = await stat(
+      accessor({
+        countDocuments: () => Promise.resolve(42),
+        listCollectionsDetailed: () =>
+          Promise.resolve([{ name: 'users', type: 'collection' }]),
+        listIndexes: () => Promise.resolve([{ name: '_id_', key: { _id: 1 } }]),
       }),
+      ps('/mongo/app/collections/users/documents.jsonl'),
     )
     expect(r.type).toBe(FileType.TEXT)
     expect(r.size).toBeNull()
@@ -76,32 +81,38 @@ describe('stat', () => {
     expect(r.extra.indexes).toEqual([{ name: '_id_', keys: { _id: 1 } }])
   })
 
-  it('single-db mode resolves /<col>.jsonl to a file', async () => {
-    vi.mocked(_client.countDocuments).mockResolvedValue(7)
-    vi.mocked(_client.listIndexes).mockResolvedValue([])
+  it('marks documents.jsonl as TEXT but with no indexes for a view', async () => {
     const r = await stat(
-      makeAccessor({ databases: ['app'] }),
-      new PathSpec({
-        original: '/mongo/users.jsonl',
-        directory: '/mongo/',
-        prefix: '/mongo',
+      accessor({
+        countDocuments: () => Promise.resolve(10),
+        listCollectionsDetailed: () =>
+          Promise.resolve([{ name: 'recent', type: 'view' }]),
       }),
+      ps('/mongo/app/views/recent/documents.jsonl'),
     )
     expect(r.type).toBe(FileType.TEXT)
-    expect(r.extra.database).toBe('app')
-    expect(r.extra.collection).toBe('users')
+    expect(r.extra.indexes).toEqual([])
+    expect(r.extra.kind).toBe('view')
   })
 
-  it('throws ENOENT for invalid paths', async () => {
-    await expect(
-      stat(
-        makeAccessor(),
-        new PathSpec({
-          original: '/mongo/a/b/c',
-          directory: '/mongo/a/b/',
-          prefix: '/mongo',
-        }),
-      ),
-    ).rejects.toMatchObject({ code: 'ENOENT' })
+  it('marks schema.json as TEXT', async () => {
+    const r = await stat(
+      accessor(),
+      ps('/mongo/app/collections/users/schema.json'),
+    )
+    expect(r.type).toBe(FileType.TEXT)
+    expect(r.name).toBe('schema.json')
+  })
+
+  it('marks database.json as TEXT', async () => {
+    const r = await stat(accessor(), ps('/mongo/app/database.json'))
+    expect(r.type).toBe(FileType.TEXT)
+    expect(r.name).toBe('database.json')
+  })
+
+  it('throws ENOENT for unrecognized paths', async () => {
+    await expect(stat(accessor(), ps('/mongo/app/foo'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
   })
 })

--- a/typescript/packages/core/src/core/mongodb/stat.ts
+++ b/typescript/packages/core/src/core/mongodb/stat.ts
@@ -14,19 +14,15 @@
 
 import type { MongoDBAccessor } from '../../accessor/mongodb.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
-import type { MongoDBConfigResolved } from '../../resource/mongodb/config.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
-import { countDocuments, listIndexes } from './_client.ts'
+import { countDocuments, isView, listIndexes } from './_client.ts'
+import { detectScope } from './scope.ts'
+import { EntityKind, KIND_TO_DIR, ScopeLevel } from './types.ts'
 
-function isSingleDb(config: MongoDBConfigResolved): boolean {
-  return config.databases !== null && config.databases.length === 1
-}
-
-function singleDbName(config: MongoDBConfigResolved): string | null {
-  if (config.databases !== null && config.databases.length === 1) {
-    return config.databases[0] ?? null
-  }
-  return null
+function notFound(p: string): Error {
+  const err = new Error(p) as Error & { code?: string }
+  err.code = 'ENOENT'
+  return err
 }
 
 export async function stat(
@@ -35,76 +31,112 @@ export async function stat(
   _index?: IndexCacheStore,
 ): Promise<FileStat> {
   const spec = typeof path === 'string' ? PathSpec.fromStrPath(path) : path
-  const prefix = spec.prefix
-  let raw = spec.original
-  if (prefix !== '' && raw.startsWith(prefix)) {
-    raw = raw.slice(prefix.length) || '/'
-  }
-  const key = raw.replace(/^\/+|\/+$/g, '')
+  const scope = detectScope(spec)
 
-  if (key === '') {
+  if (scope.level === ScopeLevel.ROOT) {
     return new FileStat({ name: '/', type: FileType.DIRECTORY })
   }
 
-  const parts = key.split('/')
-  if (parts.some((p) => p.startsWith('.'))) {
-    const err = new Error(raw) as Error & { code?: string }
-    err.code = 'ENOENT'
-    throw err
-  }
-
-  if (isSingleDb(accessor.config) && parts.length === 1 && (parts[0] ?? '').endsWith('.jsonl')) {
-    const db = singleDbName(accessor.config)
-    if (db === null) {
-      const err = new Error(raw) as Error & { code?: string }
-      err.code = 'ENOENT'
-      throw err
-    }
-    const filename = parts[0] ?? ''
-    const colName = filename.slice(0, -'.jsonl'.length)
-    return collectionStat(accessor, db, colName, filename)
-  }
-
-  if (parts.length === 1 && !(parts[0] ?? '').endsWith('.jsonl')) {
-    const dbName = parts[0] ?? ''
+  if (scope.level === ScopeLevel.DATABASE && scope.database !== null) {
     return new FileStat({
-      name: dbName,
+      name: scope.database,
       type: FileType.DIRECTORY,
-      extra: { database: dbName },
+      extra: { database: scope.database },
     })
   }
 
-  if (parts.length === 2 && (parts[1] ?? '').endsWith('.jsonl')) {
-    const dbName = parts[0] ?? ''
-    const filename = parts[1] ?? ''
-    const colName = filename.slice(0, -'.jsonl'.length)
-    return collectionStat(accessor, dbName, colName, filename)
+  if (
+    scope.level === ScopeLevel.KIND_DIR &&
+    scope.database !== null &&
+    scope.kind !== null
+  ) {
+    return new FileStat({
+      name: KIND_TO_DIR[scope.kind],
+      type: FileType.DIRECTORY,
+      extra: { database: scope.database, kind: scope.kind },
+    })
   }
 
-  const err = new Error(raw) as Error & { code?: string }
-  err.code = 'ENOENT'
-  throw err
+  if (
+    scope.level === ScopeLevel.ENTITY &&
+    scope.database !== null &&
+    scope.kind !== null &&
+    scope.name !== null
+  ) {
+    const docCount = await countDocuments(accessor, scope.database, scope.name)
+    return new FileStat({
+      name: scope.name,
+      type: FileType.DIRECTORY,
+      extra: {
+        database: scope.database,
+        kind: scope.kind,
+        name: scope.name,
+        document_count: docCount,
+      },
+    })
+  }
+
+  if (
+    scope.level === ScopeLevel.DOCUMENTS &&
+    scope.database !== null &&
+    scope.kind !== null &&
+    scope.name !== null
+  ) {
+    return documentsStat(accessor, scope.database, scope.kind, scope.name)
+  }
+
+  if (
+    scope.level === ScopeLevel.SCHEMA_JSON &&
+    scope.database !== null &&
+    scope.kind !== null &&
+    scope.name !== null
+  ) {
+    return new FileStat({
+      name: 'schema.json',
+      type: FileType.TEXT,
+      extra: {
+        database: scope.database,
+        kind: scope.kind,
+        name: scope.name,
+      },
+    })
+  }
+
+  if (scope.level === ScopeLevel.DATABASE_JSON && scope.database !== null) {
+    return new FileStat({
+      name: 'database.json',
+      type: FileType.TEXT,
+      extra: { database: scope.database },
+    })
+  }
+
+  throw notFound(spec.original)
 }
 
-async function collectionStat(
+async function documentsStat(
   accessor: MongoDBAccessor,
-  dbName: string,
-  colName: string,
-  filename: string,
+  database: string,
+  kind: EntityKind,
+  name: string,
 ): Promise<FileStat> {
-  const docCount = await countDocuments(accessor, dbName, colName)
-  const indexes = await listIndexes(accessor, dbName, colName)
-  const indexInfo = indexes.map((idx) => ({
-    name: idx.name ?? null,
-    keys: { ...((idx.key as Record<string, unknown> | undefined) ?? {}) },
-  }))
+  const view = kind === EntityKind.VIEW || (await isView(accessor, database, name))
+  const docCount = await countDocuments(accessor, database, name)
+  let indexInfo: { name: unknown; keys: Record<string, unknown> }[] = []
+  if (!view) {
+    const indexes = await listIndexes(accessor, database, name)
+    indexInfo = indexes.map((idx) => ({
+      name: idx.name ?? null,
+      keys: { ...((idx.key as Record<string, unknown> | undefined) ?? {}) },
+    }))
+  }
   return new FileStat({
-    name: filename,
+    name: 'documents.jsonl',
     type: FileType.TEXT,
     size: null,
     extra: {
-      database: dbName,
-      collection: colName,
+      database,
+      name,
+      kind: view ? EntityKind.VIEW : EntityKind.COLLECTION,
       document_count: docCount,
       indexes: indexInfo,
     },

--- a/typescript/packages/core/src/core/mongodb/stat.ts
+++ b/typescript/packages/core/src/core/mongodb/stat.ts
@@ -15,7 +15,7 @@
 import type { MongoDBAccessor } from '../../accessor/mongodb.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
-import { countDocuments, isView, listIndexes } from './_client.ts'
+import { countDocuments, databaseExists, entityExists, isView, listIndexes } from './_client.ts'
 import { detectScope } from './scope.ts'
 import { EntityKind, KIND_TO_DIR, ScopeLevel } from './types.ts'
 
@@ -38,6 +38,7 @@ export async function stat(
   }
 
   if (scope.level === ScopeLevel.DATABASE && scope.database !== null) {
+    if (!(await databaseExists(accessor, scope.database))) throw notFound(spec.original)
     return new FileStat({
       name: scope.database,
       type: FileType.DIRECTORY,
@@ -45,11 +46,8 @@ export async function stat(
     })
   }
 
-  if (
-    scope.level === ScopeLevel.KIND_DIR &&
-    scope.database !== null &&
-    scope.kind !== null
-  ) {
+  if (scope.level === ScopeLevel.KIND_DIR && scope.database !== null && scope.kind !== null) {
+    if (!(await databaseExists(accessor, scope.database))) throw notFound(spec.original)
     return new FileStat({
       name: KIND_TO_DIR[scope.kind],
       type: FileType.DIRECTORY,
@@ -63,6 +61,9 @@ export async function stat(
     scope.kind !== null &&
     scope.name !== null
   ) {
+    if (!(await entityExists(accessor, scope.database, scope.name, scope.kind))) {
+      throw notFound(spec.original)
+    }
     const docCount = await countDocuments(accessor, scope.database, scope.name)
     return new FileStat({
       name: scope.name,
@@ -82,6 +83,9 @@ export async function stat(
     scope.kind !== null &&
     scope.name !== null
   ) {
+    if (!(await entityExists(accessor, scope.database, scope.name, scope.kind))) {
+      throw notFound(spec.original)
+    }
     return documentsStat(accessor, scope.database, scope.kind, scope.name)
   }
 
@@ -91,6 +95,9 @@ export async function stat(
     scope.kind !== null &&
     scope.name !== null
   ) {
+    if (!(await entityExists(accessor, scope.database, scope.name, scope.kind))) {
+      throw notFound(spec.original)
+    }
     return new FileStat({
       name: 'schema.json',
       type: FileType.TEXT,
@@ -103,6 +110,7 @@ export async function stat(
   }
 
   if (scope.level === ScopeLevel.DATABASE_JSON && scope.database !== null) {
+    if (!(await databaseExists(accessor, scope.database))) throw notFound(spec.original)
     return new FileStat({
       name: 'database.json',
       type: FileType.TEXT,

--- a/typescript/packages/core/src/core/mongodb/stream.ts
+++ b/typescript/packages/core/src/core/mongodb/stream.ts
@@ -60,7 +60,7 @@ export function elisionPaths(
   name: string,
 ): Set<string> {
   const key = `${database}.${name}`
-  const fields = accessor.config.elideFields?.[key] ?? []
+  const fields = accessor.config.elideFields[key] ?? []
   return new Set(fields)
 }
 

--- a/typescript/packages/core/src/core/mongodb/stream.ts
+++ b/typescript/packages/core/src/core/mongodb/stream.ts
@@ -12,13 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { EJSON } from 'bson'
 import type { MongoDBAccessor } from '../../accessor/mongodb.ts'
 import { PathSpec } from '../../types.ts'
 import { iterDocuments, iterInserts } from './_client.ts'
 import { detectScope } from './scope.ts'
 import { PRIMARY_KEY, ScopeLevel } from './types.ts'
 
-function applyElision(
+export function applyElision(
   value: Record<string, unknown>,
   paths: Set<string>,
 ): Record<string, unknown> {
@@ -43,7 +44,7 @@ function applyElision(
       typeof v === 'object' &&
       v !== null &&
       !Array.isArray(v) &&
-      (v as object).constructor === Object
+      v.constructor === Object
     ) {
       out[k] = applyElision(v as Record<string, unknown>, grouped[k])
     } else {
@@ -53,15 +54,22 @@ function applyElision(
   return out
 }
 
-function elisionPaths(accessor: MongoDBAccessor, database: string, name: string): Set<string> {
+export function elisionPaths(
+  accessor: MongoDBAccessor,
+  database: string,
+  name: string,
+): Set<string> {
   const key = `${database}.${name}`
   const fields = accessor.config.elideFields?.[key] ?? []
   return new Set(fields)
 }
 
+export function stringifyDoc(doc: Record<string, unknown>): string {
+  return EJSON.stringify(doc, undefined, 0, { relaxed: true })
+}
+
 function encodeLine(doc: Record<string, unknown>): Uint8Array {
-  const json = JSON.stringify(doc)
-  return new TextEncoder().encode(`${json}\n`)
+  return new TextEncoder().encode(`${stringifyDoc(doc)}\n`)
 }
 
 export async function* readStream(
@@ -80,9 +88,8 @@ export async function* readStream(
     sort: { [PRIMARY_KEY]: 1 },
     batchSize,
   })) {
-    const final =
-      elide.size > 0 ? applyElision(doc as Record<string, unknown>, elide) : doc
-    yield encodeLine(final as Record<string, unknown>)
+    const final = elide.size > 0 ? applyElision(doc, elide) : doc
+    yield encodeLine(final)
   }
 }
 
@@ -97,8 +104,7 @@ export async function* watchStream(
   }
   const elide = elisionPaths(accessor, scope.database, scope.name)
   for await (const doc of iterInserts(accessor, scope.database, scope.name)) {
-    const final =
-      elide.size > 0 ? applyElision(doc as Record<string, unknown>, elide) : doc
-    yield encodeLine(final as Record<string, unknown>)
+    const final = elide.size > 0 ? applyElision(doc, elide) : doc
+    yield encodeLine(final)
   }
 }

--- a/typescript/packages/core/src/core/mongodb/stream.ts
+++ b/typescript/packages/core/src/core/mongodb/stream.ts
@@ -1,0 +1,104 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { MongoDBAccessor } from '../../accessor/mongodb.ts'
+import { PathSpec } from '../../types.ts'
+import { iterDocuments, iterInserts } from './_client.ts'
+import { detectScope } from './scope.ts'
+import { PRIMARY_KEY, ScopeLevel } from './types.ts'
+
+function applyElision(
+  value: Record<string, unknown>,
+  paths: Set<string>,
+): Record<string, unknown> {
+  const grouped: Record<string, Set<string>> = {}
+  const leaves = new Set<string>()
+  for (const p of paths) {
+    const dot = p.indexOf('.')
+    if (dot === -1) {
+      leaves.add(p)
+    } else {
+      const head = p.slice(0, dot)
+      const tail = p.slice(dot + 1)
+      grouped[head] ??= new Set()
+      grouped[head].add(tail)
+    }
+  }
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(value)) {
+    if (leaves.has(k)) continue
+    if (
+      grouped[k] !== undefined &&
+      typeof v === 'object' &&
+      v !== null &&
+      !Array.isArray(v) &&
+      (v as object).constructor === Object
+    ) {
+      out[k] = applyElision(v as Record<string, unknown>, grouped[k])
+    } else {
+      out[k] = v
+    }
+  }
+  return out
+}
+
+function elisionPaths(accessor: MongoDBAccessor, database: string, name: string): Set<string> {
+  const key = `${database}.${name}`
+  const fields = accessor.config.elideFields?.[key] ?? []
+  return new Set(fields)
+}
+
+function encodeLine(doc: Record<string, unknown>): Uint8Array {
+  const json = JSON.stringify(doc)
+  return new TextEncoder().encode(`${json}\n`)
+}
+
+export async function* readStream(
+  accessor: MongoDBAccessor,
+  path: PathSpec | string,
+  options: { batchSize?: number } = {},
+): AsyncIterableIterator<Uint8Array> {
+  const ps = typeof path === 'string' ? new PathSpec({ original: path, directory: path }) : path
+  const scope = detectScope(ps)
+  if (scope.level !== ScopeLevel.DOCUMENTS || scope.database === null || scope.name === null) {
+    throw new Error(`mongodb readStream: not a documents path: ${ps.original}`)
+  }
+  const elide = elisionPaths(accessor, scope.database, scope.name)
+  const batchSize = options.batchSize ?? 100
+  for await (const doc of iterDocuments(accessor, scope.database, scope.name, {
+    sort: { [PRIMARY_KEY]: 1 },
+    batchSize,
+  })) {
+    const final =
+      elide.size > 0 ? applyElision(doc as Record<string, unknown>, elide) : doc
+    yield encodeLine(final as Record<string, unknown>)
+  }
+}
+
+export async function* watchStream(
+  accessor: MongoDBAccessor,
+  path: PathSpec | string,
+): AsyncIterableIterator<Uint8Array> {
+  const ps = typeof path === 'string' ? new PathSpec({ original: path, directory: path }) : path
+  const scope = detectScope(ps)
+  if (scope.level !== ScopeLevel.DOCUMENTS || scope.database === null || scope.name === null) {
+    throw new Error(`mongodb watchStream: not a documents path: ${ps.original}`)
+  }
+  const elide = elisionPaths(accessor, scope.database, scope.name)
+  for await (const doc of iterInserts(accessor, scope.database, scope.name)) {
+    const final =
+      elide.size > 0 ? applyElision(doc as Record<string, unknown>, elide) : doc
+    yield encodeLine(final as Record<string, unknown>)
+  }
+}

--- a/typescript/packages/core/src/core/mongodb/types.ts
+++ b/typescript/packages/core/src/core/mongodb/types.ts
@@ -1,0 +1,80 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+export const ScopeLevel = {
+  ROOT: 'root',
+  DATABASE: 'database',
+  DATABASE_JSON: 'database_json',
+  KIND_DIR: 'kind_dir',
+  ENTITY: 'entity',
+  SCHEMA_JSON: 'schema_json',
+  DOCUMENTS: 'documents',
+  UNKNOWN: 'unknown',
+} as const
+export type ScopeLevel = (typeof ScopeLevel)[keyof typeof ScopeLevel]
+
+export const EntityKind = {
+  COLLECTION: 'collection',
+  VIEW: 'view',
+} as const
+export type EntityKind = (typeof EntityKind)[keyof typeof EntityKind]
+
+export const BsonTypeTag = {
+  BOOL: 'bool',
+  INT: 'int',
+  LONG: 'long',
+  DOUBLE: 'double',
+  STRING: 'string',
+  OBJECT_ID: 'objectId',
+  DECIMAL: 'decimal',
+  DATE: 'date',
+  TIMESTAMP: 'timestamp',
+  BINARY: 'binary',
+  REGEX: 'regex',
+  NULL: 'null',
+  OBJECT: 'object',
+  ARRAY: 'array',
+  UNKNOWN: 'unknown',
+} as const
+export type BsonTypeTag = (typeof BsonTypeTag)[keyof typeof BsonTypeTag]
+
+export const IndexType = {
+  BTREE: 'btree',
+  TEXT: 'text',
+  HASHED: 'hashed',
+  GEO_2D: '2d',
+  GEO_2DSPHERE: '2dsphere',
+  WILDCARD: 'wildcard',
+} as const
+export type IndexType = (typeof IndexType)[keyof typeof IndexType]
+
+export const PRIMARY_KEY = '_id'
+
+export const RESOURCE_TYPE_DATABASE = 'mongodb/database'
+export const RESOURCE_TYPE_COLLECTION = 'mongodb/collection'
+export const RESOURCE_TYPE_VIEW = 'mongodb/view'
+
+export const KIND_TO_DIR: Record<EntityKind, string> = {
+  [EntityKind.COLLECTION]: 'collections',
+  [EntityKind.VIEW]: 'views',
+}
+
+export const KIND_TO_RESOURCE_TYPE: Record<EntityKind, string> = {
+  [EntityKind.COLLECTION]: RESOURCE_TYPE_COLLECTION,
+  [EntityKind.VIEW]: RESOURCE_TYPE_VIEW,
+}
+
+export const KIND_DIR_NAMES: Record<string, EntityKind> = Object.fromEntries(
+  Object.entries(KIND_TO_DIR).map(([k, v]) => [v, k as EntityKind]),
+)

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -883,7 +883,26 @@ export {
   searchKind as postgresSearchKind,
   searchSchema as postgresSearchSchema,
 } from './core/postgres/search.ts'
-export type { MongoDriver, MongoFindOptions } from './core/mongodb/_driver.ts'
+export type {
+  MongoCollectionSpec,
+  MongoDriver,
+  MongoFindOptions,
+  MongoIndexAccess,
+  MongoIterOptions,
+} from './core/mongodb/_driver.ts'
+export {
+  BsonTypeTag,
+  EntityKind,
+  IndexType,
+  KIND_DIR_NAMES,
+  KIND_TO_DIR,
+  KIND_TO_RESOURCE_TYPE,
+  PRIMARY_KEY,
+  RESOURCE_TYPE_COLLECTION,
+  RESOURCE_TYPE_DATABASE,
+  RESOURCE_TYPE_VIEW,
+  ScopeLevel,
+} from './core/mongodb/types.ts'
 export { MongoDBAccessor } from './accessor/mongodb.ts'
 export {
   normalizeMongoDBConfig,
@@ -902,6 +921,11 @@ export { detectScope as detectMongoScope, type MongoDBScope } from './core/mongo
 export {
   countDocuments as mongoCountDocuments,
   findDocuments as mongoFindDocuments,
+  getIndexStats as mongoGetIndexStats,
+  getValidator as mongoGetValidator,
+  isView as mongoIsView,
+  iterDocuments as mongoIterDocuments,
+  iterInserts as mongoIterInserts,
   listCollections as mongoListCollections,
   listDatabases as mongoListDatabases,
   listIndexes as mongoListIndexes,

--- a/typescript/packages/core/src/ops/mongodb/read.ts
+++ b/typescript/packages/core/src/ops/mongodb/read.ts
@@ -23,11 +23,6 @@ export const readOp: RegisteredOp = {
   filetype: null,
   write: false,
   fn: (accessor, path, _args, kwargs: OpKwargs) => {
-    const limit = typeof kwargs.limit === 'number' ? kwargs.limit : null
-    const offset = typeof kwargs.offset === 'number' ? kwargs.offset : null
-    return coreRead(accessor as MongoDBAccessor, path, kwargs.index, {
-      limit,
-      offset,
-    })
+    return coreRead(accessor as MongoDBAccessor, path, kwargs.index)
   },
 }

--- a/typescript/packages/core/src/resource/mongodb/config.ts
+++ b/typescript/packages/core/src/resource/mongodb/config.ts
@@ -20,6 +20,7 @@ export interface MongoDBConfig {
   defaultDocLimit?: number
   defaultSearchLimit?: number
   maxDocLimit?: number
+  elideFields?: Record<string, readonly string[]>
 }
 
 export interface MongoDBConfigResolved {
@@ -28,6 +29,7 @@ export interface MongoDBConfigResolved {
   defaultDocLimit: number
   defaultSearchLimit: number
   maxDocLimit: number
+  elideFields: Record<string, readonly string[]>
 }
 
 export function normalizeMongoDBConfig(input: Record<string, unknown>): MongoDBConfig {
@@ -41,5 +43,6 @@ export function resolveMongoDBConfig(config: MongoDBConfig): MongoDBConfigResolv
     defaultDocLimit: config.defaultDocLimit ?? 1000,
     defaultSearchLimit: config.defaultSearchLimit ?? 100,
     maxDocLimit: config.maxDocLimit ?? 5000,
+    elideFields: config.elideFields ?? {},
   }
 }

--- a/typescript/packages/node/src/resource/mongodb/mongodb_mount.test.ts
+++ b/typescript/packages/node/src/resource/mongodb/mongodb_mount.test.ts
@@ -47,19 +47,30 @@ const ClientCtor = vi.fn((_uri: string) => {
     }
     return cursor
   }
-  const profilesCollection = {
-    find: vi.fn(() => makeCursor(profilesDocs)),
-    countDocuments: vi.fn(() => Promise.resolve(profilesDocs.length)),
-    listIndexes: vi.fn(() => ({ toArray: () => Promise.resolve([{ name: '_id_' }]) })),
+  const makeColl = (docs: Record<string, unknown>[]) => {
+    const findCursor = makeCursor(docs)
+    return {
+      find: vi.fn(() => ({ ...findCursor, batchSize: vi.fn(() => findCursor) })),
+      countDocuments: vi.fn(() => Promise.resolve(docs.length)),
+      listIndexes: vi.fn(() => ({ toArray: () => Promise.resolve([{ name: '_id_' }]) })),
+      aggregate: vi.fn(() => ({ toArray: () => Promise.resolve([]) })),
+      watch: vi.fn(() => ({
+        async *[Symbol.asyncIterator]() {
+          // no events
+        },
+        close: () => Promise.resolve(),
+      })),
+    }
   }
-  const sessionsCollection = {
-    find: vi.fn(() => makeCursor([])),
-    countDocuments: vi.fn(() => Promise.resolve(0)),
-    listIndexes: vi.fn(() => ({ toArray: () => Promise.resolve([{ name: '_id_' }]) })),
-  }
+  const profilesCollection = makeColl(profilesDocs)
+  const sessionsCollection = makeColl([])
   const db = {
     listCollections: vi.fn(() => ({
-      toArray: () => Promise.resolve([{ name: 'profiles' }, { name: 'sessions' }]),
+      toArray: () =>
+        Promise.resolve([
+          { name: 'profiles', type: 'collection' },
+          { name: 'sessions', type: 'collection' },
+        ]),
     })),
     collection: vi.fn((name: string) =>
       name === 'profiles' ? profilesCollection : sessionsCollection,
@@ -108,15 +119,23 @@ describe('MongoDBResource mount integration', () => {
     expect(stdout).not.toContain('admin')
   })
 
-  it('readdir /mongo/app lists collections as <name>.jsonl', async () => {
+  it('readdir /mongo/app exposes database.json / collections / views', async () => {
     const r = await ws.execute('ls /mongo/app')
     const stdout = new TextDecoder().decode(r.stdout)
-    expect(stdout).toContain('profiles.jsonl')
-    expect(stdout).toContain('sessions.jsonl')
+    expect(stdout).toContain('database.json')
+    expect(stdout).toContain('collections')
+    expect(stdout).toContain('views')
   })
 
-  it('cat /mongo/app/profiles.jsonl returns JSONL docs', async () => {
-    const r = await ws.execute('cat /mongo/app/profiles.jsonl')
+  it('readdir /mongo/app/collections lists collection names', async () => {
+    const r = await ws.execute('ls /mongo/app/collections')
+    const stdout = new TextDecoder().decode(r.stdout)
+    expect(stdout).toContain('profiles')
+    expect(stdout).toContain('sessions')
+  })
+
+  it('cat documents.jsonl returns one BSON-faithful JSON line per doc', async () => {
+    const r = await ws.execute('cat /mongo/app/collections/profiles/documents.jsonl')
     const text = new TextDecoder().decode(r.stdout).trim()
     const lines = text.split('\n')
     expect(lines).toHaveLength(3)
@@ -125,13 +144,13 @@ describe('MongoDBResource mount integration', () => {
   })
 
   it('head -n 2 pushes down to find().limit(2)', async () => {
-    const r = await ws.execute('head -n 2 /mongo/app/profiles.jsonl')
+    const r = await ws.execute('head -n 2 /mongo/app/collections/profiles/documents.jsonl')
     const lines = new TextDecoder().decode(r.stdout).trim().split('\n')
     expect(lines).toHaveLength(2)
   })
 
   it('wc -l pushes down to countDocuments', async () => {
-    const r = await ws.execute('wc -l /mongo/app/profiles.jsonl')
+    const r = await ws.execute('wc -l /mongo/app/collections/profiles/documents.jsonl')
     expect(new TextDecoder().decode(r.stdout).trim()).toBe('3')
   })
 })

--- a/typescript/packages/node/src/resource/mongodb/mongodb_mount.test.ts
+++ b/typescript/packages/node/src/resource/mongodb/mongodb_mount.test.ts
@@ -43,25 +43,23 @@ const ClientCtor = vi.fn((_uri: string) => {
         arr = arr.slice(0, n)
         return cursor
       }),
+      batchSize: vi.fn(() => cursor),
       toArray: vi.fn(() => Promise.resolve(arr)),
     }
     return cursor
   }
-  const makeColl = (docs: Record<string, unknown>[]) => {
-    const findCursor = makeCursor(docs)
-    return {
-      find: vi.fn(() => ({ ...findCursor, batchSize: vi.fn(() => findCursor) })),
-      countDocuments: vi.fn(() => Promise.resolve(docs.length)),
-      listIndexes: vi.fn(() => ({ toArray: () => Promise.resolve([{ name: '_id_' }]) })),
-      aggregate: vi.fn(() => ({ toArray: () => Promise.resolve([]) })),
-      watch: vi.fn(() => ({
-        async *[Symbol.asyncIterator]() {
-          // no events
-        },
-        close: () => Promise.resolve(),
-      })),
-    }
-  }
+  const makeColl = (docs: Record<string, unknown>[]) => ({
+    find: vi.fn(() => makeCursor(docs)),
+    countDocuments: vi.fn(() => Promise.resolve(docs.length)),
+    listIndexes: vi.fn(() => ({ toArray: () => Promise.resolve([{ name: '_id_' }]) })),
+    aggregate: vi.fn(() => ({ toArray: () => Promise.resolve([]) })),
+    watch: vi.fn(() => ({
+      async *[Symbol.asyncIterator]() {
+        // no events
+      },
+      close: () => Promise.resolve(),
+    })),
+  })
   const profilesCollection = makeColl(profilesDocs)
   const sessionsCollection = makeColl([])
   const db = {

--- a/typescript/packages/node/src/resource/mongodb/store.ts
+++ b/typescript/packages/node/src/resource/mongodb/store.ts
@@ -12,7 +12,15 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { loadOptionalPeer, type MongoDriver, type MongoFindOptions } from '@struktoai/mirage-core'
+import {
+  loadOptionalPeer,
+  type EntityKind,
+  type MongoCollectionSpec,
+  type MongoDriver,
+  type MongoFindOptions,
+  type MongoIndexAccess,
+  type MongoIterOptions,
+} from '@struktoai/mirage-core'
 
 interface MongoCollectionLike {
   find: (
@@ -22,21 +30,31 @@ interface MongoCollectionLike {
     sort: (sort: Record<string, 1 | -1>) => MongoCursorLike
     skip: (n: number) => MongoCursorLike
     limit: (n: number) => MongoCursorLike
+    batchSize: (n: number) => MongoCursorLike
     toArray: () => Promise<Record<string, unknown>[]>
+    [Symbol.asyncIterator]?: () => AsyncIterableIterator<Record<string, unknown>>
   }
   countDocuments: (filter?: Record<string, unknown>) => Promise<number>
   listIndexes: () => { toArray: () => Promise<Record<string, unknown>[]> }
+  aggregate: (pipeline: unknown[]) => { toArray: () => Promise<Record<string, unknown>[]> }
+  watch: (
+    pipeline?: unknown[],
+  ) => AsyncIterableIterator<Record<string, unknown>> & { close: () => Promise<void> }
 }
 
 interface MongoCursorLike {
   sort: (sort: Record<string, 1 | -1>) => MongoCursorLike
   skip: (n: number) => MongoCursorLike
   limit: (n: number) => MongoCursorLike
+  batchSize: (n: number) => MongoCursorLike
   toArray: () => Promise<Record<string, unknown>[]>
+  [Symbol.asyncIterator]?: () => AsyncIterableIterator<Record<string, unknown>>
 }
 
 interface MongoDbLike {
-  listCollections: () => { toArray: () => Promise<{ name: string }[]> }
+  listCollections: (filter?: Record<string, unknown>) => {
+    toArray: () => Promise<Record<string, unknown>[]>
+  }
   collection: (name: string) => MongoCollectionLike
   admin: () => { listDatabases: () => Promise<{ databases: { name: string }[] }> }
 }
@@ -65,10 +83,24 @@ export class MongoDBStore implements MongoDriver {
     return r.databases.map((d) => d.name)
   }
 
-  async listCollections(database: string): Promise<string[]> {
+  async listCollections(database: string, kind: EntityKind | null = null): Promise<string[]> {
     const c = await this._client()
-    const cols = await c.db(database).listCollections().toArray()
-    return cols.map((col) => col.name)
+    const filter = kind === null ? undefined : { type: kind }
+    const cols = await c.db(database).listCollections(filter).toArray()
+    return cols.map((col) => col.name as string).sort()
+  }
+
+  async listCollectionsDetailed(
+    database: string,
+    filter: { name?: string } = {},
+  ): Promise<MongoCollectionSpec[]> {
+    const c = await this._client()
+    const cols = await c.db(database).listCollections(filter).toArray()
+    return cols.map((col) => ({
+      name: col.name as string,
+      type: col.type as string | undefined,
+      options: col.options as MongoCollectionSpec['options'],
+    }))
   }
 
   async findDocuments<T = Record<string, unknown>>(
@@ -90,6 +122,50 @@ export class MongoDBStore implements MongoDriver {
     return (await cursor.toArray()) as T[]
   }
 
+  async *iterDocuments<T = Record<string, unknown>>(
+    database: string,
+    collection: string,
+    options: MongoIterOptions = {},
+  ): AsyncIterableIterator<T> {
+    const c = await this._client()
+    const filter = options.filter ?? {}
+    let cursor = c
+      .db(database)
+      .collection(collection)
+      .find(filter, {
+        ...(options.projection !== undefined ? { projection: options.projection } : {}),
+      }) as MongoCursorLike
+    if (options.sort !== undefined) cursor = cursor.sort(options.sort)
+    if (options.batchSize !== undefined) cursor = cursor.batchSize(options.batchSize)
+    if (cursor[Symbol.asyncIterator] === undefined) {
+      const all = (await cursor.toArray()) as T[]
+      for (const doc of all) yield doc
+      return
+    }
+    for await (const doc of cursor as unknown as AsyncIterableIterator<T>) {
+      yield doc
+    }
+  }
+
+  async *iterInserts<T = Record<string, unknown>>(
+    database: string,
+    collection: string,
+  ): AsyncIterableIterator<T> {
+    const c = await this._client()
+    const stream = c
+      .db(database)
+      .collection(collection)
+      .watch([{ $match: { operationType: 'insert' } }])
+    try {
+      for await (const change of stream as AsyncIterableIterator<Record<string, unknown>>) {
+        const doc = change.fullDocument
+        if (doc !== undefined && doc !== null) yield doc as T
+      }
+    } finally {
+      await stream.close()
+    }
+  }
+
   async countDocuments(
     database: string,
     collection: string,
@@ -102,6 +178,26 @@ export class MongoDBStore implements MongoDriver {
   async listIndexes(database: string, collection: string): Promise<Record<string, unknown>[]> {
     const c = await this._client()
     return c.db(database).collection(collection).listIndexes().toArray()
+  }
+
+  async getIndexStats(
+    database: string,
+    collection: string,
+  ): Promise<Record<string, MongoIndexAccess>> {
+    const c = await this._client()
+    const docs = await c
+      .db(database)
+      .collection(collection)
+      .aggregate([{ $indexStats: {} }])
+      .toArray()
+    const out: Record<string, MongoIndexAccess> = {}
+    for (const d of docs) {
+      const name = d.name as string | undefined
+      if (name !== undefined) {
+        out[name] = (d.accesses as MongoIndexAccess) ?? {}
+      }
+    }
+    return out
   }
 
   async close(): Promise<void> {

--- a/typescript/packages/node/src/resource/mongodb/store.ts
+++ b/typescript/packages/node/src/resource/mongodb/store.ts
@@ -96,11 +96,13 @@ export class MongoDBStore implements MongoDriver {
   ): Promise<MongoCollectionSpec[]> {
     const c = await this._client()
     const cols = await c.db(database).listCollections(filter).toArray()
-    return cols.map((col) => ({
-      name: col.name as string,
-      type: col.type as string | undefined,
-      options: col.options as MongoCollectionSpec['options'],
-    }))
+    return cols.map((col) => {
+      const spec: MongoCollectionSpec = { name: col.name as string }
+      if (col.type !== undefined) spec.type = col.type as string
+      if (col.options !== undefined)
+        spec.options = col.options as NonNullable<MongoCollectionSpec['options']>
+      return spec
+    })
   }
 
   async findDocuments<T = Record<string, unknown>>(

--- a/typescript/packages/node/src/resource/mongodb/store.ts
+++ b/typescript/packages/node/src/resource/mongodb/store.ts
@@ -196,7 +196,7 @@ export class MongoDBStore implements MongoDriver {
     for (const d of docs) {
       const name = d.name as string | undefined
       if (name !== undefined) {
-        out[name] = (d.accesses as MongoIndexAccess) ?? {}
+        out[name] = (d.accesses as MongoIndexAccess | undefined) ?? {}
       }
     }
     return out

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -271,6 +271,9 @@ importers:
       apache-arrow:
         specifier: ^21.1.0
         version: 21.1.0
+      bson:
+        specifier: ^6.10.4
+        version: 6.10.4
       h5wasm:
         specifier: ^0.10.1
         version: 0.10.1


### PR DESCRIPTION
## Summary

Rebuilds the MongoDB mount to match Mirage's other resources: streaming jsonl reads, faithful BSON output, a Postgres-style nested path tree, an `schema.json` derived from `$sample`, and `tail -f` over Mongo change streams. Field elision lets heavy embeddings stay out of agent reads without losing the type signal.

### Path tree

```
/mongodb/<db>/
  database.json
  collections/<coll>/
    schema.json
    documents.jsonl
  views/<view>/
    schema.json
    documents.jsonl
```

The database directory always appears, even with `databases=[one]`. Collections and views are separated; view paths skip the index / validator sections in `schema.json`.

### Streaming

- `read_stream` wraps Motor's cursor with `batch_size` and yields one BSON Extended JSON line per doc. `cat`, `head`, `tail`, `grep` and `jq` all consume from the same source; consumer-cancel closes the cursor.
- `watch_stream` opens a change stream filtered to insert events for `tail -f`; same JSONL format as `read_stream`.

### Schema

- `schema.json` samples 100 docs, unions nested field types, attaches `listIndexes` plus `$indexStats` access counts, and the registered `$jsonSchema` validator if any.
- `database.json` lists collections and views with counts.

### Elision

- `MongoDBConfig.elide_fields = {"<db>.<coll>": ["field", "nested.path"]}` drops listed fields from `documents.jsonl` output. The type stays documented in `schema.json`. Heavy embeddings / large binary stop polluting agent reads without losing the schema signal.

### Bug fixes uncovered while writing examples

- `search.py`: collections with no string fields no longer return all docs through an empty `$or` filter (early return). `search_database` filters to `kind="collection"` so views aren't double-searched.
- `grep` / `rg`: entity scope (single collection directory) now dispatches to `search_collection` server-side, matching the doc.
- `ls` (no args): preserved `cwd.prefix` when rebuilding the `PathSpec`, so `cd <entity>` + bare `ls` works instead of returning "cannot access".
- `MongoDBAccessor.client`: now created lazily per running loop. Eager construction in `__init__` pinned the client to the workspace loop, which broke the VFS sync bridge that spawns a fresh thread + loop per call.
- `format_grep_results`: emits the new `<db>/collections/<coll>/documents.jsonl` prefix.

### Types

New `python/mirage/core/mongodb/types.py` with `ScopeLevel` and `EntityKind` StrEnums. Every `scope.level == "..."` callsite switched to enum members across `scope`, `read`, `readdir`, `stat`, `stream`, `cat`, `grep`, `rg`, `tail`, `wc`.

### Examples

Three runnable examples under `examples/python/mongodb/`, all verified end-to-end against Atlas `mirage_test`:

- `mongodb.py` (32 agent-shell commands)
- `mongodb_vfs.py` (in-process VFS, every readdir level)
- `mongodb_fuse.py` (real FUSE mount, same coverage)

Seeded by `python/scripts/seed_mongodb_test.py` (8 collections + 1 view covering BSON types, heterogeneous schemas, embeddings, validators, text indexes, large counts).

### Docs

`docs/python/resource/mongodb.mdx` rewritten for the new path tree, streaming behavior, `schema.json` / `database.json`, `elide_fields`, `tail -f`, and a runnable-examples section. Bash snippets verified against `sample_mflix` on Atlas (17/17 working).

## Test plan

- [x] `cd python && uv run pytest` → 5664 passed, 229 skipped
- [x] `pre-commit run --all-files` → all Python hooks pass (TS Prettier/ESLint fail only because the worktree's TS deps aren't installed; this PR touches zero TS files)
- [x] `examples/python/mongodb/mongodb.py` runs 32 commands clean against Atlas
- [x] `examples/python/mongodb/mongodb_vfs.py` walks every readdir level, reads `database.json` + `schema.json` + `documents.jsonl` (collection + view) clean
- [x] `examples/python/mongodb/mongodb_fuse.py` mounts via FUSE, same coverage as VFS, 56 ops clean
- [x] All 17 doc snippets verified against Atlas `sample_mflix`

## Follow-ups (out of scope)

- Per-doc `by_id/<oid>.json` and `.f32` / `.b64` binary side-files for raw embeddings
- `_q/<field>=<value>` path-as-query syntax (decided against in favor of UNIX pipelines; revisit if a real use case appears)