### PR TITLE
feat(discord): add basename, dirname, realpath commands

### DIFF
--- a/examples/python/discord/discord.py
+++ b/examples/python/discord/discord.py
@@ -164,6 +164,34 @@ async def main():
     r = await ws.execute(f'wc -l "{file_path}"')
     print(f"  {(await r.stdout_str()).strip()}")
 
+    # ── basename / dirname / realpath (path ops) ─────
+    print(f"\n=== basename {file_path} ===")
+    r = await ws.execute(f'basename "{file_path}"')
+    out = (await r.stdout_str()).strip()
+    print(f"  {out}")
+    assert out == "chat.jsonl", f"basename expected 'chat.jsonl', got {out!r}"
+
+    expected_dir = f"{base}/{target_date}"
+    print(f"\n=== dirname {file_path} ===")
+    r = await ws.execute(f'dirname "{file_path}"')
+    out = (await r.stdout_str()).strip()
+    print(f"  {out}")
+    assert out == expected_dir, (
+        f"dirname expected {expected_dir!r}, got {out!r}")
+
+    print(f"\n=== realpath {file_path} ===")
+    r = await ws.execute(f'realpath "{file_path}"')
+    out = (await r.stdout_str()).strip()
+    print(f"  {out}")
+    assert out == file_path, f"realpath expected {file_path!r}, got {out!r}"
+
+    print(f"\n=== realpath -e {file_path} (must exist) ===")
+    r = await ws.execute(f'realpath -e "{file_path}"')
+    print(f"  exit={r.exit_code} {(await r.stdout_str()).strip()}")
+    assert r.exit_code == 0, (
+        "regression: realpath -e failed for existing file; "
+        f"stderr={await r.stderr_str()}")
+
     # ── tree ─────────────────────────────────────────
     print(f"\n=== tree -L 2 /discord/{guild}/ ===")
     r = await ws.execute(f'tree -L 2 "/discord/{guild}/" | head -n 20')

--- a/examples/python/slack/slack.py
+++ b/examples/python/slack/slack.py
@@ -119,6 +119,32 @@ async def main():
     if out:
         print(f"  {out[:120]}")
 
+    # ── basename / dirname / realpath (path ops) ─────
+    print(f"\n=== basename {file_path} ===")
+    r = await ws.execute(f'basename "{file_path}"')
+    out = (await r.stdout_str()).strip()
+    print(f"  {out}")
+    assert out == target, f"basename expected {target!r}, got {out!r}"
+
+    print(f"\n=== dirname {file_path} ===")
+    r = await ws.execute(f'dirname "{file_path}"')
+    out = (await r.stdout_str()).strip()
+    print(f"  {out}")
+    assert out == date_path, f"dirname expected {date_path!r}, got {out!r}"
+
+    print(f"\n=== realpath {file_path} ===")
+    r = await ws.execute(f'realpath "{file_path}"')
+    out = (await r.stdout_str()).strip()
+    print(f"  {out}")
+    assert out == file_path, f"realpath expected {file_path!r}, got {out!r}"
+
+    print(f"\n=== realpath -e {file_path} (must exist) ===")
+    r = await ws.execute(f'realpath -e "{file_path}"')
+    print(f"  exit={r.exit_code} {(await r.stdout_str()).strip()}")
+    assert r.exit_code == 0, (
+        "regression: realpath -e failed for existing file; "
+        f"stderr={await r.stderr_str()}")
+
     # ── grep at FILE level ───────────────────────────
     print(f"\n=== grep message {target} ===")
     r = await ws.execute(f'grep message "{file_path}"')

--- a/python/mirage/commands/builtin/discord/__init__.py
+++ b/python/mirage/commands/builtin/discord/__init__.py
@@ -12,7 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from mirage.commands.builtin.discord.basename import basename
 from mirage.commands.builtin.discord.cat import cat
+from mirage.commands.builtin.discord.dirname import dirname
 from mirage.commands.builtin.discord.discord_add_reaction import \
     discord_add_reaction
 from mirage.commands.builtin.discord.discord_get_server_info import \
@@ -26,6 +28,7 @@ from mirage.commands.builtin.discord.grep import grep
 from mirage.commands.builtin.discord.head import head
 from mirage.commands.builtin.discord.jq import jq
 from mirage.commands.builtin.discord.ls import ls
+from mirage.commands.builtin.discord.realpath import realpath
 from mirage.commands.builtin.discord.rg import rg
 from mirage.commands.builtin.discord.stat import stat
 from mirage.commands.builtin.discord.tail import tail
@@ -38,12 +41,15 @@ from mirage.core.discord.read import read as _ft_read
 COMMANDS = [
     *make_filetype_commands(
         "discord", _ft_resolve_glob, _ft_read, read_takes_index=True),
+    basename,
     cat,
+    dirname,
     find,
     grep,
     head,
     jq,
     ls,
+    realpath,
     rg,
     stat,
     tail,

--- a/python/mirage/commands/builtin/discord/basename.py
+++ b/python/mirage/commands/builtin/discord/basename.py
@@ -1,0 +1,32 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.discord import DiscordAccessor
+from mirage.commands.builtin.generic.basename import \
+    basename as generic_basename
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("basename", resource="discord", spec=SPECS["basename"])
+async def basename(
+    accessor: DiscordAccessor,
+    paths: list[PathSpec] | None = None,
+    *texts: str,
+    stdin: bytes | None = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    return await generic_basename(*texts)

--- a/python/mirage/commands/builtin/discord/dirname.py
+++ b/python/mirage/commands/builtin/discord/dirname.py
@@ -1,0 +1,31 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.discord import DiscordAccessor
+from mirage.commands.builtin.generic.dirname import dirname as generic_dirname
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("dirname", resource="discord", spec=SPECS["dirname"])
+async def dirname(
+    accessor: DiscordAccessor,
+    paths: list[PathSpec] | None = None,
+    *texts: str,
+    stdin: bytes | None = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    return await generic_dirname(*texts)

--- a/python/mirage/commands/builtin/discord/realpath.py
+++ b/python/mirage/commands/builtin/discord/realpath.py
@@ -1,0 +1,47 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from functools import partial
+
+from mirage.accessor.discord import DiscordAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.realpath import \
+    realpath as generic_realpath
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.discord.glob import resolve_glob
+from mirage.core.discord.stat import stat as stat_impl
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("realpath", resource="discord", spec=SPECS["realpath"])
+async def realpath(
+    accessor: DiscordAccessor,
+    paths: list[PathSpec] | None = None,
+    *texts: str,
+    stdin: bytes | None = None,
+    e: bool = False,
+    m: bool = False,
+    prefix: str = "",
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    return await generic_realpath(paths or [],
+                                  stat_fn=partial(stat_impl, index=index),
+                                  accessor=accessor,
+                                  e=e,
+                                  m=m)

--- a/python/tests/resource/discord/test_provider.py
+++ b/python/tests/resource/discord/test_provider.py
@@ -43,5 +43,5 @@ def test_resource_accessor(config):
 
 def test_resource_commands(config):
     resource = DiscordResource(config)
-    # 15 native + 9 filetype cmds x 7 columnar exts
-    assert len(resource._commands) == 15 + 9 * 7
+    # 18 native + 9 filetype cmds x 7 columnar exts
+    assert len(resource._commands) == 18 + 9 * 7


### PR DESCRIPTION
Discord was missing the `basename`, `dirname`, and `realpath` shell commands that Slack already has. This adds them as thin wrappers over the generic implementations (mirroring the Slack versions) and registers them in the Discord command set.

- `basename` / `dirname`: pure path-string ops, forward to the generic.
- `realpath`: resolves globs via `core/discord/glob` and stats via `core/discord/stat`, then forwards to the generic (also supports `-e` existence checks).

Also added basename/dirname/realpath probes (incl. `realpath -e`) to the Slack and Discord Python examples, verified live against real workspaces.