### PR TITLE
feat(gdrive): surface Shared Drives as top-level directories

### DIFF
--- a/python/mirage/core/gdrive/readdir.py
+++ b/python/mirage/core/gdrive/readdir.py
@@ -15,7 +15,7 @@
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.core.google.drive import (MIME_TO_EXT, list_files,
-                                       list_shared_drives)
+                                      list_shared_drives)
 from mirage.types import PathSpec
 
 

--- a/python/mirage/core/gdrive/readdir.py
+++ b/python/mirage/core/gdrive/readdir.py
@@ -14,7 +14,8 @@
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore, IndexEntry
-from mirage.core.google.drive import MIME_TO_EXT, list_files
+from mirage.core.google.drive import (MIME_TO_EXT, list_files,
+                                       list_shared_drives)
 from mirage.types import PathSpec
 
 
@@ -42,6 +43,7 @@ async def readdir(
 
     if not key:
         folder_id = "root"
+        drive_id = None
     else:
         if index is None:
             raise FileNotFoundError(path)
@@ -56,8 +58,11 @@ async def readdir(
             if result.entry is None:
                 raise FileNotFoundError(path)
         folder_id = result.entry.id
+        drive_id = result.entry.extra.get("drive_id")
 
-    files = await list_files(accessor.token_manager, folder_id=folder_id)
+    files = await list_files(accessor.token_manager,
+                             folder_id=folder_id,
+                             drive_id=drive_id)
     entries = []
     for f in files:
         mime = f.get("mimeType", "")
@@ -87,8 +92,32 @@ async def readdir(
             remote_time=f.get("modifiedTime", ""),
             vfs_name=filename,
             size=int(f.get("size") or f.get("quotaBytesUsed") or 0) or None,
+            extra={"drive_id": f.get("driveId")} if f.get("driveId") else {},
         )
         entries.append((filename, entry, is_dir))
+
+    if not key:
+        # Shared Drive enumeration is best-effort: if the account can't list
+        # them (missing scope, API error), still return My Drive contents.
+        try:
+            shared_drives = await list_shared_drives(accessor.token_manager)
+        except Exception:
+            shared_drives = []
+        existing_names = {name for name, _, _ in entries}
+        for d in shared_drives:
+            name = d["name"]
+            filename = name
+            if filename in existing_names:
+                filename = f"{name} [Shared Drive]"
+            existing_names.add(filename)
+            entry = IndexEntry(
+                id=d["id"],
+                name=name,
+                resource_type="gdrive/shared_drive",
+                vfs_name=filename,
+                extra={"drive_id": d["id"]},
+            )
+            entries.append((filename, entry, True))
 
     if index is not None:
         await index.set_dir(virtual_key, [(name, e) for name, e, _ in entries])

--- a/python/mirage/core/google/drive.py
+++ b/python/mirage/core/google/drive.py
@@ -19,9 +19,11 @@ from mirage.core.google._client import (DRIVE_API_BASE, TokenManager,
                                         google_get_bytes, google_get_stream)
 
 FIELDS = ("nextPageToken,"
-          "files(id,name,mimeType,size,quotaBytesUsed,"
+          "files(id,name,mimeType,driveId,size,quotaBytesUsed,"
           "createdTime,modifiedTime,"
           "owners,capabilities/canEdit,parents)")
+
+DRIVE_FIELDS = "nextPageToken,drives(id,name)"
 
 MIME_TO_EXT = {
     "application/vnd.google-apps.document": ".gdoc.json",
@@ -35,6 +37,7 @@ WORKSPACE_MIMES = set(MIME_TO_EXT.keys())
 async def list_files(
     token_manager: TokenManager,
     folder_id: str = "root",
+    drive_id: str | None = None,
     mime_type: str | None = None,
     trashed: bool = False,
     page_size: int = 1000,
@@ -46,6 +49,8 @@ async def list_files(
     Args:
         token_manager (TokenManager): OAuth2 token manager.
         folder_id (str): parent folder ID or "root".
+        drive_id (str | None): shared drive ID when listing inside a shared
+            drive.
         mime_type (str | None): filter by MIME type.
         trashed (bool): include trashed files.
         page_size (int): results per page.
@@ -76,6 +81,11 @@ async def list_files(
             "pageSize": page_size,
             "orderBy": "modifiedTime desc",
         }
+        if drive_id:
+            params["corpora"] = "drive"
+            params["driveId"] = drive_id
+            params["includeItemsFromAllDrives"] = "true"
+            params["supportsAllDrives"] = "true"
         if page_token:
             params["pageToken"] = page_token
         url = f"{DRIVE_API_BASE}/files"
@@ -85,6 +95,37 @@ async def list_files(
         if not page_token:
             break
     return files
+
+
+async def list_shared_drives(
+    token_manager: TokenManager,
+    page_size: int = 100,
+) -> list[dict]:
+    """List shared drives visible to the authenticated user.
+
+    Args:
+        token_manager (TokenManager): OAuth2 token manager.
+        page_size (int): results per page.
+
+    Returns:
+        list[dict]: shared drive metadata dicts.
+    """
+    drives: list[dict] = []
+    page_token: str | None = None
+    while True:
+        params: dict[str, str | int] = {
+            "fields": DRIVE_FIELDS,
+            "pageSize": page_size,
+        }
+        if page_token:
+            params["pageToken"] = page_token
+        url = f"{DRIVE_API_BASE}/drives"
+        data = await google_get(token_manager, url, params=params)
+        drives.extend(data.get("drives", []))
+        page_token = data.get("nextPageToken")
+        if not page_token:
+            break
+    return drives
 
 
 async def list_all_files(

--- a/python/mirage/resource/gdrive/prompt.py
+++ b/python/mirage/resource/gdrive/prompt.py
@@ -22,6 +22,7 @@ PROMPT = """\
 
   No owned/ vs shared/ split here: gdrive shows the user's full Drive view,
   including files shared with the user that have been added to My Drive.
+  Shared drives visible to the user are included as top-level directories.
 
   IMPORTANT: This is a remote mount. Prefer targeted reads over full scans.
   Date-prefixed globs (2026-05-*) push to a Drive modifiedTime range query.

--- a/python/tests/core/gdrive/test_read.py
+++ b/python/tests/core/gdrive/test_read.py
@@ -102,7 +102,7 @@ async def test_read_not_found(accessor, index):
 @pytest.mark.asyncio
 async def test_read_auto_bootstraps_from_empty_index(accessor, index):
 
-    async def fake_list_files(_tm, folder_id):
+    async def fake_list_files(_tm, folder_id, drive_id=None):
         if folder_id == "root":
             return [{
                 "id": "f1",
@@ -136,7 +136,7 @@ async def test_read_auto_bootstraps_from_empty_index(accessor, index):
 @pytest.mark.asyncio
 async def test_read_missing_file_raises_after_recursion(accessor, index):
 
-    async def fake_list_files(_tm, folder_id):
+    async def fake_list_files(_tm, folder_id, drive_id=None):
         if folder_id == "root":
             return [{
                 "id": "f1",

--- a/python/tests/core/gdrive/test_readdir.py
+++ b/python/tests/core/gdrive/test_readdir.py
@@ -128,7 +128,8 @@ async def test_readdir_subfolder(accessor, index):
                                index)
         assert "/docs/notes.txt" in result
         mock_list.assert_called_once_with(accessor.token_manager,
-                                          folder_id="folder1")
+                                          folder_id="folder1",
+                                          drive_id=None)
 
 
 @pytest.mark.asyncio
@@ -150,7 +151,7 @@ async def test_readdir_repopulates_evicted_subfolder(accessor, index):
         "capabilities": {},
     }]
 
-    async def fake_list_files(_tm, folder_id):
+    async def fake_list_files(_tm, folder_id, drive_id=None):
         if folder_id == "root":
             return root_files
         if folder_id == "folder1":
@@ -179,7 +180,7 @@ async def test_readdir_missing_subfolder_raises_after_recursion(
         "capabilities": {},
     }]
 
-    async def fake_list_files(_tm, folder_id):
+    async def fake_list_files(_tm, folder_id, drive_id=None):
         if folder_id == "root":
             return root_files
         raise AssertionError(f"should not list folder_id={folder_id}")
@@ -191,6 +192,52 @@ async def test_readdir_missing_subfolder_raises_after_recursion(
         with pytest.raises(FileNotFoundError):
             await readdir(accessor,
                           PathSpec(original="/docs", directory="/docs"), index)
+
+
+@pytest.mark.asyncio
+async def test_readdir_root_includes_shared_drives(accessor, index):
+    files = [{
+        "id": "f1",
+        "name": "readme.txt",
+        "mimeType": "text/plain",
+        "modifiedTime": "2026-04-01T00:00:00.000Z",
+        "owners": [],
+        "capabilities": {},
+    }]
+    drives = [{"id": "drive1", "name": "Team Drive"}]
+    with patch("mirage.core.gdrive.readdir.list_files",
+               new_callable=AsyncMock, return_value=files), \
+         patch("mirage.core.gdrive.readdir.list_shared_drives",
+               new_callable=AsyncMock, return_value=drives):
+        result = await readdir(accessor, PathSpec(original="/", directory="/"),
+                               index)
+        assert "/readme.txt" in result
+        # Shared Drives appear as top-level directories.
+        assert "/Team Drive/" in result
+        # The drive id is carried on the cached entry for nested listings.
+        entry = (await index.get("/Team Drive")).entry
+        assert entry is not None
+        assert entry.extra.get("drive_id") == "drive1"
+
+
+@pytest.mark.asyncio
+async def test_readdir_root_shared_drives_best_effort(accessor, index):
+    """If Shared Drive enumeration fails, My Drive listing still succeeds."""
+    files = [{
+        "id": "f1",
+        "name": "readme.txt",
+        "mimeType": "text/plain",
+        "modifiedTime": "2026-04-01T00:00:00.000Z",
+        "owners": [],
+        "capabilities": {},
+    }]
+    with patch("mirage.core.gdrive.readdir.list_files",
+               new_callable=AsyncMock, return_value=files), \
+         patch("mirage.core.gdrive.readdir.list_shared_drives",
+               new_callable=AsyncMock, side_effect=RuntimeError("no scope")):
+        result = await readdir(accessor, PathSpec(original="/", directory="/"),
+                               index)
+        assert "/readme.txt" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #121.

## Problem
The `gdrive` resource lists **My Drive** only — `list_files` queries `'<folder_id>' in parents` with no `corpora`/`driveId`, so files in Shared Drives are invisible.

## Change
- Add `list_shared_drives()` and thread an optional `drive_id` through `list_files` (sets `corpora=drive` / `driveId` / `includeItemsFromAllDrives` / `supportsAllDrives` when present).
- Include `driveId` in the file fields and carry it on the cached `IndexEntry.extra` so nested listings inside a Shared Drive query the right corpus.
- Surface visible Shared Drives as top-level directories alongside My Drive.
- **Best-effort:** if Shared Drives can't be enumerated (missing scope / API error), root listing still returns My Drive. (Flagged for your review — happy to make it strict instead.)

Default behavior (My Drive only) is unchanged when no `drive_id` is given / no Shared Drives exist.

## Tests
`tests/core/gdrive` + `tests/core/google`: **58 passed**. Added:
- shared drives appear at root and the drive id is carried for nested listings
- best-effort fallback when enumeration raises
- updated existing mocks for the new `drive_id` kwarg

## Context
Second of three generic improvements we carry downstream on a Context Engine built on Mirage. Companion: #123 (for #122); synthetic mount-parents (#120) to follow.