### PR TITLE
feat(databricks-volume): add text commands eg sort, sed, diff, awk, etc.

### DIFF
--- a/python/mirage/commands/builtin/databricks_volume/__init__.py
+++ b/python/mirage/commands/builtin/databricks_volume/__init__.py
@@ -12,28 +12,48 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from mirage.commands.builtin.databricks_volume.awk import awk
 from mirage.commands.builtin.databricks_volume.cat import cat
+from mirage.commands.builtin.databricks_volume.cut import cut
+from mirage.commands.builtin.databricks_volume.diff import diff
 from mirage.commands.builtin.databricks_volume.find import find
 from mirage.commands.builtin.databricks_volume.grep import grep
 from mirage.commands.builtin.databricks_volume.head import head
+from mirage.commands.builtin.databricks_volume.jq import jq
 from mirage.commands.builtin.databricks_volume.ls import ls
+from mirage.commands.builtin.databricks_volume.nl import nl
 from mirage.commands.builtin.databricks_volume.rg import rg
 from mirage.commands.builtin.databricks_volume.rm import rm
+from mirage.commands.builtin.databricks_volume.sed import sed
+from mirage.commands.builtin.databricks_volume.sort import sort
 from mirage.commands.builtin.databricks_volume.stat import stat
 from mirage.commands.builtin.databricks_volume.tail import tail
 from mirage.commands.builtin.databricks_volume.touch import touch
+from mirage.commands.builtin.databricks_volume.tr import tr
 from mirage.commands.builtin.databricks_volume.tree import tree
+from mirage.commands.builtin.databricks_volume.uniq import uniq
+from mirage.commands.builtin.databricks_volume.wc import wc
 
 COMMANDS = [
+    awk,
     cat,
+    cut,
+    diff,
     find,
     grep,
     head,
+    jq,
     ls,
+    nl,
     rm,
     rg,
+    sed,
+    sort,
     stat,
     tail,
     touch,
     tree,
+    tr,
+    uniq,
+    wc,
 ]

--- a/python/mirage/commands/builtin/databricks_volume/_helpers.py
+++ b/python/mirage/commands/builtin/databricks_volume/_helpers.py
@@ -1,0 +1,42 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from functools import partial
+from typing import Callable
+
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.wrap import (call_read_bytes,
+                                                call_read_stream)
+from mirage.core.databricks_volume.read import read_bytes as _read_bytes
+from mirage.core.databricks_volume.stream import read_stream as _read_stream
+from mirage.types import PathSpec
+
+
+def path_prefix(paths: list[PathSpec],
+                fallback: PathSpec | None = None) -> str:
+    if paths:
+        return paths[0].prefix
+    if fallback is not None:
+        return fallback.prefix
+    return ""
+
+
+def read_bytes_with_index(index: IndexCacheStore | None,
+                          prefix: str = "") -> Callable:
+    return partial(call_read_bytes, _read_bytes, index=index, prefix=prefix)
+
+
+def read_stream_with_index(index: IndexCacheStore | None,
+                           prefix: str = "") -> Callable:
+    return partial(call_read_stream, _read_stream, index=index, prefix=prefix)

--- a/python/mirage/commands/builtin/databricks_volume/awk.py
+++ b/python/mirage/commands/builtin/databricks_volume/awk.py
@@ -1,0 +1,58 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.databricks_volume._helpers import (
+    path_prefix, read_bytes_with_index, read_stream_with_index)
+from mirage.commands.builtin.generic.awk import awk as generic_awk
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("awk", resource="databricks_volume", spec=SPECS["awk"])
+async def awk(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    F: str | None = None,
+    v: str | None = None,
+    f: PathSpec | None = None,
+    prefix: str = "",
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    mount_prefix = path_prefix(paths, f)
+    read_bytes = read_bytes_with_index(index, mount_prefix)
+    read_stream = read_stream_with_index(index, mount_prefix)
+    return await generic_awk(
+        paths,
+        texts,
+        read_bytes=read_bytes,
+        read_stream=read_stream,
+        accessor=accessor,
+        stdin=stdin,
+        field_separator=F,
+        variable_assignment=v,
+        program_file=f,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/databricks_volume/cut.py
+++ b/python/mirage/commands/builtin/databricks_volume/cut.py
@@ -1,0 +1,54 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.databricks_volume._helpers import (
+    path_prefix, read_stream_with_index)
+from mirage.commands.builtin.generic.cut import cut as generic_cut
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("cut", resource="databricks_volume", spec=SPECS["cut"])
+async def cut(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    f: str | None = None,
+    d: str | None = None,
+    c: str | None = None,
+    complement: bool = False,
+    z: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    read_stream = read_stream_with_index(index, path_prefix(paths))
+    return await generic_cut(paths,
+                             read_stream=read_stream,
+                             accessor=accessor,
+                             stdin=stdin,
+                             f=f,
+                             d=d,
+                             c=c,
+                             complement=complement,
+                             z=z)

--- a/python/mirage/commands/builtin/databricks_volume/diff.py
+++ b/python/mirage/commands/builtin/databricks_volume/diff.py
@@ -1,0 +1,57 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.databricks_volume._helpers import (
+    path_prefix, read_bytes_with_index)
+from mirage.commands.builtin.generic.diff import diff as generic_diff
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.readdir import readdir
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("diff", resource="databricks_volume", spec=SPECS["diff"])
+async def diff(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    i: bool = False,
+    w: bool = False,
+    b: bool = False,
+    e: bool = False,
+    u: bool = False,
+    q: bool = False,
+    r: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    paths = await resolve_glob(accessor, paths, index)
+    return await generic_diff(paths,
+                              read_bytes=read_bytes_with_index(
+                                  index, path_prefix(paths)),
+                              readdir_fn=readdir,
+                              accessor=accessor,
+                              index=index,
+                              i=i,
+                              w=w,
+                              b=b,
+                              e=e,
+                              u=u,
+                              q=q,
+                              r=r)

--- a/python/mirage/commands/builtin/databricks_volume/jq.py
+++ b/python/mirage/commands/builtin/databricks_volume/jq.py
@@ -1,0 +1,53 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.databricks_volume._helpers import (
+    path_prefix, read_bytes_with_index, read_stream_with_index)
+from mirage.commands.builtin.generic.jq import jq as generic_jq
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("jq", resource="databricks_volume", spec=SPECS["jq"])
+async def jq(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    r: bool = False,
+    c: bool = False,
+    s: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    mount_prefix = path_prefix(paths)
+    return await generic_jq(
+        paths,
+        *texts,
+        read_bytes=read_bytes_with_index(index, mount_prefix),
+        read_stream=read_stream_with_index(index, mount_prefix),
+        accessor=accessor,
+        stdin=stdin,
+        r=r,
+        c=c,
+        s=s)

--- a/python/mirage/commands/builtin/databricks_volume/nl.py
+++ b/python/mirage/commands/builtin/databricks_volume/nl.py
@@ -1,0 +1,55 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.databricks_volume._helpers import (
+    path_prefix, read_stream_with_index)
+from mirage.commands.builtin.generic.nl import nl as generic_nl
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("nl", resource="databricks_volume", spec=SPECS["nl"])
+async def nl(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    b: str | None = None,
+    v: str | None = None,
+    i: str | None = None,
+    w: str | None = None,
+    s: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    return await generic_nl(
+        paths,
+        read_stream=read_stream_with_index(index, path_prefix(paths)),
+        accessor=accessor,
+        stdin=stdin,
+        body_numbering_raw=b,
+        start_raw=v,
+        increment_raw=i,
+        width_raw=w,
+        separator=s,
+    )

--- a/python/mirage/commands/builtin/databricks_volume/sed.py
+++ b/python/mirage/commands/builtin/databricks_volume/sed.py
@@ -1,0 +1,57 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.databricks_volume._helpers import (
+    path_prefix, read_bytes_with_index)
+from mirage.commands.builtin.generic.sed import sed as generic_sed
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("sed", resource="databricks_volume", spec=SPECS["sed"])
+async def sed(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    i: bool = False,
+    e: bool = False,
+    n: bool = False,
+    E: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not texts:
+        raise ValueError("sed: usage: sed EXPRESSION [path]")
+    if i:
+        raise ValueError("sed: -i is not supported for databricks_volume")
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    return await generic_sed(
+        paths,
+        texts[0],
+        read_bytes=read_bytes_with_index(index, path_prefix(paths)),
+        write_bytes=None,
+        accessor=accessor,
+        stdin=stdin,
+        suppress=n,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/databricks_volume/sort.py
+++ b/python/mirage/commands/builtin/databricks_volume/sort.py
@@ -1,0 +1,64 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.databricks_volume._helpers import (
+    path_prefix, read_bytes_with_index)
+from mirage.commands.builtin.generic.sort import sort as generic_sort
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("sort", resource="databricks_volume", spec=SPECS["sort"])
+async def sort(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    r: bool = False,
+    n: bool = False,
+    u: bool = False,
+    f: bool = False,
+    k: str | None = None,
+    t: str | None = None,
+    h: bool = False,
+    V: bool = False,
+    s: bool = False,
+    M: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    return await generic_sort(
+        paths,
+        read_bytes=read_bytes_with_index(index, path_prefix(paths)),
+        accessor=accessor,
+        stdin=stdin,
+        reverse=r,
+        numeric=n,
+        unique=u,
+        fold_case=f,
+        key_field=int(k) if k is not None else None,
+        field_separator=t,
+        human_numeric=h,
+        version_sort=V,
+        month_sort=M,
+    )

--- a/python/mirage/commands/builtin/databricks_volume/tr.py
+++ b/python/mirage/commands/builtin/databricks_volume/tr.py
@@ -1,0 +1,52 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.databricks_volume._helpers import (
+    path_prefix, read_stream_with_index)
+from mirage.commands.builtin.generic.tr import tr as generic_tr
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("tr", resource="databricks_volume", spec=SPECS["tr"])
+async def tr(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    d: bool = False,
+    s: bool = False,
+    c: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    return await generic_tr(
+        paths,
+        texts,
+        read_stream=read_stream_with_index(index, path_prefix(paths)),
+        accessor=accessor,
+        stdin=stdin,
+        delete=d,
+        squeeze=s,
+        complement=c,
+    )

--- a/python/mirage/commands/builtin/databricks_volume/uniq.py
+++ b/python/mirage/commands/builtin/databricks_volume/uniq.py
@@ -1,0 +1,59 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.databricks_volume._helpers import (
+    path_prefix, read_stream_with_index)
+from mirage.commands.builtin.generic.uniq import uniq as generic_uniq
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("uniq", resource="databricks_volume", spec=SPECS["uniq"])
+async def uniq(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    c: bool = False,
+    d: bool = False,
+    u: bool = False,
+    f: str | None = None,
+    s: str | None = None,
+    i: bool = False,
+    w: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    return await generic_uniq(
+        paths,
+        read_stream=read_stream_with_index(index, path_prefix(paths)),
+        accessor=accessor,
+        stdin=stdin,
+        count=c,
+        duplicates_only=d,
+        unique_only=u,
+        skip_fields=int(f) if f else 0,
+        skip_chars=int(s) if s else 0,
+        ignore_case=i,
+        check_chars=int(w) if w else 0,
+    )

--- a/python/mirage/commands/builtin/databricks_volume/wc.py
+++ b/python/mirage/commands/builtin/databricks_volume/wc.py
@@ -1,0 +1,74 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.databricks_volume._helpers import (
+    path_prefix, read_bytes_with_index)
+from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import wc as generic_wc
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("wc", resource="databricks_volume", spec=SPECS["wc"])
+async def wc(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    args_l: bool = False,
+    w: bool = False,
+    c: bool = False,
+    m: bool = False,
+    L: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        read_bytes = read_bytes_with_index(index, path_prefix(paths))
+        outputs: list[str] = []
+        totals = WCCounts()
+        for path in paths:
+            counts = await generic_wc(await read_bytes(accessor, path))
+            outputs.append(
+                format_wc(counts,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label=path.original))
+            totals.merge(counts)
+        if len(paths) > 1:
+            outputs.append(
+                format_wc(totals,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label="total"))
+        return "\n".join(outputs).encode(), IOResult()
+    source = _resolve_source(stdin, "wc: missing operand")
+    counts = await generic_wc(source)
+    return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
+                     L=L).encode(), IOResult()

--- a/python/tests/commands/builtin/databricks_volume/conftest.py
+++ b/python/tests/commands/builtin/databricks_volume/conftest.py
@@ -1,0 +1,100 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, Workspace
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.commands.builtin.databricks_volume import _helpers
+from mirage.types import PathSpec
+from mirage.utils.stream import collect_bytes
+from tests.resource.databricks_volume.test_databricks_volume import (
+    FakeFiles, make_resource, seed_directory, seed_file)
+
+
+def seed_text_command_fixture(files: FakeFiles) -> str:
+    root = "/Volumes/main/default/agent_files/root"
+    seed_directory(files, root)
+    seed_file(files, f"{root}/words.txt", b"beta\nalpha\nalpha\n")
+    seed_file(files, f"{root}/more.txt", b"delta\n")
+    seed_file(files, f"{root}/table.csv", b"name,score\nann,2\nbob,3\n")
+    seed_file(files, f"{root}/table_extra.csv", b"name,score\ncam,5\n")
+    seed_file(files, f"{root}/data.json", b'{"name": "mirage"}\n')
+    seed_file(files, f"{root}/data2.json", b'{"name": "agent"}\n')
+    seed_file(files, f"{root}/events.jsonl", b'{"name": "first"}\n')
+    seed_file(files, f"{root}/events_extra.jsonl", b'{"name": "second"}\n')
+    seed_file(files, f"{root}/old.txt", b"same\nold\n")
+    seed_file(files, f"{root}/new.txt", b"same\nnew\n")
+    return root
+
+
+async def materialize(source) -> bytes:
+    if source is None:
+        return b""
+    return await collect_bytes(source)
+
+
+class IndexTrackingReader:
+
+    def __init__(self) -> None:
+        self.seen_indexes: list[RAMIndexCacheStore | None] = []
+
+    async def read_bytes(self,
+                         accessor,
+                         path,
+                         index=None,
+                         *args,
+                         **kwargs) -> bytes:
+        self.seen_indexes.append(index)
+        original = path.original if isinstance(path, PathSpec) else path
+        if str(original).endswith(".json"):
+            return b'{"name": "mirage"}\n'
+        if str(original).endswith(".csv"):
+            return b"name,score\nann,2\n"
+        return b"beta\nalpha\nalpha\n"
+
+    async def read_stream(self, accessor, path, index=None, *args, **kwargs):
+        self.seen_indexes.append(index)
+        yield await self.read_bytes(accessor, path, index, *args, **kwargs)
+
+
+@pytest.fixture
+def databricks_text_files() -> FakeFiles:
+    files = FakeFiles()
+    seed_text_command_fixture(files)
+    return files
+
+
+@pytest.fixture
+def databricks_text_workspace(databricks_text_files: FakeFiles) -> Workspace:
+    return Workspace({"/dbx/": make_resource(databricks_text_files)},
+                     mode=MountMode.READ)
+
+
+@pytest.fixture
+def expected_index() -> RAMIndexCacheStore:
+    return RAMIndexCacheStore(ttl=600)
+
+
+@pytest.fixture
+def index_tracker(monkeypatch) -> IndexTrackingReader:
+    tracker = IndexTrackingReader()
+    monkeypatch.setattr(_helpers, "_read_bytes", tracker.read_bytes)
+    monkeypatch.setattr(_helpers, "_read_stream", tracker.read_stream)
+    return tracker
+
+
+@pytest.fixture
+def materialize_output():
+    return materialize

--- a/python/tests/commands/builtin/databricks_volume/test_awk.py
+++ b/python/tests/commands/builtin/databricks_volume/test_awk.py
@@ -1,0 +1,48 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.commands.builtin.databricks_volume import awk as awk_command
+from mirage.types import PathSpec
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_awk(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute(
+        "awk '{print $1}' /dbx/table.csv")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"name,score\nann,2\nbob,3\n"
+
+
+@pytest.mark.asyncio
+async def test_databricks_volume_awk_forwards_index(
+    index_tracker,
+    expected_index: RAMIndexCacheStore,
+    materialize_output,
+):
+    source, _io = await awk_command(
+        object(),
+        [PathSpec.from_str_path("/dbx/sample.csv", "/dbx")],
+        "{print $1}",
+        index=expected_index,
+    )
+
+    await materialize_output(source)
+
+    assert index_tracker.seen_indexes
+    assert all(index is expected_index for index in index_tracker.seen_indexes)

--- a/python/tests/commands/builtin/databricks_volume/test_cut.py
+++ b/python/tests/commands/builtin/databricks_volume/test_cut.py
@@ -1,0 +1,49 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.commands.builtin.databricks_volume import cut as cut_command
+from mirage.types import PathSpec
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_cut(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute("cut -d , -f 2 /dbx/table.csv"
+                                                 )
+
+    assert io.exit_code == 0
+    assert io.stdout == b"score\n2\n3\n"
+
+
+@pytest.mark.asyncio
+async def test_databricks_volume_cut_forwards_index(
+    index_tracker,
+    expected_index: RAMIndexCacheStore,
+    materialize_output,
+):
+    source, _io = await cut_command(
+        object(),
+        [PathSpec.from_str_path("/dbx/sample.csv", "/dbx")],
+        index=expected_index,
+        d=",",
+        f="1",
+    )
+
+    await materialize_output(source)
+
+    assert index_tracker.seen_indexes
+    assert all(index is expected_index for index in index_tracker.seen_indexes)

--- a/python/tests/commands/builtin/databricks_volume/test_diff.py
+++ b/python/tests/commands/builtin/databricks_volume/test_diff.py
@@ -1,0 +1,62 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.commands.builtin.databricks_volume import diff as diff_command
+from mirage.types import PathSpec
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_diff(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute(
+        "diff -u /dbx/old.txt /dbx/new.txt")
+
+    assert io.exit_code == 1
+    assert b"-old" in io.stdout
+    assert b"+new" in io.stdout
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_diff_resolves_glob(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute(
+        "diff /dbx/old*.txt /dbx/new*.txt")
+
+    assert io.exit_code == 1
+    assert b"old" in io.stdout
+    assert b"new" in io.stdout
+
+
+@pytest.mark.asyncio
+async def test_databricks_volume_diff_forwards_index(
+    index_tracker,
+    expected_index: RAMIndexCacheStore,
+    materialize_output,
+):
+    source, _io = await diff_command(
+        object(),
+        [
+            PathSpec.from_str_path("/dbx/left.txt", "/dbx"),
+            PathSpec.from_str_path("/dbx/right.txt", "/dbx"),
+        ],
+        index=expected_index,
+    )
+
+    await materialize_output(source)
+
+    assert index_tracker.seen_indexes
+    assert all(index is expected_index for index in index_tracker.seen_indexes)

--- a/python/tests/commands/builtin/databricks_volume/test_jq.py
+++ b/python/tests/commands/builtin/databricks_volume/test_jq.py
@@ -1,0 +1,57 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.commands.builtin.databricks_volume import jq as jq_command
+from mirage.types import PathSpec
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_jq(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute("jq -r .name /dbx/data.json")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"mirage\n"
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_jq_resolves_glob(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute("jq -r .name /dbx/*.json")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"mirage\nagent\n"
+
+
+@pytest.mark.asyncio
+async def test_databricks_volume_jq_forwards_index(
+    index_tracker,
+    expected_index: RAMIndexCacheStore,
+    materialize_output,
+):
+    source, _io = await jq_command(
+        object(),
+        [PathSpec.from_str_path("/dbx/sample.json", "/dbx")],
+        ".name",
+        index=expected_index,
+        r=True,
+    )
+
+    await materialize_output(source)
+
+    assert index_tracker.seen_indexes
+    assert all(index is expected_index for index in index_tracker.seen_indexes)

--- a/python/tests/commands/builtin/databricks_volume/test_nl.py
+++ b/python/tests/commands/builtin/databricks_volume/test_nl.py
@@ -1,0 +1,55 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.commands.builtin.databricks_volume import nl as nl_command
+from mirage.types import PathSpec
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_nl(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute("nl /dbx/words.txt")
+
+    assert io.exit_code == 0
+    assert b"     1\tbeta\n" in io.stdout
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_nl_resolves_glob(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute("nl /dbx/*.txt")
+
+    assert io.exit_code == 0
+    assert b"     1\tdelta\n" in io.stdout
+
+
+@pytest.mark.asyncio
+async def test_databricks_volume_nl_forwards_index(
+    index_tracker,
+    expected_index: RAMIndexCacheStore,
+    materialize_output,
+):
+    source, _io = await nl_command(
+        object(),
+        [PathSpec.from_str_path("/dbx/sample.txt", "/dbx")],
+        index=expected_index,
+    )
+
+    await materialize_output(source)
+
+    assert index_tracker.seen_indexes
+    assert all(index is expected_index for index in index_tracker.seen_indexes)

--- a/python/tests/commands/builtin/databricks_volume/test_registration.py
+++ b/python/tests/commands/builtin/databricks_volume/test_registration.py
@@ -1,0 +1,41 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.commands.builtin.databricks_volume import COMMANDS
+
+TEXT_COMMANDS = {
+    "awk",
+    "cut",
+    "diff",
+    "jq",
+    "nl",
+    "sed",
+    "sort",
+    "tr",
+    "uniq",
+    "wc",
+}
+
+
+def test_databricks_volume_text_commands_registered_read_only():
+    registered = [
+        registered for command in COMMANDS
+        for registered in command._registered_commands
+    ]
+    names = {command.name for command in registered}
+    assert TEXT_COMMANDS <= names
+    for command in registered:
+        if command.name in TEXT_COMMANDS:
+            assert command.resource == "databricks_volume"
+            assert not command.write

--- a/python/tests/commands/builtin/databricks_volume/test_sed.py
+++ b/python/tests/commands/builtin/databricks_volume/test_sed.py
@@ -1,0 +1,68 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.commands.builtin.databricks_volume import sed as sed_command
+from mirage.types import PathSpec
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_sed(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute(
+        "sed s/alpha/ALPHA/g /dbx/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"beta\nALPHA\nALPHA\n"
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_sed_resolves_glob(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute(
+        "sed s/delta/DELTA/ /dbx/*.txt")
+
+    assert io.exit_code == 0
+    assert b"DELTA\n" in io.stdout
+
+
+@pytest.mark.asyncio
+async def test_databricks_volume_sed_forwards_index(
+    index_tracker,
+    expected_index: RAMIndexCacheStore,
+    materialize_output,
+):
+    source, _io = await sed_command(
+        object(),
+        [PathSpec.from_str_path("/dbx/sample.txt", "/dbx")],
+        "s/alpha/ALPHA/g",
+        index=expected_index,
+    )
+
+    await materialize_output(source)
+
+    assert index_tracker.seen_indexes
+    assert all(index is expected_index for index in index_tracker.seen_indexes)
+
+
+@pytest.mark.asyncio
+async def test_databricks_volume_sed_in_place_is_not_supported(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute(
+        "sed -i s/alpha/ALPHA/g /dbx/words.txt")
+
+    assert io.exit_code == 1
+    assert b"-i is not supported" in io.stderr

--- a/python/tests/commands/builtin/databricks_volume/test_sort.py
+++ b/python/tests/commands/builtin/databricks_volume/test_sort.py
@@ -1,0 +1,55 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.commands.builtin.databricks_volume import sort as sort_command
+from mirage.types import PathSpec
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_sort(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute("sort /dbx/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"alpha\nalpha\nbeta\n"
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_sort_resolves_glob(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute("sort /dbx/*.txt")
+
+    assert io.exit_code == 0
+    assert b"alpha\nalpha\nbeta\n" in io.stdout
+
+
+@pytest.mark.asyncio
+async def test_databricks_volume_sort_forwards_index(
+    index_tracker,
+    expected_index: RAMIndexCacheStore,
+    materialize_output,
+):
+    source, _io = await sort_command(
+        object(),
+        [PathSpec.from_str_path("/dbx/sample.txt", "/dbx")],
+        index=expected_index,
+    )
+
+    await materialize_output(source)
+
+    assert index_tracker.seen_indexes
+    assert all(index is expected_index for index in index_tracker.seen_indexes)

--- a/python/tests/commands/builtin/databricks_volume/test_tr.py
+++ b/python/tests/commands/builtin/databricks_volume/test_tr.py
@@ -1,0 +1,48 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.commands.builtin.databricks_volume import tr as tr_command
+from mirage.types import PathSpec
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_tr(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute("tr a-z A-Z /dbx/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"BETA\nALPHA\nALPHA\n"
+
+
+@pytest.mark.asyncio
+async def test_databricks_volume_tr_forwards_index(
+    index_tracker,
+    expected_index: RAMIndexCacheStore,
+    materialize_output,
+):
+    source, _io = await tr_command(
+        object(),
+        [PathSpec.from_str_path("/dbx/sample.txt", "/dbx")],
+        "a-z",
+        "A-Z",
+        index=expected_index,
+    )
+
+    await materialize_output(source)
+
+    assert index_tracker.seen_indexes
+    assert all(index is expected_index for index in index_tracker.seen_indexes)

--- a/python/tests/commands/builtin/databricks_volume/test_uniq.py
+++ b/python/tests/commands/builtin/databricks_volume/test_uniq.py
@@ -1,0 +1,46 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.commands.builtin.databricks_volume import uniq as uniq_command
+from mirage.types import PathSpec
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_uniq(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute("uniq /dbx/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"beta\nalpha\n"
+
+
+@pytest.mark.asyncio
+async def test_databricks_volume_uniq_forwards_index(
+    index_tracker,
+    expected_index: RAMIndexCacheStore,
+    materialize_output,
+):
+    source, _io = await uniq_command(
+        object(),
+        [PathSpec.from_str_path("/dbx/sample.txt", "/dbx")],
+        index=expected_index,
+    )
+
+    await materialize_output(source)
+
+    assert index_tracker.seen_indexes
+    assert all(index is expected_index for index in index_tracker.seen_indexes)

--- a/python/tests/commands/builtin/databricks_volume/test_wc.py
+++ b/python/tests/commands/builtin/databricks_volume/test_wc.py
@@ -1,0 +1,56 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.commands.builtin.databricks_volume import wc as wc_command
+from mirage.types import PathSpec
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_wc(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute("wc -l /dbx/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"3\t/dbx/words.txt"
+
+
+@pytest.mark.asyncio
+async def test_workspace_execute_databricks_volume_wc_resolves_glob(
+        databricks_text_workspace):
+    io = await databricks_text_workspace.execute("wc -l /dbx/*.txt")
+
+    assert io.exit_code == 0
+    assert b"/dbx/more.txt" in io.stdout
+
+
+@pytest.mark.asyncio
+async def test_databricks_volume_wc_forwards_index(
+    index_tracker,
+    expected_index: RAMIndexCacheStore,
+    materialize_output,
+):
+    source, _io = await wc_command(
+        object(),
+        [PathSpec.from_str_path("/dbx/sample.txt", "/dbx")],
+        index=expected_index,
+        args_l=True,
+    )
+
+    await materialize_output(source)
+
+    assert index_tracker.seen_indexes
+    assert all(index is expected_index for index in index_tracker.seen_indexes)


### PR DESCRIPTION
## Summary

Adds text-processing commands for the Databricks Volume backend, so an agent can read and analyze file content on a mounted volume (e.g. `wc -l`, `sort | uniq -c`, `sed s/.../.../`, `jq`, `diff`). Continues the Databricks Volume feature (read #66 , write #93) and follows the "delegate to `generic`" pattern in #102. Part of #61.

Commands added (10): `awk`, `cut`, `diff`, `jq`, `nl`, `sed`, `sort`, `tr`, `uniq`, `wc`.

Existing of Databricks volume before this PR `cat`/`grep`/`rg`/`head`/`tail`/`ls`/`stat`/`tree`/`find`/`touch`/`rm`.

## How

- Each command is a thin per-resource wrapper that resolves globs against the backend and hands the bytes/stream to the shared `generic.<verb>` helper.
- **No `core`/`ops` changes.** These are read-only wrappers over the existing `read` op.

## Known limitation

This PR deliberately does not touch the shared `generic/*` helpers. A few of them (`awk`, `cut`, `tr`, `uniq`, and `jq` JSONL streaming) read only the first operand path, so a multi-match glob like `awk '{print}' /dbx/*.csv` processes only the first file today. Proper multi-file support belongs in the generic layer as a separate, cross-backend change.

## Test plan

- [x] `cd python && uv run pytest tests/commands/builtin/databricks_volume tests/core/databricks_volume tests/resource/databricks_volume`
- [x] `uv run python -c "import mirage.commands.builtin.databricks_volume"`
- [x] databricks volume integration test (running against actual volume) 