### PR TITLE
fix(node/fuse): hydrate and cache unknown-size files in getattr (mirage#83)

### DIFF
--- a/typescript/packages/node/src/fuse/fs.ts
+++ b/typescript/packages/node/src/fuse/fs.ts
@@ -283,7 +283,10 @@ export class MirageFS {
           return
         }
         let size = s.size
-        size ??= this.cachedSize(path) ?? UNKNOWN_SIZE_SENTINEL
+        if (size === null) {
+          await this.prefetch(path)
+          size = this.cachedSize(path) ?? UNKNOWN_SIZE_SENTINEL
+        }
         cb(0, this.fileStat(size))
       } catch (err) {
         cb(classifyError(err))


### PR DESCRIPTION
## Summary

Fixes **mirage#83**: unknown-size FUSE files reported as 0 bytes on macOS.

## Root Cause

`MirageFS.getattr()` in `typescript/packages/node/src/fuse/fs.ts` handled `FileStat.size === null` for API-backed resources (Linear, Trello, Slack…) by falling back to `UNKNOWN_SIZE_SENTINEL` (100 MiB) without fetching the actual content. The macFUSE/FSKit layer treated this as a 0-byte file, so `cat`/`wc`/`stat` all reported empty content even though `MirageFS.read()` could fetch the real bytes successfully.

## Fix

In `getattr()`, when `s.size === null` for a non-directory, call `await this.prefetch(path)` to hydrate and cache the file data synchronously, then return the actual byte length via `cachedSize()`. This mirrors how `open()` already handles unknown-size files and ensures `stat`, `cat`, and `wc` all agree on the real size.

**Before:**
```typescript
let size = s.size
size ??= this.cachedSize(path) ?? UNKNOWN_SIZE_SENTINEL
cb(0, this.fileStat(size))
```

**After:**
```typescript
let size = s.size
if (size === null) {
  await this.prefetch(path)
  size = this.cachedSize(path) ?? UNKNOWN_SIZE_SENTINEL
}
cb(0, this.fileStat(size))
```

## Verification

- `stat .../issue.json` now shows the correct byte size instead of 0
- `wc -c .../issue.json` reports the actual byte count
- `cat .../issue.json` outputs the real JSON content
- Existing `open()` prefetch path is unchanged; the two paths remain consistent