### PR TITLE
fix(node): enforce mount mode for FUSE buffered writes

### DIFF
--- a/examples/python/ram/ram_fuse_readonly.py
+++ b/examples/python/ram/ram_fuse_readonly.py
@@ -1,0 +1,60 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import os
+import time
+from pathlib import Path
+
+from mirage import MountMode, Workspace
+from mirage.resource.ram import RAMResource
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DATA_DIR = REPO_ROOT / "data"
+
+resource = RAMResource()
+store = resource._store
+
+for fpath in sorted(DATA_DIR.iterdir()):
+    if fpath.is_file():
+        key = "/" + fpath.name
+        store.files[key] = fpath.read_bytes()
+        store.dirs.add("/")
+
+print(f"Seeded {len(store.files)} files from {DATA_DIR}")
+
+with Workspace({"/data/": resource}, mode=MountMode.READ, fuse=True) as ws:
+    time.sleep(1)
+    mp = ws.fuse_mountpoint
+
+    print(f"\n=== FUSE MODE (READ): mounted at {mp} ===\n")
+
+    data_path = f"{mp}/data"
+    entries = sorted(os.listdir(data_path))
+    for e in entries:
+        size = os.path.getsize(f"{data_path}/{e}")
+        print(f"  {e:30s} {size:>10,} bytes")
+
+    existing = entries[0] if entries else "example.json"
+    print(f"\n>>> FUSE mounted READ-ONLY at: {mp}")
+    print(">>> In another terminal: reads ok, writes fail (EACCES).")
+    print(f">>>   cat {data_path}/{existing}             # ok")
+    print(f">>>   echo hi > {data_path}/new.txt         # EACCES (create)")
+    print(
+        f">>>   echo hi > {data_path}/{existing}        # EACCES (overwrite)")
+    print(">>> Press Enter to unmount and exit...")
+    input()
+
+    records = ws.ops.records
+    total = sum(r.bytes for r in records)
+    print(f"\nStats: {len(records)} ops, {total} bytes transferred")

--- a/examples/typescript/fuse/ram_fuse_readonly.ts
+++ b/examples/typescript/fuse/ram_fuse_readonly.ts
@@ -1,0 +1,87 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { readdir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createInterface } from 'node:readline/promises'
+import { FuseManager, MountMode, RAMResource, Workspace } from '@struktoai/mirage-node'
+
+const DATA_DIR = fileURLToPath(new URL('../../../data/', import.meta.url))
+
+async function main(): Promise<void> {
+  const resource = new RAMResource()
+
+  // Seed via a temporary WRITE-mode workspace, then mount the same resource READ-only.
+  const seedWs = new Workspace({ '/data/': resource }, { mode: MountMode.WRITE })
+  const seedEntries = readdirSync(DATA_DIR, { withFileTypes: true })
+    .filter((e) => e.isFile())
+    .sort((a, b) => (a.name < b.name ? -1 : 1))
+  for (const e of seedEntries) {
+    const raw = readFileSync(join(DATA_DIR, e.name))
+    const bytes = new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength)
+    await seedWs.fs.writeFile('/data/' + e.name, bytes)
+  }
+  await seedWs.close()
+
+  console.log(`Seeded ${String(resource.store.files.size)} files from ${DATA_DIR}`)
+
+  const ws = new Workspace({ '/data/': resource }, { mode: MountMode.READ })
+  const fm = new FuseManager()
+  const mp = await fm.setup(ws)
+  let cleaned = false
+  const handler = (sig: NodeJS.Signals): void => {
+    if (cleaned) return
+    cleaned = true
+    void (async (): Promise<void> => {
+      try { await fm.close(ws) } catch {}
+      try { await ws.close() } catch {}
+      console.error(`\n>>> unmounted ${mp}`)
+      process.exit(sig === 'SIGINT' ? 130 : 143)
+    })()
+  }
+  process.on('SIGINT', handler)
+  process.on('SIGTERM', handler)
+  try {
+    console.log(`\n=== FUSE MODE (READ): mounted at ${mp} ===\n`)
+
+    const dataPath = `${mp}/data`
+    const list = (await readdir(dataPath)).sort()
+    for (const name of list) {
+      const st = await stat(`${dataPath}/${name}`)
+      console.log(`  ${name.padEnd(30)} ${st.size.toLocaleString('en-US').padStart(10)} bytes`)
+    }
+
+    const existing = list[0] ?? 'example.json'
+    console.log(`\n>>> FUSE mounted READ-ONLY at: ${mp}`)
+    console.log('>>> In another terminal: reads should succeed, writes should fail with EACCES.')
+    console.log(`>>>   cat ${dataPath}/${existing}                 # ok`)
+    console.log(`>>>   echo hi > ${dataPath}/new.txt               # EACCES (create)`)
+    console.log(`>>>   echo hi > ${dataPath}/${existing}           # EACCES (overwrite; the bug PR #104 fixed)`)
+    console.log('>>> Press Enter to unmount and exit...')
+
+    const rl = createInterface({ input: process.stdin, output: process.stdout })
+    await rl.question('')
+    rl.close()
+  } finally {
+    await fm.close()
+    await ws.close()
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/typescript/packages/node/src/fuse/fs.test.ts
+++ b/typescript/packages/node/src/fuse/fs.test.ts
@@ -19,6 +19,7 @@ import { MirageFS, type FuseAttr } from './fs.ts'
 
 const ENOENT = -2
 const ENOTEMPTY = -66
+const EACCES = -13
 
 // Invoke a MirageFS op through its ops() surface — covers the same dispatch
 // path that @zkochan/fuse-native uses in production. Returns the callback args
@@ -174,6 +175,42 @@ describe('MirageFS — rmdir maps non-empty to ENOTEMPTY', () => {
     const mfs = new MirageFS(ws)
     const [code] = await callOp<[number]>(mfs, 'rmdir', '/data/sub')
     expect(code).toBe(ENOTEMPTY)
+  })
+})
+
+describe('MirageFS — read-only mount write consistency', () => {
+  it('rejects create and buffered flush through the same mount-mode gate', async () => {
+    const resource = new RAMResource()
+    const seedWs = new Workspace({ '/data/': resource }, { mode: MountMode.WRITE })
+    await seedWs.fs.writeFile('/data/existing.txt', 'seed')
+
+    const readonlyWs = new Workspace({ '/data/': resource }, { mode: MountMode.READ })
+    const mfs = new MirageFS(readonlyWs)
+
+    const [createCode] = await callOp<[number]>(mfs, 'create', '/data/new.txt', 0o100644)
+    expect(createCode).toBe(EACCES)
+
+    const [openCode, fh] = await callOp<[number, number]>(mfs, 'open', '/data/existing.txt', 0x8401)
+    expect(openCode).toBe(0)
+
+    const bytes = Buffer.from('changed')
+    const [writeBytes] = await callOp<[number]>(
+      mfs,
+      'write',
+      '/data/existing.txt',
+      fh,
+      bytes,
+      bytes.byteLength,
+      0,
+    )
+    expect(writeBytes).toBe(bytes.byteLength)
+
+    // The kernel reports byte acceptance before flush. Flush is the point where
+    // Mirage commits buffered FUSE writes, so it must enforce the same READ-mode
+    // restriction as create.
+    const [flushCode] = await callOp<[number]>(mfs, 'flush', '/data/existing.txt', fh)
+    expect(flushCode).toBe(EACCES)
+    expect(new TextDecoder().decode(await seedWs.fs.readFile('/data/existing.txt'))).toBe('seed')
   })
 })
 

--- a/typescript/packages/node/src/fuse/fs.ts
+++ b/typescript/packages/node/src/fuse/fs.ts
@@ -229,6 +229,15 @@ export class MirageFS {
     return records
   }
 
+  private async writeFile(path: string, data: Uint8Array): Promise<void> {
+    // Keep FUSE writes on Workspace.dispatch rather than Workspace.fs.writeFile:
+    // dispatch is where Mirage enforces mount modes, revision tracking, and
+    // post-write invalidation. The lower-level fs helper is useful internally,
+    // but using it from FUSE made READ-mode mounts reject create while still
+    // allowing buffered overwrite on flush.
+    await this.ws.dispatch('write', path, [data])
+  }
+
   // ── FUSE op surface (mirrors mfusepy Operations) ─────────────────
 
   ops(): Record<string, unknown> {
@@ -393,7 +402,7 @@ export class MirageFS {
           }
           merged = out
         }
-        await this.ws.fs.writeFile(path, merged)
+        await this.writeFile(path, merged)
         cb(len)
       } catch {
         cb(0)
@@ -414,7 +423,7 @@ export class MirageFS {
             dispatchErr instanceof Error ? dispatchErr.message : String(dispatchErr)
           ).toLowerCase()
           if (!msg.includes('no op')) throw dispatchErr
-          await this.ws.fs.writeFile(path, new Uint8Array(0))
+          await this.writeFile(path, new Uint8Array(0))
         }
         const fh = this.nextFh++
         this.handles.set(fh, { path })
@@ -498,7 +507,7 @@ export class MirageFS {
           const data = await this.ws.fs.readFile(path, { raw: true }).catch(() => new Uint8Array(0))
           const out = new Uint8Array(size)
           out.set(data.subarray(0, Math.min(data.byteLength, size)), 0)
-          await this.ws.fs.writeFile(path, out)
+          await this.writeFile(path, out)
         }
         cb(0)
       } catch (err) {
@@ -606,7 +615,7 @@ export class MirageFS {
         for (const [off, chunk] of writes) {
           merged.set(chunk, off)
         }
-        await this.ws.fs.writeFile(path, merged)
+        await this.writeFile(path, merged)
         cb(0)
       } catch (err) {
         cb(classifyError(err))


### PR DESCRIPTION
## Summary
- route Mirage FUSE buffered writes through Workspace.dispatch instead of Workspace.fs.writeFile
- keep create, direct write, truncate fallback, and flush on the same mount-mode/invalidation path
- add a regression test proving READ-mode FUSE create and buffered flush both fail with EACCES and leave the backing file unchanged

## Why
A hosted Daytona FUSE proof exposed inconsistent READ-mode behavior: MirageFS.create() returned EACCES because it used Workspace.dispatch(), but existing-file overwrite through write()+flush() could still succeed because flush used Workspace.fs.writeFile() directly. This patch makes FUSE writes consistently honor mount mode.

## Test
- pnpm --dir packages/node exec vitest run src/fuse/fs.test.ts