### PR TITLE
test(integ): cover recursive content grep on s3/gcs mounts

### DIFF
--- a/integ/s3.py
+++ b/integ/s3.py
@@ -73,6 +73,7 @@ PER_MOUNT_CASES: list[tuple[str, str]] = [
     ("grep_queue_wc", "grep queue-operation {m}/data/example.jsonl | wc -l"),
     ("grep_rl_item", "grep -rl item {m}/data/"),
     ("rg_l_item", "rg -l item {m}/data/"),
+    ("grep_rc_mirage", "grep -rc mirage {m}/data/"),
     ("grep_item_parquet", "grep item_5 {m}/data/example.parquet"),
     ("rg_item_glob_feather", "rg item_5 {m}/data/*.feather"),
     ("ls_glob_parquet", "ls {m}/data/*.parquet"),

--- a/integ/truth_s3.txt
+++ b/integ/truth_s3.txt
@@ -48,6 +48,9 @@ example.parquet
 /s3/data/example.jsonl
 === s3:rg_l_item ===
 /s3/data/example.jsonl
+=== s3:grep_rc_mirage ===
+/s3/data/example.json:3
+/s3/data/example.jsonl:5678
 === s3:grep_item_parquet ===
 id,value,label
 5,0.6709052457548175,item_5
@@ -141,6 +144,9 @@ example.parquet
 /gcs/data/example.jsonl
 === gcs:rg_l_item ===
 /gcs/data/example.jsonl
+=== gcs:grep_rc_mirage ===
+/gcs/data/example.json:3
+/gcs/data/example.jsonl:5678
 === gcs:grep_item_parquet ===
 id,value,label
 5,0.6709052457548175,item_5


### PR DESCRIPTION
Adds `grep -rc mirage {m}/data/` to the s3/gcs integ suite. The only recursive grep covered before was `-rl` (files-only), which never hit the broken path. `-rc` exercises recursive content reads through the prefix-aware wrapper, so a regression to the old non-prefix-aware stream read would resurface as NoSuchKey and fail the diff.

Closes #91.