### PR TITLE
chore: update Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
         <img src="https://img.shields.io/badge/made by-strukto.ai-0C0C0C?labelColor=FAFAFA" /></a>
     <a href="https://github.com/strukto-ai/mirage/blob/main/LICENSE" alt="License">
         <img src="https://img.shields.io/github/license/strukto-ai/mirage?color=0C0C0C&labelColor=FAFAFA" /></a>
-    <a href="https://discord.gg/QSdD7KspFu" alt="Discord">
+    <a href="https://discord.gg/u8BPQ65KsS" alt="Discord">
         <img src="https://img.shields.io/badge/discord-join-0C0C0C?labelColor=FAFAFA&logo=discord&logoColor=0C0C0C" /></a>
     <br/>
     <a href="https://docs.mirage.strukto.ai/python/quickstart" alt="Python docs">

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -425,7 +425,7 @@
       {
         "label": "Discord",
         "icon": "discord",
-        "href": "https://discord.gg/QSdD7KspFu"
+        "href": "https://discord.gg/u8BPQ65KsS"
       },
       {
         "label": "",

--- a/docs/home/introduction.mdx
+++ b/docs/home/introduction.mdx
@@ -379,7 +379,7 @@ EOF
   <Card title="Book a Call" icon="calendar" href="https://cal.com/strukto/30min">
     Talk to the team directly if you are blocked.
   </Card>
-  <Card title="Join our Discord" icon="discord" href="https://discord.gg/QSdD7KspFu">
+  <Card title="Join our Discord" icon="discord" href="https://discord.gg/u8BPQ65KsS">
     Chat with the community and get help from the team.
   </Card>
   <Card title="GitHub Issues" icon="github" href="https://github.com/strukto-ai/mirage/issues">

--- a/python/README.md
+++ b/python/README.md
@@ -9,7 +9,7 @@
         <img src="https://img.shields.io/badge/made by-strukto.ai-0C0C0C?labelColor=FAFAFA" /></a>
     <a href="https://github.com/strukto-ai/mirage/blob/main/LICENSE" alt="License">
         <img src="https://img.shields.io/github/license/strukto-ai/mirage?color=0C0C0C&labelColor=FAFAFA" /></a>
-    <a href="https://discord.gg/QSdD7KspFu" alt="Discord">
+    <a href="https://discord.gg/u8BPQ65KsS" alt="Discord">
         <img src="https://img.shields.io/badge/discord-join-0C0C0C?labelColor=FAFAFA&logo=discord&logoColor=0C0C0C" /></a>
     <br/>
     <a href="https://docs.mirage.strukto.ai/python/quickstart" alt="Python docs">

--- a/typescript/packages/agents/README.md
+++ b/typescript/packages/agents/README.md
@@ -9,7 +9,7 @@
         <img src="https://img.shields.io/badge/made by-strukto.ai-0C0C0C?labelColor=FAFAFA" /></a>
     <a href="https://github.com/strukto-ai/mirage/blob/main/LICENSE" alt="License">
         <img src="https://img.shields.io/github/license/strukto-ai/mirage?color=0C0C0C&labelColor=FAFAFA" /></a>
-    <a href="https://discord.gg/QSdD7KspFu" alt="Discord">
+    <a href="https://discord.gg/u8BPQ65KsS" alt="Discord">
         <img src="https://img.shields.io/badge/discord-join-0C0C0C?labelColor=FAFAFA&logo=discord&logoColor=0C0C0C" /></a>
     <br/>
     <a href="https://docs.mirage.strukto.ai/python/quickstart" alt="Python docs">

--- a/typescript/packages/browser/README.md
+++ b/typescript/packages/browser/README.md
@@ -9,7 +9,7 @@
         <img src="https://img.shields.io/badge/made by-strukto.ai-0C0C0C?labelColor=FAFAFA" /></a>
     <a href="https://github.com/strukto-ai/mirage/blob/main/LICENSE" alt="License">
         <img src="https://img.shields.io/github/license/strukto-ai/mirage?color=0C0C0C&labelColor=FAFAFA" /></a>
-    <a href="https://discord.gg/QSdD7KspFu" alt="Discord">
+    <a href="https://discord.gg/u8BPQ65KsS" alt="Discord">
         <img src="https://img.shields.io/badge/discord-join-0C0C0C?labelColor=FAFAFA&logo=discord&logoColor=0C0C0C" /></a>
     <br/>
     <a href="https://docs.mirage.strukto.ai/python/quickstart" alt="Python docs">

--- a/typescript/packages/cli/README.md
+++ b/typescript/packages/cli/README.md
@@ -9,7 +9,7 @@
         <img src="https://img.shields.io/badge/made by-strukto.ai-0C0C0C?labelColor=FAFAFA" /></a>
     <a href="https://github.com/strukto-ai/mirage/blob/main/LICENSE" alt="License">
         <img src="https://img.shields.io/github/license/strukto-ai/mirage?color=0C0C0C&labelColor=FAFAFA" /></a>
-    <a href="https://discord.gg/QSdD7KspFu" alt="Discord">
+    <a href="https://discord.gg/u8BPQ65KsS" alt="Discord">
         <img src="https://img.shields.io/badge/discord-join-0C0C0C?labelColor=FAFAFA&logo=discord&logoColor=0C0C0C" /></a>
     <br/>
     <a href="https://docs.mirage.strukto.ai/python/quickstart" alt="Python docs">

--- a/typescript/packages/core/README.md
+++ b/typescript/packages/core/README.md
@@ -9,7 +9,7 @@
         <img src="https://img.shields.io/badge/made by-strukto.ai-0C0C0C?labelColor=FAFAFA" /></a>
     <a href="https://github.com/strukto-ai/mirage/blob/main/LICENSE" alt="License">
         <img src="https://img.shields.io/github/license/strukto-ai/mirage?color=0C0C0C&labelColor=FAFAFA" /></a>
-    <a href="https://discord.gg/QSdD7KspFu" alt="Discord">
+    <a href="https://discord.gg/u8BPQ65KsS" alt="Discord">
         <img src="https://img.shields.io/badge/discord-join-0C0C0C?labelColor=FAFAFA&logo=discord&logoColor=0C0C0C" /></a>
     <br/>
     <a href="https://docs.mirage.strukto.ai/python/quickstart" alt="Python docs">

--- a/typescript/packages/node/README.md
+++ b/typescript/packages/node/README.md
@@ -9,7 +9,7 @@
         <img src="https://img.shields.io/badge/made by-strukto.ai-0C0C0C?labelColor=FAFAFA" /></a>
     <a href="https://github.com/strukto-ai/mirage/blob/main/LICENSE" alt="License">
         <img src="https://img.shields.io/github/license/strukto-ai/mirage?color=0C0C0C&labelColor=FAFAFA" /></a>
-    <a href="https://discord.gg/QSdD7KspFu" alt="Discord">
+    <a href="https://discord.gg/u8BPQ65KsS" alt="Discord">
         <img src="https://img.shields.io/badge/discord-join-0C0C0C?labelColor=FAFAFA&logo=discord&logoColor=0C0C0C" /></a>
     <br/>
     <a href="https://docs.mirage.strukto.ai/python/quickstart" alt="Python docs">

--- a/typescript/packages/server/README.md
+++ b/typescript/packages/server/README.md
@@ -9,7 +9,7 @@
         <img src="https://img.shields.io/badge/made by-strukto.ai-0C0C0C?labelColor=FAFAFA" /></a>
     <a href="https://github.com/strukto-ai/mirage/blob/main/LICENSE" alt="License">
         <img src="https://img.shields.io/github/license/strukto-ai/mirage?color=0C0C0C&labelColor=FAFAFA" /></a>
-    <a href="https://discord.gg/QSdD7KspFu" alt="Discord">
+    <a href="https://discord.gg/u8BPQ65KsS" alt="Discord">
         <img src="https://img.shields.io/badge/discord-join-0C0C0C?labelColor=FAFAFA&logo=discord&logoColor=0C0C0C" /></a>
     <br/>
     <a href="https://docs.mirage.strukto.ai/python/quickstart" alt="Python docs">


### PR DESCRIPTION
Updates the Discord invite link from `discord.gg/QSdD7KspFu` to `discord.gg/u8BPQ65KsS` across all READMEs and docs (10 files).