### PR TITLE
fix(databricks_volume): move blocking readdir/stat off the event loop

### DIFF
--- a/python/mirage/core/databricks_volume/readdir.py
+++ b/python/mirage/core/databricks_volume/readdir.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
 import logging
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
@@ -22,6 +23,13 @@ from mirage.types import PathSpec
 
 logger = logging.getLogger(__name__)
 SCOPE_ERROR = 10_000
+
+
+def _list_directory_sync(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+) -> list[object]:
+    return list(accessor.files.list_directory_contents(remote_path))
 
 
 async def readdir(
@@ -38,7 +46,11 @@ async def readdir(
         return listing.entries
     remote_path = backend_path(accessor.config, list_path)
     try:
-        entries = list(accessor.files.list_directory_contents(remote_path))
+        entries = await asyncio.to_thread(
+            _list_directory_sync,
+            accessor,
+            remote_path,
+        )
     except Exception as exc:
         if is_not_found(exc):
             raise FileNotFoundError(list_path.strip_prefix) from exc

--- a/python/mirage/core/databricks_volume/stat.py
+++ b/python/mirage/core/databricks_volume/stat.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
 from datetime import datetime, timezone
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
@@ -47,13 +48,14 @@ def _name_from_backend_path(path: str) -> str:
     return path.rstrip("/").rsplit("/", 1)[-1]
 
 
-def _directory_stat_or_raise(
+async def _directory_stat_or_raise(
     accessor: DatabricksVolumeAccessor,
     remote_path: str,
     path: PathSpec,
 ) -> FileStat:
     try:
-        accessor.files.get_directory_metadata(remote_path)
+        await asyncio.to_thread(accessor.files.get_directory_metadata,
+                                remote_path)
     except Exception as exc:
         if is_not_found(exc):
             raise FileNotFoundError(path.strip_prefix) from exc
@@ -74,10 +76,11 @@ async def stat(
         return FileStat(name="/", type=FileType.DIRECTORY)
     remote_path = backend_path(accessor.config, path)
     try:
-        metadata = accessor.files.get_metadata(remote_path)
+        metadata = await asyncio.to_thread(accessor.files.get_metadata,
+                                           remote_path)
     except Exception as exc:
         if is_not_found(exc):
-            return _directory_stat_or_raise(accessor, remote_path, path)
+            return await _directory_stat_or_raise(accessor, remote_path, path)
         raise
     name = _name_from_backend_path(remote_path)
     if _is_directory(metadata):

--- a/python/tests/core/databricks_volume/conftest.py
+++ b/python/tests/core/databricks_volume/conftest.py
@@ -15,6 +15,16 @@ class NotFoundError(Exception):
     status_code = 404
 
 
+class ToThreadRecorder:
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def __call__(self, fn, *args, **kwargs):
+        self.calls.append((fn, args, kwargs))
+        return fn(*args, **kwargs)
+
+
 class FakeDownload:
 
     def __init__(self, data: bytes) -> None:

--- a/python/tests/core/databricks_volume/test_read.py
+++ b/python/tests/core/databricks_volume/test_read.py
@@ -5,15 +5,7 @@ import pytest
 from mirage.core.databricks_volume.read import read_bytes
 from mirage.types import PathSpec
 
-
-class ToThreadRecorder:
-
-    def __init__(self) -> None:
-        self.calls = []
-
-    async def __call__(self, fn, *args, **kwargs):
-        self.calls.append((fn, args, kwargs))
-        return fn(*args, **kwargs)
+from .conftest import ToThreadRecorder
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/databricks_volume/test_readdir.py
+++ b/python/tests/core/databricks_volume/test_readdir.py
@@ -1,9 +1,11 @@
+import asyncio
+
 import pytest
 
 from mirage.core.databricks_volume.readdir import readdir
 from mirage.types import PathSpec
 
-from .conftest import directory_entry, file_entry
+from .conftest import ToThreadRecorder, directory_entry, file_entry
 
 
 @pytest.mark.asyncio
@@ -45,3 +47,24 @@ async def test_readdir_missing_directory_raises(accessor, index):
     path = PathSpec.from_str_path("/volume/missing", "/volume")
     with pytest.raises(FileNotFoundError):
         await readdir(accessor, path, index)
+
+
+@pytest.mark.asyncio
+async def test_readdir_runs_blocking_list_off_event_loop(
+    accessor,
+    files,
+    index,
+    remote_root,
+    monkeypatch,
+):
+    to_thread = ToThreadRecorder()
+    monkeypatch.setattr(asyncio, "to_thread", to_thread)
+    files.directories[f"{remote_root}/reports"] = [
+        file_entry(f"{remote_root}/reports/latest.md", size=6),
+    ]
+    path = PathSpec.from_str_path("/volume/reports", "/volume")
+
+    result = await readdir(accessor, path, index)
+
+    assert result == ["/volume/reports/latest.md"]
+    assert len(to_thread.calls) == 1

--- a/python/tests/core/databricks_volume/test_stat.py
+++ b/python/tests/core/databricks_volume/test_stat.py
@@ -1,9 +1,11 @@
+import asyncio
+
 import pytest
 
 from mirage.core.databricks_volume.stat import _name_from_backend_path, stat
 from mirage.types import FileType, PathSpec
 
-from .conftest import file_metadata
+from .conftest import ToThreadRecorder, file_metadata
 
 
 def test_name_from_backend_path_file():
@@ -108,3 +110,39 @@ async def test_stat_directory_metadata_error_propagates(
         await stat(accessor, path)
     assert files.get_metadata_calls == [remote_path]
     assert files.get_directory_metadata_calls == [remote_path]
+
+
+@pytest.mark.asyncio
+async def test_stat_runs_blocking_metadata_off_event_loop(
+    accessor,
+    files,
+    remote_root,
+    monkeypatch,
+):
+    to_thread = ToThreadRecorder()
+    monkeypatch.setattr(asyncio, "to_thread", to_thread)
+    files.metadata[f"{remote_root}/reports/latest.md"] = file_metadata(size=6)
+    path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
+
+    result = await stat(accessor, path)
+
+    assert result.name == "latest.md"
+    assert len(to_thread.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_stat_directory_fallback_runs_off_event_loop(
+    accessor,
+    files,
+    remote_root,
+    monkeypatch,
+):
+    to_thread = ToThreadRecorder()
+    monkeypatch.setattr(asyncio, "to_thread", to_thread)
+    files.directory_metadata.add(f"{remote_root}/reports")
+    path = PathSpec.from_str_path("/volume/reports", "/volume")
+
+    result = await stat(accessor, path)
+
+    assert result.type == FileType.DIRECTORY
+    assert len(to_thread.calls) == 2


### PR DESCRIPTION
## Summary

In the `databricks_volume` backend, `readdir` and `stat` are `async` but called the
**synchronous** Databricks SDK directly inside the coroutine, blocking the event loop
for the duration of each network round-trip:

- `readdir` → `accessor.files.list_directory_contents(...)`
- `stat` → `accessor.files.get_metadata(...)` and `accessor.files.get_directory_metadata(...)`

Fix: Move the blocking SDK calls onto a worker thread via `asyncio.to_thread`.
This also unblocks the generic `copy` path.

## Tests

- Added off-event-loop assertions for `readdir` and `stat` (monkeypatch `asyncio.to_thread`
  with a recorder and assert it's invoked).
- Re ran databricks volume tests