### PR TITLE
feat(s3): add key_prefix for multi-tenant resource scoping

### DIFF
--- a/docs/home/setup/s3.mdx
+++ b/docs/home/setup/s3.mdx
@@ -31,3 +31,29 @@ AWS_SECRET_ACCESS_KEY=wJal...
 If you have `~/.aws/credentials` configured, you can use a profile name instead of explicit access keys.
 
 For the Python resource API, see the [S3 resource doc](/python/resource/s3).
+
+## Scoping a resource to a key prefix
+
+Both runtimes support a key prefix option that transparently scopes every operation to a subpath of the bucket, so agents see clean paths while the underlying S3 keys carry the full prefix.
+
+<CodeGroup>
+
+```ts TypeScript
+const s3 = new S3Resource({
+  bucket: 'app-data',
+  region: 'eu-west-1',
+  keyPrefix: `users/${userId}/`,
+})
+```
+
+```python Python
+S3Resource(S3Config(
+    bucket="app-data",
+    region="eu-west-1",
+    key_prefix=f"users/{user_id}/",
+))
+```
+
+</CodeGroup>
+
+Leading slashes are stripped and a trailing slash is added automatically. `None` / `undefined` and empty strings both mean "no prefix." For browser security considerations, see the [TypeScript S3 setup doc](/typescript/setup/s3).

--- a/docs/python/resource/s3.mdx
+++ b/docs/python/resource/s3.mdx
@@ -253,3 +253,19 @@ for cmd in AUDIO_COMMANDS:
 - **Data pipelines**: Read and write S3 objects with shell-like commands
 - **Sandboxed cloud storage access**: Restrict agent operations to a specific bucket and prefix
 - **FUSE mounting**: Expose S3 buckets through a virtual FUSE mount for external tools
+
+## Scoping a resource to a key prefix
+
+Pass `key_prefix: str | None = None` to `S3Config` to transparently scope every operation to a subpath of the bucket:
+
+```python
+S3Resource(S3Config(
+    bucket="app-data",
+    region="eu-west-1",
+    key_prefix=f"users/{user_id}/",
+))
+```
+
+When set, every read/write/list/stat/copy/rename/delete operation is transparently scoped to that bucket subpath. Agents see clean paths like `/data/notes.md`; the underlying bucket key is `users/{user_id}/data/notes.md`. Useful for multi-tenant systems. Pairs naturally with STS AssumeRole session policies for AWS-side enforcement. Unset behavior is unchanged.
+
+**Normalization:** leading slashes are stripped and a trailing slash is added automatically. Both `None` and an empty string are treated as "no prefix."

--- a/docs/typescript/setup/s3.mdx
+++ b/docs/typescript/setup/s3.mdx
@@ -152,3 +152,27 @@ CORS is origin-exact. `http://localhost:5173` ≠ `http://localhost:5174` ≠ `h
 </Warning>
 
 See [S3 Setup](/home/setup/s3) for credential setup.
+
+## Scoping a resource to a key prefix
+
+Pass `keyPrefix` to scope every operation to a subpath of the bucket:
+
+```ts
+const s3 = new S3Resource({
+  bucket: 'app-data',
+  region: 'eu-west-1',
+  keyPrefix: `users/${userId}/`,
+})
+```
+
+When set, every read/write/list/stat/copy/rename/delete operation is transparently scoped to that bucket subpath. Agents see clean paths like `/data/notes.md`; the underlying bucket key is `users/${userId}/data/notes.md`. Useful for multi-tenant systems. Pairs naturally with STS AssumeRole session policies for AWS-side enforcement. Unset behavior is unchanged.
+
+**Normalization:** leading slashes are stripped and a trailing slash is added automatically. Both `undefined` and an empty string are treated as "no prefix."
+
+In YAML-based configs the snake-case spelling `key_prefix` is also accepted and is automatically mapped to `keyPrefix` at construction.
+
+<Warning>
+**Browser variant — security note**
+
+For `mirage-browser`'s `S3Resource` (which uses `presignedUrlProvider`), `keyPrefix` flows through the same core code path, but a client-controlled prefix is not a security boundary — a malicious client can ignore or alter it before signing. For real isolation, enforce the prefix inside your server-side `presignedUrlProvider` implementation (and in the IAM/STS session policy backing those credentials). Treat the client-side `keyPrefix` as ergonomics only.
+</Warning>

--- a/examples/python/s3/s3.py
+++ b/examples/python/s3/s3.py
@@ -35,20 +35,20 @@ config = S3Config(
     aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
 )
 
-scoped_config = S3Config(
+deep_config = S3Config(
     bucket=os.environ["AWS_S3_BUCKET"],
     region=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
     aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
     aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
-    key_prefix="data/",
+    key_prefix="subdata/subsubdata/",
 )
 
 backend = S3Resource(config)
-scoped_backend = S3Resource(scoped_config)
+deep_backend = S3Resource(deep_config)
 ws = Workspace(
     {
         "/s3/": backend,
-        "/scoped/": scoped_backend,
+        "/deep/": deep_backend,
     },
     mode=MountMode.READ,
 )
@@ -63,51 +63,103 @@ def ops_summary() -> str:
 
 
 async def main():
-    # ── key_prefix mount: same bucket, scoped to data/ subpath ──
-    # Demonstrates that /scoped/example.jsonl resolves to the same
-    # bucket object as /s3/data/example.jsonl, but agent-facing paths
-    # stay prefix-free. Same commands, same outputs.
-    print("=== KEY_PREFIX MOUNT (scoped to data/) ===\n")
+    # ── key_prefix mount: multi-segment subpath scoping ──
+    # Mounts the same bucket twice: /s3/ unscoped, /deep/ scoped to
+    # subdata/subsubdata/. Every operation against /deep/X resolves
+    # to s3://bucket/subdata/subsubdata/X with the prefix transparent
+    # to the agent.
+    print("=== KEY_PREFIX MOUNT (subdata/subsubdata/) ===\n")
 
-    print(f"  scoped key_prefix={scoped_config.key_prefix!r}")
-    print("  /scoped/example.jsonl  ←→  s3://bucket/data/example.jsonl\n")
+    print(f"  key_prefix = {deep_config.key_prefix!r}")
+    print("  /deep/X  ←→  s3://bucket/subdata/subsubdata/X\n")
 
-    print("--- ls /scoped/ ---")
-    r = await ws.execute("ls /scoped/")
-    print(f"  {(await r.stdout_str()).strip()}")
+    async def run(cmd: str, label: str | None = None) -> str:
+        r = await ws.execute(cmd)
+        out = (await r.stdout_str()).strip()
+        tag = label or cmd
+        head = out.splitlines()[0] if out else ""
+        more = f" (+{len(out.splitlines()) - 1} more)" if "\n" in out else ""
+        print(f"  $ {tag}\n    {head[:110]}{more}  [exit={r.exit_code}]")
+        return out
 
-    print("\n--- stat /scoped/example.jsonl ---")
-    r = await ws.execute("stat /scoped/example.jsonl")
-    print(f"  {(await r.stdout_str()).strip()}")
+    # ── listings ──
+    print("[listings]")
+    await run("ls /deep")
+    await run("ls -1 /deep")
+    await run("ls -la /deep")
 
-    print("\n--- parity check: grep mirage on both mounts ---")
-    a = await (await ws.execute("grep mirage /s3/data/example.jsonl"
-                                " | wc -l")).stdout_str()
-    b = await (await ws.execute("grep mirage /scoped/example.jsonl"
-                                " | wc -l")).stdout_str()
-    print(f"  /s3/data/example.jsonl   matches: {a.strip()}")
-    print(f"  /scoped/example.jsonl    matches: {b.strip()}")
+    # ── stat ──
+    print("\n[stat]")
+    await run("stat /deep/example.jsonl")
+    await run("stat /deep/example.json")
+    await run("stat /deep")
+
+    # ── existence ──
+    print("\n[exists]")
+    await run("test -f /deep/example.jsonl && echo present || echo absent")
+    await run("test -f /deep/no-such.txt && echo present || echo absent")
+    await run("test -d /deep && echo dir-present")
+
+    # ── reads ──
+    print("\n[read]")
+    await run("head -n 1 /deep/example.jsonl")
+    await run("tail -n 1 /deep/example.jsonl")
+    await run("wc -l /deep/example.jsonl")
+    await run("wc -c /deep/example.json")
+
+    # ── grep variants ──
+    print("\n[grep]")
+    await run("grep -c mirage /deep/example.jsonl")
+    await run("grep -m 1 mirage /deep/example.jsonl")
+    await run("grep -i MIRAGE /deep/example.jsonl | wc -l")
+    await run("grep -n queue-operation /deep/example.jsonl | head -n 1")
+    await run("grep -v queue-operation /deep/example.jsonl | wc -l")
+
+    # ── rg (the formerly-broken double-prefix case) ──
+    print("\n[rg]")
+    await run("rg -l mirage /deep")
+    await run("rg -c mirage /deep/example.json")
+    await run("rg -n queue-operation /deep/example.jsonl | head -n 1")
+
+    # ── find / du ──
+    print("\n[find / du]")
+    await run("find /deep -name '*.json'")
+    await run("find /deep -name 'example.*' | wc -l")
+    await run("find /deep -type f | wc -l")
+    await run("du /deep/example.jsonl")
+
+    # ── glob expansion ──
+    print("\n[glob]")
+    await run("echo /deep/*.json")
+    await run("echo /deep/example.*")
+    await run("for f in /deep/*.json; do wc -c $f; done")
+
+    # ── jq (validates content equivalence) ──
+    print("\n[jq]")
+    await run("jq .metadata.version /deep/example.json")
+    await run("jq '.departments[].teams[].name' /deep/example.json")
+
+    # ── pipelines / control flow ──
+    print("\n[pipelines]")
+    await run("cat /deep/example.jsonl | grep mirage | wc -l")
+    await run("grep queue-operation /deep/example.jsonl"
+              " | head -n 2 | cut -d , -f 1")
+    await run("grep -m 1 mirage /deep/example.jsonl && echo found")
+    await run("grep ZZZ_NOPE /deep/example.jsonl || echo fallback")
+
+    # ── parity vs /s3/ (same bucket, same object, different mount) ──
+    print("\n[parity vs /s3/]")
+    a = await (await
+               ws.execute("grep -c mirage /deep/example.jsonl")).stdout_str()
+    b = await (await ws.execute(
+        "grep -c mirage /s3/subdata/subsubdata/example.jsonl")).stdout_str()
+    print(f"  /deep/example.jsonl                       grep -c: {a.strip()}")
+    print(f"  /s3/subdata/subsubdata/example.jsonl      grep -c: {b.strip()}")
     print(f"  parity: {a.strip() == b.strip()}")
 
-    print("\n--- grep -m 1 mirage /scoped/example.jsonl ---")
-    r = await ws.execute("grep -m 1 mirage /scoped/example.jsonl")
-    out = (await r.stdout_str()).strip()
-    print(f"  {out[:80]}{'...' if len(out) > 80 else ''}")
-
-    print("\n--- jq .metadata.version /scoped/example.json ---")
-    r = await ws.execute("jq .metadata.version /scoped/example.json")
-    print(f"  {(await r.stdout_str()).strip()}")
-
-    print("\n--- glob: ls /scoped/*.json ---")
-    r = await ws.execute("ls /scoped/*.json")
-    print(f"  {(await r.stdout_str()).strip()}")
-
-    print("\n--- rg -l mirage /scoped ---")
-    r = await ws.execute("rg -l mirage /scoped")
-    print(f"  {(await r.stdout_str()).strip()}")
-
-    print("\n--- get_state: key_prefix persists in resource state ---")
-    state = scoped_backend.get_state()
+    # ── get_state ──
+    print("\n[get_state]")
+    state = deep_backend.get_state()
     print(f"  config.key_prefix = {state['config'].get('key_prefix')!r}")
     print(f"  redacted_fields  = {state['redacted_fields']}")
 

--- a/examples/python/s3/s3.py
+++ b/examples/python/s3/s3.py
@@ -35,8 +35,23 @@ config = S3Config(
     aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
 )
 
+scoped_config = S3Config(
+    bucket=os.environ["AWS_S3_BUCKET"],
+    region=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+    aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+    aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+    key_prefix="data/",
+)
+
 backend = S3Resource(config)
-ws = Workspace({"/s3/": backend}, mode=MountMode.READ)
+scoped_backend = S3Resource(scoped_config)
+ws = Workspace(
+    {
+        "/s3/": backend,
+        "/scoped/": scoped_backend,
+    },
+    mode=MountMode.READ,
+)
 
 
 def ops_summary() -> str:
@@ -48,8 +63,56 @@ def ops_summary() -> str:
 
 
 async def main():
+    # ── key_prefix mount: same bucket, scoped to data/ subpath ──
+    # Demonstrates that /scoped/example.jsonl resolves to the same
+    # bucket object as /s3/data/example.jsonl, but agent-facing paths
+    # stay prefix-free. Same commands, same outputs.
+    print("=== KEY_PREFIX MOUNT (scoped to data/) ===\n")
+
+    print(f"  scoped key_prefix={scoped_config.key_prefix!r}")
+    print("  /scoped/example.jsonl  ←→  s3://bucket/data/example.jsonl\n")
+
+    print("--- ls /scoped/ ---")
+    r = await ws.execute("ls /scoped/")
+    print(f"  {(await r.stdout_str()).strip()}")
+
+    print("\n--- stat /scoped/example.jsonl ---")
+    r = await ws.execute("stat /scoped/example.jsonl")
+    print(f"  {(await r.stdout_str()).strip()}")
+
+    print("\n--- parity check: grep mirage on both mounts ---")
+    a = await (await ws.execute("grep mirage /s3/data/example.jsonl"
+                                " | wc -l")).stdout_str()
+    b = await (await ws.execute("grep mirage /scoped/example.jsonl"
+                                " | wc -l")).stdout_str()
+    print(f"  /s3/data/example.jsonl   matches: {a.strip()}")
+    print(f"  /scoped/example.jsonl    matches: {b.strip()}")
+    print(f"  parity: {a.strip() == b.strip()}")
+
+    print("\n--- grep -m 1 mirage /scoped/example.jsonl ---")
+    r = await ws.execute("grep -m 1 mirage /scoped/example.jsonl")
+    out = (await r.stdout_str()).strip()
+    print(f"  {out[:80]}{'...' if len(out) > 80 else ''}")
+
+    print("\n--- jq .metadata.version /scoped/example.json ---")
+    r = await ws.execute("jq .metadata.version /scoped/example.json")
+    print(f"  {(await r.stdout_str()).strip()}")
+
+    print("\n--- glob: ls /scoped/*.json ---")
+    r = await ws.execute("ls /scoped/*.json")
+    print(f"  {(await r.stdout_str()).strip()}")
+
+    print("\n--- rg -l mirage /scoped ---")
+    r = await ws.execute("rg -l mirage /scoped")
+    print(f"  {(await r.stdout_str()).strip()}")
+
+    print("\n--- get_state: key_prefix persists in resource state ---")
+    state = scoped_backend.get_state()
+    print(f"  config.key_prefix = {state['config'].get('key_prefix')!r}")
+    print(f"  redacted_fields  = {state['redacted_fields']}")
+
     # ── root listing (tests stat on directory prefixes) ──
-    print("=== ROOT LISTING ===\n")
+    print("\n=== ROOT LISTING ===\n")
 
     print("--- ls /s3/ ---")
     r = await ws.execute("ls /s3/")

--- a/examples/python/s3/s3_fuse.py
+++ b/examples/python/s3/s3_fuse.py
@@ -29,9 +29,25 @@ config = S3Config(
     aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
 )
 
-resource = S3Resource(config)
+deep_config = S3Config(
+    bucket=os.environ["AWS_S3_BUCKET"],
+    region=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+    aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+    aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+    key_prefix="subdata/subsubdata/",
+)
 
-with Workspace({"/s3/": resource}, mode=MountMode.READ, fuse=True) as ws:
+resource = S3Resource(config)
+deep_resource = S3Resource(deep_config)
+
+with Workspace(
+    {
+        "/s3/": resource,
+        "/deep/": deep_resource
+    },
+        mode=MountMode.READ,
+        fuse=True,
+) as ws:
     time.sleep(1)
     mp = ws.fuse_mountpoint
 
@@ -53,12 +69,35 @@ with Workspace({"/s3/": resource}, mode=MountMode.READ, fuse=True) as ws:
     size = os.path.getsize(f"{mp}/s3/data/example.jsonl")
     print(f"  size: {size} bytes")
 
+    print("\n=== KEY_PREFIX MOUNT (/deep → subdata/subsubdata/) ===")
+    print(f"  key_prefix = {deep_config.key_prefix!r}\n")
+
+    print(f"--- os.listdir({mp}/deep) ---")
+    for e in os.listdir(f"{mp}/deep"):
+        print(f"  {e}")
+
+    print(f"\n--- open({mp}/deep/example.jsonl) + read 3 lines ---")
+    with open(f"{mp}/deep/example.jsonl") as f:
+        for i, line in enumerate(f):
+            if i >= 3:
+                break
+            print(f"  [{i}] {line.strip()[:100]}...")
+
+    print(f"\n--- os.path.getsize({mp}/deep/example.jsonl) ---")
+    deep_size = os.path.getsize(f"{mp}/deep/example.jsonl")
+    print(f"  size: {deep_size} bytes")
+    print("  (resolves to s3://bucket/subdata/subsubdata/example.jsonl)")
+
     print(f"\n>>> FUSE mounted at: {mp}")
     print(">>> Open another terminal and run:")
     print(f">>>   ls {mp}/s3/data/")
-    print(f">>>   cat {mp}/s3/data/example.json")
+    print(f">>>   ls {mp}/deep/")
+    print(f">>>   cat {mp}/deep/example.json")
     print(">>> Press Enter to unmount and exit...")
-    input()
+    try:
+        input()
+    except EOFError:
+        pass
 
     records = ws.ops.records
     total = sum(r.bytes for r in records)

--- a/examples/python/s3/s3_vfs.py
+++ b/examples/python/s3/s3_vfs.py
@@ -31,11 +31,26 @@ config = S3Config(
     aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
 )
 
+deep_config = S3Config(
+    bucket=os.environ["AWS_S3_BUCKET"],
+    region=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+    aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+    aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+    key_prefix="subdata/subsubdata/",
+)
+
 resource = S3Resource(config)
+deep_resource = S3Resource(deep_config)
 
 
 async def main():
-    with Workspace({"/s3/": resource}, mode=MountMode.READ) as ws:
+    with Workspace(
+        {
+            "/s3/": resource,
+            "/deep/": deep_resource
+        },
+            mode=MountMode.READ,
+    ) as ws:
         vos = sys.modules["os"]
         print("=== VFS MODE: open() reads from S3 transparently ===\n")
 
@@ -67,6 +82,37 @@ async def main():
         print("\n--- VFS commands ---")
         result = await ws.execute("grep -c mirage /s3/data/example.jsonl")
         print(f"  grep matches: {(await result.stdout_str()).strip()}")
+
+        print("\n=== KEY_PREFIX MOUNT (/deep → subdata/subsubdata/) ===\n")
+        print(f"  key_prefix = {deep_config.key_prefix!r}\n")
+
+        print("--- os.listdir('/deep') ---")
+        for e in vos.listdir("/deep"):
+            print(f"  {e}")
+
+        print("\n--- os.path.exists / isdir / getsize ---")
+        print(f"  /deep/example.jsonl  exists: "
+              f"{vos.path.exists('/deep/example.jsonl')}")
+        print(f"  /deep/example.json   isdir : "
+              f"{vos.path.isdir('/deep/example.json')}")
+        print(f"  /deep/example.json   size  : "
+              f"{vos.path.getsize('/deep/example.json')} bytes")
+
+        print("\n--- open() + read first 3 records ---")
+        with open("/deep/example.jsonl") as f:
+            for i, line in enumerate(f):
+                if i >= 3:
+                    break
+                rec = json.loads(line)
+                print(f"  [{i}] {json.dumps(rec)[:90]}...")
+
+        print("\n--- VFS commands against /deep ---")
+        r = await ws.execute("grep -c mirage /deep/example.jsonl")
+        print(f"  grep -c mirage     : {(await r.stdout_str()).strip()}")
+        r = await ws.execute("rg -l mirage /deep")
+        print(f"  rg -l mirage       : {(await r.stdout_str()).strip()}")
+        r = await ws.execute("jq .metadata.version /deep/example.json")
+        print(f"  jq .metadata.version: {(await r.stdout_str()).strip()}")
 
         print("\n--- session observer via VFS ---")
         day_folders = vos.listdir("/.sessions")

--- a/examples/typescript/s3/s3_fuse.ts
+++ b/examples/typescript/s3/s3_fuse.ts
@@ -12,24 +12,15 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-// S3 mounted as a real FUSE filesystem. Any OS-level tool (cat, ls,
-// external scripts, editors, other processes) can then read from the mount
-// just like a local directory.
+// S3 mounted as a real FUSE filesystem with two mounts:
+//   /s3/    — unscoped, full bucket
+//   /deep/  — same bucket, scoped via keyPrefix=subdata/subsubdata/
 //
-// Use when:
-//   - You want to pipe S3 content into non-Mirage-aware tools
-//   - You want to `cat $mountpoint/s3/foo.json` from another shell
-//   - A long-running service benefits from kernel-level caching + metadata
+// External processes can then do `cat $mp/deep/example.json` just like
+// a local directory; the prefix is transparent.
 //
 // Requires: macFUSE / libfuse3 + @zkochan/fuse-native (see /typescript/setup/fuse).
-// Also requires local MinIO (see s3_write.ts).
-//
-// Known issue: in-process `fs.promises.readdir` against a FUSE-mounted S3
-// bucket can fail with EIO on Node (the FUSE napi callback needs the event
-// loop to make network calls while the `readdir` promise is already holding
-// it). External shell access (from another terminal) works fine. For
-// in-process real-fs access, use RAM as a cache layer or host the FUSE
-// mount in a helper process — see examples/typescript/fuse/main_with_helper.ts.
+// Loads credentials from .env.development at the repo root.
 import {
   FuseManager,
   MountMode,
@@ -37,43 +28,43 @@ import {
   Workspace,
   type S3Config,
 } from '@struktoai/mirage-node'
-import { CreateBucketCommand, S3Client } from '@aws-sdk/client-s3'
+import dotenv from 'dotenv'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const config: S3Config = {
-  bucket: 'mirage-fuse-demo',
-  region: 'us-east-1',
-  endpoint: 'http://localhost:9000',
-  accessKeyId: 'minioadmin',
-  secretAccessKey: 'minioadmin',
-  forcePathStyle: true,
-}
+const __HERE = dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: resolve(__HERE, '../../../.env.development') })
 
-async function ensureBucket(): Promise<void> {
-  const sdk = new S3Client({
-    region: config.region,
-    endpoint: config.endpoint,
-    forcePathStyle: true,
-    credentials: { accessKeyId: config.accessKeyId!, secretAccessKey: config.secretAccessKey! },
-  })
-  try {
-    await sdk.send(new CreateBucketCommand({ Bucket: config.bucket }))
-  } catch (err) {
-    const code = (err as { name?: string }).name
-    if (code !== 'BucketAlreadyOwnedByYou' && code !== 'BucketAlreadyExists') throw err
-  } finally {
-    sdk.destroy()
+function baseConfig(): S3Config {
+  if (process.env.AWS_S3_BUCKET === undefined) {
+    throw new Error('AWS_S3_BUCKET not set (expected in .env.development)')
+  }
+  return {
+    bucket: process.env.AWS_S3_BUCKET,
+    region: process.env.AWS_DEFAULT_REGION ?? 'us-east-1',
+    ...(process.env.AWS_ACCESS_KEY_ID !== undefined &&
+    process.env.AWS_SECRET_ACCESS_KEY !== undefined
+      ? {
+          accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+        }
+      : {}),
   }
 }
 
 async function main(): Promise<void> {
-  await ensureBucket()
-  const ws = new Workspace({ '/s3/': new S3Resource(config) }, { mode: MountMode.WRITE })
-  try {
-    // Seed files via the virtual executor.
-    await ws.execute('rm -rf /s3/fuse-demo')
-    await ws.execute('echo "via fuse" | tee /s3/fuse-demo/hello.txt')
-    await ws.execute(`printf 'line1\\nline2\\nline3\\n' | tee /s3/fuse-demo/multi.txt`)
+  const cfg = baseConfig()
+  const deepCfg: S3Config = { ...cfg, keyPrefix: 'subdata/subsubdata/' }
 
+  const ws = new Workspace(
+    {
+      '/s3/': new S3Resource(cfg),
+      '/deep/': new S3Resource(deepCfg),
+    },
+    { mode: MountMode.READ },
+  )
+
+  try {
     const fm = new FuseManager()
     const mp = await fm.setup(ws)
     let cleaned = false
@@ -81,40 +72,42 @@ async function main(): Promise<void> {
       if (cleaned) return
       cleaned = true
       void (async (): Promise<void> => {
-        try { await fm.close(ws) } catch {}
-        try { await ws.close() } catch {}
+        try {
+          await fm.close(ws)
+        } catch {}
+        try {
+          await ws.close()
+        } catch {}
         console.error(`\n>>> unmounted ${mp}`)
         process.exit(sig === 'SIGINT' ? 130 : 143)
       })()
     }
     process.on('SIGINT', handler)
     process.on('SIGTERM', handler)
-    console.log(`=== FUSE MODE: mounted at ${mp} ===\n`)
+
+    console.log(`=== FUSE MODE — bucket: ${cfg.bucket} ===`)
+    console.log(`  mountpoint = ${mp}`)
+    console.log(`  /deep keyPrefix = ${JSON.stringify(deepCfg.keyPrefix)}\n`)
 
     try {
-      console.log(`  ws.fuseMountpoint = ${ws.fuseMountpoint ?? 'null'}`)
-      console.log(`  ws.ownsFuseMount  = ${String(ws.ownsFuseMount)}`)
-      console.log()
-
-      // The mount is live. All virtual-executor commands continue to work —
-      // they bypass the FUSE kernel path but read/write the same S3 bucket.
-      console.log('--- virtual executor still works while mounted ---')
-      const cat = await ws.execute('cat /s3/fuse-demo/hello.txt')
-      console.log(`  cat: ${JSON.stringify(cat.stdoutText)}`)
-      const grep = await ws.execute('grep line2 /s3/fuse-demo/multi.txt')
-      console.log(`  grep: ${JSON.stringify(grep.stdoutText.trim())}`)
+      console.log('--- virtual executor: stats via /deep ---')
+      const ls = await ws.execute('ls /deep')
+      console.log(`  ls /deep      : ${ls.stdoutText.trim().split('\n').slice(0, 3).join(', ')}, ...`)
+      const stat = await ws.execute('stat /deep/example.jsonl')
+      console.log(`  stat /deep/example.jsonl : ${stat.stdoutText.trim()}`)
+      const grep = await ws.execute('grep -c mirage /deep/example.jsonl')
+      console.log(`  grep -c mirage           : ${grep.stdoutText.trim()}`)
+      const rg = await ws.execute('rg -l mirage /deep')
+      console.log(`  rg -l mirage /deep       : ${rg.stdoutText.trim().split('\n').join(' | ')}`)
 
       console.log()
       console.log('>>> Mount is live. From ANOTHER terminal you can:')
-      console.log(`>>>   ls  ${mp}/s3/fuse-demo/`)
-      console.log(`>>>   cat ${mp}/s3/fuse-demo/hello.txt`)
-      console.log(`>>>   grep line2 ${mp}/s3/fuse-demo/multi.txt`)
-      console.log()
-      console.log('>>> In-process `fs.promises.readdir` on an S3-backed FUSE mount')
-      console.log('>>> may fail with EIO on Node — see the comment at the top of')
-      console.log('>>> this file for workarounds.')
+      console.log(`>>>   ls  ${mp}/s3/data/`)
+      console.log(`>>>   ls  ${mp}/deep/`)
+      console.log(`>>>   cat ${mp}/deep/example.json`)
+      console.log(`>>>   wc -l ${mp}/deep/example.jsonl`)
+      console.log('>>> (Under the hood /deep/X reads s3://<bucket>/subdata/subsubdata/X)')
     } finally {
-      await ws.execute('rm -rf /s3/fuse-demo')
       await fm.close(ws)
       console.log(`\nafter unmount: ws.fuseMountpoint = ${ws.fuseMountpoint ?? 'null'}`)
     }

--- a/examples/typescript/s3/s3_vfs.ts
+++ b/examples/typescript/s3/s3_vfs.ts
@@ -14,88 +14,103 @@
 
 // S3 in VFS mode — agent-style workflow using only `ws.execute()`. No FUSE.
 //
-// This is the default path. Every shell command you run against `/s3/...`
-// is handled by Mirage's in-process executor: pipes, redirects, jq, awk, sed,
-// grep, wc, head, tail — all reimplemented to read/write the S3 bucket
-// through the resource's streamPath/readFile/writeFile methods.
+// Two mounts:
+//   /s3/    — unscoped, full bucket
+//   /deep/  — same bucket, scoped to subdata/subsubdata/ via keyPrefix.
+//             /deep/example.jsonl resolves to s3://<bucket>/subdata/subsubdata/example.jsonl
 //
-// Use when:
-//   - You don't need a real mountpoint on disk
-//   - You don't want to install FUSE
-//   - You want the lowest-friction S3 access from an agent
-//
-// Requires local MinIO on port 9000 (see s3_write.ts for the docker command).
+// Loads credentials from .env.development at the repo root.
 import { MountMode, S3Resource, Workspace, type S3Config } from '@struktoai/mirage-node'
-import { CreateBucketCommand, S3Client } from '@aws-sdk/client-s3'
+import dotenv from 'dotenv'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const config: S3Config = {
-  bucket: 'mirage-vfs-demo',
-  region: 'us-east-1',
-  endpoint: 'http://localhost:9000',
-  accessKeyId: 'minioadmin',
-  secretAccessKey: 'minioadmin',
-  forcePathStyle: true,
-}
+const __HERE = dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: resolve(__HERE, '../../../.env.development') })
 
-async function ensureBucket(): Promise<void> {
-  const sdk = new S3Client({
-    region: config.region,
-    endpoint: config.endpoint,
-    forcePathStyle: true,
-    credentials: { accessKeyId: config.accessKeyId!, secretAccessKey: config.secretAccessKey! },
-  })
-  try {
-    await sdk.send(new CreateBucketCommand({ Bucket: config.bucket }))
-  } catch (err) {
-    const code = (err as { name?: string }).name
-    if (code !== 'BucketAlreadyOwnedByYou' && code !== 'BucketAlreadyExists') throw err
-  } finally {
-    sdk.destroy()
+function baseConfig(): S3Config {
+  if (process.env.AWS_S3_BUCKET === undefined) {
+    throw new Error('AWS_S3_BUCKET not set (expected in .env.development)')
+  }
+  return {
+    bucket: process.env.AWS_S3_BUCKET,
+    region: process.env.AWS_DEFAULT_REGION ?? 'us-east-1',
+    ...(process.env.AWS_ACCESS_KEY_ID !== undefined &&
+    process.env.AWS_SECRET_ACCESS_KEY !== undefined
+      ? {
+          accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+        }
+      : {}),
   }
 }
 
 async function main(): Promise<void> {
-  await ensureBucket()
-  const ws = new Workspace({ '/s3/': new S3Resource(config) }, { mode: MountMode.WRITE })
+  const cfg = baseConfig()
+  const deepCfg: S3Config = { ...cfg, keyPrefix: 'subdata/subsubdata/' }
+
+  const ws = new Workspace(
+    {
+      '/s3/': new S3Resource(cfg),
+      '/deep/': new S3Resource(deepCfg),
+    },
+    { mode: MountMode.READ },
+  )
+
+  const run = async (cmd: string): Promise<void> => {
+    const r = await ws.execute(cmd)
+    const out = r.stdoutText.trimEnd()
+    const lines = out ? out.split('\n') : []
+    const head = lines[0] ?? ''
+    const more = lines.length > 1 ? ` (+${String(lines.length - 1)} more)` : ''
+    console.log(`  $ ${cmd}`)
+    console.log(`    ${head.slice(0, 110)}${more}  [exit=${String(r.exitCode)}]`)
+  }
+
   try {
-    await ws.execute('rm -rf /s3/vfs-demo')
-    console.log('=== VFS MODE: every command runs in-process ===\n')
+    console.log(`=== VFS MODE — bucket: ${cfg.bucket} ===\n`)
+    console.log(`  keyPrefix on /deep = ${JSON.stringify(deepCfg.keyPrefix)}\n`)
 
-    // Seed a typical analytics workflow.
-    await ws.execute(`printf 'id,name,score\\n1,alice,87\\n2,bob,92\\n3,carol,78\\n' | tee /s3/vfs-demo/scores.csv`)
-    await ws.execute(`echo '{"user":"alice","tier":"gold"}' | tee /s3/vfs-demo/user.json`)
+    console.log('[listings]')
+    await run('ls /deep')
+    await run('ls -1 /deep')
 
-    console.log('--- cat ---')
-    const cat = await ws.execute('cat /s3/vfs-demo/scores.csv')
-    process.stdout.write(cat.stdoutText)
-    console.log()
+    console.log('\n[stat / exists]')
+    await run('stat /deep/example.jsonl')
+    await run('test -f /deep/example.jsonl && echo present || echo absent')
+    await run('test -f /deep/no-such.txt && echo present || echo absent')
 
-    console.log('--- awk: sum scores in column 3 ---')
-    const sum = await ws.execute(
-      `awk -F, 'NR>1 { s += $3 } END { print s }' /s3/vfs-demo/scores.csv`,
-    )
-    process.stdout.write(sum.stdoutText)
-    console.log()
+    console.log('\n[read]')
+    await run('head -n 1 /deep/example.jsonl')
+    await run('wc -l /deep/example.jsonl')
+    await run('wc -c /deep/example.json')
 
-    console.log('--- jq: extract user tier ---')
-    const tier = await ws.execute('jq .tier /s3/vfs-demo/user.json')
-    process.stdout.write(tier.stdoutText)
-    console.log()
+    console.log('\n[grep / rg]')
+    await run('grep -c mirage /deep/example.jsonl')
+    await run('grep -m 1 mirage /deep/example.jsonl')
+    await run('rg -l mirage /deep')
+    await run('rg -c mirage /deep/example.json')
 
-    console.log('--- grep + head pipeline ---')
-    const grep = await ws.execute(
-      "grep -i '^[12]' /s3/vfs-demo/scores.csv | head -n 5",
-    )
-    process.stdout.write(grep.stdoutText)
-    console.log()
+    console.log('\n[find / glob]')
+    await run("find /deep -name '*.json'")
+    await run('find /deep -type f | wc -l')
+    await run('echo /deep/*.json')
 
-    console.log('--- wc -l across files ---')
-    const wc = await ws.execute('wc -l /s3/vfs-demo/*.csv')
-    process.stdout.write(wc.stdoutText)
-    console.log()
+    console.log('\n[jq]')
+    await run('jq .metadata.version /deep/example.json')
 
-    // Cleanup.
-    await ws.execute('rm -rf /s3/vfs-demo')
+    console.log('\n[pipelines]')
+    await run('cat /deep/example.jsonl | grep mirage | wc -l')
+    await run('grep -m 1 mirage /deep/example.jsonl && echo found')
+
+    console.log('\n[parity: /deep vs /s3/subdata/subsubdata/]')
+    const a = (await ws.execute('grep -c mirage /deep/example.jsonl')).stdoutText.trim()
+    const b = (
+      await ws.execute('grep -c mirage /s3/subdata/subsubdata/example.jsonl')
+    ).stdoutText.trim()
+    console.log(`  /deep/example.jsonl                       grep -c: ${a}`)
+    console.log(`  /s3/subdata/subsubdata/example.jsonl      grep -c: ${b}`)
+    console.log(`  parity: ${String(a === b)}`)
   } finally {
     await ws.close()
   }

--- a/python/mirage/accessor/s3.py
+++ b/python/mirage/accessor/s3.py
@@ -12,10 +12,38 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from pydantic import BaseModel, ConfigDict, field_validator
+
 from mirage.accessor.base import Accessor
+
+
+class S3Config(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    bucket: str
+    region: str | None = None
+    endpoint_url: str | None = None
+    aws_access_key_id: str | None = None
+    aws_secret_access_key: str | None = None
+    aws_session_token: str | None = None
+    aws_profile: str | None = None
+    path_style: bool = False
+    timeout: int = 30
+    proxy: str | None = None
+    key_prefix: str | None = None
+
+    @field_validator("key_prefix")
+    @classmethod
+    def _normalize_key_prefix(cls, v: str | None) -> str | None:
+        if v is None or v == "":
+            return None
+        v = v.lstrip("/")
+        if not v.endswith("/"):
+            v = v + "/"
+        return v
 
 
 class S3Accessor(Accessor):
 
-    def __init__(self, config) -> None:
+    def __init__(self, config: S3Config) -> None:
         self.config = config

--- a/python/mirage/accessor/s3.py
+++ b/python/mirage/accessor/s3.py
@@ -15,6 +15,7 @@
 from pydantic import BaseModel, ConfigDict, field_validator
 
 from mirage.accessor.base import Accessor
+from mirage.utils import key_prefix as kp
 
 
 class S3Config(BaseModel):
@@ -35,12 +36,7 @@ class S3Config(BaseModel):
     @field_validator("key_prefix")
     @classmethod
     def _normalize_key_prefix(cls, v: str | None) -> str | None:
-        if v is None or v == "":
-            return None
-        v = v.lstrip("/")
-        if not v.endswith("/"):
-            v = v + "/"
-        return v
+        return kp.normalize(v) or None
 
 
 class S3Accessor(Accessor):

--- a/python/mirage/commands/builtin/s3/rg.py
+++ b/python/mirage/commands/builtin/s3/rg.py
@@ -126,9 +126,6 @@ async def rg(
             stderr = "\n".join(warnings).encode() if warnings else None
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            p0_prefix = paths[0].prefix if paths else ""
-            if p0_prefix and args_l:
-                results = [p0_prefix + "/" + r.lstrip("/") for r in results]
             return "\n".join(results).encode(), IOResult(stderr=stderr)
 
         needs_full = args_l or context_before or context_after or type or glob
@@ -159,9 +156,6 @@ async def rg(
             stderr = "\n".join(warnings_f).encode() if warnings_f else None
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            p0_prefix = paths[0].prefix if paths else ""
-            if p0_prefix and args_l:
-                results = [p0_prefix + "/" + r.lstrip("/") for r in results]
             return "\n".join(results).encode(), IOResult(stderr=stderr)
 
         pat = compile_pattern(pattern, i, F, w)
@@ -183,11 +177,6 @@ async def rg(
                     all_results.extend(f"{p.original}:{r}" for r in hits)
             if not all_results:
                 return b"", IOResult(exit_code=1)
-            p0_prefix = paths[0].prefix if paths else ""
-            if p0_prefix:
-                all_results = [
-                    p0_prefix + "/" + r.lstrip("/") for r in all_results
-                ]
             return "\n".join(all_results).encode(), IOResult()
 
         source = read_stream(accessor, paths[0])

--- a/python/mirage/core/s3/_client.py
+++ b/python/mirage/core/s3/_client.py
@@ -16,14 +16,27 @@ import aioboto3
 from botocore.config import Config
 
 
-def _key(path: str) -> str:
-    return path.lstrip("/")
+def _key(path: str, config: object) -> str:
+    raw = path.lstrip("/")
+    prefix = getattr(config, "key_prefix", None) or ""
+    if prefix and not prefix.endswith("/"):
+        prefix = prefix + "/"
+    return prefix + raw
 
 
-def _prefix(path: str) -> str:
-    key = _key(path)
+def _prefix(path: str, config: object) -> str:
+    key = _key(path, config)
     if key and not key.endswith("/"):
         key += "/"
+    return key
+
+
+def _strip_prefix(key: str, config: object) -> str:
+    prefix = getattr(config, "key_prefix", None) or ""
+    if prefix and not prefix.endswith("/"):
+        prefix = prefix + "/"
+    if prefix and key.startswith(prefix):
+        return key[len(prefix):]
     return key
 
 

--- a/python/mirage/core/s3/_client.py
+++ b/python/mirage/core/s3/_client.py
@@ -15,32 +15,28 @@
 import aioboto3
 from botocore.config import Config
 
-
-def _key(path: str, config: object) -> str:
-    raw = path.lstrip("/")
-    prefix = getattr(config, "key_prefix", None) or ""
-    if prefix and not prefix.endswith("/"):
-        prefix = prefix + "/"
-    return prefix + raw
+from mirage.accessor.s3 import S3Config
 
 
-def _prefix(path: str, config: object) -> str:
+def _key(path: str, config: S3Config) -> str:
+    return (config.key_prefix or "") + path.lstrip("/")
+
+
+def _prefix(path: str, config: S3Config) -> str:
     key = _key(path, config)
     if key and not key.endswith("/"):
         key += "/"
     return key
 
 
-def _strip_prefix(key: str, config: object) -> str:
-    prefix = getattr(config, "key_prefix", None) or ""
-    if prefix and not prefix.endswith("/"):
-        prefix = prefix + "/"
+def _strip_prefix(key: str, config: S3Config) -> str:
+    prefix = config.key_prefix or ""
     if prefix and key.startswith(prefix):
         return key[len(prefix):]
     return key
 
 
-def _client_kwargs(config: object) -> dict:
+def _client_kwargs(config: S3Config) -> dict:
     kwargs: dict = {"service_name": "s3"}
     if config.region:
         kwargs["region_name"] = config.region
@@ -49,7 +45,7 @@ def _client_kwargs(config: object) -> dict:
     if config.aws_access_key_id and config.aws_secret_access_key:
         kwargs["aws_access_key_id"] = config.aws_access_key_id
         kwargs["aws_secret_access_key"] = config.aws_secret_access_key
-    if getattr(config, "aws_session_token", None):
+    if config.aws_session_token:
         kwargs["aws_session_token"] = config.aws_session_token
     cfg_kwargs: dict = {
         "connect_timeout": config.timeout,
@@ -57,11 +53,11 @@ def _client_kwargs(config: object) -> dict:
     }
     if config.proxy:
         cfg_kwargs["proxies"] = {"https": config.proxy, "http": config.proxy}
-    if getattr(config, "path_style", False):
+    if config.path_style:
         cfg_kwargs["s3"] = {"addressing_style": "path"}
     kwargs["config"] = Config(**cfg_kwargs)
     return kwargs
 
 
-def async_session(config: object):
+def async_session(config: S3Config) -> aioboto3.Session:
     return aioboto3.Session(profile_name=config.aws_profile or None)

--- a/python/mirage/core/s3/_client.py
+++ b/python/mirage/core/s3/_client.py
@@ -16,24 +16,19 @@ import aioboto3
 from botocore.config import Config
 
 from mirage.accessor.s3 import S3Config
+from mirage.utils import key_prefix as kp
 
 
 def _key(path: str, config: S3Config) -> str:
-    return (config.key_prefix or "") + path.lstrip("/")
+    return kp.apply(config.key_prefix or "", path)
 
 
 def _prefix(path: str, config: S3Config) -> str:
-    key = _key(path, config)
-    if key and not key.endswith("/"):
-        key += "/"
-    return key
+    return kp.apply_dir(config.key_prefix or "", path)
 
 
 def _strip_prefix(key: str, config: S3Config) -> str:
-    prefix = config.key_prefix or ""
-    if prefix and key.startswith(prefix):
-        return key[len(prefix):]
-    return key
+    return kp.strip(config.key_prefix or "", key)
 
 
 def _client_kwargs(config: S3Config) -> dict:

--- a/python/mirage/core/s3/copy.py
+++ b/python/mirage/core/s3/copy.py
@@ -33,7 +33,7 @@ async def copy(accessor: S3Accessor, src: PathSpec, dst: PathSpec) -> None:
             Bucket=config.bucket,
             CopySource={
                 "Bucket": config.bucket,
-                "Key": _key(src)
+                "Key": _key(src, config)
             },
-            Key=_key(dst),
+            Key=_key(dst, config),
         )

--- a/python/mirage/core/s3/create.py
+++ b/python/mirage/core/s3/create.py
@@ -25,4 +25,6 @@ async def create(accessor: S3Accessor, path: PathSpec) -> None:
     config = accessor.config
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:
-        await client.put_object(Bucket=config.bucket, Key=_key(path), Body=b"")
+        await client.put_object(Bucket=config.bucket,
+                                Key=_key(path, config),
+                                Body=b"")

--- a/python/mirage/core/s3/du.py
+++ b/python/mirage/core/s3/du.py
@@ -29,7 +29,7 @@ async def du(accessor: S3Accessor, path: PathSpec) -> int:
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     config = accessor.config
-    pfx = _prefix(path)
+    pfx = _prefix(path, config)
     total = 0
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:
@@ -53,7 +53,7 @@ async def du_all(accessor: S3Accessor,
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     config = accessor.config
-    pfx = _prefix(path)
+    pfx = _prefix(path, config)
     results: list[tuple[str, int]] = []
     total = 0
     session = async_session(config)

--- a/python/mirage/core/s3/find.py
+++ b/python/mirage/core/s3/find.py
@@ -15,7 +15,8 @@
 import fnmatch
 
 from mirage.accessor.s3 import S3Accessor
-from mirage.core.s3._client import _client_kwargs, _prefix, async_session
+from mirage.core.s3._client import (_client_kwargs, _prefix, _strip_prefix,
+                                    async_session)
 from mirage.types import PathSpec
 
 
@@ -58,7 +59,7 @@ async def find(
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     config = accessor.config
-    pfx = _prefix(path)
+    pfx = _prefix(path, config)
     results: list[str] = []
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:
@@ -83,7 +84,7 @@ async def find(
                 if iname is not None and not fnmatch.fnmatch(
                         entry_name.lower(), iname.lower()):
                     continue
-                full_path = "/" + key
+                full_path = "/" + _strip_prefix(key, config)
                 if path_pattern is not None and not fnmatch.fnmatch(
                         full_path, path_pattern):
                     continue

--- a/python/mirage/core/s3/mkdir.py
+++ b/python/mirage/core/s3/mkdir.py
@@ -23,7 +23,7 @@ async def mkdir(accessor: S3Accessor, path: PathSpec) -> None:
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     config = accessor.config
-    pfx = _prefix(path)
+    pfx = _prefix(path, config)
     if pfx:
         session = async_session(config)
         async with session.client(**_client_kwargs(config)) as client:

--- a/python/mirage/core/s3/read.py
+++ b/python/mirage/core/s3/read.py
@@ -63,7 +63,7 @@ async def read_bytes(accessor: S3Accessor,
     if prefix and path.startswith(prefix):
         path = path[len(prefix):] or "/"
     config = accessor.config
-    key = _key(path)
+    key = _key(path, config)
     kwargs = {"Bucket": config.bucket, "Key": key}
     pinned_revision = revision_for(virtual)
     if pinned_revision is not None:

--- a/python/mirage/core/s3/readdir.py
+++ b/python/mirage/core/s3/readdir.py
@@ -16,7 +16,8 @@ import logging
 
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore, IndexEntry
-from mirage.core.s3._client import _client_kwargs, _prefix, async_session
+from mirage.core.s3._client import (_client_kwargs, _prefix, _strip_prefix,
+                                    async_session)
 from mirage.core.s3.constants import SCOPE_ERROR
 from mirage.types import PathSpec
 
@@ -41,7 +42,7 @@ async def readdir(accessor: S3Accessor, path: PathSpec,
     listing = await index.list_dir(virtual_key)
     if listing.entries is not None:
         return listing.entries
-    pfx = _prefix(path)
+    pfx = _prefix(path, config)
     names: list[str] = []
     dir_keys: set[str] = set()
     sizes: dict[str, int | None] = {}
@@ -54,13 +55,13 @@ async def readdir(accessor: S3Accessor, path: PathSpec,
             for cp in page.get("CommonPrefixes") or []:
                 child = cp["Prefix"].rstrip("/")
                 if child:
-                    key = "/" + child
+                    key = "/" + _strip_prefix(child, config)
                     names.append(key)
                     dir_keys.add(key)
             for obj in page.get("Contents") or []:
                 relative = obj["Key"][len(pfx):]
                 if relative and "/" not in relative:
-                    key = "/" + obj["Key"]
+                    key = "/" + _strip_prefix(obj["Key"], config)
                     names.append(key)
                     sizes[key] = obj.get("Size")
     names = sorted(names)

--- a/python/mirage/core/s3/rename.py
+++ b/python/mirage/core/s3/rename.py
@@ -33,8 +33,8 @@ async def rename(accessor: S3Accessor, src: PathSpec, dst: PathSpec) -> None:
             Bucket=config.bucket,
             CopySource={
                 "Bucket": config.bucket,
-                "Key": _key(src)
+                "Key": _key(src, config)
             },
-            Key=_key(dst),
+            Key=_key(dst, config),
         )
-        await client.delete_object(Bucket=config.bucket, Key=_key(src))
+        await client.delete_object(Bucket=config.bucket, Key=_key(src, config))

--- a/python/mirage/core/s3/rm.py
+++ b/python/mirage/core/s3/rm.py
@@ -29,7 +29,7 @@ async def rm_r(accessor: S3Accessor, path: PathSpec) -> None:
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     config = accessor.config
-    pfx = _prefix(path)
+    pfx = _prefix(path, config)
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:
         paginator = client.get_paginator("list_objects_v2")

--- a/python/mirage/core/s3/rmdir.py
+++ b/python/mirage/core/s3/rmdir.py
@@ -23,7 +23,7 @@ async def rmdir(accessor: S3Accessor, path: PathSpec) -> None:
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     config = accessor.config
-    pfx = _prefix(path)
+    pfx = _prefix(path, config)
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:
         paginator = client.get_paginator("list_objects_v2")

--- a/python/mirage/core/s3/stat.py
+++ b/python/mirage/core/s3/stat.py
@@ -75,7 +75,7 @@ async def stat(accessor: S3Accessor,
     # Slow path: no index cache available, or parent directory not yet
     # listed. Hit the network.
     config = accessor.config
-    key = _key(path)
+    key = _key(path, config)
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:
         # Try head_object first — works for files.

--- a/python/mirage/core/s3/stream.py
+++ b/python/mirage/core/s3/stream.py
@@ -50,7 +50,7 @@ async def read_stream(
     rec = record_stream("read", path, "s3")
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:
-        kwargs: dict = {"Bucket": config.bucket, "Key": _key(path)}
+        kwargs: dict = {"Bucket": config.bucket, "Key": _key(path, config)}
         if pinned_revision is not None:
             kwargs["VersionId"] = pinned_revision
         response = await client.get_object(**kwargs)
@@ -85,7 +85,7 @@ async def range_read(accessor: S3Accessor, path: PathSpec, start: int,
     async with session.client(**_client_kwargs(config)) as client:
         kwargs: dict = {
             "Bucket": config.bucket,
-            "Key": _key(path),
+            "Key": _key(path, config),
             "Range": f"bytes={start}-{end - 1}",
         }
         pinned_revision = revision_for(virtual)

--- a/python/mirage/core/s3/truncate.py
+++ b/python/mirage/core/s3/truncate.py
@@ -27,7 +27,7 @@ async def truncate(accessor: S3Accessor, path: PathSpec, length: int) -> None:
     async with session.client(**_client_kwargs(config)) as client:
         try:
             resp = await client.get_object(Bucket=config.bucket,
-                                           Key=_key(path))
+                                           Key=_key(path, config))
             data = await resp["Body"].read()
         except Exception as exc:
             if (hasattr(exc, "response") and exc.response.get(
@@ -37,5 +37,5 @@ async def truncate(accessor: S3Accessor, path: PathSpec, length: int) -> None:
                 raise
         result = data[:length].ljust(length, b"\0")
         await client.put_object(Bucket=config.bucket,
-                                Key=_key(path),
+                                Key=_key(path, config),
                                 Body=result)

--- a/python/mirage/core/s3/unlink.py
+++ b/python/mirage/core/s3/unlink.py
@@ -25,4 +25,5 @@ async def unlink(accessor: S3Accessor, path: PathSpec) -> None:
     config = accessor.config
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:
-        await client.delete_object(Bucket=config.bucket, Key=_key(path))
+        await client.delete_object(Bucket=config.bucket,
+                                   Key=_key(path, config))

--- a/python/mirage/core/s3/write.py
+++ b/python/mirage/core/s3/write.py
@@ -27,7 +27,7 @@ async def write_bytes(accessor: S3Accessor, path: PathSpec,
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     config = accessor.config
-    key = _key(path)
+    key = _key(path, config)
     start_ms = int(time.monotonic() * 1000)
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:

--- a/python/mirage/resource/s3/s3.py
+++ b/python/mirage/resource/s3/s3.py
@@ -15,7 +15,7 @@
 import dataclasses
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from mirage.accessor.s3 import S3Accessor
 from mirage.commands.builtin.s3 import COMMANDS as S3_COMMANDS
@@ -76,6 +76,17 @@ class S3Config(BaseModel):
     path_style: bool = False
     timeout: int = 30
     proxy: str | None = None
+    key_prefix: str | None = None
+
+    @field_validator("key_prefix")
+    @classmethod
+    def _normalize_key_prefix(cls, v: str | None) -> str | None:
+        if v is None or v == "":
+            return None
+        v = v.lstrip("/")
+        if not v.endswith("/"):
+            v = v + "/"
+        return v
 
 
 class S3Resource(BaseResource):

--- a/python/mirage/resource/s3/s3.py
+++ b/python/mirage/resource/s3/s3.py
@@ -15,9 +15,7 @@
 import dataclasses
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, field_validator
-
-from mirage.accessor.s3 import S3Accessor
+from mirage.accessor.s3 import S3Accessor, S3Config
 from mirage.commands.builtin.s3 import COMMANDS as S3_COMMANDS
 from mirage.core.s3.copy import copy
 from mirage.core.s3.create import create
@@ -61,32 +59,6 @@ _S3_OPS = {
     "exists": exists,
     "find_flat": find,
 }
-
-
-class S3Config(BaseModel):
-    model_config = ConfigDict(frozen=True)
-
-    bucket: str
-    region: str | None = None
-    endpoint_url: str | None = None
-    aws_access_key_id: str | None = None
-    aws_secret_access_key: str | None = None
-    aws_session_token: str | None = None
-    aws_profile: str | None = None
-    path_style: bool = False
-    timeout: int = 30
-    proxy: str | None = None
-    key_prefix: str | None = None
-
-    @field_validator("key_prefix")
-    @classmethod
-    def _normalize_key_prefix(cls, v: str | None) -> str | None:
-        if v is None or v == "":
-            return None
-        v = v.lstrip("/")
-        if not v.endswith("/"):
-            v = v + "/"
-        return v
 
 
 class S3Resource(BaseResource):

--- a/python/mirage/utils/key_prefix.py
+++ b/python/mirage/utils/key_prefix.py
@@ -1,0 +1,71 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+
+def normalize(raw: str | None) -> str:
+    """Normalize a key prefix.
+
+    Args:
+        raw: The raw prefix string, or None.
+
+    Returns:
+        Empty string if input was None/empty; otherwise the prefix with
+        leading slashes stripped and a trailing slash ensured.
+    """
+    if not raw:
+        return ""
+    v = raw.lstrip("/")
+    return v if v.endswith("/") else v + "/"
+
+
+def apply(prefix: str, path: str) -> str:
+    """Prepend a normalized prefix to a virtual path.
+
+    Args:
+        prefix: A normalized prefix (use ``normalize()`` first if unsure).
+        path: The virtual path to scope.
+
+    Returns:
+        The backend key: ``prefix + path`` with the leading slash of
+        ``path`` stripped.
+    """
+    return prefix + path.lstrip("/")
+
+
+def apply_dir(prefix: str, path: str) -> str:
+    """Same as ``apply()`` but guarantees a trailing slash for LIST-style ops.
+
+    Args:
+        prefix: A normalized prefix.
+        path: The virtual path to scope.
+
+    Returns:
+        The backend key with a trailing slash, suitable for use as a LIST
+        ``Prefix`` argument.
+    """
+    key = apply(prefix, path)
+    return key if not key or key.endswith("/") else key + "/"
+
+
+def strip(prefix: str, key: str) -> str:
+    """Strip a normalized prefix from a backend-returned key.
+
+    Args:
+        prefix: A normalized prefix.
+        key: The backend-returned key.
+
+    Returns:
+        The key with the prefix removed if present; otherwise unchanged.
+    """
+    return key[len(prefix):] if prefix and key.startswith(prefix) else key

--- a/python/tests/core/s3/test_key_prefix.py
+++ b/python/tests/core/s3/test_key_prefix.py
@@ -43,11 +43,13 @@ def test_normalize_empty_returns_none():
 
 
 def test_normalize_strips_leading_slash():
-    assert S3Config(bucket="b", key_prefix="/users/abc/").key_prefix == "users/abc/"
+    assert S3Config(bucket="b",
+                    key_prefix="/users/abc/").key_prefix == "users/abc/"
 
 
 def test_normalize_adds_trailing_slash():
-    assert S3Config(bucket="b", key_prefix="users/abc").key_prefix == "users/abc/"
+    assert S3Config(bucket="b",
+                    key_prefix="users/abc").key_prefix == "users/abc/"
 
 
 def test_write_with_prefix():
@@ -90,8 +92,10 @@ def test_resolve_glob_with_prefix():
         )
         results = asyncio.run(resolve_glob(accessor, [glob_path], index))
     for r in results:
-        assert "users" not in r.original, f"key_prefix leaked into glob result: {r.original}"
-        assert "abc" not in r.original, f"key_prefix leaked into glob result: {r.original}"
+        assert "users" not in r.original, (
+            f"key_prefix leaked into glob result: {r.original}")
+        assert "abc" not in r.original, (
+            f"key_prefix leaked into glob result: {r.original}")
 
 
 def test_stat_with_prefix():

--- a/python/tests/core/s3/test_key_prefix.py
+++ b/python/tests/core/s3/test_key_prefix.py
@@ -1,0 +1,150 @@
+import asyncio
+
+from mirage.accessor.s3 import S3Accessor
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.core.s3.copy import copy
+from mirage.core.s3.exists import exists
+from mirage.core.s3.glob import resolve_glob
+from mirage.core.s3.read import read_bytes
+from mirage.core.s3.readdir import readdir
+from mirage.core.s3.rename import rename
+from mirage.core.s3.stat import stat
+from mirage.core.s3.unlink import unlink
+from mirage.core.s3.write import write_bytes
+from mirage.resource.s3 import S3Config
+from mirage.resource.s3.s3 import S3Resource
+from mirage.types import PathSpec
+from tests.integration.s3_mock import patch_s3_multi
+
+PREFIX = "users/abc/"
+BUCKET = "test-bucket"
+
+
+def _config(key_prefix: str | None = None) -> S3Config:
+    return S3Config(
+        bucket=BUCKET,
+        region="us-east-1",
+        aws_access_key_id="fake",
+        aws_secret_access_key="fake",
+        key_prefix=key_prefix,
+    )
+
+
+def _accessor(key_prefix: str | None = None) -> S3Accessor:
+    return S3Accessor(_config(key_prefix))
+
+
+def _path(p: str) -> PathSpec:
+    return PathSpec(original=p, directory=p)
+
+
+def test_normalize_empty_returns_none():
+    assert S3Config(bucket="b", key_prefix="").key_prefix is None
+
+
+def test_normalize_strips_leading_slash():
+    assert S3Config(bucket="b", key_prefix="/users/abc/").key_prefix == "users/abc/"
+
+
+def test_normalize_adds_trailing_slash():
+    assert S3Config(bucket="b", key_prefix="users/abc").key_prefix == "users/abc/"
+
+
+def test_write_with_prefix():
+    store = {BUCKET: {}}
+    with patch_s3_multi(store):
+        accessor = _accessor(PREFIX)
+        asyncio.run(write_bytes(accessor, _path("/a.txt"), b"hello"))
+    assert store[BUCKET].get("users/abc/a.txt") == b"hello"
+
+
+def test_read_baseline_no_prefix():
+    store = {BUCKET: {"a.txt": b"baseline"}}
+    with patch_s3_multi(store):
+        accessor = _accessor(None)
+        data = asyncio.run(read_bytes(accessor, _path("/a.txt")))
+    assert data == b"baseline"
+
+
+def test_readdir_returns_user_facing_paths():
+    store = {BUCKET: {"users/abc/a.txt": b"a", "users/abc/b.txt": b"b"}}
+    with patch_s3_multi(store):
+        accessor = _accessor(PREFIX)
+        index = RAMIndexCacheStore()
+        entries = asyncio.run(readdir(accessor, _path("/"), index=index))
+    for entry in entries:
+        assert "users" not in entry, f"key_prefix leaked into entry: {entry}"
+        assert "abc" not in entry, f"key_prefix leaked into entry: {entry}"
+
+
+def test_resolve_glob_with_prefix():
+    store = {BUCKET: {"users/abc/a.txt": b"a", "users/abc/b.txt": b"b"}}
+    with patch_s3_multi(store):
+        accessor = _accessor(PREFIX)
+        index = RAMIndexCacheStore()
+        glob_path = PathSpec(
+            original="/*.txt",
+            directory="/",
+            pattern="*.txt",
+            resolved=False,
+        )
+        results = asyncio.run(resolve_glob(accessor, [glob_path], index))
+    for r in results:
+        assert "users" not in r.original, f"key_prefix leaked into glob result: {r.original}"
+        assert "abc" not in r.original, f"key_prefix leaked into glob result: {r.original}"
+
+
+def test_stat_with_prefix():
+    store = {BUCKET: {"users/abc/a.txt": b"data"}}
+    with patch_s3_multi(store):
+        accessor = _accessor(PREFIX)
+        result = asyncio.run(stat(accessor, _path("/a.txt")))
+    assert result.name == "a.txt"
+    assert "users" not in (result.name or "")
+    assert "abc" not in (result.name or "")
+
+
+def test_exists_with_prefix():
+    store = {BUCKET: {"users/abc/a.txt": b"yes"}}
+    with patch_s3_multi(store):
+        accessor = _accessor(PREFIX)
+        found = asyncio.run(exists(accessor, _path("/a.txt")))
+        not_found = asyncio.run(exists(accessor, _path("/missing.txt")))
+    assert found is True
+    assert not_found is False
+
+
+def test_copy_within_prefixed_scope():
+    store = {BUCKET: {"users/abc/a.txt": b"content"}}
+    with patch_s3_multi(store):
+        accessor = _accessor(PREFIX)
+        asyncio.run(copy(accessor, _path("/a.txt"), _path("/b.txt")))
+    assert "users/abc/b.txt" in store[BUCKET]
+    assert store[BUCKET]["users/abc/b.txt"] == b"content"
+    assert "users/abc/a.txt" in store[BUCKET]
+
+
+def test_rename_within_prefixed_scope():
+    store = {BUCKET: {"users/abc/a.txt": b"moved"}}
+    with patch_s3_multi(store):
+        accessor = _accessor(PREFIX)
+        asyncio.run(rename(accessor, _path("/a.txt"), _path("/b.txt")))
+    assert "users/abc/b.txt" in store[BUCKET]
+    assert store[BUCKET]["users/abc/b.txt"] == b"moved"
+    assert "users/abc/a.txt" not in store[BUCKET]
+
+
+def test_unlink_with_prefix():
+    store = {BUCKET: {"users/abc/a.txt": b"gone"}}
+    with patch_s3_multi(store):
+        accessor = _accessor(PREFIX)
+        asyncio.run(unlink(accessor, _path("/a.txt")))
+    assert "users/abc/a.txt" not in store[BUCKET]
+
+
+def test_get_state_includes_key_prefix():
+    config = _config(PREFIX)
+    resource = S3Resource(config)
+    state = resource.get_state()
+    assert state["config"]["key_prefix"] == PREFIX
+    assert "key_prefix" not in state["redacted_fields"]

--- a/python/tests/core/s3/test_key_prefix_threading.py
+++ b/python/tests/core/s3/test_key_prefix_threading.py
@@ -1,5 +1,4 @@
 import asyncio
-from contextlib import ExitStack
 
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index.ram import RAMIndexCacheStore

--- a/python/tests/core/s3/test_key_prefix_threading.py
+++ b/python/tests/core/s3/test_key_prefix_threading.py
@@ -1,0 +1,66 @@
+import asyncio
+from contextlib import ExitStack
+
+from mirage.accessor.s3 import S3Accessor
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.core.s3.find import find
+from mirage.core.s3.read import read_bytes
+from mirage.core.s3.readdir import readdir
+from mirage.resource.s3 import S3Config
+from mirage.types import PathSpec
+from tests.integration.s3_mock import patch_s3_multi
+
+
+def _make_config(key_prefix: str | None = None) -> S3Config:
+    return S3Config(
+        bucket="test-bucket",
+        region="us-east-1",
+        aws_access_key_id="fake",
+        aws_secret_access_key="fake",
+        key_prefix=key_prefix,
+    )
+
+
+def test_readdir_no_prefix_backward_compat():
+    store = {"test-bucket": {"dir/a.txt": b"a", "dir/b.txt": b"b"}}
+    with patch_s3_multi(store):
+        config = _make_config(key_prefix=None)
+        accessor = S3Accessor(config)
+        path = PathSpec(original="/dir", directory="/dir")
+        index = RAMIndexCacheStore()
+        entries = asyncio.run(readdir(accessor, path, index=index))
+    assert any(e.endswith("/a.txt") for e in entries)
+    assert any(e.endswith("/b.txt") for e in entries)
+
+
+def test_readdir_strips_key_prefix_from_entries():
+    store = {"test-bucket": {"prod/dir/a.txt": b"a", "prod/dir/b.txt": b"b"}}
+    with patch_s3_multi(store):
+        config = _make_config(key_prefix="prod")
+        accessor = S3Accessor(config)
+        path = PathSpec(original="/dir", directory="/dir")
+        index = RAMIndexCacheStore()
+        entries = asyncio.run(readdir(accessor, path, index=index))
+    for e in entries:
+        assert "prod" not in e, f"key_prefix leaked into entry: {e}"
+
+
+def test_read_bytes_with_key_prefix():
+    store = {"test-bucket": {"prod/hello.txt": b"hello"}}
+    with patch_s3_multi(store):
+        config = _make_config(key_prefix="prod")
+        accessor = S3Accessor(config)
+        path = PathSpec(original="/hello.txt", directory="/hello.txt")
+        data = asyncio.run(read_bytes(accessor, path))
+    assert data == b"hello"
+
+
+def test_find_strips_key_prefix_from_results():
+    store = {"test-bucket": {"prod/dir/a.txt": b"a", "prod/dir/b.txt": b"b"}}
+    with patch_s3_multi(store):
+        config = _make_config(key_prefix="prod")
+        accessor = S3Accessor(config)
+        path = PathSpec(original="/dir", directory="/dir")
+        results = asyncio.run(find(accessor, path))
+    for r in results:
+        assert "prod" not in r, f"key_prefix leaked into find result: {r}"

--- a/typescript/packages/core/src/commands/builtin/s3/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/rg.ts
@@ -164,15 +164,11 @@ async function rgCommand(
       warnings,
     )
     const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : undefined
-    let finalResults = results
-    if (first.prefix !== '' && flags.filesOnly) {
-      finalResults = finalResults.map((r) => first.prefix + '/' + r.replace(/^\/+/, ''))
-    }
-    if (finalResults.length === 0) {
+    if (results.length === 0) {
       const io = new IOResult({ exitCode: 1, ...(stderr !== undefined ? { stderr } : {}) })
       return [new Uint8Array(0), io]
     }
-    const out: ByteSource = ENC.encode(finalResults.join('\n'))
+    const out: ByteSource = ENC.encode(results.join('\n'))
     const io = new IOResult(stderr !== undefined ? { stderr } : {})
     return [out, io]
   }
@@ -215,15 +211,11 @@ async function rgCommand(
       warnings,
     )
     const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : undefined
-    let finalResults = results
-    if (first.prefix !== '' && flags.filesOnly) {
-      finalResults = finalResults.map((r) => first.prefix + '/' + r.replace(/^\/+/, ''))
-    }
-    if (finalResults.length === 0) {
+    if (results.length === 0) {
       const io = new IOResult({ exitCode: 1, ...(stderr !== undefined ? { stderr } : {}) })
       return [new Uint8Array(0), io]
     }
-    const out: ByteSource = ENC.encode(finalResults.join('\n'))
+    const out: ByteSource = ENC.encode(results.join('\n'))
     const io = new IOResult(stderr !== undefined ? { stderr } : {})
     return [out, io]
   }
@@ -251,11 +243,7 @@ async function rgCommand(
       }
     }
     if (allResults.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-    let finalResults = allResults
-    if (first.prefix !== '') {
-      finalResults = finalResults.map((r) => first.prefix + '/' + r.replace(/^\/+/, ''))
-    }
-    const out: ByteSource = ENC.encode(finalResults.join('\n'))
+    const out: ByteSource = ENC.encode(allResults.join('\n'))
     return [out, new IOResult()]
   }
 

--- a/typescript/packages/core/src/core/s3/_client.ts
+++ b/typescript/packages/core/src/core/s3/_client.ts
@@ -17,14 +17,24 @@ import type { PathSpec } from '../../types.ts'
 import { loadOptionalPeer } from '../../utils/optional_peer.ts'
 import type { S3Config } from '../../resource/s3/config.ts'
 
-export function s3Key(path: string): string {
-  return path.replace(/^\/+/, '')
+export function s3Key(path: string, config: S3Config): string {
+  const raw = path.replace(/^\/+/, '')
+  const prefix = config.keyPrefix ?? ''
+  return prefix + raw
 }
 
-export function s3Prefix(path: string): string {
-  const key = s3Key(path)
+export function s3Prefix(path: string, config: S3Config): string {
+  const key = s3Key(path, config)
   if (key === '') return ''
   return key.endsWith('/') ? key : `${key}/`
+}
+
+export function stripKeyPrefix(key: string, config: S3Config): string {
+  const prefix = config.keyPrefix ?? ''
+  if (prefix !== '' && key.startsWith(prefix)) {
+    return key.slice(prefix.length)
+  }
+  return key
 }
 
 export function rawPathOf(path: PathSpec): string {

--- a/typescript/packages/core/src/core/s3/_client.ts
+++ b/typescript/packages/core/src/core/s3/_client.ts
@@ -15,26 +15,19 @@
 import type { S3Client } from '@aws-sdk/client-s3'
 import type { PathSpec } from '../../types.ts'
 import { loadOptionalPeer } from '../../utils/optional_peer.ts'
+import * as kp from '../../utils/key_prefix.ts'
 import type { S3Config } from '../../resource/s3/config.ts'
 
 export function s3Key(path: string, config: S3Config): string {
-  const raw = path.replace(/^\/+/, '')
-  const prefix = config.keyPrefix ?? ''
-  return prefix + raw
+  return kp.apply(config.keyPrefix ?? '', path)
 }
 
 export function s3Prefix(path: string, config: S3Config): string {
-  const key = s3Key(path, config)
-  if (key === '') return ''
-  return key.endsWith('/') ? key : `${key}/`
+  return kp.applyDir(config.keyPrefix ?? '', path)
 }
 
 export function stripKeyPrefix(key: string, config: S3Config): string {
-  const prefix = config.keyPrefix ?? ''
-  if (prefix !== '' && key.startsWith(prefix)) {
-    return key.slice(prefix.length)
-  }
-  return key
+  return kp.strip(config.keyPrefix ?? '', key)
 }
 
 export function rawPathOf(path: PathSpec): string {

--- a/typescript/packages/core/src/core/s3/copy.ts
+++ b/typescript/packages/core/src/core/s3/copy.ts
@@ -18,8 +18,8 @@ import { loadS3Module, rawPathOf, s3Key, withClient } from './_client.ts'
 
 export async function copy(accessor: S3Accessor, src: PathSpec, dst: PathSpec): Promise<void> {
   const { CopyObjectCommand } = await loadS3Module(accessor.config)
-  const srcKey = s3Key(rawPathOf(src))
-  const dstKey = s3Key(rawPathOf(dst))
+  const srcKey = s3Key(rawPathOf(src), accessor.config)
+  const dstKey = s3Key(rawPathOf(dst), accessor.config)
   const { bucket } = accessor.config
   await withClient(accessor.config, async (client) => {
     await client.send(

--- a/typescript/packages/core/src/core/s3/create.ts
+++ b/typescript/packages/core/src/core/s3/create.ts
@@ -23,7 +23,7 @@ export async function create(accessor: S3Accessor, path: PathSpec): Promise<void
     await client.send(
       new PutObjectCommand({
         Bucket: accessor.config.bucket,
-        Key: s3Key(raw),
+        Key: s3Key(raw, accessor.config),
         Body: new Uint8Array(),
       }),
     )

--- a/typescript/packages/core/src/core/s3/du.ts
+++ b/typescript/packages/core/src/core/s3/du.ts
@@ -19,7 +19,7 @@ import { loadS3Module, rawPathOf, s3Prefix, withClient } from './_client.ts'
 export async function du(accessor: S3Accessor, path: PathSpec): Promise<number> {
   const { ListObjectsV2Command } = await loadS3Module(accessor.config)
   const raw = rawPathOf(path)
-  const pfx = s3Prefix(raw)
+  const pfx = s3Prefix(raw, accessor.config)
   let total = 0
   await withClient(accessor.config, async (client) => {
     let continuationToken: string | undefined
@@ -50,7 +50,7 @@ export async function du(accessor: S3Accessor, path: PathSpec): Promise<number> 
 export async function duAll(accessor: S3Accessor, path: PathSpec): Promise<[string, number][]> {
   const { ListObjectsV2Command } = await loadS3Module(accessor.config)
   const raw = rawPathOf(path)
-  const pfx = s3Prefix(raw)
+  const pfx = s3Prefix(raw, accessor.config)
   const entries: [string, number][] = []
   let total = 0
   await withClient(accessor.config, async (client) => {

--- a/typescript/packages/core/src/core/s3/find.ts
+++ b/typescript/packages/core/src/core/s3/find.ts
@@ -15,7 +15,14 @@
 import type { FindOptions } from '../../resource/base.ts'
 import type { PathSpec } from '../../types.ts'
 import type { S3Accessor } from '../../accessor/s3.ts'
-import { fnmatch, loadS3Module, rawPathOf, s3Prefix, withClient } from './_client.ts'
+import {
+  fnmatch,
+  loadS3Module,
+  rawPathOf,
+  s3Prefix,
+  stripKeyPrefix,
+  withClient,
+} from './_client.ts'
 
 export async function find(
   accessor: S3Accessor,
@@ -24,7 +31,7 @@ export async function find(
 ): Promise<string[]> {
   const { ListObjectsV2Command } = await loadS3Module(accessor.config)
   const raw = rawPathOf(path)
-  const pfx = s3Prefix(raw)
+  const pfx = s3Prefix(raw, accessor.config)
   const results: string[] = []
   await withClient(accessor.config, async (client) => {
     let continuationToken: string | undefined
@@ -71,7 +78,7 @@ export async function find(
         if (options.iname !== null && options.iname !== undefined) {
           if (!fnmatch(entryName.toLowerCase(), options.iname.toLowerCase())) continue
         }
-        const fullPath = '/' + key
+        const fullPath = '/' + stripKeyPrefix(key, accessor.config)
         if (options.pathPattern !== null && options.pathPattern !== undefined) {
           if (!fnmatch(fullPath, options.pathPattern)) continue
         }

--- a/typescript/packages/core/src/core/s3/mkdir.ts
+++ b/typescript/packages/core/src/core/s3/mkdir.ts
@@ -19,7 +19,7 @@ import { loadS3Module, rawPathOf, s3Prefix, withClient } from './_client.ts'
 export async function mkdir(accessor: S3Accessor, path: PathSpec): Promise<void> {
   const { PutObjectCommand } = await loadS3Module(accessor.config)
   const raw = rawPathOf(path)
-  const pfx = s3Prefix(raw)
+  const pfx = s3Prefix(raw, accessor.config)
   if (pfx === '') return
   await withClient(accessor.config, async (client) => {
     await client.send(

--- a/typescript/packages/core/src/core/s3/read.ts
+++ b/typescript/packages/core/src/core/s3/read.ts
@@ -52,8 +52,8 @@ export async function read(
     prefix !== '' && virtual.startsWith(prefix) ? virtual.slice(prefix.length) || '/' : virtual
   // `virtual` retains the mount prefix (e.g. /s3/foo) for snapshot records;
   // `rawPath` is the backend-relative key used for the actual S3 call.
-  const key = s3Key(rawPath)
   const { config } = accessor
+  const key = s3Key(rawPath, config)
   const { GetObjectCommand } = await loadS3Module(config)
   const client = await createS3Client(config)
   const input: Record<string, unknown> = { Bucket: config.bucket, Key: key }

--- a/typescript/packages/core/src/core/s3/readdir.ts
+++ b/typescript/packages/core/src/core/s3/readdir.ts
@@ -34,7 +34,8 @@ export async function readdir(
   // Fast path: the index cache may already have this directory populated
   // from a previous readdir. Mirror Python's mirage/core/s3/readdir.py.
   const virtualKey = rawPath === '/' ? '/' : rawPath.replace(/\/+$/, '') || '/'
-  const fullVirtualKey = prefix !== '' ? `${prefix}${virtualKey}` : virtualKey
+  const rawFullKey = prefix !== '' ? `${prefix}${virtualKey}` : virtualKey
+  const fullVirtualKey = rawFullKey.replace(/\/+$/, '') || '/'
   if (index !== undefined) {
     const listing = await index.listDir(fullVirtualKey)
     if (listing.entries !== undefined && listing.entries !== null) {

--- a/typescript/packages/core/src/core/s3/readdir.ts
+++ b/typescript/packages/core/src/core/s3/readdir.ts
@@ -57,7 +57,7 @@ export async function readdir(
     string,
     { size: number | null; etag: string; lastModified: Date | string | undefined }
   >()
-  const s3Pfx = s3Prefix(rawPath)
+  const s3Pfx = s3Prefix(rawPath, config)
   let continuationToken: string | undefined
   try {
     do {

--- a/typescript/packages/core/src/core/s3/rename.ts
+++ b/typescript/packages/core/src/core/s3/rename.ts
@@ -18,8 +18,8 @@ import { loadS3Module, rawPathOf, s3Key, withClient } from './_client.ts'
 
 export async function rename(accessor: S3Accessor, src: PathSpec, dst: PathSpec): Promise<void> {
   const { CopyObjectCommand, DeleteObjectCommand } = await loadS3Module(accessor.config)
-  const srcKey = s3Key(rawPathOf(src))
-  const dstKey = s3Key(rawPathOf(dst))
+  const srcKey = s3Key(rawPathOf(src), accessor.config)
+  const dstKey = s3Key(rawPathOf(dst), accessor.config)
   const { bucket } = accessor.config
   await withClient(accessor.config, async (client) => {
     await client.send(

--- a/typescript/packages/core/src/core/s3/rm.ts
+++ b/typescript/packages/core/src/core/s3/rm.ts
@@ -23,7 +23,7 @@ export async function rmR(accessor: S3Accessor, path: PathSpec): Promise<void> {
   // with this prefix".
   const { DeleteObjectsCommand, ListObjectsV2Command } = await loadS3Module(accessor.config)
   const raw = rawPathOf(path)
-  const pfx = s3Prefix(raw)
+  const pfx = s3Prefix(raw, accessor.config)
   await withClient(accessor.config, async (client) => {
     let continuationToken: string | undefined
     do {

--- a/typescript/packages/core/src/core/s3/rmdir.ts
+++ b/typescript/packages/core/src/core/s3/rmdir.ts
@@ -19,7 +19,7 @@ import { loadS3Module, rawPathOf, s3Prefix, withClient } from './_client.ts'
 export async function rmdir(accessor: S3Accessor, path: PathSpec): Promise<void> {
   const { DeleteObjectsCommand, ListObjectsV2Command } = await loadS3Module(accessor.config)
   const raw = rawPathOf(path)
-  const pfx = s3Prefix(raw)
+  const pfx = s3Prefix(raw, accessor.config)
   await withClient(accessor.config, async (client) => {
     let continuationToken: string | undefined
     do {

--- a/typescript/packages/core/src/core/s3/stat.ts
+++ b/typescript/packages/core/src/core/s3/stat.ts
@@ -85,7 +85,7 @@ export async function stat(
   try {
     if (hintsDirectory) {
       // Skip HeadObject — caller already said it's a directory.
-      const pfx = s3Key(rawPath).replace(/\/+$/, '') + '/'
+      const pfx = s3Key(rawPath, config).replace(/\/+$/, '') + '/'
       const listResp = (await send(
         new ListObjectsV2Command({
           Bucket: config.bucket,
@@ -104,7 +104,7 @@ export async function stat(
 
     try {
       const resp = (await send(
-        new HeadObjectCommand({ Bucket: config.bucket, Key: s3Key(rawPath) }),
+        new HeadObjectCommand({ Bucket: config.bucket, Key: s3Key(rawPath, config) }),
       )) as {
         ContentLength?: number
         LastModified?: Date
@@ -129,7 +129,7 @@ export async function stat(
     }
 
     // Not a file — probe for directory prefix.
-    const pfx = s3Key(rawPath).replace(/\/+$/, '') + '/'
+    const pfx = s3Key(rawPath, config).replace(/\/+$/, '') + '/'
     const listResp = (await send(
       new ListObjectsV2Command({
         Bucket: config.bucket,

--- a/typescript/packages/core/src/core/s3/stream.ts
+++ b/typescript/packages/core/src/core/s3/stream.ts
@@ -36,7 +36,7 @@ export async function* stream(accessor: S3Accessor, path: PathSpec): AsyncIterab
   ).send.bind(client)
 
   const pinnedRevision = revisionFor(virtual)
-  const input: Record<string, unknown> = { Bucket: config.bucket, Key: s3Key(rawPath) }
+  const input: Record<string, unknown> = { Bucket: config.bucket, Key: s3Key(rawPath, config) }
   if (pinnedRevision !== null) input.VersionId = pinnedRevision
 
   // Use virtual (mount-prefixed) path so the record stays correct even

--- a/typescript/packages/core/src/core/s3/truncate.ts
+++ b/typescript/packages/core/src/core/s3/truncate.ts
@@ -30,7 +30,7 @@ export async function truncate(
 ): Promise<void> {
   const { GetObjectCommand, PutObjectCommand } = await loadS3Module(accessor.config)
   const raw = rawPathOf(path)
-  const key = s3Key(raw)
+  const key = s3Key(raw, accessor.config)
   await withClient(accessor.config, async (client) => {
     let existing: Uint8Array = new Uint8Array()
     try {

--- a/typescript/packages/core/src/core/s3/unlink.ts
+++ b/typescript/packages/core/src/core/s3/unlink.ts
@@ -23,7 +23,7 @@ export async function unlink(accessor: S3Accessor, path: PathSpec): Promise<void
     await client.send(
       new DeleteObjectCommand({
         Bucket: accessor.config.bucket,
-        Key: s3Key(raw),
+        Key: s3Key(raw, accessor.config),
       }),
     )
   })

--- a/typescript/packages/core/src/core/s3/write.ts
+++ b/typescript/packages/core/src/core/s3/write.ts
@@ -23,7 +23,7 @@ export async function write(accessor: S3Accessor, path: PathSpec, data: Uint8Arr
     await client.send(
       new PutObjectCommand({
         Bucket: accessor.config.bucket,
-        Key: s3Key(raw),
+        Key: s3Key(raw, accessor.config),
         Body: data,
       }),
     )

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -440,6 +440,7 @@ export { expandTestExpr } from './workspace/node/test_expr.ts'
 export { executeNode, type ExecuteNodeDeps } from './workspace/node/execute_node.ts'
 export { S3Accessor, type S3ResourceLike } from './accessor/s3.ts'
 export {
+  normalizeKeyPrefix,
   redactConfig as redactS3Config,
   type S3BrowserOperation,
   type S3BrowserPresignedUrlProvider,

--- a/typescript/packages/core/src/resource/s3/config.ts
+++ b/typescript/packages/core/src/resource/s3/config.ts
@@ -47,6 +47,14 @@ export interface S3Config {
   presignedUrlProvider?: S3BrowserPresignedUrlProvider
   /** Optional default Content-Type for PUT via the presigner path. */
   defaultContentType?: string
+  /** Optional key prefix applied to all S3 paths. Leading slashes stripped; trailing slash enforced. */
+  keyPrefix?: string
+}
+
+export function normalizeKeyPrefix(v: string | undefined): string | undefined {
+  if (v === undefined || v === '') return undefined
+  const stripped = v.replace(/^\/+/, '')
+  return stripped.endsWith('/') ? stripped : `${stripped}/`
 }
 
 export interface S3ConfigRedacted extends Omit<

--- a/typescript/packages/core/src/resource/s3/config.ts
+++ b/typescript/packages/core/src/resource/s3/config.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import * as kp from '../../utils/key_prefix.ts'
+
 export type S3BrowserOperation = 'GET' | 'PUT' | 'HEAD' | 'DELETE' | 'LIST' | 'COPY'
 
 export interface S3BrowserSignOptions {
@@ -52,9 +54,8 @@ export interface S3Config {
 }
 
 export function normalizeKeyPrefix(v: string | undefined): string | undefined {
-  if (v === undefined || v === '') return undefined
-  const stripped = v.replace(/^\/+/, '')
-  return stripped.endsWith('/') ? stripped : `${stripped}/`
+  const out = kp.normalize(v)
+  return out === '' ? undefined : out
 }
 
 export interface S3ConfigRedacted extends Omit<

--- a/typescript/packages/core/src/utils/key_prefix.ts
+++ b/typescript/packages/core/src/utils/key_prefix.ts
@@ -1,0 +1,38 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+/** Normalize a key prefix: empty/undefined → '', strip leading /, ensure trailing /. */
+export function normalize(raw: string | undefined): string {
+  if (raw === undefined || raw === '') return ''
+  const stripped = raw.replace(/^\/+/, '')
+  return stripped.endsWith('/') ? stripped : `${stripped}/`
+}
+
+/** Prepend a normalized prefix to a virtual path. */
+export function apply(prefix: string, path: string): string {
+  return prefix + path.replace(/^\/+/, '')
+}
+
+/** Same as apply() but guarantees a trailing slash for LIST-style ops. */
+export function applyDir(prefix: string, path: string): string {
+  const key = apply(prefix, path)
+  if (key === '' || key.endsWith('/')) return key
+  return `${key}/`
+}
+
+/** Strip a normalized prefix from a backend-returned key. */
+export function strip(prefix: string, key: string): string {
+  if (prefix !== '' && key.startsWith(prefix)) return key.slice(prefix.length)
+  return key
+}

--- a/typescript/packages/node/src/resource/s3/config.ts
+++ b/typescript/packages/node/src/resource/s3/config.ts
@@ -62,6 +62,7 @@ export function normalizeS3Config(input: Record<string, unknown>): S3Config {
       endpoint_url: 'endpoint',
       path_style: 'forcePathStyle',
       timeout: 'timeoutMs',
+      key_prefix: 'keyPrefix',
     },
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),

--- a/typescript/packages/node/src/resource/s3/key_prefix.test.ts
+++ b/typescript/packages/node/src/resource/s3/key_prefix.test.ts
@@ -1,0 +1,146 @@
+import { PathSpec, normalizeKeyPrefix } from '@struktoai/mirage-core'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { S3Resource } from './s3.ts'
+import { installS3Mock, S3MockStore, type S3Mock } from './mock.ts'
+
+const BUCKET = 'prefix-test-bucket'
+const PREFIX = 'users/abc/'
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+function mkPath(original: string): PathSpec {
+  return new PathSpec({ original, directory: original, prefix: '' })
+}
+
+describe('normalizeKeyPrefix', () => {
+  it('returns undefined for empty string', () => {
+    expect(normalizeKeyPrefix('')).toBeUndefined()
+  })
+
+  it('appends trailing slash to prefix without one', () => {
+    expect(normalizeKeyPrefix('users/abc')).toBe('users/abc/')
+  })
+
+  it('strips leading slash and normalizes trailing slash', () => {
+    expect(normalizeKeyPrefix('/users/abc/')).toBe('users/abc/')
+  })
+})
+
+describe('S3Resource constructor with keyPrefix', () => {
+  it('does not set keyPrefix when not provided', () => {
+    const res = new S3Resource({ bucket: BUCKET })
+    expect(res.config.keyPrefix).toBeUndefined()
+  })
+
+  it('normalizes keyPrefix on construction', () => {
+    const res = new S3Resource({ bucket: BUCKET, keyPrefix: '/users/abc/' })
+    expect(res.config.keyPrefix).toBe('users/abc/')
+  })
+})
+
+describe('S3Resource operations with keyPrefix (mocked)', () => {
+  let resource: S3Resource
+  let mock: S3Mock
+  let store: S3MockStore
+
+  beforeAll(() => {
+    store = new S3MockStore()
+    mock = installS3Mock(store)
+    resource = new S3Resource({ bucket: BUCKET, keyPrefix: PREFIX })
+  })
+
+  afterEach(() => {
+    store.objects(BUCKET).clear()
+  })
+
+  afterAll(() => {
+    mock.restore()
+  })
+
+  it('write stores object under prefixed bucket key', async () => {
+    await resource.writeFile(mkPath('/b.txt'), ENC.encode('hello'))
+    expect(store.has(BUCKET, 'users/abc/b.txt')).toBe(true)
+  })
+
+  it('read retrieves content via user path (prefix-free)', async () => {
+    store.set(BUCKET, 'users/abc/r.txt', ENC.encode('world'))
+    const bytes = await resource.readFile(mkPath('/r.txt'))
+    expect(DEC.decode(bytes)).toBe('world')
+  })
+
+  it('stat resolves object under prefixed key', async () => {
+    store.set(BUCKET, 'users/abc/s.txt', ENC.encode('sized'))
+    const s = await resource.stat(mkPath('/s.txt'))
+    expect(s.size).toBe(5)
+  })
+
+  it('exists returns true for prefixed key', async () => {
+    store.set(BUCKET, 'users/abc/e.txt', ENC.encode('x'))
+    expect(await resource.exists(mkPath('/e.txt'))).toBe(true)
+  })
+
+  it('exists returns false when key not present', async () => {
+    expect(await resource.exists(mkPath('/missing.txt'))).toBe(false)
+  })
+
+  it('readdir returns prefix-free user paths and stores under prefixed keys', async () => {
+    store.set(BUCKET, 'users/abc/dir/a.txt', ENC.encode('a'))
+    store.set(BUCKET, 'users/abc/dir/b.txt', ENC.encode('b'))
+    const dirPath = new PathSpec({ original: '/dir/', directory: '/dir/', prefix: '' })
+    const entries = await resource.readdir(dirPath)
+    for (const entry of entries) {
+      expect(entry).not.toContain(PREFIX)
+    }
+    expect(entries.sort()).toEqual(['/dir/a.txt', '/dir/b.txt'])
+  })
+
+  it('glob resolves entries without keyPrefix in returned paths', async () => {
+    store.set(BUCKET, 'users/abc/gdir/x.txt', ENC.encode('x'))
+    store.set(BUCKET, 'users/abc/gdir/y.md', ENC.encode('y'))
+    const globPath = new PathSpec({
+      original: '/gdir/*.txt',
+      directory: '/gdir/',
+      pattern: '*.txt',
+      resolved: false,
+      prefix: '',
+    })
+    const results = await resource.glob([globPath])
+    expect(results.length).toBe(1)
+    expect(results[0]?.original).toBe('/gdir/x.txt')
+    expect(results[0]?.original).not.toContain(PREFIX)
+  })
+
+  it('copy stores destination under prefixed bucket key', async () => {
+    store.set(BUCKET, 'users/abc/src.txt', ENC.encode('copy me'))
+    await resource.copy(mkPath('/src.txt'), mkPath('/dst.txt'))
+    expect(store.has(BUCKET, 'users/abc/dst.txt')).toBe(true)
+    expect(DEC.decode(store.get(BUCKET, 'users/abc/dst.txt') ?? new Uint8Array())).toBe('copy me')
+  })
+
+  it('rename moves object to new prefixed key and removes old', async () => {
+    store.set(BUCKET, 'users/abc/mv_src.txt', ENC.encode('moving'))
+    await resource.rename(mkPath('/mv_src.txt'), mkPath('/mv_dst.txt'))
+    expect(store.has(BUCKET, 'users/abc/mv_dst.txt')).toBe(true)
+    expect(store.has(BUCKET, 'users/abc/mv_src.txt')).toBe(false)
+  })
+
+  it('unlink removes object at prefixed key', async () => {
+    store.set(BUCKET, 'users/abc/del.txt', ENC.encode('doomed'))
+    await resource.unlink(mkPath('/del.txt'))
+    expect(store.has(BUCKET, 'users/abc/del.txt')).toBe(false)
+  })
+})
+
+describe('S3Resource getState with keyPrefix', () => {
+  it('getState config includes keyPrefix value', async () => {
+    const res = new S3Resource({ bucket: BUCKET, keyPrefix: 'users/abc/' })
+    const state = await res.getState()
+    expect(state.config.keyPrefix).toBe('users/abc/')
+  })
+
+  it('redactedFields does not include keyPrefix', async () => {
+    const res = new S3Resource({ bucket: BUCKET, keyPrefix: 'users/abc/' })
+    const state = await res.getState()
+    expect(state.redactedFields).not.toContain('keyPrefix')
+  })
+})

--- a/typescript/packages/node/src/resource/s3/s3.ts
+++ b/typescript/packages/node/src/resource/s3/s3.ts
@@ -23,6 +23,7 @@ import {
   find as findCore,
   type IndexCacheStore,
   mkdir as mkdirCore,
+  normalizeKeyPrefix,
   PathSpec,
   RAMIndexCacheStore,
   rangeRead as rangeReadCore,
@@ -86,7 +87,14 @@ export class S3Resource implements Resource {
   }
 
   constructor(config: S3Config) {
-    this.config = config
+    const normalized = normalizeKeyPrefix(config.keyPrefix)
+    const cfg: S3Config = { ...config }
+    if (normalized !== undefined) {
+      cfg.keyPrefix = normalized
+    } else {
+      delete cfg.keyPrefix
+    }
+    this.config = cfg
     this.accessor = new S3Accessor(this.config)
     this.index = new RAMIndexCacheStore({ ttl: this.indexTtl })
   }


### PR DESCRIPTION
## Summary

Adds an opt-in `key_prefix` (Python) / `keyPrefix` (TypeScript) config field to `S3Resource` so multi-tenant systems can transparently scope each tenant to a bucket subpath without leaking the prefix into agent-visible paths.

Refs #59

## Motivation

Building a multi-tenant product on Mirage today requires either:

- one bucket per tenant (hits AWS bucket limits at scale — 100 default, 1000 hard cap), or
- each tenant gets full bucket access via STS, but then the agent has to know about its own tenant ID in every path.

Neither is ideal. A native `key_prefix` lets the agent see clean paths like `/data/notes.md` while operations under the hood touch `s3://bucket/scope-a/notes.md`. STS policies still enforce isolation at the AWS layer.

## Changes

- `S3Config` gains `key_prefix: str | None` (Python) / `keyPrefix?: string` (TypeScript).
- Normalization at config construction: leading slashes stripped, trailing slash enforced, empty string treated as unset.
- Field threaded through the existing `_key` / `_prefix` (Python) and `s3Key` / `s3Prefix` (TypeScript) utility helpers. `S3Accessor` stays a thin config holder; no architectural refactor.
- `readdir` and `find` strip the prefix from S3-returned keys before building user-facing entries, preventing leakage into the agent's view.
- `get_state` / `getState` includes `key_prefix` (identity, not credential — intentionally not in `redacted_fields`).
- TypeScript YAML configs accept the snake-case `key_prefix` alias, auto-mapped to `keyPrefix`.
- Tests for every op (read, write, readdir, glob, stat, exists, copy, rename, unlink, get_state) with prefix set and unset, plus normalization tests.
- Docs updated in `docs/python/resource/s3.mdx`, `docs/typescript/setup/s3.mdx`, and `docs/home/setup/s3.mdx`.

## Browser variant

`mirage-browser`'s `S3Resource` (presigned-URL flow) inherits the field through the shared core config. The docs add a security note that for browser flows, prefix scoping must be enforced server-side in the `presignedUrlProvider` implementation and the backing IAM/STS session policy — the client-side `keyPrefix` is ergonomics only, not a security boundary.

## Backwards compatibility

`key_prefix` defaults to `None` / `undefined`. With it unset, behavior is byte-identical to before this PR. All existing tests pass without modification.

## Security note

`key_prefix` is a path-scoping convenience, not a security boundary. For real isolation, pair with STS AssumeRole session policies that constrain the AWS-side credentials to the same prefix. The docs section explains this pairing.

## Test plan

- [x] Python: `cd python && uv run pytest tests/core/s3` — 22 passed
- [x] TypeScript: `pnpm --filter @struktoai/mirage-node test -- --run src/resource/s3` — 1286 passed
- [x] TypeScript: `pnpm typecheck` — clean across all packages
- [x] Lint/format: `pre-commit run --all-files` — clean
- [ ] Maintainer review