### PR TITLE
feat(databricks-volume): add file write

### DIFF
--- a/python/mirage/commands/builtin/databricks_volume/__init__.py
+++ b/python/mirage/commands/builtin/databricks_volume/__init__.py
@@ -18,8 +18,10 @@ from mirage.commands.builtin.databricks_volume.grep import grep
 from mirage.commands.builtin.databricks_volume.head import head
 from mirage.commands.builtin.databricks_volume.ls import ls
 from mirage.commands.builtin.databricks_volume.rg import rg
+from mirage.commands.builtin.databricks_volume.rm import rm
 from mirage.commands.builtin.databricks_volume.stat import stat
 from mirage.commands.builtin.databricks_volume.tail import tail
+from mirage.commands.builtin.databricks_volume.touch import touch
 from mirage.commands.builtin.databricks_volume.tree import tree
 
 COMMANDS = [
@@ -28,8 +30,10 @@ COMMANDS = [
     grep,
     head,
     ls,
+    rm,
     rg,
     stat,
     tail,
+    touch,
     tree,
 ]

--- a/python/mirage/commands/builtin/databricks_volume/rm.py
+++ b/python/mirage/commands/builtin/databricks_volume/rm.py
@@ -1,0 +1,62 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.unlink import unlink
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("rm", resource="databricks_volume", spec=SPECS["rm"], write=True)
+async def rm(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    r: bool = False,
+    R: bool = False,
+    f: bool = False,
+    v: bool = False,
+    d: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        raise ValueError("rm: missing operand")
+    if r or R or d:
+        raise ValueError(
+            "rm: recursive and directory removal are not supported")
+    paths = await resolve_glob(accessor, paths, index)
+    verbose_parts: list[str] = []
+    removed: dict[str, bytes] = {}
+    for path in paths:
+        try:
+            await unlink(accessor, path, index)
+        except IsADirectoryError as exc:
+            raise IsADirectoryError(
+                f"rm: cannot remove '{path.original}': Is a directory"
+            ) from exc
+        except FileNotFoundError:
+            if f:
+                continue
+            raise
+        removed[path.strip_prefix] = b""
+        if v:
+            verbose_parts.append(f"removed '{path.original}'")
+    output = "\n".join(verbose_parts).encode() if v else None
+    return output, IOResult(writes=removed)

--- a/python/mirage/commands/builtin/databricks_volume/touch.py
+++ b/python/mirage/commands/builtin/databricks_volume/touch.py
@@ -1,0 +1,51 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.create import create
+from mirage.core.databricks_volume.exists import exists
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("touch",
+         resource="databricks_volume",
+         spec=SPECS["touch"],
+         write=True)
+async def touch(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    c: bool = False,
+    r: str | None = None,
+    d: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        raise ValueError("touch: missing operand")
+    paths = await resolve_glob(accessor, paths, index)
+    created: dict[str, bytes] = {}
+    for path in paths:
+        if c:
+            continue
+        if not await exists(accessor, path):
+            await create(accessor, path, index)
+            created[path.strip_prefix] = b""
+    return None, IOResult(writes=created)

--- a/python/mirage/core/databricks_volume/_helpers.py
+++ b/python/mirage/core/databricks_volume/_helpers.py
@@ -1,0 +1,36 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.types import PathSpec
+
+
+def ensure_path_spec(path: PathSpec | str) -> PathSpec:
+    if isinstance(path, PathSpec):
+        return path
+    return PathSpec.from_str_path(path)
+
+
+def parent_path(path: PathSpec | str) -> PathSpec:
+    path = ensure_path_spec(path)
+    stripped = path.strip_prefix.rstrip("/")
+    parent_relative = stripped.rsplit("/", 1)[0] if "/" in stripped else "/"
+    if not parent_relative.startswith("/"):
+        parent_relative = "/" + parent_relative
+    if path.prefix:
+        original = path.prefix.rstrip("/")
+        if parent_relative != "/":
+            original += parent_relative
+    else:
+        original = parent_relative
+    return PathSpec.from_str_path(original or "/", path.prefix)

--- a/python/mirage/core/databricks_volume/create.py
+++ b/python/mirage/core/databricks_volume/create.py
@@ -12,11 +12,15 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.ops.databricks_volume.create import create
-from mirage.ops.databricks_volume.read import read
-from mirage.ops.databricks_volume.readdir import readdir
-from mirage.ops.databricks_volume.stat import stat
-from mirage.ops.databricks_volume.unlink import unlink
-from mirage.ops.databricks_volume.write import write
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume.write import write_bytes
+from mirage.types import PathSpec
 
-OPS = [read, readdir, stat, write, create, unlink]
+
+async def create(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> None:
+    await write_bytes(accessor, path, b"", index)

--- a/python/mirage/core/databricks_volume/unlink.py
+++ b/python/mirage/core/databricks_volume/unlink.py
@@ -1,0 +1,52 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import time
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume._helpers import ensure_path_spec
+from mirage.core.databricks_volume.errors import is_not_found
+from mirage.core.databricks_volume.path import backend_path
+from mirage.core.databricks_volume.stat import stat
+from mirage.observe.context import record
+from mirage.types import FileType, PathSpec
+
+
+def _delete_file_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+) -> None:
+    accessor.files.delete(remote_path)
+
+
+async def unlink(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> None:
+    path = ensure_path_spec(path)
+    file_stat = await stat(accessor, path, index)
+    if file_stat.type == FileType.DIRECTORY:
+        raise IsADirectoryError(path.strip_prefix)
+    remote_path = backend_path(accessor.config, path)
+    start_ms = int(time.monotonic() * 1000)
+    try:
+        await asyncio.to_thread(_delete_file_sync, accessor, remote_path)
+    except Exception as exc:
+        if is_not_found(exc):
+            raise FileNotFoundError(path.strip_prefix) from exc
+        raise
+    record("unlink", path.original, "databricks_volume", 0, start_ms)

--- a/python/mirage/core/databricks_volume/write.py
+++ b/python/mirage/core/databricks_volume/write.py
@@ -77,6 +77,7 @@ async def write_bytes(
     remote_parent = backend_path(accessor.config, parent)
     remote_path = backend_path(accessor.config, path)
     start_ms = int(time.monotonic() * 1000)
+    # TODO native async client calling HTTP API as databricks sdk is sync
     await asyncio.to_thread(
         _ensure_parent_directory_sync,
         accessor,

--- a/python/mirage/core/databricks_volume/write.py
+++ b/python/mirage/core/databricks_volume/write.py
@@ -1,0 +1,93 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import time
+from io import BytesIO
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume._helpers import (ensure_path_spec,
+                                                    parent_path)
+from mirage.core.databricks_volume.errors import is_not_found
+from mirage.core.databricks_volume.path import backend_path
+from mirage.observe.context import record
+from mirage.types import PathSpec
+
+
+def _is_directory_metadata(metadata: object) -> bool:
+    value = getattr(metadata, "is_directory", None)
+    if value is not None:
+        return bool(value)
+    object_type = getattr(metadata, "object_type", None)
+    if object_type is None:
+        return False
+    return str(object_type).lower().endswith("directory")
+
+
+def _ensure_parent_directory_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_parent: str,
+    virtual_target: str,
+) -> None:
+    try:
+        accessor.files.get_directory_metadata(remote_parent)
+        return
+    except Exception as exc:
+        if not is_not_found(exc):
+            raise
+        not_found = exc
+    try:
+        metadata = accessor.files.get_metadata(remote_parent)
+    except Exception as exc:
+        if is_not_found(exc):
+            raise FileNotFoundError(virtual_target) from not_found
+        raise
+    if not _is_directory_metadata(metadata):
+        raise NotADirectoryError(virtual_target)
+
+
+def _upload_bytes_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+    data: bytes,
+) -> None:
+    accessor.files.upload(remote_path, BytesIO(data), overwrite=True)
+
+
+async def write_bytes(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    data: bytes,
+    index: IndexCacheStore = None,
+) -> None:
+    path = ensure_path_spec(path)
+    parent = parent_path(path)
+    remote_parent = backend_path(accessor.config, parent)
+    remote_path = backend_path(accessor.config, path)
+    start_ms = int(time.monotonic() * 1000)
+    await asyncio.to_thread(
+        _ensure_parent_directory_sync,
+        accessor,
+        remote_parent,
+        path.strip_prefix,
+    )
+    try:
+        await asyncio.to_thread(_upload_bytes_sync, accessor, remote_path,
+                                data)
+    except Exception as exc:
+        if is_not_found(exc):
+            raise FileNotFoundError(path.strip_prefix) from exc
+        raise
+    record("write", path.original, "databricks_volume", len(data), start_ms)

--- a/python/mirage/ops/databricks_volume/create.py
+++ b/python/mirage/ops/databricks_volume/create.py
@@ -12,11 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.ops.databricks_volume.create import create
-from mirage.ops.databricks_volume.read import read
-from mirage.ops.databricks_volume.readdir import readdir
-from mirage.ops.databricks_volume.stat import stat
-from mirage.ops.databricks_volume.unlink import unlink
-from mirage.ops.databricks_volume.write import write
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.core.databricks_volume.create import create as create_core
+from mirage.ops.registry import op
+from mirage.types import PathSpec
 
-OPS = [read, readdir, stat, write, create, unlink]
+
+@op("create", resource="databricks_volume", write=True)
+async def create(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    *,
+    index,
+    **kwargs,
+) -> None:
+    await create_core(accessor, path, index)

--- a/python/mirage/ops/databricks_volume/unlink.py
+++ b/python/mirage/ops/databricks_volume/unlink.py
@@ -12,11 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.ops.databricks_volume.create import create
-from mirage.ops.databricks_volume.read import read
-from mirage.ops.databricks_volume.readdir import readdir
-from mirage.ops.databricks_volume.stat import stat
-from mirage.ops.databricks_volume.unlink import unlink
-from mirage.ops.databricks_volume.write import write
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.core.databricks_volume.unlink import unlink as unlink_core
+from mirage.ops.registry import op
+from mirage.types import PathSpec
 
-OPS = [read, readdir, stat, write, create, unlink]
+
+@op("unlink", resource="databricks_volume", write=True)
+async def unlink(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    *,
+    index,
+    **kwargs,
+) -> None:
+    await unlink_core(accessor, path, index)

--- a/python/mirage/ops/databricks_volume/write.py
+++ b/python/mirage/ops/databricks_volume/write.py
@@ -12,11 +12,19 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.ops.databricks_volume.create import create
-from mirage.ops.databricks_volume.read import read
-from mirage.ops.databricks_volume.readdir import readdir
-from mirage.ops.databricks_volume.stat import stat
-from mirage.ops.databricks_volume.unlink import unlink
-from mirage.ops.databricks_volume.write import write
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.core.databricks_volume.write import write_bytes
+from mirage.ops.registry import op
+from mirage.types import PathSpec
 
-OPS = [read, readdir, stat, write, create, unlink]
+
+@op("write", resource="databricks_volume", write=True)
+async def write(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    data: bytes,
+    *,
+    index,
+    **kwargs,
+) -> None:
+    await write_bytes(accessor, path, data, index)

--- a/python/mirage/resource/databricks_volume/databricks_volume.py
+++ b/python/mirage/resource/databricks_volume/databricks_volume.py
@@ -18,12 +18,15 @@ from typing import Any
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.commands.builtin.databricks_volume import \
     COMMANDS as DATABRICKS_VOLUME_COMMANDS
+from mirage.core.databricks_volume.create import create
 from mirage.core.databricks_volume.exists import exists
 from mirage.core.databricks_volume.glob import resolve_glob as _resolve_glob
 from mirage.core.databricks_volume.read import read_bytes
 from mirage.core.databricks_volume.readdir import readdir
 from mirage.core.databricks_volume.stat import stat as databricks_stat
 from mirage.core.databricks_volume.stream import range_read, read_stream
+from mirage.core.databricks_volume.unlink import unlink
+from mirage.core.databricks_volume.write import write_bytes
 from mirage.ops.databricks_volume import OPS as DATABRICKS_VOLUME_OPS
 from mirage.resource.base import BaseResource
 from mirage.resource.databricks_volume.config import DatabricksVolumeConfig
@@ -37,6 +40,9 @@ _DATABRICKS_VOLUME_OPS = {
     "read_stream": read_stream,
     "range_read": range_read,
     "exists": exists,
+    "write": write_bytes,
+    "create": create,
+    "unlink": unlink,
 }
 
 

--- a/python/tests/core/databricks_volume/conftest.py
+++ b/python/tests/core/databricks_volume/conftest.py
@@ -1,3 +1,4 @@
+import posixpath
 from io import BytesIO
 from types import SimpleNamespace
 from urllib.parse import unquote
@@ -33,6 +34,8 @@ class FakeFiles:
         self.get_metadata_calls: list[str] = []
         self.get_directory_metadata_calls: list[str] = []
         self.list_directory_calls: list[str] = []
+        self.upload_calls: list[tuple[str, bytes, bool]] = []
+        self.delete_calls: list[str] = []
 
     def download(self, path: str) -> FakeDownload:
         self.download_calls.append(path)
@@ -60,6 +63,43 @@ class FakeFiles:
         if path not in self.directories:
             raise NotFoundError(path)
         return self.directories[path]
+
+    def upload(self, path: str, contents, overwrite: bool = False) -> None:
+        data = contents.read()
+        self.upload_calls.append((path, data, overwrite))
+        parent = posixpath.dirname(path.rstrip("/")) or "/"
+        if parent not in self.directory_metadata:
+            if parent in self.metadata:
+                raise NotADirectoryError(parent)
+            raise NotFoundError(parent)
+        if path in self.directory_metadata:
+            raise IsADirectoryError(path)
+        self.downloads[path] = data
+        self.metadata[path] = file_metadata(len(data))
+        self._upsert_directory_entry(parent, file_entry(path, len(data)))
+
+    def delete(self, path: str) -> None:
+        self.delete_calls.append(path)
+        if path in self.directory_metadata:
+            raise IsADirectoryError(path)
+        if path not in self.metadata and path not in self.downloads:
+            raise NotFoundError(path)
+        self.metadata.pop(path, None)
+        self.downloads.pop(path, None)
+        parent = posixpath.dirname(path.rstrip("/")) or "/"
+        self.directories[parent] = [
+            entry for entry in self.directories.get(parent, [])
+            if getattr(entry, "path", None) != path
+        ]
+
+    def _upsert_directory_entry(self, parent: str, entry: object) -> None:
+        entries = [
+            existing for existing in self.directories.get(parent, [])
+            if getattr(existing, "path", None) != getattr(entry, "path", None)
+        ]
+        entries.append(entry)
+        self.directories[parent] = sorted(
+            entries, key=lambda item: getattr(item, "path", ""))
 
 
 def _apply_range_header(data: bytes, range_header: str) -> bytes:

--- a/python/tests/core/databricks_volume/test_write_ops.py
+++ b/python/tests/core/databricks_volume/test_write_ops.py
@@ -1,0 +1,158 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.core.databricks_volume.create import create
+from mirage.core.databricks_volume.unlink import unlink
+from mirage.core.databricks_volume.write import write_bytes
+from mirage.types import PathSpec
+
+
+def _path(path: str) -> PathSpec:
+    return PathSpec.from_str_path(path, "/dbx")
+
+
+def _seed_directory(files, path: str) -> None:
+    files.directory_metadata.add(path)
+    files.metadata[path] = type("Metadata", (), {"is_directory": True})()
+    files.directories.setdefault(path, [])
+
+
+def _seed_file(files, path: str, data: bytes) -> None:
+    parent = path.rsplit("/", 1)[0]
+    files.downloads[path] = data
+    files.metadata[path] = type(
+        "Metadata",
+        (),
+        {
+            "is_directory": False,
+            "file_size": len(data),
+        },
+    )()
+    files.directories.setdefault(parent, [])
+    files.directories[parent].append(
+        type(
+            "Entry",
+            (),
+            {
+                "path": path,
+                "is_directory": False,
+                "file_size": len(data),
+            },
+        )())
+
+
+@pytest.mark.asyncio
+async def test_write_new_file(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+
+    await write_bytes(accessor, _path("/dbx/new.txt"), b"hello", index)
+
+    assert files.downloads[f"{remote_root}/new.txt"] == b"hello"
+    assert files.upload_calls == [(f"{remote_root}/new.txt", b"hello", True)]
+
+
+@pytest.mark.asyncio
+async def test_write_overwrites_existing_file(accessor, files, remote_root,
+                                              index):
+    _seed_directory(files, remote_root)
+    _seed_file(files, f"{remote_root}/new.txt", b"old")
+
+    await write_bytes(accessor, _path("/dbx/new.txt"), b"new", index)
+
+    assert files.downloads[f"{remote_root}/new.txt"] == b"new"
+    assert files.metadata[f"{remote_root}/new.txt"].file_size == 3
+
+
+@pytest.mark.asyncio
+async def test_write_fails_when_parent_is_missing(accessor, files, remote_root,
+                                                  index):
+    _seed_directory(files, remote_root)
+
+    with pytest.raises(FileNotFoundError):
+        await write_bytes(accessor, _path("/dbx/missing/new.txt"), b"x", index)
+
+
+@pytest.mark.asyncio
+async def test_write_fails_when_parent_is_file(accessor, files, remote_root,
+                                               index):
+    _seed_directory(files, remote_root)
+    _seed_file(files, f"{remote_root}/parent.txt", b"file")
+
+    with pytest.raises(NotADirectoryError):
+        await write_bytes(accessor, _path("/dbx/parent.txt/new.txt"), b"x",
+                          index)
+
+
+@pytest.mark.asyncio
+async def test_create_empty_file(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+
+    await create(accessor, _path("/dbx/empty.txt"), index)
+
+    assert files.downloads[f"{remote_root}/empty.txt"] == b""
+
+
+@pytest.mark.asyncio
+async def test_create_fails_when_parent_is_missing(accessor, files,
+                                                   remote_root, index):
+    _seed_directory(files, remote_root)
+
+    with pytest.raises(FileNotFoundError):
+        await create(accessor, _path("/dbx/missing/empty.txt"), index)
+
+
+@pytest.mark.asyncio
+async def test_unlink_file(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_file(files, f"{remote_root}/delete.txt", b"bye")
+
+    await unlink(accessor, _path("/dbx/delete.txt"), index)
+
+    assert f"{remote_root}/delete.txt" not in files.downloads
+    assert files.delete_calls == [f"{remote_root}/delete.txt"]
+
+
+@pytest.mark.asyncio
+async def test_unlink_missing_file_raises_file_not_found(
+        accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+
+    with pytest.raises(FileNotFoundError):
+        await unlink(accessor, _path("/dbx/missing.txt"), index)
+
+
+@pytest.mark.asyncio
+async def test_unlink_directory_raises_is_a_directory(accessor, files,
+                                                      remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_directory(files, f"{remote_root}/dir")
+
+    with pytest.raises(IsADirectoryError):
+        await unlink(accessor, _path("/dbx/dir"), index)
+
+
+@pytest.mark.asyncio
+async def test_file_mutation_paths_cannot_escape_root(accessor, files,
+                                                      remote_root, index):
+    _seed_directory(files, remote_root)
+    escaping = _path("/dbx/../escape.txt")
+
+    with pytest.raises(ValueError):
+        await write_bytes(accessor, escaping, b"x", index)
+    with pytest.raises(ValueError):
+        await create(accessor, escaping, index)
+    with pytest.raises(ValueError):
+        await unlink(accessor, escaping, index)

--- a/python/tests/resource/databricks_volume/test_databricks_volume.py
+++ b/python/tests/resource/databricks_volume/test_databricks_volume.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import posixpath
 from io import BytesIO
 from types import SimpleNamespace
 from urllib.parse import unquote
@@ -20,6 +21,7 @@ import pytest
 from pydantic import ValidationError
 
 from mirage import MountMode, Workspace
+from mirage.cache.index import IndexEntry, LookupStatus
 from mirage.core.databricks_volume.path import backend_path
 from mirage.resource.databricks_volume import (DatabricksVolumeConfig,
                                                DatabricksVolumeResource)
@@ -43,6 +45,8 @@ class FakeFiles:
         self.metadata: dict[str, object] = {}
         self.directory_metadata: set[str] = set()
         self.directories: dict[str, list[object]] = {}
+        self.upload_calls: list[tuple[str, bytes, bool]] = []
+        self.delete_calls: list[str] = []
 
     def download(self, path: str) -> FakeDownload:
         if path not in self.downloads:
@@ -62,6 +66,53 @@ class FakeFiles:
         if path not in self.directories:
             raise NotFoundError(path)
         return self.directories[path]
+
+    def upload(self, path: str, contents, overwrite: bool = False) -> None:
+        data = contents.read()
+        self.upload_calls.append((path, data, overwrite))
+        parent = posixpath.dirname(path.rstrip("/")) or "/"
+        if parent not in self.directory_metadata:
+            if parent in self.metadata:
+                raise NotADirectoryError(parent)
+            raise NotFoundError(parent)
+        if path in self.directory_metadata:
+            raise IsADirectoryError(path)
+        self.downloads[path] = data
+        self.metadata[path] = SimpleNamespace(
+            is_directory=False,
+            file_size=len(data),
+        )
+        self._upsert_directory_entry(
+            parent,
+            SimpleNamespace(
+                path=path,
+                is_directory=False,
+                file_size=len(data),
+            ),
+        )
+
+    def delete(self, path: str) -> None:
+        self.delete_calls.append(path)
+        if path in self.directory_metadata:
+            raise IsADirectoryError(path)
+        if path not in self.metadata and path not in self.downloads:
+            raise NotFoundError(path)
+        self.metadata.pop(path, None)
+        self.downloads.pop(path, None)
+        parent = posixpath.dirname(path.rstrip("/")) or "/"
+        self.directories[parent] = [
+            entry for entry in self.directories.get(parent, [])
+            if getattr(entry, "path", None) != path
+        ]
+
+    def _upsert_directory_entry(self, parent: str, entry: object) -> None:
+        entries = [
+            existing for existing in self.directories.get(parent, [])
+            if getattr(existing, "path", None) != getattr(entry, "path", None)
+        ]
+        entries.append(entry)
+        self.directories[parent] = sorted(
+            entries, key=lambda item: getattr(item, "path", ""))
 
 
 def _apply_range_header(data: bytes, range_header: str) -> bytes:
@@ -128,6 +179,28 @@ def make_resource(files: FakeFiles) -> DatabricksVolumeResource:
     )
 
 
+def seed_directory(files: FakeFiles, path: str) -> None:
+    files.directory_metadata.add(path)
+    files.metadata[path] = SimpleNamespace(is_directory=True)
+    files.directories.setdefault(path, [])
+
+
+def seed_file(files: FakeFiles, path: str, data: bytes) -> None:
+    parent = path.rsplit("/", 1)[0]
+    files.downloads[path] = data
+    files.metadata[path] = SimpleNamespace(
+        is_directory=False,
+        file_size=len(data),
+    )
+    files.directories.setdefault(parent, [])
+    files.directories[parent].append(
+        SimpleNamespace(
+            path=path,
+            is_directory=False,
+            file_size=len(data),
+        ))
+
+
 def test_config_validation_and_normalization():
     config = DatabricksVolumeConfig(
         catalog="main",
@@ -172,15 +245,15 @@ def test_resource_state_redacts_token():
     assert "token" in state["redacted_fields"]
 
 
-def test_resource_registers_read_only_ops():
+def test_resource_registers_ops():
     resource = make_resource(FakeFiles())
     op_names = {op.name for op in resource.ops_list()}
-    assert {"read", "readdir", "stat"} <= op_names
+    assert {"read", "readdir", "stat", "write", "create", "unlink"} <= op_names
     assert resource.name == "databricks_volume"
     assert resource.is_remote is True
 
 
-def test_resource_registers_read_only_commands():
+def test_resource_registers_commands():
     resource = make_resource(FakeFiles())
     command_names = {command.name for command in resource.commands()}
     assert {
@@ -189,9 +262,11 @@ def test_resource_registers_read_only_commands():
         "grep",
         "head",
         "ls",
+        "rm",
         "rg",
         "stat",
         "tail",
+        "touch",
         "tree",
     } <= command_names
 
@@ -258,6 +333,189 @@ async def test_workspace_read_mode_uses_registered_ops():
     assert await ws.ops.read("/volume/latest.md") == b"hello"
     file_stat = await ws.ops.stat("/volume/latest.md")
     assert file_stat.size == 5
+
+
+@pytest.mark.asyncio
+async def test_resource_exposes_file_write_ops():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    seed_directory(files, root)
+    resource = make_resource(files)
+
+    await resource.write(
+        PathSpec.from_str_path("/volume/new.txt", "/volume"),
+        b"hello",
+        resource.index,
+    )
+    await resource.create(
+        PathSpec.from_str_path("/volume/empty.txt", "/volume"),
+        resource.index,
+    )
+    await resource.unlink(
+        PathSpec.from_str_path("/volume/new.txt", "/volume"),
+        resource.index,
+    )
+
+    assert files.downloads[f"{root}/empty.txt"] == b""
+    assert f"{root}/new.txt" not in files.downloads
+
+
+@pytest.mark.asyncio
+async def test_workspace_write_mode_uses_file_write_ops():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    seed_directory(files, root)
+    ws = Workspace({"/dbx/": make_resource(files)}, mode=MountMode.WRITE)
+
+    await ws.ops.write("/dbx/new.txt", b"hello")
+    await ws.ops.create("/dbx/empty.txt")
+    await ws.ops.unlink("/dbx/new.txt")
+
+    assert f"{root}/new.txt" not in files.downloads
+    assert files.downloads[f"{root}/empty.txt"] == b""
+
+
+@pytest.mark.asyncio
+async def test_workspace_write_mode_invalidates_parent_directory_index():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    seed_directory(files, root)
+    resource = make_resource(files)
+    ws = Workspace({"/dbx/": resource}, mode=MountMode.WRITE)
+
+    await resource.index.set_dir("/dbx", [("old.txt",
+                                           IndexEntry(
+                                               id="/dbx/old.txt",
+                                               name="old.txt",
+                                               resource_type="file",
+                                           ))])
+    assert (await resource.index.list_dir("/dbx")).entries == ["/dbx/old.txt"]
+
+    await ws.ops.write("/dbx/new.txt", b"hello")
+    assert (await
+            resource.index.list_dir("/dbx")).status == (LookupStatus.NOT_FOUND)
+
+    await resource.index.set_dir("/dbx", [("new.txt",
+                                           IndexEntry(
+                                               id="/dbx/new.txt",
+                                               name="new.txt",
+                                               resource_type="file",
+                                           ))])
+    await ws.ops.create("/dbx/empty.txt")
+    assert (await
+            resource.index.list_dir("/dbx")).status == (LookupStatus.NOT_FOUND)
+
+    await resource.index.set_dir("/dbx", [("empty.txt",
+                                           IndexEntry(
+                                               id="/dbx/empty.txt",
+                                               name="empty.txt",
+                                               resource_type="file",
+                                           ))])
+    await ws.ops.unlink("/dbx/empty.txt")
+    assert (await
+            resource.index.list_dir("/dbx")).status == (LookupStatus.NOT_FOUND)
+
+
+@pytest.mark.asyncio
+async def test_read_only_mount_rejects_file_write_ops():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    seed_directory(files, root)
+    ws = Workspace({"/dbx/": make_resource(files)}, mode=MountMode.READ)
+
+    with pytest.raises(PermissionError):
+        await ws.ops.write("/dbx/new.txt", b"hello")
+    with pytest.raises(PermissionError):
+        await ws.ops.create("/dbx/empty.txt")
+    with pytest.raises(PermissionError):
+        await ws.ops.unlink("/dbx/new.txt")
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_touch_and_rm():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    seed_directory(files, root)
+    ws = Workspace({"/dbx/": make_resource(files)}, mode=MountMode.WRITE)
+
+    touch_io = await ws.execute("touch /dbx/created.txt")
+    rm_io = await ws.execute("rm /dbx/created.txt")
+
+    assert touch_io.exit_code == 0
+    assert touch_io.writes == {"/dbx/created.txt": b""}
+    assert files.delete_calls == [f"{root}/created.txt"]
+    assert f"{root}/created.txt" not in files.downloads
+    assert rm_io.exit_code == 0
+    assert rm_io.writes == {"/dbx/created.txt": b""}
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_rm_resolves_glob():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    seed_directory(files, root)
+    seed_file(files, f"{root}/one.txt", b"one")
+    seed_file(files, f"{root}/two.txt", b"two")
+    seed_file(files, f"{root}/keep.md", b"keep")
+    ws = Workspace({"/dbx/": make_resource(files)}, mode=MountMode.WRITE)
+
+    io = await ws.execute("rm /dbx/*.txt")
+
+    assert io.exit_code == 0
+    assert files.delete_calls == [f"{root}/one.txt", f"{root}/two.txt"]
+    assert f"{root}/one.txt" not in files.downloads
+    assert f"{root}/two.txt" not in files.downloads
+    assert files.downloads[f"{root}/keep.md"] == b"keep"
+    assert io.writes == {
+        "/dbx/one.txt": b"",
+        "/dbx/two.txt": b"",
+    }
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_touch_resolves_glob():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    seed_directory(files, root)
+    seed_file(files, f"{root}/existing.txt", b"existing")
+    ws = Workspace({"/dbx/": make_resource(files)}, mode=MountMode.WRITE)
+
+    io = await ws.execute("touch /dbx/*.txt")
+
+    assert io.exit_code == 0
+    assert files.upload_calls == []
+    assert f"{root}/*.txt" not in files.downloads
+    assert io.writes == {}
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_rm_rejects_directory():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    seed_directory(files, root)
+    seed_directory(files, f"{root}/dir")
+    ws = Workspace({"/dbx/": make_resource(files)}, mode=MountMode.WRITE)
+
+    io = await ws.execute("rm /dbx/dir")
+
+    assert io.exit_code == 1
+    assert b"IsADirectoryError" in io.stderr or b"Is a directory" in io.stderr
+
+
+@pytest.mark.asyncio
+async def test_read_only_mount_rejects_file_write_commands():
+    files = FakeFiles()
+    root = "/Volumes/main/default/agent_files/root"
+    seed_directory(files, root)
+    ws = Workspace({"/dbx/": make_resource(files)}, mode=MountMode.READ)
+
+    touch_io = await ws.execute("touch /dbx/created.txt")
+    rm_io = await ws.execute("rm /dbx/created.txt")
+
+    assert touch_io.exit_code == 1
+    assert b"read-only mount" in touch_io.stderr
+    assert rm_io.exit_code == 1
+    assert b"read-only mount" in rm_io.stderr
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Adds file-level write support for Databricks Volume resources.
Continuing the existing read-only implementation #62. Part of #61

- Adds Databricks Volume core operations for `write`, `create`, and `unlink`, using `PathSpec` paths, `backend_path()` mapping,  parent-directory cache invalidation after mutations.
- Adds Databricks Volume `touch` and file-only `rm` commands for `Workspace.execute`.

Out-scope (will do in future PRs): 
- directory ops e.g. mutation, recursive delete, copy, rename, du, etc.

## Test plan
- [x] `cd python && uv run pytest tests/core/databricks_volume tests/resource/databricks_volume`
- [x] actual integration test run with my databricks volumes

<details>
  <summary>Test Result. Click to expand!</summary>
  
  ```
databricks fs ls dbfs:/Volumes/workspace/default/volume_test --profile default
debug_output.json
debug_output_5_lines.jsonl
pr93_file3.txt

../python/.venv/bin/python test_pr_93.py

============================
STEP 1: Create and write files (Happy Path)

============================
COMMAND: touch /dbx/pr93_file1.txt
EXPECTED RESULT: SUCCESS
EXIT CODE: 0

============================
COMMAND: touch /dbx/pr93_file2.txt
EXPECTED RESULT: SUCCESS
EXIT CODE: 0

============================
COMMAND: touch /dbx/pr93_file3.txt
EXPECTED RESULT: SUCCESS
EXIT CODE: 0

============================
STEP 2: Delete 2 files (file1 and file2)

============================
COMMAND: rm /dbx/pr93_file1.txt
EXPECTED RESULT: SUCCESS
EXIT CODE: 0

============================
COMMAND: rm /dbx/pr93_file2.txt
EXPECTED RESULT: SUCCESS
EXIT CODE: 0

============================
STEP 3: Read operations on leftovers (expect SUCCESS)

============================
COMMAND: ls /dbx/
EXPECTED RESULT: SUCCESS
EXIT CODE: 0
STDOUT:
codex-smoke-20260518
debug_output.json
debug_output_5_lines.jsonl
pr93_file3.txt

============================
COMMAND: find /dbx/ -type f
EXPECTED RESULT: SUCCESS
EXIT CODE: 0
STDOUT:
/dbx/codex-smoke-20260518/nested/alpha/info.txt
/dbx/codex-smoke-20260518/nested/beta/deeper/data.json
/dbx/codex-smoke-20260518/nested/beta/deeper/notes.md
/dbx/codex-smoke-20260518/root.txt
/dbx/debug_output.json
/dbx/debug_output_5_lines.jsonl
/dbx/pr93_file3.txt

============================
COMMAND: stat /dbx/pr93_file3.txt
EXPECTED RESULT: SUCCESS
EXIT CODE: 0
STDOUT:
name=pr93_file3.txt size=None modified=None type=text

============================
COMMAND: cat /dbx/pr93_file3.txt
EXPECTED RESULT: SUCCESS
EXIT CODE: 0
STDOUT:
content 3 target pr93

============================
COMMAND: head -n 2 /dbx/pr93_file3.txt
EXPECTED RESULT: SUCCESS
EXIT CODE: 0
STDOUT:
content 3 target pr93

============================
COMMAND: tail -n 2 /dbx/pr93_file3.txt
EXPECTED RESULT: SUCCESS
EXIT CODE: 0
STDOUT:
content 3 target pr93

============================
COMMAND: grep -n target /dbx/pr93_file3.txt
EXPECTED RESULT: SUCCESS
EXIT CODE: 0
STDOUT:
1:content 3 target pr93

============================
COMMAND: rg target /dbx/pr93_file3.txt
EXPECTED RESULT: SUCCESS
EXIT CODE: 0
STDOUT:
content 3 target pr93

============================
STEP 4: Read operations on deleted files (expect FAILURE)

============================
COMMAND: stat /dbx/pr93_file1.txt
EXPECTED RESULT: FAILURE
EXIT CODE: 1
STDERR:
stat: /pr93_file1.txt

============================
COMMAND: cat /dbx/pr93_file1.txt
EXPECTED RESULT: FAILURE
EXIT CODE: 1
STDERR:
cat: /pr93_file1.txt

============================
COMMAND: head -n 1 /dbx/pr93_file2.txt
EXPECTED RESULT: FAILURE
EXIT CODE: 1
STDERR:
/pr93_file2.txt

============================
COMMAND: tail -n 1 /dbx/pr93_file2.txt
EXPECTED RESULT: FAILURE
EXIT CODE: 1
STDERR:
tail: /pr93_file2.txt

============================
STEP 5: Final cleanup (expect SUCCESS)

============================
COMMAND: rm /dbx/pr93_file3.txt
EXPECTED RESULT: SUCCESS
EXIT CODE: 0
``` 
</details>
