### PR TITLE
feat(github): allow owner/repo/ref in GitHubConfig for YAML-declared repos

### DIFF
--- a/python/mirage/core/github/config.py
+++ b/python/mirage/core/github/config.py
@@ -17,3 +17,6 @@ from pydantic import BaseModel, SecretStr
 
 class GitHubConfig(BaseModel):
     token: SecretStr
+    owner: str | None = None
+    repo: str | None = None
+    ref: str = "main"

--- a/python/mirage/resource/github/github.py
+++ b/python/mirage/resource/github/github.py
@@ -47,8 +47,7 @@ class GitHubResource(BaseResource):
         if owner is None or repo is None:
             raise ValueError(
                 "GitHubResource requires owner and repo, either as "
-                "constructor kwargs or in GitHubConfig"
-            )
+                "constructor kwargs or in GitHubConfig")
         default_branch = fetch_default_branch_sync(config, owner, repo)
         tree, truncated = fetch_tree_sync(config, owner, repo, ref)
         self.accessor = GitHubAccessor(config,

--- a/python/mirage/resource/github/github.py
+++ b/python/mirage/resource/github/github.py
@@ -36,11 +36,19 @@ class GitHubResource(BaseResource):
     def __init__(
         self,
         config: GitHubConfig,
-        owner: str,
-        repo: str,
-        ref: str = "main",
+        owner: str | None = None,
+        repo: str | None = None,
+        ref: str | None = None,
     ) -> None:
         super().__init__()
+        owner = owner or config.owner
+        repo = repo or config.repo
+        ref = ref or config.ref
+        if owner is None or repo is None:
+            raise ValueError(
+                "GitHubResource requires owner and repo, either as "
+                "constructor kwargs or in GitHubConfig"
+            )
         default_branch = fetch_default_branch_sync(config, owner, repo)
         tree, truncated = fetch_tree_sync(config, owner, repo, ref)
         self.accessor = GitHubAccessor(config,

--- a/python/tests/resource/github/test_config.py
+++ b/python/tests/resource/github/test_config.py
@@ -38,7 +38,9 @@ def test_github_config_owner_repo_ref_default():
 
 
 def test_github_config_accepts_owner_repo_ref():
-    cfg = GitHubConfig(token="ghp_abc123", owner="strukto-ai", repo="mirage",
+    cfg = GitHubConfig(token="ghp_abc123",
+                       owner="strukto-ai",
+                       repo="mirage",
                        ref="dev")
     assert cfg.owner == "strukto-ai"
     assert cfg.repo == "mirage"

--- a/python/tests/resource/github/test_config.py
+++ b/python/tests/resource/github/test_config.py
@@ -30,6 +30,21 @@ def test_github_config_with_token():
     assert reveal_secret(cfg.token) == "ghp_abc123"
 
 
+def test_github_config_owner_repo_ref_default():
+    cfg = GitHubConfig(token="ghp_abc123")
+    assert cfg.owner is None
+    assert cfg.repo is None
+    assert cfg.ref == "main"
+
+
+def test_github_config_accepts_owner_repo_ref():
+    cfg = GitHubConfig(token="ghp_abc123", owner="strukto-ai", repo="mirage",
+                       ref="dev")
+    assert cfg.owner == "strukto-ai"
+    assert cfg.repo == "mirage"
+    assert cfg.ref == "dev"
+
+
 def test_tree_entry_fields():
     entry = TreeEntry(path="src/main.py", type="blob", sha="abc123", size=1024)
     assert entry.path == "src/main.py"

--- a/python/tests/resource/github/test_github.py
+++ b/python/tests/resource/github/test_github.py
@@ -63,8 +63,10 @@ def test_bind_args() -> None:
 
 
 def test_owner_repo_ref_fall_back_to_config() -> None:
-    config = GitHubConfig(token="test-token", owner="cfg-owner",
-                          repo="cfg-repo", ref="cfg-ref")
+    config = GitHubConfig(token="test-token",
+                          owner="cfg-owner",
+                          repo="cfg-repo",
+                          ref="cfg-ref")
     with patch("mirage.resource.github.github.fetch_default_branch_sync",
                return_value="main"), \
          patch("mirage.resource.github.github.fetch_tree_sync",
@@ -76,14 +78,18 @@ def test_owner_repo_ref_fall_back_to_config() -> None:
 
 
 def test_kwargs_take_precedence_over_config() -> None:
-    config = GitHubConfig(token="test-token", owner="cfg-owner",
-                          repo="cfg-repo", ref="cfg-ref")
+    config = GitHubConfig(token="test-token",
+                          owner="cfg-owner",
+                          repo="cfg-repo",
+                          ref="cfg-ref")
     with patch("mirage.resource.github.github.fetch_default_branch_sync",
                return_value="main"), \
          patch("mirage.resource.github.github.fetch_tree_sync",
                return_value=({}, False)):
-        resource = GitHubResource(config=config, owner="kw-owner",
-                                  repo="kw-repo", ref="kw-ref")
+        resource = GitHubResource(config=config,
+                                  owner="kw-owner",
+                                  repo="kw-repo",
+                                  ref="kw-ref")
     assert resource.accessor.owner == "kw-owner"
     assert resource.accessor.repo == "kw-repo"
     assert resource.accessor.ref == "kw-ref"

--- a/python/tests/resource/github/test_github.py
+++ b/python/tests/resource/github/test_github.py
@@ -62,6 +62,38 @@ def test_bind_args() -> None:
     assert resource.accessor.ref == "main"
 
 
+def test_owner_repo_ref_fall_back_to_config() -> None:
+    config = GitHubConfig(token="test-token", owner="cfg-owner",
+                          repo="cfg-repo", ref="cfg-ref")
+    with patch("mirage.resource.github.github.fetch_default_branch_sync",
+               return_value="main"), \
+         patch("mirage.resource.github.github.fetch_tree_sync",
+               return_value=({}, False)):
+        resource = GitHubResource(config=config)
+    assert resource.accessor.owner == "cfg-owner"
+    assert resource.accessor.repo == "cfg-repo"
+    assert resource.accessor.ref == "cfg-ref"
+
+
+def test_kwargs_take_precedence_over_config() -> None:
+    config = GitHubConfig(token="test-token", owner="cfg-owner",
+                          repo="cfg-repo", ref="cfg-ref")
+    with patch("mirage.resource.github.github.fetch_default_branch_sync",
+               return_value="main"), \
+         patch("mirage.resource.github.github.fetch_tree_sync",
+               return_value=({}, False)):
+        resource = GitHubResource(config=config, owner="kw-owner",
+                                  repo="kw-repo", ref="kw-ref")
+    assert resource.accessor.owner == "kw-owner"
+    assert resource.accessor.repo == "kw-repo"
+    assert resource.accessor.ref == "kw-ref"
+
+
+def test_missing_owner_repo_raises() -> None:
+    with pytest.raises(ValueError, match="requires owner and repo"):
+        GitHubResource(config=GitHubConfig(token="test-token"))
+
+
 def test_is_default_branch_true() -> None:
     resource = _make_resource(ref="main", default_branch="main")
     assert resource.is_default_branch is True


### PR DESCRIPTION
Closes #122.

## Problem
A GitHub repo can't be declared purely in workspace YAML the way other resources can — `owner`/`repo`/`ref` aren't part of `GitHubConfig`, so they must be passed as constructor kwargs out of band.

## Change
- Add optional `owner` / `repo` / `ref` to `GitHubConfig` (`ref` defaults to `"main"`).
- `GitHubResource.__init__` falls back to those config fields when kwargs are absent; explicit kwargs still take precedence (backward compatible). Raises a clear `ValueError` if neither supplies owner/repo.

## Tests
Added to `tests/resource/github/`:
- config exposes `owner`/`repo`/`ref` with correct defaults and values
- constructor falls back to config; kwargs override config; missing owner/repo raises
- `46 passed` (was 41) for `tests/resource/github tests/core/github`.

## Context
One of three generic improvements we carry downstream in a Context Engine built on Mirage; upstreaming so we can drop the local patch. Companion PRs for #120 / #121 to follow.