### PR TITLE
fix(server): reject malformed Host headers in allowlist check

### DIFF
--- a/python/mirage/cli/env.py
+++ b/python/mirage/cli/env.py
@@ -17,7 +17,7 @@ from mirage.server.auth.config import (ENV_AUTH_MODE, ENV_AUTH_TOKEN,
                                        ENV_JWT_AUTHORIZED_PARTIES,
                                        ENV_JWT_CLOCK_SKEW, ENV_JWT_ISSUER,
                                        ENV_JWT_PUBKEY, ENV_JWT_PUBKEY_FILE)
-from mirage.server.host_validation import ENV_ALLOWED_HOSTS
+from mirage.server.env import ENV_ALLOWED_HOSTS
 
 ENV_DAEMON_URL = "MIRAGE_DAEMON_URL"
 ENV_TOKEN = "MIRAGE_TOKEN"

--- a/python/mirage/server/env.py
+++ b/python/mirage/server/env.py
@@ -1,0 +1,15 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+ENV_ALLOWED_HOSTS = "MIRAGE_ALLOWED_HOSTS"

--- a/python/mirage/server/host_validation.py
+++ b/python/mirage/server/host_validation.py
@@ -19,9 +19,9 @@ from collections.abc import Iterable
 from starlette.responses import PlainTextResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-DEFAULT_ALLOWED_HOSTS: tuple[str, ...] = ("127.0.0.1", "localhost", "::1")
-
-ENV_ALLOWED_HOSTS = "MIRAGE_ALLOWED_HOSTS"
+from mirage.server.env import ENV_ALLOWED_HOSTS
+from mirage.server.host_validation_constants import (DEFAULT_ALLOWED_HOSTS,
+                                                     HOST_PATTERN)
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +60,43 @@ def resolve_allowed_hosts(
     return parse_allowed_hosts(os.environ.get(ENV_ALLOWED_HOSTS))
 
 
+def strip_port(raw_host: str) -> str:
+    """Strip the port (and IPv6 brackets) from a Host header value.
+
+    Returns the bare host only when the value matches one of
+    ``host`` / ``host:digits`` / ``[host]`` / ``[host]:digits``; any
+    other (malformed) input is returned unchanged so the allowlist
+    comparison fails closed.
+
+    Args:
+        raw_host (str): raw Host header value.
+
+    Returns:
+        str: bare host, or the raw input when malformed.
+    """
+    match = HOST_PATTERN.match(raw_host)
+    if match is None:
+        return raw_host
+    return match.group(1) or match.group(2) or raw_host
+
+
+def is_host_allowed(raw_host: str | None, allowed: list[str]) -> bool:
+    """Decide whether a Host header value is in the allowlist.
+
+    Args:
+        raw_host (str | None): raw Host header value.
+        allowed (list[str]): allowlist; ``"*"`` accepts any host.
+
+    Returns:
+        bool: True when the port-stripped host is allowed.
+    """
+    if "*" in allowed:
+        return True
+    if not raw_host:
+        return False
+    return strip_port(raw_host) in allowed
+
+
 class HostHeaderMiddleware:
     """ASGI middleware that 400s requests with disallowed Host headers.
 
@@ -85,8 +122,7 @@ class HostHeaderMiddleware:
             return
         headers = dict(scope.get("headers") or [])
         raw_host = headers.get(b"host", b"").decode("latin-1")
-        host = raw_host.split(":")[0]
-        if host in self.allowed_hosts:
+        if is_host_allowed(raw_host, self.allowed_hosts):
             await self.app(scope, receive, send)
             return
         client = scope.get("client") or ("?", 0)

--- a/python/mirage/server/host_validation_constants.py
+++ b/python/mirage/server/host_validation_constants.py
@@ -1,0 +1,19 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import re
+
+DEFAULT_ALLOWED_HOSTS: tuple[str, ...] = ("127.0.0.1", "localhost", "::1")
+
+HOST_PATTERN = re.compile(r"^(?:\[([^\]]+)\]|([^:]+))(?::\d+)?$")

--- a/python/tests/server/test_host_validation.py
+++ b/python/tests/server/test_host_validation.py
@@ -16,9 +16,10 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from mirage.server import build_app
-from mirage.server.host_validation import (DEFAULT_ALLOWED_HOSTS,
+from mirage.server.host_validation import (is_host_allowed,
                                            parse_allowed_hosts,
-                                           resolve_allowed_hosts)
+                                           resolve_allowed_hosts, strip_port)
+from mirage.server.host_validation_constants import DEFAULT_ALLOWED_HOSTS
 
 
 def test_parse_allowed_hosts_defaults_when_missing():
@@ -35,6 +36,50 @@ def test_parse_allowed_hosts_csv():
 def test_parse_allowed_hosts_wildcard_passthrough():
     assert parse_allowed_hosts("*") == ["*"]
     assert parse_allowed_hosts("*,localhost") == ["*", "localhost"]
+
+
+def test_strip_port_well_formed():
+    assert strip_port("127.0.0.1") == "127.0.0.1"
+    assert strip_port("127.0.0.1:8765") == "127.0.0.1"
+    assert strip_port("localhost:8765") == "localhost"
+
+
+def test_strip_port_ipv6_brackets():
+    assert strip_port("[::1]") == "::1"
+    assert strip_port("[::1]:8765") == "::1"
+
+
+def test_strip_port_malformed_bracketed_returns_raw():
+    assert strip_port("[::1]evil") == "[::1]evil"
+    assert strip_port("[::1]:8765x") == "[::1]:8765x"
+    assert strip_port("[::1].attacker.tld") == "[::1].attacker.tld"
+
+
+def test_strip_port_unclosed_bracket_returns_raw():
+    assert strip_port("[::1") == "[::1"
+
+
+def test_strip_port_non_digit_port_returns_raw():
+    assert strip_port("127.0.0.1:8765x") == "127.0.0.1:8765x"
+
+
+def test_strip_port_empty_host_returns_raw():
+    assert strip_port(":8765") == ":8765"
+    assert strip_port("[]") == "[]"
+
+
+def test_is_host_allowed_malformed_fail_closed():
+    allowed = list(DEFAULT_ALLOWED_HOSTS)
+    assert is_host_allowed("[::1]evil", allowed) is False
+    assert is_host_allowed("[::1]:8765x", allowed) is False
+    assert is_host_allowed("[::1].attacker.tld", allowed) is False
+
+
+def test_is_host_allowed_accepts_loopback():
+    allowed = list(DEFAULT_ALLOWED_HOSTS)
+    assert is_host_allowed("[::1]", allowed) is True
+    assert is_host_allowed("[::1]:8765", allowed) is True
+    assert is_host_allowed("127.0.0.1:8765", allowed) is True
 
 
 def test_resolve_allowed_hosts_explicit_wins(monkeypatch):
@@ -79,6 +124,43 @@ async def test_default_accepts_loopback_host(monkeypatch):
                            base_url="http://localhost") as client:
         r = await client.get("/v1/workspaces")
         assert r.status_code == 200
+
+
+@pytest.mark.no_host_override
+@pytest.mark.asyncio
+async def test_default_accepts_ipv6_loopback_host(monkeypatch):
+    monkeypatch.delenv("MIRAGE_ALLOWED_HOSTS", raising=False)
+    app = build_app(idle_grace_seconds=10.0)
+    transport = ASGITransport(app=app)
+    for base in ("http://[::1]", "http://[::1]:8765"):
+        async with AsyncClient(transport=transport, base_url=base) as client:
+            r = await client.get("/v1/workspaces")
+            assert r.status_code == 200
+
+
+@pytest.mark.no_host_override
+@pytest.mark.asyncio
+async def test_default_rejects_malformed_bracketed_host(monkeypatch):
+    monkeypatch.delenv("MIRAGE_ALLOWED_HOSTS", raising=False)
+    app = build_app(idle_grace_seconds=10.0)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport,
+                           base_url="http://127.0.0.1") as client:
+        r = await client.get("/v1/workspaces", headers={"host": "[::1]evil"})
+        assert r.status_code == 400
+
+
+@pytest.mark.no_host_override
+@pytest.mark.asyncio
+async def test_default_rejects_non_digit_port(monkeypatch):
+    monkeypatch.delenv("MIRAGE_ALLOWED_HOSTS", raising=False)
+    app = build_app(idle_grace_seconds=10.0)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport,
+                           base_url="http://127.0.0.1") as client:
+        r = await client.get("/v1/workspaces",
+                             headers={"host": "127.0.0.1:8765x"})
+        assert r.status_code == 400
 
 
 @pytest.mark.no_host_override

--- a/typescript/packages/server/src/host_validation.test.ts
+++ b/typescript/packages/server/src/host_validation.test.ts
@@ -14,11 +14,13 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { buildApp } from './app.ts'
+import { ENV_ALLOWED_HOSTS } from './env.ts'
+import { DEFAULT_ALLOWED_HOSTS } from './host_validation_constants.ts'
 import {
-  DEFAULT_ALLOWED_HOSTS,
-  ENV_VAR,
+  isHostAllowed,
   parseAllowedHosts,
   resolveAllowedHosts,
+  stripPort,
 } from './host_validation.ts'
 
 describe('parseAllowedHosts', () => {
@@ -42,40 +44,86 @@ describe('parseAllowedHosts', () => {
   })
 })
 
+describe('stripPort', () => {
+  it('strips the port from well-formed hosts', () => {
+    expect(stripPort('127.0.0.1')).toBe('127.0.0.1')
+    expect(stripPort('127.0.0.1:8765')).toBe('127.0.0.1')
+    expect(stripPort('localhost:8765')).toBe('localhost')
+  })
+
+  it('strips the brackets from well-formed IPv6 hosts', () => {
+    expect(stripPort('[::1]')).toBe('::1')
+    expect(stripPort('[::1]:8765')).toBe('::1')
+  })
+
+  it('returns the raw input when the suffix after "]" is not exactly ":digits"', () => {
+    expect(stripPort('[::1]evil')).toBe('[::1]evil')
+    expect(stripPort('[::1]:8765x')).toBe('[::1]:8765x')
+    expect(stripPort('[::1].attacker.tld')).toBe('[::1].attacker.tld')
+  })
+
+  it('returns the raw input when the bracket is never closed', () => {
+    expect(stripPort('[::1')).toBe('[::1')
+  })
+
+  it('returns the raw input when the non-bracketed port is not digits', () => {
+    expect(stripPort('127.0.0.1:8765x')).toBe('127.0.0.1:8765x')
+  })
+
+  it('returns the raw input for empty-host malformed values', () => {
+    expect(stripPort(':8765')).toBe(':8765')
+    expect(stripPort('[]')).toBe('[]')
+  })
+})
+
+describe('isHostAllowed: malformed Host headers fail closed', () => {
+  it('rejects bracketed IPv6 hosts with trailing junk after "]"', () => {
+    expect(isHostAllowed('[::1]evil', DEFAULT_ALLOWED_HOSTS)).toBe(false)
+    expect(isHostAllowed('[::1]:8765x', DEFAULT_ALLOWED_HOSTS)).toBe(false)
+    expect(isHostAllowed('[::1].attacker.tld', DEFAULT_ALLOWED_HOSTS)).toBe(false)
+  })
+
+  it('still accepts well-formed loopback hosts', () => {
+    expect(isHostAllowed('[::1]', DEFAULT_ALLOWED_HOSTS)).toBe(true)
+    expect(isHostAllowed('[::1]:8765', DEFAULT_ALLOWED_HOSTS)).toBe(true)
+    expect(isHostAllowed('127.0.0.1:8765', DEFAULT_ALLOWED_HOSTS)).toBe(true)
+  })
+})
+
 describe('resolveAllowedHosts', () => {
-  const originalEnv = process.env[ENV_VAR]
+  const originalEnv = process.env[ENV_ALLOWED_HOSTS]
 
   afterEach(() => {
-    if (originalEnv === undefined) Reflect.deleteProperty(process.env, ENV_VAR)
-    else process.env[ENV_VAR] = originalEnv
+    if (originalEnv === undefined) Reflect.deleteProperty(process.env, ENV_ALLOWED_HOSTS)
+    else process.env[ENV_ALLOWED_HOSTS] = originalEnv
   })
 
   it('returns the explicit list when provided', () => {
-    process.env[ENV_VAR] = 'elsewhere'
+    process.env[ENV_ALLOWED_HOSTS] = 'elsewhere'
     expect(resolveAllowedHosts(['override.example'])).toEqual(['override.example'])
   })
 
   it('reads the env var when no explicit list is given', () => {
-    process.env[ENV_VAR] = 'foo,bar'
+    process.env[ENV_ALLOWED_HOSTS] = 'foo,bar'
     expect(resolveAllowedHosts()).toEqual(['foo', 'bar'])
   })
 
   it('returns defaults when env is unset', () => {
-    Reflect.deleteProperty(process.env, ENV_VAR)
+    Reflect.deleteProperty(process.env, ENV_ALLOWED_HOSTS)
     expect(resolveAllowedHosts()).toEqual([...DEFAULT_ALLOWED_HOSTS])
   })
 })
 
 describe('buildApp host header enforcement', () => {
-  const originalEnv = process.env[ENV_VAR]
+  const originalEnv = process.env[ENV_ALLOWED_HOSTS]
 
   beforeEach(() => {
-    Reflect.deleteProperty(process.env, ENV_VAR)
+    Reflect.deleteProperty(process.env, ENV_ALLOWED_HOSTS)
   })
 
   afterEach(() => {
-    if (originalEnv === undefined) Reflect.deleteProperty(process.env, ENV_VAR)
-    else process.env[ENV_VAR] = originalEnv
+    if (originalEnv === undefined) Reflect.deleteProperty(process.env, ENV_ALLOWED_HOSTS)
+    else process.env[ENV_ALLOWED_HOSTS] = originalEnv
   })
 
   it('rejects unknown host with 400 under default allowlist', async () => {
@@ -85,6 +133,20 @@ describe('buildApp host header enforcement', () => {
         method: 'GET',
         url: '/v1/workspaces',
         headers: { host: 'attacker.example' },
+      })
+      expect(res.statusCode).toBe(400)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('rejects malformed bracketed IPv6 host with 400 under default allowlist', async () => {
+    const app = buildApp({})
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/v1/workspaces',
+        headers: { host: '[::1]evil' },
       })
       expect(res.statusCode).toBe(400)
     } finally {
@@ -109,7 +171,7 @@ describe('buildApp host header enforcement', () => {
   })
 
   it('extends allowlist via env var', async () => {
-    process.env[ENV_VAR] = '127.0.0.1,localhost,daemon.mirage.local'
+    process.env[ENV_ALLOWED_HOSTS] = '127.0.0.1,localhost,daemon.mirage.local'
     const app = buildApp({})
     try {
       const ok = await app.inject({

--- a/typescript/packages/server/src/host_validation.ts
+++ b/typescript/packages/server/src/host_validation.ts
@@ -12,9 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export const DEFAULT_ALLOWED_HOSTS: readonly string[] = ['127.0.0.1', 'localhost', '::1']
-
-export const ENV_VAR = 'MIRAGE_ALLOWED_HOSTS'
+import { ENV_ALLOWED_HOSTS } from './env.ts'
+import { DEFAULT_ALLOWED_HOSTS, HOST_PATTERN } from './host_validation_constants.ts'
 
 export function parseAllowedHosts(value: string | undefined): string[] {
   if (value === undefined) return [...DEFAULT_ALLOWED_HOSTS]
@@ -27,17 +26,13 @@ export function parseAllowedHosts(value: string | undefined): string[] {
 
 export function resolveAllowedHosts(allowedHosts?: readonly string[]): string[] {
   if (allowedHosts !== undefined) return [...allowedHosts]
-  return parseAllowedHosts(process.env[ENV_VAR])
+  return parseAllowedHosts(process.env[ENV_ALLOWED_HOSTS])
 }
 
 export function stripPort(rawHost: string): string {
-  if (rawHost.startsWith('[')) {
-    const close = rawHost.indexOf(']')
-    if (close !== -1) return rawHost.slice(1, close)
-  }
-  const parts = rawHost.split(':')
-  if (parts.length <= 2) return parts[0] ?? ''
-  return rawHost
+  const match = HOST_PATTERN.exec(rawHost)
+  if (match === null) return rawHost
+  return match[1] ?? match[2] ?? rawHost
 }
 
 export function isHostAllowed(rawHost: string | undefined, allowed: readonly string[]): boolean {

--- a/typescript/packages/server/src/host_validation_constants.ts
+++ b/typescript/packages/server/src/host_validation_constants.ts
@@ -12,7 +12,6 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export const ENV_ALLOWED_HOSTS = 'MIRAGE_ALLOWED_HOSTS'
-export const ENV_DAEMON_PORT = 'MIRAGE_DAEMON_PORT'
-export const ENV_IDLE_GRACE_SECONDS = 'MIRAGE_IDLE_GRACE_SECONDS'
-export const ENV_PERSIST_DIR = 'MIRAGE_PERSIST_DIR'
+export const DEFAULT_ALLOWED_HOSTS: readonly string[] = ['127.0.0.1', 'localhost', '::1']
+
+export const HOST_PATTERN = /^(?:\[([^\]]+)\]|([^:]+))(?::\d+)?$/

--- a/typescript/packages/server/src/index.ts
+++ b/typescript/packages/server/src/index.ts
@@ -42,4 +42,9 @@ export {
   type AuthConfig,
   type JWTConfig,
 } from './auth/index.ts'
-export { ENV_DAEMON_PORT, ENV_IDLE_GRACE_SECONDS, ENV_PERSIST_DIR } from './env.ts'
+export {
+  ENV_ALLOWED_HOSTS,
+  ENV_DAEMON_PORT,
+  ENV_IDLE_GRACE_SECONDS,
+  ENV_PERSIST_DIR,
+} from './env.ts'


### PR DESCRIPTION
## Summary

`stripPort` / `strip_port` accepted malformed Host headers, weakening the loopback allowlist that guards the daemon against DNS rebinding (added in #58).

### TypeScript (the reported bug, #75)
`stripPort` stripped the IPv6 brackets on the first `]` regardless of trailing data, so `[::1]evil`, `[::1]:8765x`, and `[::1].attacker.tld` all normalized to `::1` and matched the default allowlist. Requests that should return `400 Invalid host header` returned `200`.

### Python (mirror-image bug)
The middleware used `raw_host.split(":")[0]`, which rejected every bracketed IPv6 host (`[::1]`, `[::1]:8765`) and left the `::1` default-allowlist entry unreachable, so legitimate IPv6 loopback clients got `400`. It also accepted non-digit ports.

## Fix

Both implementations now use the same recognizer: the host is stripped only when the value matches `host`, `host:digits`, `[host]`, or `[host]:digits`. Anything else is returned unchanged so the allowlist comparison fails closed.

Now rejected (`400`): `[::1]evil`, `[::1]:8765x`, `[::1].attacker.tld`, `[::1`, `127.0.0.1:8765x`, `evil@127.0.0.1`.
Still accepted: `127.0.0.1`, `localhost`, `127.0.0.1:8765`, `[::1]`, `[::1]:8765`.

Constants were split into `host_validation_constants` (`DEFAULT_ALLOWED_HOSTS`, `HOST_PATTERN`) and `env` (`ENV_ALLOWED_HOSTS`) modules so both languages match.

## Tests

- TypeScript: 21 `host_validation` tests (unit + `buildApp` end-to-end); full server suite 111 passing; typecheck clean.
- Python: 22 `host_validation` tests (unit + `build_app` end-to-end, including IPv6 loopback accept and malformed reject); server and CLI suites passing.
- Cross-language parity verified: identical `stripPort` / `strip_port` output on a shared case set.

Closes #75
