### PR TITLE
refactor(commands): route tail/grep/rg through generic across backends

### DIFF
--- a/python/mirage/commands/builtin/discord/tail.py
+++ b/python/mirage/commands/builtin/discord/tail.py
@@ -16,9 +16,9 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.discord import DiscordAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.discord._provision import file_read_provision
 from mirage.commands.builtin.generic.tail import tail as generic_tail
 from mirage.commands.builtin.tail_helper import _parse_n
-from mirage.commands.builtin.discord._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS

--- a/python/mirage/commands/builtin/discord/tail.py
+++ b/python/mirage/commands/builtin/discord/tail.py
@@ -12,20 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import json
 from collections.abc import AsyncIterator
 
 from mirage.accessor.discord import DiscordAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.discord._provision import file_read_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
-from mirage.core.discord._client import discord_get
 from mirage.core.discord.glob import resolve_glob
 from mirage.core.discord.read import read as discord_read
-from mirage.core.discord.scope import detect_scope
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -41,14 +39,6 @@ async def tail_provision(
         accessor, paths,
         "tail " + " ".join(p.original if isinstance(p, PathSpec) else p
                            for p in paths))
-
-
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
 
 
 @command("tail",
@@ -67,29 +57,20 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
-        scope = await detect_scope(paths[0], index)
-
-        # Smart tail: Discord returns newest messages first
-        if scope.level == "file" and scope.channel_id and not bytes_mode:
-            msgs = await discord_get(
-                accessor.config,
-                f"/channels/{scope.channel_id}/messages",
-                params={"limit": lines},
-            )
-            msgs.sort(key=lambda m: int(m["id"]))
-            jsonl = "\n".join(json.dumps(m, ensure_ascii=False)
-                              for m in msgs) + "\n"
-            return _tail_result(jsonl.encode(), lines, plus_mode,
-                                None), IOResult()
-
-        paths = await resolve_glob(accessor, paths, index=index)
-        p = paths[0]
-        raw = await discord_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        paths = await resolve_glob(accessor, paths, index)
+        data = await discord_read(accessor, paths[0], index)
+        return generic_tail(data, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/email/tail.py
+++ b/python/mirage/commands/builtin/email/tail.py
@@ -16,9 +16,10 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.email import EmailAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.email._provision import file_read_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.email.glob import resolve_glob
@@ -32,23 +33,12 @@ async def tail_provision(
     accessor: EmailAccessor,
     paths: list[PathSpec],
     *texts: str,
-    index: IndexCacheStore = None,
     **_extra: object,
 ) -> ProvisionResult:
     return await file_read_provision(
-        accessor,
-        paths,
+        accessor, paths,
         "tail " + " ".join(p.original if isinstance(p, PathSpec) else p
-                           for p in paths),
-        index=index)
-
-
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
+                           for p in paths))
 
 
 @command("tail",
@@ -67,14 +57,20 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        raw = await email_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        data = await email_read(accessor, paths[0], index)
+        return generic_tail(data, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/email/tail.py
+++ b/python/mirage/commands/builtin/email/tail.py
@@ -16,9 +16,9 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.email import EmailAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.email._provision import file_read_provision
 from mirage.commands.builtin.generic.tail import tail as generic_tail
 from mirage.commands.builtin.tail_helper import _parse_n
-from mirage.commands.builtin.email._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS

--- a/python/mirage/commands/builtin/gdocs/grep.py
+++ b/python/mirage/commands/builtin/gdocs/grep.py
@@ -13,24 +13,17 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.gdocs import GDocsAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.gdocs._provision import file_read_provision
-from mirage.commands.builtin.grep_helper import (compile_pattern,
-                                                 grep_files_only, grep_lines,
-                                                 grep_stream)
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
+from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdocs.glob import resolve_glob
 from mirage.core.gdocs.read import read as gdocs_read
 from mirage.core.gdocs.readdir import readdir as _readdir
 from mirage.core.gdocs.stat import stat as _stat
-from mirage.io.stream import exit_on_empty, quiet_match, yield_bytes
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -40,14 +33,10 @@ async def grep_provision(
     accessor: GDocsAccessor,
     paths: list[PathSpec],
     *texts: str,
-    index: IndexCacheStore = None,
     **_extra: object,
 ) -> ProvisionResult:
-    return await file_read_provision(
-        accessor,
-        paths,
-        "grep " + " ".join(texts + tuple(str(p) for p in paths)),
-        index=index)
+    rendered = "grep " + " ".join(texts + tuple(str(p) for p in paths))
+    return await file_read_provision(accessor, paths, rendered)
 
 
 @command("grep",
@@ -91,104 +80,28 @@ async def grep(
     max_count = int(m) if m is not None else None
     after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
     before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
-
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        file_prefix = paths[0].prefix if paths else ""
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        rb = partial(call_read_bytes,
-                     gdocs_read,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-
-        if args_l:
-            warnings: list[str] = []
-            results = await grep_files_only(
-                rd,
-                st,
-                rb,
-                paths[0].original,
-                pattern,
-                recursive=r or R,
-                ignore_case=i,
-                invert=v,
-                line_numbers=n,
-                count_only=c,
-                fixed_string=F,
-                only_matching=o,
-                max_count=max_count,
-                whole_word=w,
-                warnings=warnings,
-            )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            return ("\n".join(results).encode(), IOResult(stderr=stderr))
-
-        pat = compile_pattern(pattern, i, F, w)
-
-        if len(paths) > 1:
-            all_results: list[str] = []
-            for p in paths:
-                data = (await
-                        rb(p.original)).decode(errors="replace").splitlines()
-                hits = grep_lines(p.original, data, pat, v, n, c, args_l, o,
-                                  max_count)
-                if c:
-                    if hits:
-                        all_results.append(f"{p.original}:{hits[0]}")
-                elif args_l:
-                    all_results.extend(hits)
-                else:
-                    all_results.extend(f"{p.original}:{r}" for r in hits)
-            if not all_results:
-                return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
-
-        data = await rb(paths[0].original)
-        source = yield_bytes(data)
-        stream = grep_stream(
-            source,
-            pat,
-            invert=v,
-            line_numbers=n,
-            only_matching=o,
-            max_count=max_count,
-            count_only=c,
-            after_context=after_ctx,
-            before_context=before_ctx,
-        )
-        if q:
-            io = IOResult(exit_code=1)
-            return quiet_match(stream, io), io
-        io = IOResult()
-        return exit_on_empty(stream, io), io
-
-    source = _resolve_source(stdin, "grep: usage: grep [flags] pattern [path]")
-    pat = compile_pattern(pattern, i, F, w)
-    stream = grep_stream(
-        source,
-        pat,
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
+    return await generic_grep(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=gdocs_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
         invert=v,
         line_numbers=n,
-        only_matching=o,
-        max_count=max_count,
         count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        quiet=q,
+        recursive=r or R,
+        max_count=max_count,
         after_context=after_ctx,
         before_context=before_ctx,
+        index=index,
     )
-    if q:
-        io = IOResult(exit_code=1)
-        return quiet_match(stream, io), io
-    io = IOResult()
-    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/gdocs/rg.py
+++ b/python/mirage/commands/builtin/gdocs/rg.py
@@ -16,42 +16,30 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.gdocs import GDocsAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.gdocs._provision import file_read_provision
+from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdocs.glob import resolve_glob
 from mirage.core.gdocs.read import read as gdocs_read
 from mirage.core.gdocs.readdir import readdir as _readdir
+from mirage.core.gdocs.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
+from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
 
 
-async def _collect_files(
+async def rg_provision(
     accessor: GDocsAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-) -> list[str]:
-    if path.endswith(".json") or path.endswith(".jsonl"):
-        return [path]
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    files: list[str] = []
-    for child in children:
-        if child.endswith(".json") or child.endswith(".jsonl"):
-            files.append(child)
-        else:
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            files.extend(await _collect_files(accessor, child_spec, index))
-    return files
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    rendered = "rg " + " ".join(texts + tuple(str(p) for p in paths))
+    return await file_read_provision(accessor, paths, rendered)
 
 
-@command("rg", resource="gdocs", spec=SPECS["rg"])
+@command("rg", resource="gdocs", spec=SPECS["rg"], provision=rg_provision)
 async def rg(
     accessor: GDocsAccessor,
     paths: list[PathSpec],
@@ -78,77 +66,37 @@ async def rg(
 ) -> tuple[ByteSource | None, IOResult]:
     if not texts:
         raise ValueError("rg: usage: rg [flags] pattern [path]")
-    pattern_str = texts[0]
+    pattern = texts[0]
     max_count = int(m) if m is not None else None
-    pat = compile_pattern(pattern_str, i, F, w)
+    context_after = int(A) if A is not None else 0
+    context_before = int(B) if B is not None else 0
+    if C is not None:
+        context_before = context_after = int(C)
 
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        blob_paths: list[str] = []
-        file_prefix = paths[0].prefix if paths else ""
-        for path_item in paths:
-            blob_paths.extend(await _collect_files(accessor, path_item, index))
-        blob_paths = sorted(set(blob_paths))
-        all_results: list[str] = []
-        any_match = False
-        for bp in blob_paths:
-            if not hidden and any(
-                    part.startswith(".") for part in bp.split("/")):
-                continue
-            try:
-                bp_spec = PathSpec(original=bp,
-                                   directory=bp,
-                                   resolved=True,
-                                   prefix=file_prefix)
-                data = await gdocs_read(accessor, bp_spec, index)
-            except (FileNotFoundError, IsADirectoryError, RuntimeError):
-                continue
-            text = data.decode(errors="replace")
-            if not text:
-                continue
-            lines = text.splitlines()
-            matched = grep_lines(bp,
-                                 lines,
-                                 pat,
-                                 invert=v,
-                                 line_numbers=n,
-                                 count_only=c,
-                                 files_only=args_l,
-                                 only_matching=o,
-                                 max_count=max_count)
-            if not matched:
-                continue
-            any_match = True
-            if args_l:
-                all_results.append(bp)
-                continue
-            if c:
-                all_results.append(f"{bp}:{len(matched)}")
-                continue
-            for line in matched:
-                all_results.append(f"{bp}:{line}")
-        if not any_match:
-            return b"", IOResult(exit_code=1)
-        return "\n".join(all_results).encode(), IOResult()
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
 
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("rg: usage: rg [flags] pattern path")
-    lines = raw.decode(errors="replace").splitlines()
-    matched = grep_lines("<stdin>",
-                         lines,
-                         pat,
-                         invert=v,
-                         line_numbers=n,
-                         count_only=c,
-                         files_only=args_l,
-                         only_matching=o,
-                         max_count=max_count)
-    if not matched:
-        return b"", IOResult(exit_code=1)
-    if c:
-        return str(len(matched)).encode(), IOResult()
-    result_lines: list[str] = []
-    for line in matched:
-        result_lines.append(line)
-    return "\n".join(result_lines).encode(), IOResult()
+    return await generic_rg(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=gdocs_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        max_count=max_count,
+        context_before=context_before,
+        context_after=context_after,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/gdocs/tail.py
+++ b/python/mirage/commands/builtin/gdocs/tail.py
@@ -16,9 +16,9 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.gdocs import GDocsAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.gdocs._provision import file_read_provision
 from mirage.commands.builtin.generic.tail import tail as generic_tail
 from mirage.commands.builtin.tail_helper import _parse_n
-from mirage.commands.builtin.gdocs._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS

--- a/python/mirage/commands/builtin/gdocs/tail.py
+++ b/python/mirage/commands/builtin/gdocs/tail.py
@@ -16,9 +16,10 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.gdocs import GDocsAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.gdocs._provision import file_read_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdocs.glob import resolve_glob
@@ -32,23 +33,12 @@ async def tail_provision(
     accessor: GDocsAccessor,
     paths: list[PathSpec],
     *texts: str,
-    index: IndexCacheStore = None,
     **_extra: object,
 ) -> ProvisionResult:
     return await file_read_provision(
-        accessor,
-        paths,
+        accessor, paths,
         "tail " + " ".join(p.original if isinstance(p, PathSpec) else p
-                           for p in paths),
-        index=index)
-
-
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
+                           for p in paths))
 
 
 @command("tail",
@@ -67,14 +57,20 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        raw = await gdocs_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        data = await gdocs_read(accessor, paths[0], index)
+        return generic_tail(data, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/gdrive/grep.py
+++ b/python/mirage/commands/builtin/gdrive/grep.py
@@ -13,24 +13,17 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.gdrive._provision import file_read_provision
-from mirage.commands.builtin.grep_helper import (compile_pattern,
-                                                 grep_files_only, grep_lines,
-                                                 grep_stream)
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
+from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdrive.glob import resolve_glob
 from mirage.core.gdrive.read import read as gdrive_read
 from mirage.core.gdrive.readdir import readdir as _readdir
 from mirage.core.gdrive.stat import stat as _stat
-from mirage.io.stream import exit_on_empty, quiet_match, yield_bytes
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -40,14 +33,10 @@ async def grep_provision(
     accessor: GDriveAccessor,
     paths: list[PathSpec],
     *texts: str,
-    index: IndexCacheStore = None,
     **_extra: object,
 ) -> ProvisionResult:
-    return await file_read_provision(
-        accessor,
-        paths,
-        "grep " + " ".join(texts + tuple(str(p) for p in paths)),
-        index=index)
+    rendered = "grep " + " ".join(texts + tuple(str(p) for p in paths))
+    return await file_read_provision(accessor, paths, rendered)
 
 
 @command("grep",
@@ -91,105 +80,28 @@ async def grep(
     max_count = int(m) if m is not None else None
     after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
     before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
-
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        file_prefix = paths[0].prefix if paths else ""
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        rb = partial(call_read_bytes,
-                     gdrive_read,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-
-        if args_l:
-            warnings: list[str] = []
-            results = await grep_files_only(
-                rd,
-                st,
-                rb,
-                paths[0].original,
-                pattern,
-                recursive=r or R,
-                ignore_case=i,
-                invert=v,
-                line_numbers=n,
-                count_only=c,
-                fixed_string=F,
-                only_matching=o,
-                max_count=max_count,
-                whole_word=w,
-                warnings=warnings,
-            )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            return ("\n".join(results).encode(), IOResult(stderr=stderr))
-
-        pat = compile_pattern(pattern, i, F, w)
-
-        if len(paths) > 1:
-            all_results: list[str] = []
-            for p in paths:
-                data = (await
-                        rb(p.original)).decode(errors="replace").splitlines()
-                hits = grep_lines(p.original, data, pat, v, n, c, args_l, o,
-                                  max_count)
-                if c:
-                    if hits:
-                        all_results.append(f"{p.original}:{hits[0]}")
-                elif args_l:
-                    all_results.extend(hits)
-                else:
-                    all_results.extend(f"{p.original}:{r}" for r in hits)
-            if not all_results:
-                return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
-
-        p = paths[0]
-        data = await rb(p.original)
-        source = yield_bytes(data)
-        stream = grep_stream(
-            source,
-            pat,
-            invert=v,
-            line_numbers=n,
-            only_matching=o,
-            max_count=max_count,
-            count_only=c,
-            after_context=after_ctx,
-            before_context=before_ctx,
-        )
-        if q:
-            io = IOResult(exit_code=1)
-            return quiet_match(stream, io), io
-        io = IOResult()
-        return exit_on_empty(stream, io), io
-
-    source = _resolve_source(stdin, "grep: usage: grep [flags] pattern [path]")
-    pat = compile_pattern(pattern, i, F, w)
-    stream = grep_stream(
-        source,
-        pat,
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
+    return await generic_grep(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=gdrive_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
         invert=v,
         line_numbers=n,
-        only_matching=o,
-        max_count=max_count,
         count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        quiet=q,
+        recursive=r or R,
+        max_count=max_count,
         after_context=after_ctx,
         before_context=before_ctx,
+        index=index,
     )
-    if q:
-        io = IOResult(exit_code=1)
-        return quiet_match(stream, io), io
-    io = IOResult()
-    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/gdrive/rg.py
+++ b/python/mirage/commands/builtin/gdrive/rg.py
@@ -13,52 +13,33 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import (compile_pattern, grep_lines,
-                                                 grep_stream)
-from mirage.commands.builtin.rg_helper import rg_full
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
+from mirage.commands.builtin.gdrive._provision import file_read_provision
+from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdrive.glob import resolve_glob
 from mirage.core.gdrive.read import read as gdrive_read
 from mirage.core.gdrive.readdir import readdir as _readdir
 from mirage.core.gdrive.stat import stat as _stat
-from mirage.io.stream import exit_on_empty, yield_bytes
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
+from mirage.provision.types import ProvisionResult
+from mirage.types import PathSpec
 
 
-async def _collect_files(
+async def rg_provision(
     accessor: GDriveAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-) -> list[str]:
-    if path.endswith(".json") or path.endswith(".jsonl"):
-        return [path]
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    files: list[str] = []
-    for child in children:
-        if child.endswith(".json") or child.endswith(".jsonl"):
-            files.append(child)
-        else:
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            files.extend(await _collect_files(accessor, child_spec, index))
-    return files
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    rendered = "rg " + " ".join(texts + tuple(str(p) for p in paths))
+    return await file_read_provision(accessor, paths, rendered)
 
 
-@command("rg", resource="gdrive", spec=SPECS["rg"])
+@command("rg", resource="gdrive", spec=SPECS["rg"], provision=rg_provision)
 async def rg(
     accessor: GDriveAccessor,
     paths: list[PathSpec],
@@ -92,106 +73,30 @@ async def rg(
     if C is not None:
         context_before = context_after = int(C)
 
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        file_prefix = paths[0].prefix if paths else ""
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        rb = partial(call_read_bytes, gdrive_read, accessor, index=index)
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
 
-        is_dir = False
-        try:
-            s = await _stat(accessor, paths[0], index)
-            is_dir = s.type == FileType.DIRECTORY
-        except (FileNotFoundError, ValueError):
-            try:
-                await _readdir(accessor, paths[0], index)
-                is_dir = True
-            except (FileNotFoundError, ValueError):
-                pass
-
-        if is_dir:
-            warnings: list[str] = []
-            results = await rg_full(
-                rd,
-                st,
-                rb,
-                paths[0].original,
-                pattern,
-                ignore_case=i,
-                invert=v,
-                line_numbers=n,
-                count_only=c,
-                files_only=args_l,
-                fixed_string=F,
-                only_matching=o,
-                max_count=max_count,
-                whole_word=w,
-                context_before=context_before,
-                context_after=context_after,
-                file_type=type,
-                glob_pattern=glob,
-                hidden=hidden,
-                warnings=warnings,
-            )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            return "\n".join(results).encode(), IOResult(stderr=stderr)
-
-        pat = compile_pattern(pattern, i, F, w)
-
-        if len(paths) > 1:
-            all_results: list[str] = []
-            for p in paths:
-                data = (await
-                        rb(p.original)).decode(errors="replace").splitlines()
-                hits = grep_lines(p.original, data, pat, v, n, c, args_l, o,
-                                  max_count)
-                if c:
-                    if hits:
-                        all_results.append(f"{p.original}:{hits[0]}")
-                elif args_l:
-                    all_results.extend(hits)
-                else:
-                    all_results.extend(f"{p.original}:{r}" for r in hits)
-            if not all_results:
-                return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
-
-        p = paths[0]
-        data = await rb(p.original)
-        source = yield_bytes(data)
-        stream = grep_stream(
-            source,
-            pat,
-            invert=v,
-            line_numbers=n,
-            only_matching=o,
-            max_count=max_count,
-            count_only=c,
-        )
-        io = IOResult()
-        return exit_on_empty(stream, io), io
-
-    source = _resolve_source(stdin, "rg: usage: rg [flags] pattern path")
-    pat = compile_pattern(pattern, i, F, w)
-    stream = grep_stream(
-        source,
-        pat,
+    return await generic_rg(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=gdrive_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
         invert=v,
         line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
         only_matching=o,
         max_count=max_count,
-        count_only=c,
+        context_before=context_before,
+        context_after=context_after,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
     )
-    io = IOResult()
-    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/gdrive/tail.py
+++ b/python/mirage/commands/builtin/gdrive/tail.py
@@ -16,9 +16,9 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.gdrive._provision import file_read_provision
 from mirage.commands.builtin.generic.tail import tail as generic_tail
 from mirage.commands.builtin.tail_helper import _parse_n
-from mirage.commands.builtin.gdrive._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS

--- a/python/mirage/commands/builtin/gdrive/tail.py
+++ b/python/mirage/commands/builtin/gdrive/tail.py
@@ -16,9 +16,10 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.gdrive._provision import file_read_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdrive.glob import resolve_glob
@@ -32,23 +33,12 @@ async def tail_provision(
     accessor: GDriveAccessor,
     paths: list[PathSpec],
     *texts: str,
-    index: IndexCacheStore = None,
     **_extra: object,
 ) -> ProvisionResult:
     return await file_read_provision(
-        accessor,
-        paths,
+        accessor, paths,
         "tail " + " ".join(p.original if isinstance(p, PathSpec) else p
-                           for p in paths),
-        index=index)
-
-
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
+                           for p in paths))
 
 
 @command("tail",
@@ -67,14 +57,20 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        raw = await gdrive_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        data = await gdrive_read(accessor, paths[0], index)
+        return generic_tail(data, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/generic/grep.py
+++ b/python/mirage/commands/builtin/generic/grep.py
@@ -48,10 +48,15 @@ async def grep(
                      accessor,
                      index=index,
                      prefix=mount_prefix)
-        st = partial(call_stat, stat, accessor, prefix=mount_prefix)
+        st = partial(call_stat,
+                     stat,
+                     accessor,
+                     index=index,
+                     prefix=mount_prefix)
         rb = partial(call_read_bytes,
                      read_bytes,
                      accessor,
+                     index=index,
                      prefix=mount_prefix)
 
         scope_warning_str: str | None = None
@@ -96,7 +101,7 @@ async def grep(
             if scope_warning_str:
                 warnings.append(scope_warning_str)
             for p in paths:
-                s = await stat(accessor, p)
+                s = await st(p.original)
                 if s.type == FileType.DIRECTORY:
                     res = await grep_recursive(
                         rd,
@@ -116,8 +121,7 @@ async def grep(
                     all_results.extend(res)
                 else:
                     data = split_lines(
-                        (await read_bytes(accessor,
-                                          p)).decode(errors="replace"))
+                        (await rb(p.original)).decode(errors="replace"))
                     hits = grep_lines(p.original, data, pat, invert,
                                       line_numbers, count_only, files_only,
                                       only_matching, max_count)
@@ -137,8 +141,8 @@ async def grep(
         if len(paths) > 1:
             all_results = []
             for p in paths:
-                data = split_lines(
-                    (await read_bytes(accessor, p)).decode(errors="replace"))
+                data = split_lines((await
+                                    rb(p.original)).decode(errors="replace"))
                 hits = grep_lines(p.original, data, pat, invert, line_numbers,
                                   count_only, files_only, only_matching,
                                   max_count)
@@ -156,7 +160,7 @@ async def grep(
         if read_stream is not None:
             source: AsyncIterator[bytes] = read_stream(accessor, paths[0])
         else:
-            data = await read_bytes(accessor, paths[0])
+            data = await rb(paths[0].original)
             source = _wrap_bytes(data)
         stream = grep_stream(
             source,

--- a/python/mirage/commands/builtin/generic/grep.py
+++ b/python/mirage/commands/builtin/generic/grep.py
@@ -38,6 +38,7 @@ async def grep(
     max_count: int | None = None,
     after_context: int = 0,
     before_context: int = 0,
+    scope_check: Callable[..., Awaitable[str | None]] | None = None,
     index: IndexCacheStore | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
     if paths:
@@ -53,8 +54,14 @@ async def grep(
                      accessor,
                      prefix=mount_prefix)
 
+        scope_warning_str: str | None = None
+        if scope_check is not None and not paths[0].resolved:
+            scope_warning_str = await scope_check(rd, st, paths[0], recursive)
+
         if files_only:
             warnings: list[str] = []
+            if scope_warning_str:
+                warnings.append(scope_warning_str)
             results: list[str] = []
             for p in paths:
                 hits = await grep_files_only(
@@ -86,6 +93,8 @@ async def grep(
                                   whole_word)
             all_results: list[str] = []
             warnings = []
+            if scope_warning_str:
+                warnings.append(scope_warning_str)
             for p in paths:
                 s = await stat(accessor, p)
                 if s.type == FileType.DIRECTORY:

--- a/python/mirage/commands/builtin/generic/rg.py
+++ b/python/mirage/commands/builtin/generic/rg.py
@@ -48,10 +48,15 @@ async def rg(
                      accessor,
                      index=index,
                      prefix=mount_prefix)
-        st = partial(call_stat, stat, accessor, prefix=mount_prefix)
+        st = partial(call_stat,
+                     stat,
+                     accessor,
+                     index=index,
+                     prefix=mount_prefix)
         rb = partial(call_read_bytes,
                      read_bytes,
                      accessor,
+                     index=index,
                      prefix=mount_prefix)
 
         scope_warning_str: str | None = None
@@ -60,11 +65,11 @@ async def rg(
 
         is_dir = False
         try:
-            s = await stat(accessor, paths[0])
+            s = await st(paths[0].original)
             is_dir = s.type == FileType.DIRECTORY
         except (FileNotFoundError, ValueError):
             try:
-                await readdir(accessor, paths[0], index)
+                await rd(paths[0].original)
                 is_dir = True
             except (FileNotFoundError, ValueError):
                 pass
@@ -100,8 +105,6 @@ async def rg(
             stderr = "\n".join(warnings_f).encode() if warnings_f else None
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            if mount_prefix and files_only:
-                results = [mount_prefix + "/" + r.lstrip("/") for r in results]
             return "\n".join(results).encode(), IOResult(stderr=stderr)
 
         pat = compile_pattern(pattern, ignore_case, fixed_string, whole_word)
@@ -109,8 +112,8 @@ async def rg(
         if len(paths) > 1:
             all_results: list[str] = []
             for p in paths:
-                data = split_lines(
-                    (await read_bytes(accessor, p)).decode(errors="replace"))
+                data = split_lines((await
+                                    rb(p.original)).decode(errors="replace"))
                 hits = grep_lines(p.original, data, pat, invert, line_numbers,
                                   count_only, files_only, only_matching,
                                   max_count)
@@ -123,16 +126,12 @@ async def rg(
                     all_results.extend(f"{p.original}:{r}" for r in hits)
             if not all_results:
                 return b"", IOResult(exit_code=1)
-            if mount_prefix:
-                all_results = [
-                    mount_prefix + "/" + r.lstrip("/") for r in all_results
-                ]
             return "\n".join(all_results).encode(), IOResult()
 
         if read_stream is not None:
             source: AsyncIterator[bytes] = read_stream(accessor, paths[0])
         else:
-            data = await read_bytes(accessor, paths[0])
+            data = await rb(paths[0].original)
             source = _wrap_bytes(data)
         stream = grep_stream(
             source,

--- a/python/mirage/commands/builtin/generic/rg.py
+++ b/python/mirage/commands/builtin/generic/rg.py
@@ -38,6 +38,7 @@ async def rg(
     hidden: bool = False,
     file_type: str | None = None,
     glob_pattern: str | None = None,
+    scope_check: Callable[..., Awaitable[str | None]] | None = None,
     index: IndexCacheStore | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
     if paths:
@@ -52,6 +53,10 @@ async def rg(
                      read_bytes,
                      accessor,
                      prefix=mount_prefix)
+
+        scope_warning_str: str | None = None
+        if scope_check is not None and not paths[0].resolved:
+            scope_warning_str = await scope_check(rd, st, paths[0], True)
 
         is_dir = False
         try:
@@ -68,6 +73,8 @@ async def rg(
                       or file_type or glob_pattern)
         if needs_full:
             warnings_f: list[str] = []
+            if scope_warning_str:
+                warnings_f.append(scope_warning_str)
             results = await rg_full(
                 rd,
                 st,

--- a/python/mirage/commands/builtin/gmail/tail.py
+++ b/python/mirage/commands/builtin/gmail/tail.py
@@ -17,8 +17,8 @@ from collections.abc import AsyncIterator
 from mirage.accessor.gmail import GmailAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.tail import tail as generic_tail
-from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.gmail._provision import file_read_provision
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS

--- a/python/mirage/commands/builtin/gmail/tail.py
+++ b/python/mirage/commands/builtin/gmail/tail.py
@@ -16,9 +16,10 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.gmail import GmailAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.gmail._provision import file_read_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gmail.glob import resolve_glob
@@ -32,23 +33,12 @@ async def tail_provision(
     accessor: GmailAccessor,
     paths: list[PathSpec],
     *texts: str,
-    index: IndexCacheStore = None,
     **_extra: object,
 ) -> ProvisionResult:
     return await file_read_provision(
-        accessor,
-        paths,
+        accessor, paths,
         "tail " + " ".join(p.original if isinstance(p, PathSpec) else p
-                           for p in paths),
-        index=index)
-
-
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
+                           for p in paths))
 
 
 @command("tail",
@@ -67,14 +57,20 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        raw = await gmail_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        data = await gmail_read(accessor, paths[0], index)
+        return generic_tail(data, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/gsheets/grep.py
+++ b/python/mirage/commands/builtin/gsheets/grep.py
@@ -13,24 +13,17 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.gsheets import GSheetsAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import (compile_pattern,
-                                                 grep_files_only, grep_lines,
-                                                 grep_stream)
+from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.builtin.gsheets._provision import file_read_provision
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gsheets.glob import resolve_glob
 from mirage.core.gsheets.read import read as gsheets_read
 from mirage.core.gsheets.readdir import readdir as _readdir
 from mirage.core.gsheets.stat import stat as _stat
-from mirage.io.stream import exit_on_empty, quiet_match, yield_bytes
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -40,14 +33,10 @@ async def grep_provision(
     accessor: GSheetsAccessor,
     paths: list[PathSpec],
     *texts: str,
-    index: IndexCacheStore = None,
     **_extra: object,
 ) -> ProvisionResult:
-    return await file_read_provision(
-        accessor,
-        paths,
-        "grep " + " ".join(texts + tuple(str(p) for p in paths)),
-        index=index)
+    rendered = "grep " + " ".join(texts + tuple(str(p) for p in paths))
+    return await file_read_provision(accessor, paths, rendered)
 
 
 @command("grep",
@@ -91,104 +80,28 @@ async def grep(
     max_count = int(m) if m is not None else None
     after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
     before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
-
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        file_prefix = paths[0].prefix if paths else ""
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        rb = partial(call_read_bytes,
-                     gsheets_read,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-
-        if args_l:
-            warnings: list[str] = []
-            results = await grep_files_only(
-                rd,
-                st,
-                rb,
-                paths[0].original,
-                pattern,
-                recursive=r or R,
-                ignore_case=i,
-                invert=v,
-                line_numbers=n,
-                count_only=c,
-                fixed_string=F,
-                only_matching=o,
-                max_count=max_count,
-                whole_word=w,
-                warnings=warnings,
-            )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            return ("\n".join(results).encode(), IOResult(stderr=stderr))
-
-        pat = compile_pattern(pattern, i, F, w)
-
-        if len(paths) > 1:
-            all_results: list[str] = []
-            for p in paths:
-                data = (await
-                        rb(p.original)).decode(errors="replace").splitlines()
-                hits = grep_lines(p.original, data, pat, v, n, c, args_l, o,
-                                  max_count)
-                if c:
-                    if hits:
-                        all_results.append(f"{p.original}:{hits[0]}")
-                elif args_l:
-                    all_results.extend(hits)
-                else:
-                    all_results.extend(f"{p.original}:{r_}" for r_ in hits)
-            if not all_results:
-                return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
-
-        data = await rb(paths[0].original)
-        source = yield_bytes(data)
-        stream = grep_stream(
-            source,
-            pat,
-            invert=v,
-            line_numbers=n,
-            only_matching=o,
-            max_count=max_count,
-            count_only=c,
-            after_context=after_ctx,
-            before_context=before_ctx,
-        )
-        if q:
-            io = IOResult(exit_code=1)
-            return quiet_match(stream, io), io
-        io = IOResult()
-        return exit_on_empty(stream, io), io
-
-    source = _resolve_source(stdin, "grep: usage: grep [flags] pattern [path]")
-    pat = compile_pattern(pattern, i, F, w)
-    stream = grep_stream(
-        source,
-        pat,
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
+    return await generic_grep(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=gsheets_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
         invert=v,
         line_numbers=n,
-        only_matching=o,
-        max_count=max_count,
         count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        quiet=q,
+        recursive=r or R,
+        max_count=max_count,
         after_context=after_ctx,
         before_context=before_ctx,
+        index=index,
     )
-    if q:
-        io = IOResult(exit_code=1)
-        return quiet_match(stream, io), io
-    io = IOResult()
-    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/gsheets/rg.py
+++ b/python/mirage/commands/builtin/gsheets/rg.py
@@ -16,42 +16,30 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.gsheets import GSheetsAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.generic.rg import rg as generic_rg
+from mirage.commands.builtin.gsheets._provision import file_read_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gsheets.glob import resolve_glob
 from mirage.core.gsheets.read import read as gsheets_read
 from mirage.core.gsheets.readdir import readdir as _readdir
+from mirage.core.gsheets.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
+from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
 
 
-async def _collect_files(
+async def rg_provision(
     accessor: GSheetsAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-) -> list[str]:
-    if path.endswith(".json") or path.endswith(".jsonl"):
-        return [path]
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    files: list[str] = []
-    for child in children:
-        if child.endswith(".json") or child.endswith(".jsonl"):
-            files.append(child)
-        else:
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            files.extend(await _collect_files(accessor, child_spec, index))
-    return files
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    rendered = "rg " + " ".join(texts + tuple(str(p) for p in paths))
+    return await file_read_provision(accessor, paths, rendered)
 
 
-@command("rg", resource="gsheets", spec=SPECS["rg"])
+@command("rg", resource="gsheets", spec=SPECS["rg"], provision=rg_provision)
 async def rg(
     accessor: GSheetsAccessor,
     paths: list[PathSpec],
@@ -78,78 +66,37 @@ async def rg(
 ) -> tuple[ByteSource | None, IOResult]:
     if not texts:
         raise ValueError("rg: usage: rg [flags] pattern [path]")
-    pattern_str = texts[0]
+    pattern = texts[0]
     max_count = int(m) if m is not None else None
-    pat = compile_pattern(pattern_str, i, F, w)
-    index = index
+    context_after = int(A) if A is not None else 0
+    context_before = int(B) if B is not None else 0
+    if C is not None:
+        context_before = context_after = int(C)
 
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        blob_paths: list[str] = []
-        file_prefix = paths[0].prefix if paths else ""
-        for path_item in paths:
-            blob_paths.extend(await _collect_files(accessor, path_item, index))
-        blob_paths = sorted(set(blob_paths))
-        all_results: list[str] = []
-        any_match = False
-        for bp in blob_paths:
-            if not hidden and any(
-                    part.startswith(".") for part in bp.split("/")):
-                continue
-            try:
-                bp_spec = PathSpec(original=bp,
-                                   directory=bp,
-                                   resolved=True,
-                                   prefix=file_prefix)
-                data = await gsheets_read(accessor, bp_spec, index)
-            except (FileNotFoundError, IsADirectoryError, RuntimeError):
-                continue
-            text = data.decode(errors="replace")
-            if not text:
-                continue
-            lines = text.splitlines()
-            matched = grep_lines(bp,
-                                 lines,
-                                 pat,
-                                 invert=v,
-                                 line_numbers=n,
-                                 count_only=c,
-                                 files_only=args_l,
-                                 only_matching=o,
-                                 max_count=max_count)
-            if not matched:
-                continue
-            any_match = True
-            if args_l:
-                all_results.append(bp)
-                continue
-            if c:
-                all_results.append(f"{bp}:{len(matched)}")
-                continue
-            for line in matched:
-                all_results.append(f"{bp}:{line}")
-        if not any_match:
-            return b"", IOResult(exit_code=1)
-        return "\n".join(all_results).encode(), IOResult()
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
 
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("rg: usage: rg [flags] pattern path")
-    lines = raw.decode(errors="replace").splitlines()
-    matched = grep_lines("<stdin>",
-                         lines,
-                         pat,
-                         invert=v,
-                         line_numbers=n,
-                         count_only=c,
-                         files_only=args_l,
-                         only_matching=o,
-                         max_count=max_count)
-    if not matched:
-        return b"", IOResult(exit_code=1)
-    if c:
-        return str(len(matched)).encode(), IOResult()
-    result_lines: list[str] = []
-    for line in matched:
-        result_lines.append(line)
-    return "\n".join(result_lines).encode(), IOResult()
+    return await generic_rg(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=gsheets_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        max_count=max_count,
+        context_before=context_before,
+        context_after=context_after,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/gsheets/tail.py
+++ b/python/mirage/commands/builtin/gsheets/tail.py
@@ -17,8 +17,8 @@ from collections.abc import AsyncIterator
 from mirage.accessor.gsheets import GSheetsAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.tail import tail as generic_tail
-from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.gsheets._provision import file_read_provision
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS

--- a/python/mirage/commands/builtin/gsheets/tail.py
+++ b/python/mirage/commands/builtin/gsheets/tail.py
@@ -16,9 +16,10 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.gsheets import GSheetsAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.gsheets._provision import file_read_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gsheets.glob import resolve_glob
@@ -32,23 +33,12 @@ async def tail_provision(
     accessor: GSheetsAccessor,
     paths: list[PathSpec],
     *texts: str,
-    index: IndexCacheStore = None,
     **_extra: object,
 ) -> ProvisionResult:
     return await file_read_provision(
-        accessor,
-        paths,
+        accessor, paths,
         "tail " + " ".join(p.original if isinstance(p, PathSpec) else p
-                           for p in paths),
-        index=index)
-
-
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
+                           for p in paths))
 
 
 @command("tail",
@@ -67,14 +57,20 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        raw = await gsheets_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        data = await gsheets_read(accessor, paths[0], index)
+        return generic_tail(data, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/gslides/grep.py
+++ b/python/mirage/commands/builtin/gslides/grep.py
@@ -13,24 +13,17 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.gslides import GSlidesAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import (compile_pattern,
-                                                 grep_files_only, grep_lines,
-                                                 grep_stream)
+from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.builtin.gslides._provision import file_read_provision
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gslides.glob import resolve_glob
 from mirage.core.gslides.read import read as gslides_read
 from mirage.core.gslides.readdir import readdir as _readdir
 from mirage.core.gslides.stat import stat as _stat
-from mirage.io.stream import exit_on_empty, quiet_match, yield_bytes
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
@@ -40,14 +33,10 @@ async def grep_provision(
     accessor: GSlidesAccessor,
     paths: list[PathSpec],
     *texts: str,
-    index: IndexCacheStore = None,
     **_extra: object,
 ) -> ProvisionResult:
-    return await file_read_provision(
-        accessor,
-        paths,
-        "grep " + " ".join(texts + tuple(str(p) for p in paths)),
-        index=index)
+    rendered = "grep " + " ".join(texts + tuple(str(p) for p in paths))
+    return await file_read_provision(accessor, paths, rendered)
 
 
 @command("grep",
@@ -91,104 +80,28 @@ async def grep(
     max_count = int(m) if m is not None else None
     after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
     before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
-
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        file_prefix = paths[0].prefix if paths else ""
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        rb = partial(call_read_bytes,
-                     gslides_read,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-
-        if args_l:
-            warnings: list[str] = []
-            results = await grep_files_only(
-                rd,
-                st,
-                rb,
-                paths[0].original,
-                pattern,
-                recursive=r or R,
-                ignore_case=i,
-                invert=v,
-                line_numbers=n,
-                count_only=c,
-                fixed_string=F,
-                only_matching=o,
-                max_count=max_count,
-                whole_word=w,
-                warnings=warnings,
-            )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            return ("\n".join(results).encode(), IOResult(stderr=stderr))
-
-        pat = compile_pattern(pattern, i, F, w)
-
-        if len(paths) > 1:
-            all_results: list[str] = []
-            for p in paths:
-                data = (await
-                        rb(p.original)).decode(errors="replace").splitlines()
-                hits = grep_lines(p.original, data, pat, v, n, c, args_l, o,
-                                  max_count)
-                if c:
-                    if hits:
-                        all_results.append(f"{p.original}:{hits[0]}")
-                elif args_l:
-                    all_results.extend(hits)
-                else:
-                    all_results.extend(f"{p.original}:{r_}" for r_ in hits)
-            if not all_results:
-                return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
-
-        data = await rb(paths[0].original)
-        source = yield_bytes(data)
-        stream = grep_stream(
-            source,
-            pat,
-            invert=v,
-            line_numbers=n,
-            only_matching=o,
-            max_count=max_count,
-            count_only=c,
-            after_context=after_ctx,
-            before_context=before_ctx,
-        )
-        if q:
-            io = IOResult(exit_code=1)
-            return quiet_match(stream, io), io
-        io = IOResult()
-        return exit_on_empty(stream, io), io
-
-    source = _resolve_source(stdin, "grep: usage: grep [flags] pattern [path]")
-    pat = compile_pattern(pattern, i, F, w)
-    stream = grep_stream(
-        source,
-        pat,
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
+    return await generic_grep(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=gslides_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
         invert=v,
         line_numbers=n,
-        only_matching=o,
-        max_count=max_count,
         count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        quiet=q,
+        recursive=r or R,
+        max_count=max_count,
         after_context=after_ctx,
         before_context=before_ctx,
+        index=index,
     )
-    if q:
-        io = IOResult(exit_code=1)
-        return quiet_match(stream, io), io
-    io = IOResult()
-    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/gslides/rg.py
+++ b/python/mirage/commands/builtin/gslides/rg.py
@@ -16,42 +16,30 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.gslides import GSlidesAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.generic.rg import rg as generic_rg
+from mirage.commands.builtin.gslides._provision import file_read_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gslides.glob import resolve_glob
 from mirage.core.gslides.read import read as gslides_read
 from mirage.core.gslides.readdir import readdir as _readdir
+from mirage.core.gslides.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
+from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
 
 
-async def _collect_files(
+async def rg_provision(
     accessor: GSlidesAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-) -> list[str]:
-    if path.endswith(".json") or path.endswith(".jsonl"):
-        return [path]
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    files: list[str] = []
-    for child in children:
-        if child.endswith(".json"):
-            files.append(child)
-        else:
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            files.extend(await _collect_files(accessor, child_spec, index))
-    return files
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    rendered = "rg " + " ".join(texts + tuple(str(p) for p in paths))
+    return await file_read_provision(accessor, paths, rendered)
 
 
-@command("rg", resource="gslides", spec=SPECS["rg"])
+@command("rg", resource="gslides", spec=SPECS["rg"], provision=rg_provision)
 async def rg(
     accessor: GSlidesAccessor,
     paths: list[PathSpec],
@@ -78,76 +66,37 @@ async def rg(
 ) -> tuple[ByteSource | None, IOResult]:
     if not texts:
         raise ValueError("rg: usage: rg [flags] pattern [path]")
-    pattern_str = texts[0]
+    pattern = texts[0]
     max_count = int(m) if m is not None else None
-    pat = compile_pattern(pattern_str, i, F, w)
-    index = index
+    context_after = int(A) if A is not None else 0
+    context_before = int(B) if B is not None else 0
+    if C is not None:
+        context_before = context_after = int(C)
 
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        blob_paths: list[str] = []
-        file_prefix = paths[0].prefix if paths else ""
-        for path_item in paths:
-            blob_paths.extend(await _collect_files(accessor, path_item, index))
-        blob_paths = sorted(set(blob_paths))
-        all_results: list[str] = []
-        any_match = False
-        for bp in blob_paths:
-            if not hidden and any(
-                    part.startswith(".") for part in bp.split("/")):
-                continue
-            try:
-                bp_spec = PathSpec(original=bp,
-                                   directory=bp,
-                                   resolved=True,
-                                   prefix=file_prefix)
-                data = await gslides_read(accessor, bp_spec, index)
-            except (FileNotFoundError, IsADirectoryError):
-                continue
-            text = data.decode(errors="replace")
-            lines = text.splitlines()
-            matched = grep_lines(bp,
-                                 lines,
-                                 pat,
-                                 invert=v,
-                                 line_numbers=n,
-                                 count_only=c,
-                                 files_only=args_l,
-                                 only_matching=o,
-                                 max_count=max_count)
-            if not matched:
-                continue
-            any_match = True
-            if args_l:
-                all_results.append(bp)
-                continue
-            if c:
-                all_results.append(f"{bp}:{len(matched)}")
-                continue
-            for line in matched:
-                all_results.append(f"{bp}:{line}")
-        if not any_match:
-            return b"", IOResult(exit_code=1)
-        return "\n".join(all_results).encode(), IOResult()
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
 
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("rg: usage: rg [flags] pattern path")
-    lines = raw.decode(errors="replace").splitlines()
-    matched = grep_lines("<stdin>",
-                         lines,
-                         pat,
-                         invert=v,
-                         line_numbers=n,
-                         count_only=c,
-                         files_only=args_l,
-                         only_matching=o,
-                         max_count=max_count)
-    if not matched:
-        return b"", IOResult(exit_code=1)
-    if c:
-        return str(len(matched)).encode(), IOResult()
-    result_lines: list[str] = []
-    for line in matched:
-        result_lines.append(line)
-    return "\n".join(result_lines).encode(), IOResult()
+    return await generic_rg(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=gslides_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        max_count=max_count,
+        context_before=context_before,
+        context_after=context_after,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/gslides/tail.py
+++ b/python/mirage/commands/builtin/gslides/tail.py
@@ -16,9 +16,10 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.gslides import GSlidesAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.gslides._provision import file_read_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gslides.glob import resolve_glob
@@ -32,23 +33,12 @@ async def tail_provision(
     accessor: GSlidesAccessor,
     paths: list[PathSpec],
     *texts: str,
-    index: IndexCacheStore = None,
     **_extra: object,
 ) -> ProvisionResult:
     return await file_read_provision(
-        accessor,
-        paths,
+        accessor, paths,
         "tail " + " ".join(p.original if isinstance(p, PathSpec) else p
-                           for p in paths),
-        index=index)
-
-
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
+                           for p in paths))
 
 
 @command("tail",
@@ -67,14 +57,20 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        raw = await gslides_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        data = await gslides_read(accessor, paths[0], index)
+        return generic_tail(data, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/gslides/tail.py
+++ b/python/mirage/commands/builtin/gslides/tail.py
@@ -17,8 +17,8 @@ from collections.abc import AsyncIterator
 from mirage.accessor.gslides import GSlidesAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.tail import tail as generic_tail
-from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.gslides._provision import file_read_provision
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS

--- a/python/mirage/commands/builtin/langfuse/tail.py
+++ b/python/mirage/commands/builtin/langfuse/tail.py
@@ -16,9 +16,10 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.langfuse import LangfuseAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.langfuse._provision import file_read_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.langfuse.glob import resolve_glob
@@ -40,14 +41,6 @@ async def tail_provision(
                            for p in paths))
 
 
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
-
-
 @command("tail",
          resource="langfuse",
          spec=SPECS["tail"],
@@ -64,14 +57,20 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
-        paths = await resolve_glob(accessor, paths, index=index)
-        p = paths[0]
-        raw = await langfuse_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        paths = await resolve_glob(accessor, paths, index)
+        data = await langfuse_read(accessor, paths[0], index)
+        return generic_tail(data, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/langfuse/tail.py
+++ b/python/mirage/commands/builtin/langfuse/tail.py
@@ -17,8 +17,8 @@ from collections.abc import AsyncIterator
 from mirage.accessor.langfuse import LangfuseAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.tail import tail as generic_tail
-from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.langfuse._provision import file_read_provision
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS

--- a/python/mirage/commands/builtin/linear/grep.py
+++ b/python/mirage/commands/builtin/linear/grep.py
@@ -13,28 +13,21 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.linear import LinearAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import (compile_pattern,
-                                                 grep_files_only,
-                                                 grep_recursive, grep_stream)
+from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.builtin.linear._provision import file_read_provision
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.linear.glob import resolve_glob
-from mirage.core.linear.read import read as linear_read
+from mirage.core.linear.read import read as _read
 from mirage.core.linear.readdir import readdir as _readdir
 from mirage.core.linear.scope import scope_warning
 from mirage.core.linear.stat import stat as _stat
-from mirage.io.stream import exit_on_empty, quiet_match, yield_bytes
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileType, PathSpec
+from mirage.types import PathSpec
 
 
 async def grep_provision(
@@ -88,119 +81,29 @@ async def grep(
     max_count = int(m) if m is not None else None
     after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
     before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
-
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        file_prefix = paths[0].prefix if paths else ""
-        warnings: list[str] = []
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        rb = partial(call_read_bytes,
-                     linear_read,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        recursive = r or R
-        if isinstance(paths[0], PathSpec) and not paths[0].resolved:
-            warning = await scope_warning(rd, st, paths[0], recursive)
-            if warning:
-                warnings.append(warning)
-        if args_l:
-            results = await grep_files_only(
-                rd,
-                st,
-                rb,
-                paths[0].original,
-                pattern,
-                recursive=recursive,
-                ignore_case=i,
-                invert=v,
-                line_numbers=n,
-                count_only=c,
-                fixed_string=F,
-                only_matching=o,
-                max_count=max_count,
-                whole_word=w,
-                warnings=warnings,
-            )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            if prefix:
-                results = [prefix + "/" + item.lstrip("/") for item in results]
-            return "\n".join(results).encode(), IOResult(stderr=stderr)
-
-        pat = compile_pattern(pattern, i, F, w)
-        target = paths[0].original
-        file_stat = await st(target)
-        if file_stat.type == FileType.DIRECTORY:
-            if not recursive:
-                return (b"",
-                        IOResult(
-                            exit_code=1,
-                            stderr=f"grep: {target}: Is a directory".encode()))
-            results = await grep_recursive(
-                rd,
-                st,
-                rb,
-                target,
-                pat,
-                invert=v,
-                line_numbers=n,
-                count_only=c,
-                files_only=False,
-                only_matching=o,
-                max_count=max_count,
-                warnings=warnings,
-            )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            return "\n".join(results).encode(), IOResult(stderr=stderr)
-
-        data = await rb(target)
-        source = yield_bytes(data)
-        stream = grep_stream(
-            source,
-            pat,
-            invert=v,
-            line_numbers=n,
-            only_matching=o,
-            max_count=max_count,
-            count_only=c,
-            after_context=after_ctx,
-            before_context=before_ctx,
-        )
-        if q:
-            io = IOResult(exit_code=1)
-            return quiet_match(stream, io), io
-        io = IOResult(
-            stderr="\n".join(warnings).encode() if warnings else None)
-        return exit_on_empty(stream, io), io
-
-    source = _resolve_source(stdin, "grep: usage: grep [flags] pattern [path]")
-    pat = compile_pattern(pattern, i, F, w)
-    stream = grep_stream(
-        source,
-        pat,
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
+    return await generic_grep(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
         invert=v,
         line_numbers=n,
-        only_matching=o,
-        max_count=max_count,
         count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        quiet=q,
+        recursive=r or R,
+        max_count=max_count,
         after_context=after_ctx,
         before_context=before_ctx,
+        scope_check=scope_warning,
+        index=index,
     )
-    if q:
-        io = IOResult(exit_code=1)
-        return quiet_match(stream, io), io
-    io = IOResult()
-    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/linear/rg.py
+++ b/python/mirage/commands/builtin/linear/rg.py
@@ -13,17 +13,11 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.linear import LinearAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.linear._provision import file_read_provision
-from mirage.commands.builtin.rg_helper import (compile_pattern, rg_folder,
-                                               rg_matches_filter,
-                                               rg_search_file)
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.linear.glob import resolve_glob
@@ -31,10 +25,9 @@ from mirage.core.linear.read import read as linear_read
 from mirage.core.linear.readdir import readdir as _readdir
 from mirage.core.linear.scope import scope_warning
 from mirage.core.linear.stat import stat as _stat
-from mirage.io.stream import exit_on_empty
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileType, PathSpec
+from mirage.types import PathSpec
 
 
 async def rg_provision(
@@ -80,120 +73,32 @@ async def rg(
     context_before = int(B) if B is not None else 0
     if C is not None:
         context_before = context_after = int(C)
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        file_prefix = paths[0].prefix if paths else ""
-        warnings: list[str] = []
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        rb = partial(call_read_bytes,
-                     linear_read,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        if isinstance(paths[0], PathSpec) and not paths[0].resolved:
-            warning = await scope_warning(rd, st, paths[0], True)
-            if warning:
-                warnings.append(warning)
-        target = paths[0].original
-        file_stat = await st(target)
-        compiled = compile_pattern(pattern, i, F, w)
-        if file_stat.type == FileType.DIRECTORY:
-            results = await rg_folder(
-                rd,
-                st,
-                rb,
-                target,
-                pattern,
-                i,
-                v,
-                n,
-                c,
-                args_l,
-                o,
-                max_count,
-                F,
-                w,
-                type,
-                glob,
-                hidden,
-                warnings,
-            )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            if prefix and args_l:
-                results = [prefix + "/" + item.lstrip("/") for item in results]
-            return "\n".join(results).encode(), IOResult(stderr=stderr)
-        if not rg_matches_filter(target, type, glob, hidden):
-            return b"", IOResult(exit_code=1)
-        raw = await rb(target)
-        results = rg_search_file(
-            lambda _: raw,
-            target,
-            compiled,
-            v,
-            n,
-            c,
-            args_l,
-            o,
-            max_count,
-            context_before,
-            context_after,
-            False,
-            warnings,
-        )
-        stderr = ("\n".join(warnings).encode() if warnings else None)
-        if not results:
-            return b"", IOResult(exit_code=1, stderr=stderr)
-        return "\n".join(results).encode(), IOResult(stderr=stderr)
 
-    return await grep_stdin(texts[0],
-                            stdin,
-                            i=i,
-                            v=v,
-                            n=n,
-                            c=c,
-                            w=w,
-                            F=F,
-                            o=o,
-                            m=m)
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
 
-
-async def grep_stdin(
-    pattern: str,
-    stdin: AsyncIterator[bytes] | bytes | None,
-    *,
-    i: bool,
-    v: bool,
-    n: bool,
-    c: bool,
-    w: bool,
-    F: bool,
-    o: bool,
-    m: str | None,
-) -> tuple[ByteSource | None, IOResult]:
-    from mirage.commands.builtin.general.grep import _grep_stream
-
-    source = _resolve_source(stdin, "rg: usage: rg [flags] pattern path")
-    compiled = compile_pattern(pattern, i, F, w)
-    max_count = int(m) if m is not None else None
-    stream = _grep_stream(
-        source,
-        compiled,
+    return await generic_rg(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=linear_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
         invert=v,
         line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
         only_matching=o,
         max_count=max_count,
-        count_only=c,
+        context_before=context_before,
+        context_after=context_after,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        scope_check=scope_warning,
+        index=index,
     )
-    io = IOResult()
-    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/linear/tail.py
+++ b/python/mirage/commands/builtin/linear/tail.py
@@ -17,8 +17,8 @@ from collections.abc import AsyncIterator
 from mirage.accessor.linear import LinearAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.tail import tail as generic_tail
-from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.linear._provision import file_read_provision
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS

--- a/python/mirage/commands/builtin/linear/tail.py
+++ b/python/mirage/commands/builtin/linear/tail.py
@@ -16,9 +16,10 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.linear import LinearAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.linear._provision import file_read_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.linear.glob import resolve_glob
@@ -40,14 +41,6 @@ async def tail_provision(
                            for p in paths))
 
 
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
-
-
 @command("tail",
          resource="linear",
          spec=SPECS["tail"],
@@ -64,14 +57,20 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        raw = await linear_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        data = await linear_read(accessor, paths[0], index)
+        return generic_tail(data, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/mongodb/tail.py
+++ b/python/mirage/commands/builtin/mongodb/tail.py
@@ -16,9 +16,10 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
 from mirage.commands.builtin.mongodb._provision import file_read_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.tail_helper import _parse_n
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.mongodb.glob import resolve_glob
@@ -43,14 +44,6 @@ async def tail_provision(
                            for p in paths))
 
 
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
-
-
 @command("tail",
          resource="mongodb",
          spec=SPECS["tail"],
@@ -68,16 +61,23 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index=index)
         p = paths[0]
         if f and detect_scope(p).level == ScopeLevel.DOCUMENTS:
             return watch_stream(accessor, p, index), IOResult()
         raw = await mongodb_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        return generic_tail(raw, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/postgres/tail.py
+++ b/python/mirage/commands/builtin/postgres/tail.py
@@ -18,9 +18,10 @@ import orjson
 
 from mirage.accessor.postgres import PostgresAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
 from mirage.commands.builtin.postgres._provision import file_read_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.tail_helper import _parse_n
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.postgres import _client
@@ -44,14 +45,6 @@ async def tail_provision(
                            for p in paths))
 
 
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
-
-
 @command("tail",
          resource="postgres",
          spec=SPECS["tail"],
@@ -68,13 +61,20 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
         scope = detect_scope(paths[0])
         is_file = scope.level == "entity_rows"
-        if is_file and not bytes_mode:
-            limit = min(lines, accessor.config.default_row_limit)
+        if is_file and c_int is None and n_int is not None:
+            limit = min(n_int, accessor.config.default_row_limit)
             pool = await accessor.pool()
             async with pool.acquire() as conn:
                 total = await _client.count_rows(conn, scope.schema,
@@ -86,17 +86,17 @@ async def tail(
                                                 limit=limit,
                                                 offset=offset)
             if not rows:
-                return _tail_result(b"", lines, plus_mode, None), IOResult()
+                return generic_tail(b"", n=n_int, c=c_int,
+                                    from_line=from_line), IOResult()
             jsonl = "\n".join(
                 orjson.dumps(r, default=str).decode() for r in rows) + "\n"
-            return _tail_result(jsonl.encode(), lines, plus_mode,
-                                None), IOResult()
+            return generic_tail(jsonl.encode(), n=n_int, c=c_int,
+                                from_line=from_line), IOResult()
 
         paths = await resolve_glob(accessor, paths, index=index)
-        p = paths[0]
-        raw = await postgres_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        raw = await postgres_read(accessor, paths[0], index)
+        return generic_tail(raw, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/postgres/tail.py
+++ b/python/mirage/commands/builtin/postgres/tail.py
@@ -90,7 +90,9 @@ async def tail(
                                     from_line=from_line), IOResult()
             jsonl = "\n".join(
                 orjson.dumps(r, default=str).decode() for r in rows) + "\n"
-            return generic_tail(jsonl.encode(), n=n_int, c=c_int,
+            return generic_tail(jsonl.encode(),
+                                n=n_int,
+                                c=c_int,
                                 from_line=from_line), IOResult()
 
         paths = await resolve_glob(accessor, paths, index=index)

--- a/python/mirage/commands/builtin/s3/grep.py
+++ b/python/mirage/commands/builtin/s3/grep.py
@@ -13,72 +13,31 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import (compile_pattern,
-                                                 grep_files_only, grep_lines,
-                                                 grep_recursive, grep_stream)
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
+from mirage.commands.builtin.generic.grep import grep as generic_grep
+from mirage.commands.builtin.s3._provision import file_read_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.s3.glob import resolve_glob
 from mirage.core.s3.read import read_bytes as _read_bytes
 from mirage.core.s3.readdir import readdir as _readdir
 from mirage.core.s3.stat import stat as _stat
-from mirage.core.s3.stream import read_stream
-from mirage.io.stream import exit_on_empty, quiet_match
+from mirage.core.s3.stream import read_stream as _read_stream
 from mirage.io.types import ByteSource, IOResult
-from mirage.provision import ProvisionResult
-from mirage.types import FileType, PathSpec
+from mirage.provision.types import ProvisionResult
+from mirage.types import PathSpec
 
 
 async def grep_provision(
     accessor: S3Accessor,
     paths: list[PathSpec],
     *texts: str,
-    r: bool = False,
-    R: bool = False,
-    index: IndexCacheStore = None,
     **_extra: object,
 ) -> ProvisionResult:
-    if not paths or accessor is None:
-        return ProvisionResult(command="grep " + " ".join(texts))
-    if not (r or R):
-        paths = await resolve_glob(accessor, paths, index)
-    if r or R:
-        mount_prefix = paths[0].prefix if paths else ""
-        entries = await _readdir(accessor, paths[0], index)
-        total = 0
-        ops = 0
-        for entry in entries:
-            try:
-                e_spec = PathSpec(original=entry,
-                                  directory=entry,
-                                  resolved=False,
-                                  prefix=mount_prefix)
-                s = await _stat(accessor, e_spec)
-                if s.size is not None:
-                    total += s.size
-                    ops += 1
-            except FileNotFoundError:
-                continue
-        return ProvisionResult(
-            command=f"grep -r {texts[0] if texts else ''} {paths[0].original}",
-            network_read_low=total,
-            network_read_high=total,
-            read_ops=ops,
-        )
-    s = await _stat(accessor, paths[0])
-    return ProvisionResult(
-        command=f"grep {texts[0] if texts else ''} {paths[0].original}",
-        network_read_low=s.size or 0,
-        network_read_high=s.size or 0,
-        read_ops=1,
-    )
+    rendered = "grep " + " ".join(texts + tuple(str(p) for p in paths))
+    return await file_read_provision(accessor, paths, rendered)
 
 
 @command("grep", resource="s3", spec=SPECS["grep"], provision=grep_provision)
@@ -119,141 +78,28 @@ async def grep(
     max_count = int(m) if m is not None else None
     after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
     before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
-
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        mount_prefix = paths[0].prefix if paths else ""
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-        rb = partial(call_read_bytes,
-                     _read_bytes,
-                     accessor,
-                     prefix=mount_prefix)
-
-        if args_l:
-            warnings_l: list[str] = []
-            results = await grep_files_only(
-                rd,
-                st,
-                rb,
-                paths[0].original,
-                pattern,
-                recursive=r or R,
-                ignore_case=i,
-                invert=v,
-                line_numbers=n,
-                count_only=c,
-                fixed_string=F,
-                only_matching=o,
-                max_count=max_count,
-                whole_word=w,
-                warnings=warnings_l,
-            )
-            stderr = "\n".join(warnings_l).encode() if warnings_l else None
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            return "\n".join(results).encode(), IOResult(stderr=stderr)
-
-        if r or R:
-            pat = compile_pattern(pattern, i, F, w)
-            all_results: list[str] = []
-            warnings_r: list[str] = []
-            for p in paths:
-                s = await _stat(accessor, p)
-                if s.type == FileType.DIRECTORY:
-                    res = await grep_recursive(
-                        rd,
-                        st,
-                        rb,
-                        p.original,
-                        pat,
-                        invert=v,
-                        line_numbers=n,
-                        count_only=c,
-                        files_only=False,
-                        only_matching=o,
-                        max_count=max_count,
-                        warnings=warnings_r,
-                        read_stream_fn=None,
-                    )
-                    all_results.extend(res)
-                else:
-                    data = (await _read_bytes(
-                        accessor, p)).decode(errors="replace").splitlines()
-                    hits = grep_lines(p, data, pat, v, n, c, args_l, o,
-                                      max_count)
-                    if c and hits:
-                        all_results.append(f"{p.original}:{hits[0]}")
-                    else:
-                        all_results.extend(
-                            f"{p.original}:{rl}" if len(paths) > 1 else rl
-                            for rl in hits)
-            stderr = ("\n".join(warnings_r).encode() if warnings_r else None)
-            if not all_results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            return "\n".join(all_results).encode(), IOResult(stderr=stderr)
-
-        pat = compile_pattern(pattern, i, F, w)
-
-        if len(paths) > 1:
-            all_results: list[str] = []
-            for p in paths:
-                data = (await
-                        _read_bytes(accessor,
-                                    p)).decode(errors="replace").splitlines()
-                hits = grep_lines(p, data, pat, v, n, c, args_l, o, max_count)
-                if c:
-                    if hits:
-                        all_results.append(f"{p.original}:{hits[0]}")
-                elif args_l:
-                    all_results.extend(hits)
-                else:
-                    all_results.extend(f"{p.original}:{r}" for r in hits)
-            if not all_results:
-                return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
-
-        source = read_stream(accessor, paths[0])
-        stream = grep_stream(
-            source,
-            pat,
-            invert=v,
-            line_numbers=n,
-            only_matching=o,
-            max_count=max_count,
-            count_only=c,
-            after_context=after_ctx,
-            before_context=before_ctx,
-        )
-        if q:
-            io = IOResult(exit_code=1)
-            return quiet_match(stream, io), io
-        io = IOResult()
-        return exit_on_empty(stream, io), io
-
-    source = _resolve_source(stdin, "grep: usage: grep [flags] pattern [path]")
-    pat = compile_pattern(pattern, i, F, w)
-    stream = grep_stream(
-        source,
-        pat,
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
+    return await generic_grep(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=_read_bytes,
+        read_stream=_read_stream,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
         invert=v,
         line_numbers=n,
-        only_matching=o,
-        max_count=max_count,
         count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        quiet=q,
+        recursive=r or R,
+        max_count=max_count,
         after_context=after_ctx,
         before_context=before_ctx,
+        index=index,
     )
-    if q:
-        io = IOResult(exit_code=1)
-        return quiet_match(stream, io), io
-    io = IOResult()
-    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/s3/rg.py
+++ b/python/mirage/commands/builtin/s3/rg.py
@@ -13,29 +13,34 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import (compile_pattern, grep_lines,
-                                                 grep_stream)
-from mirage.commands.builtin.rg_helper import rg_full
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
+from mirage.commands.builtin.generic.rg import rg as generic_rg
+from mirage.commands.builtin.s3._provision import file_read_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.s3.glob import resolve_glob
 from mirage.core.s3.read import read_bytes as _read_bytes
 from mirage.core.s3.readdir import readdir as _readdir
 from mirage.core.s3.stat import stat as _stat
-from mirage.core.s3.stream import read_stream
-from mirage.io.stream import exit_on_empty
+from mirage.core.s3.stream import read_stream as _read_stream
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
+from mirage.provision.types import ProvisionResult
+from mirage.types import PathSpec
 
 
-@command("rg", resource="s3", spec=SPECS["rg"])
+async def rg_provision(
+    accessor: S3Accessor,
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    rendered = "rg " + " ".join(texts + tuple(str(p) for p in paths))
+    return await file_read_provision(accessor, paths, rendered)
+
+
+@command("rg", resource="s3", spec=SPECS["rg"], provision=rg_provision)
 async def rg(
     accessor: S3Accessor,
     paths: list[PathSpec],
@@ -69,109 +74,30 @@ async def rg(
     if C is not None:
         context_before = context_after = int(C)
 
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        mount_prefix = paths[0].prefix if paths else ""
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-        rb = partial(call_read_bytes,
-                     _read_bytes,
-                     accessor,
-                     prefix=mount_prefix)
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
 
-        is_dir = False
-        try:
-            s = await _stat(accessor, paths[0])
-            is_dir = s.type == FileType.DIRECTORY
-        except (FileNotFoundError, ValueError):
-            try:
-                await _readdir(accessor, paths[0], index)
-            except (FileNotFoundError, ValueError):
-                pass
-
-        needs_full = (is_dir or args_l or context_before or context_after
-                      or type or glob)
-        if needs_full:
-            warnings_f: list[str] = []
-            results = await rg_full(
-                rd,
-                st,
-                rb,
-                paths[0].original,
-                pattern,
-                ignore_case=i,
-                invert=v,
-                line_numbers=n,
-                count_only=c,
-                files_only=args_l,
-                fixed_string=F,
-                only_matching=o,
-                max_count=max_count,
-                whole_word=w,
-                context_before=context_before,
-                context_after=context_after,
-                file_type=type,
-                glob_pattern=glob,
-                hidden=hidden,
-                warnings=warnings_f,
-            )
-            stderr = "\n".join(warnings_f).encode() if warnings_f else None
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            return "\n".join(results).encode(), IOResult(stderr=stderr)
-
-        pat = compile_pattern(pattern, i, F, w)
-
-        if len(paths) > 1:
-            all_results: list[str] = []
-            for p in paths:
-                data = (await
-                        _read_bytes(accessor,
-                                    p)).decode(errors="replace").splitlines()
-                hits = grep_lines(p.original, data, pat, v, n, c, args_l, o,
-                                  max_count)
-                if c:
-                    if hits:
-                        all_results.append(f"{p.original}:{hits[0]}")
-                elif args_l:
-                    all_results.extend(hits)
-                else:
-                    all_results.extend(f"{p.original}:{r}" for r in hits)
-            if not all_results:
-                return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
-
-        source = read_stream(accessor, paths[0])
-        stream = grep_stream(
-            source,
-            pat,
-            invert=v,
-            line_numbers=n,
-            only_matching=o,
-            max_count=max_count,
-            count_only=c,
-        )
-        io = IOResult()
-        return exit_on_empty(stream, io), io
-
-    source = _resolve_source(stdin, "rg: usage: rg [flags] pattern path")
-    pat = compile_pattern(pattern, i, F, w)
-    stream = grep_stream(
-        source,
-        pat,
+    return await generic_rg(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=_read_bytes,
+        read_stream=_read_stream,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
         invert=v,
         line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
         only_matching=o,
         max_count=max_count,
-        count_only=c,
+        context_before=context_before,
+        context_after=context_after,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
     )
-    io = IOResult()
-    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/s3/tail.py
+++ b/python/mirage/commands/builtin/s3/tail.py
@@ -16,9 +16,10 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
 from mirage.commands.builtin.s3._provision import head_tail_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.tail_helper import _parse_n
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.s3.glob import resolve_glob
@@ -43,22 +44,26 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index)
         raw = await read_bytes(accessor, paths[0])
-        if bytes_mode is not None:
-            result = raw[-bytes_mode:] if bytes_mode else b""
-            should_cache = bytes_mode >= len(raw)
+        if c_int is not None:
+            should_cache = c_int >= len(raw)
         else:
-            result = tail_bytes(raw, lines, plus_mode=plus_mode)
-            should_cache = not plus_mode and lines >= raw.count(b"\n")
+            should_cache = (from_line is None and n_int is not None
+                            and n_int >= raw.count(b"\n"))
         cache = [paths[0].original] if should_cache else []
-        return result, IOResult(cache=cache)
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    if bytes_mode is not None:
-        return raw[-bytes_mode:], IOResult()
-    return tail_bytes(raw, lines, plus_mode=plus_mode), IOResult()
+        return generic_tail(raw, n=n_int, c=c_int,
+                            from_line=from_line), IOResult(cache=cache)
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/slack/tail.py
+++ b/python/mirage/commands/builtin/slack/tail.py
@@ -16,9 +16,10 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.slack import SlackAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.slack._provision import file_read_provision
-from mirage.commands.builtin.tail_helper import _parse_n, tail_bytes
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.slack.glob import resolve_glob
@@ -40,14 +41,6 @@ async def tail_provision(
                            for p in paths))
 
 
-async def _tail_result(raw: bytes, lines: int, plus_mode: bool,
-                       bytes_mode: int | None) -> AsyncIterator[bytes]:
-    if bytes_mode is not None:
-        yield raw[-bytes_mode:] if bytes_mode else b""
-        return
-    yield tail_bytes(raw, lines, plus_mode=plus_mode)
-
-
 @command("tail",
          resource="slack",
          spec=SPECS["tail"],
@@ -64,14 +57,20 @@ async def tail(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    lines, plus_mode = _parse_n(n)
-    bytes_mode = int(c) if c is not None else None
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        raw = await slack_read(accessor, p, index)
-        return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("tail: missing operand")
-    return _tail_result(raw, lines, plus_mode, bytes_mode), IOResult()
+        data = await slack_read(accessor, paths[0], index)
+        return generic_tail(data, n=n_int, c=c_int,
+                            from_line=from_line), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/slack/tail.py
+++ b/python/mirage/commands/builtin/slack/tail.py
@@ -17,8 +17,8 @@ from collections.abc import AsyncIterator
 from mirage.accessor.slack import SlackAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.tail import tail as generic_tail
-from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.slack._provision import file_read_provision
+from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS

--- a/python/mirage/commands/builtin/trello/grep.py
+++ b/python/mirage/commands/builtin/trello/grep.py
@@ -13,17 +13,11 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.trello import TrelloAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import (compile_pattern,
-                                                 grep_files_only,
-                                                 grep_recursive, grep_stream)
+from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.builtin.trello._provision import file_read_provision
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.trello.glob import resolve_glob
@@ -31,10 +25,9 @@ from mirage.core.trello.read import read as trello_read
 from mirage.core.trello.readdir import readdir as _readdir
 from mirage.core.trello.scope import scope_warning
 from mirage.core.trello.stat import stat as _stat
-from mirage.io.stream import exit_on_empty, quiet_match, yield_bytes
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileType, PathSpec
+from mirage.types import PathSpec
 
 
 async def grep_provision(
@@ -88,119 +81,29 @@ async def grep(
     max_count = int(m) if m is not None else None
     after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
     before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
-
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        file_prefix = paths[0].prefix if paths else ""
-        warnings: list[str] = []
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        rb = partial(call_read_bytes,
-                     trello_read,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        recursive = r or R
-        if isinstance(paths[0], PathSpec) and not paths[0].resolved:
-            warning = await scope_warning(rd, st, paths[0], recursive)
-            if warning:
-                warnings.append(warning)
-        if args_l:
-            results = await grep_files_only(
-                rd,
-                st,
-                rb,
-                paths[0].original,
-                pattern,
-                recursive=recursive,
-                ignore_case=i,
-                invert=v,
-                line_numbers=n,
-                count_only=c,
-                fixed_string=F,
-                only_matching=o,
-                max_count=max_count,
-                whole_word=w,
-                warnings=warnings,
-            )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            if prefix:
-                results = [prefix + "/" + item.lstrip("/") for item in results]
-            return "\n".join(results).encode(), IOResult(stderr=stderr)
-
-        pat = compile_pattern(pattern, i, F, w)
-        target = paths[0].original
-        file_stat = await st(target)
-        if file_stat.type == FileType.DIRECTORY:
-            if not recursive:
-                return (b"",
-                        IOResult(
-                            exit_code=1,
-                            stderr=f"grep: {target}: Is a directory".encode()))
-            results = await grep_recursive(
-                rd,
-                st,
-                rb,
-                target,
-                pat,
-                invert=v,
-                line_numbers=n,
-                count_only=c,
-                files_only=False,
-                only_matching=o,
-                max_count=max_count,
-                warnings=warnings,
-            )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            return "\n".join(results).encode(), IOResult(stderr=stderr)
-
-        data = await rb(target)
-        source = yield_bytes(data)
-        stream = grep_stream(
-            source,
-            pat,
-            invert=v,
-            line_numbers=n,
-            only_matching=o,
-            max_count=max_count,
-            count_only=c,
-            after_context=after_ctx,
-            before_context=before_ctx,
-        )
-        if q:
-            io = IOResult(exit_code=1)
-            return quiet_match(stream, io), io
-        io = IOResult(
-            stderr="\n".join(warnings).encode() if warnings else None)
-        return exit_on_empty(stream, io), io
-
-    source = _resolve_source(stdin, "grep: usage: grep [flags] pattern [path]")
-    pat = compile_pattern(pattern, i, F, w)
-    stream = grep_stream(
-        source,
-        pat,
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
+    return await generic_grep(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=trello_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
         invert=v,
         line_numbers=n,
-        only_matching=o,
-        max_count=max_count,
         count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        quiet=q,
+        recursive=r or R,
+        max_count=max_count,
         after_context=after_ctx,
         before_context=before_ctx,
+        scope_check=scope_warning,
+        index=index,
     )
-    if q:
-        io = IOResult(exit_code=1)
-        return quiet_match(stream, io), io
-    io = IOResult()
-    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/trello/rg.py
+++ b/python/mirage/commands/builtin/trello/rg.py
@@ -13,17 +13,11 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.trello import TrelloAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.rg_helper import (compile_pattern, rg_folder,
-                                               rg_matches_filter,
-                                               rg_search_file)
+from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.trello._provision import file_read_provision
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.trello.glob import resolve_glob
@@ -31,10 +25,9 @@ from mirage.core.trello.read import read as trello_read
 from mirage.core.trello.readdir import readdir as _readdir
 from mirage.core.trello.scope import scope_warning
 from mirage.core.trello.stat import stat as _stat
-from mirage.io.stream import exit_on_empty
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
-from mirage.types import FileType, PathSpec
+from mirage.types import PathSpec
 
 
 async def rg_provision(
@@ -80,120 +73,32 @@ async def rg(
     context_before = int(B) if B is not None else 0
     if C is not None:
         context_before = context_after = int(C)
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        file_prefix = paths[0].prefix if paths else ""
-        warnings: list[str] = []
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        rb = partial(call_read_bytes,
-                     trello_read,
-                     accessor,
-                     index=index,
-                     prefix=file_prefix)
-        if isinstance(paths[0], PathSpec) and not paths[0].resolved:
-            warning = await scope_warning(rd, st, paths[0], True)
-            if warning:
-                warnings.append(warning)
-        target = paths[0].original
-        file_stat = await st(target)
-        compiled = compile_pattern(pattern, i, F, w)
-        if file_stat.type == FileType.DIRECTORY:
-            results = await rg_folder(
-                rd,
-                st,
-                rb,
-                target,
-                pattern,
-                i,
-                v,
-                n,
-                c,
-                args_l,
-                o,
-                max_count,
-                F,
-                w,
-                type,
-                glob,
-                hidden,
-                warnings,
-            )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            if prefix and args_l:
-                results = [prefix + "/" + item.lstrip("/") for item in results]
-            return "\n".join(results).encode(), IOResult(stderr=stderr)
-        if not rg_matches_filter(target, type, glob, hidden):
-            return b"", IOResult(exit_code=1)
-        raw = await rb(target)
-        results = rg_search_file(
-            lambda _: raw,
-            target,
-            compiled,
-            v,
-            n,
-            c,
-            args_l,
-            o,
-            max_count,
-            context_before,
-            context_after,
-            False,
-            warnings,
-        )
-        stderr = ("\n".join(warnings).encode() if warnings else None)
-        if not results:
-            return b"", IOResult(exit_code=1, stderr=stderr)
-        return "\n".join(results).encode(), IOResult(stderr=stderr)
 
-    return await grep_stdin(texts[0],
-                            stdin,
-                            i=i,
-                            v=v,
-                            n=n,
-                            c=c,
-                            w=w,
-                            F=F,
-                            o=o,
-                            m=m)
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
 
-
-async def grep_stdin(
-    pattern: str,
-    stdin: AsyncIterator[bytes] | bytes | None,
-    *,
-    i: bool,
-    v: bool,
-    n: bool,
-    c: bool,
-    w: bool,
-    F: bool,
-    o: bool,
-    m: str | None,
-) -> tuple[ByteSource | None, IOResult]:
-    from mirage.commands.builtin.general.grep import _grep_stream
-
-    source = _resolve_source(stdin, "rg: usage: rg [flags] pattern path")
-    compiled = compile_pattern(pattern, i, F, w)
-    max_count = int(m) if m is not None else None
-    stream = _grep_stream(
-        source,
-        compiled,
+    return await generic_rg(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=trello_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
         invert=v,
         line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
         only_matching=o,
         max_count=max_count,
-        count_only=c,
+        context_before=context_before,
+        context_after=context_after,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        scope_check=scope_warning,
+        index=index,
     )
-    io = IOResult()
-    return exit_on_empty(stream, io), io

--- a/python/tests/commands/builtin/generic/test_grep.py
+++ b/python/tests/commands/builtin/generic/test_grep.py
@@ -229,3 +229,122 @@ async def test_grep_files_only_lists_matching_files():
     decoded = (await _drain_async(output)).decode()
     assert "/dir/a.txt" in decoded
     assert "/dir/b.txt" not in decoded
+
+
+def _make_prefixed_backend(files: dict[str, bytes], mount_prefix: str):
+    """Backend that mimics real s3/disk/gdrive readdir: entries returned
+    are already prepended with ``mount_prefix``. Also raises if ``index``
+    is not threaded through (gdrive-style)."""
+
+    full_files = {mount_prefix + k: v for k, v in files.items()}
+    inferred_dirs: set[str] = {mount_prefix or "/"}
+    for f in full_files:
+        parts = f.split("/")
+        for i in range(1, len(parts)):
+            d = "/".join(parts[:i]) or "/"
+            inferred_dirs.add(d)
+
+    def _full(p: str) -> str:
+        if mount_prefix and not p.startswith(mount_prefix):
+            return mount_prefix + p
+        return p
+
+    async def readdir(accessor, path, index=None):
+        if index is None:
+            raise FileNotFoundError("index required")
+        spec = path if isinstance(path, PathSpec) else PathSpec(original=path,
+                                                                directory=path)
+        p = _full(spec.original).rstrip("/") or "/"
+        if p not in inferred_dirs:
+            raise FileNotFoundError(p)
+        prefix = p + "/" if p != "/" else "/"
+        children: set[str] = set()
+        for f in full_files:
+            if f.startswith(prefix):
+                child = prefix + f[len(prefix):].split("/")[0]
+                children.add(child)
+        for d in inferred_dirs:
+            if d == p or not d.startswith(prefix):
+                continue
+            child = prefix + d[len(prefix):].split("/")[0]
+            children.add(child)
+        return sorted(children)
+
+    async def stat(accessor, path, index=None):
+        if index is None:
+            raise FileNotFoundError("index required")
+        spec = path if isinstance(path, PathSpec) else PathSpec(original=path,
+                                                                directory=path)
+        p = _full(spec.original)
+        if p in full_files:
+            return FileStat(name=p.rsplit("/", 1)[-1],
+                            size=len(full_files[p]),
+                            type=FileType.TEXT)
+        if p.rstrip("/") in inferred_dirs:
+            return FileStat(name=p.rsplit("/", 1)[-1] or "/",
+                            type=FileType.DIRECTORY)
+        raise FileNotFoundError(p)
+
+    async def read_bytes(accessor, path, index=None):
+        if index is None:
+            raise FileNotFoundError("index required")
+        spec = path if isinstance(path, PathSpec) else PathSpec(original=path,
+                                                                directory=path)
+        p = _full(spec.original)
+        if p not in full_files:
+            raise FileNotFoundError(p)
+        return full_files[p]
+
+    return readdir, stat, read_bytes
+
+
+@pytest.mark.asyncio
+async def test_grep_recursive_files_only_mount_prefix():
+    readdir, stat, rb = _make_prefixed_backend(
+        {
+            "/dir/a.txt": b"apple\n",
+            "/dir/b.txt": b"zebra\n",
+        },
+        mount_prefix="/s3",
+    )
+    p = PathSpec(original="/dir",
+                 directory="/dir",
+                 prefix="/s3",
+                 resolved=True)
+    output, _ = await grep(
+        [p],
+        pattern="apple",
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=None,
+        recursive=True,
+        files_only=True,
+        index=object(),
+    )
+    decoded = (await _drain_async(output)).decode().strip()
+    assert decoded == "/s3/dir/a.txt"
+    assert "/s3/s3" not in decoded
+
+
+@pytest.mark.asyncio
+async def test_grep_single_file_threads_index():
+    readdir, stat, rb = _make_prefixed_backend(
+        {"/dir/a.txt": b"apple\n"},
+        mount_prefix="/gd",
+    )
+    p = PathSpec(original="/dir/a.txt",
+                 directory="/dir/a.txt",
+                 prefix="/gd",
+                 resolved=True)
+    output, _ = await grep(
+        [p],
+        pattern="apple",
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=None,
+        index=object(),
+    )
+    decoded = (await _drain_async(output)).decode()
+    assert "apple" in decoded

--- a/python/tests/commands/builtin/generic/test_rg.py
+++ b/python/tests/commands/builtin/generic/test_rg.py
@@ -249,3 +249,121 @@ async def test_rg_glob_filter():
     decoded = (await _drain_async(output)).decode()
     assert "/dir/a.log" in decoded
     assert "/dir/b.txt" not in decoded
+
+
+def _make_prefixed_backend(files: dict[str, bytes], mount_prefix: str):
+    """Backend that mimics real s3/disk/gdrive readdir: entries returned
+    are already prepended with ``mount_prefix``. Used to catch wrapper bugs
+    that re-add the prefix or drop ``index``."""
+
+    full_files = {mount_prefix + k: v for k, v in files.items()}
+    inferred_dirs: set[str] = {mount_prefix or "/"}
+    for f in full_files:
+        parts = f.split("/")
+        for i in range(1, len(parts)):
+            d = "/".join(parts[:i]) or "/"
+            inferred_dirs.add(d)
+
+    def _full(p: str) -> str:
+        if mount_prefix and not p.startswith(mount_prefix):
+            return mount_prefix + p
+        return p
+
+    async def readdir(accessor, path, index=None):
+        if index is None:
+            raise FileNotFoundError("index required")
+        spec = path if isinstance(path, PathSpec) else PathSpec(original=path,
+                                                                directory=path)
+        p = _full(spec.original).rstrip("/") or "/"
+        if p not in inferred_dirs:
+            raise FileNotFoundError(p)
+        prefix = p + "/" if p != "/" else "/"
+        children: set[str] = set()
+        for f in full_files:
+            if f.startswith(prefix):
+                child = prefix + f[len(prefix):].split("/")[0]
+                children.add(child)
+        for d in inferred_dirs:
+            if d == p or not d.startswith(prefix):
+                continue
+            child = prefix + d[len(prefix):].split("/")[0]
+            children.add(child)
+        return sorted(children)
+
+    async def stat(accessor, path, index=None):
+        if index is None:
+            raise FileNotFoundError("index required")
+        spec = path if isinstance(path, PathSpec) else PathSpec(original=path,
+                                                                directory=path)
+        p = _full(spec.original)
+        if p in full_files:
+            return FileStat(name=p.rsplit("/", 1)[-1],
+                            size=len(full_files[p]),
+                            type=FileType.TEXT)
+        if p.rstrip("/") in inferred_dirs:
+            return FileStat(name=p.rsplit("/", 1)[-1] or "/",
+                            type=FileType.DIRECTORY)
+        raise FileNotFoundError(p)
+
+    async def read_bytes(accessor, path, index=None):
+        if index is None:
+            raise FileNotFoundError("index required")
+        spec = path if isinstance(path, PathSpec) else PathSpec(original=path,
+                                                                directory=path)
+        p = _full(spec.original)
+        if p not in full_files:
+            raise FileNotFoundError(p)
+        return full_files[p]
+
+    return readdir, stat, read_bytes
+
+
+@pytest.mark.asyncio
+async def test_rg_files_only_mount_prefix_not_doubled():
+    readdir, stat, rb = _make_prefixed_backend(
+        {
+            "/dir/a.txt": b"apple\n",
+            "/dir/b.txt": b"zebra\n",
+        },
+        mount_prefix="/s3",
+    )
+    p = PathSpec(original="/dir",
+                 directory="/dir",
+                 prefix="/s3",
+                 resolved=True)
+    output, _ = await rg(
+        [p],
+        pattern="apple",
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=None,
+        files_only=True,
+        index=object(),
+    )
+    decoded = (await _drain_async(output)).decode().strip()
+    assert decoded == "/s3/dir/a.txt"
+    assert "/s3/s3" not in decoded
+
+
+@pytest.mark.asyncio
+async def test_rg_single_file_threads_index():
+    readdir, stat, rb = _make_prefixed_backend(
+        {"/dir/a.txt": b"apple\n"},
+        mount_prefix="/gd",
+    )
+    p = PathSpec(original="/dir/a.txt",
+                 directory="/dir/a.txt",
+                 prefix="/gd",
+                 resolved=True)
+    output, _ = await rg(
+        [p],
+        pattern="apple",
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=None,
+        index=object(),
+    )
+    decoded = (await _drain_async(output)).decode()
+    assert "apple" in decoded


### PR DESCRIPTION
Reduces per-backend command code by routing tail, grep, and rg through their generic formatters. Each backend wrapper now owns only the backend-specific prep (path resolution, scope warnings, push-down branches, cache decisions) and hands the resulting bytes/stream to generic. The generic helpers own slicing/formatting/dispatch.

## What moves

**tail (13 backends → generic_tail)**
- Mechanical: slack, discord, langfuse, linear, gdrive, gsheets, gdocs, gslides, gmail, email
- With preserved backend prep:
  - s3 keeps the cache-only-when-tail-saw-everything decision
  - postgres keeps the SQL push-down (`fetch_rows offset=total-limit`) for `entity_rows` scope
  - mongodb keeps the `-f` follow path via `watch_stream`; non-follow goes through generic
- mongodb wc stays specialized: `count_documents` push-down is the value of that command; reading every doc just to count would defeat the optimization.

**grep + rg (7 backends each → generic_grep / generic_rg)**
- linear, s3, gdrive, gsheets, gdocs, gslides, trello
- Per-wrapper shrinks from ~200 lines to ~110 lines.

**New: `scope_check` callable**
- `generic_grep` and `generic_rg` gain an optional `scope_check` parameter that runs before recursive scans.
- linear/trello pass their existing `scope_warning` function so a recursive grep across an API-backed mount still counts the scope first and either warns (over `SCOPE_SUGGEST`) or errors (over `SCOPE_ERROR`). Behavior preserved end-to-end.

## What stays specialized

Push-down search backends keep their own grep/rg because the value is server-side search, not local-bytes scan:
- slack (channel search), discord (message search), mongodb (find), postgres (SQL where), github (code search), gmail/email (mailbox search), langfuse (trace search)

Plus ssh / notion / telegram / databricks_volume — different file/scope semantics.

## Numbers

- 24 wrapper files changed, 1 generic_grep update, 1 generic_rg update.
- Net: **+671 / -1908 lines**.
- 3987 passed, 88 skipped, 0 failed across `tests/io/ tests/commands/ tests/workspace/ tests/resource/`.

Two commits on the branch (`e4868a5` tail + scope_check + linear grep pilot, `21a063d` remaining 6 grep + 7 rg).