### PR TITLE
ci: skip CLI and Examples workflows on no-code changes

### DIFF
--- a/.github/workflows/infra-example.yml
+++ b/.github/workflows/infra-example.yml
@@ -3,8 +3,18 @@ name: Examples
 "on":
   push:
     branches: [main]
+    paths:
+      - examples/**
+      - python/**
+      - typescript/**
+      - .github/workflows/infra-example.yml
   pull_request:
     branches: [main]
+    paths:
+      - examples/**
+      - python/**
+      - typescript/**
+      - .github/workflows/infra-example.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -3,8 +3,16 @@ name: CLI exit codes
 "on":
   push:
     branches: [main]
+    paths:
+      - python/**
+      - typescript/**
+      - .github/workflows/test_cli.yml
   pull_request:
     branches: [main]
+    paths:
+      - python/**
+      - typescript/**
+      - .github/workflows/test_cli.yml
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Mirror the path-filter pattern already used by \`test_python.yml\` and \`test_typescript.yml\` on the two remaining workflows that lacked it. Docs-only and unrelated PRs no longer trigger \`test_cli.yml\` or \`infra-example.yml\`.

- **test_cli.yml** triggers on: \`python/**\`, \`typescript/**\`, or the workflow itself.
- **infra-example.yml** triggers on: \`examples/**\`, \`python/**\`, \`typescript/**\`, or the workflow itself.

When the filter doesn't match, GitHub treats the workflow as not applicable for that PR (same behavior as the existing filtered workflows).

## Test plan

- [x] YAML parses
- [x] Pre-commit clean
- [ ] Confirm on a follow-up docs-only PR that only \`Pre-commit\` runs