### PR TITLE
fix(ts/slack/cat): concat all globbed files instead of dropping after the first

### DIFF
--- a/typescript/packages/core/src/commands/builtin/slack/cat.test.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/cat.test.ts
@@ -101,4 +101,43 @@ describe('slack cat', () => {
     )
     expect(out.startsWith('     1\t')).toBe(true)
   })
+
+  it('concatenates multiple jsonl files in order (regression: previously only read the first)', async () => {
+    const idx = new RAMIndexCacheStore()
+    await seedChannel(idx, '/mnt/slack', 'general__C1', 'C1', {
+      dates: ['2024-01-01', '2024-01-02', '2024-01-03'],
+    })
+    // FakeSlackTransport returns deterministic messages per call. We map each
+    // day's `oldest` (00:00 UTC) to a distinct message so we can assert order.
+    const day1Oldest = String(Math.floor(Date.UTC(2024, 0, 1) / 1000))
+    const day2Oldest = String(Math.floor(Date.UTC(2024, 0, 2) / 1000))
+    const day3Oldest = String(Math.floor(Date.UTC(2024, 0, 3) / 1000))
+    const transport = new FakeSlackTransport((endpoint, params) => {
+      if (endpoint === 'conversations.history') {
+        const oldest = params?.oldest
+        if (oldest === day1Oldest) return { ok: true, messages: [{ ts: '1.0', text: 'day1' }] }
+        if (oldest === day2Oldest) return { ok: true, messages: [{ ts: '2.0', text: 'day2' }] }
+        if (oldest === day3Oldest) return { ok: true, messages: [{ ts: '3.0', text: 'day3' }] }
+        return { ok: true, messages: [] }
+      }
+      return { ok: true }
+    })
+    const mkPath = (date: string): PathSpec =>
+      new PathSpec({
+        original: `/mnt/slack/channels/general__C1/${date}/chat.jsonl`,
+        directory: `/mnt/slack/channels/general__C1/`,
+        resolved: false,
+        prefix: '/mnt/slack',
+      })
+    const out = await runCat(
+      [mkPath('2024-01-01'), mkPath('2024-01-02'), mkPath('2024-01-03')],
+      {},
+      { index: idx, transport },
+    )
+    const lines = out.trimEnd().split('\n')
+    expect(lines).toHaveLength(3)
+    expect(JSON.parse(lines[0] ?? '')).toMatchObject({ ts: '1.0', text: 'day1' })
+    expect(JSON.parse(lines[1] ?? '')).toMatchObject({ ts: '2.0', text: 'day2' })
+    expect(JSON.parse(lines[2] ?? '')).toMatchObject({ ts: '3.0', text: 'day3' })
+  })
 })

--- a/typescript/packages/core/src/commands/builtin/slack/cat.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/cat.ts
@@ -37,6 +37,20 @@ function numberLines(data: Uint8Array): Uint8Array {
   return ENC.encode(out.join(''))
 }
 
+function concatBuffers(buffers: readonly Uint8Array[]): Uint8Array {
+  if (buffers.length === 0) return new Uint8Array(0)
+  if (buffers.length === 1) return buffers[0] ?? new Uint8Array(0)
+  let total = 0
+  for (const b of buffers) total += b.length
+  const out = new Uint8Array(total)
+  let off = 0
+  for (const b of buffers) {
+    out.set(b, off)
+    off += b.length
+  }
+  return out
+}
+
 async function catCommand(
   accessor: SlackAccessor,
   paths: PathSpec[],
@@ -46,15 +60,19 @@ async function catCommand(
   const nFlag = opts.flags.n === true
   if (paths.length > 0) {
     const resolved = await resolveSlackGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const data = await slackRead(accessor, first, opts.index ?? undefined)
-    const out: ByteSource = nFlag ? numberLines(data) : data
-    const io = new IOResult({
-      reads: { [first.stripPrefix]: data },
-      cache: [first.stripPrefix],
-    })
-    return [out, io]
+    if (resolved.length === 0) return [null, new IOResult()]
+    const reads: Record<string, Uint8Array> = {}
+    const cache: string[] = []
+    const buffers: Uint8Array[] = []
+    for (const p of resolved) {
+      const data = await slackRead(accessor, p, opts.index ?? undefined)
+      reads[p.stripPrefix] = data
+      cache.push(p.stripPrefix)
+      buffers.push(data)
+    }
+    const merged = concatBuffers(buffers)
+    const out: ByteSource = nFlag ? numberLines(merged) : merged
+    return [out, new IOResult({ reads, cache })]
   }
   const raw = await readStdinAsync(opts.stdin)
   if (raw === null) {


### PR DESCRIPTION
## Bug

`SLACK_CAT` resolved the glob into a list of `PathSpec`s but only read `resolved[0]`, silently discarding the rest.

```ts
const resolved = await resolveSlackGlob(accessor, paths, opts.index ?? undefined)
const first = resolved[0]   // ← drops everything after [0]
if (first === undefined) return [null, new IOResult()]
const data = await slackRead(accessor, first, opts.index ?? undefined)
```

Real-world impact reproduced against a live Slack workspace:

```bash
$ cat /slack/channels/<chan>/2026-05-*.jsonl | wc -l
9
```

The channel actually had 20 messages across 6 days (including one with file attachments). Calling `conversations.history` directly returned all 20; `cat` of any single day's `.jsonl` returned the right content. Only the glob path was broken — and silently. An agent reading "the last week" this way would conclude the channel was empty.

## Fix

Iterate over the full resolved list, read each, concat the byte buffers — matching the [disk backend behavior](https://github.com/strukto-ai/mirage/blob/main/typescript/packages/node/src/commands/builtin/disk/cat/cat.ts) and POSIX `cat`. `IOResult.reads` / `cache` now record every file read, not just the first.

## Test plan

- New regression test in `cat.test.ts` seeds 3 days of channel history with day-distinct messages (matching by `oldest` UTC bound) and asserts the output contains all 3 in chronological order.
- Existing tests still pass (24 slack test files, 63 tests, all green).
- `tsc --noEmit` clean.

```
 ✓ src/commands/builtin/slack/cat.test.ts (3 tests) 4ms
 ...
 Test Files  24 passed (24)
      Tests  63 passed (63)
```

## Out of scope (follow-ups)

Same `resolved[0]` pattern exists in (grep `'const first = resolved\[0\]'`):

- `slack/head.ts`, `slack/tail.ts`, `slack/wc.ts` — POSIX semantics more complex (per-file `==> X <==` headers in head/tail; total line in wc). Happy to send these in a follow-up PR if you'd like.
- `discord/cat.ts`, `linear/cat.ts`, `langfuse/cat.ts`, `notion/cat.ts`, `github/cat.ts`, `github_ci/cat.ts`, `sscholar_*/cat.ts`, `box/cat.ts`, `s3/cat.ts` — all copy-paste of the same single-arg `cat` template.
- Python mirror at `python/mirage/commands/builtin/slack/cat.py` (`p = paths[0]` on line 55) has the same bug.

I noticed PR #102 routes some commands through generic across backends — if the slack commands are slated for that same migration, this fix is essentially the generic version of just the multi-arg piece for `cat`, and could either land standalone now or be absorbed into the migration.

🤖 AI-assisted (Claude Code), reviewed and tested locally per CONTRIBUTING.md guidance.