### PR TITLE
refactor(commands): use generic for linear/postgres/langfuse unix commands

### DIFF
--- a/python/mirage/commands/builtin/langfuse/cat.py
+++ b/python/mirage/commands/builtin/langfuse/cat.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.langfuse import LangfuseAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cat import cat as generic_cat
 from mirage.commands.builtin.langfuse._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
@@ -39,12 +40,6 @@ async def cat_provision(
                           for p in paths))
 
 
-async def _number_lines(data: bytes) -> AsyncIterator[bytes]:
-    lines = data.decode(errors="replace").splitlines()
-    for i, line in enumerate(lines, 1):
-        yield f"     {i}\t{line}\n".encode()
-
-
 @command("cat",
          resource="langfuse",
          spec=SPECS["cat"],
@@ -64,12 +59,9 @@ async def cat(
         data = await langfuse_read(accessor, p, index)
         io = IOResult(reads={p.strip_prefix: data}, cache=[p.strip_prefix])
         if n:
-            return _number_lines(data), io
+            return generic_cat(data, number_lines=True), io
         return data, io
     source = _resolve_source(stdin, "cat: missing operand")
     if n:
-        raw = b""
-        async for chunk in source:
-            raw += chunk
-        return _number_lines(raw), IOResult()
+        return generic_cat(source, number_lines=True), IOResult()
     return source, IOResult()

--- a/python/mirage/commands/builtin/langfuse/head.py
+++ b/python/mirage/commands/builtin/langfuse/head.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.langfuse import LangfuseAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.head import head as generic_head
 from mirage.commands.builtin.langfuse._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
@@ -39,15 +40,6 @@ async def head_provision(
                            for p in paths))
 
 
-async def _head_bytes(data: bytes, lines: int,
-                      bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield data[:bytes_mode]
-        return
-    parts = data.split(b"\n", lines)
-    yield b"\n".join(parts[:lines])
-
-
 @command("head",
          resource="langfuse",
          spec=SPECS["head"],
@@ -62,14 +54,14 @@ async def head(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines = int(n) if n is not None else 10
-    bytes_mode = int(c) if c is not None else None
+    n_int = int(n) if n is not None else None
+    c_int = int(c) if c is not None else None
     if paths:
-        paths = await resolve_glob(accessor, paths, index=index)
+        paths = await resolve_glob(accessor, paths, index)
         p = paths[0]
         data = await langfuse_read(accessor, p, index)
-        return _head_bytes(data, lines, bytes_mode), IOResult()
+        return generic_head(data, n=n_int, c=c_int), IOResult()
     raw = await _read_stdin_async(stdin)
     if raw is None:
         raise ValueError("head: missing operand")
-    return _head_bytes(raw, lines, bytes_mode), IOResult()
+    return generic_head(raw, n=n_int, c=c_int), IOResult()

--- a/python/mirage/commands/builtin/langfuse/ls.py
+++ b/python/mirage/commands/builtin/langfuse/ls.py
@@ -12,10 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.langfuse import LangfuseAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.ls import ls as generic_ls
 from mirage.commands.builtin.langfuse._provision import metadata_provision
-from mirage.commands.builtin.utils.formatting import _human_size
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.langfuse.glob import resolve_glob
@@ -23,68 +25,7 @@ from mirage.core.langfuse.readdir import readdir
 from mirage.core.langfuse.stat import stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileType, PathSpec
-
-
-async def _ls_async(
-    accessor: LangfuseAccessor,
-    path: PathSpec,
-    long: bool = False,
-    all_files: bool = False,
-    sort_by: str = "name",
-    reverse: bool = False,
-    recursive: bool = False,
-    list_dir: bool = False,
-    warnings: list[str] | None = None,
-    index: IndexCacheStore = None,
-):
-    if list_dir:
-        entries = [await stat(accessor, path, index)]
-    else:
-        raw = await readdir(accessor, path, index)
-        entries = []
-        for e in raw:
-            try:
-                e_spec = PathSpec(original=e,
-                                  directory=e,
-                                  resolved=False,
-                                  prefix=path.prefix)
-                entries.append(await stat(accessor, e_spec, index))
-            except (FileNotFoundError, ValueError) as exc:
-                if warnings is not None:
-                    warnings.append(f"ls: cannot access '{e}': {exc}")
-
-    if not all_files:
-        entries = [e for e in entries if not e.name.startswith(".")]
-
-    if sort_by == "size":
-        entries = sorted(entries,
-                         key=lambda e: e.size or 0,
-                         reverse=not reverse)
-    else:
-        entries = sorted(entries, key=lambda e: e.name, reverse=reverse)
-
-    if recursive:
-        all_entries = []
-        for e in entries:
-            all_entries.append(e)
-            if e.type == FileType.DIRECTORY:
-                sub_path = path.child(e.name)
-                sub_spec = PathSpec(original=sub_path,
-                                    directory=sub_path,
-                                    resolved=False,
-                                    prefix=path.prefix)
-                sub = await _ls_async(accessor,
-                                      sub_spec,
-                                      long=long,
-                                      all_files=all_files,
-                                      sort_by=sort_by,
-                                      reverse=reverse,
-                                      recursive=True,
-                                      warnings=warnings)
-                all_entries.extend(sub)
-        return all_entries
-    return entries
+from mirage.types import LsSortBy, PathSpec
 
 
 async def ls_provision(
@@ -115,60 +56,33 @@ async def ls(
     d: bool = False,
     F: bool = False,
     index: IndexCacheStore = None,
+    cwd: PathSpec | str = "/",
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    all_files = a or A
-    sort_by = "name"
-    if S:
-        sort_by = "size"
-    warnings: list[str] = []
-    results: list[str] = []
     if not paths:
-        cwd = _extra.get("cwd", "/")
-        if isinstance(cwd, PathSpec):
-            paths = [
-                PathSpec(
-                    original=cwd.original,
-                    directory=cwd.directory,
-                    resolved=False,
-                )
-            ]
-        else:
-            paths = [PathSpec(
-                original=cwd,
-                directory=cwd,
-                resolved=False,
-            )]
+        cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
+        cwd_prefix = cwd.prefix if isinstance(cwd, PathSpec) else ""
+        paths = [
+            PathSpec(original=cwd_str,
+                     directory=cwd_str,
+                     resolved=False,
+                     prefix=cwd_prefix)
+        ]
     paths = await resolve_glob(accessor, paths, index)
-    for p in paths:
-        try:
-            entries = await _ls_async(
-                accessor,
-                p,
-                long=args_l,
-                all_files=all_files,
-                sort_by=sort_by,
-                reverse=r,
-                recursive=R,
-                list_dir=d,
-                warnings=warnings,
-                index=index,
-            )
-        except (FileNotFoundError, ValueError) as exc:
-            warnings.append(f"ls: cannot access '{p.original}': {exc}")
-            continue
-        if args_l and not args_1:
-            for e in entries:
-                size_str = _human_size(e.size or 0) if h else str(e.size or 0)
-                line = (f"{e.type or '-'}\t{size_str}"
-                        f"\t{e.modified or ''}\t{e.name}")
-                results.append(line)
-        else:
-            for e in entries:
-                is_dir = F and e.type == FileType.DIRECTORY
-                name = e.name + "/" if is_dir else e.name
-                results.append(name)
-    stderr = "\n".join(warnings).encode() if warnings else None
-    exit_code = 1 if warnings and not results else 0
-    output = "\n".join(results).encode()
-    return output, IOResult(stderr=stderr, exit_code=exit_code)
+    sort_by = LsSortBy.TIME if t else LsSortBy.SIZE if S else LsSortBy.NAME
+    return await generic_ls(
+        paths,
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        long=args_l,
+        one_per_line=args_1,
+        all_files=a or A,
+        human=h,
+        sort_by=sort_by,
+        reverse=r,
+        recursive=R,
+        list_dir=d,
+        classify=F,
+        index=index,
+        trailing_newline=True,
+    )

--- a/python/mirage/commands/builtin/langfuse/stat.py
+++ b/python/mirage/commands/builtin/langfuse/stat.py
@@ -12,46 +12,17 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import re
-
 from mirage.accessor.langfuse import LangfuseAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.stat import stat as generic_stat
 from mirage.commands.builtin.langfuse._provision import metadata_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.langfuse.glob import resolve_glob
-from mirage.core.langfuse.stat import stat as stat_impl
+from mirage.core.langfuse.stat import stat as stat_core
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileStat, FileType, PathSpec
-
-_FORMAT_RE = re.compile(r"%([nsFy]|.)")
-
-_TYPE_LABELS = {
-    FileType.DIRECTORY: "directory",
-    FileType.TEXT: "regular file",
-    FileType.BINARY: "regular file",
-    FileType.JSON: "regular file",
-    FileType.CSV: "regular file",
-}
-
-
-def _format_stat(fmt: str, s: FileStat) -> str:
-
-    def _replace(m: re.Match) -> str:
-        spec = m.group(1)
-        if spec == "n":
-            return s.name
-        if spec == "s":
-            return str(s.size if s.size is not None else 0)
-        if spec == "F":
-            return _TYPE_LABELS.get(
-                s.type, "regular file") if s.type else "regular file"
-        if spec == "y":
-            return s.modified or ""
-        return "?"
-
-    return _FORMAT_RE.sub(_replace, fmt)
+from mirage.types import PathSpec
 
 
 async def stat_provision(
@@ -81,14 +52,9 @@ async def stat(
     if not paths:
         raise ValueError("stat: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    fmt = c if c is not None else f
-    lines: list[str] = []
-    for p in paths:
-        s = await stat_impl(accessor, p, index)
-        if fmt is not None:
-            lines.append(_format_stat(fmt, s))
-        else:
-            lines.append(f"name={s.name} size={s.size}"
-                         f" modified={s.modified}"
-                         f" type={s.type.value if s.type else None}")
-    return "\n".join(lines).encode(), IOResult()
+    return await generic_stat(paths,
+                              stat_fn=stat_core,
+                              accessor=accessor,
+                              c=c,
+                              f=f,
+                              index=index)

--- a/python/mirage/commands/builtin/langfuse/tree.py
+++ b/python/mirage/commands/builtin/langfuse/tree.py
@@ -12,82 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import fnmatch
+from functools import partial
 
 from mirage.accessor.langfuse import LangfuseAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tree import tree as generic_tree
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.langfuse.glob import resolve_glob
 from mirage.core.langfuse.readdir import readdir
 from mirage.core.langfuse.stat import stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
-
-
-async def _tree_async(
-    accessor: LangfuseAccessor,
-    path: PathSpec,
-    _prefix: str = "",
-    max_depth: int | None = None,
-    show_hidden: bool = False,
-    ignore_pattern: str | None = None,
-    dirs_only: bool = False,
-    match_pattern: str | None = None,
-    _depth: int = 0,
-    warnings: list[str] | None = None,
-    index: IndexCacheStore = None,
-) -> list[str]:
-    lines: list[str] = []
-    try:
-        entries = await readdir(accessor, path, index)
-    except (FileNotFoundError, ValueError) as exc:
-        if warnings is not None:
-            warnings.append(f"tree: '{path.original}': {exc}")
-        return lines
-    filtered = []
-    for entry in entries:
-        try:
-            entry_spec = PathSpec(original=entry,
-                                  directory=entry,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            s = await stat(accessor, entry_spec, index)
-        except (FileNotFoundError, ValueError) as exc:
-            if warnings is not None:
-                warnings.append(f"tree: '{entry}': {exc}")
-            continue
-        if not show_hidden and s.name.startswith("."):
-            continue
-        if ignore_pattern and fnmatch.fnmatch(s.name, ignore_pattern):
-            continue
-        if dirs_only and s.type != FileType.DIRECTORY:
-            continue
-        not_dir = s.type != FileType.DIRECTORY
-        if match_pattern and not_dir and not fnmatch.fnmatch(
-                s.name, match_pattern):
-            continue
-        filtered.append((entry_spec, s))
-    for i, (entry_spec, s) in enumerate(filtered):
-        is_last = i == len(filtered) - 1
-        connector = "\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 "
-        lines.append(_prefix + connector + s.name)
-        if s.type == FileType.DIRECTORY:
-            if max_depth is not None and _depth >= max_depth:
-                continue
-            extension = "    " if is_last else "\u2502   "
-            lines.extend(await _tree_async(accessor,
-                                           entry_spec,
-                                           _prefix + extension,
-                                           max_depth=max_depth,
-                                           show_hidden=show_hidden,
-                                           ignore_pattern=ignore_pattern,
-                                           dirs_only=dirs_only,
-                                           match_pattern=match_pattern,
-                                           _depth=_depth + 1,
-                                           warnings=warnings,
-                                           index=index))
-    return lines
+from mirage.types import PathSpec
 
 
 @command("tree", resource="langfuse", spec=SPECS["tree"])
@@ -105,20 +41,14 @@ async def tree(
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     paths = await resolve_glob(accessor, paths, index)
-    p0 = paths[0]
-    max_depth = int(L) if L is not None else None
-    warnings: list[str] = []
-    results = await _tree_async(
-        accessor,
-        p0,
-        max_depth=max_depth,
+    return await generic_tree(
+        paths[0],
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        max_depth=int(L) if L is not None else None,
         show_hidden=a,
         ignore_pattern=args_I,
         dirs_only=d,
         match_pattern=P,
-        warnings=warnings,
         index=index,
     )
-    stderr = "\n".join(warnings).encode() if warnings else None
-    output = "\n".join(results).encode()
-    return output, IOResult(stderr=stderr)

--- a/python/mirage/commands/builtin/langfuse/wc.py
+++ b/python/mirage/commands/builtin/langfuse/wc.py
@@ -16,12 +16,14 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.langfuse import LangfuseAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.langfuse._provision import file_read_provision
+from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.langfuse.glob import resolve_glob
 from mirage.core.langfuse.read import read as langfuse_read
-from mirage.core.langfuse.scope import detect_scope
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -53,29 +55,35 @@ async def wc(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if w or m or L:
-        msg = "wc: only -l and -c supported for Langfuse"
-        return None, IOResult(
-            exit_code=1,
-            stderr=msg.encode(),
-        )
-
-    if not paths:
-        raise ValueError("wc: missing operand")
-
-    scope = detect_scope(paths[0])
-
-    if scope.level == "file":
+    if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        data = await langfuse_read(
-            accessor,
-            p,
-            index,
-        )
-        if c:
-            return str(len(data)).encode(), IOResult()
-        line_count = data.count(b"\n")
-        return str(line_count).encode(), IOResult()
-
-    raise ValueError("wc: path must target a file")
+        outputs: list[str] = []
+        totals = WCCounts()
+        for p in paths:
+            data = await langfuse_read(accessor, p, index)
+            counts = await generic_wc(data)
+            outputs.append(
+                format_wc(counts,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label=p.original))
+            totals.merge(counts)
+        if len(paths) > 1:
+            outputs.append(
+                format_wc(totals,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label="total"))
+        return "\n".join(outputs).encode(), IOResult()
+    data = await _read_stdin_async(stdin)
+    if data is None:
+        raise ValueError("wc: missing operand")
+    counts = await generic_wc(data)
+    return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
+                     L=L).encode(), IOResult()

--- a/python/mirage/commands/builtin/linear/cat.py
+++ b/python/mirage/commands/builtin/linear/cat.py
@@ -16,13 +16,13 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.linear import LinearAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cat import cat as generic_cat
 from mirage.commands.builtin.linear._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.linear.glob import resolve_glob
 from mirage.core.linear.read import read as linear_read
-from mirage.io.stream import yield_bytes
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -38,12 +38,6 @@ async def cat_provision(
         accessor, paths,
         "cat " + " ".join(p.original if isinstance(p, PathSpec) else p
                           for p in paths))
-
-
-async def _number_lines(data: bytes) -> AsyncIterator[bytes]:
-    lines = data.decode(errors="replace").splitlines()
-    for i, line in enumerate(lines, 1):
-        yield f"     {i}\t{line}\n".encode()
 
 
 @command("cat", resource="linear", spec=SPECS["cat"], provision=cat_provision)
@@ -62,12 +56,9 @@ async def cat(
         data = await linear_read(accessor, p, index)
         io = IOResult(reads={p.strip_prefix: data}, cache=[p.strip_prefix])
         if n:
-            return _number_lines(data), io
-        return yield_bytes(data), io
+            return generic_cat(data, number_lines=True), io
+        return data, io
     source = _resolve_source(stdin, "cat: missing operand")
     if n:
-        raw = b""
-        async for chunk in source:
-            raw += chunk
-        return _number_lines(raw), IOResult()
+        return generic_cat(source, number_lines=True), IOResult()
     return source, IOResult()

--- a/python/mirage/commands/builtin/linear/head.py
+++ b/python/mirage/commands/builtin/linear/head.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.linear import LinearAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.head import head as generic_head
 from mirage.commands.builtin.linear._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
@@ -39,15 +40,6 @@ async def head_provision(
                            for p in paths))
 
 
-async def _head_bytes(data: bytes, lines: int,
-                      bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield data[:bytes_mode]
-        return
-    parts = data.split(b"\n", lines)
-    yield b"\n".join(parts[:lines])
-
-
 @command("head",
          resource="linear",
          spec=SPECS["head"],
@@ -62,14 +54,14 @@ async def head(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines = int(n) if n is not None else 10
-    bytes_mode = int(c) if c is not None else None
+    n_int = int(n) if n is not None else None
+    c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index)
         p = paths[0]
         data = await linear_read(accessor, p, index)
-        return _head_bytes(data, lines, bytes_mode), IOResult()
+        return generic_head(data, n=n_int, c=c_int), IOResult()
     raw = await _read_stdin_async(stdin)
     if raw is None:
         raise ValueError("head: missing operand")
-    return _head_bytes(raw, lines, bytes_mode), IOResult()
+    return generic_head(raw, n=n_int, c=c_int), IOResult()

--- a/python/mirage/commands/builtin/linear/ls.py
+++ b/python/mirage/commands/builtin/linear/ls.py
@@ -12,10 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.linear import LinearAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.ls import ls as generic_ls
 from mirage.commands.builtin.linear._provision import metadata_provision
-from mirage.commands.builtin.utils.formatting import _human_size
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.linear.glob import resolve_glob
@@ -23,7 +25,7 @@ from mirage.core.linear.readdir import readdir
 from mirage.core.linear.stat import stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileType, PathSpec
+from mirage.types import LsSortBy, PathSpec
 
 
 async def ls_provision(
@@ -54,50 +56,33 @@ async def ls(
     d: bool = False,
     F: bool = False,
     index: IndexCacheStore = None,
+    cwd: PathSpec | str = "/",
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    all_files = a or A
-    sort_by = "size" if S else "name"
-    reverse = r
-    index: IndexCacheStore | None = index
+    if not paths:
+        cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
+        cwd_prefix = cwd.prefix if isinstance(cwd, PathSpec) else ""
+        paths = [
+            PathSpec(original=cwd_str,
+                     directory=cwd_str,
+                     resolved=False,
+                     prefix=cwd_prefix)
+        ]
     paths = await resolve_glob(accessor, paths, index)
-    warnings: list[str] = []
-    results: list[str] = []
-    for p in paths:
-        try:
-            targets = ([p.original] if d else await readdir(
-                accessor, p, index))
-        except (FileNotFoundError, ValueError) as exc:
-            warnings.append(f"ls: cannot access '{p.original}': {exc}")
-            continue
-        entries = []
-        for entry_path in targets:
-            entry_spec = PathSpec(original=entry_path,
-                                  directory=entry_path,
-                                  resolved=False,
-                                  prefix=p.prefix)
-            try:
-                entries.append(await stat(accessor, entry_spec, index))
-            except (FileNotFoundError, ValueError) as exc:
-                warnings.append(f"ls: cannot access '{entry_path}': {exc}")
-        if not all_files:
-            entries = [
-                entry for entry in entries if not entry.name.startswith(".")
-            ]
-        if sort_by == "size":
-            entries.sort(key=lambda item: item.size or 0, reverse=not reverse)
-        else:
-            entries.sort(key=lambda item: item.name, reverse=reverse)
-        for entry in entries:
-            if args_l and not args_1:
-                size_str = _human_size(entry.size or 0) if h else str(
-                    entry.size or 0)
-                results.append(f"{entry.type or '-'}\t{size_str}\t"
-                               f"{entry.modified or ''}\t{entry.name}")
-            else:
-                suffix = "/" if F and entry.type == FileType.DIRECTORY else ""
-                results.append(entry.name + suffix)
-    stderr = "\n".join(warnings).encode() if warnings else None
-    exit_code = 1 if warnings and not results else 0
-    return "\n".join(results).encode(), IOResult(stderr=stderr,
-                                                 exit_code=exit_code)
+    sort_by = LsSortBy.TIME if t else LsSortBy.SIZE if S else LsSortBy.NAME
+    return await generic_ls(
+        paths,
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        long=args_l,
+        one_per_line=args_1,
+        all_files=a or A,
+        human=h,
+        sort_by=sort_by,
+        reverse=r,
+        recursive=R,
+        list_dir=d,
+        classify=F,
+        index=index,
+        trailing_newline=True,
+    )

--- a/python/mirage/commands/builtin/linear/stat.py
+++ b/python/mirage/commands/builtin/linear/stat.py
@@ -12,15 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import json
-
 from mirage.accessor.linear import LinearAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.stat import stat as generic_stat
 from mirage.commands.builtin.linear._provision import metadata_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.linear.glob import resolve_glob
-from mirage.core.linear.stat import stat as linear_stat
+from mirage.core.linear.stat import stat as stat_core
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -45,14 +44,17 @@ async def stat(
     paths: list[PathSpec],
     *texts: str,
     stdin: bytes | None = None,
+    c: str | None = None,
+    f: str | None = None,
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    index = index
+    if not paths:
+        raise ValueError("stat: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    payload = []
-    for p in paths:
-        payload.append(await linear_stat(accessor, p, index))
-    data = [item.model_dump(mode="json") for item in payload]
-    return json.dumps(data[0] if len(data) == 1 else data,
-                      ensure_ascii=False).encode(), IOResult()
+    return await generic_stat(paths,
+                              stat_fn=stat_core,
+                              accessor=accessor,
+                              c=c,
+                              f=f,
+                              index=index)

--- a/python/mirage/commands/builtin/linear/tree.py
+++ b/python/mirage/commands/builtin/linear/tree.py
@@ -12,82 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import fnmatch
+from functools import partial
 
 from mirage.accessor.linear import LinearAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tree import tree as generic_tree
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.linear.glob import resolve_glob
 from mirage.core.linear.readdir import readdir
 from mirage.core.linear.stat import stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
-
-
-async def _tree_async(
-    accessor: LinearAccessor,
-    path: PathSpec,
-    _prefix: str = "",
-    max_depth: int | None = None,
-    show_hidden: bool = False,
-    ignore_pattern: str | None = None,
-    dirs_only: bool = False,
-    match_pattern: str | None = None,
-    _depth: int = 0,
-    warnings: list[str] | None = None,
-    index: IndexCacheStore = None,
-) -> list[str]:
-    lines: list[str] = []
-    try:
-        entries = await readdir(accessor, path, index)
-    except (FileNotFoundError, ValueError) as exc:
-        if warnings is not None:
-            warnings.append(f"tree: '{path.original}': {exc}")
-        return lines
-    filtered = []
-    for entry in entries:
-        try:
-            entry_spec = PathSpec(original=entry,
-                                  directory=entry,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            s = await stat(accessor, entry_spec, index)
-        except (FileNotFoundError, ValueError) as exc:
-            if warnings is not None:
-                warnings.append(f"tree: '{entry}': {exc}")
-            continue
-        if not show_hidden and s.name.startswith("."):
-            continue
-        if ignore_pattern and fnmatch.fnmatch(s.name, ignore_pattern):
-            continue
-        if dirs_only and s.type != FileType.DIRECTORY:
-            continue
-        not_dir = s.type != FileType.DIRECTORY
-        if match_pattern and not_dir and not fnmatch.fnmatch(
-                s.name, match_pattern):
-            continue
-        filtered.append((entry_spec, s))
-    for i, (entry_spec, s) in enumerate(filtered):
-        is_last = i == len(filtered) - 1
-        connector = "\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 "
-        lines.append(_prefix + connector + s.name)
-        if s.type == FileType.DIRECTORY:
-            if max_depth is not None and _depth >= max_depth:
-                continue
-            extension = "    " if is_last else "\u2502   "
-            lines.extend(await _tree_async(accessor,
-                                           entry_spec,
-                                           _prefix + extension,
-                                           max_depth=max_depth,
-                                           show_hidden=show_hidden,
-                                           ignore_pattern=ignore_pattern,
-                                           dirs_only=dirs_only,
-                                           match_pattern=match_pattern,
-                                           _depth=_depth + 1,
-                                           warnings=warnings,
-                                           index=index))
-    return lines
+from mirage.types import PathSpec
 
 
 @command("tree", resource="linear", spec=SPECS["tree"])
@@ -104,22 +40,15 @@ async def tree(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    index = index
     paths = await resolve_glob(accessor, paths, index)
-    p0 = paths[0]
-    max_depth = int(L) if L is not None else None
-    warnings: list[str] = []
-    results = await _tree_async(
-        accessor,
-        p0,
-        max_depth=max_depth,
+    return await generic_tree(
+        paths[0],
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        max_depth=int(L) if L is not None else None,
         show_hidden=a,
         ignore_pattern=args_I,
         dirs_only=d,
         match_pattern=P,
-        warnings=warnings,
         index=index,
     )
-    stderr = "\n".join(warnings).encode() if warnings else None
-    output = "\n".join(results).encode()
-    return output, IOResult(stderr=stderr)

--- a/python/mirage/commands/builtin/linear/wc.py
+++ b/python/mirage/commands/builtin/linear/wc.py
@@ -16,6 +16,8 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.linear import LinearAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.linear._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
@@ -55,25 +57,33 @@ async def wc(
 ) -> tuple[ByteSource | None, IOResult]:
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        data = await linear_read(accessor, p, index)
-    else:
-        data = await _read_stdin_async(stdin)
-        if data is None:
-            raise ValueError("wc: missing operand")
-    text = data.decode(errors="replace")
-    line_count = text.count("\n")
-    word_count = len(text.split())
-    byte_count = len(data)
-    if L:
-        max_len = max((len(ln) for ln in text.splitlines()), default=0)
-        return str(max_len).encode(), IOResult()
-    if args_l:
-        return str(line_count).encode(), IOResult()
-    if w:
-        return str(word_count).encode(), IOResult()
-    if m:
-        return str(len(text)).encode(), IOResult()
-    if c:
-        return str(byte_count).encode(), IOResult()
-    return f"{line_count}\t{word_count}\t{byte_count}".encode(), IOResult()
+        outputs: list[str] = []
+        totals = WCCounts()
+        for p in paths:
+            data = await linear_read(accessor, p, index)
+            counts = await generic_wc(data)
+            outputs.append(
+                format_wc(counts,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label=p.original))
+            totals.merge(counts)
+        if len(paths) > 1:
+            outputs.append(
+                format_wc(totals,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label="total"))
+        return "\n".join(outputs).encode(), IOResult()
+    data = await _read_stdin_async(stdin)
+    if data is None:
+        raise ValueError("wc: missing operand")
+    counts = await generic_wc(data)
+    return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
+                     L=L).encode(), IOResult()

--- a/python/mirage/commands/builtin/postgres/cat.py
+++ b/python/mirage/commands/builtin/postgres/cat.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.postgres import PostgresAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cat import cat as generic_cat
 from mirage.commands.builtin.postgres._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
@@ -37,12 +38,6 @@ async def cat_provision(
         accessor, paths,
         "cat " + " ".join(p.original if isinstance(p, PathSpec) else p
                           for p in paths))
-
-
-async def _number_lines(data: bytes) -> AsyncIterator[bytes]:
-    lines = data.decode(errors="replace").splitlines()
-    for i, line in enumerate(lines, 1):
-        yield f"     {i}\t{line}\n".encode()
 
 
 @command("cat",
@@ -67,12 +62,9 @@ async def cat(
             return None, IOResult(exit_code=1, stderr=str(exc).encode())
         io = IOResult(reads={p.strip_prefix: data}, cache=[p.strip_prefix])
         if n:
-            return _number_lines(data), io
+            return generic_cat(data, number_lines=True), io
         return data, io
     source = _resolve_source(stdin, "cat: missing operand")
     if n:
-        raw = b""
-        async for chunk in source:
-            raw += chunk
-        return _number_lines(raw), IOResult()
+        return generic_cat(source, number_lines=True), IOResult()
     return source, IOResult()

--- a/python/mirage/commands/builtin/postgres/head.py
+++ b/python/mirage/commands/builtin/postgres/head.py
@@ -14,18 +14,15 @@
 
 from collections.abc import AsyncIterator
 
-import orjson
-
 from mirage.accessor.postgres import PostgresAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.head import head as generic_head
 from mirage.commands.builtin.postgres._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
-from mirage.core.postgres import _client
 from mirage.core.postgres.glob import resolve_glob
 from mirage.core.postgres.read import read as postgres_read
-from mirage.core.postgres.scope import detect_scope
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -43,15 +40,6 @@ async def head_provision(
                            for p in paths))
 
 
-async def _head_bytes(data: bytes, lines: int,
-                      bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield data[:bytes_mode]
-        return
-    parts = data.split(b"\n", lines)
-    yield b"\n".join(parts[:lines])
-
-
 @command("head",
          resource="postgres",
          spec=SPECS["head"],
@@ -66,31 +54,14 @@ async def head(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines = int(n) if n is not None else 10
-    bytes_mode = int(c) if c is not None else None
+    n_int = int(n) if n is not None else None
+    c_int = int(c) if c is not None else None
     if paths:
-        scope = detect_scope(paths[0])
-        is_file = scope.level == "entity_rows"
-        if is_file and not bytes_mode:
-            limit = min(lines, accessor.config.default_row_limit)
-            pool = await accessor.pool()
-            async with pool.acquire() as conn:
-                rows = await _client.fetch_rows(conn,
-                                                scope.schema,
-                                                scope.entity,
-                                                limit=limit,
-                                                offset=0)
-            if not rows:
-                return _head_bytes(b"", lines, None), IOResult()
-            jsonl = "\n".join(
-                orjson.dumps(r, default=str).decode() for r in rows) + "\n"
-            return _head_bytes(jsonl.encode(), lines, None), IOResult()
-
-        paths = await resolve_glob(accessor, paths, index=index)
+        paths = await resolve_glob(accessor, paths, index)
         p = paths[0]
         data = await postgres_read(accessor, p, index)
-        return _head_bytes(data, lines, bytes_mode), IOResult()
+        return generic_head(data, n=n_int, c=c_int), IOResult()
     raw = await _read_stdin_async(stdin)
     if raw is None:
         raise ValueError("head: missing operand")
-    return _head_bytes(raw, lines, bytes_mode), IOResult()
+    return generic_head(raw, n=n_int, c=c_int), IOResult()

--- a/python/mirage/commands/builtin/postgres/ls.py
+++ b/python/mirage/commands/builtin/postgres/ls.py
@@ -12,10 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.postgres import PostgresAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.ls import ls as generic_ls
 from mirage.commands.builtin.postgres._provision import metadata_provision
-from mirage.commands.builtin.utils.formatting import _human_size
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.postgres.glob import resolve_glob
@@ -23,68 +25,7 @@ from mirage.core.postgres.readdir import readdir
 from mirage.core.postgres.stat import stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileType, PathSpec
-
-
-async def _ls_async(
-    accessor: PostgresAccessor,
-    path: PathSpec,
-    long: bool = False,
-    all_files: bool = False,
-    sort_by: str = "name",
-    reverse: bool = False,
-    recursive: bool = False,
-    list_dir: bool = False,
-    warnings: list[str] | None = None,
-    index: IndexCacheStore = None,
-):
-    if list_dir:
-        entries = [await stat(accessor, path, index)]
-    else:
-        raw = await readdir(accessor, path, index)
-        entries = []
-        for e in raw:
-            try:
-                e_spec = PathSpec(original=e,
-                                  directory=e,
-                                  resolved=False,
-                                  prefix=path.prefix)
-                entries.append(await stat(accessor, e_spec, index))
-            except (FileNotFoundError, ValueError) as exc:
-                if warnings is not None:
-                    warnings.append(f"ls: cannot access '{e}': {exc}")
-
-    if not all_files:
-        entries = [e for e in entries if not e.name.startswith(".")]
-
-    if sort_by == "size":
-        entries = sorted(entries,
-                         key=lambda e: e.size or 0,
-                         reverse=not reverse)
-    else:
-        entries = sorted(entries, key=lambda e: e.name, reverse=reverse)
-
-    if recursive:
-        all_entries = []
-        for e in entries:
-            all_entries.append(e)
-            if e.type == FileType.DIRECTORY:
-                sub_path = path.child(e.name)
-                sub_spec = PathSpec(original=sub_path,
-                                    directory=sub_path,
-                                    resolved=False,
-                                    prefix=path.prefix)
-                sub = await _ls_async(accessor,
-                                      sub_spec,
-                                      long=long,
-                                      all_files=all_files,
-                                      sort_by=sort_by,
-                                      reverse=reverse,
-                                      recursive=True,
-                                      warnings=warnings)
-                all_entries.extend(sub)
-        return all_entries
-    return entries
+from mirage.types import LsSortBy, PathSpec
 
 
 async def ls_provision(
@@ -115,61 +56,33 @@ async def ls(
     d: bool = False,
     F: bool = False,
     index: IndexCacheStore = None,
+    cwd: PathSpec | str = "/",
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    all_files = a or A
-    sort_by = "name"
-    if S:
-        sort_by = "size"
-    warnings: list[str] = []
-    results: list[str] = []
     if not paths:
-        cwd = _extra.get("cwd", "/")
-        if isinstance(cwd, PathSpec):
-            paths = [
-                PathSpec(
-                    original=cwd.original,
-                    directory=cwd.directory,
-                    resolved=False,
-                    prefix=cwd.prefix,
-                )
-            ]
-        else:
-            paths = [PathSpec(
-                original=cwd,
-                directory=cwd,
-                resolved=False,
-            )]
+        cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
+        cwd_prefix = cwd.prefix if isinstance(cwd, PathSpec) else ""
+        paths = [
+            PathSpec(original=cwd_str,
+                     directory=cwd_str,
+                     resolved=False,
+                     prefix=cwd_prefix)
+        ]
     paths = await resolve_glob(accessor, paths, index)
-    for p in paths:
-        try:
-            entries = await _ls_async(
-                accessor,
-                p,
-                long=args_l,
-                all_files=all_files,
-                sort_by=sort_by,
-                reverse=r,
-                recursive=R,
-                list_dir=d,
-                warnings=warnings,
-                index=index,
-            )
-        except (FileNotFoundError, ValueError) as exc:
-            warnings.append(f"ls: cannot access '{p.original}': {exc}")
-            continue
-        if args_l and not args_1:
-            for e in entries:
-                size_str = _human_size(e.size or 0) if h else str(e.size or 0)
-                line = (f"{e.type or '-'}\t{size_str}"
-                        f"\t{e.modified or ''}\t{e.name}")
-                results.append(line)
-        else:
-            for e in entries:
-                is_dir = F and e.type == FileType.DIRECTORY
-                name = e.name + "/" if is_dir else e.name
-                results.append(name)
-    stderr = "\n".join(warnings).encode() if warnings else None
-    exit_code = 1 if warnings and not results else 0
-    output = "\n".join(results).encode()
-    return output, IOResult(stderr=stderr, exit_code=exit_code)
+    sort_by = LsSortBy.TIME if t else LsSortBy.SIZE if S else LsSortBy.NAME
+    return await generic_ls(
+        paths,
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        long=args_l,
+        one_per_line=args_1,
+        all_files=a or A,
+        human=h,
+        sort_by=sort_by,
+        reverse=r,
+        recursive=R,
+        list_dir=d,
+        classify=F,
+        index=index,
+        trailing_newline=True,
+    )

--- a/python/mirage/commands/builtin/postgres/stat.py
+++ b/python/mirage/commands/builtin/postgres/stat.py
@@ -12,46 +12,17 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import re
-
 from mirage.accessor.postgres import PostgresAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.stat import stat as generic_stat
 from mirage.commands.builtin.postgres._provision import metadata_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.postgres.glob import resolve_glob
-from mirage.core.postgres.stat import stat as stat_impl
+from mirage.core.postgres.stat import stat as stat_core
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileStat, FileType, PathSpec
-
-_FORMAT_RE = re.compile(r"%([nsFy]|.)")
-
-_TYPE_LABELS = {
-    FileType.DIRECTORY: "directory",
-    FileType.TEXT: "regular file",
-    FileType.BINARY: "regular file",
-    FileType.JSON: "regular file",
-    FileType.CSV: "regular file",
-}
-
-
-def _format_stat(fmt: str, s: FileStat) -> str:
-
-    def _replace(m: re.Match) -> str:
-        spec = m.group(1)
-        if spec == "n":
-            return s.name
-        if spec == "s":
-            return str(s.size if s.size is not None else 0)
-        if spec == "F":
-            return _TYPE_LABELS.get(
-                s.type, "regular file") if s.type else "regular file"
-        if spec == "y":
-            return s.modified or ""
-        return "?"
-
-    return _FORMAT_RE.sub(_replace, fmt)
+from mirage.types import PathSpec
 
 
 async def stat_provision(
@@ -81,14 +52,9 @@ async def stat(
     if not paths:
         raise ValueError("stat: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    fmt = c if c is not None else f
-    lines: list[str] = []
-    for p in paths:
-        s = await stat_impl(accessor, p, index)
-        if fmt is not None:
-            lines.append(_format_stat(fmt, s))
-        else:
-            lines.append(f"name={s.name} size={s.size}"
-                         f" modified={s.modified}"
-                         f" type={s.type.value if s.type else None}")
-    return "\n".join(lines).encode(), IOResult()
+    return await generic_stat(paths,
+                              stat_fn=stat_core,
+                              accessor=accessor,
+                              c=c,
+                              f=f,
+                              index=index)

--- a/python/mirage/commands/builtin/postgres/tree.py
+++ b/python/mirage/commands/builtin/postgres/tree.py
@@ -12,82 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import fnmatch
+from functools import partial
 
 from mirage.accessor.postgres import PostgresAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tree import tree as generic_tree
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.postgres.glob import resolve_glob
 from mirage.core.postgres.readdir import readdir
 from mirage.core.postgres.stat import stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
-
-
-async def _tree_async(
-    accessor: PostgresAccessor,
-    path: PathSpec,
-    _prefix: str = "",
-    max_depth: int | None = None,
-    show_hidden: bool = False,
-    ignore_pattern: str | None = None,
-    dirs_only: bool = False,
-    match_pattern: str | None = None,
-    _depth: int = 0,
-    warnings: list[str] | None = None,
-    index: IndexCacheStore = None,
-) -> list[str]:
-    lines: list[str] = []
-    try:
-        entries = await readdir(accessor, path, index)
-    except (FileNotFoundError, ValueError) as exc:
-        if warnings is not None:
-            warnings.append(f"tree: '{path.original}': {exc}")
-        return lines
-    filtered = []
-    for entry in entries:
-        try:
-            entry_spec = PathSpec(original=entry,
-                                  directory=entry,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            s = await stat(accessor, entry_spec, index)
-        except (FileNotFoundError, ValueError) as exc:
-            if warnings is not None:
-                warnings.append(f"tree: '{entry}': {exc}")
-            continue
-        if not show_hidden and s.name.startswith("."):
-            continue
-        if ignore_pattern and fnmatch.fnmatch(s.name, ignore_pattern):
-            continue
-        if dirs_only and s.type != FileType.DIRECTORY:
-            continue
-        not_dir = s.type != FileType.DIRECTORY
-        if match_pattern and not_dir and not fnmatch.fnmatch(
-                s.name, match_pattern):
-            continue
-        filtered.append((entry_spec, s))
-    for i, (entry_spec, s) in enumerate(filtered):
-        is_last = i == len(filtered) - 1
-        connector = "\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 "
-        lines.append(_prefix + connector + s.name)
-        if s.type == FileType.DIRECTORY:
-            if max_depth is not None and _depth >= max_depth:
-                continue
-            extension = "    " if is_last else "\u2502   "
-            lines.extend(await _tree_async(accessor,
-                                           entry_spec,
-                                           _prefix + extension,
-                                           max_depth=max_depth,
-                                           show_hidden=show_hidden,
-                                           ignore_pattern=ignore_pattern,
-                                           dirs_only=dirs_only,
-                                           match_pattern=match_pattern,
-                                           _depth=_depth + 1,
-                                           warnings=warnings,
-                                           index=index))
-    return lines
+from mirage.types import PathSpec
 
 
 @command("tree", resource="postgres", spec=SPECS["tree"])
@@ -105,20 +41,14 @@ async def tree(
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     paths = await resolve_glob(accessor, paths, index)
-    p0 = paths[0]
-    max_depth = int(L) if L is not None else None
-    warnings: list[str] = []
-    results = await _tree_async(
-        accessor,
-        p0,
-        max_depth=max_depth,
+    return await generic_tree(
+        paths[0],
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        max_depth=int(L) if L is not None else None,
         show_hidden=a,
         ignore_pattern=args_I,
         dirs_only=d,
         match_pattern=P,
-        warnings=warnings,
         index=index,
     )
-    stderr = "\n".join(warnings).encode() if warnings else None
-    output = "\n".join(results).encode()
-    return output, IOResult(stderr=stderr)

--- a/python/mirage/commands/builtin/postgres/wc.py
+++ b/python/mirage/commands/builtin/postgres/wc.py
@@ -16,13 +16,14 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.postgres import PostgresAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.postgres._provision import file_read_provision
+from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
-from mirage.core.postgres import _client
 from mirage.core.postgres.glob import resolve_glob
 from mirage.core.postgres.read import read as postgres_read
-from mirage.core.postgres.scope import detect_scope
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -54,26 +55,35 @@ async def wc(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if w or m or L:
-        msg = "wc: only -l and -c supported for Postgres"
-        return None, IOResult(
-            exit_code=1,
-            stderr=msg.encode(),
-        )
-
-    if not paths:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        outputs: list[str] = []
+        totals = WCCounts()
+        for p in paths:
+            data = await postgres_read(accessor, p, index)
+            counts = await generic_wc(data)
+            outputs.append(
+                format_wc(counts,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label=p.original))
+            totals.merge(counts)
+        if len(paths) > 1:
+            outputs.append(
+                format_wc(totals,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label="total"))
+        return "\n".join(outputs).encode(), IOResult()
+    data = await _read_stdin_async(stdin)
+    if data is None:
         raise ValueError("wc: missing operand")
-
-    scope = detect_scope(paths[0])
-
-    if scope.level == "entity_rows":
-        if c:
-            paths = await resolve_glob(accessor, paths, index)
-            data = await postgres_read(accessor, paths[0], index)
-            return str(len(data)).encode(), IOResult()
-        pool = await accessor.pool()
-        async with pool.acquire() as conn:
-            count = await _client.count_rows(conn, scope.schema, scope.entity)
-        return str(count).encode(), IOResult()
-
-    raise ValueError("wc: path must target an entity rows.jsonl file")
+    counts = await generic_wc(data)
+    return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
+                     L=L).encode(), IOResult()


### PR DESCRIPTION
Linear, Postgres, and Langfuse reimplemented the read-style unix commands (`cat`, `head`, `wc`, `stat`, `ls`, `tree`) with their own logic. This routes them through the shared generic implementations (injecting each backend's `read`/`readdir`/`stat`/`resolve_glob`), matching how Slack and Discord already work.

Pure refactor, no behavior change:
- `stat` now emits the generic coreutils-style output (and supports `-c`/`-f`), consistent with the other backends.
- `cat`/`head`/`wc` use the generic formatters.
- Postgres `cat` keeps its size-guard handling (surfaces "too large" as exit 1 + stderr).
- `tail`/`grep`/`rg`/`find` remain backend-specific (unchanged), same split as Slack/Discord.

Verified: 185 tests across all linear/postgres/langfuse tests pass (incl. each backend's resource provider count guard); linear example runs clean against a live workspace.

A follow-up PR will add an optional per-command output safeguard (config-driven, mount-level).