### PR TITLE
feat(databricks-volume): add directory/structural write ops (mkdir, rmdir, rm -r, cp, mv)

### DIFF
--- a/python/mirage/commands/builtin/databricks_volume/__init__.py
+++ b/python/mirage/commands/builtin/databricks_volume/__init__.py
@@ -14,6 +14,7 @@
 
 from mirage.commands.builtin.databricks_volume.awk import awk
 from mirage.commands.builtin.databricks_volume.cat import cat
+from mirage.commands.builtin.databricks_volume.cp import cp
 from mirage.commands.builtin.databricks_volume.cut import cut
 from mirage.commands.builtin.databricks_volume.diff import diff
 from mirage.commands.builtin.databricks_volume.find import find
@@ -21,6 +22,8 @@ from mirage.commands.builtin.databricks_volume.grep import grep
 from mirage.commands.builtin.databricks_volume.head import head
 from mirage.commands.builtin.databricks_volume.jq import jq
 from mirage.commands.builtin.databricks_volume.ls import ls
+from mirage.commands.builtin.databricks_volume.mkdir import mkdir
+from mirage.commands.builtin.databricks_volume.mv import mv
 from mirage.commands.builtin.databricks_volume.nl import nl
 from mirage.commands.builtin.databricks_volume.rg import rg
 from mirage.commands.builtin.databricks_volume.rm import rm
@@ -37,6 +40,7 @@ from mirage.commands.builtin.databricks_volume.wc import wc
 COMMANDS = [
     awk,
     cat,
+    cp,
     cut,
     diff,
     find,
@@ -44,6 +48,8 @@ COMMANDS = [
     head,
     jq,
     ls,
+    mkdir,
+    mv,
     nl,
     rm,
     rg,

--- a/python/mirage/commands/builtin/databricks_volume/_helpers.py
+++ b/python/mirage/commands/builtin/databricks_volume/_helpers.py
@@ -15,12 +15,14 @@
 from functools import partial
 from typing import Callable
 
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.utils.wrap import (call_read_bytes,
                                                 call_read_stream)
 from mirage.core.databricks_volume.read import read_bytes as _read_bytes
+from mirage.core.databricks_volume.stat import stat as _stat
 from mirage.core.databricks_volume.stream import read_stream as _read_stream
-from mirage.types import PathSpec
+from mirage.types import FileType, PathSpec
 
 
 def path_prefix(paths: list[PathSpec],
@@ -30,6 +32,31 @@ def path_prefix(paths: list[PathSpec],
     if fallback is not None:
         return fallback.prefix
     return ""
+
+
+async def is_directory(accessor: DatabricksVolumeAccessor,
+                       path: PathSpec,
+                       index: IndexCacheStore | None = None) -> bool:
+    try:
+        file_stat = await _stat(accessor, path, index)
+    except FileNotFoundError:
+        return False
+    return file_stat.type == FileType.DIRECTORY
+
+
+async def path_exists(accessor: DatabricksVolumeAccessor,
+                      path: PathSpec,
+                      index: IndexCacheStore | None = None) -> bool:
+    try:
+        await _stat(accessor, path, index)
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def child_path(parent: PathSpec, name: str) -> PathSpec:
+    base = parent.original.rstrip("/")
+    return PathSpec.from_str_path(f"{base}/{name}", parent.prefix)
 
 
 def read_bytes_with_index(index: IndexCacheStore | None,

--- a/python/mirage/commands/builtin/databricks_volume/cp.py
+++ b/python/mirage/commands/builtin/databricks_volume/cp.py
@@ -1,0 +1,63 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.databricks_volume._helpers import (child_path,
+                                                                is_directory,
+                                                                path_exists)
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.copy import copy as copy_core
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("cp", resource="databricks_volume", spec=SPECS["cp"], write=True)
+async def cp(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    r: bool = False,
+    R: bool = False,
+    a: bool = False,
+    f: bool = False,
+    n: bool = False,
+    v: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if len(paths) < 2:
+        raise ValueError("cp: requires src and dst")
+    paths = await resolve_glob(accessor, paths, index)
+    recursive = r or R or a
+    *sources, dst = paths
+    dst_is_dir = await is_directory(accessor, dst, index)
+    writes: dict[str, bytes] = {}
+    lines: list[str] = []
+    for src in sources:
+        target = dst
+        if dst_is_dir:
+            name = src.strip_prefix.rstrip("/").rsplit("/", 1)[-1]
+            target = child_path(dst, name)
+        if n and await path_exists(accessor, target, index):
+            continue
+        await copy_core(accessor, src, target, index, recursive=recursive)
+        writes[target.strip_prefix] = b""
+        if v:
+            lines.append(f"'{src.original}' -> '{target.original}'")
+    output = ("\n".join(lines) + "\n").encode() if lines else None
+    return output, IOResult(writes=writes)

--- a/python/mirage/commands/builtin/databricks_volume/mkdir.py
+++ b/python/mirage/commands/builtin/databricks_volume/mkdir.py
@@ -1,0 +1,50 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.mkdir import mkdir as mkdir_core
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("mkdir",
+         resource="databricks_volume",
+         spec=SPECS["mkdir"],
+         write=True)
+async def mkdir(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    p: bool = False,
+    v: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        raise ValueError("mkdir: missing operand")
+    paths = await resolve_glob(accessor, paths, index)
+    created: dict[str, bytes] = {}
+    lines: list[str] = []
+    for path in paths:
+        await mkdir_core(accessor, path, index, parents=p)
+        created[path.strip_prefix] = b""
+        if v:
+            lines.append(f"mkdir: created directory '{path.original}'")
+    output = ("\n".join(lines) + "\n").encode() if lines else None
+    return output, IOResult(writes=created)

--- a/python/mirage/commands/builtin/databricks_volume/mv.py
+++ b/python/mirage/commands/builtin/databricks_volume/mv.py
@@ -1,0 +1,60 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.databricks_volume._helpers import (child_path,
+                                                                is_directory,
+                                                                path_exists)
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.rename import rename as rename_core
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("mv", resource="databricks_volume", spec=SPECS["mv"], write=True)
+async def mv(
+    accessor: DatabricksVolumeAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    f: bool = False,
+    n: bool = False,
+    v: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if len(paths) < 2:
+        raise ValueError("mv: requires src and dst")
+    paths = await resolve_glob(accessor, paths, index)
+    *sources, dst = paths
+    dst_is_dir = await is_directory(accessor, dst, index)
+    writes: dict[str, bytes] = {}
+    lines: list[str] = []
+    for src in sources:
+        target = dst
+        if dst_is_dir:
+            name = src.strip_prefix.rstrip("/").rsplit("/", 1)[-1]
+            target = child_path(dst, name)
+        if n and await path_exists(accessor, target, index):
+            continue
+        await rename_core(accessor, src, target, index)
+        writes[src.strip_prefix] = b""
+        writes[target.strip_prefix] = b""
+        if v:
+            lines.append(f"'{src.original}' -> '{target.original}'")
+    output = ("\n".join(lines) + "\n").encode() if lines else None
+    return output, IOResult(writes=writes)

--- a/python/mirage/commands/builtin/databricks_volume/rm.py
+++ b/python/mirage/commands/builtin/databricks_volume/rm.py
@@ -17,9 +17,12 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.rm import rm_recursive
+from mirage.core.databricks_volume.rmdir import rmdir
+from mirage.core.databricks_volume.stat import stat
 from mirage.core.databricks_volume.unlink import unlink
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import PathSpec
+from mirage.types import FileType, PathSpec
 
 
 @command("rm", resource="databricks_volume", spec=SPECS["rm"], write=True)
@@ -38,24 +41,30 @@ async def rm(
 ) -> tuple[ByteSource | None, IOResult]:
     if not paths:
         raise ValueError("rm: missing operand")
-    if r or R or d:
-        raise ValueError(
-            "rm: recursive and directory removal are not supported")
     paths = await resolve_glob(accessor, paths, index)
+    recursive = r or R
     verbose_parts: list[str] = []
     removed: dict[str, bytes] = {}
     for path in paths:
         try:
-            await unlink(accessor, path, index)
-        except IsADirectoryError as exc:
-            raise IsADirectoryError(
-                f"rm: cannot remove '{path.original}': Is a directory"
-            ) from exc
+            file_stat = await stat(accessor, path, index)
         except FileNotFoundError:
             if f:
                 continue
             raise
-        removed[path.strip_prefix] = b""
+        if file_stat.type == FileType.DIRECTORY:
+            if recursive:
+                for relative in await rm_recursive(accessor, path, index):
+                    removed[relative] = b""
+            elif d:
+                await rmdir(accessor, path, index)
+                removed[path.strip_prefix] = b""
+            else:
+                raise IsADirectoryError(
+                    f"rm: cannot remove '{path.original}': Is a directory")
+        else:
+            await unlink(accessor, path, index)
+            removed[path.strip_prefix] = b""
         if v:
             verbose_parts.append(f"removed '{path.original}'")
     output = "\n".join(verbose_parts).encode() if v else None

--- a/python/mirage/core/databricks_volume/copy.py
+++ b/python/mirage/core/databricks_volume/copy.py
@@ -1,0 +1,96 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+from io import BytesIO
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume._helpers import ensure_path_spec
+from mirage.core.databricks_volume.path import backend_path
+from mirage.core.databricks_volume.read import read_bytes
+from mirage.core.databricks_volume.stat import stat
+from mirage.core.databricks_volume.write import write_bytes
+from mirage.types import FileType, PathSpec
+
+
+def _download_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+) -> bytes:
+    response = accessor.files.download(remote_path)
+    contents = getattr(response, "contents", response)
+    if hasattr(contents, "read"):
+        return contents.read()
+    return bytes(contents)
+
+
+def _upload_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+    data: bytes,
+) -> None:
+    accessor.files.upload(remote_path, BytesIO(data), overwrite=True)
+
+
+def _create_directory_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+) -> None:
+    accessor.files.create_directory(remote_path)
+
+
+def _list_directory_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+) -> list:
+    return list(accessor.files.list_directory_contents(remote_path))
+
+
+def _copy_tree_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_src: str,
+    remote_dst: str,
+) -> None:
+    _create_directory_sync(accessor, remote_dst)
+    for entry in _list_directory_sync(accessor, remote_src):
+        name = entry.path.rstrip("/").rsplit("/", 1)[-1]
+        child_dst = remote_dst.rstrip("/") + "/" + name
+        if getattr(entry, "is_directory", False):
+            _copy_tree_sync(accessor, entry.path, child_dst)
+        else:
+            _upload_sync(accessor, child_dst,
+                         _download_sync(accessor, entry.path))
+
+
+async def copy(
+    accessor: DatabricksVolumeAccessor,
+    src: PathSpec,
+    dst: PathSpec,
+    index: IndexCacheStore = None,
+    recursive: bool = False,
+) -> None:
+    src = ensure_path_spec(src)
+    dst = ensure_path_spec(dst)
+    src_stat = await stat(accessor, src, index)
+    if src_stat.type == FileType.DIRECTORY:
+        if not recursive:
+            raise IsADirectoryError(src.strip_prefix)
+        remote_src = backend_path(accessor.config, src)
+        remote_dst = backend_path(accessor.config, dst)
+        await asyncio.to_thread(_copy_tree_sync, accessor, remote_src,
+                                remote_dst)
+        return
+    data = await read_bytes(accessor, src, index)
+    await write_bytes(accessor, dst, data, index)

--- a/python/mirage/core/databricks_volume/mkdir.py
+++ b/python/mirage/core/databricks_volume/mkdir.py
@@ -1,0 +1,57 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume._helpers import (ensure_path_spec,
+                                                    parent_path)
+from mirage.core.databricks_volume.errors import is_not_found
+from mirage.core.databricks_volume.exists import exists
+from mirage.core.databricks_volume.path import backend_path
+from mirage.core.databricks_volume.stat import stat
+from mirage.types import FileType, PathSpec
+
+
+def _create_directory_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+) -> None:
+    accessor.files.create_directory(remote_path)
+
+
+async def mkdir(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+    parents: bool = False,
+) -> None:
+    path = ensure_path_spec(path)
+    remote_path = backend_path(accessor.config, path)
+    if parents:
+        await asyncio.to_thread(_create_directory_sync, accessor, remote_path)
+        return
+    if await exists(accessor, path):
+        raise FileExistsError(path.strip_prefix)
+    parent = parent_path(path)
+    parent_stat = await stat(accessor, parent, index)
+    if parent_stat.type != FileType.DIRECTORY:
+        raise NotADirectoryError(path.strip_prefix)
+    try:
+        await asyncio.to_thread(_create_directory_sync, accessor, remote_path)
+    except Exception as exc:
+        if is_not_found(exc):
+            raise FileNotFoundError(path.strip_prefix) from exc
+        raise

--- a/python/mirage/core/databricks_volume/rename.py
+++ b/python/mirage/core/databricks_volume/rename.py
@@ -1,0 +1,41 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume._helpers import ensure_path_spec
+from mirage.core.databricks_volume.copy import copy
+from mirage.core.databricks_volume.rm import rm_recursive
+from mirage.core.databricks_volume.stat import stat
+from mirage.core.databricks_volume.unlink import unlink
+from mirage.types import FileType, PathSpec
+
+
+async def rename(
+    accessor: DatabricksVolumeAccessor,
+    src: PathSpec,
+    dst: PathSpec,
+    index: IndexCacheStore = None,
+) -> None:
+    # Non-atomic: the Databricks Files API has no native rename, so this is
+    # implemented as copy + delete and can leave partial state on failure.
+    src = ensure_path_spec(src)
+    dst = ensure_path_spec(dst)
+    src_stat = await stat(accessor, src, index)
+    if src_stat.type == FileType.DIRECTORY:
+        await copy(accessor, src, dst, index, recursive=True)
+        await rm_recursive(accessor, src, index)
+    else:
+        await copy(accessor, src, dst, index)
+        await unlink(accessor, src, index)

--- a/python/mirage/core/databricks_volume/rm.py
+++ b/python/mirage/core/databricks_volume/rm.py
@@ -1,0 +1,90 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume._helpers import ensure_path_spec
+from mirage.core.databricks_volume.errors import is_not_found
+from mirage.core.databricks_volume.path import backend_path, virtual_path
+from mirage.core.databricks_volume.stat import stat
+from mirage.core.databricks_volume.unlink import unlink
+from mirage.types import FileType, PathSpec
+
+
+def _list_directory_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+) -> list:
+    return list(accessor.files.list_directory_contents(remote_path))
+
+
+def _delete_file_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+) -> None:
+    accessor.files.delete(remote_path)
+
+
+def _delete_directory_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+) -> None:
+    accessor.files.delete_directory(remote_path)
+
+
+def _remove_tree_recurse(
+    accessor: DatabricksVolumeAccessor,
+    remote_dir: str,
+    removed: list[str],
+) -> None:
+    for entry in _list_directory_sync(accessor, remote_dir):
+        if getattr(entry, "is_directory", False):
+            _remove_tree_recurse(accessor, entry.path, removed)
+        else:
+            _delete_file_sync(accessor, entry.path)
+            removed.append(entry.path)
+    _delete_directory_sync(accessor, remote_dir)
+    removed.append(remote_dir)
+
+
+def _remove_tree_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_root: str,
+) -> list[str]:
+    removed: list[str] = []
+    _remove_tree_recurse(accessor, remote_root, removed)
+    return removed
+
+
+async def rm_recursive(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> list[str]:
+    path = ensure_path_spec(path)
+    file_stat = await stat(accessor, path, index)
+    if file_stat.type != FileType.DIRECTORY:
+        await unlink(accessor, path, index)
+        return [path.strip_prefix]
+    remote_root = backend_path(accessor.config, path)
+    try:
+        removed = await asyncio.to_thread(_remove_tree_sync, accessor,
+                                          remote_root)
+    except Exception as exc:
+        if is_not_found(exc):
+            raise FileNotFoundError(path.strip_prefix) from exc
+        raise
+    return [virtual_path(accessor.config, backend, "") for backend in removed]

--- a/python/mirage/core/databricks_volume/rmdir.py
+++ b/python/mirage/core/databricks_volume/rmdir.py
@@ -1,0 +1,64 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume._helpers import ensure_path_spec
+from mirage.core.databricks_volume.errors import is_not_found
+from mirage.core.databricks_volume.path import backend_path
+from mirage.core.databricks_volume.stat import stat
+from mirage.types import FileType, PathSpec
+
+
+def _list_directory_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+) -> list:
+    return list(accessor.files.list_directory_contents(remote_path))
+
+
+def _delete_directory_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+) -> None:
+    accessor.files.delete_directory(remote_path)
+
+
+async def rmdir(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> None:
+    path = ensure_path_spec(path)
+    file_stat = await stat(accessor, path, index)
+    if file_stat.type != FileType.DIRECTORY:
+        raise NotADirectoryError(path.strip_prefix)
+    remote_path = backend_path(accessor.config, path)
+    try:
+        entries = await asyncio.to_thread(_list_directory_sync, accessor,
+                                          remote_path)
+    except Exception as exc:
+        if is_not_found(exc):
+            raise FileNotFoundError(path.strip_prefix) from exc
+        raise
+    if entries:
+        raise OSError(f"directory not empty: {path.strip_prefix}")
+    try:
+        await asyncio.to_thread(_delete_directory_sync, accessor, remote_path)
+    except Exception as exc:
+        if is_not_found(exc):
+            raise FileNotFoundError(path.strip_prefix) from exc
+        raise

--- a/python/mirage/ops/databricks_volume/mkdir.py
+++ b/python/mirage/ops/databricks_volume/mkdir.py
@@ -12,14 +12,16 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.ops.databricks_volume.create import create
-from mirage.ops.databricks_volume.mkdir import mkdir
-from mirage.ops.databricks_volume.read import read
-from mirage.ops.databricks_volume.readdir import readdir
-from mirage.ops.databricks_volume.rename import rename
-from mirage.ops.databricks_volume.rmdir import rmdir
-from mirage.ops.databricks_volume.stat import stat
-from mirage.ops.databricks_volume.unlink import unlink
-from mirage.ops.databricks_volume.write import write
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.core.databricks_volume.mkdir import mkdir as mkdir_core
+from mirage.ops.registry import op
+from mirage.types import PathSpec
 
-OPS = [read, readdir, stat, write, create, unlink, mkdir, rmdir, rename]
+
+@op("mkdir", resource="databricks_volume", write=True)
+async def mkdir(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    **kwargs,
+) -> None:
+    await mkdir_core(accessor, path, kwargs.get("index"), parents=True)

--- a/python/mirage/ops/databricks_volume/rename.py
+++ b/python/mirage/ops/databricks_volume/rename.py
@@ -12,14 +12,17 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.ops.databricks_volume.create import create
-from mirage.ops.databricks_volume.mkdir import mkdir
-from mirage.ops.databricks_volume.read import read
-from mirage.ops.databricks_volume.readdir import readdir
-from mirage.ops.databricks_volume.rename import rename
-from mirage.ops.databricks_volume.rmdir import rmdir
-from mirage.ops.databricks_volume.stat import stat
-from mirage.ops.databricks_volume.unlink import unlink
-from mirage.ops.databricks_volume.write import write
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.core.databricks_volume.rename import rename as rename_core
+from mirage.ops.registry import op
+from mirage.types import PathSpec
 
-OPS = [read, readdir, stat, write, create, unlink, mkdir, rmdir, rename]
+
+@op("rename", resource="databricks_volume", write=True)
+async def rename(
+    accessor: DatabricksVolumeAccessor,
+    src: PathSpec,
+    dst: PathSpec,
+    **kwargs,
+) -> None:
+    await rename_core(accessor, src, dst, kwargs.get("index"))

--- a/python/mirage/ops/databricks_volume/rmdir.py
+++ b/python/mirage/ops/databricks_volume/rmdir.py
@@ -12,14 +12,16 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.ops.databricks_volume.create import create
-from mirage.ops.databricks_volume.mkdir import mkdir
-from mirage.ops.databricks_volume.read import read
-from mirage.ops.databricks_volume.readdir import readdir
-from mirage.ops.databricks_volume.rename import rename
-from mirage.ops.databricks_volume.rmdir import rmdir
-from mirage.ops.databricks_volume.stat import stat
-from mirage.ops.databricks_volume.unlink import unlink
-from mirage.ops.databricks_volume.write import write
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.core.databricks_volume.rmdir import rmdir as rmdir_core
+from mirage.ops.registry import op
+from mirage.types import PathSpec
 
-OPS = [read, readdir, stat, write, create, unlink, mkdir, rmdir, rename]
+
+@op("rmdir", resource="databricks_volume", write=True)
+async def rmdir(
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    **kwargs,
+) -> None:
+    await rmdir_core(accessor, path, kwargs.get("index"))

--- a/python/mirage/resource/databricks_volume/databricks_volume.py
+++ b/python/mirage/resource/databricks_volume/databricks_volume.py
@@ -18,11 +18,16 @@ from typing import Any
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.commands.builtin.databricks_volume import \
     COMMANDS as DATABRICKS_VOLUME_COMMANDS
+from mirage.core.databricks_volume.copy import copy
 from mirage.core.databricks_volume.create import create
 from mirage.core.databricks_volume.exists import exists
 from mirage.core.databricks_volume.glob import resolve_glob as _resolve_glob
+from mirage.core.databricks_volume.mkdir import mkdir
 from mirage.core.databricks_volume.read import read_bytes
 from mirage.core.databricks_volume.readdir import readdir
+from mirage.core.databricks_volume.rename import rename
+from mirage.core.databricks_volume.rm import rm_recursive
+from mirage.core.databricks_volume.rmdir import rmdir
 from mirage.core.databricks_volume.stat import stat as databricks_stat
 from mirage.core.databricks_volume.stream import range_read, read_stream
 from mirage.core.databricks_volume.unlink import unlink
@@ -43,6 +48,11 @@ _DATABRICKS_VOLUME_OPS = {
     "write": write_bytes,
     "create": create,
     "unlink": unlink,
+    "mkdir": mkdir,
+    "rmdir": rmdir,
+    "copy": copy,
+    "rename": rename,
+    "rm_recursive": rm_recursive,
 }
 
 

--- a/python/mirage/resource/databricks_volume/prompt.py
+++ b/python/mirage/resource/databricks_volume/prompt.py
@@ -15,6 +15,12 @@
 PROMPT = """\
 {prefix}
   Remote Databricks Unity Catalog volume filesystem.
-  IMPORTANT: This is a remote mount. Prefer targeted reads (ls, head, grep, rg)
-  over full scans. Avoid cat on large files without piping to head/tail.
-  Supports: ls, cat, head, tail, grep, rg, find, tree, stat."""
+  IMPORTANT: This is a remote mount - every file/dir access is an API round-trip.
+  Prefer targeted reads (ls, head, grep, rg, find with a path/glob) over full
+  scans; recursive ops (rm -r, cp -r, tree, grep -r) over a large tree are slow.
+  Create parent dirs before writing: `mkdir -p /path && cmd > /path/out`.
+  mv/cp are non-atomic full copies (no server-side rename) - avoid on large files.
+  sed -i is not supported; transform and redirect to a new file instead.
+  Read/analyze: ls, cat, head, tail, grep, rg, find, tree, stat, wc, sort, uniq,
+    cut, nl, tr, sed, awk, jq, diff.
+  Write: touch, rm, rm -r, mkdir, mkdir -p, cp, mv, and >/>> redirects."""

--- a/python/tests/commands/builtin/databricks_volume/test_cp.py
+++ b/python/tests/commands/builtin/databricks_volume/test_cp.py
@@ -1,0 +1,75 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, Workspace
+from tests.resource.databricks_volume.test_databricks_volume import (
+    FakeFiles, make_resource, seed_directory, seed_file)
+
+ROOT = "/Volumes/main/default/agent_files/root"
+
+
+@pytest.fixture
+def dbx_files() -> FakeFiles:
+    files = FakeFiles()
+    seed_directory(files, ROOT)
+    seed_file(files, f"{ROOT}/src.txt", b"hello")
+    return files
+
+
+@pytest.fixture
+def write_ws(dbx_files: FakeFiles) -> Workspace:
+    return Workspace({"/dbx/": make_resource(dbx_files)}, mode=MountMode.WRITE)
+
+
+@pytest.fixture
+def read_ws(dbx_files: FakeFiles) -> Workspace:
+    return Workspace({"/dbx/": make_resource(dbx_files)}, mode=MountMode.READ)
+
+
+@pytest.mark.asyncio
+async def test_cp_file_preserves_bytes(write_ws, dbx_files):
+    io = await write_ws.execute("cp /dbx/src.txt /dbx/dst.txt")
+
+    assert io.exit_code == 0
+    assert dbx_files.downloads[f"{ROOT}/dst.txt"] == b"hello"
+
+
+@pytest.mark.asyncio
+async def test_cp_directory_without_recursive_fails(write_ws, dbx_files):
+    seed_directory(dbx_files, f"{ROOT}/d")
+
+    io = await write_ws.execute("cp /dbx/d /dbx/d2")
+
+    assert io.exit_code != 0
+
+
+@pytest.mark.asyncio
+async def test_cp_writes_are_mount_relative(write_ws):
+    io = await write_ws.execute("cp /dbx/src.txt /dbx/dst.txt")
+
+    assert io.exit_code == 0
+    for key in io.writes:
+        assert key.startswith("/dbx/")
+        assert not key.startswith("/dbx/dbx/")
+
+
+@pytest.mark.asyncio
+async def test_cp_read_only_mount_rejected(read_ws, dbx_files):
+    io = await read_ws.execute("cp /dbx/src.txt /dbx/dst.txt")
+
+    assert io.exit_code != 0
+    assert b"read-only" in io.stderr
+    assert f"{ROOT}/dst.txt" not in dbx_files.downloads

--- a/python/tests/commands/builtin/databricks_volume/test_mkdir.py
+++ b/python/tests/commands/builtin/databricks_volume/test_mkdir.py
@@ -1,0 +1,93 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, Workspace
+from tests.resource.databricks_volume.test_databricks_volume import (
+    FakeFiles, make_resource, seed_directory)
+
+ROOT = "/Volumes/main/default/agent_files/root"
+
+
+@pytest.fixture
+def dbx_files() -> FakeFiles:
+    files = FakeFiles()
+    seed_directory(files, ROOT)
+    return files
+
+
+@pytest.fixture
+def write_ws(dbx_files: FakeFiles) -> Workspace:
+    return Workspace({"/dbx/": make_resource(dbx_files)}, mode=MountMode.WRITE)
+
+
+@pytest.fixture
+def read_ws(dbx_files: FakeFiles) -> Workspace:
+    return Workspace({"/dbx/": make_resource(dbx_files)}, mode=MountMode.READ)
+
+
+@pytest.mark.asyncio
+async def test_mkdir_creates_directory(write_ws, dbx_files):
+    io = await write_ws.execute("mkdir /dbx/newdir")
+
+    assert io.exit_code == 0
+    assert f"{ROOT}/newdir" in dbx_files.directory_metadata
+
+
+@pytest.mark.asyncio
+async def test_mkdir_parent_missing_fails(write_ws):
+    io = await write_ws.execute("mkdir /dbx/a/b")
+
+    assert io.exit_code != 0
+
+
+@pytest.mark.asyncio
+async def test_mkdir_parents_creates_chain(write_ws, dbx_files):
+    io = await write_ws.execute("mkdir -p /dbx/a/b/c")
+
+    assert io.exit_code == 0
+    assert f"{ROOT}/a/b/c" in dbx_files.directory_metadata
+
+
+@pytest.mark.asyncio
+async def test_mkdir_writes_are_mount_relative(write_ws):
+    io = await write_ws.execute("mkdir /dbx/newdir")
+
+    assert io.exit_code == 0
+    for key in io.writes:
+        assert key.startswith("/dbx/")
+        assert not key.startswith("/dbx/dbx/")
+
+
+@pytest.mark.asyncio
+async def test_mkdir_read_only_mount_rejected(read_ws, dbx_files):
+    io = await read_ws.execute("mkdir /dbx/newdir")
+
+    assert io.exit_code != 0
+    assert b"read-only" in io.stderr
+    assert dbx_files.create_directory_calls == []
+
+
+@pytest.mark.asyncio
+async def test_ops_mkdir(write_ws, dbx_files):
+    await write_ws.ops.mkdir("/dbx/opdir")
+
+    assert f"{ROOT}/opdir" in dbx_files.directory_metadata
+
+
+@pytest.mark.asyncio
+async def test_ops_mkdir_read_only_rejected(read_ws):
+    with pytest.raises(PermissionError):
+        await read_ws.ops.mkdir("/dbx/opdir")

--- a/python/tests/commands/builtin/databricks_volume/test_mv.py
+++ b/python/tests/commands/builtin/databricks_volume/test_mv.py
@@ -1,0 +1,87 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, Workspace
+from tests.resource.databricks_volume.test_databricks_volume import (
+    FakeFiles, make_resource, seed_directory, seed_file)
+
+ROOT = "/Volumes/main/default/agent_files/root"
+
+
+@pytest.fixture
+def dbx_files() -> FakeFiles:
+    files = FakeFiles()
+    seed_directory(files, ROOT)
+    seed_file(files, f"{ROOT}/src.txt", b"data")
+    return files
+
+
+@pytest.fixture
+def write_ws(dbx_files: FakeFiles) -> Workspace:
+    return Workspace({"/dbx/": make_resource(dbx_files)}, mode=MountMode.WRITE)
+
+
+@pytest.fixture
+def read_ws(dbx_files: FakeFiles) -> Workspace:
+    return Workspace({"/dbx/": make_resource(dbx_files)}, mode=MountMode.READ)
+
+
+@pytest.mark.asyncio
+async def test_mv_file_moves_bytes(write_ws, dbx_files):
+    io = await write_ws.execute("mv /dbx/src.txt /dbx/dst.txt")
+
+    assert io.exit_code == 0
+    assert dbx_files.downloads[f"{ROOT}/dst.txt"] == b"data"
+    assert f"{ROOT}/src.txt" not in dbx_files.downloads
+
+
+@pytest.mark.asyncio
+async def test_mv_writes_both_parents_mount_relative(write_ws):
+    io = await write_ws.execute("mv /dbx/src.txt /dbx/dst.txt")
+
+    assert io.exit_code == 0
+    assert "/dbx/src.txt" in io.writes
+    assert "/dbx/dst.txt" in io.writes
+    for key in io.writes:
+        assert not key.startswith("/dbx/dbx/")
+
+
+@pytest.mark.asyncio
+async def test_mv_no_clobber_skips_existing(write_ws, dbx_files):
+    seed_file(dbx_files, f"{ROOT}/dst.txt", b"keep")
+
+    io = await write_ws.execute("mv -n /dbx/src.txt /dbx/dst.txt")
+
+    assert io.exit_code == 0
+    assert dbx_files.downloads[f"{ROOT}/dst.txt"] == b"keep"
+    assert dbx_files.downloads[f"{ROOT}/src.txt"] == b"data"
+
+
+@pytest.mark.asyncio
+async def test_mv_read_only_mount_rejected(read_ws, dbx_files):
+    io = await read_ws.execute("mv /dbx/src.txt /dbx/dst.txt")
+
+    assert io.exit_code != 0
+    assert b"read-only" in io.stderr
+    assert dbx_files.downloads[f"{ROOT}/src.txt"] == b"data"
+
+
+@pytest.mark.asyncio
+async def test_ops_rename(write_ws, dbx_files):
+    await write_ws.ops.rename("/dbx/src.txt", "/dbx/renamed.txt")
+
+    assert dbx_files.downloads[f"{ROOT}/renamed.txt"] == b"data"
+    assert f"{ROOT}/src.txt" not in dbx_files.downloads

--- a/python/tests/commands/builtin/databricks_volume/test_rm_recursive.py
+++ b/python/tests/commands/builtin/databricks_volume/test_rm_recursive.py
@@ -1,0 +1,93 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, Workspace
+from tests.resource.databricks_volume.test_databricks_volume import (
+    FakeFiles, make_resource, seed_directory, seed_file)
+
+ROOT = "/Volumes/main/default/agent_files/root"
+
+
+@pytest.fixture
+def dbx_files() -> FakeFiles:
+    files = FakeFiles()
+    seed_directory(files, ROOT)
+    files.create_directory(f"{ROOT}/d")
+    seed_file(files, f"{ROOT}/d/a.txt", b"a")
+    files.create_directory(f"{ROOT}/d/sub")
+    seed_file(files, f"{ROOT}/d/sub/b.txt", b"b")
+    return files
+
+
+@pytest.fixture
+def write_ws(dbx_files: FakeFiles) -> Workspace:
+    return Workspace({"/dbx/": make_resource(dbx_files)}, mode=MountMode.WRITE)
+
+
+@pytest.fixture
+def read_ws(dbx_files: FakeFiles) -> Workspace:
+    return Workspace({"/dbx/": make_resource(dbx_files)}, mode=MountMode.READ)
+
+
+@pytest.mark.asyncio
+async def test_rm_recursive_removes_tree(write_ws, dbx_files):
+    io = await write_ws.execute("rm -r /dbx/d")
+
+    assert io.exit_code == 0
+    assert f"{ROOT}/d" not in dbx_files.directory_metadata
+    assert f"{ROOT}/d/sub/b.txt" not in dbx_files.downloads
+
+
+@pytest.mark.asyncio
+async def test_rm_recursive_writes_are_mount_relative(write_ws):
+    io = await write_ws.execute("rm -r /dbx/d")
+
+    assert io.exit_code == 0
+    assert io.writes
+    for key in io.writes:
+        assert key.startswith("/dbx/")
+        assert not key.startswith("/dbx/dbx/")
+
+
+@pytest.mark.asyncio
+async def test_plain_rm_on_directory_fails(write_ws, dbx_files):
+    io = await write_ws.execute("rm /dbx/d")
+
+    assert io.exit_code != 0
+    assert f"{ROOT}/d" in dbx_files.directory_metadata
+
+
+@pytest.mark.asyncio
+async def test_rm_force_missing_succeeds(write_ws):
+    io = await write_ws.execute("rm -f /dbx/missing.txt")
+
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_rm_missing_fails(write_ws):
+    io = await write_ws.execute("rm /dbx/missing.txt")
+
+    assert io.exit_code != 0
+
+
+@pytest.mark.asyncio
+async def test_rm_recursive_read_only_rejected(read_ws, dbx_files):
+    io = await read_ws.execute("rm -r /dbx/d")
+
+    assert io.exit_code != 0
+    assert b"read-only" in io.stderr
+    assert f"{ROOT}/d" in dbx_files.directory_metadata

--- a/python/tests/core/databricks_volume/conftest.py
+++ b/python/tests/core/databricks_volume/conftest.py
@@ -36,6 +36,8 @@ class FakeFiles:
         self.list_directory_calls: list[str] = []
         self.upload_calls: list[tuple[str, bytes, bool]] = []
         self.delete_calls: list[str] = []
+        self.create_directory_calls: list[str] = []
+        self.delete_directory_calls: list[str] = []
 
     def download(self, path: str) -> FakeDownload:
         self.download_calls.append(path)
@@ -63,6 +65,35 @@ class FakeFiles:
         if path not in self.directories:
             raise NotFoundError(path)
         return self.directories[path]
+
+    def create_directory(self, path: str) -> None:
+        self.create_directory_calls.append(path)
+        cur = ""
+        for part in path.strip("/").split("/"):
+            cur = cur + "/" + part
+            if cur in self.directory_metadata:
+                continue
+            self.directory_metadata.add(cur)
+            self.metadata[cur] = SimpleNamespace(is_directory=True)
+            self.directories.setdefault(cur, [])
+            parent = posixpath.dirname(cur) or "/"
+            self._upsert_directory_entry(
+                parent, SimpleNamespace(path=cur, is_directory=True))
+
+    def delete_directory(self, path: str) -> None:
+        self.delete_directory_calls.append(path)
+        if path not in self.directory_metadata:
+            raise NotFoundError(path)
+        if self.directories.get(path):
+            raise OSError(f"directory not empty: {path}")
+        self.directory_metadata.discard(path)
+        self.metadata.pop(path, None)
+        self.directories.pop(path, None)
+        parent = posixpath.dirname(path.rstrip("/")) or "/"
+        self.directories[parent] = [
+            entry for entry in self.directories.get(parent, [])
+            if getattr(entry, "path", None) != path
+        ]
 
     def upload(self, path: str, contents, overwrite: bool = False) -> None:
         data = contents.read()

--- a/python/tests/core/databricks_volume/test_copy.py
+++ b/python/tests/core/databricks_volume/test_copy.py
@@ -1,0 +1,98 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from types import SimpleNamespace
+
+import pytest
+
+from mirage.core.databricks_volume.copy import copy
+from mirage.types import PathSpec
+
+
+def _path(path: str) -> PathSpec:
+    return PathSpec.from_str_path(path, "/dbx")
+
+
+def _seed_directory(files, path: str) -> None:
+    files.directory_metadata.add(path)
+    files.directories.setdefault(path, [])
+    parent = path.rsplit("/", 1)[0]
+    if parent and parent != path:
+        files.directories.setdefault(parent, []).append(
+            SimpleNamespace(path=path, is_directory=True, file_size=None))
+
+
+def _seed_file(files, path: str, data: bytes) -> None:
+    parent = path.rsplit("/", 1)[0]
+    files.downloads[path] = data
+    files.metadata[path] = SimpleNamespace(is_directory=False,
+                                           file_size=len(data))
+    files.directories.setdefault(parent, []).append(
+        SimpleNamespace(path=path, is_directory=False, file_size=len(data)))
+
+
+@pytest.mark.asyncio
+async def test_copy_file_preserves_bytes(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_file(files, f"{remote_root}/src.txt", b"hello")
+
+    await copy(accessor, _path("/dbx/src.txt"), _path("/dbx/dst.txt"), index)
+
+    assert files.downloads[f"{remote_root}/dst.txt"] == b"hello"
+    assert files.downloads[f"{remote_root}/src.txt"] == b"hello"
+
+
+@pytest.mark.asyncio
+async def test_copy_missing_source_fails(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+
+    with pytest.raises(FileNotFoundError):
+        await copy(accessor, _path("/dbx/missing.txt"), _path("/dbx/dst.txt"),
+                   index)
+
+
+@pytest.mark.asyncio
+async def test_copy_missing_parent_fails(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_file(files, f"{remote_root}/src.txt", b"hi")
+
+    with pytest.raises(FileNotFoundError):
+        await copy(accessor, _path("/dbx/src.txt"),
+                   _path("/dbx/missing/dst.txt"), index)
+
+
+@pytest.mark.asyncio
+async def test_copy_directory_without_recursive_fails(accessor, files,
+                                                      remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_directory(files, f"{remote_root}/d")
+
+    with pytest.raises(IsADirectoryError):
+        await copy(accessor, _path("/dbx/d"), _path("/dbx/d2"), index)
+
+
+@pytest.mark.asyncio
+async def test_copy_recursive_tree(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_directory(files, f"{remote_root}/d")
+    _seed_file(files, f"{remote_root}/d/a.txt", b"aaa")
+
+    await copy(accessor,
+               _path("/dbx/d"),
+               _path("/dbx/d2"),
+               index,
+               recursive=True)
+
+    assert f"{remote_root}/d2" in files.directory_metadata
+    assert files.downloads[f"{remote_root}/d2/a.txt"] == b"aaa"

--- a/python/tests/core/databricks_volume/test_mkdir.py
+++ b/python/tests/core/databricks_volume/test_mkdir.py
@@ -1,0 +1,78 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from types import SimpleNamespace
+
+import pytest
+
+from mirage.core.databricks_volume.mkdir import mkdir
+from mirage.types import PathSpec
+
+
+def _path(path: str) -> PathSpec:
+    return PathSpec.from_str_path(path, "/dbx")
+
+
+def _seed_directory(files, path: str) -> None:
+    files.directory_metadata.add(path)
+    files.directories.setdefault(path, [])
+
+
+@pytest.mark.asyncio
+async def test_mkdir_creates_directory(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+
+    await mkdir(accessor, _path("/dbx/newdir"), index)
+
+    assert f"{remote_root}/newdir" in files.create_directory_calls
+    assert f"{remote_root}/newdir" in files.directory_metadata
+
+
+@pytest.mark.asyncio
+async def test_mkdir_parent_missing_fails(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+
+    with pytest.raises(FileNotFoundError):
+        await mkdir(accessor, _path("/dbx/a/b"), index)
+    assert files.create_directory_calls == []
+
+
+@pytest.mark.asyncio
+async def test_mkdir_parents_creates_chain(accessor, files, remote_root,
+                                           index):
+    _seed_directory(files, remote_root)
+
+    await mkdir(accessor, _path("/dbx/a/b/c"), index, parents=True)
+
+    assert f"{remote_root}/a/b/c" in files.directory_metadata
+
+
+@pytest.mark.asyncio
+async def test_mkdir_existing_target_fails(accessor, files, remote_root,
+                                           index):
+    _seed_directory(files, remote_root)
+    _seed_directory(files, f"{remote_root}/exists")
+
+    with pytest.raises(FileExistsError):
+        await mkdir(accessor, _path("/dbx/exists"), index)
+
+
+@pytest.mark.asyncio
+async def test_mkdir_parent_is_file_fails(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+    files.metadata[f"{remote_root}/file.txt"] = SimpleNamespace(
+        is_directory=False, file_size=3)
+
+    with pytest.raises(NotADirectoryError):
+        await mkdir(accessor, _path("/dbx/file.txt/sub"), index)

--- a/python/tests/core/databricks_volume/test_rename.py
+++ b/python/tests/core/databricks_volume/test_rename.py
@@ -1,0 +1,76 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from types import SimpleNamespace
+
+import pytest
+
+from mirage.core.databricks_volume.rename import rename
+from mirage.types import PathSpec
+
+
+def _path(path: str) -> PathSpec:
+    return PathSpec.from_str_path(path, "/dbx")
+
+
+def _seed_directory(files, path: str) -> None:
+    files.directory_metadata.add(path)
+    files.directories.setdefault(path, [])
+    parent = path.rsplit("/", 1)[0]
+    if parent and parent != path:
+        files.directories.setdefault(parent, []).append(
+            SimpleNamespace(path=path, is_directory=True, file_size=None))
+
+
+def _seed_file(files, path: str, data: bytes) -> None:
+    parent = path.rsplit("/", 1)[0]
+    files.downloads[path] = data
+    files.metadata[path] = SimpleNamespace(is_directory=False,
+                                           file_size=len(data))
+    files.directories.setdefault(parent, []).append(
+        SimpleNamespace(path=path, is_directory=False, file_size=len(data)))
+
+
+@pytest.mark.asyncio
+async def test_rename_file_moves_bytes(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_file(files, f"{remote_root}/src.txt", b"data")
+
+    await rename(accessor, _path("/dbx/src.txt"), _path("/dbx/dst.txt"), index)
+
+    assert files.downloads[f"{remote_root}/dst.txt"] == b"data"
+    assert f"{remote_root}/src.txt" not in files.downloads
+
+
+@pytest.mark.asyncio
+async def test_rename_missing_source_fails(accessor, files, remote_root,
+                                           index):
+    _seed_directory(files, remote_root)
+
+    with pytest.raises(FileNotFoundError):
+        await rename(accessor, _path("/dbx/missing.txt"),
+                     _path("/dbx/dst.txt"), index)
+
+
+@pytest.mark.asyncio
+async def test_rename_directory_moves_tree(accessor, files, remote_root,
+                                           index):
+    _seed_directory(files, remote_root)
+    _seed_directory(files, f"{remote_root}/d")
+    _seed_file(files, f"{remote_root}/d/a.txt", b"aaa")
+
+    await rename(accessor, _path("/dbx/d"), _path("/dbx/d2"), index)
+
+    assert files.downloads[f"{remote_root}/d2/a.txt"] == b"aaa"
+    assert f"{remote_root}/d" not in files.directory_metadata

--- a/python/tests/core/databricks_volume/test_rm_recursive.py
+++ b/python/tests/core/databricks_volume/test_rm_recursive.py
@@ -1,0 +1,80 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from types import SimpleNamespace
+
+import pytest
+
+from mirage.core.databricks_volume.rm import rm_recursive
+from mirage.types import PathSpec
+
+
+def _path(path: str) -> PathSpec:
+    return PathSpec.from_str_path(path, "/dbx")
+
+
+def _seed_directory(files, path: str) -> None:
+    files.directory_metadata.add(path)
+    files.directories.setdefault(path, [])
+    parent = path.rsplit("/", 1)[0]
+    if parent and parent != path:
+        files.directories.setdefault(parent, []).append(
+            SimpleNamespace(path=path, is_directory=True, file_size=None))
+
+
+def _seed_file(files, path: str, data: bytes = b"x") -> None:
+    parent = path.rsplit("/", 1)[0]
+    files.downloads[path] = data
+    files.metadata[path] = SimpleNamespace(is_directory=False,
+                                           file_size=len(data))
+    files.directories.setdefault(parent, []).append(
+        SimpleNamespace(path=path, is_directory=False, file_size=len(data)))
+
+
+@pytest.mark.asyncio
+async def test_rm_recursive_file(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_file(files, f"{remote_root}/a.txt")
+
+    removed = await rm_recursive(accessor, _path("/dbx/a.txt"), index)
+
+    assert removed == ["/a.txt"]
+    assert f"{remote_root}/a.txt" not in files.downloads
+
+
+@pytest.mark.asyncio
+async def test_rm_recursive_nested_tree(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_directory(files, f"{remote_root}/d")
+    _seed_file(files, f"{remote_root}/d/a.txt")
+    _seed_directory(files, f"{remote_root}/d/sub")
+    _seed_file(files, f"{remote_root}/d/sub/b.txt")
+
+    removed = await rm_recursive(accessor, _path("/dbx/d"), index)
+
+    assert f"{remote_root}/d/a.txt" in files.delete_calls
+    assert f"{remote_root}/d/sub/b.txt" in files.delete_calls
+    assert f"{remote_root}/d/sub" in files.delete_directory_calls
+    assert f"{remote_root}/d" in files.delete_directory_calls
+    assert "/d" in removed
+    assert f"{remote_root}/d" not in files.directory_metadata
+
+
+@pytest.mark.asyncio
+async def test_rm_recursive_missing_raises(accessor, files, remote_root,
+                                           index):
+    _seed_directory(files, remote_root)
+
+    with pytest.raises(FileNotFoundError):
+        await rm_recursive(accessor, _path("/dbx/missing"), index)

--- a/python/tests/core/databricks_volume/test_rmdir.py
+++ b/python/tests/core/databricks_volume/test_rmdir.py
@@ -1,0 +1,78 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from types import SimpleNamespace
+
+import pytest
+
+from mirage.core.databricks_volume.rmdir import rmdir
+from mirage.types import PathSpec
+
+
+def _path(path: str) -> PathSpec:
+    return PathSpec.from_str_path(path, "/dbx")
+
+
+def _seed_directory(files, path: str) -> None:
+    files.directory_metadata.add(path)
+    files.directories.setdefault(path, [])
+
+
+def _seed_file(files, path: str, data: bytes = b"x") -> None:
+    parent = path.rsplit("/", 1)[0]
+    files.downloads[path] = data
+    files.metadata[path] = SimpleNamespace(is_directory=False,
+                                           file_size=len(data))
+    files.directories.setdefault(parent, [])
+    files.directories[parent].append(
+        SimpleNamespace(path=path, is_directory=False, file_size=len(data)))
+
+
+@pytest.mark.asyncio
+async def test_rmdir_empty_succeeds(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_directory(files, f"{remote_root}/empty")
+
+    await rmdir(accessor, _path("/dbx/empty"), index)
+
+    assert files.delete_directory_calls == [f"{remote_root}/empty"]
+    assert f"{remote_root}/empty" not in files.directory_metadata
+
+
+@pytest.mark.asyncio
+async def test_rmdir_non_empty_fails(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_directory(files, f"{remote_root}/full")
+    _seed_file(files, f"{remote_root}/full/a.txt")
+
+    with pytest.raises(OSError):
+        await rmdir(accessor, _path("/dbx/full"), index)
+    assert files.delete_directory_calls == []
+
+
+@pytest.mark.asyncio
+async def test_rmdir_file_target_fails(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_file(files, f"{remote_root}/a.txt")
+
+    with pytest.raises(NotADirectoryError):
+        await rmdir(accessor, _path("/dbx/a.txt"), index)
+
+
+@pytest.mark.asyncio
+async def test_rmdir_missing_fails(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+
+    with pytest.raises(FileNotFoundError):
+        await rmdir(accessor, _path("/dbx/missing"), index)

--- a/python/tests/resource/databricks_volume/test_databricks_volume.py
+++ b/python/tests/resource/databricks_volume/test_databricks_volume.py
@@ -47,6 +47,8 @@ class FakeFiles:
         self.directories: dict[str, list[object]] = {}
         self.upload_calls: list[tuple[str, bytes, bool]] = []
         self.delete_calls: list[str] = []
+        self.create_directory_calls: list[str] = []
+        self.delete_directory_calls: list[str] = []
 
     def download(self, path: str) -> FakeDownload:
         if path not in self.downloads:
@@ -66,6 +68,35 @@ class FakeFiles:
         if path not in self.directories:
             raise NotFoundError(path)
         return self.directories[path]
+
+    def create_directory(self, path: str) -> None:
+        self.create_directory_calls.append(path)
+        cur = ""
+        for part in path.strip("/").split("/"):
+            cur = cur + "/" + part
+            if cur in self.directory_metadata:
+                continue
+            self.directory_metadata.add(cur)
+            self.metadata[cur] = SimpleNamespace(is_directory=True)
+            self.directories.setdefault(cur, [])
+            parent = posixpath.dirname(cur) or "/"
+            self._upsert_directory_entry(
+                parent, SimpleNamespace(path=cur, is_directory=True))
+
+    def delete_directory(self, path: str) -> None:
+        self.delete_directory_calls.append(path)
+        if path not in self.directory_metadata:
+            raise NotFoundError(path)
+        if self.directories.get(path):
+            raise OSError(f"directory not empty: {path}")
+        self.directory_metadata.discard(path)
+        self.metadata.pop(path, None)
+        self.directories.pop(path, None)
+        parent = posixpath.dirname(path.rstrip("/")) or "/"
+        self.directories[parent] = [
+            entry for entry in self.directories.get(parent, [])
+            if getattr(entry, "path", None) != path
+        ]
 
     def upload(self, path: str, contents, overwrite: bool = False) -> None:
         data = contents.read()


### PR DESCRIPTION
## Summary

Follow-up of #109. Part of #61

Adds: `mkdir`, `mkdir -p`, `rm -r`, `rm -d`, `cp`, `cp -r`, `mv`, plus the `mkdir`/`rmdir`/`rename` ops.

## Some correctness notes

- **`create_directory()` is idempotent + mkdir-p**, so `mkdir(parents=False)` pre-checks target-absent (`FileExistsError`) **and** parent-exists-as-dir (`FileNotFoundError`/`NotADirectoryError`) before calling the SDK.
- **`delete_directory()` is empty-only**; `rm_recursive` is a Mirage tree walk (files first, dirs deepest-first, root last). The fake `FakeFiles` test harness models this.
- **Rename is non-atomic** (no native Files API rename): `stat(src) → copy(src,dst) → unlink/rm_recursive(src)`. Documented in the core module and prompt.

## Test plan

- [x] `cd python && uv run pytest tests/core/databricks_volume tests/resource/databricks_volume tests/commands/builtin/databricks_volume` 
- [x] `tests/workspace/test_dispatch_write.py` + `tests/workspace/test_index_integration.py` 
- [x] databricks volume integration tests (locally)