### PR TITLE
feat: add Databricks volume resource

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -224,7 +224,8 @@
                   "python/resource/r2",
                   "python/resource/gcs",
                   "python/resource/supabase",
-                  "python/resource/oci"
+                  "python/resource/oci",
+                  "python/resource/databricks_volume"
                 ]
               },
               {

--- a/docs/home/resource-matrix.mdx
+++ b/docs/home/resource-matrix.mdx
@@ -33,6 +33,7 @@ No external setup, these run locally or against a connection string you already 
 | GCS | read, write | [GCS](/home/setup/gcs) | [<Icon icon="python" />](/python/resource/gcs) [<Icon icon="node-js" />](/typescript/setup/gcs) [<Icon icon="globe" />](/typescript/setup/gcs) | GCP object storage |
 | OCI | read, write | [OCI](/home/setup/oci) | [<Icon icon="python" />](/python/resource/oci) [<Icon icon="node-js" />](/typescript/setup/oci) [<Icon icon="globe" />](/typescript/setup/oci) | Oracle object storage |
 | Supabase | read, write | [Supabase](/home/setup/supabase) | [<Icon icon="python" />](/python/resource/supabase) [<Icon icon="node-js" />](/typescript/setup/supabase) [<Icon icon="globe" />](/typescript/setup/supabase) | Storage-oriented workflows |
+| Databricks Volume | read, write | | [<Icon icon="python" />](/python/resource/databricks_volume) | Unity Catalog volume files |
 
 ## Google Workspace
 

--- a/docs/python/resource/databricks_volume.mdx
+++ b/docs/python/resource/databricks_volume.mdx
@@ -1,0 +1,78 @@
+---
+title: Databricks Volume
+icon: database
+---
+
+The Databricks Volume resource mounts a Unity Catalog volume into a Mirage
+workspace. It uses the Databricks SDK `WorkspaceClient.files` API and maps
+workspace paths to `/Volumes/<catalog>/<schema>/<volume>/...`.
+
+Install the optional dependency:
+
+```bash
+pip install "mirage-ai[databricks]"
+```
+
+## Config
+
+```python
+from mirage import MountMode, Workspace
+from mirage.resource.databricks_volume import (
+    DatabricksVolumeConfig,
+    DatabricksVolumeResource,
+)
+
+resource = DatabricksVolumeResource(
+    DatabricksVolumeConfig(
+        catalog="main",
+        schema="default",
+        volume="agent_files",
+    )
+)
+
+ws = Workspace({"/volume": resource}, mode=MountMode.READ)
+data = await ws.ops.read("/volume/reports/latest.md")
+```
+
+By default, `WorkspaceClient()` uses Databricks SDK unified authentication.
+This works in Databricks Apps and other environments where Databricks
+authentication is already configured.
+
+For explicit personal access token auth:
+
+```python
+import os
+
+resource = DatabricksVolumeResource(
+    DatabricksVolumeConfig(
+        catalog="main",
+        schema="default",
+        volume="agent_files",
+        host=os.environ["DATABRICKS_HOST"],
+        token=os.environ["DATABRICKS_TOKEN"],
+    )
+)
+```
+
+## Filesystem Layout
+
+If the Databricks volume path contains:
+
+```text
+/Volumes/main/default/agent_files/reports/latest.md
+/Volumes/main/default/agent_files/uploads/data.csv
+```
+
+Then mounting at `/volume` exposes:
+
+```text
+/volume/
+  reports/
+    latest.md
+  uploads/
+    data.csv
+```
+
+The resource supports Mirage workspace ops for reading, writing, listing,
+metadata, directory creation, file deletion, directory deletion, create,
+append, truncate, and file rename.

--- a/docs/python/resource/index.mdx
+++ b/docs/python/resource/index.mdx
@@ -20,6 +20,7 @@ Each page describes a Python-supported resource: what config it needs, what the 
 - [GCS](/python/resource/gcs)
 - [OCI](/python/resource/oci)
 - [Supabase](/python/resource/supabase)
+- [Databricks Volume](/python/resource/databricks_volume)
 
 ## Google Workspace
 

--- a/python/mirage/accessor/databricks_volume.py
+++ b/python/mirage/accessor/databricks_volume.py
@@ -1,0 +1,31 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from typing import TYPE_CHECKING, Any
+
+from mirage.accessor.base import Accessor
+
+if TYPE_CHECKING:
+    from mirage.resource.databricks_volume.config import DatabricksVolumeConfig
+
+
+class DatabricksVolumeAccessor(Accessor):
+
+    def __init__(self, config: "DatabricksVolumeConfig", client: Any) -> None:
+        self.config = config
+        self.client = client
+
+    @property
+    def files(self) -> Any:
+        return self.client.files

--- a/python/mirage/core/databricks_volume/__init__.py
+++ b/python/mirage/core/databricks_volume/__init__.py
@@ -1,0 +1,13 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========

--- a/python/mirage/core/databricks_volume/files.py
+++ b/python/mirage/core/databricks_volume/files.py
@@ -1,0 +1,335 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+from datetime import datetime, timezone
+from io import BytesIO
+from typing import Any
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore, IndexEntry
+from mirage.types import FileStat, FileType, PathSpec
+from mirage.utils.filetype import filetype_from_mimetype, guess_type
+
+
+def _base_path(accessor: DatabricksVolumeAccessor) -> str:
+    cfg = accessor.config
+    return f"/Volumes/{cfg.catalog}/{cfg.schema}/{cfg.volume}"
+
+
+def _path_value(path: PathSpec | str) -> str:
+    if isinstance(path, str):
+        return path
+    return path.strip_prefix
+
+
+def _relative_parts(path: PathSpec | str) -> list[str]:
+    raw = _path_value(path)
+    parts = [p for p in raw.replace("\\", "/").split("/") if p and p != "."]
+    if any(p == ".." for p in parts):
+        raise ValueError(f"path escapes Databricks volume root: {raw!r}")
+    return parts
+
+
+def _remote_path(accessor: DatabricksVolumeAccessor,
+                 path: PathSpec | str) -> str:
+    parts = _relative_parts(path)
+    base = _base_path(accessor)
+    return base if not parts else f"{base}/{'/'.join(parts)}"
+
+
+def _virtual_path(accessor: DatabricksVolumeAccessor, remote_path: str,
+                  prefix: str) -> str:
+    base = _base_path(accessor)
+    rel = remote_path[len(base):].strip("/") if remote_path.startswith(
+        base) else remote_path.strip("/")
+    virtual = "/" + rel if rel else "/"
+    if not prefix:
+        return virtual
+    mount = prefix.rstrip("/")
+    return mount if virtual == "/" else mount + virtual
+
+
+def _name(path: str) -> str:
+    return path.rstrip("/").rsplit("/", 1)[-1] or "/"
+
+
+def _modified_from_millis(value: int | None) -> str:
+    if value is None:
+        return ""
+    return datetime.fromtimestamp(value / 1000, tz=timezone.utc).isoformat()
+
+
+def _is_not_found(exc: Exception) -> bool:
+    status_code = getattr(exc, "status_code", None)
+    if status_code == 404:
+        return True
+    error_code = getattr(exc, "error_code", None)
+    if error_code in {"RESOURCE_DOES_NOT_EXIST", "NOT_FOUND"}:
+        return True
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        code = response.get("Error", {}).get("Code")
+        if code in {"404", "NoSuchKey", "NotFound"}:
+            return True
+    message = str(exc)
+    return ("RESOURCE_DOES_NOT_EXIST" in message or "NOT_FOUND" in message
+            or "404" in message)
+
+
+def _download_all(files: Any, remote_path: str) -> bytes:
+    resp = files.download(remote_path)
+    contents = resp.contents
+    if contents is None:
+        return b""
+    if hasattr(contents, "__enter__"):
+        with contents as stream:
+            data = stream.read()
+    else:
+        data = contents.read()
+    return data if isinstance(data, bytes) else bytes(data)
+
+
+def _metadata_fingerprint(modified: str | None,
+                          size: int | None) -> str | None:
+    if not modified and size is None:
+        return None
+    return f"{modified or ''}:{size or 0}"
+
+
+def _file_stat_from_metadata(path: str, metadata: Any) -> FileStat:
+    content_type = getattr(metadata, "content_type", None)
+    ftype = guess_type(path)
+    if ftype == FileType.BINARY and content_type:
+        ftype = filetype_from_mimetype(content_type)
+    size = getattr(metadata, "content_length", None)
+    modified = getattr(metadata, "last_modified", None)
+    return FileStat(
+        name=_name(path),
+        size=size,
+        modified=modified,
+        fingerprint=_metadata_fingerprint(modified, size),
+        type=ftype,
+        extra={"content_type": content_type} if content_type else {},
+    )
+
+
+def _entry_to_index(entry: Any) -> tuple[str, IndexEntry]:
+    name = entry.name or _name(entry.path or "")
+    is_directory = bool(getattr(entry, "is_directory", False))
+    modified = _modified_from_millis(getattr(entry, "last_modified", None))
+    idx_entry = IndexEntry(
+        id=entry.path or name,
+        name=name,
+        resource_type="folder" if is_directory else "file",
+        remote_time=modified,
+        size=getattr(entry, "file_size", None),
+        extra={"path": entry.path},
+    )
+    return name, idx_entry
+
+
+async def read_bytes(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    index: IndexCacheStore | None = None,
+    offset: int = 0,
+    size: int | None = None,
+) -> bytes:
+    remote = _remote_path(accessor, path)
+    try:
+        data = await asyncio.to_thread(_download_all, accessor.files, remote)
+    except Exception as exc:
+        if _is_not_found(exc):
+            raise FileNotFoundError(_path_value(path))
+        raise
+    if offset or size is not None:
+        end = offset + size if size is not None else None
+        data = data[offset:end]
+    return data
+
+
+async def write_bytes(accessor: DatabricksVolumeAccessor, path: PathSpec,
+                      data: bytes) -> None:
+    remote = _remote_path(accessor, path)
+    await asyncio.to_thread(accessor.files.upload,
+                            remote,
+                            BytesIO(data),
+                            overwrite=True)
+
+
+async def append_bytes(accessor: DatabricksVolumeAccessor, path: PathSpec,
+                       data: bytes) -> None:
+    try:
+        current = await read_bytes(accessor, path)
+    except FileNotFoundError:
+        current = b""
+    await write_bytes(accessor, path, current + data)
+
+
+async def readdir(accessor: DatabricksVolumeAccessor, path: PathSpec,
+                  index: IndexCacheStore | None) -> list[str]:
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    list_path = path.directory if path.pattern else path.original
+    scope = PathSpec(original=list_path,
+                     directory=list_path,
+                     pattern=path.pattern,
+                     prefix=path.prefix)
+    virtual_key = list_path.rstrip("/") or "/"
+    if index is not None:
+        listing = await index.list_dir(virtual_key)
+        if listing.entries is not None:
+            return listing.entries
+
+    remote = _remote_path(accessor, scope)
+    try:
+        entries = await asyncio.to_thread(
+            lambda: list(accessor.files.list_directory_contents(remote)))
+    except Exception as exc:
+        if _is_not_found(exc):
+            raise FileNotFoundError(list_path)
+        raise
+
+    children: list[tuple[str, str, IndexEntry]] = []
+    for entry in entries:
+        entry_path = entry.path or f"{remote.rstrip('/')}/{entry.name}"
+        virtual = _virtual_path(accessor, entry_path, path.prefix)
+        name, idx_entry = _entry_to_index(entry)
+        children.append((virtual, name, idx_entry))
+    children.sort(key=lambda item: item[0])
+    result = [virtual for virtual, _, _ in children]
+    if index is not None:
+        index_entries = [(name, entry) for _, name, entry in children]
+        await index.set_dir(virtual_key, index_entries)
+    return result
+
+
+async def stat(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    index: IndexCacheStore | None = None,
+) -> FileStat:
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    if not _relative_parts(path):
+        return FileStat(name="/", type=FileType.DIRECTORY)
+
+    if index is not None:
+        lookup = await index.get(path.original)
+        if lookup.entry is not None:
+            entry = lookup.entry
+            if entry.resource_type == "folder":
+                return FileStat(name=entry.name, type=FileType.DIRECTORY)
+            fingerprint = _metadata_fingerprint(entry.remote_time, entry.size)
+            return FileStat(
+                name=entry.name,
+                size=entry.size,
+                modified=entry.remote_time or None,
+                fingerprint=fingerprint,
+                type=guess_type(entry.name),
+                extra=entry.extra,
+            )
+
+    remote = _remote_path(accessor, path)
+    try:
+        metadata = await asyncio.to_thread(accessor.files.get_metadata, remote)
+        return _file_stat_from_metadata(path.original, metadata)
+    except Exception as exc:
+        if not _is_not_found(exc):
+            raise
+
+    try:
+        await asyncio.to_thread(accessor.files.get_directory_metadata, remote)
+    except Exception as exc:
+        if _is_not_found(exc):
+            raise FileNotFoundError(path.original)
+        raise
+    return FileStat(name=_name(path.original), type=FileType.DIRECTORY)
+
+
+async def mkdir(accessor: DatabricksVolumeAccessor, path: PathSpec) -> None:
+    await asyncio.to_thread(accessor.files.create_directory,
+                            _remote_path(accessor, path))
+
+
+async def unlink(accessor: DatabricksVolumeAccessor, path: PathSpec) -> None:
+    remote = _remote_path(accessor, path)
+    try:
+        await asyncio.to_thread(accessor.files.delete, remote)
+    except Exception as exc:
+        if _is_not_found(exc):
+            raise FileNotFoundError(_path_value(path))
+        raise
+
+
+async def rmdir(accessor: DatabricksVolumeAccessor, path: PathSpec) -> None:
+    remote = _remote_path(accessor, path)
+    try:
+        await asyncio.to_thread(accessor.files.delete_directory, remote)
+    except Exception as exc:
+        if _is_not_found(exc):
+            raise FileNotFoundError(_path_value(path))
+        raise
+
+
+async def create(accessor: DatabricksVolumeAccessor, path: PathSpec) -> None:
+    remote = _remote_path(accessor, path)
+    await asyncio.to_thread(accessor.files.upload,
+                            remote,
+                            BytesIO(b""),
+                            overwrite=False)
+
+
+async def truncate(accessor: DatabricksVolumeAccessor, path: PathSpec,
+                   length: int) -> None:
+    try:
+        data = await read_bytes(accessor, path)
+    except FileNotFoundError:
+        data = b""
+    await write_bytes(accessor, path, data[:length].ljust(length, b"\0"))
+
+
+async def exists(accessor: DatabricksVolumeAccessor, path: PathSpec) -> bool:
+    try:
+        await stat(accessor, path)
+        return True
+    except FileNotFoundError:
+        return False
+
+
+async def rename(accessor: DatabricksVolumeAccessor, src: PathSpec,
+                 dst: PathSpec) -> None:
+    source_stat = await stat(accessor, src)
+    if source_stat.type == FileType.DIRECTORY:
+        raise IsADirectoryError(src.original)
+    data = await read_bytes(accessor, src)
+    await write_bytes(accessor, dst, data)
+    await unlink(accessor, src)
+
+
+async def rm_r(accessor: DatabricksVolumeAccessor, path: PathSpec) -> None:
+    try:
+        entries = await readdir(accessor, path, index=None)
+    except FileNotFoundError:
+        await unlink(accessor, path)
+        return
+    for entry in entries:
+        child = PathSpec.from_str_path(entry, path.prefix)
+        child_stat = await stat(accessor, child)
+        if child_stat.type == FileType.DIRECTORY:
+            await rm_r(accessor, child)
+        else:
+            await unlink(accessor, child)
+    await rmdir(accessor, path)

--- a/python/mirage/core/databricks_volume/glob.py
+++ b/python/mirage/core/databricks_volume/glob.py
@@ -1,0 +1,57 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import fnmatch
+import logging
+import posixpath
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume.files import readdir
+from mirage.types import PathSpec
+
+logger = logging.getLogger(__name__)
+SCOPE_ERROR = 5000
+
+
+async def resolve_glob(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    index: IndexCacheStore,
+) -> list[PathSpec]:
+    result: list[PathSpec] = []
+    for p in paths:
+        if isinstance(p, str):
+            result.append(PathSpec(original=p, directory=posixpath.dirname(p)))
+            continue
+        if p.resolved:
+            result.append(p)
+        elif p.pattern:
+            entries = await readdir(accessor, p.dir, index)
+            matched = [
+                PathSpec.from_str_path(e, p.prefix) for e in entries
+                if fnmatch.fnmatch(e.rsplit("/", 1)[-1], p.pattern)
+            ]
+            if len(matched) > SCOPE_ERROR:
+                logger.warning(
+                    "%s: %d matches exceeds limit (%d), truncating",
+                    p.directory,
+                    len(matched),
+                    SCOPE_ERROR,
+                )
+                matched = matched[:SCOPE_ERROR]
+            result.extend(matched)
+        else:
+            result.append(p)
+    return result

--- a/python/mirage/ops/databricks_volume/__init__.py
+++ b/python/mirage/ops/databricks_volume/__init__.py
@@ -1,0 +1,114 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.core.databricks_volume.files import append_bytes, create
+from mirage.core.databricks_volume.files import mkdir as mkdir_impl
+from mirage.core.databricks_volume.files import read_bytes, readdir
+from mirage.core.databricks_volume.files import rename as rename_impl
+from mirage.core.databricks_volume.files import rmdir as rmdir_impl
+from mirage.core.databricks_volume.files import stat as stat_impl
+from mirage.core.databricks_volume.files import truncate as truncate_impl
+from mirage.core.databricks_volume.files import unlink as unlink_impl
+from mirage.core.databricks_volume.files import write_bytes
+from mirage.ops.registry import op
+from mirage.types import FileStat, PathSpec
+
+
+@op("read", resource="databricks_volume")
+async def read(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    offset: int = 0,
+    size: int | None = None,
+    *,
+    index,
+    **kwargs,
+) -> bytes:
+    return await read_bytes(accessor, path, index, offset, size)
+
+
+@op("write", resource="databricks_volume", write=True)
+async def write(accessor: DatabricksVolumeAccessor, path: PathSpec,
+                data: bytes, **kwargs) -> None:
+    await write_bytes(accessor, path, data)
+
+
+@op("append", resource="databricks_volume", write=True)
+async def append(accessor: DatabricksVolumeAccessor, path: PathSpec,
+                 data: bytes, **kwargs) -> None:
+    await append_bytes(accessor, path, data)
+
+
+@op("readdir", resource="databricks_volume")
+async def list_dir(accessor: DatabricksVolumeAccessor, path: PathSpec, *,
+                   index, **kwargs) -> list[str]:
+    return await readdir(accessor, path, index)
+
+
+@op("stat", resource="databricks_volume")
+async def stat(accessor: DatabricksVolumeAccessor, path: PathSpec, *, index,
+               **kwargs) -> FileStat:
+    return await stat_impl(accessor, path, index)
+
+
+@op("mkdir", resource="databricks_volume", write=True)
+async def mkdir(accessor: DatabricksVolumeAccessor, path: PathSpec,
+                **kwargs) -> None:
+    await mkdir_impl(accessor, path)
+
+
+@op("unlink", resource="databricks_volume", write=True)
+async def unlink(accessor: DatabricksVolumeAccessor, path: PathSpec,
+                 **kwargs) -> None:
+    await unlink_impl(accessor, path)
+
+
+@op("rmdir", resource="databricks_volume", write=True)
+async def rmdir(accessor: DatabricksVolumeAccessor, path: PathSpec,
+                **kwargs) -> None:
+    await rmdir_impl(accessor, path)
+
+
+@op("create", resource="databricks_volume", write=True)
+async def create_file(accessor: DatabricksVolumeAccessor, path: PathSpec,
+                      **kwargs) -> None:
+    await create(accessor, path)
+
+
+@op("truncate", resource="databricks_volume", write=True)
+async def truncate(accessor: DatabricksVolumeAccessor, path: PathSpec,
+                   length: int, **kwargs) -> None:
+    await truncate_impl(accessor, path, length)
+
+
+@op("rename", resource="databricks_volume", write=True)
+async def rename(accessor: DatabricksVolumeAccessor, src: PathSpec,
+                 dst: PathSpec) -> None:
+    await rename_impl(accessor, src, dst)
+
+
+OPS = [
+    append,
+    create_file,
+    list_dir,
+    mkdir,
+    read,
+    rename,
+    rmdir,
+    stat,
+    truncate,
+    unlink,
+    write,
+]

--- a/python/mirage/resource/databricks_volume/__init__.py
+++ b/python/mirage/resource/databricks_volume/__init__.py
@@ -1,0 +1,19 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.resource.databricks_volume.config import DatabricksVolumeConfig
+from mirage.resource.databricks_volume.databricks_volume import \
+    DatabricksVolumeResource
+
+__all__ = ["DatabricksVolumeConfig", "DatabricksVolumeResource"]

--- a/python/mirage/resource/databricks_volume/config.py
+++ b/python/mirage/resource/databricks_volume/config.py
@@ -1,0 +1,41 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class DatabricksVolumeConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
+
+    catalog: str
+    schema_name: str = Field(alias="schema")
+    volume: str
+    host: str | None = None
+    token: str | None = None
+
+    @property
+    def schema(self) -> str:
+        return self.schema_name
+
+    @field_validator("catalog", "schema_name", "volume")
+    @classmethod
+    def _validate_path_component(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError(
+                "Databricks volume path components cannot be empty")
+        if "/" in value or "\\" in value:
+            raise ValueError(
+                "Databricks volume path components cannot contain slashes")
+        return value

--- a/python/mirage/resource/databricks_volume/databricks_volume.py
+++ b/python/mirage/resource/databricks_volume/databricks_volume.py
@@ -1,0 +1,112 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import dataclasses
+from typing import Any
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.core.databricks_volume.files import (append_bytes, create, exists,
+                                                 mkdir, read_bytes, readdir,
+                                                 rename, rm_r, rmdir, stat,
+                                                 truncate, unlink, write_bytes)
+from mirage.core.databricks_volume.glob import resolve_glob as _resolve_glob
+from mirage.ops.databricks_volume import OPS as DATABRICKS_VOLUME_OPS
+from mirage.resource.base import BaseResource
+from mirage.resource.databricks_volume.config import DatabricksVolumeConfig
+from mirage.resource.databricks_volume.prompt import PROMPT
+from mirage.types import PathSpec, ResourceName
+
+_DATABRICKS_VOLUME_OPS = {
+    "read_bytes": read_bytes,
+    "write": write_bytes,
+    "append": append_bytes,
+    "readdir": readdir,
+    "stat": stat,
+    "unlink": unlink,
+    "rmdir": rmdir,
+    "rename": rename,
+    "mkdir": mkdir,
+    "rm_recursive": rm_r,
+    "create": create,
+    "truncate": truncate,
+    "exists": exists,
+}
+
+
+def _workspace_client(config: DatabricksVolumeConfig):
+    try:
+        from databricks.sdk import WorkspaceClient
+    except ImportError:
+        raise ImportError(
+            "DatabricksVolumeResource requires the 'databricks' extra. "
+            "Install with: pip install mirage-ai[databricks]")
+    kwargs = {}
+    if config.host is not None:
+        kwargs["host"] = config.host
+    if config.token is not None:
+        kwargs["token"] = config.token
+    return WorkspaceClient(**kwargs)
+
+
+class DatabricksVolumeResource(BaseResource):
+
+    name: str = ResourceName.DATABRICKS_VOLUME
+    is_remote: bool = True
+    _ops: dict[str, Any] = _DATABRICKS_VOLUME_OPS
+    PROMPT: str = PROMPT
+
+    def __init__(
+        self,
+        config: DatabricksVolumeConfig,
+        client: Any | None = None,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.accessor = DatabricksVolumeAccessor(
+            self.config,
+            client if client is not None else _workspace_client(config))
+        for fn in DATABRICKS_VOLUME_OPS:
+            self.register_op(fn)
+
+    async def resolve_glob(self, paths, prefix: str = ""):
+        if prefix:
+            paths = [
+                dataclasses.replace(p, prefix=prefix)
+                if isinstance(p, PathSpec) and not p.prefix else p
+                for p in paths
+            ]
+        return await _resolve_glob(self.accessor, paths, self._index)
+
+    async def fingerprint(self, path: str) -> str | None:
+        try:
+            remote = await stat(self.accessor, PathSpec.from_str_path(path))
+            return remote.fingerprint
+        except FileNotFoundError:
+            return None
+
+    def get_state(self) -> dict:
+        redacted = ["token"]
+        cfg = self.config.model_dump(by_alias=True)
+        for f in redacted:
+            if cfg.get(f) is not None:
+                cfg[f] = "<REDACTED>"
+        return {
+            "type": self.name,
+            "needs_override": True,
+            "redacted_fields": redacted,
+            "config": cfg,
+        }
+
+    def load_state(self, state: dict) -> None:
+        pass

--- a/python/mirage/resource/databricks_volume/prompt.py
+++ b/python/mirage/resource/databricks_volume/prompt.py
@@ -1,0 +1,15 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+PROMPT = """Databricks volume mount at {prefix}: Unity Catalog volume files are exposed as regular paths."""

--- a/python/mirage/resource/registry.py
+++ b/python/mirage/resource/registry.py
@@ -47,6 +47,9 @@ REGISTRY: dict[str, ResourceEntry] = {
     "gcs":
     ResourceEntry("mirage.resource.gcs:GCSResource",
                   "mirage.resource.gcs:GCSConfig"),
+    "databricks_volume":
+    ResourceEntry("mirage.resource.databricks_volume:DatabricksVolumeResource",
+                  "mirage.resource.databricks_volume:DatabricksVolumeConfig"),
     "github":
     ResourceEntry("mirage.resource.github:GitHubResource",
                   "mirage.resource.github:GitHubConfig"),

--- a/python/mirage/types.py
+++ b/python/mirage/types.py
@@ -109,6 +109,7 @@ class ResourceName(str, Enum):
     REDIS = "redis"
     GITHUB_CI = "github_ci"
     GCS = "gcs"
+    DATABRICKS_VOLUME = "databricks_volume"
     EMAIL = "email"
     PAPERCLIP = "paperclip"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -76,6 +76,7 @@ s3       = ["aioboto3>=13.0"]
 r2       = ["aioboto3>=13.0"]
 gcs      = ["aioboto3>=13.0"]
 oci      = ["aioboto3>=13.0"]
+databricks = ["databricks-sdk>=0.72.0"]
 
 # --- network / remote ---
 ssh      = ["asyncssh>=2.22.0", "paramiko>=4.0.0"]
@@ -137,6 +138,7 @@ all = [
     "mirage-ai[r2]",
     "mirage-ai[gcs]",
     "mirage-ai[oci]",
+    "mirage-ai[databricks]",
     "mirage-ai[ssh]",
     "mirage-ai[fuse]",
     "mirage-ai[mongodb]",

--- a/python/tests/core/databricks_volume/test_files.py
+++ b/python/tests/core/databricks_volume/test_files.py
@@ -1,0 +1,311 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+
+from mirage import MountMode, Workspace
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.core.databricks_volume.files import (create, mkdir, read_bytes,
+                                                 readdir, stat, truncate,
+                                                 unlink, write_bytes)
+from mirage.resource.databricks_volume import (DatabricksVolumeConfig,
+                                               DatabricksVolumeResource)
+from mirage.types import FileType, PathSpec
+
+
+class FakeDatabricksNotFound(Exception):
+
+    status_code = 404
+    error_code = "RESOURCE_DOES_NOT_EXIST"
+
+
+class FakeFilesAPI:
+
+    def __init__(
+        self,
+        files: dict[str, bytes] | None = None,
+        directories: set[str] | None = None,
+    ) -> None:
+        self.files = dict(files or {})
+        self.directories = set(directories or set())
+        self.downloaded: list[str] = []
+        self.uploaded: list[tuple[str, bytes, bool | None]] = []
+        self.created_directories: list[str] = []
+        self.deleted_files: list[str] = []
+        self.deleted_directories: list[str] = []
+
+    def download(self, file_path: str):
+        if file_path not in self.files:
+            raise FakeDatabricksNotFound(file_path)
+        self.downloaded.append(file_path)
+        return SimpleNamespace(contents=BytesIO(self.files[file_path]))
+
+    def upload(self,
+               file_path: str,
+               contents,
+               overwrite: bool | None = None,
+               **kwargs) -> None:
+        data = contents.read()
+        self.files[file_path] = data
+        self.uploaded.append((file_path, data, overwrite))
+
+    def list_directory_contents(self, directory_path: str):
+        if not self._is_directory(directory_path):
+            raise FakeDatabricksNotFound(directory_path)
+
+        prefix = directory_path.rstrip("/") + "/"
+        children: dict[str, SimpleNamespace] = {}
+        for directory in self.directories:
+            if not directory.startswith(prefix):
+                continue
+            rest = directory[len(prefix):]
+            if not rest or "/" in rest:
+                continue
+            children[rest] = SimpleNamespace(
+                name=rest,
+                path=directory,
+                is_directory=True,
+                file_size=None,
+                last_modified=None,
+            )
+        for file_path, data in self.files.items():
+            if not file_path.startswith(prefix):
+                continue
+            rest = file_path[len(prefix):]
+            name = rest.split("/", 1)[0]
+            child_path = prefix + name
+            is_directory = "/" in rest
+            children.setdefault(
+                name,
+                SimpleNamespace(
+                    name=name,
+                    path=child_path,
+                    is_directory=is_directory,
+                    file_size=None if is_directory else len(data),
+                    last_modified=None if is_directory else 1710000000000,
+                ),
+            )
+        return iter(children.values())
+
+    def get_metadata(self, file_path: str):
+        if file_path not in self.files:
+            raise FakeDatabricksNotFound(file_path)
+        return SimpleNamespace(
+            content_length=len(self.files[file_path]),
+            content_type="text/plain",
+            last_modified="Wed, 01 May 2024 12:00:00 GMT",
+        )
+
+    def get_directory_metadata(self, directory_path: str):
+        if not self._is_directory(directory_path):
+            raise FakeDatabricksNotFound(directory_path)
+        return SimpleNamespace()
+
+    def create_directory(self, directory_path: str) -> None:
+        self.directories.add(directory_path.rstrip("/"))
+        self.created_directories.append(directory_path)
+
+    def delete(self, file_path: str) -> None:
+        if file_path not in self.files:
+            raise FakeDatabricksNotFound(file_path)
+        del self.files[file_path]
+        self.deleted_files.append(file_path)
+
+    def delete_directory(self, directory_path: str) -> None:
+        directory_path = directory_path.rstrip("/")
+        if not self._is_directory(directory_path):
+            raise FakeDatabricksNotFound(directory_path)
+        self.directories.discard(directory_path)
+        self.deleted_directories.append(directory_path)
+
+    def _is_directory(self, directory_path: str) -> bool:
+        directory_path = directory_path.rstrip("/")
+        prefix = directory_path + "/"
+        return (directory_path in self.directories
+                or any(path.startswith(prefix) for path in self.files)
+                or any(path.startswith(prefix) for path in self.directories))
+
+
+class FakeWorkspaceClient:
+
+    def __init__(self, files: FakeFilesAPI) -> None:
+        self.files = files
+
+
+def make_accessor(files: FakeFilesAPI) -> DatabricksVolumeAccessor:
+    config = DatabricksVolumeConfig(
+        catalog="main",
+        schema="default",
+        volume="agent_files",
+    )
+    return DatabricksVolumeAccessor(config, FakeWorkspaceClient(files))
+
+
+def test_resource_state_redacts_token_and_keeps_schema_alias():
+    files = FakeFilesAPI()
+    config = DatabricksVolumeConfig(
+        catalog="main",
+        schema="default",
+        volume="agent_files",
+        host="https://example.cloud.databricks.com",
+        token="dapi-token",
+    )
+    resource = DatabricksVolumeResource(config,
+                                        client=FakeWorkspaceClient(files))
+
+    state = resource.get_state()
+
+    assert state["config"]["schema"] == "default"
+    assert "schema_name" not in state["config"]
+    assert state["config"]["token"] == "<REDACTED>"
+
+
+@pytest.mark.asyncio
+async def test_read_maps_virtual_path_to_volume_path():
+    remote_path = "/Volumes/main/default/agent_files/reports/latest.md"
+    files = FakeFilesAPI({remote_path: b"hello"})
+    accessor = make_accessor(files)
+
+    result = await read_bytes(
+        accessor,
+        PathSpec(
+            original="/volume/reports/latest.md",
+            directory="/volume/reports",
+            prefix="/volume",
+        ),
+    )
+
+    assert result == b"hello"
+    assert files.downloaded == [remote_path]
+
+
+@pytest.mark.asyncio
+async def test_readdir_returns_virtual_paths_with_mount_prefix():
+    files = FakeFilesAPI(
+        {
+            "/Volumes/main/default/agent_files/readme.txt": b"hello",
+            "/Volumes/main/default/agent_files/reports/latest.md": b"report",
+        },
+        directories={"/Volumes/main/default/agent_files/reports"},
+    )
+    accessor = make_accessor(files)
+    index = RAMIndexCacheStore(ttl=0)
+
+    result = await readdir(
+        accessor,
+        PathSpec(original="/volume", directory="/volume", prefix="/volume"),
+        index,
+    )
+
+    assert result == ["/volume/readme.txt", "/volume/reports"]
+
+
+@pytest.mark.asyncio
+async def test_stat_returns_file_and_directory_metadata():
+    files = FakeFilesAPI(
+        {"/Volumes/main/default/agent_files/reports/latest.md": b"hello"},
+        directories={"/Volumes/main/default/agent_files/reports"},
+    )
+    accessor = make_accessor(files)
+
+    file_stat = await stat(
+        accessor,
+        PathSpec(
+            original="/volume/reports/latest.md",
+            directory="/volume/reports",
+            prefix="/volume",
+        ),
+    )
+    dir_stat = await stat(
+        accessor,
+        PathSpec(
+            original="/volume/reports",
+            directory="/volume",
+            prefix="/volume",
+        ),
+    )
+
+    assert file_stat.name == "latest.md"
+    assert file_stat.size == 5
+    assert file_stat.type == FileType.TEXT
+    assert file_stat.fingerprint == "Wed, 01 May 2024 12:00:00 GMT:5"
+    assert dir_stat.name == "reports"
+    assert dir_stat.type == FileType.DIRECTORY
+
+
+@pytest.mark.asyncio
+async def test_write_create_truncate_and_delete_use_files_api():
+    remote_path = "/Volumes/main/default/agent_files/reports/new.txt"
+    files = FakeFilesAPI(directories={"/Volumes/main/default/agent_files"})
+    accessor = make_accessor(files)
+    path = PathSpec(
+        original="/volume/reports/new.txt",
+        directory="/volume/reports",
+        prefix="/volume",
+    )
+
+    await mkdir(
+        accessor,
+        PathSpec(
+            original="/volume/reports",
+            directory="/volume",
+            prefix="/volume",
+        ),
+    )
+    await write_bytes(accessor, path, b"abcdef")
+    await truncate(accessor, path, 3)
+    await create(
+        accessor,
+        PathSpec(
+            original="/volume/reports/empty.txt",
+            directory="/volume/reports",
+            prefix="/volume",
+        ),
+    )
+    await unlink(accessor, path)
+
+    assert files.created_directories == [
+        "/Volumes/main/default/agent_files/reports"
+    ]
+    assert files.uploaded == [
+        (remote_path, b"abcdef", True),
+        (remote_path, b"abc", True),
+        ("/Volumes/main/default/agent_files/reports/empty.txt", b"", False),
+    ]
+    assert files.deleted_files == [remote_path]
+
+
+@pytest.mark.asyncio
+async def test_workspace_ops_route_to_databricks_volume_resource():
+    read_path = "/Volumes/main/default/agent_files/reports/latest.md"
+    write_path = "/Volumes/main/default/agent_files/reports/new.txt"
+    files = FakeFilesAPI({read_path: b"hello"})
+    config = DatabricksVolumeConfig(
+        catalog="main",
+        schema="default",
+        volume="agent_files",
+    )
+    resource = DatabricksVolumeResource(config,
+                                        client=FakeWorkspaceClient(files))
+    ws = Workspace({"/volume": resource}, mode=MountMode.WRITE)
+
+    data = await ws.ops.read("/volume/reports/latest.md")
+    await ws.ops.write("/volume/reports/new.txt", b"new")
+
+    assert data == b"hello"
+    assert files.uploaded[-1] == (write_path, b"new", True)

--- a/python/tests/resource/test_registry.py
+++ b/python/tests/resource/test_registry.py
@@ -25,6 +25,7 @@ EXPECTED_RESOURCES = {
     "oci",
     "supabase",
     "gcs",
+    "databricks_volume",
     "github",
     "github_ci",
     "linear",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1204,6 +1204,20 @@ wheels = [
 ]
 
 [[package]]
+name = "databricks-sdk"
+version = "0.108.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/13/05a1dbf9c2c43639b032128c18227953777a2a2da66e4b97d1914ceacb68/databricks_sdk-0.108.0.tar.gz", hash = "sha256:c43f1099b8228e5e9ecb4569381ec8f49b739129d35a826be72a61bc5eaaf1a6", size = 940266, upload-time = "2026-05-12T09:04:03.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/38/9b59ebb34ccaef79095f168eff1fab5f8d645b961680c7bcbc320434acd0/databricks_sdk-0.108.0-py3-none-any.whl", hash = "sha256:010528183abb475acf7f4058e331049dc7932e73a314d9808b123f5cbb722579", size = 887647, upload-time = "2026-05-12T09:04:01.771Z" },
+]
+
+[[package]]
 name = "deepagents"
 version = "0.4.12"
 source = { registry = "https://pypi.org/simple" }
@@ -3079,6 +3093,7 @@ all = [
     { name = "asyncpg" },
     { name = "asyncssh" },
     { name = "av" },
+    { name = "databricks-sdk" },
     { name = "daytona" },
     { name = "deepagents" },
     { name = "h5py" },
@@ -3112,6 +3127,9 @@ audio = [
 camel = [
     { name = "camel-ai" },
     { name = "markitdown" },
+]
+databricks = [
+    { name = "databricks-sdk" },
 ]
 daytona = [
     { name = "daytona" },
@@ -3210,6 +3228,7 @@ requires-dist = [
     { name = "asyncssh", marker = "extra == 'ssh'", specifier = ">=2.22.0" },
     { name = "av", marker = "extra == 'audio'", specifier = ">=17.0.0" },
     { name = "camel-ai", marker = "extra == 'camel'", specifier = ">=0.2.40,<0.3" },
+    { name = "databricks-sdk", marker = "extra == 'databricks'", specifier = ">=0.72.0" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.176.0" },
     { name = "deepagents", marker = "extra == 'deepagents'", specifier = ">=0.4.12" },
     { name = "fastapi", specifier = ">=0.135.1" },
@@ -3222,6 +3241,7 @@ requires-dist = [
     { name = "mfusepy", marker = "extra == 'fuse'", specifier = ">=1.0.0" },
     { name = "mirage-ai", extras = ["anthropic"], marker = "extra == 'all'" },
     { name = "mirage-ai", extras = ["audio"], marker = "extra == 'all'" },
+    { name = "mirage-ai", extras = ["databricks"], marker = "extra == 'all'" },
     { name = "mirage-ai", extras = ["daytona"], marker = "extra == 'all'" },
     { name = "mirage-ai", extras = ["deepagents"], marker = "extra == 'all'" },
     { name = "mirage-ai", extras = ["email"], marker = "extra == 'all'" },
@@ -3272,7 +3292,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
 ]
-provides-extras = ["s3", "r2", "gcs", "oci", "ssh", "fuse", "mongodb", "postgres", "redis", "email", "parquet", "hdf5", "pdf", "audio", "langfuse", "anthropic", "openai", "pydantic-ai", "deepagents", "openhands", "camel", "daytona", "all"]
+provides-extras = ["s3", "r2", "gcs", "oci", "databricks", "ssh", "fuse", "mongodb", "postgres", "redis", "email", "parquet", "hdf5", "pdf", "audio", "langfuse", "anthropic", "openai", "pydantic-ai", "deepagents", "openhands", "camel", "daytona", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION

  Fixes #61.

  ## Summary
  - Add `DatabricksVolumeConfig` and `DatabricksVolumeResource` for Unity Catalog volume paths under `/Volumes/<catalog>/
  <schema>/<volume>`.
  - Wire the backend into the Python resource registry and add `mirage-ai[databricks]`.
  - Implement workspace ops for read, write, append, list, stat, mkdir, create, truncate, delete, directory delete, and file
  rename using `WorkspaceClient.files`.
  - Add tests, docs, resource index entry, resource matrix entry, and lockfile update.

  ## Testing
  - `python -m compileall ...` passed.
  - Direct Databricks Volume smoke tests with a fake Files API client passed.
  - `python -m uv run --with pre-commit pre-commit run --files ...` passed.
  - `python -m uv run pytest tests\core\databricks_volume\test_files.py -q` is blocked on this Windows host because `tests/
  conftest.py` imports Unix-only `resource`.

  References used: issue #61 (https://github.com/strukto-ai/mirage/issues/61), CONTRIBUTING.md
  (https://github.com/strukto-ai/mirage/blob/main/CONTRIBUTING.md), and the Databricks SDK Files API docs
  (https://databricks-sdk-py.readthedocs.io/en/latest/workspace/files/files.html).
