### PR TITLE
feat(py/databricks): add read-only volume resource docs and examples

### DIFF
--- a/docs/home/resource-matrix.mdx
+++ b/docs/home/resource-matrix.mdx
@@ -48,6 +48,7 @@ No external setup, these run locally or against a connection string you already 
 
 | Resource | Mount Mode | Setup | Docs | Notes |
 | --- | --- | --- | --- | --- |
+| Databricks Volume | read | [Databricks Volume](/home/setup/databricks) | [<Icon icon="python" />](/python/resource/databricks_volume) | Unity Catalog volume subtree; read-only today |
 | Dropbox | read | [Dropbox](/home/setup/dropbox) | [<Icon icon="node-js" />](/typescript/setup/dropbox) [<Icon icon="globe" />](/typescript/setup/dropbox) | OAuth2 + PKCE; Node and browser |
 | Box | read | [Box](/home/setup/box) | [<Icon icon="node-js" />](/typescript/setup/box) [<Icon icon="globe" />](/typescript/setup/box) | OAuth2 + PKCE or developer token; `.boxnote.json` / `.boxcanvas.json` / `.gdoc.json` decoded |
 

--- a/docs/python/agents/langchain.mdx
+++ b/docs/python/agents/langchain.mdx
@@ -56,3 +56,4 @@ for text in extract_text(result["messages"]):
 ## Examples
 
 - [`examples/python/agents/langchain/s3_deepagent.py`](https://github.com/strukto-ai/mirage/blob/main/examples/python/agents/langchain/s3_deepagent.py), read-only S3 exploration.
+- [`examples/python/agents/langchain/databricks_volume_deepagent.py`](https://github.com/strukto-ai/mirage/blob/main/examples/python/agents/langchain/databricks_volume_deepagent.py), Databricks volume exploration inside Databricks Apps or local SDK-auth setups.

--- a/docs/python/resource/databricks_volume.mdx
+++ b/docs/python/resource/databricks_volume.mdx
@@ -1,0 +1,157 @@
+---
+title: Databricks Volume
+icon: folder-open
+description: Mount a Databricks Unity Catalog volume as a read-only filesystem.
+---
+
+`DatabricksVolumeResource` exposes files from a Unity Catalog volume through
+Mirage's standard filesystem interface. The current branch is read-only:
+agents can list, stat, read, stream, and glob files under the configured
+volume root.
+
+For auth and environment setup, see [Databricks Volume Setup](/python/setup/databricks).
+
+## Config
+
+```python
+from mirage import MountMode, Workspace
+from mirage.resource.databricks_volume import (
+    DatabricksVolumeConfig,
+    DatabricksVolumeResource,
+)
+
+resource = DatabricksVolumeResource(DatabricksVolumeConfig(
+    catalog="main",
+    schema="default",
+    volume="agent_files",
+    root_path="/reports",
+))
+ws = Workspace({"/dbx": resource}, mode=MountMode.READ)
+```
+
+| Field | Default | Notes |
+| --- | --- | --- |
+| `catalog` | required | Unity Catalog catalog name. |
+| `schema` | required | Unity Catalog schema name. |
+| `volume` | required | Unity Catalog volume name. |
+| `root_path` | `/` | Subdirectory inside the volume to expose. |
+| `host` | `None` | Optional workspace host override. |
+| `token` | `None` | Optional PAT override. Redacted in snapshots. |
+| `profile` | `None` | Optional Databricks SDK profile name. |
+| `timeout` | `30` | Request timeout in seconds. |
+
+## Mount mode
+
+`read` only.
+
+## Filesystem layout
+
+Mirage maps the configured mount prefix onto the configured volume subtree.
+
+Given:
+
+```python
+DatabricksVolumeConfig(
+    catalog="main",
+    schema="default",
+    volume="agent_files",
+    root_path="/reports/2026",
+)
+```
+
+and mount prefix `/dbx/`, the volume path:
+
+```text
+/Volumes/main/default/agent_files/reports/2026/q1/summary.md
+```
+
+appears in Mirage as:
+
+```text
+/dbx/q1/summary.md
+```
+
+`root_path` is normalized before use, and Mirage rejects any virtual path that
+would escape above that configured subtree.
+
+## Supported operations
+
+This branch wires the core read surface:
+
+- `readdir`
+- `stat`
+- `exists`
+- `read_bytes`
+- `read_stream`
+- `range_read`
+- glob resolution
+
+Standard shell commands like `ls`, `cat`, `head`, `tail`, `grep`, `rg`,
+`find`, and `tree` work through those primitives.
+
+## Snapshot behavior
+
+`token` is redacted in resource state. Loading a snapshot back requires an
+override config that provides fresh credentials if the runtime auth chain does
+not already supply them.
+
+## Databricks Apps
+
+For Databricks Apps, prefer SDK-default auth and keep Mirage in-process:
+
+```python
+config = DatabricksVolumeConfig(
+    catalog="main",
+    schema="default",
+    volume="agent_files",
+)
+resource = DatabricksVolumeResource(config)
+ws = Workspace({"/dbx/": resource}, mode=MountMode.READ)
+```
+
+This does not require FUSE. The agent can access the mounted workspace through
+Mirage's backend adapters or `Workspace.execute(...)`.
+
+## Example
+
+```python
+import asyncio
+
+from mirage import MountMode, Workspace
+from mirage.resource.databricks_volume import (
+    DatabricksVolumeConfig,
+    DatabricksVolumeResource,
+)
+
+resource = DatabricksVolumeResource(DatabricksVolumeConfig(
+    catalog="main",
+    schema="default",
+    volume="agent_files",
+    root_path="/reports",
+))
+
+
+async def main() -> None:
+    ws = Workspace({"/dbx/": resource}, mode=MountMode.READ)
+
+    r = await ws.execute("ls /dbx/")
+    print(await r.stdout_str())
+
+    r = await ws.execute("find /dbx/ -name '*.md'")
+    print(await r.stdout_str())
+
+    r = await ws.execute('head -n 20 "/dbx/q1/summary.md"')
+    print(await r.stdout_str())
+
+    r = await ws.execute('stat "/dbx/q1/summary.md"')
+    print(await r.stdout_str())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+See:
+
+- `examples/python/databricks_volume/databricks_volume.py`
+- `examples/python/agents/langchain/databricks_volume_deepagent.py`

--- a/docs/python/resource/index.mdx
+++ b/docs/python/resource/index.mdx
@@ -21,6 +21,10 @@ Each page describes a Python-supported resource: what config it needs, what the 
 - [OCI](/python/resource/oci)
 - [Supabase](/python/resource/supabase)
 
+## Cloud Files
+
+- [Databricks Volume](/python/resource/databricks_volume)
+
 ## Google Workspace
 
 - [Gmail](/python/resource/gmail)

--- a/docs/python/setup/databricks.mdx
+++ b/docs/python/setup/databricks.mdx
@@ -1,0 +1,83 @@
+---
+title: Databricks Volume
+icon: folder-open
+description: Set up the Databricks Unity Catalog volume resource in Python.
+---
+
+## Dependencies
+
+```bash
+uv add 'mirage-ai[databricks]'
+```
+
+For credential setup, see the [Databricks Volume Setup](/home/setup/databricks)
+guide.
+
+## Configuration
+
+### Databricks Apps or SDK-default auth
+
+```python
+from mirage import Workspace, MountMode
+from mirage.resource.databricks_volume import (
+    DatabricksVolumeConfig,
+    DatabricksVolumeResource,
+)
+
+config = DatabricksVolumeConfig(
+    catalog="main",
+    schema="default",
+    volume="agent_files",
+)
+resource = DatabricksVolumeResource(config=config)
+ws = Workspace({"/dbx/": resource}, mode=MountMode.READ)
+```
+
+### Explicit host and token
+
+```python
+import os
+
+config = DatabricksVolumeConfig(
+    catalog="main",
+    schema="default",
+    volume="agent_files",
+    host=os.environ["DATABRICKS_HOST"],
+    token=os.environ["DATABRICKS_TOKEN"],
+    root_path="/reports",
+)
+resource = DatabricksVolumeResource(config=config)
+ws = Workspace({"/dbx/": resource}, mode=MountMode.READ)
+```
+
+### Profile-based auth
+
+```python
+config = DatabricksVolumeConfig(
+    catalog="main",
+    schema="default",
+    volume="agent_files",
+    profile="DEV",
+)
+resource = DatabricksVolumeResource(config=config)
+ws = Workspace({"/dbx/": resource}, mode=MountMode.READ)
+```
+
+## Config Reference
+
+| Field | Required | Default | Description |
+| --- | --- | --- | --- |
+| `catalog` | Yes |  | Unity Catalog catalog name. |
+| `schema` | Yes |  | Unity Catalog schema name. |
+| `volume` | Yes |  | Unity Catalog volume name. |
+| `root_path` | No | `/` | Subdirectory inside the volume to expose. |
+| `host` | No |  | Databricks workspace host. |
+| `token` | No |  | Databricks personal access token. Redacted in snapshots. |
+| `profile` | No |  | Databricks SDK profile name. |
+| `timeout` | No | `30` | Request timeout in seconds. |
+
+## Notes
+
+- The resource is read-only in this branch.
+- Auth falls through to the Databricks SDK defaults when `host`, `token`, and `profile` are omitted.
+- `root_path` is normalized and cannot contain `..`.

--- a/examples/python/agents/langchain/databricks_volume_deepagent.py
+++ b/examples/python/agents/langchain/databricks_volume_deepagent.py
@@ -1,0 +1,61 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import os
+
+from databricks_langchain import ChatDatabricks
+from deepagents import create_deep_agent
+from dotenv import load_dotenv
+
+from mirage import MountMode, Workspace
+from mirage.agents.langchain import (LangchainWorkspace, build_system_prompt,
+                                     extract_text)
+from mirage.resource.databricks_volume import (DatabricksVolumeConfig,
+                                               DatabricksVolumeResource)
+
+load_dotenv(".env.development")
+
+resource = DatabricksVolumeResource(
+    DatabricksVolumeConfig(
+        catalog=os.environ["DATABRICKS_VOLUME_CATALOG"],
+        schema=os.environ["DATABRICKS_VOLUME_SCHEMA"],
+        volume=os.environ["DATABRICKS_VOLUME_NAME"],
+        root_path=os.environ.get("DATABRICKS_VOLUME_ROOT_PATH", "/"),
+        host=os.environ.get("DATABRICKS_HOST"),
+        token=os.environ.get("DATABRICKS_TOKEN"),
+        profile=os.environ.get("DATABRICKS_CONFIG_PROFILE"),
+    ))
+
+ws = Workspace({"/dbx/": resource}, mode=MountMode.READ)
+
+agent = create_deep_agent(
+    model=ChatDatabricks(endpoint=os.environ["DATABRICKS_CHAT_ENDPOINT"], ),
+    system_prompt=build_system_prompt(workspace=ws),
+    backend=LangchainWorkspace(ws),
+)
+
+task = ("Inspect /dbx/, identify the most relevant text or markdown files, "
+        "and summarize their contents. Use head for large files.")
+result = agent.invoke({"messages": [{"role": "user", "content": task}]})
+
+for text in extract_text(result["messages"]):
+    print(text)
+
+records = ws.ops.records
+if records:
+    total = sum(record.bytes for record in records)
+    print(f"\n--- {len(records)} ops, {total:,} bytes ---")
+    for record in records:
+        print(f"  {record.op:<8} {record.source:<18} {record.bytes:>10,} B "
+              f"{record.duration_ms:>5} ms  {record.path}")

--- a/examples/python/databricks_volume/databricks_volume.py
+++ b/examples/python/databricks_volume/databricks_volume.py
@@ -1,0 +1,72 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+from mirage import MountMode, Workspace
+from mirage.resource.databricks_volume import (DatabricksVolumeConfig,
+                                               DatabricksVolumeResource)
+
+load_dotenv(".env.development")
+
+config = DatabricksVolumeConfig(
+    catalog=os.environ["DATABRICKS_VOLUME_CATALOG"],
+    schema=os.environ["DATABRICKS_VOLUME_SCHEMA"],
+    volume=os.environ["DATABRICKS_VOLUME_NAME"],
+    root_path=os.environ.get("DATABRICKS_VOLUME_ROOT_PATH", "/"),
+    host=os.environ.get("DATABRICKS_HOST"),
+    token=os.environ.get("DATABRICKS_TOKEN"),
+    profile=os.environ.get("DATABRICKS_CONFIG_PROFILE"),
+)
+resource = DatabricksVolumeResource(config=config)
+
+
+async def _run(ws, cmd):
+    print(f"\n>>> {cmd}")
+    result = await ws.execute(cmd)
+    stdout = (await result.stdout_str()).strip()
+    stderr = (await result.stderr_str()).strip()
+    if stdout:
+        for line in stdout.splitlines()[:12]:
+            print(f"  {line[:140]}")
+        if len(stdout.splitlines()) > 12:
+            print(f"  ... ({len(stdout.splitlines())} lines total)")
+    if stderr:
+        print(f"  [stderr] {stderr[:140]}")
+    if not stdout and not stderr:
+        print(f"  (empty, exit={result.exit_code})")
+    return result
+
+
+async def main():
+    ws = Workspace({"/dbx/": resource}, mode=MountMode.READ)
+
+    await _run(ws, "ls /dbx/")
+    await _run(ws, "tree -L 2 /dbx/")
+    await _run(ws, 'find /dbx/ -name "*.md"')
+
+    target = os.environ.get("DATABRICKS_VOLUME_SAMPLE_FILE")
+    if target:
+        await _run(ws, f'stat "{target}"')
+        await _run(ws, f'head -n 20 "{target}"')
+        await _run(ws, f'grep -n TODO "{target}"')
+    else:
+        print("\nSet DATABRICKS_VOLUME_SAMPLE_FILE to run file reads.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/mirage/accessor/databricks_volume.py
+++ b/python/mirage/accessor/databricks_volume.py
@@ -1,0 +1,60 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from typing import Any
+
+from mirage.accessor.base import Accessor
+from mirage.resource.databricks_volume.config import DatabricksVolumeConfig
+
+try:
+    from databricks.sdk import WorkspaceClient
+    from databricks.sdk.config import Config as WorkspaceConfig
+except ImportError:
+    WorkspaceConfig = None
+    WorkspaceClient = None
+
+
+class DatabricksVolumeAccessor(Accessor):
+
+    def __init__(
+        self,
+        config: DatabricksVolumeConfig,
+        client: Any | None = None,
+    ) -> None:
+        self.config = config
+        self._client = client
+
+    @property
+    def client(self) -> Any:
+        if self._client is None:
+            if WorkspaceClient is None or WorkspaceConfig is None:
+                raise ImportError("DatabricksVolumeResource requires the "
+                                  "'databricks' extra. Install with: "
+                                  "pip install mirage-ai[databricks]")
+            kwargs = {
+                "host": self.config.host,
+                "token": self.config.token,
+                "profile": self.config.profile,
+                "http_timeout_seconds": self.config.timeout,
+            }
+            sdk_config = WorkspaceConfig(**{
+                k: v
+                for k, v in kwargs.items() if v is not None
+            })
+            self._client = WorkspaceClient(config=sdk_config)
+        return self._client
+
+    @property
+    def files(self) -> Any:
+        return self.client.files

--- a/python/mirage/commands/builtin/databricks_volume/__init__.py
+++ b/python/mirage/commands/builtin/databricks_volume/__init__.py
@@ -1,0 +1,35 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.commands.builtin.databricks_volume.cat import cat
+from mirage.commands.builtin.databricks_volume.find import find
+from mirage.commands.builtin.databricks_volume.grep import grep
+from mirage.commands.builtin.databricks_volume.head import head
+from mirage.commands.builtin.databricks_volume.ls import ls
+from mirage.commands.builtin.databricks_volume.rg import rg
+from mirage.commands.builtin.databricks_volume.stat import stat
+from mirage.commands.builtin.databricks_volume.tail import tail
+from mirage.commands.builtin.databricks_volume.tree import tree
+
+COMMANDS = [
+    cat,
+    find,
+    grep,
+    head,
+    ls,
+    rg,
+    stat,
+    tail,
+    tree,
+]

--- a/python/mirage/commands/builtin/databricks_volume/cat.py
+++ b/python/mirage/commands/builtin/databricks_volume/cat.py
@@ -1,0 +1,65 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.stat import stat
+from mirage.core.databricks_volume.stream import read_stream
+from mirage.io.async_line_iterator import AsyncLineIterator
+from mirage.io.cachable_iterator import CachableAsyncIterator
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+async def _number_lines_stream(
+        source: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
+    line_number = 1
+    async for line in AsyncLineIterator(source):
+        yield f"     {line_number}\t".encode() + line + b"\n"
+        line_number += 1
+
+
+@command("cat", resource="databricks_volume", spec=SPECS["cat"])
+async def cat(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    n: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        path = paths[0]
+        await stat(accessor, path, index)
+        source = read_stream(accessor, path, index)
+        cachable = CachableAsyncIterator(source)
+        key = path.strip_prefix
+        if n:
+            return _number_lines_stream(cachable), IOResult(
+                reads={key: cachable},
+                cache=[key],
+            )
+        return cachable, IOResult(reads={key: cachable}, cache=[key])
+    source = _resolve_source(stdin, "cat: missing operand")
+    if n:
+        return _number_lines_stream(source), IOResult()
+    return source, IOResult()

--- a/python/mirage/commands/builtin/databricks_volume/find.py
+++ b/python/mirage/commands/builtin/databricks_volume/find.py
@@ -1,0 +1,104 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import fnmatch
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.readdir import readdir
+from mirage.core.databricks_volume.stat import stat
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import FileStat, FileType, PathSpec
+
+
+def _matches_find(
+    path: PathSpec,
+    file_stat: FileStat,
+    name: str | None,
+    type_filter: str | None,
+) -> bool:
+    if type_filter == "file" and file_stat.type == FileType.DIRECTORY:
+        return False
+    if type_filter == "directory" and file_stat.type != FileType.DIRECTORY:
+        return False
+    if name is not None and not fnmatch.fnmatch(file_stat.name, name):
+        return False
+    return bool(path.original)
+
+
+async def _find_recurse(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    name: str | None,
+    type_filter: str | None,
+    maxdepth: int | None,
+    depth: int,
+    index: IndexCacheStore | None,
+) -> list[str]:
+    results: list[str] = []
+    file_stat = await stat(accessor, path, index)
+    if depth > 0 and _matches_find(path, file_stat, name, type_filter):
+        results.append(path.original)
+    if file_stat.type != FileType.DIRECTORY:
+        return results
+    if maxdepth is not None and depth >= maxdepth:
+        return results
+    entries = await readdir(accessor, path, index)
+    for entry in entries:
+        entry_path = PathSpec(
+            original=entry,
+            directory=entry,
+            resolved=False,
+            prefix=path.prefix,
+        )
+        results.extend(await _find_recurse(
+            accessor,
+            entry_path,
+            name,
+            type_filter,
+            maxdepth,
+            depth + 1,
+            index,
+        ))
+    return results
+
+
+@command("find", resource="databricks_volume", spec=SPECS["find"])
+async def find(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    name: str | None = None,
+    type: str | None = None,
+    maxdepth: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    paths = await resolve_glob(accessor, paths, index)
+    path = paths[0]
+    type_filter = None
+    if type == "d":
+        type_filter = "directory"
+    elif type == "f":
+        type_filter = "file"
+    elif type is not None:
+        type_filter = type
+    depth = int(maxdepth) if maxdepth is not None else None
+    results = await _find_recurse(accessor, path, name, type_filter, depth, 0,
+                                  index)
+    return "\n".join(results).encode(), IOResult()

--- a/python/mirage/commands/builtin/databricks_volume/grep.py
+++ b/python/mirage/commands/builtin/databricks_volume/grep.py
@@ -1,0 +1,309 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+from functools import partial
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.grep_helper import (compile_pattern,
+                                                 grep_files_only,
+                                                 grep_folder_filetype,
+                                                 grep_lines, grep_recursive,
+                                                 grep_stream)
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.builtin.utils.wrap import (call_read_bytes,
+                                                call_read_stream, call_readdir,
+                                                call_stat)
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.read import read_bytes as _read_bytes
+from mirage.core.databricks_volume.readdir import readdir as _readdir
+from mirage.core.databricks_volume.stat import stat as _stat
+from mirage.core.databricks_volume.stream import read_stream
+from mirage.io.stream import exit_on_empty, quiet_match
+from mirage.io.types import ByteSource, IOResult
+from mirage.provision import ProvisionResult
+from mirage.types import FileType, PathSpec
+
+
+async def grep_provision(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    r: bool = False,
+    R: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> ProvisionResult:
+    if not paths or accessor is None:
+        return ProvisionResult(command="grep " + " ".join(texts))
+    if not (r or R):
+        paths = await resolve_glob(accessor, paths, index)
+    if r or R:
+        mount_prefix = paths[0].prefix if paths else ""
+        entries = await _readdir(accessor, paths[0], index)
+        total = 0
+        ops = 0
+        for entry in entries:
+            try:
+                entry_spec = PathSpec(original=entry,
+                                      directory=entry,
+                                      resolved=False,
+                                      prefix=mount_prefix)
+                file_stat = await _stat(accessor, entry_spec, index)
+                if file_stat.size is not None:
+                    total += file_stat.size
+                    ops += 1
+            except FileNotFoundError:
+                continue
+        return ProvisionResult(
+            command=f"grep -r {texts[0] if texts else ''} {paths[0].original}",
+            network_read_low=total,
+            network_read_high=total,
+            read_ops=ops,
+        )
+    file_stat = await _stat(accessor, paths[0], index)
+    return ProvisionResult(
+        command=f"grep {texts[0] if texts else ''} {paths[0].original}",
+        network_read_low=file_stat.size or 0,
+        network_read_high=file_stat.size or 0,
+        read_ops=1,
+    )
+
+
+@command("grep",
+         resource="databricks_volume",
+         spec=SPECS["grep"],
+         provision=grep_provision)
+async def grep(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    r: bool = False,
+    R: bool = False,
+    i: bool = False,
+    v: bool = False,
+    n: bool = False,
+    c: bool = False,
+    args_l: bool = False,
+    w: bool = False,
+    F: bool = False,
+    E: bool = False,
+    o: bool = False,
+    m: str | None = None,
+    q: bool = False,
+    H: bool = False,
+    args_h: bool = False,
+    A: str | None = None,
+    B: str | None = None,
+    C: str | None = None,
+    e: str | None = None,
+    prefix: str = "",
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if e is not None:
+        pattern = e
+    elif texts:
+        pattern = texts[0]
+    else:
+        raise ValueError("grep: usage: grep [flags] pattern [path]")
+    max_count = int(m) if m is not None else None
+    after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
+    before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
+
+    filetype_fns = _extra.get("filetype_fns") or {}
+
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        mount_prefix = paths[0].prefix if paths else ""
+        rd = partial(call_readdir,
+                     _readdir,
+                     accessor,
+                     index=index,
+                     prefix=mount_prefix)
+        st = partial(call_stat,
+                     _stat,
+                     accessor,
+                     index=index,
+                     prefix=mount_prefix)
+        rb = partial(call_read_bytes,
+                     _read_bytes,
+                     accessor,
+                     index=index,
+                     prefix=mount_prefix)
+
+        if (r or R) and filetype_fns:
+            bound_ft = {
+                ext: partial(fn, accessor)
+                for ext, fn in filetype_fns.items()
+            }
+            warnings: list[str] = []
+            results = await grep_folder_filetype(
+                rd,
+                st,
+                rb,
+                paths[0].original,
+                pattern,
+                bound_ft,
+                ignore_case=i,
+                invert=v,
+                line_numbers=n,
+                count_only=c,
+                files_only=args_l,
+                only_matching=o,
+                max_count=max_count,
+                fixed_string=F,
+                whole_word=w,
+                warnings=warnings,
+                prefix=mount_prefix,
+            )
+            stderr = "\n".join(warnings).encode() if warnings else None
+            if not results:
+                return b"", IOResult(exit_code=1, stderr=stderr)
+            return "\n".join(results).encode(), IOResult(stderr=stderr)
+
+        if args_l:
+            warnings_l: list[str] = []
+            results = await grep_files_only(
+                rd,
+                st,
+                rb,
+                paths[0].original,
+                pattern,
+                recursive=r or R,
+                ignore_case=i,
+                invert=v,
+                line_numbers=n,
+                count_only=c,
+                fixed_string=F,
+                only_matching=o,
+                max_count=max_count,
+                whole_word=w,
+                warnings=warnings_l,
+                read_stream_fn=partial(call_read_stream,
+                                       read_stream,
+                                       accessor,
+                                       index=index,
+                                       prefix=mount_prefix),
+            )
+            stderr = "\n".join(warnings_l).encode() if warnings_l else None
+            if not results:
+                return b"", IOResult(exit_code=1, stderr=stderr)
+            return "\n".join(results).encode(), IOResult(stderr=stderr)
+
+        if r or R:
+            compiled = compile_pattern(pattern, i, F, w)
+            all_results: list[str] = []
+            warnings_r: list[str] = []
+            for path in paths:
+                file_stat = await _stat(accessor, path, index)
+                if file_stat.type == FileType.DIRECTORY:
+                    results = await grep_recursive(
+                        rd,
+                        st,
+                        rb,
+                        path.original,
+                        compiled,
+                        invert=v,
+                        line_numbers=n,
+                        count_only=c,
+                        files_only=False,
+                        only_matching=o,
+                        max_count=max_count,
+                        warnings=warnings_r,
+                        read_stream_fn=partial(call_read_stream,
+                                               read_stream,
+                                               accessor,
+                                               index=index,
+                                               prefix=mount_prefix),
+                    )
+                    all_results.extend(results)
+                else:
+                    data = (await _read_bytes(
+                        accessor, path,
+                        index)).decode(errors="replace").splitlines()
+                    hits = grep_lines(path.original, data, compiled, v, n, c,
+                                      args_l, o, max_count)
+                    if c and hits:
+                        all_results.append(f"{path.original}:{hits[0]}")
+                    else:
+                        all_results.extend(
+                            f"{path.original}:{line}" if len(paths) >
+                            1 else line for line in hits)
+            stderr = ("\n".join(warnings_r).encode() if warnings_r else None)
+            if not all_results:
+                return b"", IOResult(exit_code=1, stderr=stderr)
+            return "\n".join(all_results).encode(), IOResult(stderr=stderr)
+
+        compiled = compile_pattern(pattern, i, F, w)
+
+        if len(paths) > 1:
+            all_results: list[str] = []
+            for path in paths:
+                data = (await _read_bytes(
+                    accessor, path,
+                    index)).decode(errors="replace").splitlines()
+                hits = grep_lines(path.original, data, compiled, v, n, c,
+                                  args_l, o, max_count)
+                if c:
+                    if hits:
+                        all_results.append(f"{path.original}:{hits[0]}")
+                elif args_l:
+                    all_results.extend(hits)
+                else:
+                    all_results.extend(f"{path.original}:{line}"
+                                       for line in hits)
+            if not all_results:
+                return b"", IOResult(exit_code=1)
+            return "\n".join(all_results).encode(), IOResult()
+
+        source = read_stream(accessor, paths[0], index)
+        stream = grep_stream(
+            source,
+            compiled,
+            invert=v,
+            line_numbers=n,
+            only_matching=o,
+            max_count=max_count,
+            count_only=c,
+            after_context=after_ctx,
+            before_context=before_ctx,
+        )
+        if q:
+            io = IOResult(exit_code=1)
+            return quiet_match(stream, io), io
+        io = IOResult()
+        return exit_on_empty(stream, io), io
+    source = _resolve_source(stdin, "grep: usage: grep [flags] pattern [path]")
+    compiled = compile_pattern(pattern, i, F, w)
+    stream = grep_stream(
+        source,
+        compiled,
+        invert=v,
+        line_numbers=n,
+        only_matching=o,
+        max_count=max_count,
+        count_only=c,
+        after_context=after_ctx,
+        before_context=before_ctx,
+    )
+    if q:
+        io = IOResult(exit_code=1)
+        return quiet_match(stream, io), io
+    io = IOResult()
+    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/databricks_volume/head.py
+++ b/python/mirage/commands/builtin/databricks_volume/head.py
@@ -1,0 +1,80 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.stream import range_read, read_stream
+from mirage.io.async_line_iterator import AsyncLineIterator
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+async def _head_stream(
+    source: AsyncIterator[bytes],
+    lines: int = 10,
+    bytes_mode: int | None = None,
+) -> AsyncIterator[bytes]:
+    if bytes_mode is not None:
+        remaining = bytes_mode
+        async for chunk in source:
+            if len(chunk) <= remaining:
+                yield chunk
+                remaining -= len(chunk)
+                if remaining <= 0:
+                    return
+            else:
+                yield chunk[:remaining]
+                return
+        return
+    count = 0
+    async for line in AsyncLineIterator(source):
+        yield line + b"\n"
+        count += 1
+        if count >= lines:
+            return
+
+
+async def _single_chunk_stream(data: bytes) -> AsyncIterator[bytes]:
+    if data:
+        yield data
+
+
+@command("head", resource="databricks_volume", spec=SPECS["head"])
+async def head(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    n: str | None = None,
+    c: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    lines = int(n) if n is not None else 10
+    bytes_mode = int(c) if c is not None else None
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        if bytes_mode is not None:
+            data = await range_read(accessor, paths[0], 0, bytes_mode)
+            return _single_chunk_stream(data), IOResult()
+        source = read_stream(accessor, paths[0], index)
+        return _head_stream(source, lines, bytes_mode), IOResult()
+    source = _resolve_source(stdin, "head: missing operand")
+    return _head_stream(source, lines, bytes_mode), IOResult()

--- a/python/mirage/commands/builtin/databricks_volume/ls.py
+++ b/python/mirage/commands/builtin/databricks_volume/ls.py
@@ -1,0 +1,172 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.readdir import readdir
+from mirage.core.databricks_volume.stat import stat
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import FileStat, FileType, PathSpec
+
+
+async def _ls_entries(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    all_files: bool,
+    sort_by: str,
+    reverse: bool,
+    recursive: bool,
+    list_dir: bool,
+    warnings: list[str],
+    index: IndexCacheStore | None = None,
+) -> list[FileStat]:
+    if list_dir:
+        return [await stat(accessor, path, index)]
+
+    try:
+        entries = await readdir(accessor, path, index)
+    except (FileNotFoundError, ValueError) as exc:
+        warnings.append(f"ls: cannot access '{path.original}': {exc}")
+        return []
+
+    stats: list[FileStat] = []
+    for entry in entries:
+        try:
+            entry_spec = PathSpec(
+                original=entry,
+                directory=entry,
+                resolved=False,
+                prefix=path.prefix,
+            )
+            entry_stat = await stat(accessor, entry_spec, index)
+        except (FileNotFoundError, ValueError) as exc:
+            warnings.append(f"ls: cannot access '{entry}': {exc}")
+            continue
+        if not all_files and entry_stat.name.startswith("."):
+            continue
+        stats.append(entry_stat)
+
+    if sort_by == "time":
+        stats.sort(key=lambda entry: entry.modified or "", reverse=not reverse)
+    elif sort_by == "size":
+        stats.sort(key=lambda entry: entry.size or 0, reverse=not reverse)
+    else:
+        stats.sort(key=lambda entry: entry.name, reverse=reverse)
+
+    if recursive:
+        sub_entries: list[FileStat] = []
+        for entry_stat in stats:
+            sub_entries.append(entry_stat)
+            if entry_stat.type == FileType.DIRECTORY:
+                entry_path = path.child(entry_stat.name)
+                entry_spec = PathSpec(
+                    original=entry_path,
+                    directory=entry_path,
+                    resolved=False,
+                    prefix=path.prefix,
+                )
+                sub_entries.extend(await _ls_entries(
+                    accessor,
+                    entry_spec,
+                    all_files,
+                    sort_by,
+                    reverse,
+                    recursive,
+                    False,
+                    warnings,
+                    index,
+                ))
+        return sub_entries
+
+    return stats
+
+
+@command("ls", resource="databricks_volume", spec=SPECS["ls"])
+async def ls(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    args_l: bool = False,
+    args_1: bool = False,
+    a: bool = False,
+    A: bool = False,
+    h: bool = False,
+    t: bool = False,
+    S: bool = False,
+    r: bool = False,
+    R: bool = False,
+    d: bool = False,
+    F: bool = False,
+    index: IndexCacheStore = None,
+    cwd: PathSpec | str = "/",
+    prefix: str = "",
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
+        cwd_prefix = cwd.prefix if isinstance(cwd, PathSpec) else ""
+        paths = [
+            PathSpec(
+                original=cwd_str,
+                directory=cwd_str,
+                resolved=False,
+                prefix=cwd_prefix,
+            )
+        ]
+    paths = await resolve_glob(accessor, paths, index)
+    all_files = a or A
+    sort_by = "name"
+    if t:
+        sort_by = "time"
+    elif S:
+        sort_by = "size"
+    warnings: list[str] = []
+    results: list[str] = []
+    for path in paths:
+        try:
+            entries = await _ls_entries(
+                accessor,
+                path,
+                all_files,
+                sort_by,
+                r,
+                R,
+                d,
+                warnings,
+                index,
+            )
+        except (FileNotFoundError, ValueError) as exc:
+            warnings.append(f"ls: cannot access '{path.original}': {exc}")
+            continue
+        if args_l and not args_1:
+            for entry in entries:
+                size_str = _human_size(entry.size or 0) if h else str(
+                    entry.size or 0)
+                results.append(f"{entry.type or '-'}\t{size_str}\t"
+                               f"{entry.modified or ''}\t{entry.name}")
+        else:
+            for entry in entries:
+                is_dir = F and entry.type == FileType.DIRECTORY
+                results.append(entry.name + ("/" if is_dir else ""))
+    stderr = "\n".join(warnings).encode() if warnings else None
+    exit_code = 1 if warnings and not results else 0
+    return "\n".join(results).encode(), IOResult(
+        stderr=stderr,
+        exit_code=exit_code,
+    )

--- a/python/mirage/commands/builtin/databricks_volume/rg.py
+++ b/python/mirage/commands/builtin/databricks_volume/rg.py
@@ -1,0 +1,222 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+from functools import partial
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.grep_helper import (compile_pattern, grep_lines,
+                                                 grep_stream)
+from mirage.commands.builtin.rg_helper import rg_folder_filetype, rg_full
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
+                                                call_stat)
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.read import read_bytes as _read_bytes
+from mirage.core.databricks_volume.readdir import readdir as _readdir
+from mirage.core.databricks_volume.stat import stat as _stat
+from mirage.core.databricks_volume.stream import read_stream
+from mirage.io.stream import exit_on_empty
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import FileType, PathSpec
+
+
+@command("rg", resource="databricks_volume", spec=SPECS["rg"])
+async def rg(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    i: bool = False,
+    v: bool = False,
+    n: bool = False,
+    c: bool = False,
+    args_l: bool = False,
+    w: bool = False,
+    F: bool = False,
+    o: bool = False,
+    m: str | None = None,
+    A: str | None = None,
+    B: str | None = None,
+    C: str | None = None,
+    hidden: bool = False,
+    type: str | None = None,
+    glob: str | None = None,
+    prefix: str = "",
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not texts:
+        raise ValueError("rg: usage: rg [flags] pattern [path]")
+    pattern = texts[0]
+    max_count = int(m) if m is not None else None
+    context_after = int(A) if A is not None else 0
+    context_before = int(B) if B is not None else 0
+    if C is not None:
+        context_before = context_after = int(C)
+
+    filetype_fns = _extra.get("filetype_fns") or {}
+
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        mount_prefix = paths[0].prefix if paths else ""
+        rd = partial(call_readdir,
+                     _readdir,
+                     accessor,
+                     index=index,
+                     prefix=mount_prefix)
+        st = partial(call_stat,
+                     _stat,
+                     accessor,
+                     index=index,
+                     prefix=mount_prefix)
+        rb = partial(call_read_bytes,
+                     _read_bytes,
+                     accessor,
+                     index=index,
+                     prefix=mount_prefix)
+
+        is_dir = False
+        try:
+            file_stat = await _stat(accessor, paths[0], index)
+            is_dir = file_stat.type == FileType.DIRECTORY
+        except (FileNotFoundError, ValueError):
+            try:
+                await _readdir(accessor, paths[0], index)
+                is_dir = True
+            except (FileNotFoundError, ValueError):
+                pass
+
+        if is_dir and filetype_fns:
+            bound_ft = {
+                ext: partial(fn, accessor)
+                for ext, fn in filetype_fns.items()
+            }
+            warnings: list[str] = []
+            results = await rg_folder_filetype(
+                rd,
+                st,
+                rb,
+                paths[0].original,
+                pattern,
+                bound_ft,
+                ignore_case=i,
+                invert=v,
+                line_numbers=n,
+                count_only=c,
+                files_only=args_l,
+                only_matching=o,
+                max_count=max_count,
+                fixed_string=F,
+                whole_word=w,
+                file_type=type,
+                glob_pattern=glob,
+                hidden=hidden,
+                warnings=warnings,
+            )
+            stderr = "\n".join(warnings).encode() if warnings else None
+            if not results:
+                return b"", IOResult(exit_code=1, stderr=stderr)
+            if mount_prefix and args_l:
+                results = [mount_prefix + "/" + r.lstrip("/") for r in results]
+            return "\n".join(results).encode(), IOResult(stderr=stderr)
+
+        needs_full = (is_dir or args_l or context_before or context_after
+                      or type or glob)
+        if needs_full:
+            warnings_f: list[str] = []
+            results = await rg_full(
+                rd,
+                st,
+                rb,
+                paths[0].original,
+                pattern,
+                ignore_case=i,
+                invert=v,
+                line_numbers=n,
+                count_only=c,
+                files_only=args_l,
+                fixed_string=F,
+                only_matching=o,
+                max_count=max_count,
+                whole_word=w,
+                context_before=context_before,
+                context_after=context_after,
+                file_type=type,
+                glob_pattern=glob,
+                hidden=hidden,
+                warnings=warnings_f,
+            )
+            stderr = "\n".join(warnings_f).encode() if warnings_f else None
+            if not results:
+                return b"", IOResult(exit_code=1, stderr=stderr)
+            if mount_prefix and args_l:
+                results = [mount_prefix + "/" + r.lstrip("/") for r in results]
+            return "\n".join(results).encode(), IOResult(stderr=stderr)
+
+        compiled = compile_pattern(pattern, i, F, w)
+
+        if len(paths) > 1:
+            all_results: list[str] = []
+            for path in paths:
+                data = (await _read_bytes(
+                    accessor, path,
+                    index)).decode(errors="replace").splitlines()
+                hits = grep_lines(path.original, data, compiled, v, n, c,
+                                  args_l, o, max_count)
+                if c:
+                    if hits:
+                        all_results.append(f"{path.original}:{hits[0]}")
+                elif args_l:
+                    all_results.extend(hits)
+                else:
+                    all_results.extend(f"{path.original}:{line}"
+                                       for line in hits)
+            if not all_results:
+                return b"", IOResult(exit_code=1)
+            if mount_prefix:
+                all_results = [
+                    mount_prefix + "/" + result.lstrip("/")
+                    for result in all_results
+                ]
+            return "\n".join(all_results).encode(), IOResult()
+
+        source = read_stream(accessor, paths[0], index)
+        stream = grep_stream(
+            source,
+            compiled,
+            invert=v,
+            line_numbers=n,
+            only_matching=o,
+            max_count=max_count,
+            count_only=c,
+        )
+        io = IOResult()
+        return exit_on_empty(stream, io), io
+    source = _resolve_source(stdin, "rg: usage: rg [flags] pattern path")
+    compiled = compile_pattern(pattern, i, F, w)
+    stream = grep_stream(
+        source,
+        compiled,
+        invert=v,
+        line_numbers=n,
+        only_matching=o,
+        max_count=max_count,
+        count_only=c,
+    )
+    io = IOResult()
+    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/databricks_volume/stat.py
+++ b/python/mirage/commands/builtin/databricks_volume/stat.py
@@ -1,0 +1,85 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import re
+from functools import partial
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.stat import stat as stat_impl
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import FileStat, FileType, PathSpec
+
+_FORMAT_RE = re.compile(r"%([nsFy]|.)")
+
+_TYPE_LABELS = {
+    FileType.DIRECTORY: "directory",
+    FileType.TEXT: "regular file",
+    FileType.BINARY: "regular file",
+    FileType.JSON: "regular file",
+    FileType.CSV: "regular file",
+}
+
+
+def _stat_type_label(file_stat: FileStat) -> str:
+    if file_stat.type is None:
+        return "regular file"
+    return _TYPE_LABELS.get(file_stat.type, "regular file")
+
+
+def _replace_stat_format(file_stat: FileStat, match: re.Match) -> str:
+    spec = match.group(1)
+    if spec == "n":
+        return file_stat.name
+    if spec == "s":
+        return str(file_stat.size if file_stat.size is not None else 0)
+    if spec == "F":
+        return _stat_type_label(file_stat)
+    if spec == "y":
+        return file_stat.modified or ""
+    return "?"
+
+
+def _format_stat(fmt: str, file_stat: FileStat) -> str:
+    return _FORMAT_RE.sub(partial(_replace_stat_format, file_stat), fmt)
+
+
+@command("stat", resource="databricks_volume", spec=SPECS["stat"])
+async def stat(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    c: str | None = None,
+    f: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        raise ValueError("stat: missing operand")
+    paths = await resolve_glob(accessor, paths, index)
+    fmt = c if c is not None else f
+    lines: list[str] = []
+    for path in paths:
+        file_stat = await stat_impl(accessor, path, index)
+        if fmt is not None:
+            lines.append(_format_stat(fmt, file_stat))
+        else:
+            type_value = file_stat.type.value if file_stat.type else None
+            lines.append(f"name={file_stat.name} size={file_stat.size}"
+                         f" modified={file_stat.modified} type={type_value}")
+    return "\n".join(lines).encode(), IOResult()

--- a/python/mirage/commands/builtin/databricks_volume/tail.py
+++ b/python/mirage/commands/builtin/databricks_volume/tail.py
@@ -1,0 +1,53 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
+from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("tail", resource="databricks_volume", spec=SPECS["tail"])
+async def tail(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    n: str | None = None,
+    c: str | None = None,
+    q: bool = False,
+    v: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    lines, plus_mode = _parse_n(n)
+    bytes_mode = int(c) if c is not None else None
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        raw = await read_bytes(accessor, paths[0], index)
+    else:
+        raw = await _read_stdin_async(stdin)
+        if raw is None:
+            raise ValueError("tail: missing operand")
+    if bytes_mode is not None:
+        return raw[-bytes_mode:] if bytes_mode else b"", IOResult()
+    return tail_bytes(raw, lines, plus_mode=plus_mode), IOResult()

--- a/python/mirage/commands/builtin/databricks_volume/tree.py
+++ b/python/mirage/commands/builtin/databricks_volume/tree.py
@@ -1,0 +1,112 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.readdir import readdir
+from mirage.core.databricks_volume.stat import stat
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import FileType, PathSpec
+
+
+async def _tree_recurse(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    prefix: str = "",
+    max_depth: int | None = None,
+    show_hidden: bool = False,
+    dirs_only: bool = False,
+    depth: int = 0,
+    warnings: list[str] | None = None,
+    index: IndexCacheStore | None = None,
+) -> list[str]:
+    lines: list[str] = []
+    try:
+        entries = await readdir(accessor, path, index)
+    except (FileNotFoundError, ValueError) as exc:
+        if warnings is not None:
+            warnings.append(f"tree: '{path.original}': {exc}")
+        return lines
+    filtered: list[tuple[PathSpec, str, FileType | None]] = []
+    for entry in entries:
+        try:
+            entry_spec = PathSpec(
+                original=entry,
+                directory=entry,
+                resolved=False,
+                prefix=path.prefix,
+            )
+            entry_stat = await stat(accessor, entry_spec, index)
+        except (FileNotFoundError, ValueError) as exc:
+            if warnings is not None:
+                warnings.append(f"tree: '{entry}': {exc}")
+            continue
+        if not show_hidden and entry_stat.name.startswith("."):
+            continue
+        if dirs_only and entry_stat.type != FileType.DIRECTORY:
+            continue
+        filtered.append((entry_spec, entry_stat.name, entry_stat.type))
+    for i, (entry_spec, name, file_type) in enumerate(filtered):
+        is_last = i == len(filtered) - 1
+        connector = "\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 "
+        lines.append(prefix + connector + name)
+        if file_type != FileType.DIRECTORY:
+            continue
+        if max_depth is not None and depth >= max_depth:
+            continue
+        extension = "    " if is_last else "\u2502   "
+        lines.extend(await _tree_recurse(
+            accessor,
+            entry_spec,
+            prefix + extension,
+            max_depth=max_depth,
+            show_hidden=show_hidden,
+            dirs_only=dirs_only,
+            depth=depth + 1,
+            warnings=warnings,
+            index=index,
+        ))
+    return lines
+
+
+@command("tree", resource="databricks_volume", spec=SPECS["tree"])
+async def tree(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    L: str | None = None,
+    a: bool = False,
+    d: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    paths = await resolve_glob(accessor, paths, index)
+    path = paths[0]
+    max_depth = int(L) if L is not None else None
+    warnings: list[str] = []
+    results = await _tree_recurse(
+        accessor,
+        path,
+        max_depth=max_depth,
+        show_hidden=a,
+        dirs_only=d,
+        warnings=warnings,
+        index=index,
+    )
+    stderr = "\n".join(warnings).encode() if warnings else None
+    return "\n".join(results).encode(), IOResult(stderr=stderr)

--- a/python/mirage/commands/builtin/utils/wrap.py
+++ b/python/mirage/commands/builtin/utils/wrap.py
@@ -62,3 +62,13 @@ async def stream_from_bytes(
     prefix: str = "",
 ) -> AsyncIterator[bytes]:
     yield await read_fn(accessor, to_pathspec(path, prefix), index)
+
+
+def call_read_stream(
+    read_fn: Callable,
+    accessor: Any,
+    path: Any,
+    index: Any = None,
+    prefix: str = "",
+):
+    return read_fn(accessor, to_pathspec(path, prefix), index)

--- a/python/mirage/core/databricks_volume/__init__.py
+++ b/python/mirage/core/databricks_volume/__init__.py
@@ -1,0 +1,13 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========

--- a/python/mirage/core/databricks_volume/errors.py
+++ b/python/mirage/core/databricks_volume/errors.py
@@ -1,0 +1,24 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+
+def is_not_found(exc: Exception) -> bool:
+    status_code = getattr(exc, "status_code", None)
+    if status_code == 404:
+        return True
+    error_code = getattr(exc, "error_code", None)
+    if error_code in {"RESOURCE_DOES_NOT_EXIST", "NOT_FOUND"}:
+        return True
+    message = str(exc).lower()
+    return "not found" in message or "does not exist" in message

--- a/python/mirage/core/databricks_volume/exists.py
+++ b/python/mirage/core/databricks_volume/exists.py
@@ -1,0 +1,25 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.core.databricks_volume.stat import stat
+from mirage.types import PathSpec
+
+
+async def exists(accessor: DatabricksVolumeAccessor, path: PathSpec) -> bool:
+    try:
+        await stat(accessor, path)
+        return True
+    except FileNotFoundError:
+        return False

--- a/python/mirage/core/databricks_volume/glob.py
+++ b/python/mirage/core/databricks_volume/glob.py
@@ -1,0 +1,58 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import fnmatch
+import logging
+import posixpath
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume.readdir import readdir
+from mirage.types import PathSpec
+
+logger = logging.getLogger(__name__)
+SCOPE_ERROR = 10_000
+
+
+async def resolve_glob(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    index: IndexCacheStore,
+) -> list[PathSpec]:
+    result: list[PathSpec] = []
+    for path in paths:
+        if isinstance(path, str):
+            result.append(
+                PathSpec(original=path, directory=posixpath.dirname(path)))
+            continue
+        if path.resolved:
+            result.append(path)
+        elif path.pattern:
+            entries = await readdir(accessor, path.dir, index)
+            matched = [
+                PathSpec.from_str_path(entry, path.prefix) for entry in entries
+                if fnmatch.fnmatch(entry.rsplit("/", 1)[-1], path.pattern)
+            ]
+            if len(matched) > SCOPE_ERROR:
+                logger.warning(
+                    "%s: %d matches exceeds limit (%d), truncating",
+                    path.directory,
+                    len(matched),
+                    SCOPE_ERROR,
+                )
+                matched = matched[:SCOPE_ERROR]
+            result.extend(matched)
+        else:
+            result.append(path)
+    return result

--- a/python/mirage/core/databricks_volume/path.py
+++ b/python/mirage/core/databricks_volume/path.py
@@ -1,0 +1,72 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import posixpath
+
+from mirage.resource.databricks_volume.config import DatabricksVolumeConfig
+from mirage.types import PathSpec
+
+
+def volume_root(config: DatabricksVolumeConfig) -> str:
+    return posixpath.join("/Volumes", config.catalog, config.schema_name,
+                          config.volume)
+
+
+def _assert_inside_root(root: str, path: str, message: str) -> None:
+    if path == root or path.startswith(root + "/"):
+        return
+    raise ValueError(message)
+
+
+def configured_root(config: DatabricksVolumeConfig) -> str:
+    root_relative = config.root_path.strip("/")
+    if root_relative:
+        return posixpath.normpath(
+            posixpath.join(volume_root(config), root_relative))
+    return posixpath.normpath(volume_root(config))
+
+
+def backend_path(config: DatabricksVolumeConfig, path: PathSpec | str) -> str:
+    if isinstance(path, PathSpec):
+        raw = path.strip_prefix
+    else:
+        raw = path
+    relative = raw.strip("/")
+    root = configured_root(config)
+    parts = [root]
+    if relative:
+        parts.append(relative)
+    remote_path = posixpath.normpath(posixpath.join(*parts))
+    _assert_inside_root(
+        root,
+        remote_path,
+        f"path escapes Databricks volume root: {raw}",
+    )
+    return remote_path
+
+
+def virtual_path(config: DatabricksVolumeConfig,
+                 backend: str,
+                 prefix: str = "") -> str:
+    root = configured_root(config)
+    remote_path = posixpath.normpath(backend)
+    _assert_inside_root(
+        root,
+        remote_path,
+        f"backend path is outside Databricks volume root: {backend}",
+    )
+    relative = remote_path.removeprefix(root).strip("/")
+    path = "/" + relative if relative else "/"
+    return prefix.rstrip(
+        "/") + path if prefix and path != "/" else prefix or path

--- a/python/mirage/core/databricks_volume/read.py
+++ b/python/mirage/core/databricks_volume/read.py
@@ -1,0 +1,109 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import time
+from urllib.parse import quote
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume.errors import is_not_found
+from mirage.core.databricks_volume.path import backend_path
+from mirage.observe.context import record
+from mirage.types import PathSpec
+
+
+def _read_response_bytes(response) -> bytes:
+    if isinstance(response, dict):
+        contents = response.get("contents", response)
+    else:
+        contents = getattr(response, "contents", response)
+    if isinstance(contents, bytes):
+        return contents
+    if hasattr(contents, "read"):
+        return contents.read()
+    return bytes(contents)
+
+
+def _range_header(offset: int, size: int | None) -> str | None:
+    if offset < 0:
+        raise ValueError("offset must be non-negative")
+    if size is not None and size < 0:
+        raise ValueError("size must be non-negative")
+    if offset == 0 and size is None:
+        return None
+    if size is None:
+        return f"bytes={offset}-"
+    return f"bytes={offset}-{offset + size - 1}"
+
+
+def _download_bytes_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+    range_header: str | None,
+) -> bytes:
+    if range_header is None:
+        return _read_response_bytes(accessor.files.download(remote_path))
+    headers = {
+        "Accept": "application/octet-stream",
+        "Range": range_header,
+    }
+    cfg = getattr(accessor.client.api_client, "_cfg", None)
+    workspace_id = getattr(cfg, "workspace_id", None)
+    if workspace_id:
+        headers["X-Databricks-Org-Id"] = workspace_id
+    response = accessor.client.api_client.do(
+        "GET",
+        f"/api/2.0/fs/files{quote(remote_path)}",
+        headers=headers,
+        response_headers=[
+            "content-length",
+            "content-range",
+            "accept-ranges",
+            "content-type",
+            "last-modified",
+        ],
+        raw=True,
+    )
+    return _read_response_bytes(response)
+
+
+async def read_bytes(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+    offset: int = 0,
+    size: int | None = None,
+) -> bytes:
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    virtual = path.original
+    remote_path = backend_path(accessor.config, path)
+    start_ms = int(time.monotonic() * 1000)
+    if size == 0:
+        record("read", virtual, "databricks_volume", 0, start_ms)
+        return b""
+    try:
+        data = await asyncio.to_thread(
+            _download_bytes_sync,
+            accessor,
+            remote_path,
+            _range_header(offset, size),
+        )
+    except Exception as exc:
+        if is_not_found(exc):
+            raise FileNotFoundError(path.strip_prefix) from exc
+        raise
+    record("read", virtual, "databricks_volume", len(data), start_ms)
+    return data

--- a/python/mirage/core/databricks_volume/readdir.py
+++ b/python/mirage/core/databricks_volume/readdir.py
@@ -1,0 +1,70 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import logging
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore, IndexEntry
+from mirage.core.databricks_volume.errors import is_not_found
+from mirage.core.databricks_volume.path import backend_path, virtual_path
+from mirage.types import PathSpec
+
+logger = logging.getLogger(__name__)
+SCOPE_ERROR = 10_000
+
+
+async def readdir(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    index: IndexCacheStore,
+) -> list[str]:
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    list_path = path.dir if path.pattern else path
+    virtual_key = list_path.original.rstrip("/") or "/"
+    listing = await index.list_dir(virtual_key)
+    if listing.entries is not None:
+        return listing.entries
+    remote_path = backend_path(accessor.config, list_path)
+    try:
+        entries = list(accessor.files.list_directory_contents(remote_path))
+    except Exception as exc:
+        if is_not_found(exc):
+            raise FileNotFoundError(list_path.strip_prefix) from exc
+        raise
+    pairs = sorted(
+        (virtual_path(accessor.config, entry.path, path.prefix), entry)
+        for entry in entries)
+    names = [name for name, _ in pairs]
+    if len(names) > SCOPE_ERROR:
+        logger.warning(
+            "databricks_volume readdir: %s returned %d entries (limit %d)",
+            virtual_key,
+            len(names),
+            SCOPE_ERROR,
+        )
+    index_entries = []
+    for full_path, entry in pairs:
+        name = full_path.rstrip("/").rsplit("/", 1)[-1]
+        resource_type = "folder" if getattr(entry, "is_directory",
+                                            False) else "file"
+        index_entries.append((name,
+                              IndexEntry(
+                                  id=full_path,
+                                  name=name,
+                                  resource_type=resource_type,
+                                  size=getattr(entry, "file_size", None),
+                              )))
+    await index.set_dir(virtual_key, index_entries)
+    return names

--- a/python/mirage/core/databricks_volume/stat.py
+++ b/python/mirage/core/databricks_volume/stat.py
@@ -1,0 +1,90 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from datetime import datetime, timezone
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume.errors import is_not_found
+from mirage.core.databricks_volume.path import backend_path
+from mirage.types import FileStat, FileType, PathSpec
+from mirage.utils.filetype import guess_type
+
+
+def _modified(value) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).isoformat()
+    if isinstance(value, (int, float)):
+        timestamp = value / 1000 if value > 10_000_000_000 else value
+        return datetime.fromtimestamp(timestamp, timezone.utc).isoformat()
+    return str(value)
+
+
+def _is_directory(metadata) -> bool:
+    value = getattr(metadata, "is_directory", None)
+    if value is not None:
+        return bool(value)
+    object_type = getattr(metadata, "object_type", None)
+    if object_type is None:
+        return False
+    return str(object_type).lower().endswith("directory")
+
+
+def _name_from_backend_path(path: str) -> str:
+    return path.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _directory_stat_or_raise(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+    path: PathSpec,
+) -> FileStat:
+    try:
+        accessor.files.get_directory_metadata(remote_path)
+    except Exception as exc:
+        if is_not_found(exc):
+            raise FileNotFoundError(path.strip_prefix) from exc
+        raise
+    return FileStat(name=_name_from_backend_path(remote_path),
+                    type=FileType.DIRECTORY)
+
+
+async def stat(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> FileStat:
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    stripped = path.strip_prefix.strip("/")
+    if not stripped:
+        return FileStat(name="/", type=FileType.DIRECTORY)
+    remote_path = backend_path(accessor.config, path)
+    try:
+        metadata = accessor.files.get_metadata(remote_path)
+    except Exception as exc:
+        if is_not_found(exc):
+            return _directory_stat_or_raise(accessor, remote_path, path)
+        raise
+    name = _name_from_backend_path(remote_path)
+    if _is_directory(metadata):
+        return FileStat(name=name, type=FileType.DIRECTORY)
+    size = getattr(metadata, "file_size", None)
+    modified = _modified(getattr(metadata, "modification_time", None))
+    return FileStat(name=name,
+                    size=size,
+                    modified=modified,
+                    type=guess_type(name))

--- a/python/mirage/core/databricks_volume/stream.py
+++ b/python/mirage/core/databricks_volume/stream.py
@@ -1,0 +1,54 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume.read import read_bytes
+from mirage.observe.context import record_stream
+from mirage.types import PathSpec
+
+
+async def read_stream(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+    chunk_size: int = 8192,
+) -> AsyncIterator[bytes]:
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be positive")
+    rec = record_stream("read", path.original, "databricks_volume")
+    offset = 0
+    while True:
+        chunk = await read_bytes(accessor, path, index, offset, chunk_size)
+        if not chunk:
+            return
+        if rec is not None:
+            rec.bytes += len(chunk)
+        yield chunk
+        if len(chunk) < chunk_size:
+            return
+        offset += chunk_size
+
+
+async def range_read(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    start: int,
+    end: int,
+) -> bytes:
+    return await read_bytes(accessor, path, offset=start, size=end - start)

--- a/python/mirage/ops/databricks_volume/__init__.py
+++ b/python/mirage/ops/databricks_volume/__init__.py
@@ -1,0 +1,19 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.ops.databricks_volume.read import read
+from mirage.ops.databricks_volume.readdir import readdir
+from mirage.ops.databricks_volume.stat import stat
+
+OPS = [read, readdir, stat]

--- a/python/mirage/ops/databricks_volume/read.py
+++ b/python/mirage/ops/databricks_volume/read.py
@@ -1,0 +1,29 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.core.databricks_volume.read import read_bytes
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("read", resource="databricks_volume")
+async def read(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    *,
+    index,
+    **kwargs,
+) -> bytes:
+    return await read_bytes(accessor, path, index)

--- a/python/mirage/ops/databricks_volume/readdir.py
+++ b/python/mirage/ops/databricks_volume/readdir.py
@@ -1,0 +1,29 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.core.databricks_volume.readdir import readdir as readdir_impl
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("readdir", resource="databricks_volume")
+async def readdir(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    *,
+    index,
+    **kwargs,
+) -> list[str]:
+    return await readdir_impl(accessor, path, index)

--- a/python/mirage/ops/databricks_volume/stat.py
+++ b/python/mirage/ops/databricks_volume/stat.py
@@ -1,0 +1,29 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.core.databricks_volume.stat import stat as stat_impl
+from mirage.ops.registry import op
+from mirage.types import FileStat, PathSpec
+
+
+@op("stat", resource="databricks_volume")
+async def stat(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    *,
+    index,
+    **kwargs,
+) -> FileStat:
+    return await stat_impl(accessor, path, index)

--- a/python/mirage/resource/databricks_volume/__init__.py
+++ b/python/mirage/resource/databricks_volume/__init__.py
@@ -1,0 +1,25 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.resource.databricks_volume.config import DatabricksVolumeConfig
+
+__all__ = ["DatabricksVolumeConfig", "DatabricksVolumeResource"]
+
+
+def __getattr__(name: str):
+    if name == "DatabricksVolumeResource":
+        from mirage.resource.databricks_volume.databricks_volume import \
+            DatabricksVolumeResource
+        return DatabricksVolumeResource
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/mirage/resource/databricks_volume/config.py
+++ b/python/mirage/resource/databricks_volume/config.py
@@ -1,0 +1,52 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import posixpath
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class DatabricksVolumeConfig(BaseModel):
+    model_config = ConfigDict(frozen=True,
+                              populate_by_name=True,
+                              serialize_by_alias=True)
+
+    catalog: str
+    # Public config key is still "schema"
+    # internal name avoids warning overwriting BaseModel.schema.
+    schema_name: str = Field(alias="schema")
+    volume: str
+    root_path: str = "/"
+    host: str | None = None
+    token: str | None = None
+    profile: str | None = None
+    timeout: int = 30
+
+    @field_validator("catalog", "schema_name", "volume")
+    @classmethod
+    def validate_volume_part(cls, value: str) -> str:
+        if not value or "/" in value:
+            raise ValueError("must be a non-empty path segment")
+        return value
+
+    @field_validator("root_path")
+    @classmethod
+    def normalize_root_path(cls, value: str) -> str:
+        stripped = value.strip("/")
+        if not stripped:
+            return "/"
+        if any(part == ".." for part in stripped.split("/")):
+            raise ValueError("root_path must not contain '..' segments")
+        normalized = posixpath.normpath("/" + stripped)
+        return "/" if normalized == "/." else normalized

--- a/python/mirage/resource/databricks_volume/databricks_volume.py
+++ b/python/mirage/resource/databricks_volume/databricks_volume.py
@@ -1,0 +1,86 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import dataclasses
+from typing import Any
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.commands.builtin.databricks_volume import \
+    COMMANDS as DATABRICKS_VOLUME_COMMANDS
+from mirage.core.databricks_volume.exists import exists
+from mirage.core.databricks_volume.glob import resolve_glob as _resolve_glob
+from mirage.core.databricks_volume.read import read_bytes
+from mirage.core.databricks_volume.readdir import readdir
+from mirage.core.databricks_volume.stat import stat as databricks_stat
+from mirage.core.databricks_volume.stream import range_read, read_stream
+from mirage.ops.databricks_volume import OPS as DATABRICKS_VOLUME_OPS
+from mirage.resource.base import BaseResource
+from mirage.resource.databricks_volume.config import DatabricksVolumeConfig
+from mirage.resource.databricks_volume.prompt import PROMPT
+from mirage.types import PathSpec, ResourceName
+
+_DATABRICKS_VOLUME_OPS = {
+    "read_bytes": read_bytes,
+    "readdir": readdir,
+    "stat": databricks_stat,
+    "read_stream": read_stream,
+    "range_read": range_read,
+    "exists": exists,
+}
+
+
+class DatabricksVolumeResource(BaseResource):
+    name: str = ResourceName.DATABRICKS_VOLUME
+    is_remote: bool = True
+    _ops: dict[str, Any] = _DATABRICKS_VOLUME_OPS
+    PROMPT: str = PROMPT
+
+    def __init__(
+        self,
+        config: DatabricksVolumeConfig,
+        client: Any | None = None,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.accessor = DatabricksVolumeAccessor(self.config, client)
+
+        for fn in DATABRICKS_VOLUME_COMMANDS:
+            self.register(fn)
+        for fn in DATABRICKS_VOLUME_OPS:
+            self.register_op(fn)
+
+    async def resolve_glob(self, paths, prefix: str = ""):
+        if prefix:
+            paths = [
+                dataclasses.replace(p, prefix=prefix)
+                if isinstance(p, PathSpec) and not p.prefix else p
+                for p in paths
+            ]
+        return await _resolve_glob(self.accessor, paths, self._index)
+
+    def get_state(self) -> dict:
+        redacted = ["token"]
+        cfg = self.config.model_dump()
+        for field in redacted:
+            if cfg.get(field) is not None:
+                cfg[field] = "<REDACTED>"
+        return {
+            "type": self.name,
+            "needs_override": True,
+            "redacted_fields": redacted,
+            "config": cfg,
+        }
+
+    def load_state(self, state: dict) -> None:
+        pass

--- a/python/mirage/resource/databricks_volume/prompt.py
+++ b/python/mirage/resource/databricks_volume/prompt.py
@@ -1,0 +1,20 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+PROMPT = """\
+{prefix}
+  Remote Databricks Unity Catalog volume filesystem.
+  IMPORTANT: This is a remote mount. Prefer targeted reads (ls, head, grep, rg)
+  over full scans. Avoid cat on large files without piping to head/tail.
+  Supports: ls, cat, head, tail, grep, rg, find, tree, stat."""

--- a/python/mirage/resource/registry.py
+++ b/python/mirage/resource/registry.py
@@ -104,6 +104,9 @@ REGISTRY: dict[str, ResourceEntry] = {
     "paperclip":
     ResourceEntry("mirage.resource.paperclip:PaperclipResource",
                   "mirage.resource.paperclip:PaperclipConfig"),
+    "databricks_volume":
+    ResourceEntry("mirage.resource.databricks_volume:DatabricksVolumeResource",
+                  "mirage.resource.databricks_volume:DatabricksVolumeConfig"),
 }
 
 

--- a/python/mirage/types.py
+++ b/python/mirage/types.py
@@ -111,6 +111,7 @@ class ResourceName(str, Enum):
     GCS = "gcs"
     EMAIL = "email"
     PAPERCLIP = "paperclip"
+    DATABRICKS_VOLUME = "databricks_volume"
 
 
 @dataclass(frozen=True)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -76,6 +76,7 @@ s3       = ["aioboto3>=13.0"]
 r2       = ["aioboto3>=13.0"]
 gcs      = ["aioboto3>=13.0"]
 oci      = ["aioboto3>=13.0"]
+databricks = ["databricks-sdk>=0.72.0"]
 
 # --- network / remote ---
 ssh      = ["asyncssh>=2.22.0", "paramiko>=4.0.0"]
@@ -137,6 +138,7 @@ all = [
     "mirage-ai[r2]",
     "mirage-ai[gcs]",
     "mirage-ai[oci]",
+    "mirage-ai[databricks]",
     "mirage-ai[ssh]",
     "mirage-ai[fuse]",
     "mirage-ai[mongodb]",

--- a/python/tests/core/databricks_volume/conftest.py
+++ b/python/tests/core/databricks_volume/conftest.py
@@ -1,0 +1,178 @@
+from io import BytesIO
+from types import SimpleNamespace
+from urllib.parse import unquote
+
+import pytest
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.core.databricks_volume.path import backend_path
+from mirage.resource.databricks_volume import DatabricksVolumeConfig
+
+
+class NotFoundError(Exception):
+    status_code = 404
+
+
+class FakeDownload:
+
+    def __init__(self, data: bytes) -> None:
+        self.contents = BytesIO(data)
+
+
+class FakeFiles:
+
+    def __init__(self) -> None:
+        self.downloads: dict[str, bytes] = {}
+        self.metadata: dict[str, object] = {}
+        self.directory_metadata: set[str] = set()
+        self.directories: dict[str, list[object]] = {}
+        self.metadata_errors: dict[str, Exception] = {}
+        self.directory_metadata_errors: dict[str, Exception] = {}
+        self.download_calls: list[str] = []
+        self.get_metadata_calls: list[str] = []
+        self.get_directory_metadata_calls: list[str] = []
+        self.list_directory_calls: list[str] = []
+
+    def download(self, path: str) -> FakeDownload:
+        self.download_calls.append(path)
+        if path not in self.downloads:
+            raise NotFoundError(path)
+        return FakeDownload(self.downloads[path])
+
+    def get_metadata(self, path: str) -> object:
+        self.get_metadata_calls.append(path)
+        if path in self.metadata_errors:
+            raise self.metadata_errors[path]
+        if path not in self.metadata:
+            raise NotFoundError(path)
+        return self.metadata[path]
+
+    def get_directory_metadata(self, path: str) -> None:
+        self.get_directory_metadata_calls.append(path)
+        if path in self.directory_metadata_errors:
+            raise self.directory_metadata_errors[path]
+        if path not in self.directory_metadata:
+            raise NotFoundError(path)
+
+    def list_directory_contents(self, path: str) -> list[object]:
+        self.list_directory_calls.append(path)
+        if path not in self.directories:
+            raise NotFoundError(path)
+        return self.directories[path]
+
+
+def _apply_range_header(data: bytes, range_header: str) -> bytes:
+    if not range_header.startswith("bytes="):
+        raise ValueError(f"unsupported range header: {range_header}")
+    start_text, end_text = range_header.removeprefix("bytes=").split("-", 1)
+    start = int(start_text) if start_text else 0
+    end = int(end_text) + 1 if end_text else None
+    return data[start:end]
+
+
+class FakeApiClient:
+
+    def __init__(self, files: FakeFiles) -> None:
+        self.files = files
+        self.do_calls: list[dict[str, object]] = []
+
+    def do(
+        self,
+        method: str,
+        path: str | None = None,
+        url: str | None = None,
+        query: dict | None = None,
+        headers: dict | None = None,
+        body: dict | None = None,
+        raw: bool = False,
+        files: object = None,
+        data: object = None,
+        auth: object = None,
+        response_headers: list[str] | None = None,
+    ) -> dict:
+        call = {
+            "method": method,
+            "path": path,
+            "url": url,
+            "query": query,
+            "headers": headers or {},
+            "body": body,
+            "raw": raw,
+            "files": files,
+            "data": data,
+            "auth": auth,
+            "response_headers": response_headers,
+        }
+        self.do_calls.append(call)
+        if method != "GET" or path is None:
+            raise ValueError(f"unsupported fake API call: {method} {path}")
+        remote_path = unquote(path.removeprefix("/api/2.0/fs/files"))
+        if remote_path not in self.files.downloads:
+            raise NotFoundError(remote_path)
+        payload = self.files.downloads[remote_path]
+        range_header = (headers or {}).get("Range")
+        if range_header is not None:
+            payload = _apply_range_header(payload, range_header)
+        return {
+            "contents": BytesIO(payload),
+            "content-length": str(len(payload)),
+            "accept-ranges": "bytes",
+        }
+
+
+class FakeClient:
+
+    def __init__(self, files: FakeFiles) -> None:
+        self.files = files
+        self.api_client = FakeApiClient(files)
+
+
+@pytest.fixture
+def databricks_config() -> DatabricksVolumeConfig:
+    return DatabricksVolumeConfig(
+        catalog="main",
+        schema="default",
+        volume="agent_files",
+        root_path="/root",
+        token="secret",
+    )
+
+
+@pytest.fixture
+def remote_root(databricks_config: DatabricksVolumeConfig) -> str:
+    return backend_path(databricks_config, "/")
+
+
+@pytest.fixture
+def files() -> FakeFiles:
+    return FakeFiles()
+
+
+@pytest.fixture
+def accessor(
+    databricks_config: DatabricksVolumeConfig,
+    files: FakeFiles,
+) -> DatabricksVolumeAccessor:
+    return DatabricksVolumeAccessor(databricks_config, FakeClient(files))
+
+
+@pytest.fixture
+def index() -> RAMIndexCacheStore:
+    return RAMIndexCacheStore(ttl=600)
+
+
+def file_metadata(size: int = 0, modified: int | None = None) -> object:
+    return SimpleNamespace(
+        is_directory=False,
+        file_size=size,
+        modification_time=modified,
+    )
+
+
+def directory_entry(path: str) -> object:
+    return SimpleNamespace(path=path, is_directory=True, file_size=None)
+
+
+def file_entry(path: str, size: int = 0) -> object:
+    return SimpleNamespace(path=path, is_directory=False, file_size=size)

--- a/python/tests/core/databricks_volume/test_exists.py
+++ b/python/tests/core/databricks_volume/test_exists.py
@@ -1,0 +1,19 @@
+import pytest
+
+from mirage.core.databricks_volume.exists import exists
+from mirage.types import PathSpec
+
+from .conftest import file_metadata
+
+
+@pytest.mark.asyncio
+async def test_exists_true_for_file(accessor, files, remote_root):
+    files.metadata[f"{remote_root}/reports/latest.md"] = file_metadata(size=6)
+    path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+    assert await exists(accessor, path) is True
+
+
+@pytest.mark.asyncio
+async def test_exists_false_for_missing_path(accessor):
+    path = PathSpec.from_str_path("/volume/missing.md", "/volume")
+    assert await exists(accessor, path) is False

--- a/python/tests/core/databricks_volume/test_glob.py
+++ b/python/tests/core/databricks_volume/test_glob.py
@@ -1,0 +1,44 @@
+import pytest
+
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.types import PathSpec
+
+from .conftest import file_entry
+
+
+@pytest.mark.asyncio
+async def test_resolve_file_path(accessor, index):
+    scope = PathSpec.from_str_path("/volume/readme.md", "/volume")
+    result = await resolve_glob(accessor, [scope], index)
+    assert result == [scope]
+
+
+@pytest.mark.asyncio
+async def test_resolve_glob_pattern(accessor, files, index, remote_root):
+    files.directories[f"{remote_root}/src"] = [
+        file_entry(f"{remote_root}/src/main.py"),
+        file_entry(f"{remote_root}/src/util.py"),
+        file_entry(f"{remote_root}/src/data.json"),
+    ]
+    scope = PathSpec(
+        original="/volume/src/*.py",
+        directory="/volume/src",
+        pattern="*.py",
+        resolved=False,
+        prefix="/volume",
+    )
+    result = await resolve_glob(accessor, [scope], index)
+    originals = sorted(path.original for path in result)
+    assert originals == ["/volume/src/main.py", "/volume/src/util.py"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_directory_path(accessor, index):
+    scope = PathSpec(
+        original="/volume/src",
+        directory="/volume/src",
+        resolved=False,
+        prefix="/volume",
+    )
+    result = await resolve_glob(accessor, [scope], index)
+    assert result == [scope]

--- a/python/tests/core/databricks_volume/test_head.py
+++ b/python/tests/core/databricks_volume/test_head.py
@@ -1,0 +1,26 @@
+import pytest
+
+from mirage.commands.builtin.databricks_volume.head import head
+from mirage.types import PathSpec
+
+
+async def collect_bytes(source) -> bytes:
+    return b"".join([chunk async for chunk in source])
+
+
+@pytest.mark.asyncio
+async def test_head_bytes_mode_uses_single_small_range_request(
+    accessor,
+    files,
+    remote_root,
+):
+    files.downloads[f"{remote_root}/reports/latest.md"] = b"abcdef"
+    path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+
+    source, _io = await head(accessor, [path], c="3")
+
+    assert await collect_bytes(source) == b"abc"
+    assert files.download_calls == []
+    assert len(accessor.client.api_client.do_calls) == 1
+    assert accessor.client.api_client.do_calls[0]["headers"]["Range"] == (
+        "bytes=0-2")

--- a/python/tests/core/databricks_volume/test_path.py
+++ b/python/tests/core/databricks_volume/test_path.py
@@ -1,0 +1,58 @@
+import pytest
+from pydantic import ValidationError
+
+from mirage.core.databricks_volume.path import backend_path, virtual_path
+from mirage.resource.databricks_volume import DatabricksVolumeConfig
+from mirage.types import PathSpec
+
+
+def test_backend_path_uses_volume_root_and_strips_mount_prefix(
+        databricks_config):
+    path = PathSpec(
+        original="/volume/reports/latest.md",
+        directory="/volume/reports",
+        prefix="/volume",
+    )
+    assert backend_path(
+        databricks_config,
+        path) == ("/Volumes/main/default/agent_files/root/reports/latest.md")
+
+
+def test_backend_path_allows_normalized_path_inside_root(databricks_config):
+    path = PathSpec(
+        original="/volume/reports/../latest.md",
+        directory="/volume/reports",
+        prefix="/volume",
+    )
+    assert backend_path(
+        databricks_config,
+        path) == ("/Volumes/main/default/agent_files/root/latest.md")
+
+
+def test_backend_path_rejects_escape_above_configured_root(databricks_config):
+    path = PathSpec(
+        original="/volume/../../other_schema/other_volume/secret.txt",
+        directory="/volume",
+        prefix="/volume",
+    )
+    with pytest.raises(ValueError, match="escapes Databricks volume root"):
+        backend_path(databricks_config, path)
+
+
+def test_config_rejects_parent_segments_in_root_path():
+    with pytest.raises(ValidationError):
+        DatabricksVolumeConfig(
+            catalog="main",
+            schema="default",
+            volume="agent_files",
+            root_path="/root/../other",
+        )
+
+
+def test_virtual_path_rejects_backend_outside_root(databricks_config):
+    with pytest.raises(ValueError, match="outside Databricks volume root"):
+        virtual_path(
+            databricks_config,
+            "/Volumes/main/default/other_volume/secret.txt",
+            "/volume",
+        )

--- a/python/tests/core/databricks_volume/test_read.py
+++ b/python/tests/core/databricks_volume/test_read.py
@@ -1,0 +1,109 @@
+import asyncio
+
+import pytest
+
+from mirage.core.databricks_volume.read import read_bytes
+from mirage.types import PathSpec
+
+
+class ToThreadRecorder:
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def __call__(self, fn, *args, **kwargs):
+        self.calls.append((fn, args, kwargs))
+        return fn(*args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_read_file(accessor, files, remote_root):
+    files.downloads[f"{remote_root}/reports/latest.md"] = b"hello"
+    path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+    result = await read_bytes(accessor, path)
+    assert result == b"hello"
+    assert files.download_calls == [f"{remote_root}/reports/latest.md"]
+
+
+@pytest.mark.asyncio
+async def test_read_file_not_found(accessor):
+    path = PathSpec.from_str_path("/volume/missing.md", "/volume")
+    with pytest.raises(FileNotFoundError):
+        await read_bytes(accessor, path)
+
+
+@pytest.mark.asyncio
+async def test_read_slice(accessor, files, remote_root):
+    files.downloads[f"{remote_root}/reports/latest.md"] = b"abcdef"
+    path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+    result = await read_bytes(accessor, path, offset=1, size=3)
+    assert result == b"bcd"
+
+
+@pytest.mark.asyncio
+async def test_read_file_runs_blocking_download_off_event_loop(
+    accessor,
+    files,
+    remote_root,
+    monkeypatch,
+):
+    to_thread = ToThreadRecorder()
+    monkeypatch.setattr(asyncio, "to_thread", to_thread)
+    files.downloads[f"{remote_root}/reports/latest.md"] = b"hello"
+    path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+
+    result = await read_bytes(accessor, path)
+
+    assert result == b"hello"
+    assert len(to_thread.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_read_slice_uses_databricks_range_request(
+    accessor,
+    files,
+    remote_root,
+):
+    files.downloads[f"{remote_root}/reports/latest.md"] = b"abcdef"
+    path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+
+    result = await read_bytes(accessor, path, offset=1, size=3)
+
+    assert result == b"bcd"
+    assert files.download_calls == []
+    assert accessor.client.api_client.do_calls[0]["headers"]["Range"] == (
+        "bytes=1-3")
+    assert accessor.client.api_client.do_calls[0]["raw"] is True
+
+
+@pytest.mark.asyncio
+async def test_read_from_offset_uses_open_ended_range(
+    accessor,
+    files,
+    remote_root,
+):
+    files.downloads[f"{remote_root}/reports/latest.md"] = b"abcdef"
+    path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+
+    result = await read_bytes(accessor, path, offset=3)
+
+    assert result == b"def"
+    assert files.download_calls == []
+    assert accessor.client.api_client.do_calls[0]["headers"]["Range"] == (
+        "bytes=3-")
+
+
+@pytest.mark.asyncio
+async def test_read_zero_size_returns_empty_without_network(
+    accessor,
+    files,
+    remote_root,
+):
+    files.downloads[f"{remote_root}/reports/latest.md"] = b"abcdef"
+    path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+
+    result = await read_bytes(accessor, path, size=0)
+
+    assert result == b""
+    assert files.download_calls == []
+    assert accessor.client.api_client.do_calls == []

--- a/python/tests/core/databricks_volume/test_readdir.py
+++ b/python/tests/core/databricks_volume/test_readdir.py
@@ -1,0 +1,47 @@
+import pytest
+
+from mirage.core.databricks_volume.readdir import readdir
+from mirage.types import PathSpec
+
+from .conftest import directory_entry, file_entry
+
+
+@pytest.mark.asyncio
+async def test_readdir_returns_full_virtual_paths(
+    accessor,
+    files,
+    index,
+    remote_root,
+):
+    files.directories[f"{remote_root}/reports"] = [
+        file_entry(f"{remote_root}/reports/latest.md", size=6),
+        directory_entry(f"{remote_root}/reports/archive"),
+    ]
+    path = PathSpec.from_str_path("/volume/reports", "/volume")
+    result = await readdir(accessor, path, index)
+    assert result == [
+        "/volume/reports/archive",
+        "/volume/reports/latest.md",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_readdir_uses_cached_listing(accessor, files, index,
+                                           remote_root):
+    files.directories[f"{remote_root}/reports"] = [
+        file_entry(f"{remote_root}/reports/latest.md", size=6),
+    ]
+    path = PathSpec.from_str_path("/volume/reports", "/volume")
+    assert await readdir(accessor, path,
+                         index) == ["/volume/reports/latest.md"]
+    files.directories[f"{remote_root}/reports"] = []
+    assert await readdir(accessor, path,
+                         index) == ["/volume/reports/latest.md"]
+    assert files.list_directory_calls == [f"{remote_root}/reports"]
+
+
+@pytest.mark.asyncio
+async def test_readdir_missing_directory_raises(accessor, index):
+    path = PathSpec.from_str_path("/volume/missing", "/volume")
+    with pytest.raises(FileNotFoundError):
+        await readdir(accessor, path, index)

--- a/python/tests/core/databricks_volume/test_stat.py
+++ b/python/tests/core/databricks_volume/test_stat.py
@@ -1,0 +1,110 @@
+import pytest
+
+from mirage.core.databricks_volume.stat import _name_from_backend_path, stat
+from mirage.types import FileType, PathSpec
+
+from .conftest import file_metadata
+
+
+def test_name_from_backend_path_file():
+    assert _name_from_backend_path(
+        "/Volumes/main/default/agent_files/root/latest.md") == "latest.md"
+
+
+def test_name_from_backend_path_directory_with_trailing_slash():
+    assert _name_from_backend_path(
+        "/Volumes/main/default/agent_files/root/reports/") == "reports"
+
+
+@pytest.mark.asyncio
+async def test_stat_file(accessor, files, remote_root):
+    files.metadata[f"{remote_root}/reports/latest.md"] = file_metadata(
+        size=6,
+        modified=1_700_000_000_000,
+    )
+    path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+    result = await stat(accessor, path)
+    assert result.name == "latest.md"
+    assert result.size == 6
+    assert result.modified == "2023-11-14T22:13:20+00:00"
+    assert result.type != FileType.DIRECTORY
+
+
+@pytest.mark.asyncio
+async def test_stat_root_does_not_call_sdk(accessor, files):
+    path = PathSpec.from_str_path("/volume", "/volume")
+    result = await stat(accessor, path)
+    assert result.name == "/"
+    assert result.type == FileType.DIRECTORY
+    assert files.get_metadata_calls == []
+    assert files.get_directory_metadata_calls == []
+
+
+@pytest.mark.asyncio
+async def test_stat_directory_uses_directory_metadata_fallback(
+    accessor,
+    files,
+    remote_root,
+):
+    files.directory_metadata.add(f"{remote_root}/reports")
+    path = PathSpec.from_str_path("/volume/reports", "/volume")
+    result = await stat(accessor, path)
+    assert result.name == "reports"
+    assert result.size is None
+    assert result.type == FileType.DIRECTORY
+    assert files.get_metadata_calls == [f"{remote_root}/reports"]
+    assert files.get_directory_metadata_calls == [f"{remote_root}/reports"]
+
+
+@pytest.mark.asyncio
+async def test_stat_missing_path_raises(accessor):
+    path = PathSpec.from_str_path("/volume/missing", "/volume")
+    with pytest.raises(FileNotFoundError):
+        await stat(accessor, path)
+
+
+@pytest.mark.asyncio
+async def test_stat_missing_path_checks_directory_metadata(
+    accessor,
+    files,
+    remote_root,
+):
+    path = PathSpec.from_str_path("/volume/missing", "/volume")
+    with pytest.raises(FileNotFoundError):
+        await stat(accessor, path)
+    assert files.get_metadata_calls == [f"{remote_root}/missing"]
+    assert files.get_directory_metadata_calls == [f"{remote_root}/missing"]
+
+
+@pytest.mark.asyncio
+async def test_stat_rejects_path_escape(accessor):
+    path = PathSpec.from_str_path("/volume/../outside", "/volume")
+    with pytest.raises(ValueError, match="escapes Databricks volume root"):
+        await stat(accessor, path)
+
+
+@pytest.mark.asyncio
+async def test_stat_metadata_error_propagates(accessor, files, remote_root):
+    remote_path = f"{remote_root}/reports"
+    files.metadata_errors[remote_path] = RuntimeError("metadata failed")
+    path = PathSpec.from_str_path("/volume/reports", "/volume")
+    with pytest.raises(RuntimeError, match="metadata failed"):
+        await stat(accessor, path)
+    assert files.get_metadata_calls == [remote_path]
+    assert files.get_directory_metadata_calls == []
+
+
+@pytest.mark.asyncio
+async def test_stat_directory_metadata_error_propagates(
+    accessor,
+    files,
+    remote_root,
+):
+    remote_path = f"{remote_root}/reports"
+    files.directory_metadata_errors[remote_path] = RuntimeError(
+        "directory metadata failed")
+    path = PathSpec.from_str_path("/volume/reports", "/volume")
+    with pytest.raises(RuntimeError, match="directory metadata failed"):
+        await stat(accessor, path)
+    assert files.get_metadata_calls == [remote_path]
+    assert files.get_directory_metadata_calls == [remote_path]

--- a/python/tests/core/databricks_volume/test_stream.py
+++ b/python/tests/core/databricks_volume/test_stream.py
@@ -1,0 +1,58 @@
+import pytest
+
+from mirage.core.databricks_volume.stream import range_read, read_stream
+from mirage.types import PathSpec
+
+
+@pytest.mark.asyncio
+async def test_read_stream_chunks_file(accessor, files, remote_root):
+    files.downloads[f"{remote_root}/reports/latest.md"] = b"abcdef"
+    path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+    chunks = [
+        chunk async for chunk in read_stream(accessor, path, chunk_size=2)
+    ]
+    assert chunks == [b"ab", b"cd", b"ef"]
+
+
+@pytest.mark.asyncio
+async def test_range_read_uses_end_exclusive(accessor, files, remote_root):
+    files.downloads[f"{remote_root}/reports/latest.md"] = b"abcdef"
+    path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+    result = await range_read(accessor, path, 1, 4)
+    assert result == b"bcd"
+
+
+@pytest.mark.asyncio
+async def test_range_read_uses_single_databricks_range_request(
+    accessor,
+    files,
+    remote_root,
+):
+    files.downloads[f"{remote_root}/reports/latest.md"] = b"abcdef"
+    path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+
+    result = await range_read(accessor, path, 1, 4)
+
+    assert result == b"bcd"
+    assert files.download_calls == []
+    assert len(accessor.client.api_client.do_calls) == 1
+    assert accessor.client.api_client.do_calls[0]["headers"]["Range"] == (
+        "bytes=1-3")
+
+
+@pytest.mark.asyncio
+async def test_read_stream_does_not_download_whole_file_before_yielding(
+    accessor,
+    files,
+    remote_root,
+):
+    files.downloads[f"{remote_root}/reports/latest.md"] = b"abcdef"
+    path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+
+    chunks = [
+        chunk async for chunk in read_stream(accessor, path, chunk_size=2)
+    ]
+
+    assert chunks == [b"ab", b"cd", b"ef"]
+    assert files.download_calls == []
+    assert accessor.client.api_client.do_calls

--- a/python/tests/resource/databricks_volume/__init__.py
+++ b/python/tests/resource/databricks_volume/__init__.py
@@ -1,0 +1,13 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========

--- a/python/tests/resource/databricks_volume/test_accessor.py
+++ b/python/tests/resource/databricks_volume/test_accessor.py
@@ -1,0 +1,46 @@
+from mirage.accessor import databricks_volume as accessor_module
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.resource.databricks_volume import DatabricksVolumeConfig
+
+
+class FakeWorkspaceClient:
+    calls: list[dict] = []
+
+    def __init__(self, **kwargs) -> None:
+        self.calls.append(kwargs)
+        self.files = object()
+
+
+class FakeWorkspaceConfig:
+
+    def __init__(self, **kwargs) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def test_accessor_passes_timeout_to_workspace_client(monkeypatch):
+    FakeWorkspaceClient.calls = []
+    monkeypatch.setattr(
+        accessor_module,
+        "WorkspaceClient",
+        FakeWorkspaceClient,
+    )
+    monkeypatch.setattr(
+        accessor_module,
+        "WorkspaceConfig",
+        FakeWorkspaceConfig,
+    )
+    config = DatabricksVolumeConfig(
+        catalog="main",
+        schema="default",
+        volume="agent_files",
+        host="https://example.cloud.databricks.com",
+        token="secret",
+        timeout=17,
+    )
+    accessor = DatabricksVolumeAccessor(config)
+    assert accessor.files is not None
+    sdk_config = FakeWorkspaceClient.calls[0]["config"]
+    assert sdk_config.host == "https://example.cloud.databricks.com"
+    assert sdk_config.token == "secret"
+    assert sdk_config.http_timeout_seconds == 17

--- a/python/tests/resource/databricks_volume/test_databricks_volume.py
+++ b/python/tests/resource/databricks_volume/test_databricks_volume.py
@@ -1,0 +1,412 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from io import BytesIO
+from types import SimpleNamespace
+from urllib.parse import unquote
+
+import pytest
+from pydantic import ValidationError
+
+from mirage import MountMode, Workspace
+from mirage.core.databricks_volume.path import backend_path
+from mirage.resource.databricks_volume import (DatabricksVolumeConfig,
+                                               DatabricksVolumeResource)
+from mirage.types import PathSpec, ResourceName
+
+
+class NotFoundError(Exception):
+    status_code = 404
+
+
+class FakeDownload:
+
+    def __init__(self, data: bytes) -> None:
+        self.contents = BytesIO(data)
+
+
+class FakeFiles:
+
+    def __init__(self) -> None:
+        self.downloads: dict[str, bytes] = {}
+        self.metadata: dict[str, object] = {}
+        self.directory_metadata: set[str] = set()
+        self.directories: dict[str, list[object]] = {}
+
+    def download(self, path: str) -> FakeDownload:
+        if path not in self.downloads:
+            raise NotFoundError(path)
+        return FakeDownload(self.downloads[path])
+
+    def get_metadata(self, path: str) -> object:
+        if path not in self.metadata:
+            raise NotFoundError(path)
+        return self.metadata[path]
+
+    def get_directory_metadata(self, path: str) -> None:
+        if path not in self.directory_metadata:
+            raise NotFoundError(path)
+
+    def list_directory_contents(self, path: str) -> list[object]:
+        if path not in self.directories:
+            raise NotFoundError(path)
+        return self.directories[path]
+
+
+def _apply_range_header(data: bytes, range_header: str) -> bytes:
+    if not range_header.startswith("bytes="):
+        raise ValueError(f"unsupported range header: {range_header}")
+    start_text, end_text = range_header.removeprefix("bytes=").split("-", 1)
+    start = int(start_text) if start_text else 0
+    end = int(end_text) + 1 if end_text else None
+    return data[start:end]
+
+
+class FakeApiClient:
+
+    def __init__(self, files: FakeFiles) -> None:
+        self.files = files
+
+    def do(
+        self,
+        method: str,
+        path: str | None = None,
+        url: str | None = None,
+        query: dict | None = None,
+        headers: dict | None = None,
+        body: dict | None = None,
+        raw: bool = False,
+        files: object = None,
+        data: object = None,
+        auth: object = None,
+        response_headers: list[str] | None = None,
+    ) -> dict:
+        if method != "GET" or path is None:
+            raise ValueError(f"unsupported fake API call: {method} {path}")
+        remote_path = unquote(path.removeprefix("/api/2.0/fs/files"))
+        if remote_path not in self.files.downloads:
+            raise NotFoundError(remote_path)
+        payload = self.files.downloads[remote_path]
+        range_header = (headers or {}).get("Range")
+        if range_header is not None:
+            payload = _apply_range_header(payload, range_header)
+        return {
+            "contents": BytesIO(payload),
+            "content-length": str(len(payload)),
+            "accept-ranges": "bytes",
+        }
+
+
+class FakeClient:
+
+    def __init__(self, files: FakeFiles) -> None:
+        self.files = files
+        self.api_client = FakeApiClient(files)
+
+
+def make_resource(files: FakeFiles) -> DatabricksVolumeResource:
+    return DatabricksVolumeResource(
+        DatabricksVolumeConfig(
+            catalog="main",
+            schema="default",
+            volume="agent_files",
+            root_path="/root",
+            token="secret",
+        ),
+        client=FakeClient(files),
+    )
+
+
+def test_config_validation_and_normalization():
+    config = DatabricksVolumeConfig(
+        catalog="main",
+        schema="default",
+        volume="agent_files",
+        root_path="nested/path",
+    )
+    assert config.root_path == "/nested/path"
+    with pytest.raises(ValidationError):
+        DatabricksVolumeConfig(
+            catalog="main/other",
+            schema="default",
+            volume="agent_files",
+        )
+
+
+def test_backend_path_uses_volume_root_and_strips_mount_prefix():
+    config = DatabricksVolumeConfig(
+        catalog="main",
+        schema="default",
+        volume="agent_files",
+        root_path="/root",
+    )
+    path = PathSpec(
+        original="/volume/reports/latest.md",
+        directory="/volume/reports",
+        prefix="/volume",
+    )
+    assert backend_path(
+        config,
+        path) == ("/Volumes/main/default/agent_files/root/reports/latest.md")
+
+
+def test_resource_state_redacts_token():
+    resource = make_resource(FakeFiles())
+    state = resource.get_state()
+    assert state["type"] == ResourceName.DATABRICKS_VOLUME
+    assert state["needs_override"] is True
+    assert state["config"]["token"] == "<REDACTED>"
+    assert state["config"]["host"] is None
+    assert state["config"]["catalog"] == "main"
+    assert "token" in state["redacted_fields"]
+
+
+def test_resource_registers_read_only_ops():
+    resource = make_resource(FakeFiles())
+    op_names = {op.name for op in resource.ops_list()}
+    assert {"read", "readdir", "stat"} <= op_names
+    assert resource.name == "databricks_volume"
+    assert resource.is_remote is True
+
+
+def test_resource_registers_read_only_commands():
+    resource = make_resource(FakeFiles())
+    command_names = {command.name for command in resource.commands()}
+    assert {
+        "cat",
+        "find",
+        "grep",
+        "head",
+        "ls",
+        "rg",
+        "stat",
+        "tail",
+        "tree",
+    } <= command_names
+
+
+@pytest.mark.asyncio
+async def test_read_stat_readdir_range_stream_and_exists():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    files.downloads[f"{root}/reports/latest.md"] = b"abcdef"
+    files.metadata[f"{root}/reports/latest.md"] = SimpleNamespace(
+        is_directory=False,
+        file_size=6,
+        modification_time=1_700_000_000_000,
+    )
+    files.metadata[f"{root}/reports"] = SimpleNamespace(is_directory=True)
+    files.directories[f"{root}/reports"] = [
+        SimpleNamespace(
+            path=f"{root}/reports/latest.md",
+            is_directory=False,
+            file_size=6,
+        )
+    ]
+    resource = make_resource(files)
+
+    assert await resource.read_bytes(
+        PathSpec.from_str_path("/volume/reports/latest.md",
+                               "/volume")) == b"abcdef"
+    assert await resource.range_read(
+        PathSpec.from_str_path("/volume/reports/latest.md", "/volume"), 1,
+        4) == b"bcd"
+    chunks = [
+        chunk async for chunk in resource.read_stream(
+            PathSpec.from_str_path("/volume/reports/latest.md", "/volume"),
+            chunk_size=2,
+        )
+    ]
+    assert chunks == [b"ab", b"cd", b"ef"]
+    file_stat = await resource.stat(
+        PathSpec.from_str_path("/volume/reports/latest.md", "/volume"))
+    assert file_stat.name == "latest.md"
+    assert file_stat.size == 6
+    assert await resource.exists(
+        PathSpec.from_str_path("/volume/reports/latest.md", "/volume"))
+    assert not await resource.exists(
+        PathSpec.from_str_path("/volume/missing.md", "/volume"))
+    entries = await resource.readdir(
+        PathSpec.from_str_path("/volume/reports", "/volume"),
+        resource.index,
+    )
+    assert entries == ["/volume/reports/latest.md"]
+
+
+@pytest.mark.asyncio
+async def test_workspace_read_mode_uses_registered_ops():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    files.downloads[f"{root}/latest.md"] = b"hello"
+    files.metadata[f"{root}/latest.md"] = SimpleNamespace(
+        is_directory=False,
+        file_size=5,
+    )
+    ws = Workspace({"/volume": make_resource(files)}, mode=MountMode.READ)
+
+    assert await ws.ops.read("/volume/latest.md") == b"hello"
+    file_stat = await ws.ops.stat("/volume/latest.md")
+    assert file_stat.size == 5
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_uses_databricks_volume_mount_for_ls():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    files.directory_metadata.add(root)
+    files.metadata[f"{root}/debug_output.json"] = SimpleNamespace(
+        is_directory=False,
+        file_size=18,
+    )
+    files.directories[root] = [
+        SimpleNamespace(
+            path=f"{root}/debug_output.json",
+            is_directory=False,
+            file_size=18,
+        )
+    ]
+    ws = Workspace({"/dbx/": make_resource(files)}, mode=MountMode.READ)
+
+    io = await ws.execute("ls /dbx")
+    slash_io = await ws.execute("ls /dbx/")
+
+    assert io.exit_code == 0
+    assert b"debug_output.json" in io.stdout
+    assert slash_io.exit_code == 0
+    assert b"debug_output.json" in slash_io.stdout
+    mount = await ws._registry.resolve_mount(
+        "ls",
+        [PathSpec.from_str_path("/dbx", "/dbx")],
+        "/",
+    )
+    assert mount is not None
+    assert mount.prefix == "/dbx/"
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_stat_and_cat():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    files.downloads[f"{root}/debug_output.json"] = b'{"ok": true}\nsecond\n'
+    files.metadata[f"{root}/debug_output.json"] = SimpleNamespace(
+        is_directory=False,
+        file_size=20,
+    )
+    ws = Workspace({"/dbx/": make_resource(files)}, mode=MountMode.READ)
+
+    stat_io = await ws.execute("stat /dbx/debug_output.json")
+    cat_io = await ws.execute("cat /dbx/debug_output.json")
+    head_io = await ws.execute("head -n 1 /dbx/debug_output.json")
+
+    assert stat_io.exit_code == 0
+    assert b"name=debug_output.json" in stat_io.stdout
+    assert cat_io.exit_code == 0
+    assert b'{"ok": true}' in cat_io.stdout
+    assert head_io.exit_code == 0
+    assert head_io.stdout == b'{"ok": true}\n'
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_find_files():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    files.directory_metadata.update({root, f"{root}/nested"})
+    files.metadata[f"{root}/nested"] = SimpleNamespace(is_directory=True)
+    files.metadata[f"{root}/debug_output.json"] = SimpleNamespace(
+        is_directory=False,
+        file_size=2,
+    )
+    files.metadata[f"{root}/nested/result.txt"] = SimpleNamespace(
+        is_directory=False,
+        file_size=2,
+    )
+    files.directories[root] = [
+        SimpleNamespace(
+            path=f"{root}/debug_output.json",
+            is_directory=False,
+            file_size=2,
+        ),
+        SimpleNamespace(path=f"{root}/nested", is_directory=True),
+    ]
+    files.directories[f"{root}/nested"] = [
+        SimpleNamespace(
+            path=f"{root}/nested/result.txt",
+            is_directory=False,
+            file_size=2,
+        )
+    ]
+    ws = Workspace({"/dbx/": make_resource(files)}, mode=MountMode.READ)
+
+    io = await ws.execute("find /dbx -maxdepth 2 -type f")
+
+    assert io.exit_code == 0
+    assert b"/dbx/debug_output.json" in io.stdout
+    assert b"/dbx/nested/result.txt" in io.stdout
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_recursive_grep_and_rg():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    files.directory_metadata.update({
+        root,
+        f"{root}/nested",
+        f"{root}/nested/deeper",
+    })
+    files.metadata[f"{root}/nested"] = SimpleNamespace(is_directory=True)
+    files.metadata[f"{root}/nested/deeper"] = SimpleNamespace(
+        is_directory=True)
+    files.metadata[f"{root}/nested/info.txt"] = SimpleNamespace(
+        is_directory=False,
+        file_size=17,
+    )
+    files.metadata[f"{root}/nested/deeper/notes.md"] = SimpleNamespace(
+        is_directory=False,
+        file_size=26,
+    )
+    files.downloads[f"{root}/nested/info.txt"] = b"alpha debug line\n"
+    files.downloads[f"{root}/nested/deeper/notes.md"] = (
+        b"# Notes\nbeta debug detail\n")
+    files.directories[root] = [
+        SimpleNamespace(path=f"{root}/nested", is_directory=True),
+    ]
+    files.directories[f"{root}/nested"] = [
+        SimpleNamespace(
+            path=f"{root}/nested/info.txt",
+            is_directory=False,
+            file_size=17,
+        ),
+        SimpleNamespace(path=f"{root}/nested/deeper", is_directory=True),
+    ]
+    files.directories[f"{root}/nested/deeper"] = [
+        SimpleNamespace(
+            path=f"{root}/nested/deeper/notes.md",
+            is_directory=False,
+            file_size=26,
+        )
+    ]
+    ws = Workspace({"/dbx/": make_resource(files)}, mode=MountMode.READ)
+
+    grep_io = await ws.execute("grep -R -n debug /dbx/nested")
+    rg_io = await ws.execute("rg debug /dbx/nested")
+
+    assert grep_io.exit_code == 0
+    assert b"/dbx/nested/info.txt:1:alpha debug line" in grep_io.stdout
+    assert b"/dbx/nested/deeper/notes.md:2:beta debug detail" in (
+        grep_io.stdout)
+    assert not grep_io.stderr
+    assert rg_io.exit_code == 0
+    assert b"/dbx/nested/info.txt:alpha debug line" in rg_io.stdout
+    assert b"/dbx/nested/deeper/notes.md:beta debug detail" in rg_io.stdout
+    assert not rg_io.stderr

--- a/python/tests/resource/test_registry.py
+++ b/python/tests/resource/test_registry.py
@@ -44,6 +44,7 @@ EXPECTED_RESOURCES = {
     "ssh",
     "email",
     "paperclip",
+    "databricks_volume",
 }
 
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1247,6 +1247,20 @@ wheels = [
 ]
 
 [[package]]
+name = "databricks-sdk"
+version = "0.108.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/13/05a1dbf9c2c43639b032128c18227953777a2a2da66e4b97d1914ceacb68/databricks_sdk-0.108.0.tar.gz", hash = "sha256:c43f1099b8228e5e9ecb4569381ec8f49b739129d35a826be72a61bc5eaaf1a6", size = 940266, upload-time = "2026-05-12T09:04:03.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/38/9b59ebb34ccaef79095f168eff1fab5f8d645b961680c7bcbc320434acd0/databricks_sdk-0.108.0-py3-none-any.whl", hash = "sha256:010528183abb475acf7f4058e331049dc7932e73a314d9808b123f5cbb722579", size = 887647, upload-time = "2026-05-12T09:04:01.771Z" },
+]
+
+[[package]]
 name = "daytona"
 version = "0.176.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3336,6 +3350,7 @@ all = [
     { name = "asyncpg" },
     { name = "asyncssh" },
     { name = "av" },
+    { name = "databricks-sdk" },
     { name = "daytona" },
     { name = "deepagents" },
     { name = "h5py" },
@@ -3369,6 +3384,9 @@ audio = [
 camel = [
     { name = "camel-ai" },
     { name = "markitdown" },
+]
+databricks = [
+    { name = "databricks-sdk" },
 ]
 daytona = [
     { name = "daytona" },
@@ -3467,6 +3485,7 @@ requires-dist = [
     { name = "asyncssh", marker = "extra == 'ssh'", specifier = ">=2.22.0" },
     { name = "av", marker = "extra == 'audio'", specifier = ">=17.0.0" },
     { name = "camel-ai", marker = "extra == 'camel'", specifier = ">=0.2.40,<0.3" },
+    { name = "databricks-sdk", marker = "extra == 'databricks'", specifier = ">=0.72.0" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.176.0" },
     { name = "deepagents", marker = "extra == 'deepagents'", specifier = ">=0.4.12" },
     { name = "fastapi", specifier = ">=0.135.1" },
@@ -3479,6 +3498,7 @@ requires-dist = [
     { name = "mfusepy", marker = "extra == 'fuse'", specifier = ">=1.0.0" },
     { name = "mirage-ai", extras = ["anthropic"], marker = "extra == 'all'" },
     { name = "mirage-ai", extras = ["audio"], marker = "extra == 'all'" },
+    { name = "mirage-ai", extras = ["databricks"], marker = "extra == 'all'" },
     { name = "mirage-ai", extras = ["daytona"], marker = "extra == 'all'" },
     { name = "mirage-ai", extras = ["deepagents"], marker = "extra == 'all'" },
     { name = "mirage-ai", extras = ["email"], marker = "extra == 'all'" },
@@ -3529,7 +3549,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
 ]
-provides-extras = ["s3", "r2", "gcs", "oci", "ssh", "fuse", "mongodb", "postgres", "redis", "email", "parquet", "hdf5", "pdf", "audio", "langfuse", "anthropic", "openai", "pydantic-ai", "deepagents", "openhands", "camel", "daytona", "all"]
+provides-extras = ["s3", "r2", "gcs", "oci", "ssh", "fuse", "mongodb", "postgres", "redis", "email", "parquet", "hdf5", "pdf", "audio", "langfuse", "anthropic", "openai", "pydantic-ai", "deepagents", "openhands", "camel", "daytona", "databricks", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Add a read-only Python support for `DatabricksVolumeResource` for Databricks Unity Catalog volumes.

This branch adds the resource/config/registry wiring, SDK-backed auth config (`host`, `token`, `profile`, `timeout`), read-only file ops (`readdir`, `stat`, `exists`, `read_bytes`, `read_stream`, `range_read`, glob), `root_path` handling, token redaction, expanded tests, and docs/examples.

Part of #61. Will add write support and higher-level filesystem ops in follow-up PRs.

Use case: stated in #61, basically projects (mine included), companies building agents and apps on Databricks Apps runtime (their abstration ~ EKS) can use this with Databricks Volume (their storage abstraction for files).

### Supporting

new resource
- add `DatabricksVolumeResource` and `DatabricksVolumeConfig`
- register `databricks_volume` in the Python resource registry

ops
- add `readdir`
- add `stat`
- add `exists`
- add `read_bytes`
- add `read_stream`
- add `range_read`
- add glob resolution

shell commands
- support `ls`
- support `find`
- support `cat`
- support `head`
- support `tail`
- support `stat`
- support `grep`
- support `rg`
- support `tree`

docs and examples
- add Python setup/resource docs
- wire docs navigation and resource matrix
- add a basic workspace example
- add a LangChain deepagents example

### Path handling

- map Mirage paths onto `/Volumes/<catalog>/<schema>/<volume>/...`
- support mounting a subtree with `root_path`
- reject paths that escape above the configured volume root


## Testing

Added tests
- unit tests for path handling, reads, streams, globbing, accessor config, resource wiring, `stat`
- coverage for mounted command dispatch on `databricks_volume`

Ran
- [x] `cd python && uv run pytest tests/core/databricks_volume tests/resource/databricks_volume`
- [x] `./python/.venv/bin/pre-commit run --all-files`
- [x] Databricks volume test
  - mount `DatabricksVolumeResource` at `/dbx/` in a read-only `Workspace`. test
    - `ls /dbx`
    - `find /dbx -maxdepth 2 -type f`
    - `cat /dbx/debug_output.json`
    - `head -n 5 /dbx/debug_output.json`
    - `tail -n 5 /dbx/debug_output.json`
    - `stat /dbx/debug_output.json`
    - `tree /dbx`
  - verify nested traversal / file reads
    - `ls -l /dbx/smoke-20260518`
    - `find /dbx/smoke-20260518 -maxdepth 4 -type f`
    - `cat /dbx/smoke-20260518/root.txt`
    - `head -n 2 /dbx/smoke-20260518/nested/alpha/info.txt`
    - `tail -n 1 /dbx/smoke-20260518/nested/alpha/info.txt`
    - `stat /dbx/smoke-20260518/nested/beta/deeper/data.json`
    - `grep debug /dbx/smoke-20260518/nested/alpha/info.txt`
    - `rg debug /dbx/smoke-20260518/root.txt`
    - `tree /dbx/smoke-20260518`
