### PR TITLE
refactor(trello): delegate read/text commands to generic

### DIFF
--- a/python/mirage/commands/builtin/trello/cat.py
+++ b/python/mirage/commands/builtin/trello/cat.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.trello import TrelloAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cat import cat as generic_cat
 from mirage.commands.builtin.trello._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
@@ -40,12 +41,6 @@ async def cat_provision(
                           for p in paths))
 
 
-async def _number_lines(data: bytes) -> AsyncIterator[bytes]:
-    lines = data.decode(errors="replace").splitlines()
-    for i, line in enumerate(lines, 1):
-        yield f"     {i}\t{line}\n".encode()
-
-
 @command("cat", resource="trello", spec=SPECS["cat"], provision=cat_provision)
 async def cat(
     accessor: TrelloAccessor,
@@ -61,13 +56,8 @@ async def cat(
         p = paths[0]
         data = await trello_read(accessor, p, index)
         io = IOResult(reads={p.strip_prefix: data}, cache=[p.strip_prefix])
-        if n:
-            return _number_lines(data), io
-        return yield_bytes(data), io
+        return (generic_cat(data, number_lines=True)
+                if n else yield_bytes(data)), io
     source = _resolve_source(stdin, "cat: missing operand")
-    if n:
-        raw = b""
-        async for chunk in source:
-            raw += chunk
-        return _number_lines(raw), IOResult()
-    return source, IOResult()
+    return (generic_cat(source, number_lines=True)
+            if n else source), IOResult()

--- a/python/mirage/commands/builtin/trello/head.py
+++ b/python/mirage/commands/builtin/trello/head.py
@@ -16,8 +16,9 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.trello import TrelloAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.head import head as generic_head
 from mirage.commands.builtin.trello._provision import file_read_provision
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.trello.glob import resolve_glob
@@ -39,15 +40,6 @@ async def head_provision(
                            for p in paths))
 
 
-async def _head_bytes(data: bytes, lines: int,
-                      bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield data[:bytes_mode]
-        return
-    parts = data.split(b"\n", lines)
-    yield b"\n".join(parts[:lines])
-
-
 @command("head",
          resource="trello",
          spec=SPECS["head"],
@@ -62,14 +54,11 @@ async def head(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines = int(n) if n is not None else 10
-    bytes_mode = int(c) if c is not None else None
+    n_int = int(n) if n is not None else None
+    c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        data = await trello_read(accessor, p, index)
-        return _head_bytes(data, lines, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("head: missing operand")
-    return _head_bytes(raw, lines, bytes_mode), IOResult()
+        data = await trello_read(accessor, paths[0], index)
+        return generic_head(data, n=n_int, c=c_int), IOResult()
+    source = _resolve_source(stdin, "head: missing operand")
+    return generic_head(source, n=n_int, c=c_int), IOResult()

--- a/python/mirage/commands/builtin/trello/ls.py
+++ b/python/mirage/commands/builtin/trello/ls.py
@@ -12,10 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.trello import TrelloAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.ls import ls as generic_ls
 from mirage.commands.builtin.trello._provision import metadata_provision
-from mirage.commands.builtin.utils.formatting import _human_size
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.trello.glob import resolve_glob
@@ -23,7 +25,7 @@ from mirage.core.trello.readdir import readdir
 from mirage.core.trello.stat import stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileType, PathSpec
+from mirage.types import LsSortBy, PathSpec
 
 
 async def ls_provision(
@@ -56,48 +58,20 @@ async def ls(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    all_files = a or A
-    sort_by = "size" if S else "name"
-    reverse = r
-    index: IndexCacheStore | None = index
     paths = await resolve_glob(accessor, paths, index)
-    warnings: list[str] = []
-    results: list[str] = []
-    for p in paths:
-        try:
-            targets = ([p.original] if d else await readdir(
-                accessor, p, index))
-        except (FileNotFoundError, ValueError) as exc:
-            warnings.append(f"ls: cannot access '{p.original}': {exc}")
-            continue
-        entries = []
-        for entry_path in targets:
-            entry_spec = PathSpec(original=entry_path,
-                                  directory=entry_path,
-                                  resolved=False,
-                                  prefix=p.prefix)
-            try:
-                entries.append(await stat(accessor, entry_spec, index))
-            except (FileNotFoundError, ValueError) as exc:
-                warnings.append(f"ls: cannot access '{entry_path}': {exc}")
-        if not all_files:
-            entries = [
-                entry for entry in entries if not entry.name.startswith(".")
-            ]
-        if sort_by == "size":
-            entries.sort(key=lambda item: item.size or 0, reverse=not reverse)
-        else:
-            entries.sort(key=lambda item: item.name, reverse=reverse)
-        for entry in entries:
-            if args_l and not args_1:
-                size_str = _human_size(entry.size or 0) if h else str(
-                    entry.size or 0)
-                results.append(f"{entry.type or '-'}\t{size_str}\t"
-                               f"{entry.modified or ''}\t{entry.name}")
-            else:
-                suffix = "/" if F and entry.type == FileType.DIRECTORY else ""
-                results.append(entry.name + suffix)
-    stderr = "\n".join(warnings).encode() if warnings else None
-    exit_code = 1 if warnings and not results else 0
-    return "\n".join(results).encode(), IOResult(stderr=stderr,
-                                                 exit_code=exit_code)
+    sort_by = LsSortBy.TIME if t else LsSortBy.SIZE if S else LsSortBy.NAME
+    return await generic_ls(
+        paths,
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        long=args_l,
+        one_per_line=args_1,
+        all_files=a or A,
+        human=h,
+        sort_by=sort_by,
+        reverse=r,
+        recursive=R,
+        list_dir=d,
+        classify=F,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/trello/stat.py
+++ b/python/mirage/commands/builtin/trello/stat.py
@@ -12,10 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import json
-
 from mirage.accessor.trello import TrelloAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.stat import stat as generic_stat
 from mirage.commands.builtin.trello._provision import metadata_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -45,14 +44,17 @@ async def stat(
     paths: list[PathSpec],
     *texts: str,
     stdin: bytes | None = None,
+    c: str | None = None,
+    f: str | None = None,
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    index = index
+    if not paths:
+        raise ValueError("stat: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    payload = []
-    for p in paths:
-        payload.append(await trello_stat(accessor, p, index))
-    data = [item.model_dump(mode="json") for item in payload]
-    return json.dumps(data[0] if len(data) == 1 else data,
-                      ensure_ascii=False).encode(), IOResult()
+    return await generic_stat(paths,
+                              stat_fn=trello_stat,
+                              accessor=accessor,
+                              c=c,
+                              f=f,
+                              index=index)

--- a/python/mirage/commands/builtin/trello/tail.py
+++ b/python/mirage/commands/builtin/trello/tail.py
@@ -16,9 +16,10 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.trello import TrelloAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
+from mirage.commands.builtin.generic.tail import tail as generic_tail
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.trello._provision import file_read_provision
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.trello.glob import resolve_glob
@@ -40,14 +41,6 @@ async def tail_provision(
                            for p in paths))
 
 
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
-
-
 @command("tail",
          resource="trello",
          spec=SPECS["tail"],
@@ -64,14 +57,20 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        raw = await trello_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        data = await trello_read(accessor, paths[0], index)
+        return generic_tail(data, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/trello/tree.py
+++ b/python/mirage/commands/builtin/trello/tree.py
@@ -12,82 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import fnmatch
+from functools import partial
 
 from mirage.accessor.trello import TrelloAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tree import tree as generic_tree
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.trello.glob import resolve_glob
 from mirage.core.trello.readdir import readdir
 from mirage.core.trello.stat import stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
-
-
-async def _tree_async(
-    accessor: TrelloAccessor,
-    path: PathSpec,
-    _prefix: str = "",
-    max_depth: int | None = None,
-    show_hidden: bool = False,
-    ignore_pattern: str | None = None,
-    dirs_only: bool = False,
-    match_pattern: str | None = None,
-    _depth: int = 0,
-    warnings: list[str] | None = None,
-    index: IndexCacheStore = None,
-) -> list[str]:
-    lines: list[str] = []
-    try:
-        entries = await readdir(accessor, path, index)
-    except (FileNotFoundError, ValueError) as exc:
-        if warnings is not None:
-            warnings.append(f"tree: '{path.original}': {exc}")
-        return lines
-    filtered = []
-    for entry in entries:
-        try:
-            entry_spec = PathSpec(original=entry,
-                                  directory=entry,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            s = await stat(accessor, entry_spec, index)
-        except (FileNotFoundError, ValueError) as exc:
-            if warnings is not None:
-                warnings.append(f"tree: '{entry}': {exc}")
-            continue
-        if not show_hidden and s.name.startswith("."):
-            continue
-        if ignore_pattern and fnmatch.fnmatch(s.name, ignore_pattern):
-            continue
-        if dirs_only and s.type != FileType.DIRECTORY:
-            continue
-        not_dir = s.type != FileType.DIRECTORY
-        if match_pattern and not_dir and not fnmatch.fnmatch(
-                s.name, match_pattern):
-            continue
-        filtered.append((entry_spec, s))
-    for i, (entry_spec, s) in enumerate(filtered):
-        is_last = i == len(filtered) - 1
-        connector = "\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 "
-        lines.append(_prefix + connector + s.name)
-        if s.type == FileType.DIRECTORY:
-            if max_depth is not None and _depth >= max_depth:
-                continue
-            extension = "    " if is_last else "\u2502   "
-            lines.extend(await _tree_async(accessor,
-                                           entry_spec,
-                                           _prefix + extension,
-                                           max_depth=max_depth,
-                                           show_hidden=show_hidden,
-                                           ignore_pattern=ignore_pattern,
-                                           dirs_only=dirs_only,
-                                           match_pattern=match_pattern,
-                                           _depth=_depth + 1,
-                                           warnings=warnings,
-                                           index=index))
-    return lines
+from mirage.types import PathSpec
 
 
 @command("tree", resource="trello", spec=SPECS["tree"])
@@ -104,22 +40,15 @@ async def tree(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    index = index
     paths = await resolve_glob(accessor, paths, index)
-    p0 = paths[0]
-    max_depth = int(L) if L is not None else None
-    warnings: list[str] = []
-    results = await _tree_async(
-        accessor,
-        p0,
-        max_depth=max_depth,
+    return await generic_tree(
+        paths[0],
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        max_depth=int(L) if L is not None else None,
         show_hidden=a,
         ignore_pattern=args_I,
         dirs_only=d,
         match_pattern=P,
-        warnings=warnings,
         index=index,
     )
-    stderr = "\n".join(warnings).encode() if warnings else None
-    output = "\n".join(results).encode()
-    return output, IOResult(stderr=stderr)

--- a/python/mirage/commands/builtin/trello/wc.py
+++ b/python/mirage/commands/builtin/trello/wc.py
@@ -16,6 +16,8 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.trello import TrelloAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.trello._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
@@ -55,25 +57,32 @@ async def wc(
 ) -> tuple[ByteSource | None, IOResult]:
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        data = await trello_read(accessor, p, index)
-    else:
-        data = await _read_stdin_async(stdin)
-        if data is None:
-            raise ValueError("wc: missing operand")
-    text = data.decode(errors="replace")
-    line_count = text.count("\n")
-    word_count = len(text.split())
-    byte_count = len(data)
-    if L:
-        max_len = max((len(ln) for ln in text.splitlines()), default=0)
-        return str(max_len).encode(), IOResult()
-    if args_l:
-        return str(line_count).encode(), IOResult()
-    if w:
-        return str(word_count).encode(), IOResult()
-    if m:
-        return str(len(text)).encode(), IOResult()
-    if c:
-        return str(byte_count).encode(), IOResult()
-    return f"{line_count}\t{word_count}\t{byte_count}".encode(), IOResult()
+        outputs: list[str] = []
+        totals = WCCounts()
+        for p in paths:
+            counts = await generic_wc(await trello_read(accessor, p, index))
+            outputs.append(
+                format_wc(counts,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label=p.original))
+            totals.merge(counts)
+        if len(paths) > 1:
+            outputs.append(
+                format_wc(totals,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label="total"))
+        return "\n".join(outputs).encode(), IOResult()
+    data = await _read_stdin_async(stdin)
+    if data is None:
+        raise ValueError("wc: missing operand")
+    counts = await generic_wc(data)
+    return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
+                     L=L).encode(), IOResult()


### PR DESCRIPTION
## Summary

Convert trello's read/text commands (`cat`, `head`, `tail`, `wc`, `stat`, `ls`, `tree`) to delegate to the shared `generic.*` command layer, removing the hand-rolled reimplementations. trello has no backend push-downs for these (it just reads card/board JSON), so they were plain duplications of the generic logic.

Kept custom: `grep`/`rg` (already reuse `grep_helper`), `find`, `jq`, and the `trello_card_*` write/action commands.

Output is standardized to match the generic layer (e.g. `stat` now emits the standard `name=.. size=.. type=..` form instead of bespoke JSON; `wc` appends the filename label).

## Test plan
- [x] Import check of all converted modules
- [x] Live run of `examples/python/trello/trello.py` (exit 0): ls / cat / head / tail / wc / stat / tree all produce correct output against a real Trello board