### PR TITLE
fix(databricks): fix volume stream downloads

### DIFF
--- a/python/mirage/core/databricks_volume/stream.py
+++ b/python/mirage/core/databricks_volume/stream.py
@@ -12,13 +12,34 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
 from collections.abc import AsyncIterator
+from typing import BinaryIO
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume.errors import is_not_found
+from mirage.core.databricks_volume.path import backend_path
 from mirage.core.databricks_volume.read import read_bytes
 from mirage.observe.context import record_stream
 from mirage.types import PathSpec
+
+
+def _download_contents(response) -> BinaryIO:
+    if isinstance(response, dict):
+        contents = response.get("contents")
+    else:
+        contents = getattr(response, "contents", None)
+    if contents is None:
+        raise RuntimeError("Databricks download response has no contents")
+    return contents
+
+
+def _open_download_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+) -> BinaryIO:
+    return _download_contents(accessor.files.download(remote_path))
 
 
 async def read_stream(
@@ -32,17 +53,28 @@ async def read_stream(
     if chunk_size <= 0:
         raise ValueError("chunk_size must be positive")
     rec = record_stream("read", path.original, "databricks_volume")
-    offset = 0
-    while True:
-        chunk = await read_bytes(accessor, path, index, offset, chunk_size)
-        if not chunk:
-            return
-        if rec is not None:
-            rec.bytes += len(chunk)
-        yield chunk
-        if len(chunk) < chunk_size:
-            return
-        offset += chunk_size
+    remote_path = backend_path(accessor.config, path)
+    contents = None
+    try:
+        contents = await asyncio.to_thread(
+            _open_download_sync,
+            accessor,
+            remote_path,
+        )
+        while True:
+            chunk = await asyncio.to_thread(contents.read, chunk_size)
+            if not chunk:
+                return
+            if rec is not None:
+                rec.bytes += len(chunk)
+            yield chunk
+    except Exception as exc:
+        if is_not_found(exc):
+            raise FileNotFoundError(path.strip_prefix) from exc
+        raise
+    finally:
+        if contents is not None:
+            await asyncio.to_thread(contents.close)
 
 
 async def range_read(

--- a/python/tests/core/databricks_volume/test_stream.py
+++ b/python/tests/core/databricks_volume/test_stream.py
@@ -4,6 +4,43 @@ from mirage.core.databricks_volume.stream import range_read, read_stream
 from mirage.types import PathSpec
 
 
+class TrackingContents:
+
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+        self.offset = 0
+        self.read_sizes: list[int] = []
+        self.closed = False
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_sizes.append(size)
+        if size < 0:
+            size = len(self.data) - self.offset
+        chunk = self.data[self.offset:self.offset + size]
+        self.offset += len(chunk)
+        return chunk
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class TrackingDownload:
+
+    def __init__(self, contents: TrackingContents) -> None:
+        self.contents = contents
+
+
+class TrackingFiles:
+
+    def __init__(self, contents: TrackingContents) -> None:
+        self.contents = contents
+        self.download_calls: list[str] = []
+
+    def download(self, path: str) -> TrackingDownload:
+        self.download_calls.append(path)
+        return TrackingDownload(self.contents)
+
+
 @pytest.mark.asyncio
 async def test_read_stream_chunks_file(accessor, files, remote_root):
     files.downloads[f"{remote_root}/reports/latest.md"] = b"abcdef"
@@ -12,6 +49,9 @@ async def test_read_stream_chunks_file(accessor, files, remote_root):
         chunk async for chunk in read_stream(accessor, path, chunk_size=2)
     ]
     assert chunks == [b"ab", b"cd", b"ef"]
+    # Streaming should use one download body, not one Range GET per chunk.
+    assert files.download_calls == [f"{remote_root}/reports/latest.md"]
+    assert accessor.client.api_client.do_calls == []
 
 
 @pytest.mark.asyncio
@@ -41,18 +81,25 @@ async def test_range_read_uses_single_databricks_range_request(
 
 
 @pytest.mark.asyncio
-async def test_read_stream_does_not_download_whole_file_before_yielding(
+async def test_read_stream_reads_single_download_body_in_chunks(
     accessor,
-    files,
     remote_root,
 ):
-    files.downloads[f"{remote_root}/reports/latest.md"] = b"abcdef"
+    contents = TrackingContents(b"abcdef")
+    tracking_files = TrackingFiles(contents)
+    accessor.client.files = tracking_files
     path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+    stream = read_stream(accessor, path, chunk_size=2)
 
-    chunks = [
-        chunk async for chunk in read_stream(accessor, path, chunk_size=2)
+    first = await anext(stream)
+    second = await anext(stream)
+
+    assert first == b"ab"
+    assert second == b"cd"
+    assert tracking_files.download_calls == [
+        f"{remote_root}/reports/latest.md"
     ]
-
-    assert chunks == [b"ab", b"cd", b"ef"]
-    assert files.download_calls == []
-    assert accessor.client.api_client.do_calls
+    assert contents.read_sizes == [2, 2]
+    assert not contents.closed
+    await stream.aclose()
+    assert contents.closed


### PR DESCRIPTION
## Summary

Part of #61 roadmap.

Fix Databricks Volume `read_stream` so sequential streaming uses a single Databricks file download response instead of one Range GET per yielded chunk.

Before this change, streaming a 100 MB file with the default 8192-byte chunk size caused roughly 12k network GETs. `read_stream` now opens one `files.download()` response, reads the returned body incrementally with `contents.read(chunk_size)`, and closes the body when the stream finishes or is closed early.

`range_read` is unchanged and still uses Range GETs for bounded/random byte reads.

## Tests

- `cd python && uv run pytest tests/core/databricks_volume/test_stream.py`
- `cd python && uv run pytest tests/core/databricks_volume/test_stream.py tests/core/databricks_volume/test_read.py tests/core/databricks_volume/test_head.py`
- `cd python && uv run pytest tests/core/databricks_volume tests/resource/databricks_volume`