### PR TITLE
feat(generic/wc): add format_multi helper, emit POSIX trailing newline

### DIFF
--- a/python/mirage/commands/builtin/databricks_volume/wc.py
+++ b/python/mirage/commands/builtin/databricks_volume/wc.py
@@ -18,7 +18,7 @@ from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.databricks_volume._helpers import (
     path_prefix, read_bytes_with_index)
-from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import format_multi, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
@@ -44,30 +44,16 @@ async def wc(
 ) -> tuple[ByteSource | None, IOResult]:
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        read_bytes = read_bytes_with_index(index, path_prefix(paths))
-        outputs: list[str] = []
-        totals = WCCounts()
-        for path in paths:
-            counts = await generic_wc(await read_bytes(accessor, path))
-            outputs.append(
-                format_wc(counts,
-                          args_l=args_l,
-                          w=w,
-                          c=c,
-                          m=m,
-                          L=L,
-                          label=path.original))
-            totals.merge(counts)
-        if len(paths) > 1:
-            outputs.append(
-                format_wc(totals,
-                          args_l=args_l,
-                          w=w,
-                          c=c,
-                          m=m,
-                          L=L,
-                          label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        read = read_bytes_with_index(index, path_prefix(paths))
+        body = await format_multi(paths,
+                                  read=read,
+                                  accessor=accessor,
+                                  args_l=args_l,
+                                  w=w,
+                                  c=c,
+                                  m=m,
+                                  L=L)
+        return body, IOResult()
     source = _resolve_source(stdin, "wc: missing operand")
     counts = await generic_wc(source)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,

--- a/python/mirage/commands/builtin/databricks_volume/wc.py
+++ b/python/mirage/commands/builtin/databricks_volume/wc.py
@@ -57,4 +57,4 @@ async def wc(
     source = _resolve_source(stdin, "wc: missing operand")
     counts = await generic_wc(source)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/disk/wc.py
+++ b/python/mirage/commands/builtin/disk/wc.py
@@ -59,7 +59,7 @@ async def wc(
                                                    "wc: missing operand")
     if args_l and not (L or w or c or m):
         line_count = await generic_wc_lines(source)
-        return str(line_count).encode(), IOResult()
+        return str(line_count).encode() + b"\n", IOResult()
     counts = await generic_wc(source)
-    return format_wc(counts, args_l=args_l, w=w, c=c, m=m, L=L).encode(), \
-        IOResult()
+    return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/disk/wc.py
+++ b/python/mirage/commands/builtin/disk/wc.py
@@ -17,7 +17,7 @@ from collections.abc import AsyncIterator
 from mirage.accessor.disk import DiskAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.aggregators import wc_aggregate
-from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import format_multi, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.generic.wc import wc_lines as generic_wc_lines
 from mirage.commands.builtin.utils.stream import _resolve_source
@@ -45,29 +45,15 @@ async def wc(
 ) -> tuple[ByteSource | None, IOResult]:
     if paths and accessor.root is not None:
         paths = await resolve_glob(accessor, paths, index)
-        outputs: list[str] = []
-        totals = WCCounts()
-        for p in paths:
-            counts = await generic_wc(read_stream(accessor, p))
-            outputs.append(
-                format_wc(counts,
-                          args_l=args_l,
-                          w=w,
-                          c=c,
-                          m=m,
-                          L=L,
-                          label=p.original))
-            totals.merge(counts)
-        if len(paths) > 1:
-            outputs.append(
-                format_wc(totals,
-                          args_l=args_l,
-                          w=w,
-                          c=c,
-                          m=m,
-                          L=L,
-                          label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        body = await format_multi(paths,
+                                  read=read_stream,
+                                  accessor=accessor,
+                                  args_l=args_l,
+                                  w=w,
+                                  c=c,
+                                  m=m,
+                                  L=L)
+        return body, IOResult()
 
     source: AsyncIterator[bytes] = _resolve_source(stdin,
                                                    "wc: missing operand")

--- a/python/mirage/commands/builtin/generic/wc.py
+++ b/python/mirage/commands/builtin/generic/wc.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, Callable
 
+from mirage.types import PathSpec
 from mirage.utils.stream import ensure_stream
 
 
@@ -122,7 +123,7 @@ def format_wc(
 
 
 async def format_multi(
-    paths: list[Any],
+    paths: list[PathSpec],
     *,
     read: Callable[..., Any],
     accessor: object = None,
@@ -132,6 +133,27 @@ async def format_multi(
     m: bool = False,
     L: bool = False,
 ) -> bytes:
+    """Format wc output for multiple already-resolved paths.
+
+    Globs are expanded by the caller (``resolve_glob``) before this runs, so
+    ``paths`` is always a flat list of concrete entries, never patterns. One
+    record is emitted per path, plus a trailing ``total`` row when more than
+    one path is given; every record ends with a newline per POSIX wc.
+
+    Args:
+        paths (list[PathSpec]): Resolved paths; only ``.original`` is read.
+        read (Callable[..., Any]): Reader called as ``read(accessor, path)``;
+            returns bytes, an awaitable of bytes, or an async byte iterator.
+        accessor (object): Backend accessor passed through to ``read``.
+        args_l (bool): Report line count only.
+        w (bool): Report word count only.
+        c (bool): Report byte count only.
+        m (bool): Report character count only.
+        L (bool): Report longest line length only.
+
+    Returns:
+        bytes: Encoded wc output, or ``b""`` when ``paths`` is empty.
+    """
     outputs: list[str] = []
     totals = WCCounts()
     for path in paths:

--- a/python/mirage/commands/builtin/generic/wc.py
+++ b/python/mirage/commands/builtin/generic/wc.py
@@ -1,6 +1,8 @@
 import codecs
+import inspect
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from typing import Any, Callable
 
 from mirage.utils.stream import ensure_stream
 
@@ -117,3 +119,39 @@ def format_wc(
     if label is None:
         return body
     return f"{body}\t{label}"
+
+
+async def format_multi(
+    paths: list[Any],
+    *,
+    read: Callable[..., Any],
+    accessor: object = None,
+    args_l: bool = False,
+    w: bool = False,
+    c: bool = False,
+    m: bool = False,
+    L: bool = False,
+) -> bytes:
+    outputs: list[str] = []
+    totals = WCCounts()
+    for path in paths:
+        source = read(accessor, path)
+        if inspect.isawaitable(source):
+            source = await source
+        counts = await wc(source)
+        outputs.append(
+            format_wc(counts,
+                      args_l=args_l,
+                      w=w,
+                      c=c,
+                      m=m,
+                      L=L,
+                      label=path.original))
+        totals.merge(counts)
+    if len(paths) > 1:
+        outputs.append(
+            format_wc(totals, args_l=args_l, w=w, c=c, m=m, L=L,
+                      label="total"))
+    if not outputs:
+        return b""
+    return ("\n".join(outputs) + "\n").encode()

--- a/python/mirage/commands/builtin/hf_buckets/wc.py
+++ b/python/mirage/commands/builtin/hf_buckets/wc.py
@@ -17,7 +17,7 @@ from collections.abc import AsyncIterator
 from mirage.accessor._hf import HF_RESOURCES
 from mirage.accessor.hf_buckets import HfBucketsAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import format_multi, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.hf_buckets._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
@@ -48,30 +48,15 @@ async def wc(
 ) -> tuple[ByteSource | None, IOResult]:
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        outputs: list[str] = []
-        totals = WCCounts()
-        for p in paths:
-            data = await read_bytes(accessor, p)
-            counts = await generic_wc(data)
-            outputs.append(
-                format_wc(counts,
-                          args_l=args_l,
-                          w=w,
-                          c=c,
-                          m=m,
-                          L=L,
-                          label=p.original))
-            totals.merge(counts)
-        if len(paths) > 1:
-            outputs.append(
-                format_wc(totals,
-                          args_l=args_l,
-                          w=w,
-                          c=c,
-                          m=m,
-                          L=L,
-                          label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        body = await format_multi(paths,
+                                  read=read_bytes,
+                                  accessor=accessor,
+                                  args_l=args_l,
+                                  w=w,
+                                  c=c,
+                                  m=m,
+                                  L=L)
+        return body, IOResult()
     source = _resolve_source(stdin, "wc: missing operand")
     counts = await generic_wc(source)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,

--- a/python/mirage/commands/builtin/hf_buckets/wc.py
+++ b/python/mirage/commands/builtin/hf_buckets/wc.py
@@ -60,4 +60,4 @@ async def wc(
     source = _resolve_source(stdin, "wc: missing operand")
     counts = await generic_wc(source)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/nextcloud/wc.py
+++ b/python/mirage/commands/builtin/nextcloud/wc.py
@@ -16,7 +16,7 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import format_multi, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.nextcloud._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
@@ -47,30 +47,15 @@ async def wc(
 ) -> tuple[ByteSource | None, IOResult]:
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        outputs: list[str] = []
-        totals = WCCounts()
-        for p in paths:
-            data = await read_bytes(accessor, p)
-            counts = await generic_wc(data)
-            outputs.append(
-                format_wc(counts,
-                          args_l=args_l,
-                          w=w,
-                          c=c,
-                          m=m,
-                          L=L,
-                          label=p.original))
-            totals.merge(counts)
-        if len(paths) > 1:
-            outputs.append(
-                format_wc(totals,
-                          args_l=args_l,
-                          w=w,
-                          c=c,
-                          m=m,
-                          L=L,
-                          label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        body = await format_multi(paths,
+                                  read=read_bytes,
+                                  accessor=accessor,
+                                  args_l=args_l,
+                                  w=w,
+                                  c=c,
+                                  m=m,
+                                  L=L)
+        return body, IOResult()
     source = _resolve_source(stdin, "wc: missing operand")
     counts = await generic_wc(source)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,

--- a/python/mirage/commands/builtin/nextcloud/wc.py
+++ b/python/mirage/commands/builtin/nextcloud/wc.py
@@ -59,4 +59,4 @@ async def wc(
     source = _resolve_source(stdin, "wc: missing operand")
     counts = await generic_wc(source)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/s3/wc.py
+++ b/python/mirage/commands/builtin/s3/wc.py
@@ -16,7 +16,7 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import format_multi, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.s3._provision import file_read_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
@@ -44,30 +44,15 @@ async def wc(
 ) -> tuple[ByteSource | None, IOResult]:
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        outputs: list[str] = []
-        totals = WCCounts()
-        for p in paths:
-            data = await read_bytes(accessor, p)
-            counts = await generic_wc(data)
-            outputs.append(
-                format_wc(counts,
-                          args_l=args_l,
-                          w=w,
-                          c=c,
-                          m=m,
-                          L=L,
-                          label=p.original))
-            totals.merge(counts)
-        if len(paths) > 1:
-            outputs.append(
-                format_wc(totals,
-                          args_l=args_l,
-                          w=w,
-                          c=c,
-                          m=m,
-                          L=L,
-                          label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        body = await format_multi(paths,
+                                  read=read_bytes,
+                                  accessor=accessor,
+                                  args_l=args_l,
+                                  w=w,
+                                  c=c,
+                                  m=m,
+                                  L=L)
+        return body, IOResult()
     source = _resolve_source(stdin, "wc: missing operand")
     counts = await generic_wc(source)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,

--- a/python/mirage/commands/builtin/s3/wc.py
+++ b/python/mirage/commands/builtin/s3/wc.py
@@ -56,4 +56,4 @@ async def wc(
     source = _resolve_source(stdin, "wc: missing operand")
     counts = await generic_wc(source)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/tests/commands/builtin/databricks_volume/test_wc.py
+++ b/python/tests/commands/builtin/databricks_volume/test_wc.py
@@ -25,7 +25,7 @@ async def test_workspace_execute_databricks_volume_wc(
     io = await databricks_text_workspace.execute("wc -l /dbx/words.txt")
 
     assert io.exit_code == 0
-    assert io.stdout == b"3\t/dbx/words.txt"
+    assert io.stdout == b"3\t/dbx/words.txt\n"
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/builtin/disk/test_wc.py
+++ b/python/tests/commands/builtin/disk/test_wc.py
@@ -28,7 +28,7 @@ async def test_wc_default(workspace):
     await workspace.ops.write("/f.txt", b"hello world\nfoo bar\n")
     io = await workspace.execute("wc /f.txt", session_id="default")
     assert io.exit_code == 0
-    parts = io.stdout.decode().split("\t")
+    parts = io.stdout.decode().rstrip("\n").split("\t")
     assert parts[0] == "2"
     assert parts[1] == "4"
     assert parts[2] == "20"

--- a/python/tests/commands/builtin/generic/test_wc.py
+++ b/python/tests/commands/builtin/generic/test_wc.py
@@ -289,3 +289,16 @@ async def test_format_multi_empty_paths_returns_empty():
 
     out = await format_multi([], read=fake_read, args_l=True)
     assert out == b""
+
+
+async def _async_byte_read(_accessor, _path):
+    yield b"hello "
+    yield b"world\n"
+
+
+@pytest.mark.asyncio
+async def test_format_multi_accepts_async_iterator_read():
+    paths = [PathSpec.from_str_path("/a.txt")]
+
+    out = await format_multi(paths, read=_async_byte_read, args_l=True)
+    assert out == b"1\t/a.txt\n"

--- a/python/tests/commands/builtin/generic/test_wc.py
+++ b/python/tests/commands/builtin/generic/test_wc.py
@@ -1,7 +1,8 @@
 import pytest
 
-from mirage.commands.builtin.generic.wc import (WCCounts, format_wc, wc,
-                                                wc_lines)
+from mirage.commands.builtin.generic.wc import (WCCounts, format_multi,
+                                                format_wc, wc, wc_lines)
+from mirage.types import PathSpec
 
 
 @pytest.mark.asyncio
@@ -239,3 +240,52 @@ def test_wc_counts_merge():
     assert a.bytes_ == 28
     assert a.chars == 26
     assert a.max_line_length == 20
+
+
+@pytest.mark.asyncio
+async def test_format_multi_single_path_emits_trailing_newline():
+    paths = [PathSpec.from_str_path("/a.txt")]
+
+    async def fake_read(_accessor, _path):
+        return b"hello\n"
+
+    out = await format_multi(paths, read=fake_read, args_l=True)
+    assert out == b"1\t/a.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_format_multi_multi_path_emits_total_and_trailing_newline():
+    paths = [
+        PathSpec.from_str_path("/a.txt"),
+        PathSpec.from_str_path("/b.txt"),
+    ]
+    data = {"/a.txt": b"hello\n", "/b.txt": b"world\nworld\n"}
+
+    async def fake_read(_accessor, path):
+        return data[path.original]
+
+    out = await format_multi(paths, read=fake_read, args_l=True)
+    assert out.endswith(b"\n")
+    lines = out.decode().rstrip("\n").split("\n")
+    assert lines == ["1\t/a.txt", "2\t/b.txt", "3\ttotal"]
+
+
+@pytest.mark.asyncio
+async def test_format_multi_accepts_sync_read_returning_bytes():
+    paths = [PathSpec.from_str_path("/a.txt")]
+
+    def sync_read(_accessor, _path):
+        return b"x\n"
+
+    out = await format_multi(paths, read=sync_read, args_l=True)
+    assert out == b"1\t/a.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_format_multi_empty_paths_returns_empty():
+
+    async def fake_read(_accessor, _path):
+        return b""
+
+    out = await format_multi([], read=fake_read, args_l=True)
+    assert out == b""

--- a/python/tests/integration/test_s3_complex.py
+++ b/python/tests/integration/test_s3_complex.py
@@ -282,10 +282,8 @@ async def test_wc_report_through_redirect_chain(ws):
         io = await ws.execute(
             "echo -n '/s3/data/example.json ' > /tmp/size_report.txt && "
             "wc -c /s3/data/example.json >> /tmp/size_report.txt && "
-            "echo >> /tmp/size_report.txt && "
             "echo -n '/s3/data/example.jsonl ' >> /tmp/size_report.txt && "
             "wc -c /s3/data/example.jsonl >> /tmp/size_report.txt && "
-            "echo >> /tmp/size_report.txt && "
             "cat /tmp/size_report.txt")
         json_size = len(objects["data/example.json"])
         jsonl_size = len(objects["data/example.jsonl"])


### PR DESCRIPTION
## Summary

Closes #114.

`generic.wc` previously only handled a single source; every backend wrapper duplicated the per-file loop + totals row, and **all of them produced output without a trailing newline** violating POSIX (the `wc` spec terminates every record format string with `\n`, including the totals row).

## POSIX bug

Code in wrapper before the fix:

```python
return "\n".join(outputs).encode(), IOResult()
```

`"\n".join(...)` uses `\n` as a **separator**, not a **terminator** — so the last record (single file, or the `total` row) had no trailing newline. POSIX `wc` (IEEE Std 1003.1-2024) defines the output format with `\n` inside every `printf` string:

```
per-file: "%d %d %d %s\n"
stdin:    "%d %d %d\n"
totals:   "%d %d %d total\n"
```

Without the terminator, downstream tools (`while read`, `tail`, `awk`) treat the last record as incomplete and can drop it.

## Resources wrappers fixed (5)

| Wrapper | Notes |
|---|---|
| `s3/wc.py` | Issue scope. |
| `databricks_volume/wc.py` | Issue scope. |
| `disk/wc.py` | Canonical reference backend, same bug. |
| `hf_buckets/wc.py` | Same pattern as s3, fixed. |
| `nextcloud/wc.py` | Same pattern as s3, fixed. |

Each is now ~10 lines: resolve glob → call helper → return.

## Out of scope (follow-up)

The same buggy pattern still exists in **16 other wrappers**, they all use `"\n".join(outputs).encode()` identically:

```
discord, email, gdocs, gdrive, github, github_ci, gmail, gsheets,
gslides, langfuse, linear, postgres, ram, redis, slack, trello
```

created #131 for this 

## Test plan

- [x] **New helper coverage** in `tests/commands/builtin/generic/test_wc.py`
- [x] **Existing tests updated** to assert the POSIX trailing newline (they were asserting the *bug*):
  - `disk/test_wc.py::test_wc_default`
  - `databricks_volume/test_wc.py::test_workspace_execute_databricks_volume_wc`
- [x] `databricks_volume + disk + generic + native` test suites — **1552 passed**.
- [x] `yapf` / `isort` / `flake8` clean on all changed files.