### PR TITLE
refactor(commands): delegate github/github_ci/mongodb read commands to generic

### DIFF
--- a/.github/workflows/test_integ_mongodb.yml
+++ b/.github/workflows/test_integ_mongodb.yml
@@ -1,0 +1,69 @@
+name: Integ (mongodb)
+
+"on":
+  push:
+    branches: [main]
+    paths:
+      - integ/mongodb.py
+      - integ/truth_mongodb.txt
+      - integ/check_lines.sh
+      - python/mirage/accessor/mongodb.py
+      - python/mirage/core/mongodb/**
+      - python/mirage/commands/builtin/mongodb/**
+      - python/mirage/resource/mongodb/**
+      - .github/workflows/test_integ_mongodb.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - integ/mongodb.py
+      - integ/truth_mongodb.txt
+      - integ/check_lines.sh
+      - python/mirage/accessor/mongodb.py
+      - python/mirage/core/mongodb/**
+      - python/mirage/commands/builtin/mongodb/**
+      - python/mirage/resource/mongodb/**
+      - .github/workflows/test_integ_mongodb.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integ-mongodb:
+    runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo:8
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.runCommand({ping:1}).ok'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      MONGODB_URI: mongodb://localhost:27017
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install Python dependencies
+        working-directory: python
+        run: uv sync --all-extras --no-extra camel
+
+      - name: Run MongoDB backend and check against truth
+        shell: bash
+        run: |
+          set -o pipefail
+          ./python/.venv/bin/python integ/mongodb.py 2>&1 \
+            | bash integ/check_lines.sh integ/truth_mongodb.txt

--- a/examples/python/github_ci/github_ci.py
+++ b/examples/python/github_ci/github_ci.py
@@ -146,13 +146,13 @@ async def main():
     r = await ws.execute("tree -L 2 /ci/")
     print(await r.stdout_str())
 
-    # ── find ──────────────────────────────────────────
-    print("=== find /ci/runs/ -name '*.log' | head -n 10 ===")
-    r = await ws.execute('find /ci/runs/ -name "*.log" | head -n 10')
+    # ── find (scoped to a single run) ─────────────────
+    print(f"=== find {run_path}/ -name '*.log' | head -n 10 ===")
+    r = await ws.execute(f'find "{run_path}/" -name "*.log" | head -n 10')
     print(await r.stdout_str())
 
-    print("=== find /ci/runs/ -name '*.json' | head -n 10 ===")
-    r = await ws.execute('find /ci/runs/ -name "*.json" | head -n 10')
+    print(f"=== find {run_path}/ -name '*.json' | head -n 10 ===")
+    r = await ws.execute(f'find "{run_path}/" -name "*.json" | head -n 10')
     print(await r.stdout_str())
 
     # ── cd into a run ─────────────────────────────────

--- a/examples/python/mongodb/mongodb.py
+++ b/examples/python/mongodb/mongodb.py
@@ -81,6 +81,8 @@ async def main():
     await _run(ws, f'cat "{db_json}"')
     await _run(ws, f'cat "{coll_schema}"')
     await _run(ws, f'cat "{view_schema}"')
+    await _run(ws, f'cat -n "{coll_schema}"')
+    await _run(ws, f'cat -n "{coll_doc}"')
 
     print("\n" + "=" * 60)
     print("HEAD / TAIL / WC / STAT")

--- a/integ/mongodb.py
+++ b/integ/mongodb.py
@@ -1,0 +1,158 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import os
+
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from mirage import MountMode, Workspace
+from mirage.resource.mongodb import MongoDBConfig, MongoDBResource
+
+MONGODB_URI = os.environ.get("MONGODB_URI", "mongodb://localhost:27017")
+DB = "mirage_integ"
+MOUNT = "/mongodb"
+
+BOOKS = [
+    {
+        "_id": 1,
+        "title": "alpha",
+        "author": "ada",
+        "year": 2020,
+        "tags": ["fiction", "classic"],
+        "rating": 4.5,
+    },
+    {
+        "_id": 2,
+        "title": "beta",
+        "author": "ben",
+        "year": 2021,
+        "tags": ["fiction"],
+        "rating": 3.2,
+    },
+    {
+        "_id": 3,
+        "title": "gamma",
+        "author": "cara",
+        "year": 2022,
+        "rating": 5.0,
+    },
+    {
+        "_id": 4,
+        "title": "delta",
+        "author": "ada",
+        "year": 2023,
+        "tags": ["history"],
+        "rating": 4.0,
+    },
+    {
+        "_id": 5,
+        "title": "epsilon",
+        "author": "ben",
+        "year": 2024,
+        "rating": 2.5,
+    },
+]
+
+AUTHORS = [
+    {
+        "_id": 1,
+        "name": "ada",
+        "books": 2
+    },
+    {
+        "_id": 2,
+        "name": "ben",
+        "books": 2
+    },
+    {
+        "_id": 3,
+        "name": "cara",
+        "books": 1
+    },
+]
+
+CASES: list[tuple[str, str]] = [
+    ("ls_root", f"ls {MOUNT}/"),
+    ("ls_db", f"ls {MOUNT}/{DB}/"),
+    ("ls_collections", f"ls {MOUNT}/{DB}/collections/"),
+    ("ls_views", f"ls {MOUNT}/{DB}/views/"),
+    ("ls_entity", f"ls {MOUNT}/{DB}/collections/books/"),
+    ("tree", f"tree -L 3 {MOUNT}/{DB}/"),
+    ("cat_database_json", f"cat {MOUNT}/{DB}/database.json"),
+    ("cat_schema_json", f"cat {MOUNT}/{DB}/collections/books/schema.json"),
+    ("cat_docs", f"cat {MOUNT}/{DB}/collections/books/documents.jsonl"),
+    ("head_2", f"head -n 2 {MOUNT}/{DB}/collections/books/documents.jsonl"),
+    ("tail_2", f"tail -n 2 {MOUNT}/{DB}/collections/books/documents.jsonl"),
+    ("wc_l_books", f"wc -l {MOUNT}/{DB}/collections/books/documents.jsonl"),
+    ("wc_l_authors",
+     f"wc -l {MOUNT}/{DB}/collections/authors/documents.jsonl"),
+    ("stat_docs", f"stat {MOUNT}/{DB}/collections/books/documents.jsonl"),
+    ("grep_c_title",
+     f"grep -c title {MOUNT}/{DB}/collections/books/documents.jsonl"),
+    ("grep_ada", f"grep ada {MOUNT}/{DB}/collections/books/documents.jsonl"),
+    ("grep_db_scope", f"grep ada {MOUNT}/{DB}/"),
+    ("grep_root_scope", f"grep ada {MOUNT}/"),
+    ("rg_db_scope", f"rg ben {MOUNT}/{DB}/"),
+    ("find_docs", f"find {MOUNT}/{DB}/ -name documents.jsonl"),
+    ("find_schema", f"find {MOUNT}/{DB}/ -name schema.json"),
+    ("jq_titles",
+     f"jq '.title' {MOUNT}/{DB}/collections/books/documents.jsonl"),
+    ("pipe_grep_c",
+     f"cat {MOUNT}/{DB}/collections/books/documents.jsonl | grep -c fiction"),
+    ("cat_view_docs", f"cat {MOUNT}/{DB}/views/recent_books/documents.jsonl"),
+    ("wc_l_view", f"wc -l {MOUNT}/{DB}/views/recent_books/documents.jsonl"),
+]
+
+
+async def _seed(client: AsyncIOMotorClient) -> None:
+    await client.drop_database(DB)
+    db = client[DB]
+    await db["books"].insert_many([dict(d) for d in BOOKS])
+    await db["authors"].insert_many([dict(d) for d in AUTHORS])
+    await db.create_collection(
+        "recent_books",
+        viewOn="books",
+        pipeline=[{
+            "$match": {
+                "year": {
+                    "$gte": 2022
+                }
+            }
+        }],
+    )
+
+
+async def _run(ws: Workspace, name: str, cmd: str) -> None:
+    result = await ws.execute(cmd)
+    out = await result.stdout_str()
+    print(f"=== {name} ===")
+    print(out, end="" if out.endswith("\n") else "\n")
+
+
+async def main() -> None:
+    seed_client = AsyncIOMotorClient(MONGODB_URI)
+    try:
+        await _seed(seed_client)
+    finally:
+        seed_client.close()
+    resource = MongoDBResource(
+        config=MongoDBConfig(uri=MONGODB_URI, databases=[DB]))
+    ws = Workspace({MOUNT: resource}, mode=MountMode.READ)
+    for name, cmd in CASES:
+        await _run(ws, name, cmd)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integ/truth_mongodb.txt
+++ b/integ/truth_mongodb.txt
@@ -1,0 +1,54 @@
+# Expected substrings for the MongoDB integ run (integ/mongodb.py).
+# Matched as fixed substrings by integ/check_lines.sh, so volatile output
+# (index $indexStats timestamps, system.views internal collection, stat sizes)
+# is tolerated. Seed data is fixed (integer _ids) so content is deterministic.
+
+# ---- directory structure (ls / tree) ----
+mirage_integ
+collections
+views
+database.json
+documents.jsonl
+schema.json
+authors
+books
+recent_books
+
+# ---- database.json ----
+"database": "mirage_integ"
+"name": "authors", "document_count": 3
+"name": "books", "document_count": 5
+"views": [{"name": "recent_books"}]
+
+# ---- schema.json sampled fields (volatile index stats ignored) ----
+"name": "books", "kind": "collection"
+"path": "author"
+"path": "rating"
+"path": "tags"
+"path": "title"
+"path": "year"
+"primary_key": "_id"
+"sampled": 100
+
+# ---- documents (cat / head / tail / view) ----
+"title": "alpha", "author": "ada"
+"title": "beta", "author": "ben"
+"title": "gamma", "author": "cara"
+"title": "delta", "author": "ada"
+"title": "epsilon", "author": "ben"
+{"_id": 1, "name": "ada", "books": 2}
+
+# ---- wc (content cached by prior cat -> generic count<TAB>name) ----
+5	/mongodb/mirage_integ/collections/books/documents.jsonl
+
+# ---- stat ----
+name=documents.jsonl
+
+# ---- grep / rg at db + root scope (search push-down, path-prefixed) ----
+mirage_integ/collections/authors/documents.jsonl:
+mirage_integ/collections/books/documents.jsonl:
+
+# ---- find ----
+/mongodb/mirage_integ/collections/books/documents.jsonl
+/mongodb/mirage_integ/collections/books/schema.json
+/mongodb/mirage_integ/views/recent_books/documents.jsonl

--- a/python/mirage/commands/builtin/github/cat.py
+++ b/python/mirage/commands/builtin/github/cat.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cat import cat as generic_cat
 from mirage.commands.builtin.github._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
@@ -35,17 +36,10 @@ async def cat_provision(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> ProvisionResult:
-    path_strs = [
-        p.original if isinstance(p, PathSpec) else str(p) for p in paths
-    ]
-    return await file_read_provision(accessor, index, paths,
-                                     "cat " + " ".join(path_strs))
-
-
-async def _number_lines(data: bytes) -> AsyncIterator[bytes]:
-    lines = data.decode(errors="replace").splitlines()
-    for i, line in enumerate(lines, 1):
-        yield f"     {i}\t{line}\n".encode()
+    return await file_read_provision(
+        accessor, index, paths,
+        "cat " + " ".join(p.original if isinstance(p, PathSpec) else p
+                          for p in paths))
 
 
 @command("cat", resource="github", spec=SPECS["cat"], provision=cat_provision)
@@ -64,12 +58,9 @@ async def cat(
         data = await github_read(accessor, p, index)
         io = IOResult(reads={p.strip_prefix: data}, cache=[p.strip_prefix])
         if n:
-            return _number_lines(data), io
+            return generic_cat(data, number_lines=True), io
         return yield_bytes(data), io
     source = _resolve_source(stdin, "cat: missing operand")
     if n:
-        raw = b""
-        async for chunk in source:
-            raw += chunk
-        return _number_lines(raw), IOResult()
+        return generic_cat(source, number_lines=True), IOResult()
     return source, IOResult()

--- a/python/mirage/commands/builtin/github/head.py
+++ b/python/mirage/commands/builtin/github/head.py
@@ -16,8 +16,9 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.head import head as generic_head
 from mirage.commands.builtin.github._provision import file_read_provision
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github.glob import resolve_glob
@@ -41,15 +42,6 @@ async def head_provision(
                                      "head " + " ".join(path_strs))
 
 
-async def _head_bytes(data: bytes, lines: int,
-                      bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield data[:bytes_mode]
-        return
-    parts = data.split(b"\n", lines)
-    yield b"\n".join(parts[:lines])
-
-
 @command("head",
          resource="github",
          spec=SPECS["head"],
@@ -64,14 +56,11 @@ async def head(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines = int(n) if n is not None else 10
-    bytes_mode = int(c) if c is not None else None
+    n_int = int(n) if n is not None else None
+    c_int = int(c) if c is not None else None
     if paths and index is not None:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        data = await github_read(accessor, p, index)
-        return _head_bytes(data, lines, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("head: missing operand")
-    return _head_bytes(raw, lines, bytes_mode), IOResult()
+        data = await github_read(accessor, paths[0], index)
+        return generic_head(data, n=n_int, c=c_int), IOResult()
+    source = _resolve_source(stdin, "head: missing operand")
+    return generic_head(source, n=n_int, c=c_int), IOResult()

--- a/python/mirage/commands/builtin/github/ls.py
+++ b/python/mirage/commands/builtin/github/ls.py
@@ -12,10 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.ls import ls as generic_ls
 from mirage.commands.builtin.github._provision import metadata_provision
-from mirage.commands.builtin.utils.formatting import _human_size
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github.glob import resolve_glob
@@ -23,69 +25,7 @@ from mirage.core.github.readdir import readdir
 from mirage.core.github.stat import stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileType, PathSpec
-
-
-async def _ls_async(
-    accessor,
-    path: PathSpec,
-    index,
-    long: bool = False,
-    all_files: bool = False,
-    sort_by: str = "name",
-    reverse: bool = False,
-    recursive: bool = False,
-    list_dir: bool = False,
-    warnings: list[str] | None = None,
-):
-    if list_dir:
-        entries = [await stat(accessor, path, index)]
-    else:
-        raw = await readdir(accessor, path, index)
-        entries = []
-        for e in raw:
-            try:
-                e_spec = PathSpec(original=e,
-                                  directory=e,
-                                  resolved=False,
-                                  prefix=path.prefix)
-                entries.append(await stat(accessor, e_spec, index))
-            except (FileNotFoundError, ValueError) as exc:
-                if warnings is not None:
-                    warnings.append(f"ls: cannot access '{e}': {exc}")
-
-    if not all_files:
-        entries = [e for e in entries if not e.name.startswith(".")]
-
-    if sort_by == "size":
-        entries = sorted(entries,
-                         key=lambda e: e.size or 0,
-                         reverse=not reverse)
-    else:
-        entries = sorted(entries, key=lambda e: e.name, reverse=reverse)
-
-    if recursive:
-        all_entries = []
-        for e in entries:
-            all_entries.append(e)
-            if e.type == FileType.DIRECTORY:
-                sub_path = path.child(e.name)
-                sub_spec = PathSpec(original=sub_path,
-                                    directory=sub_path,
-                                    resolved=False,
-                                    prefix=path.prefix)
-                sub = await _ls_async(accessor,
-                                      sub_spec,
-                                      index,
-                                      long=long,
-                                      all_files=all_files,
-                                      sort_by=sort_by,
-                                      reverse=reverse,
-                                      recursive=True,
-                                      warnings=warnings)
-                all_entries.extend(sub)
-        return all_entries
-    return entries
+from mirage.types import LsSortBy, PathSpec
 
 
 async def ls_provision(
@@ -124,41 +64,19 @@ async def ls(
     if index is None:
         raise ValueError("ls: no tree loaded")
     paths = await resolve_glob(accessor, paths, index)
-    all_files = a or A
-    sort_by = "name"
-    if S:
-        sort_by = "size"
-    warnings: list[str] = []
-    results: list[str] = []
-    for p in paths:
-        try:
-            entries = await _ls_async(
-                accessor,
-                p,
-                index,
-                long=args_l,
-                all_files=all_files,
-                sort_by=sort_by,
-                reverse=r,
-                recursive=R,
-                list_dir=d,
-                warnings=warnings,
-            )
-        except (FileNotFoundError, ValueError) as exc:
-            warnings.append(f"ls: cannot access '{p.original}': {exc}")
-            continue
-        if args_l and not args_1:
-            for e in entries:
-                size_str = _human_size(e.size or 0) if h else str(e.size or 0)
-                line = (f"{e.type or '-'}\t{size_str}"
-                        f"\t{e.modified or ''}\t{e.name}")
-                results.append(line)
-        else:
-            for e in entries:
-                is_dir = F and e.type == FileType.DIRECTORY
-                name = e.name + "/" if is_dir else e.name
-                results.append(name)
-    stderr = "\n".join(warnings).encode() if warnings else None
-    exit_code = 1 if warnings and not results else 0
-    output = "\n".join(results).encode()
-    return output, IOResult(stderr=stderr, exit_code=exit_code)
+    sort_by = LsSortBy.TIME if t else LsSortBy.SIZE if S else LsSortBy.NAME
+    return await generic_ls(
+        paths,
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        long=args_l,
+        one_per_line=args_1,
+        all_files=a or A,
+        human=h,
+        sort_by=sort_by,
+        reverse=r,
+        recursive=R,
+        list_dir=d,
+        classify=F,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/github/stat.py
+++ b/python/mirage/commands/builtin/github/stat.py
@@ -12,10 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import re
-
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.stat import stat as generic_stat
 from mirage.commands.builtin.github._provision import metadata_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -23,42 +22,13 @@ from mirage.core.github.glob import resolve_glob
 from mirage.core.github.stat import stat as stat_impl
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileStat, FileType, PathSpec
-
-_FORMAT_RE = re.compile(r"%([nsFy]|.)")
-
-_TYPE_LABELS = {
-    FileType.DIRECTORY: "directory",
-    FileType.TEXT: "regular file",
-    FileType.BINARY: "regular file",
-    FileType.JSON: "regular file",
-    FileType.CSV: "regular file",
-}
-
-
-def _format_stat(fmt: str, s: FileStat) -> str:
-
-    def _replace(m: re.Match) -> str:
-        spec = m.group(1)
-        if spec == "n":
-            return s.name
-        if spec == "s":
-            return str(s.size if s.size is not None else 0)
-        if spec == "F":
-            return _TYPE_LABELS.get(
-                s.type, "regular file") if s.type else "regular file"
-        if spec == "y":
-            return s.modified or ""
-        return "?"
-
-    return _FORMAT_RE.sub(_replace, fmt)
+from mirage.types import PathSpec
 
 
 async def stat_provision(
     accessor: GitHubAccessor,
     paths: list[PathSpec],
     *texts: str,
-    index: IndexCacheStore = None,
     **_extra: object,
 ) -> ProvisionResult:
     return await metadata_provision("stat " + " ".join(
@@ -79,19 +49,12 @@ async def stat(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if index is None:
-        raise ValueError("stat: no tree loaded")
-    paths = await resolve_glob(accessor, paths, index)
     if not paths:
         raise ValueError("stat: missing operand")
-    fmt = c if c is not None else f
-    lines: list[str] = []
-    for p in paths:
-        s = await stat_impl(accessor, p, index)
-        if fmt is not None:
-            lines.append(_format_stat(fmt, s))
-        else:
-            lines.append(f"name={s.name} size={s.size}"
-                         f" modified={s.modified}"
-                         f" type={s.type.value if s.type else None}")
-    return "\n".join(lines).encode(), IOResult()
+    paths = await resolve_glob(accessor, paths, index)
+    return await generic_stat(paths,
+                              stat_fn=stat_impl,
+                              accessor=accessor,
+                              c=c,
+                              f=f,
+                              index=index)

--- a/python/mirage/commands/builtin/github/tail.py
+++ b/python/mirage/commands/builtin/github/tail.py
@@ -16,9 +16,10 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
 from mirage.commands.builtin.github._provision import file_read_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.tail_helper import _parse_n
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github.glob import resolve_glob
@@ -41,14 +42,6 @@ async def tail_provision(
                            for p in paths))
 
 
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
-
-
 @command("tail",
          resource="github",
          spec=SPECS["tail"],
@@ -65,14 +58,20 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths and index is not None:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        raw = await github_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        data = await github_read(accessor, paths[0], index)
+        return generic_tail(data, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/github/tree.py
+++ b/python/mirage/commands/builtin/github/tree.py
@@ -12,82 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import fnmatch
+from functools import partial
 
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tree import tree as generic_tree
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github.glob import resolve_glob
 from mirage.core.github.readdir import readdir
 from mirage.core.github.stat import stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
-
-
-async def _tree_async(
-    accessor,
-    path: PathSpec,
-    index,
-    _prefix: str = "",
-    max_depth: int | None = None,
-    show_hidden: bool = False,
-    ignore_pattern: str | None = None,
-    dirs_only: bool = False,
-    match_pattern: str | None = None,
-    _depth: int = 0,
-    warnings: list[str] | None = None,
-) -> list[str]:
-    lines: list[str] = []
-    try:
-        entries = await readdir(accessor, path, index)
-    except (FileNotFoundError, ValueError) as exc:
-        if warnings is not None:
-            warnings.append(f"tree: '{path.original}': {exc}")
-        return lines
-    filtered = []
-    for entry in entries:
-        entry_spec = PathSpec(original=entry,
-                              directory=entry,
-                              resolved=False,
-                              prefix=path.prefix)
-        try:
-            s = await stat(accessor, entry_spec, index)
-        except (FileNotFoundError, ValueError) as exc:
-            if warnings is not None:
-                warnings.append(f"tree: '{entry}': {exc}")
-            continue
-        if not show_hidden and s.name.startswith("."):
-            continue
-        if ignore_pattern and fnmatch.fnmatch(s.name, ignore_pattern):
-            continue
-        if dirs_only and s.type != FileType.DIRECTORY:
-            continue
-        not_dir = s.type != FileType.DIRECTORY
-        if match_pattern and not_dir and not fnmatch.fnmatch(
-                s.name, match_pattern):
-            continue
-        filtered.append((entry_spec, s))
-    for i, (entry_spec, s) in enumerate(filtered):
-        is_last = i == len(filtered) - 1
-        connector = "\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 "
-        lines.append(_prefix + connector + s.name)
-        if s.type == FileType.DIRECTORY:
-            if max_depth is not None and _depth >= max_depth:
-                continue
-            extension = "    " if is_last else "\u2502   "
-            lines.extend(await _tree_async(accessor,
-                                           entry_spec,
-                                           index,
-                                           _prefix + extension,
-                                           max_depth=max_depth,
-                                           show_hidden=show_hidden,
-                                           ignore_pattern=ignore_pattern,
-                                           dirs_only=dirs_only,
-                                           match_pattern=match_pattern,
-                                           _depth=_depth + 1,
-                                           warnings=warnings))
-    return lines
+from mirage.types import PathSpec
 
 
 @command("tree", resource="github", spec=SPECS["tree"])
@@ -104,23 +40,15 @@ async def tree(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if index is None:
-        raise ValueError("tree: no tree loaded")
     paths = await resolve_glob(accessor, paths, index)
-    p = paths[0]
-    max_depth = int(L) if L is not None else None
-    warnings: list[str] = []
-    results = await _tree_async(
-        accessor,
-        p,
-        index,
-        max_depth=max_depth,
+    return await generic_tree(
+        paths[0],
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        max_depth=int(L) if L is not None else None,
         show_hidden=a,
         ignore_pattern=args_I,
         dirs_only=d,
         match_pattern=P,
-        warnings=warnings,
+        index=index,
     )
-    stderr = "\n".join(warnings).encode() if warnings else None
-    output = "\n".join(results).encode()
-    return output, IOResult(stderr=stderr)

--- a/python/mirage/commands/builtin/github/wc.py
+++ b/python/mirage/commands/builtin/github/wc.py
@@ -16,6 +16,8 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.github._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
@@ -56,25 +58,33 @@ async def wc(
 ) -> tuple[ByteSource | None, IOResult]:
     if paths and index is not None:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        data = await github_read(accessor, p, index)
-    else:
-        data = await _read_stdin_async(stdin)
-        if data is None:
-            raise ValueError("wc: missing operand")
-    text = data.decode(errors="replace")
-    line_count = text.count("\n")
-    word_count = len(text.split())
-    byte_count = len(data)
-    if L:
-        max_len = max((len(ln) for ln in text.splitlines()), default=0)
-        return str(max_len).encode(), IOResult()
-    if args_l:
-        return str(line_count).encode(), IOResult()
-    if w:
-        return str(word_count).encode(), IOResult()
-    if m:
-        return str(len(text)).encode(), IOResult()
-    if c:
-        return str(byte_count).encode(), IOResult()
-    return f"{line_count}\t{word_count}\t{byte_count}".encode(), IOResult()
+        outputs: list[str] = []
+        totals = WCCounts()
+        for p in paths:
+            data = await github_read(accessor, p, index)
+            counts = await generic_wc(data)
+            outputs.append(
+                format_wc(counts,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label=p.original))
+            totals.merge(counts)
+        if len(paths) > 1:
+            outputs.append(
+                format_wc(totals,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label="total"))
+        return "\n".join(outputs).encode(), IOResult()
+    data = await _read_stdin_async(stdin)
+    if data is None:
+        raise ValueError("wc: missing operand")
+    counts = await generic_wc(data)
+    return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
+                     L=L).encode(), IOResult()

--- a/python/mirage/commands/builtin/github_ci/cat.py
+++ b/python/mirage/commands/builtin/github_ci/cat.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.github_ci import GitHubCIAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cat import cat as generic_cat
 from mirage.commands.builtin.github_ci._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
@@ -39,12 +40,6 @@ async def cat_provision(
                           for p in paths))
 
 
-async def _number_lines(data: bytes) -> AsyncIterator[bytes]:
-    lines = data.decode(errors="replace").splitlines()
-    for i, line in enumerate(lines, 1):
-        yield f"     {i}\t{line}\n".encode()
-
-
 @command("cat",
          resource="github_ci",
          spec=SPECS["cat"],
@@ -64,12 +59,9 @@ async def cat(
         data = await ci_read(accessor, p, index)
         io = IOResult(reads={p.strip_prefix: data}, cache=[p.strip_prefix])
         if n:
-            return _number_lines(data), io
+            return generic_cat(data, number_lines=True), io
         return data, io
     source = _resolve_source(stdin, "cat: missing operand")
     if n:
-        raw = b""
-        async for chunk in source:
-            raw += chunk
-        return _number_lines(raw), IOResult()
+        return generic_cat(source, number_lines=True), IOResult()
     return source, IOResult()

--- a/python/mirage/commands/builtin/github_ci/find.py
+++ b/python/mirage/commands/builtin/github_ci/find.py
@@ -19,7 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.github_ci._provision import metadata_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
-from mirage.core.github_ci.glob import resolve_glob
+from mirage.core.github_ci.glob import is_cross_run_root, resolve_glob
 from mirage.core.github_ci.readdir import readdir as _readdir
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
@@ -98,6 +98,9 @@ async def find(
                            directory=search_path,
                            resolved=False,
                            prefix=search_prefix)
+    if is_cross_run_root(search_spec):
+        raise ValueError("find: recursive search across runs is disabled; "
+                         "target a specific run (e.g. /ci/runs/<run>)")
     all_paths = await _walk(accessor, search_spec, index, md)
     results: list[str] = []
     base_depth = search_path.strip("/").count("/") if search_path.strip(

--- a/python/mirage/commands/builtin/github_ci/grep.py
+++ b/python/mirage/commands/builtin/github_ci/grep.py
@@ -19,7 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
-from mirage.core.github_ci.glob import resolve_glob
+from mirage.core.github_ci.glob import is_cross_run_root, resolve_glob
 from mirage.core.github_ci.read import read as ci_read
 from mirage.core.github_ci.readdir import readdir as _readdir
 from mirage.core.github_ci.stat import stat as _stat
@@ -65,6 +65,9 @@ async def grep(
     after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
     before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
     resolved = await resolve_glob(accessor, paths, index) if paths else []
+    if (r or R) and any(is_cross_run_root(p) for p in resolved):
+        raise ValueError("grep: recursive search across runs is disabled; "
+                         "target a specific run (e.g. /ci/runs/<run>/jobs)")
     return await generic_grep(
         resolved,
         pattern=pattern,

--- a/python/mirage/commands/builtin/github_ci/grep.py
+++ b/python/mirage/commands/builtin/github_ci/grep.py
@@ -13,25 +13,18 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.github_ci import GitHubCIAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import (compile_pattern,
-                                                 grep_files_only, grep_lines,
-                                                 grep_recursive, grep_stream)
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
+from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github_ci.glob import resolve_glob
 from mirage.core.github_ci.read import read as ci_read
 from mirage.core.github_ci.readdir import readdir as _readdir
 from mirage.core.github_ci.stat import stat as _stat
-from mirage.io.stream import exit_on_empty, quiet_match
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
+from mirage.types import PathSpec
 
 
 @command("grep", resource="github_ci", spec=SPECS["grep"])
@@ -71,126 +64,28 @@ async def grep(
     max_count = int(m) if m is not None else None
     after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
     before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
-
-    if paths and index is not None:
-        paths = await resolve_glob(accessor, paths, index)
-        mount_prefix = paths[0].prefix if paths else ""
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-        rb = partial(call_read_bytes,
-                     ci_read,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-
-        recursive = r or R
-        multi = len(paths) > 1 or recursive
-
-        if args_l:
-            warnings_l: list[str] = []
-            results = await grep_files_only(
-                rd,
-                st,
-                rb,
-                paths[0].original,
-                pattern,
-                recursive=recursive,
-                ignore_case=i,
-                invert=v,
-                line_numbers=n,
-                count_only=c,
-                fixed_string=F,
-                only_matching=o,
-                max_count=max_count,
-                whole_word=w,
-                warnings=warnings_l,
-            )
-            stderr = "\n".join(warnings_l).encode() if warnings_l else None
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            return "\n".join(results).encode(), IOResult(stderr=stderr)
-
-        pat = compile_pattern(pattern, i, F, w)
-        all_results: list[str] = []
-        warnings_g: list[str] = []
-        for p in paths:
-            try:
-                s = await st(p.original)
-            except FileNotFoundError as exc:
-                warnings_g.append(f"grep: {p.original}: {exc}")
-                continue
-            if s.type == FileType.DIRECTORY:
-                if recursive:
-                    res = await grep_recursive(
-                        rd,
-                        st,
-                        rb,
-                        p.original,
-                        pat,
-                        invert=v,
-                        line_numbers=n,
-                        count_only=c,
-                        files_only=False,
-                        only_matching=o,
-                        max_count=max_count,
-                        warnings=warnings_g,
-                    )
-                    all_results.extend(res)
-                else:
-                    warnings_g.append(f"grep: {p.original}: Is a directory")
-                continue
-            try:
-                data = await rb(p.original)
-            except FileNotFoundError:
-                warnings_g.append(
-                    f"grep: {p.original}: No such file or directory")
-                continue
-            text_lines = data.decode(errors="replace").splitlines()
-            file_lines = grep_lines(p.original,
-                                    text_lines,
-                                    pat,
-                                    invert=v,
-                                    line_numbers=n,
-                                    count_only=c,
-                                    files_only=False,
-                                    only_matching=o,
-                                    max_count=max_count)
-            if multi:
-                if c and file_lines:
-                    all_results.append(f"{p.original}:{file_lines[0]}")
-                else:
-                    all_results.extend(f"{p.original}:{line}"
-                                       for line in file_lines)
-            else:
-                all_results.extend(file_lines)
-        stderr = "\n".join(warnings_g).encode() if warnings_g else None
-        if not all_results:
-            return b"", IOResult(exit_code=1, stderr=stderr)
-        return "\n".join(all_results).encode(), IOResult(stderr=stderr)
-
-    source = _resolve_source(stdin, "grep: usage: grep [flags] pattern [path]")
-    pat = compile_pattern(pattern, i, F, w)
-    stream = grep_stream(
-        source,
-        pat,
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
+    return await generic_grep(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=ci_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
         invert=v,
         line_numbers=n,
-        only_matching=o,
-        max_count=max_count,
         count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        quiet=q,
+        recursive=r or R,
+        max_count=max_count,
         after_context=after_ctx,
         before_context=before_ctx,
+        index=index,
     )
-    if q:
-        io = IOResult(exit_code=1)
-        return quiet_match(stream, io), io
-    io = IOResult()
-    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/github_ci/head.py
+++ b/python/mirage/commands/builtin/github_ci/head.py
@@ -15,8 +15,10 @@
 from collections.abc import AsyncIterator
 
 from mirage.accessor.github_ci import GitHubCIAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.head import head as generic_head
 from mirage.commands.builtin.github_ci._provision import file_read_provision
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github_ci.glob import resolve_glob
@@ -38,15 +40,6 @@ async def head_provision(
                            for p in paths))
 
 
-async def _head_bytes(data: bytes, lines: int,
-                      bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield data[:bytes_mode]
-        return
-    parts = data.split(b"\n", lines)
-    yield b"\n".join(parts[:lines])
-
-
 @command("head",
          resource="github_ci",
          spec=SPECS["head"],
@@ -58,17 +51,14 @@ async def head(
     stdin: AsyncIterator[bytes] | bytes | None = None,
     n: str | None = None,
     c: str | None = None,
-    index=None,
+    index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines = int(n) if n is not None else 10
-    bytes_mode = int(c) if c is not None else None
+    n_int = int(n) if n is not None else None
+    c_int = int(c) if c is not None else None
     if paths:
-        paths = await resolve_glob(accessor, paths, index=index)
-        p = paths[0]
-        data = await ci_read(accessor, p, index)
-        return _head_bytes(data, lines, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("head: missing operand")
-    return _head_bytes(raw, lines, bytes_mode), IOResult()
+        paths = await resolve_glob(accessor, paths, index)
+        data = await ci_read(accessor, paths[0], index)
+        return generic_head(data, n=n_int, c=c_int), IOResult()
+    source = _resolve_source(stdin, "head: missing operand")
+    return generic_head(source, n=n_int, c=c_int), IOResult()

--- a/python/mirage/commands/builtin/github_ci/ls.py
+++ b/python/mirage/commands/builtin/github_ci/ls.py
@@ -12,10 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.github_ci import GitHubCIAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.ls import ls as generic_ls
 from mirage.commands.builtin.github_ci._provision import metadata_provision
-from mirage.commands.builtin.utils.formatting import _human_size
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github_ci.glob import resolve_glob
@@ -23,68 +25,7 @@ from mirage.core.github_ci.readdir import readdir
 from mirage.core.github_ci.stat import stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileType, PathSpec
-
-
-async def _ls_async(
-    accessor: GitHubCIAccessor,
-    path: PathSpec,
-    long: bool = False,
-    all_files: bool = False,
-    sort_by: str = "name",
-    reverse: bool = False,
-    recursive: bool = False,
-    list_dir: bool = False,
-    warnings: list[str] | None = None,
-    index: IndexCacheStore = None,
-):
-    if list_dir:
-        entries = [await stat(accessor, path, index)]
-    else:
-        raw = await readdir(accessor, path, index)
-        entries = []
-        for e in raw:
-            try:
-                e_spec = PathSpec(original=e,
-                                  directory=e,
-                                  resolved=False,
-                                  prefix=path.prefix)
-                entries.append(await stat(accessor, e_spec, index))
-            except (FileNotFoundError, ValueError) as exc:
-                if warnings is not None:
-                    warnings.append(f"ls: cannot access '{e}': {exc}")
-
-    if not all_files:
-        entries = [e for e in entries if not e.name.startswith(".")]
-
-    if sort_by == "size":
-        entries = sorted(entries,
-                         key=lambda e: e.size or 0,
-                         reverse=not reverse)
-    else:
-        entries = sorted(entries, key=lambda e: e.name, reverse=reverse)
-
-    if recursive:
-        all_entries = []
-        for e in entries:
-            all_entries.append(e)
-            if e.type == FileType.DIRECTORY:
-                sub_path = path.child(e.name)
-                sub_spec = PathSpec(original=sub_path,
-                                    directory=sub_path,
-                                    resolved=False,
-                                    prefix=path.prefix)
-                sub = await _ls_async(accessor,
-                                      sub_spec,
-                                      long=long,
-                                      all_files=all_files,
-                                      sort_by=sort_by,
-                                      reverse=reverse,
-                                      recursive=True,
-                                      warnings=warnings)
-                all_entries.extend(sub)
-        return all_entries
-    return entries
+from mirage.types import LsSortBy, PathSpec
 
 
 async def ls_provision(
@@ -117,47 +58,25 @@ async def ls(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    all_files = a or A
-    sort_by = "name"
-    if S:
-        sort_by = "size"
-    warnings: list[str] = []
-    results: list[str] = []
     if not paths:
         cwd = _extra.get("cwd", "/")
         paths = [cwd] if isinstance(cwd, PathSpec) else [
             PathSpec(original=cwd, directory=cwd, resolved=False)
         ]
     paths = await resolve_glob(accessor, paths, index)
-    for p in paths:
-        try:
-            entries = await _ls_async(
-                accessor,
-                p,
-                long=args_l,
-                all_files=all_files,
-                sort_by=sort_by,
-                reverse=r,
-                recursive=R,
-                list_dir=d,
-                warnings=warnings,
-                index=index,
-            )
-        except (FileNotFoundError, ValueError) as exc:
-            warnings.append(f"ls: cannot access '{p.original}': {exc}")
-            continue
-        if args_l and not args_1:
-            for e in entries:
-                size_str = _human_size(e.size or 0) if h else str(e.size or 0)
-                line = (f"{e.type or '-'}\t{size_str}"
-                        f"\t{e.modified or ''}\t{e.name}")
-                results.append(line)
-        else:
-            for e in entries:
-                is_dir = F and e.type == FileType.DIRECTORY
-                name = e.name + "/" if is_dir else e.name
-                results.append(name)
-    stderr = "\n".join(warnings).encode() if warnings else None
-    exit_code = 1 if warnings and not results else 0
-    output = "\n".join(results).encode()
-    return output, IOResult(stderr=stderr, exit_code=exit_code)
+    sort_by = LsSortBy.TIME if t else LsSortBy.SIZE if S else LsSortBy.NAME
+    return await generic_ls(
+        paths,
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        long=args_l,
+        one_per_line=args_1,
+        all_files=a or A,
+        human=h,
+        sort_by=sort_by,
+        reverse=r,
+        recursive=R,
+        list_dir=d,
+        classify=F,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/github_ci/rg.py
+++ b/python/mirage/commands/builtin/github_ci/rg.py
@@ -19,7 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
-from mirage.core.github_ci.glob import resolve_glob
+from mirage.core.github_ci.glob import is_cross_run_root, resolve_glob
 from mirage.core.github_ci.read import read as ci_read
 from mirage.core.github_ci.readdir import readdir as _readdir
 from mirage.core.github_ci.stat import stat as _stat
@@ -60,6 +60,9 @@ async def rg(
     if C is not None:
         context_before = context_after = int(C)
     resolved = await resolve_glob(accessor, paths, index) if paths else []
+    if any(is_cross_run_root(p) for p in resolved):
+        raise ValueError("rg: recursive search across runs is disabled; "
+                         "target a specific run (e.g. /ci/runs/<run>/jobs)")
     return await generic_rg(
         resolved,
         pattern=pattern,

--- a/python/mirage/commands/builtin/github_ci/rg.py
+++ b/python/mirage/commands/builtin/github_ci/rg.py
@@ -13,15 +13,10 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.github_ci import GitHubCIAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import (compile_pattern, grep_lines,
-                                                 grep_recursive)
-from mirage.commands.builtin.utils.stream import _read_stdin_async
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
+from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github_ci.glob import resolve_glob
@@ -29,7 +24,7 @@ from mirage.core.github_ci.read import read as ci_read
 from mirage.core.github_ci.readdir import readdir as _readdir
 from mirage.core.github_ci.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
+from mirage.types import PathSpec
 
 
 @command("rg", resource="github_ci", spec=SPECS["rg"])
@@ -58,102 +53,35 @@ async def rg(
 ) -> tuple[ByteSource | None, IOResult]:
     if not texts:
         raise ValueError("rg: usage: rg [flags] pattern [path]")
-    pattern_str = texts[0]
+    pattern = texts[0]
     max_count = int(m) if m is not None else None
-    pat = compile_pattern(pattern_str, i, F, w)
-
-    if paths and index is not None:
-        paths = await resolve_glob(accessor, paths, index)
-        mount_prefix = paths[0].prefix if paths else ""
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-        rb = partial(call_read_bytes,
-                     ci_read,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-
-        all_results: list[str] = []
-        warnings_g: list[str] = []
-        any_match = False
-        for p in paths:
-            try:
-                s = await st(p.original)
-            except FileNotFoundError as exc:
-                warnings_g.append(f"rg: {p.original}: {exc}")
-                continue
-            if s.type == FileType.DIRECTORY:
-                res = await grep_recursive(
-                    rd,
-                    st,
-                    rb,
-                    p.original,
-                    pat,
-                    invert=v,
-                    line_numbers=n,
-                    count_only=c,
-                    files_only=args_l,
-                    only_matching=o,
-                    max_count=max_count,
-                    warnings=warnings_g,
-                )
-                if res:
-                    any_match = True
-                all_results.extend(res)
-                continue
-            try:
-                data = await rb(p.original)
-            except FileNotFoundError:
-                warnings_g.append(
-                    f"rg: {p.original}: No such file or directory")
-                continue
-            text_lines = data.decode(errors="replace").splitlines()
-            matched = grep_lines(p.original,
-                                 text_lines,
-                                 pat,
-                                 invert=v,
-                                 line_numbers=n,
-                                 count_only=c,
-                                 files_only=args_l,
-                                 only_matching=o,
-                                 max_count=max_count)
-            if not matched:
-                continue
-            any_match = True
-            if args_l:
-                all_results.append(p.original)
-            elif c:
-                all_results.append(f"{p.original}:{len(matched)}")
-            else:
-                all_results.extend(f"{p.original}:{line}" for line in matched)
-        stderr = "\n".join(warnings_g).encode() if warnings_g else None
-        if not any_match:
-            return b"", IOResult(exit_code=1, stderr=stderr)
-        return "\n".join(all_results).encode(), IOResult(stderr=stderr)
-
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("rg: usage: rg [flags] pattern path")
-    text_lines = raw.decode(errors="replace").splitlines()
-    matched = grep_lines("<stdin>",
-                         text_lines,
-                         pat,
-                         invert=v,
-                         line_numbers=n,
-                         count_only=c,
-                         files_only=args_l,
-                         only_matching=o,
-                         max_count=max_count)
-    if not matched:
-        return b"", IOResult(exit_code=1)
-    if c:
-        return str(len(matched)).encode(), IOResult()
-    return "\n".join(matched).encode(), IOResult()
+    context_after = int(A) if A is not None else 0
+    context_before = int(B) if B is not None else 0
+    if C is not None:
+        context_before = context_after = int(C)
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
+    return await generic_rg(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=ci_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        max_count=max_count,
+        context_before=context_before,
+        context_after=context_after,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/github_ci/stat.py
+++ b/python/mirage/commands/builtin/github_ci/stat.py
@@ -12,10 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import re
-
 from mirage.accessor.github_ci import GitHubCIAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.stat import stat as generic_stat
 from mirage.commands.builtin.github_ci._provision import metadata_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -23,35 +22,7 @@ from mirage.core.github_ci.glob import resolve_glob
 from mirage.core.github_ci.stat import stat as stat_impl
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileStat, FileType, PathSpec
-
-_FORMAT_RE = re.compile(r"%([nsFy]|.)")
-
-_TYPE_LABELS = {
-    FileType.DIRECTORY: "directory",
-    FileType.TEXT: "regular file",
-    FileType.BINARY: "regular file",
-    FileType.JSON: "regular file",
-    FileType.CSV: "regular file",
-}
-
-
-def _format_stat(fmt: str, s: FileStat) -> str:
-
-    def _replace(m: re.Match) -> str:
-        spec = m.group(1)
-        if spec == "n":
-            return s.name
-        if spec == "s":
-            return str(s.size if s.size is not None else 0)
-        if spec == "F":
-            return _TYPE_LABELS.get(
-                s.type, "regular file") if s.type else "regular file"
-        if spec == "y":
-            return s.modified or ""
-        return "?"
-
-    return _FORMAT_RE.sub(_replace, fmt)
+from mirage.types import PathSpec
 
 
 async def stat_provision(
@@ -81,14 +52,9 @@ async def stat(
     if not paths:
         raise ValueError("stat: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    fmt = c if c is not None else f
-    lines: list[str] = []
-    for p in paths:
-        s = await stat_impl(accessor, p, index)
-        if fmt is not None:
-            lines.append(_format_stat(fmt, s))
-        else:
-            lines.append(f"name={s.name} size={s.size}"
-                         f" modified={s.modified}"
-                         f" type={s.type.value if s.type else None}")
-    return "\n".join(lines).encode(), IOResult()
+    return await generic_stat(paths,
+                              stat_fn=stat_impl,
+                              accessor=accessor,
+                              c=c,
+                              f=f,
+                              index=index)

--- a/python/mirage/commands/builtin/github_ci/tail.py
+++ b/python/mirage/commands/builtin/github_ci/tail.py
@@ -15,9 +15,11 @@
 from collections.abc import AsyncIterator
 
 from mirage.accessor.github_ci import GitHubCIAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
 from mirage.commands.builtin.github_ci._provision import file_read_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.tail_helper import _parse_n
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github_ci.glob import resolve_glob
@@ -39,14 +41,6 @@ async def tail_provision(
                            for p in paths))
 
 
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
-
-
 @command("tail",
          resource="github_ci",
          spec=SPECS["tail"],
@@ -60,17 +54,23 @@ async def tail(
     c: str | None = None,
     q: bool = False,
     v: bool = False,
-    index=None,
+    index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
-        paths = await resolve_glob(accessor, paths, index=index)
-        p = paths[0]
-        raw = await ci_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        paths = await resolve_glob(accessor, paths, index)
+        data = await ci_read(accessor, paths[0], index)
+        return generic_tail(data, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/github_ci/tree.py
+++ b/python/mirage/commands/builtin/github_ci/tree.py
@@ -12,82 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import fnmatch
+from functools import partial
 
 from mirage.accessor.github_ci import GitHubCIAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tree import tree as generic_tree
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github_ci.glob import resolve_glob
 from mirage.core.github_ci.readdir import readdir
 from mirage.core.github_ci.stat import stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
-
-
-async def _tree_async(
-    accessor: GitHubCIAccessor,
-    path: PathSpec,
-    _prefix: str = "",
-    max_depth: int | None = None,
-    show_hidden: bool = False,
-    ignore_pattern: str | None = None,
-    dirs_only: bool = False,
-    match_pattern: str | None = None,
-    _depth: int = 0,
-    warnings: list[str] | None = None,
-    index: IndexCacheStore = None,
-) -> list[str]:
-    lines: list[str] = []
-    try:
-        entries = await readdir(accessor, path, index)
-    except (FileNotFoundError, ValueError) as exc:
-        if warnings is not None:
-            warnings.append(f"tree: '{path.original}': {exc}")
-        return lines
-    filtered = []
-    for entry in entries:
-        try:
-            entry_spec = PathSpec(original=entry,
-                                  directory=entry,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            s = await stat(accessor, entry_spec, index)
-        except (FileNotFoundError, ValueError) as exc:
-            if warnings is not None:
-                warnings.append(f"tree: '{entry}': {exc}")
-            continue
-        if not show_hidden and s.name.startswith("."):
-            continue
-        if ignore_pattern and fnmatch.fnmatch(s.name, ignore_pattern):
-            continue
-        if dirs_only and s.type != FileType.DIRECTORY:
-            continue
-        not_dir = s.type != FileType.DIRECTORY
-        if match_pattern and not_dir and not fnmatch.fnmatch(
-                s.name, match_pattern):
-            continue
-        filtered.append((entry_spec, s))
-    for i, (entry_spec, s) in enumerate(filtered):
-        is_last = i == len(filtered) - 1
-        connector = "\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 "
-        lines.append(_prefix + connector + s.name)
-        if s.type == FileType.DIRECTORY:
-            if max_depth is not None and _depth >= max_depth:
-                continue
-            extension = "    " if is_last else "\u2502   "
-            lines.extend(await _tree_async(accessor,
-                                           entry_spec,
-                                           _prefix + extension,
-                                           max_depth=max_depth,
-                                           show_hidden=show_hidden,
-                                           ignore_pattern=ignore_pattern,
-                                           dirs_only=dirs_only,
-                                           match_pattern=match_pattern,
-                                           _depth=_depth + 1,
-                                           warnings=warnings,
-                                           index=index))
-    return lines
+from mirage.types import PathSpec
 
 
 @command("tree", resource="github_ci", spec=SPECS["tree"])
@@ -105,20 +41,14 @@ async def tree(
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     paths = await resolve_glob(accessor, paths, index)
-    p0 = paths[0]
-    max_depth = int(L) if L is not None else None
-    warnings: list[str] = []
-    results = await _tree_async(
-        accessor,
-        p0,
-        max_depth=max_depth,
+    return await generic_tree(
+        paths[0],
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        max_depth=int(L) if L is not None else None,
         show_hidden=a,
         ignore_pattern=args_I,
         dirs_only=d,
         match_pattern=P,
-        warnings=warnings,
         index=index,
     )
-    stderr = "\n".join(warnings).encode() if warnings else None
-    output = "\n".join(results).encode()
-    return output, IOResult(stderr=stderr)

--- a/python/mirage/commands/builtin/github_ci/wc.py
+++ b/python/mirage/commands/builtin/github_ci/wc.py
@@ -16,6 +16,8 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.github_ci import GitHubCIAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.github_ci._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
@@ -55,25 +57,33 @@ async def wc(
 ) -> tuple[ByteSource | None, IOResult]:
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        data = await ci_read(accessor, p, index)
-    else:
-        data = await _read_stdin_async(stdin)
-        if data is None:
-            raise ValueError("wc: missing operand")
-    text = data.decode(errors="replace")
-    line_count = text.count("\n")
-    word_count = len(text.split())
-    byte_count = len(data)
-    if L:
-        max_len = max((len(ln) for ln in text.splitlines()), default=0)
-        return str(max_len).encode(), IOResult()
-    if args_l:
-        return str(line_count).encode(), IOResult()
-    if w:
-        return str(word_count).encode(), IOResult()
-    if m:
-        return str(len(text)).encode(), IOResult()
-    if c:
-        return str(byte_count).encode(), IOResult()
-    return f"{line_count}\t{word_count}\t{byte_count}".encode(), IOResult()
+        outputs: list[str] = []
+        totals = WCCounts()
+        for p in paths:
+            data = await ci_read(accessor, p, index)
+            counts = await generic_wc(data)
+            outputs.append(
+                format_wc(counts,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label=p.original))
+            totals.merge(counts)
+        if len(paths) > 1:
+            outputs.append(
+                format_wc(totals,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label="total"))
+        return "\n".join(outputs).encode(), IOResult()
+    data = await _read_stdin_async(stdin)
+    if data is None:
+        raise ValueError("wc: missing operand")
+    counts = await generic_wc(data)
+    return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
+                     L=L).encode(), IOResult()

--- a/python/mirage/commands/builtin/mongodb/cat.py
+++ b/python/mirage/commands/builtin/mongodb/cat.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cat import cat as generic_cat
 from mirage.commands.builtin.mongodb._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
@@ -25,7 +26,6 @@ from mirage.core.mongodb.read import read as mongodb_read
 from mirage.core.mongodb.scope import detect_scope
 from mirage.core.mongodb.stream import read_stream
 from mirage.core.mongodb.types import ScopeLevel
-from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -41,18 +41,6 @@ async def cat_provision(
         accessor, paths,
         "cat " + " ".join(p.original if isinstance(p, PathSpec) else p
                           for p in paths))
-
-
-async def _number_lines_stream(
-        source: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
-    num = 1
-    async for line in AsyncLineIterator(source):
-        yield f"     {num}\t".encode() + line + b"\n"
-        num += 1
-
-
-async def _bytes_to_stream(data: bytes) -> AsyncIterator[bytes]:
-    yield data
 
 
 @command("cat", resource="mongodb", spec=SPECS["cat"], provision=cat_provision)
@@ -73,15 +61,11 @@ async def cat(
             source = read_stream(accessor, p, index)
             io = IOResult(reads={p.strip_prefix: source},
                           cache=[p.strip_prefix])
-            if n:
-                return _number_lines_stream(source), io
-            return source, io
+            return (generic_cat(source, number_lines=True)
+                    if n else source), io
         data = await mongodb_read(accessor, p, index)
         io = IOResult(reads={p.strip_prefix: data}, cache=[p.strip_prefix])
-        if n:
-            return _number_lines_stream(_bytes_to_stream(data)), io
-        return data, io
+        return (generic_cat(data, number_lines=True) if n else data), io
     source = _resolve_source(stdin, "cat: missing operand")
-    if n:
-        return _number_lines_stream(source), IOResult()
-    return source, IOResult()
+    return (generic_cat(source, number_lines=True)
+            if n else source), IOResult()

--- a/python/mirage/commands/builtin/mongodb/head.py
+++ b/python/mirage/commands/builtin/mongodb/head.py
@@ -16,13 +16,13 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.head import head as generic_head
 from mirage.commands.builtin.mongodb._provision import file_read_provision
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.mongodb.glob import resolve_glob
 from mirage.core.mongodb.stream import read_stream
-from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -40,39 +40,6 @@ async def head_provision(
                            for p in paths))
 
 
-async def _head_stream(source: AsyncIterator[bytes], lines: int,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        total = 0
-        async for chunk in source:
-            remaining = bytes_mode - total
-            if remaining <= 0:
-                return
-            if len(chunk) <= remaining:
-                yield chunk
-                total += len(chunk)
-            else:
-                yield chunk[:remaining]
-                return
-        return
-    line_iter = AsyncLineIterator(source)
-    count = 0
-    async for line in line_iter:
-        if count >= lines:
-            return
-        yield line + b"\n"
-        count += 1
-
-
-async def _head_bytes_static(data: bytes, lines: int,
-                             bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield data[:bytes_mode]
-        return
-    parts = data.split(b"\n", lines)
-    yield b"\n".join(parts[:lines])
-
-
 @command("head",
          resource="mongodb",
          spec=SPECS["head"],
@@ -87,14 +54,11 @@ async def head(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines = int(n) if n is not None else 10
-    bytes_mode = int(c) if c is not None else None
+    n_int = int(n) if n is not None else None
+    c_int = int(c) if c is not None else None
     if paths:
-        paths = await resolve_glob(accessor, paths, index=index)
-        p = paths[0]
-        source = read_stream(accessor, p, index)
-        return _head_stream(source, lines, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("head: missing operand")
-    return _head_bytes_static(raw, lines, bytes_mode), IOResult()
+        paths = await resolve_glob(accessor, paths, index)
+        source = read_stream(accessor, paths[0], index)
+        return generic_head(source, n=n_int, c=c_int), IOResult()
+    source = _resolve_source(stdin, "head: missing operand")
+    return generic_head(source, n=n_int, c=c_int), IOResult()

--- a/python/mirage/commands/builtin/mongodb/ls.py
+++ b/python/mirage/commands/builtin/mongodb/ls.py
@@ -12,10 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.ls import ls as generic_ls
 from mirage.commands.builtin.mongodb._provision import metadata_provision
-from mirage.commands.builtin.utils.formatting import _human_size
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.mongodb.glob import resolve_glob
@@ -23,68 +25,7 @@ from mirage.core.mongodb.readdir import readdir
 from mirage.core.mongodb.stat import stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileType, PathSpec
-
-
-async def _ls_async(
-    accessor: MongoDBAccessor,
-    path: PathSpec,
-    long: bool = False,
-    all_files: bool = False,
-    sort_by: str = "name",
-    reverse: bool = False,
-    recursive: bool = False,
-    list_dir: bool = False,
-    warnings: list[str] | None = None,
-    index: IndexCacheStore = None,
-):
-    if list_dir:
-        entries = [await stat(accessor, path, index)]
-    else:
-        raw = await readdir(accessor, path, index)
-        entries = []
-        for e in raw:
-            try:
-                e_spec = PathSpec(original=e,
-                                  directory=e,
-                                  resolved=False,
-                                  prefix=path.prefix)
-                entries.append(await stat(accessor, e_spec, index))
-            except (FileNotFoundError, ValueError) as exc:
-                if warnings is not None:
-                    warnings.append(f"ls: cannot access '{e}': {exc}")
-
-    if not all_files:
-        entries = [e for e in entries if not e.name.startswith(".")]
-
-    if sort_by == "size":
-        entries = sorted(entries,
-                         key=lambda e: e.size or 0,
-                         reverse=not reverse)
-    else:
-        entries = sorted(entries, key=lambda e: e.name, reverse=reverse)
-
-    if recursive:
-        all_entries = []
-        for e in entries:
-            all_entries.append(e)
-            if e.type == FileType.DIRECTORY:
-                sub_path = path.child(e.name)
-                sub_spec = PathSpec(original=sub_path,
-                                    directory=sub_path,
-                                    resolved=False,
-                                    prefix=path.prefix)
-                sub = await _ls_async(accessor,
-                                      sub_spec,
-                                      long=long,
-                                      all_files=all_files,
-                                      sort_by=sort_by,
-                                      reverse=reverse,
-                                      recursive=True,
-                                      warnings=warnings)
-                all_entries.extend(sub)
-        return all_entries
-    return entries
+from mirage.types import LsSortBy, PathSpec
 
 
 async def ls_provision(
@@ -117,59 +58,25 @@ async def ls(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    all_files = a or A
-    sort_by = "name"
-    if S:
-        sort_by = "size"
-    warnings: list[str] = []
-    results: list[str] = []
     if not paths:
         cwd = _extra.get("cwd", "/")
-        if isinstance(cwd, PathSpec):
-            paths = [
-                PathSpec(
-                    original=cwd.original,
-                    directory=cwd.directory,
-                    prefix=cwd.prefix,
-                    resolved=False,
-                )
-            ]
-        else:
-            paths = [PathSpec(
-                original=cwd,
-                directory=cwd,
-                resolved=False,
-            )]
+        paths = [cwd] if isinstance(cwd, PathSpec) else [
+            PathSpec(original=cwd, directory=cwd, resolved=False)
+        ]
     paths = await resolve_glob(accessor, paths, index)
-    for p in paths:
-        try:
-            entries = await _ls_async(
-                accessor,
-                p,
-                long=args_l,
-                all_files=all_files,
-                sort_by=sort_by,
-                reverse=r,
-                recursive=R,
-                list_dir=d,
-                warnings=warnings,
-                index=index,
-            )
-        except (FileNotFoundError, ValueError) as exc:
-            warnings.append(f"ls: cannot access '{p.original}': {exc}")
-            continue
-        if args_l and not args_1:
-            for e in entries:
-                size_str = _human_size(e.size or 0) if h else str(e.size or 0)
-                line = (f"{e.type or '-'}\t{size_str}"
-                        f"\t{e.modified or ''}\t{e.name}")
-                results.append(line)
-        else:
-            for e in entries:
-                is_dir = F and e.type == FileType.DIRECTORY
-                name = e.name + "/" if is_dir else e.name
-                results.append(name)
-    stderr = "\n".join(warnings).encode() if warnings else None
-    exit_code = 1 if warnings and not results else 0
-    output = "\n".join(results).encode()
-    return output, IOResult(stderr=stderr, exit_code=exit_code)
+    sort_by = LsSortBy.TIME if t else LsSortBy.SIZE if S else LsSortBy.NAME
+    return await generic_ls(
+        paths,
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        long=args_l,
+        one_per_line=args_1,
+        all_files=a or A,
+        human=h,
+        sort_by=sort_by,
+        reverse=r,
+        recursive=R,
+        list_dir=d,
+        classify=F,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/mongodb/stat.py
+++ b/python/mirage/commands/builtin/mongodb/stat.py
@@ -12,10 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import re
-
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.stat import stat as generic_stat
 from mirage.commands.builtin.mongodb._provision import metadata_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -23,35 +22,7 @@ from mirage.core.mongodb.glob import resolve_glob
 from mirage.core.mongodb.stat import stat as stat_impl
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileStat, FileType, PathSpec
-
-_FORMAT_RE = re.compile(r"%([nsFy]|.)")
-
-_TYPE_LABELS = {
-    FileType.DIRECTORY: "directory",
-    FileType.TEXT: "regular file",
-    FileType.BINARY: "regular file",
-    FileType.JSON: "regular file",
-    FileType.CSV: "regular file",
-}
-
-
-def _format_stat(fmt: str, s: FileStat) -> str:
-
-    def _replace(m: re.Match) -> str:
-        spec = m.group(1)
-        if spec == "n":
-            return s.name
-        if spec == "s":
-            return str(s.size if s.size is not None else 0)
-        if spec == "F":
-            return _TYPE_LABELS.get(
-                s.type, "regular file") if s.type else "regular file"
-        if spec == "y":
-            return s.modified or ""
-        return "?"
-
-    return _FORMAT_RE.sub(_replace, fmt)
+from mirage.types import PathSpec
 
 
 async def stat_provision(
@@ -81,14 +52,9 @@ async def stat(
     if not paths:
         raise ValueError("stat: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    fmt = c if c is not None else f
-    lines: list[str] = []
-    for p in paths:
-        s = await stat_impl(accessor, p, index)
-        if fmt is not None:
-            lines.append(_format_stat(fmt, s))
-        else:
-            lines.append(f"name={s.name} size={s.size}"
-                         f" modified={s.modified}"
-                         f" type={s.type.value if s.type else None}")
-    return "\n".join(lines).encode(), IOResult()
+    return await generic_stat(paths,
+                              stat_fn=stat_impl,
+                              accessor=accessor,
+                              c=c,
+                              f=f,
+                              index=index)

--- a/python/mirage/commands/builtin/mongodb/tree.py
+++ b/python/mirage/commands/builtin/mongodb/tree.py
@@ -12,82 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import fnmatch
+from functools import partial
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tree import tree as generic_tree
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.mongodb.glob import resolve_glob
 from mirage.core.mongodb.readdir import readdir
 from mirage.core.mongodb.stat import stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
-
-
-async def _tree_async(
-    accessor: MongoDBAccessor,
-    path: PathSpec,
-    _prefix: str = "",
-    max_depth: int | None = None,
-    show_hidden: bool = False,
-    ignore_pattern: str | None = None,
-    dirs_only: bool = False,
-    match_pattern: str | None = None,
-    _depth: int = 0,
-    warnings: list[str] | None = None,
-    index: IndexCacheStore = None,
-) -> list[str]:
-    lines: list[str] = []
-    try:
-        entries = await readdir(accessor, path, index)
-    except (FileNotFoundError, ValueError) as exc:
-        if warnings is not None:
-            warnings.append(f"tree: '{path.original}': {exc}")
-        return lines
-    filtered = []
-    for entry in entries:
-        try:
-            entry_spec = PathSpec(original=entry,
-                                  directory=entry,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            s = await stat(accessor, entry_spec, index)
-        except (FileNotFoundError, ValueError) as exc:
-            if warnings is not None:
-                warnings.append(f"tree: '{entry}': {exc}")
-            continue
-        if not show_hidden and s.name.startswith("."):
-            continue
-        if ignore_pattern and fnmatch.fnmatch(s.name, ignore_pattern):
-            continue
-        if dirs_only and s.type != FileType.DIRECTORY:
-            continue
-        not_dir = s.type != FileType.DIRECTORY
-        if match_pattern and not_dir and not fnmatch.fnmatch(
-                s.name, match_pattern):
-            continue
-        filtered.append((entry_spec, s))
-    for i, (entry_spec, s) in enumerate(filtered):
-        is_last = i == len(filtered) - 1
-        connector = "\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 "
-        lines.append(_prefix + connector + s.name)
-        if s.type == FileType.DIRECTORY:
-            if max_depth is not None and _depth >= max_depth:
-                continue
-            extension = "    " if is_last else "\u2502   "
-            lines.extend(await _tree_async(accessor,
-                                           entry_spec,
-                                           _prefix + extension,
-                                           max_depth=max_depth,
-                                           show_hidden=show_hidden,
-                                           ignore_pattern=ignore_pattern,
-                                           dirs_only=dirs_only,
-                                           match_pattern=match_pattern,
-                                           _depth=_depth + 1,
-                                           warnings=warnings,
-                                           index=index))
-    return lines
+from mirage.types import PathSpec
 
 
 @command("tree", resource="mongodb", spec=SPECS["tree"])
@@ -105,20 +41,14 @@ async def tree(
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     paths = await resolve_glob(accessor, paths, index)
-    p0 = paths[0]
-    max_depth = int(L) if L is not None else None
-    warnings: list[str] = []
-    results = await _tree_async(
-        accessor,
-        p0,
-        max_depth=max_depth,
+    return await generic_tree(
+        paths[0],
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        max_depth=int(L) if L is not None else None,
         show_hidden=a,
         ignore_pattern=args_I,
         dirs_only=d,
         match_pattern=P,
-        warnings=warnings,
         index=index,
     )
-    stderr = "\n".join(warnings).encode() if warnings else None
-    output = "\n".join(results).encode()
-    return output, IOResult(stderr=stderr)

--- a/python/mirage/core/github_ci/glob.py
+++ b/python/mirage/core/github_ci/glob.py
@@ -25,6 +25,16 @@ from mirage.types import PathSpec
 logger = logging.getLogger(__name__)
 
 
+def is_cross_run_root(path: PathSpec) -> bool:
+    original = path.original if isinstance(path, PathSpec) else path
+    prefix = path.prefix if isinstance(path, PathSpec) else ""
+    if prefix and original.startswith(prefix):
+        rest = original[len(prefix):]
+        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
+            original = rest or "/"
+    return original.strip("/") in ("", "runs")
+
+
 async def resolve_glob(
     accessor: GitHubCIAccessor,
     paths: list[PathSpec],

--- a/python/tests/commands/builtin/github/test_commands.py
+++ b/python/tests/commands/builtin/github/test_commands.py
@@ -110,12 +110,13 @@ async def test_wc_full(github_env):
     data = await materialize(stdout)
     text = data.decode()
     parts = text.split("\t")
-    assert len(parts) == 3
+    assert len(parts) == 4
     line_count, word_count, byte_count = int(parts[0]), int(parts[1]), int(
         parts[2])
     assert line_count > 0
     assert word_count > 0
     assert byte_count == len(MOCK_BLOBS["bbb333"])
+    assert parts[3] == "/src/utils.py"
 
 
 @pytest.mark.asyncio
@@ -128,7 +129,7 @@ async def test_wc_line_only(github_env):
         index=index,
     )
     data = await materialize(stdout)
-    count = int(data.decode().strip())
+    count = int(data.decode().split("\t")[0])
     expected = MOCK_BLOBS["bbb333"].decode().count("\n")
     assert count == expected
 

--- a/python/tests/commands/builtin/github_ci/test_find.py
+++ b/python/tests/commands/builtin/github_ci/test_find.py
@@ -1,0 +1,73 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mirage.accessor.github_ci import GitHubCIAccessor
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.commands.builtin.github_ci.find import find
+from mirage.io.stream import materialize
+from mirage.resource.github_ci.config import GitHubCIConfig
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def accessor():
+    return GitHubCIAccessor(
+        config=GitHubCIConfig(token="t", owner="o", repo="r"))
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+def _scope(path: str, prefix: str = "") -> PathSpec:
+    return PathSpec(original=path, directory=path, prefix=prefix)
+
+
+@pytest.mark.asyncio
+async def test_find_runs_root_rejected(accessor, index):
+    with pytest.raises(ValueError, match="across runs is disabled"):
+        await find(accessor, [_scope("/runs")], name="*.log", index=index)
+
+
+@pytest.mark.asyncio
+async def test_find_root_rejected(accessor, index):
+    with pytest.raises(ValueError, match="across runs is disabled"):
+        await find(accessor, [], name="*.log", index=index)
+
+
+@pytest.mark.asyncio
+async def test_find_single_run_allowed(accessor, index):
+
+    async def fake_readdir(_acc, p, _idx=None):
+        if p.original == "/runs/wf_1":
+            return ["/runs/wf_1/run.json", "/runs/wf_1/jobs"]
+        if p.original == "/runs/wf_1/jobs":
+            return ["/runs/wf_1/jobs/build_1.log"]
+        return []
+
+    with patch("mirage.commands.builtin.github_ci.find._readdir",
+               new=AsyncMock(side_effect=fake_readdir)):
+        out, io = await find(
+            accessor,
+            [_scope("/runs/wf_1")],
+            name="*.log",
+            index=index,
+        )
+        data = await materialize(out)
+        assert b"/runs/wf_1/jobs/build_1.log" in data

--- a/python/tests/commands/builtin/github_ci/test_grep.py
+++ b/python/tests/commands/builtin/github_ci/test_grep.py
@@ -83,17 +83,17 @@ async def test_grep_recursive_directory(accessor, index):
     dir_stat = FileStat(name="workflows", type=FileType.DIRECTORY)
     file_stat = FileStat(name="ci.json", type=FileType.JSON)
 
-    async def fake_stat(_acc, p, _idx):
+    async def fake_stat(_acc, p, _idx=None):
         if p.original.endswith(".json"):
             return file_stat
         return dir_stat
 
-    async def fake_readdir(_acc, p, _idx):
+    async def fake_readdir(_acc, p, _idx=None):
         if p.original == "/workflows":
             return ["/workflows/ci_1.json", "/workflows/build_2.json"]
         return []
 
-    async def fake_read(_acc, p, _idx):
+    async def fake_read(_acc, p, _idx=None):
         if "ci_1" in p.original:
             return b"name: Test\non: push\n"
         return b"name: Build\non: push\n"

--- a/python/tests/commands/builtin/github_ci/test_grep.py
+++ b/python/tests/commands/builtin/github_ci/test_grep.py
@@ -119,6 +119,12 @@ async def test_grep_recursive_directory(accessor, index):
 
 
 @pytest.mark.asyncio
+async def test_grep_recursive_runs_rejected(accessor, index):
+    with pytest.raises(ValueError, match="across runs is disabled"):
+        await grep(accessor, [_scope("/runs")], "x", r=True, index=index)
+
+
+@pytest.mark.asyncio
 async def test_grep_stdin(accessor, index):
     out, io = await grep(
         accessor,

--- a/python/tests/commands/builtin/github_ci/test_rg.py
+++ b/python/tests/commands/builtin/github_ci/test_rg.py
@@ -118,6 +118,12 @@ async def test_rg_directory_implicit_recursive(accessor, index):
 
 
 @pytest.mark.asyncio
+async def test_rg_runs_root_rejected(accessor, index):
+    with pytest.raises(ValueError, match="across runs is disabled"):
+        await rg(accessor, [_scope("/runs")], "x", index=index)
+
+
+@pytest.mark.asyncio
 async def test_rg_stdin(accessor, index):
     out, io = await rg(
         accessor,

--- a/python/tests/commands/builtin/github_ci/test_rg.py
+++ b/python/tests/commands/builtin/github_ci/test_rg.py
@@ -19,6 +19,7 @@ import pytest
 from mirage.accessor.github_ci import GitHubCIAccessor
 from mirage.cache.index.ram import RAMIndexCacheStore
 from mirage.commands.builtin.github_ci.rg import rg
+from mirage.io.stream import materialize
 from mirage.resource.github_ci.config import GitHubCIConfig
 from mirage.types import FileStat, FileType, PathSpec
 
@@ -53,7 +54,8 @@ async def test_rg_single_file_match(accessor, index):
             "beta",
             index=index,
         )
-        assert b"beta" in out
+        data = await materialize(out)
+        assert b"beta" in data
         assert io.exit_code == 0
 
 
@@ -66,12 +68,13 @@ async def test_rg_no_match_exit_one(accessor, index):
             patch("mirage.commands.builtin.github_ci.rg.ci_read",
                   new=AsyncMock(return_value=b"abc\ndef\n")),
     ):
-        _, io = await rg(
+        out, io = await rg(
             accessor,
             [_scope("/runs/wf_1/run.json")],
             "missing",
             index=index,
         )
+        await materialize(out)
         assert io.exit_code == 1
 
 
@@ -80,17 +83,17 @@ async def test_rg_directory_implicit_recursive(accessor, index):
     dir_stat = FileStat(name="workflows", type=FileType.DIRECTORY)
     file_stat = FileStat(name="ci.json", type=FileType.JSON)
 
-    async def fake_stat(_acc, p, _idx):
+    async def fake_stat(_acc, p, _idx=None):
         if p.original.endswith(".json"):
             return file_stat
         return dir_stat
 
-    async def fake_readdir(_acc, p, _idx):
+    async def fake_readdir(_acc, p, _idx=None):
         if p.original == "/workflows":
             return ["/workflows/ci_1.json", "/workflows/build_2.json"]
         return []
 
-    async def fake_read(_acc, p, _idx):
+    async def fake_read(_acc, p, _idx=None):
         if "ci_1" in p.original:
             return b"name: Test\non: push\n"
         return b"name: Build\non: push\n"
@@ -109,7 +112,8 @@ async def test_rg_directory_implicit_recursive(accessor, index):
             "Test",
             index=index,
         )
-        assert b"name: Test" in out
+        data = await materialize(out)
+        assert b"name: Test" in data
         assert io.exit_code == 0
 
 
@@ -122,5 +126,6 @@ async def test_rg_stdin(accessor, index):
         stdin=b"line one\nline two\nline three\n",
         index=index,
     )
-    assert b"line two" in out
+    data = await materialize(out)
+    assert b"line two" in data
     assert io.exit_code == 0

--- a/python/tests/core/github_ci/test_runs_cap.py
+++ b/python/tests/core/github_ci/test_runs_cap.py
@@ -18,9 +18,10 @@ import pytest
 
 from mirage.accessor.github_ci import GitHubCIAccessor
 from mirage.cache.index.ram import RAMIndexCacheStore
-from mirage.commands.builtin.github_ci.find import find as find_cmd
+from mirage.commands.builtin.github_ci.ls import ls as ls_cmd
 from mirage.core.github_ci import _client as ci_client
 from mirage.core.github_ci.runs import list_runs
+from mirage.io.stream import materialize
 from mirage.resource.github_ci.config import GitHubCIConfig
 from mirage.types import PathSpec
 
@@ -153,23 +154,19 @@ async def test_list_runs_default_caps_at_300(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_find_runs_listing_capped(monkeypatch):
+async def test_ls_runs_listing_capped(monkeypatch):
     session = _MockSession("workflow_runs", total=1000)
     _patch_session(monkeypatch, session)
     cfg = GitHubCIConfig(token="t", owner="o", repo="r", max_runs=5)
     accessor = GitHubCIAccessor(config=cfg)
     index = RAMIndexCacheStore()
     runs_path = PathSpec(original="/runs", directory="/runs", prefix="")
-    out, _ = await find_cmd(
+    out, _ = await ls_cmd(
         accessor,
         [runs_path],
-        maxdepth="1",
-        prefix="",
+        args_1=True,
         index=index,
     )
-    assert out is not None
-    run_dirs = [
-        line for line in out.decode().splitlines()
-        if line.startswith("/runs/") and line.count("/") == 2
-    ]
-    assert len(run_dirs) == 5
+    data = await materialize(out)
+    names = [line for line in data.decode().splitlines() if line.strip()]
+    assert len(names) == 5


### PR DESCRIPTION
## Summary

Convert the read/text commands of `github`, `github_ci`, and `mongodb` to delegate to the shared `generic.*` command layer, removing per-backend reimplementations of `cat`/`head`/`tail`/`wc`/`stat`/`ls`/`tree` (and `grep`/`rg` for github_ci).

Backend-specific push-downs and native search are kept custom:
- **github**: native `search.code` grep/rg, find, content-processors unchanged.
- **mongodb**: `cat`/`tail`/`rg`/`grep`/`wc` keep scope detection and `count_documents` push-downs.

Output formats are standardized to match the generic layer (e.g. `wc` appends the filename label; `ls -l` uses the standard long format).

## Test plan
- [x] `pytest tests/commands/builtin/{github,github_ci,mongodb}` (62 passed)
- [x] `pre-commit run` on changed files (Python hooks pass)