### PR TITLE
[codex] Report read-only resource commands

### DIFF
--- a/typescript/packages/core/src/workspace/mount/registry.test.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.test.ts
@@ -271,7 +271,7 @@ describe('MountRegistry.resolveMount: cross-mount fallback', () => {
     expect(mount).toBe(b)
   })
 
-  it('skips fallback mount when cmd is write-only and target mount is READ', async () => {
+  it('resolves write command on READ fallback mount so execution reports read-only', async () => {
     const reg = new MountRegistry(
       { '/a': new RAMStubResource(), '/b': new RAMStubResource() },
       MountMode.READ,
@@ -288,6 +288,12 @@ describe('MountRegistry.resolveMount: cross-mount fallback', () => {
     if (writeCmd === undefined) throw new Error('missing write cmd')
     b.register(writeCmd)
     const mount = await reg.resolveMount('mutate', [], '/a/x')
-    expect(mount).toBeNull()
+    expect(mount).toBe(b)
+    if (mount === null) throw new Error('missing mutate mount')
+    const [, io] = await mount.executeCmd('mutate', [], [], {})
+    expect(io.exitCode).toBe(1)
+    expect(new TextDecoder().decode(io.stderr as Uint8Array)).toContain(
+      'mutate: read-only mount at /b/',
+    )
   })
 })

--- a/typescript/packages/core/src/workspace/mount/registry.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.ts
@@ -288,7 +288,6 @@ export class MountRegistry {
       if (m.prefix === DEV_PREFIX) continue
       const cmd = m.resolveCommand(cmdName)
       if (cmd === null) continue
-      if (cmd.write && m.mode === MountMode.READ) continue
       return m
     }
     return null


### PR DESCRIPTION
## Summary
- allow write-flagged resource commands on READ mounts to resolve to their owning mount
- preserve the existing mount-level read-only error instead of returning command not found
- update the mount registry regression test to cover no-path write command fallback

Fixes #28.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm exec vitest run src/workspace/mount/registry.test.ts`
- `pnpm exec vitest run src/workspace/mount/registry.test.ts src/workspace/mount/mount.test.ts src/workspace/executor/command.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec prettier --check src/workspace/mount/registry.ts src/workspace/mount/registry.test.ts`
- `git diff --check`

Note: `pnpm install --frozen-lockfile` without `--ignore-scripts` failed locally because `@zkochan/fuse-native` needs system FUSE headers (`fuse.h`), which are not present on this machine. The changed package tests do not require native FUSE.

## AI Assistance
This PR was prepared with AI assistance. I reviewed the code changes and validated them with the commands listed above.