### PR TITLE
feat(onedrive): OneDrive/SharePoint backend (versioned, snapshot-capable)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -132,6 +132,13 @@
                 ]
               },
               {
+                "group": "Microsoft",
+                "icon": "microsoft",
+                "pages": [
+                  "home/setup/onedrive"
+                ]
+              },
+              {
                 "group": "Cloud Files",
                 "icon": "folder-open",
                 "pages": [

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -285,6 +285,13 @@
                 ]
               },
               {
+                "group": "Microsoft",
+                "icon": "microsoft",
+                "pages": [
+                  "python/resource/onedrive"
+                ]
+              },
+              {
                 "group": "Cloud Files",
                 "icon": "folder-open",
                 "pages": [

--- a/docs/home/setup/onedrive.mdx
+++ b/docs/home/setup/onedrive.mdx
@@ -1,0 +1,103 @@
+---
+title: OneDrive
+icon: microsoft
+description: Get a Microsoft Graph access token and drive ID for the OneDrive resource.
+---
+
+The OneDrive resource talks to Microsoft OneDrive and SharePoint document
+libraries through the [Microsoft Graph API](https://learn.microsoft.com/en-us/graph/).
+It authenticates with an OAuth2 **bearer access token**, optionally scoped to a
+specific **drive**.
+
+## Credentials
+
+You need two things: an **access token**, and (for app-only tokens or SharePoint)
+a **drive ID**. Pick whichever token path fits.
+
+### Option A: Quick token (Graph Explorer)
+
+Fastest way to try it. The token lasts about an hour, which is plenty for a test run.
+
+1. Open [Graph Explorer](https://developer.microsoft.com/graph/graph-explorer) and **Sign in**.
+1. Run any query (for example `GET /me/drive`) and consent when prompted.
+1. Open the **Access token** tab and copy the token.
+
+This is a **delegated** token, so it works against your own `/me/drive` and you do
+**not** need a drive ID.
+
+### Option B: Repeatable token (app registration + device code)
+
+Use this for scripted or CI runs.
+
+1. In the [Microsoft Entra admin center](https://entra.microsoft.com), go to
+   **Identity** -> **Applications** -> **App registrations** -> **New registration**.
+   For a personal account, choose *Accounts in any organizational directory and
+   personal Microsoft accounts*.
+1. Under **Authentication** -> **Advanced settings**, set
+   **Allow public client flows** to **Yes**.
+1. Under **API permissions** -> **Microsoft Graph** -> **Delegated**, add
+   `Files.ReadWrite.All` (add `Sites.ReadWrite.All` for SharePoint libraries).
+1. Run the device-code flow with your **Application (client) ID**:
+
+```bash
+CLIENT_ID="<your app client id>"
+
+# 1) request a device code
+curl -s -X POST "https://login.microsoftonline.com/common/oauth2/v2.0/devicecode" \
+  -d "client_id=$CLIENT_ID" \
+  -d "scope=Files.ReadWrite.All offline_access"
+#   -> open https://microsoft.com/devicelogin and enter the user_code it prints
+
+# 2) after you sign in, exchange the device_code for a token
+curl -s -X POST "https://login.microsoftonline.com/common/oauth2/v2.0/token" \
+  -d "grant_type=urn:ietf:params:oauth:grant-type:device_code" \
+  -d "client_id=$CLIENT_ID" \
+  -d "device_code=<device_code from step 1>" | jq -r .access_token
+```
+
+<Note>
+**App-only tokens** (client-credentials flow) have no signed-in user, so
+`/me/drive` returns an error. With an app-only token you **must** pass a
+`drive_id` (or `site_id`). Delegated tokens (Options A and B) can use `/me/drive`
+with no drive ID.
+</Note>
+
+### Get your drive ID
+
+Only needed for app-only tokens or to target a specific SharePoint library. With
+your token exported as `TOKEN`:
+
+```bash
+# your personal OneDrive drive id
+curl -s -H "Authorization: Bearer $TOKEN" \
+  https://graph.microsoft.com/v1.0/me/drive | jq -r .id
+
+# list every drive you can see (name + id)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  https://graph.microsoft.com/v1.0/me/drives | jq '.value[] | {name, id}'
+
+# a SharePoint site's drives
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://graph.microsoft.com/v1.0/sites/{hostname}:/sites/{site-path}" | jq -r .id
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://graph.microsoft.com/v1.0/sites/{site-id}/drives" | jq '.value[] | {name, id}'
+```
+
+The drive ID looks like `b!a1B2c3...`.
+
+### Set environment variables
+
+```bash
+# .env.development
+ONEDRIVE_ACCESS_TOKEN=<token>
+ONEDRIVE_DRIVE_ID=<drive id>   # omit when using a delegated /me/drive token
+```
+
+<Note>
+Snapshots and version pinning rely on OneDrive/SharePoint **version history**,
+which is on by default. Older versions are only readable while the library
+retains them (the version cap is configurable, and an admin can disable
+versioning).
+</Note>
+
+For Python configuration, see the [Python OneDrive Setup](/python/setup/onedrive) guide.

--- a/docs/python/resource/onedrive.mdx
+++ b/docs/python/resource/onedrive.mdx
@@ -1,0 +1,216 @@
+---
+title: OneDrive
+description: Mount Microsoft OneDrive or SharePoint document libraries as a Mirage filesystem with async access, versioning, and shell commands.
+icon: microsoft
+---
+The OneDrive resource mounts a Microsoft OneDrive (or SharePoint document
+library) at some prefix such as `/onedrive/`. All operations involve network
+I/O to Microsoft Graph. Files are served as raw bytes (no Office filetype
+conversion). Uses aiohttp for async Graph access.
+
+Compatible with: personal OneDrive, OneDrive for Business, and SharePoint
+document libraries (driveItems on Microsoft Graph v1.0).
+
+For credential setup (tokens, drive ids, app vs delegated auth), see the
+[OneDrive Setup](/home/setup/onedrive) guide.
+
+## Config
+
+```python
+import os
+
+from mirage import MountMode, Workspace
+from mirage.resource.onedrive import OneDriveResource, OneDriveConfig
+
+config = OneDriveConfig(
+    access_token=os.environ["MS_GRAPH_DRIVE_TOKEN"],
+    # Optional:
+    # drive_id="b!...",        # target a specific drive (required for app-only tokens)
+    # site_id="contoso.sharepoint.com,...",  # use a SharePoint site's default drive
+    # key_prefix="Documents/",  # mount a sub-folder as the root
+    # timeout=30,
+)
+
+resource = OneDriveResource(config)
+ws = Workspace({"/onedrive": resource}, mode=MountMode.WRITE)
+```
+
+`OneDriveResource(config)` takes an `OneDriveConfig` object with a Microsoft
+Graph bearer token and optional drive/site targeting. Both `READ` and `WRITE`
+modes are supported.
+
+### Config Reference
+
+| Field          | Required | Description                                                           |
+| -------------- | -------- | --------------------------------------------------------------------- |
+| `access_token` | Yes      | Microsoft Graph OAuth2 bearer token                                   |
+| `drive_id`     | No       | Target a specific drive. Required for app-only tokens (no `/me/drive`) |
+| `site_id`      | No       | Resolve a SharePoint site's default drive instead of `/me/drive`      |
+| `key_prefix`   | No       | Mount a sub-folder of the drive as the root                           |
+| `timeout`      | No       | Request timeout in seconds (default `30`)                             |
+
+Drive resolution order: `drive_id`, then the `site_id` site's default drive,
+then `/me/drive`.
+
+## Filesystem Layout
+
+The OneDrive resource maps Graph driveItems (path-addressed) to virtual paths
+under the mount prefix. Folders are real driveItems, so the tree matches what
+you see in OneDrive.
+
+For example, if the drive contains:
+
+```text
+Documents/file.txt
+Documents/config.json
+Reports/q1.csv
+Reports/q2.csv
+```
+
+Then mounting at `/onedrive/` exposes:
+
+```text
+/onedrive/
+  Documents/
+    file.txt
+    config.json
+  Reports/
+    q1.csv
+    q2.csv
+```
+
+Path mapping: virtual `/onedrive/Documents/file.txt` maps to the driveItem at
+`/root:/Documents/file.txt`.
+
+## Versioning and Snapshots
+
+OneDrive keeps per-file version history. The resource exposes it the same way
+the S3 backend does:
+
+- **Fingerprint** is the driveItem `cTag`, so normal reads and `stat` reflect
+  the current content without extra Graph calls.
+- **Snapshots** pin each path to a Graph driveItem version id. Replaying a
+  snapshot reads `/versions/{id}/content`, giving time-travel to the exact
+  bytes captured at snapshot time.
+- **Restore** writes a previous version back as the current one.
+
+This makes the OneDrive resource `SUPPORTS_SNAPSHOT = True`.
+
+## Cache
+
+The OneDrive resource caches directory listings via `IndexCacheStore` to reduce
+repeated Graph calls during traversal.
+
+## Example
+
+```python
+import asyncio
+import os
+
+from mirage import MountMode, Workspace
+from mirage.resource.onedrive import OneDriveResource, OneDriveConfig
+
+config = OneDriveConfig(
+    access_token=os.environ["MS_GRAPH_DRIVE_TOKEN"],
+    drive_id=os.environ.get("MS_GRAPH_DRIVE_ID") or None,
+)
+
+resource = OneDriveResource(config)
+
+
+async def main() -> None:
+    ws = Workspace({"/onedrive/": resource}, mode=MountMode.WRITE)
+
+    r = await ws.execute("ls /onedrive/")
+    print(await r.stdout_str())
+
+    await ws.execute("echo 'hello from mirage' > /onedrive/note.txt")
+
+    r = await ws.execute("cat /onedrive/note.txt")
+    print(await r.stdout_str())
+
+    r = await ws.execute("stat /onedrive/note.txt")
+    print(await r.stdout_str())
+
+    r = await ws.execute("tree /onedrive/")
+    print(await r.stdout_str())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+A runnable version lives at `examples/python/onedrive/onedrive.py`.
+
+## Shell Commands
+
+The OneDrive resource supports the full set of shell commands since it operates
+on real file content (text, binary, JSON, CSV, etc.). Large files benefit from
+range reads to avoid downloading entire items.
+
+### Read Commands
+
+| Command         | Notes                                      |
+| --------------- | ------------------------------------------ |
+| `cat`           | Read file content                          |
+| `head` / `tail` | First/last N lines                         |
+| `grep` / `rg`   | Pattern search (file or directory level)   |
+| `jq`            | Query JSON fields                          |
+| `wc`            | Line/word/byte counts                      |
+| `stat`          | File metadata (name, size, type, modified) |
+| `find`          | Recursive search with `-name`, `-maxdepth` |
+| `tree`          | Directory tree view                        |
+| `nl`            | Number lines                               |
+| `du`            | Disk usage summary                         |
+| `file`          | Detect file type                           |
+| `strings`       | Extract printable strings from binary      |
+| `xxd`           | Hex dump                                   |
+| `md5`           | MD5 checksum                               |
+| `sha256sum`     | SHA-256 checksum                           |
+
+### File Operations
+
+| Command  | Notes                                 |
+| -------- | ------------------------------------- |
+| `cp`     | Copy files                            |
+| `mv`     | Move/rename files                     |
+| `rm`     | Remove files                          |
+| `mkdir`  | Create directories                    |
+| `touch`  | Create empty file or update timestamp |
+| `tee`    | Write stdin to file and stdout        |
+
+### Path Utilities
+
+| Command    | Notes                     |
+| ---------- | ------------------------- |
+| `basename` | Strip directory from path |
+| `dirname`  | Strip filename from path  |
+| `realpath` | Resolve path              |
+| `ls`       | List directory contents   |
+
+## Use Cases
+
+- **AI agents accessing org documents**: Mount OneDrive/SharePoint for agents to read and process files
+- **Versioned document workflows**: Snapshot and replay exact file states over time
+- **Sandboxed access**: Restrict agent operations to a specific drive and sub-folder via `key_prefix`
+- **FUSE mounting**: Expose a OneDrive through a virtual FUSE mount for external tools
+
+## Scoping a resource to a folder
+
+Pass `key_prefix: str | None = None` to `OneDriveConfig` to transparently scope
+every operation to a sub-folder of the drive:
+
+```python
+OneDriveResource(OneDriveConfig(
+    access_token=token,
+    drive_id=drive_id,
+    key_prefix=f"users/{user_id}/",
+))
+```
+
+When set, every read/write/list/stat/copy/rename/delete operation is scoped to
+that sub-folder. Agents see clean paths like `/data/notes.md`; the underlying
+driveItem is `users/{user_id}/data/notes.md`. Useful for multi-tenant systems.
+
+**Normalization:** leading slashes are stripped and a trailing slash is added
+automatically. Both `None` and an empty string are treated as "no prefix."

--- a/docs/python/setup/onedrive.mdx
+++ b/docs/python/setup/onedrive.mdx
@@ -1,0 +1,39 @@
+---
+title: OneDrive
+icon: microsoft
+description: Set up the OneDrive resource in Python.
+---
+
+## Dependencies
+
+No additional dependencies - uses `aiohttp` (included).
+
+For credential setup, see the [OneDrive Setup](/home/setup/onedrive) guide.
+
+## Configuration
+
+```python
+import os
+from mirage import Workspace, MountMode
+from mirage.resource.onedrive import OneDriveConfig, OneDriveResource
+
+config = OneDriveConfig(
+    access_token=os.environ["ONEDRIVE_ACCESS_TOKEN"],
+    drive_id=os.environ.get("ONEDRIVE_DRIVE_ID"),  # omit for delegated /me/drive
+)
+resource = OneDriveResource(config=config)
+ws = Workspace({"/onedrive/": resource}, mode=MountMode.WRITE)
+```
+
+## Config Reference
+
+| Field          | Required | Description                                                              |
+| -------------- | -------- | ------------------------------------------------------------------------ |
+| `access_token` | Yes      | Microsoft Graph OAuth2 bearer token                                       |
+| `drive_id`     | No       | Target a specific drive. Required for app-only tokens (no `/me/drive`)    |
+| `site_id`      | No       | Resolve a SharePoint site's default drive instead of `/me/drive`         |
+| `key_prefix`   | No       | Mount a sub-folder of the drive as the root                              |
+| `timeout`      | No       | Request timeout in seconds (default `30`)                                |
+
+Drive resolution order: `drive_id` -> the `site_id` site's default drive ->
+`/me/drive`.

--- a/examples/python/onedrive/onedrive.py
+++ b/examples/python/onedrive/onedrive.py
@@ -1,0 +1,67 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+from mirage import MountMode, Workspace
+from mirage.resource.onedrive import OneDriveConfig, OneDriveResource
+
+load_dotenv(".env.development")
+
+config = OneDriveConfig(
+    access_token=os.environ["MS_GRAPH_DRIVE_TOKEN"],
+    drive_id=os.environ.get("MS_GRAPH_DRIVE_ID") or None,
+)
+backend = OneDriveResource(config)
+ws = Workspace({"/onedrive/": backend}, mode=MountMode.WRITE)
+
+TEST_FILE = "/onedrive/mirage_onedrive_example.txt"
+
+
+async def main() -> None:
+    print("=== ls /onedrive/ (top level) ===")
+    print((await (await ws.execute("ls /onedrive/")).stdout_str())
+          or "(empty)")
+
+    print(f"\n=== write {TEST_FILE} ===")
+    await ws.execute(f"echo 'hello from mirage onedrive' > {TEST_FILE}")
+
+    print("=== cat it back ===")
+    print(await (await ws.execute(f"cat {TEST_FILE}")).stdout_str())
+
+    print("=== stat (fingerprint = cTag) ===")
+    print(await (await ws.execute(f"stat {TEST_FILE}")).stdout_str())
+
+    print("=== overwrite (creates a new version) ===")
+    await ws.execute(f"echo 'second version' > {TEST_FILE}")
+    print(await (await ws.execute(f"cat {TEST_FILE}")).stdout_str())
+
+    print("=== version history ===")
+    from mirage.core.onedrive.versions import list_versions
+    from mirage.types import PathSpec
+    versions = await list_versions(backend.accessor,
+                                   PathSpec.from_str_path(TEST_FILE))
+    for v in versions:
+        print(f"  version {v.get('id')}  size={v.get('size')}  "
+              f"modified={v.get('lastModifiedDateTime')}")
+
+    print("\n=== cleanup ===")
+    await ws.execute(f"rm {TEST_FILE}")
+    print("done")
+
+
+asyncio.run(main())

--- a/python/mirage/accessor/onedrive.py
+++ b/python/mirage/accessor/onedrive.py
@@ -1,0 +1,33 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from pydantic import BaseModel, ConfigDict, SecretStr
+
+from mirage.accessor.base import Accessor
+
+
+class OneDriveConfig(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    access_token: SecretStr
+    drive_id: str | None = None
+    site_id: str | None = None
+    key_prefix: str | None = None
+    timeout: int = 30
+
+
+class OneDriveAccessor(Accessor):
+
+    def __init__(self, config: OneDriveConfig) -> None:
+        self.config = config

--- a/python/mirage/accessor/onedrive.py
+++ b/python/mirage/accessor/onedrive.py
@@ -12,19 +12,22 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from collections.abc import Callable
+
 from pydantic import BaseModel, ConfigDict, SecretStr
 
 from mirage.accessor.base import Accessor
 
 
 class OneDriveConfig(BaseModel):
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
-    access_token: SecretStr
+    access_token: SecretStr | Callable[[], str | SecretStr]
     drive_id: str | None = None
     site_id: str | None = None
     key_prefix: str | None = None
     timeout: int = 30
+    max_retries: int = 5
 
 
 class OneDriveAccessor(Accessor):

--- a/python/mirage/commands/builtin/onedrive/__init__.py
+++ b/python/mirage/commands/builtin/onedrive/__init__.py
@@ -1,0 +1,150 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.commands.builtin.filetype_factory import make_filetype_commands
+from mirage.commands.builtin.onedrive._provision import \
+    file_read_provision as _ft_provision
+from mirage.commands.builtin.onedrive.awk import awk
+from mirage.commands.builtin.onedrive.base64_cmd import base64_cmd
+from mirage.commands.builtin.onedrive.basename import basename
+from mirage.commands.builtin.onedrive.cat import cat
+from mirage.commands.builtin.onedrive.cmp import cmp_cmd
+from mirage.commands.builtin.onedrive.column import column
+from mirage.commands.builtin.onedrive.comm import comm
+from mirage.commands.builtin.onedrive.cp import cp
+from mirage.commands.builtin.onedrive.csplit import csplit
+from mirage.commands.builtin.onedrive.cut import cut
+from mirage.commands.builtin.onedrive.diff import diff
+from mirage.commands.builtin.onedrive.dirname import dirname
+from mirage.commands.builtin.onedrive.du import du
+from mirage.commands.builtin.onedrive.expand import expand
+from mirage.commands.builtin.onedrive.file import file
+from mirage.commands.builtin.onedrive.find import find
+from mirage.commands.builtin.onedrive.fmt import fmt
+from mirage.commands.builtin.onedrive.fold import fold
+from mirage.commands.builtin.onedrive.grep import grep
+from mirage.commands.builtin.onedrive.gunzip import gunzip
+from mirage.commands.builtin.onedrive.gzip import gzip
+from mirage.commands.builtin.onedrive.head import head
+from mirage.commands.builtin.onedrive.iconv import iconv
+from mirage.commands.builtin.onedrive.join import join
+from mirage.commands.builtin.onedrive.jq import jq
+from mirage.commands.builtin.onedrive.ln import ln
+from mirage.commands.builtin.onedrive.look import look
+from mirage.commands.builtin.onedrive.ls import ls
+from mirage.commands.builtin.onedrive.md5 import md5
+from mirage.commands.builtin.onedrive.mkdir import mkdir
+from mirage.commands.builtin.onedrive.mktemp import mktemp
+from mirage.commands.builtin.onedrive.mv import mv
+from mirage.commands.builtin.onedrive.nl import nl
+from mirage.commands.builtin.onedrive.paste import paste
+from mirage.commands.builtin.onedrive.patch import patch
+from mirage.commands.builtin.onedrive.readlink import readlink
+from mirage.commands.builtin.onedrive.realpath import realpath
+from mirage.commands.builtin.onedrive.rev import rev
+from mirage.commands.builtin.onedrive.rg import rg
+from mirage.commands.builtin.onedrive.rm import rm
+from mirage.commands.builtin.onedrive.sed import sed
+from mirage.commands.builtin.onedrive.sha256sum import sha256sum
+from mirage.commands.builtin.onedrive.shuf import shuf
+from mirage.commands.builtin.onedrive.sort import sort
+from mirage.commands.builtin.onedrive.split import split
+from mirage.commands.builtin.onedrive.stat import stat
+from mirage.commands.builtin.onedrive.strings import strings
+from mirage.commands.builtin.onedrive.tac import tac
+from mirage.commands.builtin.onedrive.tail import tail
+from mirage.commands.builtin.onedrive.tar import tar
+from mirage.commands.builtin.onedrive.tee import tee
+from mirage.commands.builtin.onedrive.touch import touch
+from mirage.commands.builtin.onedrive.tr import tr
+from mirage.commands.builtin.onedrive.tree import tree
+from mirage.commands.builtin.onedrive.tsort import tsort
+from mirage.commands.builtin.onedrive.unexpand import unexpand
+from mirage.commands.builtin.onedrive.uniq import uniq
+from mirage.commands.builtin.onedrive.unzip import unzip as unzip_cmd
+from mirage.commands.builtin.onedrive.wc import wc
+from mirage.commands.builtin.onedrive.xxd import xxd
+from mirage.commands.builtin.onedrive.zcat import zcat
+from mirage.commands.builtin.onedrive.zgrep import zgrep
+from mirage.commands.builtin.onedrive.zip_cmd import zip_cmd
+from mirage.core.onedrive.glob import resolve_glob as _ft_resolve_glob
+from mirage.core.onedrive.read import read_bytes as _ft_read
+
+COMMANDS = [
+    *make_filetype_commands(
+        "onedrive", _ft_resolve_glob, _ft_read, provision=_ft_provision),
+    awk,
+    base64_cmd,
+    basename,
+    cat,
+    cmp_cmd,
+    column,
+    comm,
+    cp,
+    csplit,
+    cut,
+    diff,
+    dirname,
+    du,
+    expand,
+    file,
+    find,
+    fmt,
+    fold,
+    grep,
+    gunzip,
+    gzip,
+    head,
+    iconv,
+    join,
+    jq,
+    ln,
+    look,
+    ls,
+    md5,
+    mkdir,
+    mktemp,
+    mv,
+    nl,
+    paste,
+    patch,
+    readlink,
+    realpath,
+    rev,
+    rg,
+    rm,
+    sed,
+    sha256sum,
+    shuf,
+    sort,
+    split,
+    stat,
+    strings,
+    tac,
+    tail,
+    tar,
+    tee,
+    touch,
+    tr,
+    tree,
+    tsort,
+    unexpand,
+    uniq,
+    unzip_cmd,
+    wc,
+    xxd,
+    zcat,
+    zgrep,
+    zip_cmd,
+]

--- a/python/mirage/commands/builtin/onedrive/_provision.py
+++ b/python/mirage/commands/builtin/onedrive/_provision.py
@@ -1,0 +1,155 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.onedrive.stat import stat as s3_stat
+from mirage.provision.types import Precision, ProvisionResult
+from mirage.types import PathSpec
+
+
+async def _resolve_sizes(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    index: IndexCacheStore | None,
+) -> tuple[list[tuple[str, int]], int]:
+    """Walk paths, return (path, size) pairs. Self-heals via stat fallback.
+
+    Order of resolution per path:
+        1. Index lookup -- free, no network call.
+        2. ``head_object`` via ``s3_stat`` -- one S3 metadata call (~50ms,
+           ~100 bytes). Populates the index as a side effect, so the next
+           provision is free.
+
+    Returns:
+        (resolved, missing): list of (path_str, size) for paths whose
+            size could be determined, and the count of paths that
+            could not be resolved (e.g. file not found).
+    """
+    resolved: list[tuple[str, int]] = []
+    missing = 0
+    for p in paths:
+        path_str = p.original if isinstance(p, PathSpec) else p
+        size = None
+        if index is not None:
+            lookup = await index.get(path_str)
+            if lookup.entry is not None:
+                size = lookup.entry.size
+        if size is None:
+            try:
+                file_stat = await s3_stat(accessor, p, index)
+                size = file_stat.size
+            except (FileNotFoundError, ValueError):
+                pass
+        if size is not None:
+            resolved.append((path_str, size))
+        else:
+            missing += 1
+    return resolved, missing
+
+
+async def file_read_provision(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *_args: object,
+    command: str = "",
+    index: IndexCacheStore | None = None,
+    **_extra: object,
+) -> ProvisionResult:
+    """Cost estimate for full file reads (cat, wc).
+
+    Sums index-known file sizes. If any path is unknown, marks
+    precision UNKNOWN for safety -- the caller might be reading a
+    much larger file than we account for.
+    """
+    if not paths:
+        return ProvisionResult(command=command, precision=Precision.UNKNOWN)
+    resolved, missing = await _resolve_sizes(accessor, paths, index)
+    if missing > 0 or not resolved:
+        return ProvisionResult(command=command, precision=Precision.UNKNOWN)
+    total = sum(size for _, size in resolved)
+    return ProvisionResult(
+        command=command,
+        network_read_low=total,
+        network_read_high=total,
+        read_ops=len(resolved),
+        precision=Precision.EXACT,
+    )
+
+
+async def head_tail_provision(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *_args: object,
+    command: str = "",
+    n: str | int | None = None,
+    c: str | int | None = None,
+    index: IndexCacheStore | None = None,
+    **_extra: object,
+) -> ProvisionResult:
+    """Cost estimate for partial reads (head, tail).
+
+    With ``-c BYTES`` the byte count is exact: ``min(c, file_size)``
+    per file. With ``-n LINES`` (the default) we cannot predict bytes
+    without reading, so we mark precision RANGE with the full file
+    size as the upper bound.
+    """
+    if not paths:
+        return ProvisionResult(command=command, precision=Precision.UNKNOWN)
+    resolved, missing = await _resolve_sizes(accessor, paths, index)
+    if missing > 0 or not resolved:
+        return ProvisionResult(command=command, precision=Precision.UNKNOWN)
+
+    if c is not None:
+        c_bytes = int(c)
+        total = sum(min(c_bytes, size) for _, size in resolved)
+        return ProvisionResult(
+            command=command,
+            network_read_low=total,
+            network_read_high=total,
+            read_ops=len(resolved),
+            precision=Precision.EXACT,
+        )
+
+    full = sum(size for _, size in resolved)
+    return ProvisionResult(
+        command=command,
+        network_read_low=0,
+        network_read_high=full,
+        read_ops=len(resolved),
+        precision=Precision.RANGE,
+    )
+
+
+async def metadata_provision(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *_args: object,
+    command: str = "",
+    index: IndexCacheStore | None = None,
+    **_extra: object,
+) -> ProvisionResult:
+    """Cost estimate for metadata-only ops (stat, ls, find).
+
+    These hit the S3 API but don't transfer bytes. We report
+    ``read_ops`` so callers can multiply by the per-request cost.
+    """
+    n = max(1, len(paths) if paths else 1)
+    return ProvisionResult(
+        command=command,
+        network_read_low=0,
+        network_read_high=0,
+        read_ops=n,
+        precision=Precision.EXACT,
+    )

--- a/python/mirage/commands/builtin/onedrive/_provision.py
+++ b/python/mirage/commands/builtin/onedrive/_provision.py
@@ -14,7 +14,7 @@
 
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.core.onedrive.stat import stat as s3_stat
+from mirage.core.onedrive.stat import stat as onedrive_stat
 from mirage.provision.types import Precision, ProvisionResult
 from mirage.types import PathSpec
 
@@ -28,9 +28,8 @@ async def _resolve_sizes(
 
     Order of resolution per path:
         1. Index lookup -- free, no network call.
-        2. ``head_object`` via ``s3_stat`` -- one S3 metadata call (~50ms,
-           ~100 bytes). Populates the index as a side effect, so the next
-           provision is free.
+        2. ``onedrive_stat`` -- one Graph metadata call. Populates the
+           index as a side effect, so the next provision is free.
 
     Returns:
         (resolved, missing): list of (path_str, size) for paths whose
@@ -48,7 +47,7 @@ async def _resolve_sizes(
                 size = lookup.entry.size
         if size is None:
             try:
-                file_stat = await s3_stat(accessor, p, index)
+                file_stat = await onedrive_stat(accessor, p, index)
                 size = file_stat.size
             except (FileNotFoundError, ValueError):
                 pass
@@ -142,7 +141,7 @@ async def metadata_provision(
 ) -> ProvisionResult:
     """Cost estimate for metadata-only ops (stat, ls, find).
 
-    These hit the S3 API but don't transfer bytes. We report
+    These hit the Graph API but don't transfer bytes. We report
     ``read_ops`` so callers can multiply by the per-request cost.
     """
     n = max(1, len(paths) if paths else 1)

--- a/python/mirage/commands/builtin/onedrive/awk.py
+++ b/python/mirage/commands/builtin/onedrive/awk.py
@@ -1,0 +1,58 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.awk import awk as generic_awk
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.stream import read_stream
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("awk", resource="onedrive", spec=SPECS["awk"])
+async def awk(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    F: str | None = None,
+    v: str | None = None,
+    f: PathSpec | None = None,
+    prefix: str = "",
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+
+    return await generic_awk(
+        paths,
+        texts,
+        read_bytes=read_bytes,
+        read_stream=read_stream,
+        accessor=accessor,
+        stdin=stdin,
+        field_separator=F,
+        variable_assignment=v,
+        program_file=f,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/onedrive/base64_cmd.py
+++ b/python/mirage/commands/builtin/onedrive/base64_cmd.py
@@ -1,0 +1,50 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.base64_cmd import \
+    base64_cmd as generic_base64
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.stream import read_stream
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("base64", resource="onedrive", spec=SPECS["base64"])
+async def base64_cmd(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    d: bool = False,
+    D: bool = False,
+    w: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_base64(paths,
+                                read_stream=read_stream,
+                                accessor=accessor,
+                                stdin=stdin,
+                                decode=d or D,
+                                wrap=int(w) if w is not None else None)

--- a/python/mirage/commands/builtin/onedrive/basename.py
+++ b/python/mirage/commands/builtin/onedrive/basename.py
@@ -1,0 +1,32 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.commands.builtin.generic.basename import \
+    basename as generic_basename
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("basename", resource="onedrive", spec=SPECS["basename"])
+async def basename(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec] | None = None,
+    *texts: str,
+    stdin: bytes | None = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    return await generic_basename(*texts)

--- a/python/mirage/commands/builtin/onedrive/cat.py
+++ b/python/mirage/commands/builtin/onedrive/cat.py
@@ -1,0 +1,58 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cat import cat as generic_cat
+from mirage.commands.builtin.onedrive._provision import file_read_provision
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.stat import stat
+from mirage.core.onedrive.stream import read_stream
+from mirage.io.cachable_iterator import CachableAsyncIterator
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("cat",
+         resource="onedrive",
+         spec=SPECS["cat"],
+         provision=file_read_provision)
+async def cat(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    n: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        await stat(accessor, paths[0], index)
+        source = read_stream(accessor, paths[0])
+        cachable = CachableAsyncIterator(source)
+        key = paths[0].strip_prefix
+        io = IOResult(reads={key: cachable}, cache=[key])
+        if n:
+            return generic_cat(cachable, number_lines=True), io
+        return cachable, io
+    source = _resolve_source(stdin, "cat: missing operand")
+    if n:
+        return generic_cat(source, number_lines=True), IOResult()
+    return source, IOResult()

--- a/python/mirage/commands/builtin/onedrive/cat.py
+++ b/python/mirage/commands/builtin/onedrive/cat.py
@@ -22,9 +22,11 @@ from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
 from mirage.core.onedrive.stat import stat
 from mirage.core.onedrive.stream import read_stream
 from mirage.io.cachable_iterator import CachableAsyncIterator
+from mirage.io.stream import async_chain
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -44,14 +46,25 @@ async def cat(
 ) -> tuple[ByteSource | None, IOResult]:
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        await stat(accessor, paths[0], index)
-        source = read_stream(accessor, paths[0])
-        cachable = CachableAsyncIterator(source)
-        key = paths[0].strip_prefix
-        io = IOResult(reads={key: cachable}, cache=[key])
+        if len(paths) == 1:
+            p = paths[0]
+            await stat(accessor, p, index)
+            cachable = CachableAsyncIterator(read_stream(accessor, p))
+            io = IOResult(reads={p.strip_prefix: cachable},
+                          cache=[p.strip_prefix])
+            source: ByteSource = cachable
+        else:
+            reads: dict[str, ByteSource] = {}
+            parts: list[bytes] = []
+            for p in paths:
+                data = await read_bytes(accessor, p, index)
+                reads[p.strip_prefix] = data
+                parts.append(data)
+            io = IOResult(reads=reads, cache=list(reads))
+            source = async_chain(*parts)
         if n:
-            return generic_cat(cachable, number_lines=True), io
-        return cachable, io
+            return generic_cat(source, number_lines=True), io
+        return source, io
     source = _resolve_source(stdin, "cat: missing operand")
     if n:
         return generic_cat(source, number_lines=True), IOResult()

--- a/python/mirage/commands/builtin/onedrive/cmp.py
+++ b/python/mirage/commands/builtin/onedrive/cmp.py
@@ -1,0 +1,52 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cmp import cmp_cmd as generic_cmp
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("cmp", resource="onedrive", spec=SPECS["cmp"])
+async def cmp_cmd(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    s: bool = False,
+    args_l: bool = False,
+    n: str | None = None,
+    b: bool = False,
+    i: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if len(paths) < 2:
+        raise ValueError("cmp: requires two paths")
+    paths = await resolve_glob(accessor, paths, index)
+    return await generic_cmp(paths,
+                             read_bytes=read_bytes,
+                             accessor=accessor,
+                             silent=s,
+                             verbose=args_l,
+                             limit=int(n) if n is not None else None,
+                             print_bytes=b,
+                             skip=int(i) if i is not None else None)

--- a/python/mirage/commands/builtin/onedrive/column.py
+++ b/python/mirage/commands/builtin/onedrive/column.py
@@ -1,0 +1,50 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.column import column as generic_column
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("column", resource="onedrive", spec=SPECS["column"])
+async def column(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    t: bool = False,
+    s: str | None = None,
+    o: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_column(paths,
+                                read_bytes=read_bytes,
+                                accessor=accessor,
+                                stdin=stdin,
+                                table=t,
+                                separator=s,
+                                output_separator=o)

--- a/python/mirage/commands/builtin/onedrive/comm.py
+++ b/python/mirage/commands/builtin/onedrive/comm.py
@@ -1,0 +1,50 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.comm import comm as generic_comm
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("comm", resource="onedrive", spec=SPECS["comm"])
+async def comm(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    check_order: bool = False,
+    nocheck_order: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if len(paths) < 2:
+        raise ValueError("comm: requires two paths")
+    paths = await resolve_glob(accessor, paths, index)
+    return await generic_comm(
+        paths,
+        read_bytes=read_bytes,
+        accessor=accessor,
+        suppress1=bool(_extra.get("args_1", False)),
+        suppress2=bool(_extra.get("2", False)),
+        suppress3=bool(_extra.get("3", False)),
+        check_order=check_order,
+    )

--- a/python/mirage/commands/builtin/onedrive/cp.py
+++ b/python/mirage/commands/builtin/onedrive/cp.py
@@ -1,0 +1,76 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.copy import copy
+from mirage.core.onedrive.find import find as find_impl
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.stat import stat as stat_impl
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+async def _exists(accessor: OneDriveAccessor, path: PathSpec | str) -> bool:
+    try:
+        await stat_impl(accessor, path)
+        return True
+    except (FileNotFoundError, ValueError, Exception):
+        return False
+
+
+@command("cp", resource="onedrive", spec=SPECS["cp"], write=True)
+async def cp(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    r: bool = False,
+    R: bool = False,
+    a: bool = False,  # -a: alias for -r, no attributes in virtual fs
+    f: bool = False,
+    n: bool = False,
+    v: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if len(paths) < 2:
+        raise ValueError("cp: requires src and dst")
+    paths = await resolve_glob(accessor, paths, index)
+    recursive = r or R or a
+    verbose_lines: list[str] = []
+    if recursive:
+        src_base = paths[0].strip_prefix.rstrip("/")
+        dst_base = paths[1].strip_prefix.rstrip("/")
+        entries = await find_impl(accessor, paths[0], type="f")
+        for entry in entries:
+            rel = entry[len(src_base):]
+            dst = dst_base + rel
+            if n and await _exists(accessor, dst):
+                continue
+            await copy(accessor, entry, dst)
+            if v:
+                verbose_lines.append(f"{entry} -> {dst}")
+        writes = {dst_base + entry[len(src_base):]: b"" for entry in entries}
+        output = "\n".join(verbose_lines) + "\n" if verbose_lines else None
+        return output.encode() if output else None, IOResult(writes=writes)
+    if n and await _exists(accessor, paths[1]):
+        return None, IOResult()
+    await copy(accessor, paths[0], paths[1])
+    output = None
+    if v:
+        output = f"{paths[0].original} -> {paths[1].original}\n".encode()
+    return output, IOResult(writes={paths[1].original: b""})

--- a/python/mirage/commands/builtin/onedrive/cp.py
+++ b/python/mirage/commands/builtin/onedrive/cp.py
@@ -28,7 +28,7 @@ async def _exists(accessor: OneDriveAccessor, path: PathSpec | str) -> bool:
     try:
         await stat_impl(accessor, path)
         return True
-    except (FileNotFoundError, ValueError, Exception):
+    except FileNotFoundError:
         return False
 
 
@@ -51,22 +51,18 @@ async def cp(
         raise ValueError("cp: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
     recursive = r or R or a
-    verbose_lines: list[str] = []
     if recursive:
         src_base = paths[0].strip_prefix.rstrip("/")
         dst_base = paths[1].strip_prefix.rstrip("/")
-        entries = await find_impl(accessor, paths[0], type="f")
-        for entry in entries:
-            rel = entry[len(src_base):]
-            dst = dst_base + rel
-            if n and await _exists(accessor, dst):
-                continue
-            await copy(accessor, entry, dst)
-            if v:
-                verbose_lines.append(f"{entry} -> {dst}")
-        writes = {dst_base + entry[len(src_base):]: b"" for entry in entries}
-        output = "\n".join(verbose_lines) + "\n" if verbose_lines else None
-        return output.encode() if output else None, IOResult(writes=writes)
+        if n and await _exists(accessor, paths[1]):
+            return None, IOResult()
+        files = await find_impl(accessor, paths[0], type="file")
+        await copy(accessor, paths[0], paths[1])
+        writes = {dst_base + f[len(src_base):]: b"" for f in files}
+        if v:
+            lines = [f"{f} -> {dst_base + f[len(src_base):]}" for f in files]
+            return ("\n".join(lines) + "\n").encode(), IOResult(writes=writes)
+        return None, IOResult(writes=writes)
     if n and await _exists(accessor, paths[1]):
         return None, IOResult()
     await copy(accessor, paths[0], paths[1])

--- a/python/mirage/commands/builtin/onedrive/csplit.py
+++ b/python/mirage/commands/builtin/onedrive/csplit.py
@@ -1,0 +1,96 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import re
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.write import write_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+def _split_by_patterns(
+    lines: list[str],
+    patterns: list[str],
+) -> list[list[str]]:
+    parts: list[list[str]] = []
+    current_start = 0
+    for pat in patterns:
+        if pat.startswith("/") and pat.endswith("/"):
+            regex = pat[1:-1]
+            for idx in range(current_start, len(lines)):
+                if re.search(regex, lines[idx]):
+                    parts.append(lines[current_start:idx])
+                    current_start = idx
+                    break
+        else:
+            line_num = int(pat)
+            split_at = line_num - 1
+            if split_at > current_start:
+                parts.append(lines[current_start:split_at])
+                current_start = split_at
+    if current_start < len(lines):
+        parts.append(lines[current_start:])
+    return parts
+
+
+@command("csplit", resource="onedrive", spec=SPECS["csplit"], write=True)
+async def csplit(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    f: str | None = None,
+    n: str | None = None,
+    b: str | None = None,
+    k: bool = False,
+    s: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    prefix = f or "xx"
+    digits = int(n) if n else 2
+    suffix_fmt = b if b else f"%0{digits}d"
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        raw = await read_bytes(accessor, paths[0])
+    else:
+        raw = await _read_stdin_async(stdin)
+        if raw is None:
+            raise ValueError("csplit: missing input")
+    text = raw.decode(errors="replace")
+    lines = text.splitlines()
+    patterns = list(texts)
+    parts = _split_by_patterns(lines, patterns)
+    writes: dict[str, bytes] = {}
+    sizes: list[str] = []
+    try:
+        for idx, part in enumerate(parts):
+            filename = prefix + (suffix_fmt % idx)
+            data = ("\n".join(part) + "\n").encode() if part else b""
+            await write_bytes(accessor, filename, data)
+            writes[filename] = data
+            sizes.append(str(len(data)))
+    except Exception:
+        if not k:
+            raise
+    output = "" if s else "\n".join(sizes) + "\n"
+    return output.encode(), IOResult(writes=writes)

--- a/python/mirage/commands/builtin/onedrive/cut.py
+++ b/python/mirage/commands/builtin/onedrive/cut.py
@@ -1,0 +1,54 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cut import cut as generic_cut
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.stream import read_stream
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("cut", resource="onedrive", spec=SPECS["cut"])
+async def cut(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    f: str | None = None,
+    d: str | None = None,
+    c: str | None = None,
+    complement: bool = False,
+    z: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_cut(paths,
+                             read_stream=read_stream,
+                             accessor=accessor,
+                             stdin=stdin,
+                             f=f,
+                             d=d,
+                             c=c,
+                             complement=complement,
+                             z=z)

--- a/python/mirage/commands/builtin/onedrive/diff.py
+++ b/python/mirage/commands/builtin/onedrive/diff.py
@@ -1,0 +1,55 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.diff import diff as generic_diff
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.readdir import readdir
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("diff", resource="onedrive", spec=SPECS["diff"])
+async def diff(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    i: bool = False,
+    w: bool = False,
+    b: bool = False,
+    e: bool = False,
+    u: bool = False,
+    q: bool = False,
+    r: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    paths = await resolve_glob(accessor, paths, index)
+    return await generic_diff(paths,
+                              read_bytes=read_bytes,
+                              readdir_fn=readdir,
+                              accessor=accessor,
+                              index=index,
+                              i=i,
+                              w=w,
+                              b=b,
+                              e=e,
+                              u=u,
+                              q=q,
+                              r=r)

--- a/python/mirage/commands/builtin/onedrive/dirname.py
+++ b/python/mirage/commands/builtin/onedrive/dirname.py
@@ -1,0 +1,31 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.commands.builtin.generic.dirname import dirname as generic_dirname
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("dirname", resource="onedrive", spec=SPECS["dirname"])
+async def dirname(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec] | None = None,
+    *texts: str,
+    stdin: bytes | None = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    return await generic_dirname(*texts)

--- a/python/mirage/commands/builtin/onedrive/du.py
+++ b/python/mirage/commands/builtin/onedrive/du.py
@@ -1,0 +1,89 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.du import du as du_impl
+from mirage.core.onedrive.du import du_all as du_all_impl
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+def _format_size(size: int, human: bool) -> str:
+    return _human_size(size) if human else str(size)
+
+
+def _depth(entry_path: str, base_path: str) -> int:
+    base = base_path.rstrip("/")
+    rel = entry_path.rstrip("/")[len(base):]
+    if not rel:
+        return 0
+    return rel.strip("/").count("/") + 1
+
+
+@command("du", resource="onedrive", spec=SPECS["du"])
+async def du(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    h: bool = False,
+    s: bool = False,
+    a: bool = False,
+    max_depth: str | None = None,
+    c: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    paths = await resolve_glob(accessor, paths, index)
+    p0 = paths[0]
+    path = p0
+    if s:
+        total = await du_impl(accessor, path)
+        output = _format_size(total, h) + "\t" + p0.original
+        if c:
+            output += "\n" + _format_size(total, h) + "\ttotal"
+        return output.encode(), IOResult()
+    all_entries = await du_all_impl(accessor, path)
+    if not all_entries:
+        total = await du_impl(accessor, path)
+        output = _format_size(total, h) + "\t" + p0.original
+        if c:
+            output += "\n" + _format_size(total, h) + "\ttotal"
+        return output.encode(), IOResult()
+    if not a:
+        dir_entries: list[tuple[str, int]] = []
+        for p, sz in all_entries:
+            if p == p0.original:
+                dir_entries.append((p, sz))
+        all_entries = dir_entries
+    if max_depth is not None:
+        md = int(max_depth)
+        all_entries = [(p, sz) for p, sz in all_entries
+                       if _depth(p, p0.original) <= md]
+    if not all_entries:
+        total = await du_impl(accessor, path)
+        output = _format_size(total, h) + "\t" + p0.original
+        if c:
+            output += "\n" + _format_size(total, h) + "\ttotal"
+        return output.encode(), IOResult()
+    lines = [_format_size(sz, h) + "\t" + p for p, sz in all_entries]
+    if c:
+        grand = sum(sz for _, sz in all_entries)
+        lines.append(_format_size(grand, h) + "\ttotal")
+    return "\n".join(lines).encode(), IOResult()

--- a/python/mirage/commands/builtin/onedrive/du.py
+++ b/python/mirage/commands/builtin/onedrive/du.py
@@ -12,9 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.commands.builtin.generic.du import du_multi
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.onedrive.du import du as du_impl
@@ -22,18 +24,6 @@ from mirage.core.onedrive.du import du_all as du_all_impl
 from mirage.core.onedrive.glob import resolve_glob
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-def _format_size(size: int, human: bool) -> str:
-    return _human_size(size) if human else str(size)
-
-
-def _depth(entry_path: str, base_path: str) -> int:
-    base = base_path.rstrip("/")
-    rel = entry_path.rstrip("/")[len(base):]
-    if not rel:
-        return 0
-    return rel.strip("/").count("/") + 1
 
 
 @command("du", resource="onedrive", spec=SPECS["du"])
@@ -51,39 +41,14 @@ async def du(
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     paths = await resolve_glob(accessor, paths, index)
-    p0 = paths[0]
-    path = p0
-    if s:
-        total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
-        if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
-    all_entries = await du_all_impl(accessor, path)
-    if not all_entries:
-        total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
-        if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
-    if not a:
-        dir_entries: list[tuple[str, int]] = []
-        for p, sz in all_entries:
-            if p == p0.original:
-                dir_entries.append((p, sz))
-        all_entries = dir_entries
-    if max_depth is not None:
-        md = int(max_depth)
-        all_entries = [(p, sz) for p, sz in all_entries
-                       if _depth(p, p0.original) <= md]
-    if not all_entries:
-        total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
-        if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
-    lines = [_format_size(sz, h) + "\t" + p for p, sz in all_entries]
-    if c:
-        grand = sum(sz for _, sz in all_entries)
-        lines.append(_format_size(grand, h) + "\ttotal")
-    return "\n".join(lines).encode(), IOResult()
+    out = await du_multi(
+        paths,
+        compute_total=partial(du_impl, accessor),
+        compute_all=partial(du_all_impl, accessor),
+        h=h,
+        s=s,
+        a=a,
+        max_depth=int(max_depth) if max_depth is not None else None,
+        c=c,
+    )
+    return out, IOResult()

--- a/python/mirage/commands/builtin/onedrive/expand.py
+++ b/python/mirage/commands/builtin/onedrive/expand.py
@@ -1,0 +1,48 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.expand import expand as generic_expand
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("expand", resource="onedrive", spec=SPECS["expand"])
+async def expand(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    t: str | None = None,
+    i: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_expand(paths,
+                                read_bytes=read_bytes,
+                                accessor=accessor,
+                                stdin=stdin,
+                                tabsize=int(t) if t is not None else 8,
+                                initial_only=i)

--- a/python/mirage/commands/builtin/onedrive/file.py
+++ b/python/mirage/commands/builtin/onedrive/file.py
@@ -1,0 +1,83 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.file_helper import _detect
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.stat import stat
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import FileType, PathSpec
+
+_MIME_MAP: dict[str, str] = {
+    "text": "text/plain; charset=us-ascii",
+    "json": "application/json; charset=us-ascii",
+    "csv": "text/csv; charset=us-ascii",
+    "directory": "inode/directory",
+    "binary": "application/octet-stream",
+    "image/png": "image/png",
+    "image/jpeg": "image/jpeg",
+    "image/gif": "image/gif",
+    "application/zip": "application/zip",
+    "application/gzip": "application/gzip",
+    "application/pdf": "application/pdf",
+    "parquet": "application/octet-stream",
+    "orc": "application/octet-stream",
+    "feather": "application/octet-stream",
+    "hdf5": "application/octet-stream",
+}
+
+
+def _format_file_result(
+    path: str,
+    result: FileType | str,
+    brief: bool,
+    mime: bool,
+) -> str:
+    key = result.value if isinstance(result, FileType) else str(result)
+    desc = _MIME_MAP.get(key, key) if mime else key
+    if brief:
+        return desc
+    return f"{path}: {desc}"
+
+
+@command("file", resource="onedrive", spec=SPECS["file"])
+async def file(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    b: bool = False,
+    i: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        raise ValueError("file: missing operand")
+    paths = await resolve_glob(accessor, paths, index)
+    s = await stat(accessor, paths[0], index)
+    if s.type == FileType.DIRECTORY:
+        result = FileType.DIRECTORY
+    else:
+        try:
+            data = await read_bytes(accessor, paths[0])
+            header = data[:512]
+        except Exception:
+            header = b""
+        result = _detect(paths[0].original, header, s)
+    return _format_file_result(paths[0].original, result, b,
+                               i).encode(), IOResult()

--- a/python/mirage/commands/builtin/onedrive/file.py
+++ b/python/mirage/commands/builtin/onedrive/file.py
@@ -12,47 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.file_helper import _detect
+from mirage.commands.builtin.generic.file import file_cmd as generic_file
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.onedrive.glob import resolve_glob
 from mirage.core.onedrive.read import read_bytes
 from mirage.core.onedrive.stat import stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
-
-_MIME_MAP: dict[str, str] = {
-    "text": "text/plain; charset=us-ascii",
-    "json": "application/json; charset=us-ascii",
-    "csv": "text/csv; charset=us-ascii",
-    "directory": "inode/directory",
-    "binary": "application/octet-stream",
-    "image/png": "image/png",
-    "image/jpeg": "image/jpeg",
-    "image/gif": "image/gif",
-    "application/zip": "application/zip",
-    "application/gzip": "application/gzip",
-    "application/pdf": "application/pdf",
-    "parquet": "application/octet-stream",
-    "orc": "application/octet-stream",
-    "feather": "application/octet-stream",
-    "hdf5": "application/octet-stream",
-}
-
-
-def _format_file_result(
-    path: str,
-    result: FileType | str,
-    brief: bool,
-    mime: bool,
-) -> str:
-    key = result.value if isinstance(result, FileType) else str(result)
-    desc = _MIME_MAP.get(key, key) if mime else key
-    if brief:
-        return desc
-    return f"{path}: {desc}"
+from mirage.types import PathSpec
 
 
 @command("file", resource="onedrive", spec=SPECS["file"])
@@ -69,15 +40,11 @@ async def file(
     if not paths:
         raise ValueError("file: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    s = await stat(accessor, paths[0], index)
-    if s.type == FileType.DIRECTORY:
-        result = FileType.DIRECTORY
-    else:
-        try:
-            data = await read_bytes(accessor, paths[0])
-            header = data[:512]
-        except Exception:
-            header = b""
-        result = _detect(paths[0].original, header, s)
-    return _format_file_result(paths[0].original, result, b,
-                               i).encode(), IOResult()
+    return await generic_file(
+        paths,
+        read_bytes=partial(read_bytes, index=index),
+        stat_fn=partial(stat, index=index),
+        accessor=accessor,
+        b=b,
+        i=i,
+    )

--- a/python/mirage/commands/builtin/onedrive/find.py
+++ b/python/mirage/commands/builtin/onedrive/find.py
@@ -1,0 +1,90 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.find_helper import (_extract_not_name,
+                                                 _extract_or_names,
+                                                 _parse_mtime, _parse_size)
+from mirage.commands.builtin.onedrive._provision import metadata_provision
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.find import find as find_impl
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("find",
+         resource="onedrive",
+         spec=SPECS["find"],
+         provision=metadata_provision)
+async def find(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    name: str | None = None,
+    type: str | None = None,
+    maxdepth: str | None = None,
+    size: str | None = None,
+    mtime: str | None = None,
+    iname: str | None = None,
+    path: str | None = None,
+    mindepth: str | None = None,
+    prefix: str = "",
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    paths = await resolve_glob(accessor, paths, index)
+    path_pattern = path
+    p0 = paths[0]
+    search_path = p0
+    ftype = None
+    if type == "d":
+        ftype = "directory"
+    elif type == "f":
+        ftype = "file"
+    elif type is not None:
+        ftype = type
+    md = int(maxdepth) if maxdepth is not None else None
+    min_size, max_size = (None, None)
+    if size is not None:
+        min_size, max_size = _parse_size(size)
+    mtime_min, mtime_max = (None, None)
+    if mtime is not None:
+        mtime_min, mtime_max = _parse_mtime(mtime)
+    name_exclude = _extract_not_name(texts)
+    or_names = _extract_or_names(name, texts)
+    md_min = int(mindepth) if mindepth is not None else None
+    results = await find_impl(
+        accessor,
+        search_path,
+        name=name,
+        type=ftype,
+        min_size=min_size,
+        max_size=max_size,
+        maxdepth=md,
+        name_exclude=name_exclude,
+        or_names=or_names if len(or_names) > 1 else None,
+        mtime_min=mtime_min,
+        mtime_max=mtime_max,
+        iname=iname,
+        path_pattern=path_pattern,
+        mindepth=md_min,
+    )
+    if p0.prefix:
+        results = [p0.prefix + "/" + r.lstrip("/") for r in results]
+    output = "\n".join(results).encode()
+    return output, IOResult()

--- a/python/mirage/commands/builtin/onedrive/fmt.py
+++ b/python/mirage/commands/builtin/onedrive/fmt.py
@@ -1,0 +1,46 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.fmt import fmt as generic_fmt
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("fmt", resource="onedrive", spec=SPECS["fmt"])
+async def fmt(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    w: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_fmt(paths,
+                             read_bytes=read_bytes,
+                             accessor=accessor,
+                             stdin=stdin,
+                             width=int(w) if w is not None else 75)

--- a/python/mirage/commands/builtin/onedrive/fold.py
+++ b/python/mirage/commands/builtin/onedrive/fold.py
@@ -1,0 +1,48 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.fold import fold as generic_fold
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("fold", resource="onedrive", spec=SPECS["fold"])
+async def fold(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    w: str | None = None,
+    s: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_fold(paths,
+                              read_bytes=read_bytes,
+                              accessor=accessor,
+                              stdin=stdin,
+                              width=int(w) if w is not None else 80,
+                              break_spaces=s)

--- a/python/mirage/commands/builtin/onedrive/grep.py
+++ b/python/mirage/commands/builtin/onedrive/grep.py
@@ -1,0 +1,108 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.grep import grep as generic_grep
+from mirage.commands.builtin.onedrive._provision import file_read_provision
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes as _read_bytes
+from mirage.core.onedrive.readdir import readdir as _readdir
+from mirage.core.onedrive.stat import stat as _stat
+from mirage.core.onedrive.stream import read_stream as _read_stream
+from mirage.io.types import ByteSource, IOResult
+from mirage.provision.types import ProvisionResult
+from mirage.types import PathSpec
+
+
+async def grep_provision(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    rendered = "grep " + " ".join(texts + tuple(str(p) for p in paths))
+    return await file_read_provision(accessor, paths, rendered)
+
+
+@command("grep",
+         resource="onedrive",
+         spec=SPECS["grep"],
+         provision=grep_provision)
+async def grep(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    r: bool = False,
+    R: bool = False,
+    i: bool = False,
+    v: bool = False,
+    n: bool = False,
+    c: bool = False,
+    args_l: bool = False,
+    w: bool = False,
+    F: bool = False,
+    E: bool = False,
+    o: bool = False,
+    m: str | None = None,
+    q: bool = False,
+    H: bool = False,
+    args_h: bool = False,
+    A: str | None = None,
+    B: str | None = None,
+    C: str | None = None,
+    e: str | None = None,
+    prefix: str = "",
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if e is not None:
+        pattern = e
+    elif texts:
+        pattern = texts[0]
+    else:
+        raise ValueError("grep: usage: grep [flags] pattern [path]")
+    max_count = int(m) if m is not None else None
+    after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
+    before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
+    return await generic_grep(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=_read_bytes,
+        read_stream=_read_stream,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        quiet=q,
+        recursive=r or R,
+        max_count=max_count,
+        after_context=after_ctx,
+        before_context=before_ctx,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/onedrive/gunzip.py
+++ b/python/mirage/commands/builtin/onedrive/gunzip.py
@@ -1,0 +1,85 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import zlib
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.unlink import unlink
+from mirage.core.onedrive.write import write_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+async def _gzip_decompress_stream(
+        source: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
+    decompressor = zlib.decompressobj(zlib.MAX_WBITS | 16)
+    async for chunk in source:
+        decompressed = decompressor.decompress(chunk)
+        if decompressed:
+            yield decompressed
+    tail = decompressor.flush()
+    if tail:
+        yield tail
+
+
+@command("gunzip", resource="onedrive", spec=SPECS["gunzip"], write=True)
+async def gunzip(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    k: bool = False,
+    f: bool = False,
+    c: bool = False,
+    t: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        source = _resolve_source(stdin, "gunzip: missing input")
+        return _gzip_decompress_stream(source), IOResult()
+
+    paths = await resolve_glob(accessor, paths, index)
+    if t:
+        for p in paths:
+            raw = await read_bytes(accessor, p)
+            zlib.decompress(raw, zlib.MAX_WBITS | 16)
+        return None, IOResult()
+
+    if c:
+        chunks: list[bytes] = []
+        for p in paths:
+            raw = await read_bytes(accessor, p)
+            chunks.append(zlib.decompress(raw, zlib.MAX_WBITS | 16))
+        return b"".join(chunks), IOResult()
+
+    writes: dict[str, bytes] = {}
+    for p in paths:
+        raw = await read_bytes(accessor, p)
+        p_str = p.strip_prefix
+        out_path = p_str.removesuffix(".gz") if p_str.endswith(
+            ".gz") else p_str + ".out"
+        out_data = zlib.decompress(raw, zlib.MAX_WBITS | 16)
+        await write_bytes(accessor, out_path, out_data)
+        writes[out_path] = out_data
+        if not k:
+            await unlink(accessor, p)
+    return None, IOResult(writes=writes)

--- a/python/mirage/commands/builtin/onedrive/gzip.py
+++ b/python/mirage/commands/builtin/onedrive/gzip.py
@@ -1,0 +1,114 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import zlib
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.unlink import unlink
+from mirage.core.onedrive.write import write_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+def _extract_level(extra: dict) -> int:
+    for n in range(9, 0, -1):
+        if extra.get(str(n)):
+            return n
+    return zlib.Z_DEFAULT_COMPRESSION
+
+
+async def _gzip_compress_stream(
+    source: AsyncIterator[bytes],
+    level: int = zlib.Z_DEFAULT_COMPRESSION,
+) -> AsyncIterator[bytes]:
+    compressor = zlib.compressobj(level, zlib.DEFLATED, zlib.MAX_WBITS | 16)
+    async for chunk in source:
+        compressed = compressor.compress(chunk)
+        if compressed:
+            yield compressed
+    tail = compressor.flush()
+    if tail:
+        yield tail
+
+
+async def _gzip_decompress_stream(
+        source: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
+    decompressor = zlib.decompressobj(zlib.MAX_WBITS | 16)
+    async for chunk in source:
+        decompressed = decompressor.decompress(chunk)
+        if decompressed:
+            yield decompressed
+    tail = decompressor.flush()
+    if tail:
+        yield tail
+
+
+@command("gzip", resource="onedrive", spec=SPECS["gzip"], write=True)
+async def gzip(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    d: bool = False,
+    k: bool = False,
+    f: bool = False,
+    c: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    level = _extract_level(_extra)
+    if not paths:
+        source = _resolve_source(stdin, "gzip: missing input")
+        if d:
+            return _gzip_decompress_stream(source), IOResult()
+        return _gzip_compress_stream(source, level=level), IOResult()
+
+    paths = await resolve_glob(accessor, paths, index)
+    if c:
+        chunks: list[bytes] = []
+        for p in paths:
+            raw = await read_bytes(accessor, p)
+            if d:
+                chunks.append(zlib.decompress(raw, zlib.MAX_WBITS | 16))
+            else:
+                chunks.append(
+                    zlib.compress(raw, level=level, wbits=zlib.MAX_WBITS | 16))
+        return b"".join(chunks), IOResult()
+
+    writes: dict[str, bytes] = {}
+    for p in paths:
+        raw = await read_bytes(accessor, p)
+        p_stripped = p.strip_prefix if isinstance(p, PathSpec) else p
+        if d:
+            out_path = p_stripped.removesuffix(".gz") if p_stripped.endswith(
+                ".gz") else p_stripped + ".out"
+            out_data = zlib.decompress(raw, zlib.MAX_WBITS | 16)
+        else:
+            out_path = p_stripped + ".gz"
+            out_data = zlib.compress(raw,
+                                     level=level,
+                                     wbits=zlib.MAX_WBITS | 16)
+        await write_bytes(accessor, out_path, out_data)
+        writes[out_path] = out_data
+        if not k:
+            await unlink(accessor,
+                         p.strip_prefix if isinstance(p, PathSpec) else p)
+    return None, IOResult(writes=writes)

--- a/python/mirage/commands/builtin/onedrive/head.py
+++ b/python/mirage/commands/builtin/onedrive/head.py
@@ -1,0 +1,51 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.head import head as generic_head
+from mirage.commands.builtin.onedrive._provision import head_tail_provision
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.stream import read_stream
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("head",
+         resource="onedrive",
+         spec=SPECS["head"],
+         provision=head_tail_provision)
+async def head(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    n: str | None = None,
+    c: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    n_int = int(n) if n is not None else None
+    c_int = int(c) if c is not None else None
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        source = read_stream(accessor, paths[0])
+        return generic_head(source, n=n_int, c=c_int), IOResult()
+    source = _resolve_source(stdin, "head: missing operand")
+    return generic_head(source, n=n_int, c=c_int), IOResult()

--- a/python/mirage/commands/builtin/onedrive/head.py
+++ b/python/mirage/commands/builtin/onedrive/head.py
@@ -17,6 +17,7 @@ from collections.abc import AsyncIterator
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.head import head as generic_head
+from mirage.commands.builtin.generic.head import head_multi
 from mirage.commands.builtin.onedrive._provision import head_tail_provision
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
@@ -45,7 +46,12 @@ async def head(
     c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        source = read_stream(accessor, paths[0])
-        return generic_head(source, n=n_int, c=c_int), IOResult()
+        return head_multi(paths,
+                          read=read_stream,
+                          accessor=accessor,
+                          index=index,
+                          n=n_int,
+                          c=c_int,
+                          show_headers=len(paths) > 1), IOResult()
     source = _resolve_source(stdin, "head: missing operand")
     return generic_head(source, n=n_int, c=c_int), IOResult()

--- a/python/mirage/commands/builtin/onedrive/iconv.py
+++ b/python/mirage/commands/builtin/onedrive/iconv.py
@@ -1,0 +1,58 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.write import write_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("iconv", resource="onedrive", spec=SPECS["iconv"], write=True)
+async def iconv(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    f: str | None = None,
+    t: str | None = None,
+    c: bool = False,
+    o: PathSpec | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    from_enc = f or "utf-8"
+    to_enc = t or "utf-8"
+    err_mode = "ignore" if c else "strict"
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        raw = await read_bytes(accessor, paths[0])
+    else:
+        raw = await _read_stdin_async(stdin)
+        if raw is None:
+            raise ValueError("iconv: missing input")
+    decoded = raw.decode(from_enc, errors=err_mode)
+    encoded = decoded.encode(to_enc, errors=err_mode)
+    if o is not None:
+        o_path = o.strip_prefix
+        await write_bytes(accessor, o_path, encoded)
+        return None, IOResult(writes={o_path: encoded})
+    return encoded, IOResult()

--- a/python/mirage/commands/builtin/onedrive/join.py
+++ b/python/mirage/commands/builtin/onedrive/join.py
@@ -1,0 +1,54 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.join import join_cmd as generic_join
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("join", resource="onedrive", spec=SPECS["join"])
+async def join(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    t: str | None = None,
+    a: str | None = None,
+    v: str | None = None,
+    e: str | None = None,
+    o: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if len(paths) < 2:
+        raise ValueError("join: requires two paths")
+    paths = await resolve_glob(accessor, paths, index)
+    return await generic_join(paths,
+                              read_bytes=read_bytes,
+                              accessor=accessor,
+                              field1=int(_extra.get("args_1", 1)) - 1,
+                              field2=int(_extra.get("2", 1)) - 1,
+                              separator=t,
+                              also_unpairable=a,
+                              only_unpairable=v,
+                              empty_value=e,
+                              output_format=o)

--- a/python/mirage/commands/builtin/onedrive/jq.py
+++ b/python/mirage/commands/builtin/onedrive/jq.py
@@ -1,0 +1,86 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.jq import jq as generic_jq
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.jq import is_jsonl_path, is_streamable_jsonl_expr
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.stat import stat as _stat_async
+from mirage.core.onedrive.stream import read_stream as _stream
+from mirage.io.types import ByteSource, IOResult
+from mirage.provision import Precision, ProvisionResult
+from mirage.types import PathSpec
+
+
+async def jq_provision(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec] | None = None,
+    *texts: str,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> ProvisionResult:
+    if not paths or not texts:
+        return ProvisionResult(command="jq")
+    p = paths[0]
+    s = await _stat_async(accessor, p)
+    file_size = s.size or 0
+    expr = texts[0]
+    if is_jsonl_path(p.original) and is_streamable_jsonl_expr(expr):
+        return ProvisionResult(
+            command=f"jq {expr!r} {p.original}",
+            network_read_low=0,
+            network_read_high=file_size,
+            read_ops=1,
+            precision=Precision.RANGE,
+        )
+    return ProvisionResult(
+        command=f"jq {expr!r} {p.original}",
+        network_read_low=file_size,
+        network_read_high=file_size,
+        read_ops=1,
+        precision=Precision.EXACT,
+    )
+
+
+@command("jq", resource="onedrive", spec=SPECS["jq"], provision=jq_provision)
+async def jq(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    r: bool = False,
+    c: bool = False,
+    s: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_jq(paths,
+                            *texts,
+                            read_bytes=read_bytes,
+                            read_stream=_stream,
+                            accessor=accessor,
+                            stdin=stdin,
+                            r=r,
+                            c=c,
+                            s=s)

--- a/python/mirage/commands/builtin/onedrive/ln.py
+++ b/python/mirage/commands/builtin/onedrive/ln.py
@@ -1,0 +1,53 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.exists import exists
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.write import write_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("ln", resource="onedrive", spec=SPECS["ln"], write=True)
+async def ln(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    s: bool = False,
+    f: bool = False,
+    n: bool = False,
+    v: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if len(paths) < 2:
+        raise ValueError("ln: usage: ln [-s] [-f] source dest")
+    paths = await resolve_glob(accessor, paths, index)
+    source_path = paths[0]
+    dest_path = paths[1]
+    if n and await exists(accessor, dest_path):
+        return None, IOResult()
+    data = await read_bytes(accessor, source_path)
+    await write_bytes(accessor, dest_path, data)
+    output = f"'{source_path.original}' -> '{dest_path.original}'\n".encode(
+    ) if v else None
+    return output, IOResult(writes={dest_path.original: data})

--- a/python/mirage/commands/builtin/onedrive/look.py
+++ b/python/mirage/commands/builtin/onedrive/look.py
@@ -1,0 +1,49 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.look import look as generic_look
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("look", resource="onedrive", spec=SPECS["look"])
+async def look(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    f: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not texts:
+        raise ValueError("look: missing prefix")
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_look(paths,
+                              texts[0],
+                              read_bytes=read_bytes,
+                              accessor=accessor,
+                              stdin=stdin,
+                              fold_case=f)

--- a/python/mirage/commands/builtin/onedrive/ls.py
+++ b/python/mirage/commands/builtin/onedrive/ls.py
@@ -1,0 +1,80 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from functools import partial
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.ls import ls as generic_ls
+from mirage.commands.builtin.onedrive._provision import metadata_provision
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.readdir import readdir
+from mirage.core.onedrive.stat import stat
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import LsSortBy, PathSpec
+
+
+@command("ls",
+         resource="onedrive",
+         spec=SPECS["ls"],
+         provision=metadata_provision)
+async def ls(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    args_l: bool = False,
+    args_1: bool = False,
+    a: bool = False,
+    A: bool = False,
+    h: bool = False,
+    t: bool = False,
+    S: bool = False,
+    r: bool = False,
+    R: bool = False,
+    d: bool = False,
+    F: bool = False,
+    index: IndexCacheStore = None,
+    cwd: PathSpec | str = "/",
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
+        cwd_prefix = cwd.prefix if isinstance(cwd, PathSpec) else ""
+        paths = [
+            PathSpec(original=cwd_str,
+                     directory=cwd_str,
+                     resolved=False,
+                     prefix=cwd_prefix)
+        ]
+    paths = await resolve_glob(accessor, paths, index)
+    sort_by = LsSortBy.TIME if t else LsSortBy.SIZE if S else LsSortBy.NAME
+    return await generic_ls(
+        paths,
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        long=args_l,
+        one_per_line=args_1,
+        all_files=a or A,
+        human=h,
+        sort_by=sort_by,
+        reverse=r,
+        recursive=R,
+        list_dir=d,
+        classify=F,
+        index=index,
+        trailing_newline=True,
+    )

--- a/python/mirage/commands/builtin/onedrive/md5.py
+++ b/python/mirage/commands/builtin/onedrive/md5.py
@@ -1,0 +1,42 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.md5 import md5 as generic_md5
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("md5", resource="onedrive", spec=SPECS["md5"])
+async def md5(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_md5(paths,
+                             read_bytes=read_bytes,
+                             accessor=accessor,
+                             stdin=stdin)

--- a/python/mirage/commands/builtin/onedrive/mkdir.py
+++ b/python/mirage/commands/builtin/onedrive/mkdir.py
@@ -1,0 +1,47 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.mkdir import mkdir as mkdir_impl
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("mkdir", resource="onedrive", spec=SPECS["mkdir"], write=True)
+async def mkdir(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    p: bool = False,
+    v: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        raise ValueError("mkdir: missing operand")
+    paths = await resolve_glob(accessor, paths, index)
+    lines: list[str] = []
+    writes: dict[str, bytes] = {}
+    for path in paths:
+        await mkdir_impl(accessor, path)
+        writes[path.original] = b""
+        if v:
+            lines.append(f"mkdir: created directory '{path.original}'")
+    output = ("\n".join(lines) + "\n").encode() if lines else None
+    return output, IOResult(writes=writes)

--- a/python/mirage/commands/builtin/onedrive/mktemp.py
+++ b/python/mirage/commands/builtin/onedrive/mktemp.py
@@ -1,0 +1,48 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import uuid
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.mkdir import mkdir
+from mirage.core.onedrive.write import write_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("mktemp", resource="onedrive", spec=SPECS["mktemp"], write=True)
+async def mktemp(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    d: bool = False,
+    p: str | None = None,
+    t: bool = False,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    parent = "/tmp" if t else (p if p else "/tmp")
+    suffix = str(uuid.uuid4())[:8]
+    template = texts[0] if texts else "tmp.XXXXXXXXXX"
+    name = template.replace(
+        "X" * template.count("X"),
+        suffix) if "X" in template else f"{template}.{suffix}"
+    path = f"{parent.rstrip('/')}/{name}"
+    if d:
+        await mkdir(accessor, path)
+    else:
+        await write_bytes(accessor, path, b"")
+    return (path + "\n").encode(), IOResult(writes={path: b""})

--- a/python/mirage/commands/builtin/onedrive/mv.py
+++ b/python/mirage/commands/builtin/onedrive/mv.py
@@ -1,0 +1,59 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.rename import rename
+from mirage.core.onedrive.stat import stat as stat_impl
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+async def _exists(accessor: OneDriveAccessor, path: PathSpec | str) -> bool:
+    try:
+        await stat_impl(accessor, path)
+        return True
+    except (FileNotFoundError, ValueError, Exception):
+        return False
+
+
+@command("mv", resource="onedrive", spec=SPECS["mv"], write=True)
+async def mv(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    f: bool = False,
+    n: bool = False,
+    v: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if len(paths) < 2:
+        raise ValueError("mv: requires src and dst")
+    paths = await resolve_glob(accessor, paths, index)
+    if n and await _exists(accessor, paths[1]):
+        return None, IOResult()
+    await rename(accessor, paths[0], paths[1])
+    writes = {
+        paths[0].original: b"",
+        paths[1].original: b"",
+    }
+    output = None
+    if v:
+        output = f"'{paths[0].original}' -> '{paths[1].original}'\n".encode()
+    return output, IOResult(writes=writes)

--- a/python/mirage/commands/builtin/onedrive/nl.py
+++ b/python/mirage/commands/builtin/onedrive/nl.py
@@ -1,0 +1,56 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.nl import nl as generic_nl
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.stream import read_stream
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("nl", resource="onedrive", spec=SPECS["nl"])
+async def nl(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    b: str | None = None,
+    v: str | None = None,
+    i: str | None = None,
+    w: str | None = None,
+    s: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_nl(
+        paths,
+        read_stream=read_stream,
+        accessor=accessor,
+        stdin=stdin,
+        body_numbering_raw=b,
+        start_raw=v,
+        increment_raw=i,
+        width_raw=w,
+        separator=s,
+    )

--- a/python/mirage/commands/builtin/onedrive/paste.py
+++ b/python/mirage/commands/builtin/onedrive/paste.py
@@ -1,0 +1,46 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.paste import paste as generic_paste
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("paste", resource="onedrive", spec=SPECS["paste"])
+async def paste(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    d: str | None = None,
+    s: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    return await generic_paste(paths,
+                               read_bytes=read_bytes,
+                               accessor=accessor,
+                               stdin=stdin,
+                               delimiter=d if d else "\t",
+                               serial=s)

--- a/python/mirage/commands/builtin/onedrive/patch.py
+++ b/python/mirage/commands/builtin/onedrive/patch.py
@@ -1,0 +1,161 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import re
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.write import write_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+def _strip_path(path: str, strip_count: int) -> str:
+    parts = path.split("/")
+    return "/".join(
+        parts[strip_count:]) if strip_count < len(parts) else parts[-1]
+
+
+def _apply_hunks(original_lines: list[str],
+                 hunks: list[tuple[int, list[str]]],
+                 forward_only: bool = False) -> list[str]:
+    result = list(original_lines)
+    offset = 0
+    for start_line, hunk_lines in hunks:
+        idx = start_line - 1 + offset
+        removals = 0
+        additions: list[str] = []
+        context_lines: list[str] = []
+        for hl in hunk_lines:
+            if hl.startswith("-"):
+                removals += 1
+                context_lines.append(hl[1:])
+            elif hl.startswith("+"):
+                additions.append(hl[1:])
+            elif hl.startswith(" "):
+                context_lines.append(hl[1:])
+        if forward_only and removals > 0:
+            expected = context_lines[:removals]
+            actual = result[idx:idx + removals]
+            if expected != actual:
+                continue
+        result[idx:idx + removals] = additions
+        offset += len(additions) - removals
+    return result
+
+
+def _parse_patch(patch_text: str,
+                 strip_count: int) -> dict[str, list[tuple[int, list[str]]]]:
+    files: dict[str, list[tuple[int, list[str]]]] = {}
+    current_file: str | None = None
+    current_hunks: list[tuple[int, list[str]]] = []
+    current_hunk_lines: list[str] = []
+    current_start = 0
+
+    for line in patch_text.splitlines():
+        if line.startswith("--- "):
+            continue
+        if line.startswith("+++ "):
+            if current_file and current_hunk_lines:
+                current_hunks.append((current_start, current_hunk_lines))
+            if current_file:
+                files[current_file] = current_hunks
+            raw_path = line[4:].split("\t")[0].strip()
+            current_file = "/" + _strip_path(raw_path, strip_count).lstrip("/")
+            current_hunks = []
+            current_hunk_lines = []
+            continue
+        m = re.match(r"@@ -(\d+)", line)
+        if m:
+            if current_hunk_lines:
+                current_hunks.append((current_start, current_hunk_lines))
+            current_start = int(m.group(1))
+            current_hunk_lines = []
+            continue
+        if current_file and (line.startswith("+") or line.startswith("-")
+                             or line.startswith(" ")):
+            current_hunk_lines.append(line)
+
+    if current_file and current_hunk_lines:
+        current_hunks.append((current_start, current_hunk_lines))
+    if current_file:
+        files[current_file] = current_hunks
+
+    return files
+
+
+@command("patch", resource="onedrive", spec=SPECS["patch"], write=True)
+async def patch(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    p: str | None = None,
+    R: bool = False,
+    i: PathSpec | None = None,
+    N: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    strip_count = int(p) if p else 0
+
+    if i is not None:
+        i_path = i.strip_prefix
+        patch_data = await read_bytes(accessor, i_path)
+    elif paths:
+        paths = await resolve_glob(accessor, paths, index)
+        patch_data = await read_bytes(accessor, paths[0])
+    else:
+        patch_data = await _read_stdin_async(stdin)
+    if not patch_data:
+        raise ValueError("patch: missing input")
+
+    patch_text = patch_data.decode(errors="replace")
+    file_hunks = _parse_patch(patch_text, strip_count)
+
+    writes: dict[str, bytes] = {}
+    for file_path, hunks in file_hunks.items():
+        try:
+            original = (await read_bytes(accessor,
+                                         file_path)).decode(errors="replace")
+        except FileNotFoundError:
+            original = ""
+        original_lines = original.splitlines()
+
+        if R:
+            reversed_hunks: list[tuple[int, list[str]]] = []
+            for start, hunk_lines in hunks:
+                reversed_lines = []
+                for hl in hunk_lines:
+                    if hl.startswith("+"):
+                        reversed_lines.append("-" + hl[1:])
+                    elif hl.startswith("-"):
+                        reversed_lines.append("+" + hl[1:])
+                    else:
+                        reversed_lines.append(hl)
+                reversed_hunks.append((start, reversed_lines))
+            hunks = reversed_hunks
+
+        patched_lines = _apply_hunks(original_lines, hunks, forward_only=N)
+        patched_data = ("\n".join(patched_lines) + "\n").encode()
+        await write_bytes(accessor, file_path, patched_data)
+        writes[file_path] = patched_data
+
+    return None, IOResult(writes=writes)

--- a/python/mirage/commands/builtin/onedrive/readlink.py
+++ b/python/mirage/commands/builtin/onedrive/readlink.py
@@ -1,0 +1,45 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.readlink import \
+    readlink as generic_readlink
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("readlink", resource="onedrive", spec=SPECS["readlink"])
+async def readlink(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    f: bool = False,
+    e: bool = False,
+    m: bool = False,
+    n: bool = False,
+    prefix: str = "",
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        raise ValueError("readlink: missing operand")
+    paths = await resolve_glob(accessor, paths, index)
+    return await generic_readlink(paths, f=f, e=e, m=m, n=n)

--- a/python/mirage/commands/builtin/onedrive/realpath.py
+++ b/python/mirage/commands/builtin/onedrive/realpath.py
@@ -1,0 +1,45 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.realpath import \
+    realpath as generic_realpath
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.stat import stat as stat_impl
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("realpath", resource="onedrive", spec=SPECS["realpath"])
+async def realpath(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec] | None = None,
+    *texts: str,
+    stdin: bytes | None = None,
+    e: bool = False,
+    m: bool = False,
+    prefix: str = "",
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    return await generic_realpath(paths or [],
+                                  stat_fn=stat_impl,
+                                  accessor=accessor,
+                                  e=e,
+                                  m=m)

--- a/python/mirage/commands/builtin/onedrive/rev.py
+++ b/python/mirage/commands/builtin/onedrive/rev.py
@@ -1,0 +1,44 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.rev import rev as generic_rev
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("rev", resource="onedrive", spec=SPECS["rev"])
+async def rev(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_rev(paths,
+                             read_bytes=read_bytes,
+                             accessor=accessor,
+                             stdin=stdin)

--- a/python/mirage/commands/builtin/onedrive/rg.py
+++ b/python/mirage/commands/builtin/onedrive/rg.py
@@ -1,0 +1,103 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.rg import rg as generic_rg
+from mirage.commands.builtin.onedrive._provision import file_read_provision
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes as _read_bytes
+from mirage.core.onedrive.readdir import readdir as _readdir
+from mirage.core.onedrive.stat import stat as _stat
+from mirage.core.onedrive.stream import read_stream as _read_stream
+from mirage.io.types import ByteSource, IOResult
+from mirage.provision.types import ProvisionResult
+from mirage.types import PathSpec
+
+
+async def rg_provision(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    rendered = "rg " + " ".join(texts + tuple(str(p) for p in paths))
+    return await file_read_provision(accessor, paths, rendered)
+
+
+@command("rg", resource="onedrive", spec=SPECS["rg"], provision=rg_provision)
+async def rg(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    i: bool = False,
+    v: bool = False,
+    n: bool = False,
+    c: bool = False,
+    args_l: bool = False,
+    w: bool = False,
+    F: bool = False,
+    o: bool = False,
+    m: str | None = None,
+    A: str | None = None,
+    B: str | None = None,
+    C: str | None = None,
+    hidden: bool = False,
+    type: str | None = None,
+    glob: str | None = None,
+    prefix: str = "",
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not texts:
+        raise ValueError("rg: usage: rg [flags] pattern [path]")
+    pattern = texts[0]
+    max_count = int(m) if m is not None else None
+    context_after = int(A) if A is not None else 0
+    context_before = int(B) if B is not None else 0
+    if C is not None:
+        context_before = context_after = int(C)
+
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
+
+    return await generic_rg(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=_read_bytes,
+        read_stream=_read_stream,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        max_count=max_count,
+        context_before=context_before,
+        context_after=context_after,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/onedrive/rm.py
+++ b/python/mirage/commands/builtin/onedrive/rm.py
@@ -1,0 +1,89 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.readdir import readdir
+from mirage.core.onedrive.rm import rm_r
+from mirage.core.onedrive.rmdir import rmdir
+from mirage.core.onedrive.stat import stat
+from mirage.core.onedrive.unlink import unlink
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import FileType, PathSpec
+
+
+async def _rm(
+    accessor: OneDriveAccessor,
+    path: PathSpec | str,
+    recursive: bool = False,
+    force: bool = False,
+    remove_dir: bool = False,
+    index: IndexCacheStore = None,
+) -> None:
+    try:
+        s = await stat(accessor, path)
+    except (FileNotFoundError, ValueError):
+        if force:
+            return
+        raise
+    label = path.original if isinstance(path, PathSpec) else path
+    if s.type == FileType.DIRECTORY:
+        if recursive:
+            await rm_r(accessor, path)
+        elif remove_dir:
+            children = await readdir(accessor, path, index)
+            if children:
+                raise OSError(f"directory not empty: {label}")
+            await rmdir(accessor, path)
+        else:
+            raise IsADirectoryError(
+                f"{label}: is a directory (use recursive=True)")
+    else:
+        await unlink(accessor, path)
+
+
+@command("rm", resource="onedrive", spec=SPECS["rm"], write=True)
+async def rm(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    r: bool = False,
+    R: bool = False,
+    f: bool = False,
+    v: bool = False,
+    d: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        raise ValueError("rm: missing operand")
+    paths = await resolve_glob(accessor, paths, index)
+    verbose_parts: list[str] = []
+    removed: dict[str, bytes] = {}
+    for p in paths:
+        await _rm(accessor,
+                  p,
+                  recursive=r or R,
+                  force=f,
+                  remove_dir=d,
+                  index=index)
+        removed[p.strip_prefix] = b""
+        if v:
+            verbose_parts.append(f"removed '{p.original}'")
+    output = "\n".join(verbose_parts).encode() if v else None
+    return output, IOResult(writes=removed)

--- a/python/mirage/commands/builtin/onedrive/sed.py
+++ b/python/mirage/commands/builtin/onedrive/sed.py
@@ -1,0 +1,60 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.sed import sed as generic_sed
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.write import write_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("sed", resource="onedrive", spec=SPECS["sed"])
+async def sed(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    i: bool = False,
+    e: bool = False,
+    n: bool = False,
+    E: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not texts:
+        raise ValueError("sed: usage: sed EXPRESSION [path]")
+
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+
+    return await generic_sed(
+        paths,
+        texts[0],
+        read_bytes=read_bytes,
+        write_bytes=write_bytes,
+        accessor=accessor,
+        stdin=stdin,
+        in_place=i,
+        suppress=n,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/onedrive/sha256sum.py
+++ b/python/mirage/commands/builtin/onedrive/sha256sum.py
@@ -1,0 +1,49 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.sha256sum import \
+    sha256sum as generic_sha256sum
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.stream import read_stream
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("sha256sum", resource="onedrive", spec=SPECS["sha256sum"])
+async def sha256sum(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    c: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_sha256sum(paths,
+                                   read_bytes=read_bytes,
+                                   read_stream=read_stream,
+                                   accessor=accessor,
+                                   stdin=stdin,
+                                   check=c)

--- a/python/mirage/commands/builtin/onedrive/shuf.py
+++ b/python/mirage/commands/builtin/onedrive/shuf.py
@@ -1,0 +1,53 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.shuf import shuf as generic_shuf
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("shuf", resource="onedrive", spec=SPECS["shuf"])
+async def shuf(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    n: str | None = None,
+    e: bool = False,
+    z: bool = False,
+    r: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    elif accessor.root is None:
+        paths = []
+    return await generic_shuf(paths,
+                              texts,
+                              read_bytes=read_bytes,
+                              accessor=accessor,
+                              stdin=stdin,
+                              count=int(n) if n is not None else None,
+                              echo=e,
+                              zero_terminated=z,
+                              with_replacement=r)

--- a/python/mirage/commands/builtin/onedrive/sort.py
+++ b/python/mirage/commands/builtin/onedrive/sort.py
@@ -1,0 +1,65 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.sort import sort as generic_sort
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("sort", resource="onedrive", spec=SPECS["sort"])
+async def sort(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    r: bool = False,
+    n: bool = False,
+    u: bool = False,
+    f: bool = False,
+    k: str | None = None,
+    t: str | None = None,
+    h: bool = False,
+    V: bool = False,
+    s: bool = False,
+    M: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_sort(
+        paths,
+        read_bytes=read_bytes,
+        accessor=accessor,
+        stdin=stdin,
+        reverse=r,
+        numeric=n,
+        unique=u,
+        fold_case=f,
+        key_field=int(k) if k is not None else None,
+        field_separator=t,
+        human_numeric=h,
+        version_sort=V,
+        month_sort=M,
+    )

--- a/python/mirage/commands/builtin/onedrive/split.py
+++ b/python/mirage/commands/builtin/onedrive/split.py
@@ -1,0 +1,122 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.stream import read_stream
+from mirage.core.onedrive.write import write_bytes
+from mirage.io.async_line_iterator import AsyncLineIterator
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+def _alpha_suffix(index: int, length: int) -> str:
+    chars: list[str] = []
+    for _ in range(length):
+        chars.append(chr(ord("a") + index % 26))
+        index //= 26
+    return "".join(reversed(chars))
+
+
+def _numeric_suffix(index: int, length: int) -> str:
+    return str(index).zfill(length)
+
+
+@command("split", resource="onedrive", spec=SPECS["split"], write=True)
+async def split(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    args_l: str | None = None,
+    b: str | None = None,
+    n: str | None = None,
+    d: bool = False,
+    a: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    prefix_name = paths[1].strip_prefix if len(paths) >= 2 else "x"
+    lines_per_file = int(args_l) if args_l else (
+        1000 if not b and not n else 0)
+    byte_limit = int(b) if b else 0
+    n_chunks = int(n) if n else 0
+    suffix_len = int(a) if a else 2
+    suffix_fn = _numeric_suffix if d else _alpha_suffix
+
+    if paths:
+        source: AsyncIterator[bytes] = read_stream(accessor, paths[0])
+    else:
+        source = _resolve_source(stdin, "split: missing input")
+
+    writes: dict[str, bytes] = {}
+    file_idx = 0
+
+    if n_chunks > 0:
+        all_data = bytearray()
+        async for chunk in source:
+            all_data.extend(chunk)
+        total = len(all_data)
+        chunk_size = max(1, (total + n_chunks - 1) // n_chunks)
+        offset = 0
+        for i in range(n_chunks):
+            part = bytes(all_data[offset:offset + chunk_size])
+            if not part:
+                break
+            out_path = prefix_name + suffix_fn(i, suffix_len)
+            await write_bytes(accessor, out_path, part)
+            writes[out_path] = part
+            offset += chunk_size
+    elif byte_limit > 0:
+        buf = bytearray()
+        async for chunk in source:
+            buf.extend(chunk)
+            while len(buf) >= byte_limit:
+                out_path = prefix_name + suffix_fn(file_idx, suffix_len)
+                data = bytes(buf[:byte_limit])
+                await write_bytes(accessor, out_path, data)
+                writes[out_path] = data
+                buf = buf[byte_limit:]
+                file_idx += 1
+        if buf:
+            out_path = prefix_name + suffix_fn(file_idx, suffix_len)
+            data = bytes(buf)
+            await write_bytes(accessor, out_path, data)
+            writes[out_path] = data
+    else:
+        line_buf: list[bytes] = []
+        async for line in AsyncLineIterator(source):
+            line_buf.append(line)
+            if len(line_buf) >= lines_per_file:
+                out_path = prefix_name + suffix_fn(file_idx, suffix_len)
+                data = b"\n".join(line_buf) + b"\n"
+                await write_bytes(accessor, out_path, data)
+                writes[out_path] = data
+                line_buf = []
+                file_idx += 1
+        if line_buf:
+            out_path = prefix_name + suffix_fn(file_idx, suffix_len)
+            data = b"\n".join(line_buf) + b"\n"
+            await write_bytes(accessor, out_path, data)
+            writes[out_path] = data
+
+    return None, IOResult(writes=writes)

--- a/python/mirage/commands/builtin/onedrive/stat.py
+++ b/python/mirage/commands/builtin/onedrive/stat.py
@@ -1,0 +1,49 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.stat import stat as generic_stat
+from mirage.commands.builtin.onedrive._provision import metadata_provision
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.stat import stat as stat_core
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("stat",
+         resource="onedrive",
+         spec=SPECS["stat"],
+         provision=metadata_provision)
+async def stat(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    c: str | None = None,
+    f: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        raise ValueError("stat: missing operand")
+    paths = await resolve_glob(accessor, paths, index)
+    return await generic_stat(paths,
+                              stat_fn=stat_core,
+                              accessor=accessor,
+                              c=c,
+                              f=f,
+                              index=index)

--- a/python/mirage/commands/builtin/onedrive/strings.py
+++ b/python/mirage/commands/builtin/onedrive/strings.py
@@ -1,0 +1,46 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.strings import strings as generic_strings
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("strings", resource="onedrive", spec=SPECS["strings"])
+async def strings(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    n: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_strings(paths,
+                                 read_bytes=read_bytes,
+                                 accessor=accessor,
+                                 stdin=stdin,
+                                 min_len=int(n) if n else 4)

--- a/python/mirage/commands/builtin/onedrive/tac.py
+++ b/python/mirage/commands/builtin/onedrive/tac.py
@@ -1,0 +1,44 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tac import tac as generic_tac
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.stream import read_stream
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("tac", resource="onedrive", spec=SPECS["tac"])
+async def tac(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_tac(paths,
+                             read_stream=read_stream,
+                             accessor=accessor,
+                             stdin=stdin)

--- a/python/mirage/commands/builtin/onedrive/tail.py
+++ b/python/mirage/commands/builtin/onedrive/tail.py
@@ -1,0 +1,69 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
+from mirage.commands.builtin.onedrive._provision import head_tail_provision
+from mirage.commands.builtin.tail_helper import _parse_n
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("tail",
+         resource="onedrive",
+         spec=SPECS["tail"],
+         provision=head_tail_provision)
+async def tail(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    n: str | None = None,
+    c: str | None = None,
+    q: bool = False,
+    v: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        raw = await read_bytes(accessor, paths[0])
+        if c_int is not None:
+            should_cache = c_int >= len(raw)
+        else:
+            should_cache = (from_line is None and n_int is not None
+                            and n_int >= raw.count(b"\n"))
+        cache = [paths[0].original] if should_cache else []
+        return generic_tail(raw, n=n_int, c=c_int,
+                            from_line=from_line), IOResult(cache=cache)
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/onedrive/tail.py
+++ b/python/mirage/commands/builtin/onedrive/tail.py
@@ -17,13 +17,14 @@ from collections.abc import AsyncIterator
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.tail import tail as generic_tail
+from mirage.commands.builtin.generic.tail import tail_multi
 from mirage.commands.builtin.onedrive._provision import head_tail_provision
 from mirage.commands.builtin.tail_helper import _parse_n
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.onedrive.glob import resolve_glob
-from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.stream import read_stream
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -55,15 +56,15 @@ async def tail(
     c_int = int(c) if c is not None else None
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        raw = await read_bytes(accessor, paths[0])
-        if c_int is not None:
-            should_cache = c_int >= len(raw)
-        else:
-            should_cache = (from_line is None and n_int is not None
-                            and n_int >= raw.count(b"\n"))
-        cache = [paths[0].original] if should_cache else []
-        return generic_tail(raw, n=n_int, c=c_int,
-                            from_line=from_line), IOResult(cache=cache)
+        show_headers = (v or len(paths) > 1) and not q
+        return tail_multi(paths,
+                          read=read_stream,
+                          accessor=accessor,
+                          index=index,
+                          n=n_int,
+                          c=c_int,
+                          from_line=from_line,
+                          show_headers=show_headers), IOResult()
     source = _resolve_source(stdin, "tail: missing operand")
     return generic_tail(source, n=n_int, c=c_int,
                         from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/onedrive/tar.py
+++ b/python/mirage/commands/builtin/onedrive/tar.py
@@ -1,0 +1,114 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import io
+import tarfile
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.write import write_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+def _compression_suffix(z: bool, j: bool, J: bool) -> str:
+    if z:
+        return ":gz"
+    if j:
+        return ":bz2"
+    if J:
+        return ":xz"
+    return ""
+
+
+@command("tar", resource="onedrive", spec=SPECS["tar"], write=True)
+async def tar(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    c: bool = False,
+    x: bool = False,
+    t: bool = False,
+    z: bool = False,
+    j: bool = False,
+    J: bool = False,
+    v: bool = False,
+    f: PathSpec | None = None,
+    C: PathSpec | None = None,
+    strip_components: str | None = None,
+    exclude: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    paths = await resolve_glob(accessor, paths, index)
+    archive_path = f.strip_prefix if f else None
+    dest_path = C.strip_prefix if C else "/"
+    mode_suffix = _compression_suffix(z, j, J)
+    strip_n = int(strip_components) if strip_components else 0
+    if c:
+        if not archive_path:
+            raise ValueError("tar: -f is required")
+        filtered_paths = paths
+        if exclude:
+            filtered_paths = [
+                p for p in paths if exclude not in p.original.split("/")[-1]
+            ]
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode=f"w{mode_suffix}") as tf:
+            for p in filtered_paths:
+                data = await read_bytes(accessor, p)
+                name = p.original.lstrip("/")
+                info = tarfile.TarInfo(name=name)
+                info.size = len(data)
+                tf.addfile(info, io.BytesIO(data))
+        archive = buf.getvalue()
+        await write_bytes(accessor, archive_path, archive)
+        return None, IOResult(writes={archive_path: archive})
+    if t:
+        if not archive_path:
+            raise ValueError("tar: -f is required")
+        data = await read_bytes(accessor, archive_path)
+        with tarfile.open(fileobj=io.BytesIO(data),
+                          mode=f"r{mode_suffix}") as tf:
+            names = tf.getnames()
+        return ("\n".join(names) + "\n").encode(), IOResult()
+    if x:
+        if not archive_path:
+            raise ValueError("tar: -f is required")
+        data = await read_bytes(accessor, archive_path)
+        writes: dict[str, bytes] = {}
+        with tarfile.open(fileobj=io.BytesIO(data),
+                          mode=f"r{mode_suffix}") as tf:
+            for member in tf.getmembers():
+                if member.isfile():
+                    extracted = tf.extractfile(member)
+                    if extracted:
+                        content = extracted.read()
+                        name_parts = member.name.split("/")
+                        if strip_n > 0:
+                            name_parts = name_parts[strip_n:]
+                        if not name_parts:
+                            continue
+                        out_path = dest_path.rstrip("/") + "/" + "/".join(
+                            name_parts)
+                        await write_bytes(accessor, out_path, content)
+                        writes[out_path] = content
+        return None, IOResult(writes=writes)
+    raise ValueError("tar: must specify -c, -x, or -t")

--- a/python/mirage/commands/builtin/onedrive/tee.py
+++ b/python/mirage/commands/builtin/onedrive/tee.py
@@ -1,0 +1,56 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.stream import read_stream
+from mirage.core.onedrive.write import write_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("tee", resource="onedrive", spec=SPECS["tee"], write=True)
+async def tee(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    a: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        raise ValueError("tee: missing operand")
+    paths = await resolve_glob(accessor, paths, index)
+    raw = await _read_stdin_async(stdin)
+    if raw is None:
+        raw = (" ".join(texts)).encode() if texts else b""
+    write_data = raw
+    if a:
+        try:
+            existing = b""
+            async for chunk in read_stream(accessor, paths[0]):
+                existing += chunk
+            write_data = existing + raw
+        except FileNotFoundError:
+            pass
+    await write_bytes(accessor, paths[0], write_data)
+    return raw, IOResult(writes={paths[0].original: write_data},
+                         cache=[paths[0].strip_prefix])

--- a/python/mirage/commands/builtin/onedrive/touch.py
+++ b/python/mirage/commands/builtin/onedrive/touch.py
@@ -1,0 +1,48 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.exists import exists
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.write import write_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("touch", resource="onedrive", spec=SPECS["touch"], write=True)
+async def touch(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    c: bool = False,
+    r: str | None = None,
+    d: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        raise ValueError("touch: missing operand")
+    paths = await resolve_glob(accessor, paths, index)
+    writes: dict[str, bytes] = {}
+    for p in paths:
+        if c:
+            continue
+        if not await exists(accessor, p):
+            await write_bytes(accessor, p, b"")
+            writes[p.original] = b""
+    return None, IOResult(writes=writes)

--- a/python/mirage/commands/builtin/onedrive/tr.py
+++ b/python/mirage/commands/builtin/onedrive/tr.py
@@ -1,0 +1,53 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tr import tr as generic_tr
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.stream import read_stream
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("tr", resource="onedrive", spec=SPECS["tr"])
+async def tr(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    d: bool = False,
+    s: bool = False,
+    c: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_tr(
+        paths,
+        texts,
+        read_stream=read_stream,
+        accessor=accessor,
+        stdin=stdin,
+        delete=d,
+        squeeze=s,
+        complement=c,
+    )

--- a/python/mirage/commands/builtin/onedrive/tree.py
+++ b/python/mirage/commands/builtin/onedrive/tree.py
@@ -1,0 +1,54 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from functools import partial
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tree import tree as generic_tree
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.readdir import readdir
+from mirage.core.onedrive.stat import stat
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("tree", resource="onedrive", spec=SPECS["tree"])
+async def tree(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    L: str | None = None,
+    a: bool = False,
+    args_I: str | None = None,
+    d: bool = False,
+    P: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    paths = await resolve_glob(accessor, paths, index)
+    return await generic_tree(
+        paths[0],
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        max_depth=int(L) if L is not None else None,
+        show_hidden=a,
+        ignore_pattern=args_I,
+        dirs_only=d,
+        match_pattern=P,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/onedrive/tsort.py
+++ b/python/mirage/commands/builtin/onedrive/tsort.py
@@ -1,0 +1,44 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tsort import tsort as generic_tsort
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("tsort", resource="onedrive", spec=SPECS["tsort"])
+async def tsort(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_tsort(paths,
+                               read_bytes=read_bytes,
+                               accessor=accessor,
+                               stdin=stdin)

--- a/python/mirage/commands/builtin/onedrive/unexpand.py
+++ b/python/mirage/commands/builtin/onedrive/unexpand.py
@@ -1,0 +1,49 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.unexpand import \
+    unexpand as generic_unexpand
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("unexpand", resource="onedrive", spec=SPECS["unexpand"])
+async def unexpand(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    t: str | None = None,
+    a: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_unexpand(paths,
+                                  read_bytes=read_bytes,
+                                  accessor=accessor,
+                                  stdin=stdin,
+                                  tabsize=int(t) if t is not None else 8,
+                                  all_spaces=a)

--- a/python/mirage/commands/builtin/onedrive/uniq.py
+++ b/python/mirage/commands/builtin/onedrive/uniq.py
@@ -1,0 +1,60 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.uniq import uniq as generic_uniq
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.stream import read_stream
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("uniq", resource="onedrive", spec=SPECS["uniq"])
+async def uniq(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    c: bool = False,
+    d: bool = False,
+    u: bool = False,
+    f: str | None = None,
+    s: str | None = None,
+    i: bool = False,
+    w: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_uniq(
+        paths,
+        read_stream=read_stream,
+        accessor=accessor,
+        stdin=stdin,
+        count=c,
+        duplicates_only=d,
+        unique_only=u,
+        skip_fields=int(f) if f else 0,
+        skip_chars=int(s) if s else 0,
+        ignore_case=i,
+        check_chars=int(w) if w else 0,
+    )

--- a/python/mirage/commands/builtin/onedrive/unzip.py
+++ b/python/mirage/commands/builtin/onedrive/unzip.py
@@ -1,0 +1,84 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import io
+import zipfile
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.write import write_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("unzip", resource="onedrive", spec=SPECS["unzip"], write=True)
+async def unzip(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    o: bool = False,
+    args_l: bool = False,
+    d: str | None = None,
+    q: bool = False,
+    p: bool = False,
+    t: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        raise ValueError("unzip: missing operand")
+    paths = await resolve_glob(accessor, paths, index)
+    archive_path = paths[0]
+    data = await read_bytes(accessor, archive_path)
+    with zipfile.ZipFile(io.BytesIO(data), "r") as zf:
+        if args_l:
+            lines = ["  Length      Name", "---------  ----"]
+            for info in zf.infolist():
+                lines.append(f"{info.file_size:>9}  {info.filename}")
+            return ("\n".join(lines) + "\n").encode(), IOResult()
+        if t:
+            bad = zf.testzip()
+            if bad is None:
+                msg = f"No errors detected in {archive_path.original}\n"
+            else:
+                msg = f"first bad file: {bad}\n"
+            return msg.encode(), IOResult()
+        if p:
+            chunks: list[bytes] = []
+            for info in zf.infolist():
+                if not info.is_dir():
+                    chunks.append(zf.read(info.filename))
+            return b"".join(chunks), IOResult()
+        dest = d if d else "/"
+        writes: dict[str, bytes] = {}
+        output_lines: list[str] = []
+        for info in zf.infolist():
+            if not info.is_dir():
+                content = zf.read(info.filename)
+                name = info.filename.split(
+                    "/")[-1] if "/" in info.filename else info.filename
+                out_path = dest.rstrip("/") + "/" + name
+                await write_bytes(accessor, out_path, content)
+                writes[out_path] = content
+                if not q:
+                    output_lines.append(f"  inflating: {out_path}")
+    output = ("\n".join(output_lines) +
+              "\n").encode() if output_lines else None
+    return output, IOResult(writes=writes)

--- a/python/mirage/commands/builtin/onedrive/wc.py
+++ b/python/mirage/commands/builtin/onedrive/wc.py
@@ -1,0 +1,77 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import wc as generic_wc
+from mirage.commands.builtin.onedrive._provision import file_read_provision
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("wc",
+         resource="onedrive",
+         spec=SPECS["wc"],
+         provision=file_read_provision)
+async def wc(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    args_l: bool = False,
+    w: bool = False,
+    c: bool = False,
+    m: bool = False,
+    L: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        outputs: list[str] = []
+        totals = WCCounts()
+        for p in paths:
+            data = await read_bytes(accessor, p)
+            counts = await generic_wc(data)
+            outputs.append(
+                format_wc(counts,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label=p.original))
+            totals.merge(counts)
+        if len(paths) > 1:
+            outputs.append(
+                format_wc(totals,
+                          args_l=args_l,
+                          w=w,
+                          c=c,
+                          m=m,
+                          L=L,
+                          label="total"))
+        return "\n".join(outputs).encode(), IOResult()
+    source = _resolve_source(stdin, "wc: missing operand")
+    counts = await generic_wc(source)
+    return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
+                     L=L).encode(), IOResult()

--- a/python/mirage/commands/builtin/onedrive/xxd.py
+++ b/python/mirage/commands/builtin/onedrive/xxd.py
@@ -1,0 +1,62 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.xxd import xxd as generic_xxd
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.stream import read_stream
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("xxd", resource="onedrive", spec=SPECS["xxd"])
+async def xxd(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    r: bool = False,
+    p: bool = False,
+    args_l: str | bool = False,
+    c: str | bool = False,
+    s: str | bool = False,
+    g: str | bool = False,
+    u: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    skip = int(s) if s and s is not True else 0
+    limit = int(args_l) if args_l and args_l is not True else 0
+    cols = int(c) if c and c is not True else 16
+    group = int(g) if g and g is not True else 2
+    return await generic_xxd(paths,
+                             read_stream=read_stream,
+                             accessor=accessor,
+                             stdin=stdin,
+                             reverse=r,
+                             plain=p,
+                             uppercase=u,
+                             cols=cols,
+                             group=group,
+                             skip=skip,
+                             limit=limit)

--- a/python/mirage/commands/builtin/onedrive/zcat.py
+++ b/python/mirage/commands/builtin/onedrive/zcat.py
@@ -1,0 +1,44 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.zcat import zcat as generic_zcat
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("zcat", resource="onedrive", spec=SPECS["zcat"])
+async def zcat(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_zcat(paths,
+                              read_bytes=read_bytes,
+                              accessor=accessor,
+                              stdin=stdin)

--- a/python/mirage/commands/builtin/onedrive/zgrep.py
+++ b/python/mirage/commands/builtin/onedrive/zgrep.py
@@ -1,0 +1,73 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.zgrep import zgrep as generic_zgrep
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("zgrep", resource="onedrive", spec=SPECS["zgrep"])
+async def zgrep(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    i: bool = False,
+    c: bool = False,
+    args_l: bool = False,
+    n: bool = False,
+    v: bool = False,
+    e: str | None = None,
+    E: bool = False,
+    F: bool = False,
+    H: bool = False,
+    h: bool = False,
+    m: str | None = None,
+    o: bool = False,
+    q: bool = False,
+    w: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    raw_pattern = e if e is not None else (texts[0] if texts else "")
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+    else:
+        paths = []
+    return await generic_zgrep(paths,
+                               pattern=raw_pattern,
+                               read_bytes=read_bytes,
+                               accessor=accessor,
+                               stdin=stdin,
+                               ignore_case=i,
+                               invert=v,
+                               count=c,
+                               files_only=args_l,
+                               line_numbers=n,
+                               extended=E,
+                               fixed=F,
+                               force_filename=H,
+                               suppress_filename=h,
+                               max_count=int(m) if m is not None else None,
+                               only_matching=o,
+                               quiet=q,
+                               whole_word=w)

--- a/python/mirage/commands/builtin/onedrive/zip_cmd.py
+++ b/python/mirage/commands/builtin/onedrive/zip_cmd.py
@@ -1,0 +1,62 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import io
+import posixpath
+import zipfile
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.onedrive.glob import resolve_glob
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.write import write_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("zip", resource="onedrive", spec=SPECS["zip"], write=True)
+async def zip_cmd(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    r: bool = False,
+    j: bool = False,
+    q: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if len(paths) < 2:
+        raise ValueError("zip: usage: zip archive.zip file1 [file2 ...]")
+    paths = await resolve_glob(accessor, paths, index)
+    archive_path = paths[0]
+    file_paths = paths[1:]
+    buf = io.BytesIO()
+    output_lines: list[str] = []
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in file_paths:
+            data = await read_bytes(accessor, p)
+            arcname = (posixpath.basename(p.original)
+                       if j else p.original.lstrip("/"))
+            zf.writestr(arcname, data)
+            if not q:
+                output_lines.append(f"  adding: {arcname}")
+    archive = buf.getvalue()
+    await write_bytes(accessor, archive_path, archive)
+    stdout = ("\n".join(output_lines) +
+              "\n").encode() if output_lines else None
+    return stdout, IOResult(writes={archive_path.original: archive})

--- a/python/mirage/core/onedrive/__init__.py
+++ b/python/mirage/core/onedrive/__init__.py
@@ -1,0 +1,13 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========

--- a/python/mirage/core/onedrive/_client.py
+++ b/python/mirage/core/onedrive/_client.py
@@ -1,0 +1,197 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from urllib.parse import quote
+
+import aiohttp
+
+from mirage.accessor.onedrive import OneDriveConfig
+from mirage.resource.secrets import reveal_secret
+from mirage.types import PathSpec
+
+GRAPH_API = "https://graph.microsoft.com/v1.0"
+
+
+def split_path(path: PathSpec | str) -> tuple[str, str]:
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    prefix = path.prefix or ""
+    raw = path.original
+    if prefix and raw.startswith(prefix):
+        raw = raw[len(prefix):] or "/"
+    return prefix, raw.strip("/")
+
+
+class GraphError(RuntimeError):
+
+    def __init__(self, status: int, code: str, message: str) -> None:
+        self.status = status
+        self.code = code
+        super().__init__(f"Graph API error {status} ({code}): {message}")
+
+
+def drive_base(config: OneDriveConfig) -> str:
+    if config.drive_id:
+        return f"{GRAPH_API}/drives/{config.drive_id}"
+    if config.site_id:
+        return f"{GRAPH_API}/sites/{config.site_id}/drive"
+    return f"{GRAPH_API}/me/drive"
+
+
+def _full_path(config: OneDriveConfig, path: str) -> str:
+    p = path.strip("/")
+    prefix = (config.key_prefix or "").strip("/")
+    if prefix and p:
+        return f"{prefix}/{p}"
+    return prefix or p
+
+
+def item_url(config: OneDriveConfig, path: str, action: str = "") -> str:
+    base = drive_base(config)
+    full = _full_path(config, path)
+    if not full:
+        return f"{base}/root{action}"
+    stem = f"{base}/root:/{quote(full, safe='/')}"
+    if action:
+        return f"{stem}:{action}"
+    return stem
+
+
+def drive_ref_path(config: OneDriveConfig, folder: str = "") -> str:
+    base = drive_base(config)[len(GRAPH_API):]
+    if folder:
+        return f"{base}/root:/{quote(folder, safe='/')}"
+    return f"{base}/root:"
+
+
+def headers(config: OneDriveConfig) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {reveal_secret(config.access_token)}",
+        "Content-Type": "application/json",
+    }
+
+
+def _timeout(config: OneDriveConfig) -> aiohttp.ClientTimeout:
+    return aiohttp.ClientTimeout(total=config.timeout)
+
+
+async def _raise_for_status(method: str, url: str,
+                            resp: aiohttp.ClientResponse) -> None:
+    if resp.status < 400:
+        return
+    try:
+        data = await resp.json()
+        err = data.get("error", {}) if isinstance(data, dict) else {}
+    except (aiohttp.ContentTypeError, ValueError):
+        err = {}
+    raise GraphError(resp.status, err.get("code", "unknownError"),
+                     err.get("message", f"{method} {url}"))
+
+
+async def graph_get(config: OneDriveConfig,
+                    url: str,
+                    params: dict | None = None) -> dict:
+    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
+        async with session.get(url, headers=headers(config),
+                               params=params) as resp:
+            await _raise_for_status("GET", url, resp)
+            return await resp.json()
+
+
+async def graph_list(config: OneDriveConfig,
+                     url: str,
+                     params: dict | None = None) -> list[dict]:
+    items: list[dict] = []
+    next_url: str | None = url
+    next_params = params
+    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
+        while next_url:
+            async with session.get(next_url,
+                                   headers=headers(config),
+                                   params=next_params) as resp:
+                await _raise_for_status("GET", next_url, resp)
+                data = await resp.json()
+            items.extend(data.get("value", []))
+            next_url = data.get("@odata.nextLink")
+            next_params = None
+    return items
+
+
+async def graph_get_bytes(config: OneDriveConfig,
+                          url: str,
+                          range_header: str | None = None) -> bytes:
+    hdrs = headers(config)
+    if range_header:
+        hdrs["Range"] = range_header
+    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
+        async with session.get(url, headers=hdrs) as resp:
+            await _raise_for_status("GET", url, resp)
+            return await resp.read()
+
+
+async def graph_stream(config: OneDriveConfig,
+                       url: str,
+                       chunk_size: int = 8192):
+    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
+        async with session.get(url, headers=headers(config)) as resp:
+            await _raise_for_status("GET", url, resp)
+            async for chunk in resp.content.iter_chunked(chunk_size):
+                yield chunk
+
+
+async def graph_post(config: OneDriveConfig,
+                     url: str,
+                     body: dict | None = None) -> dict:
+    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
+        async with session.post(url, headers=headers(config), json=body
+                                or {}) as resp:
+            await _raise_for_status("POST", url, resp)
+            return await resp.json()
+
+
+async def graph_patch(config: OneDriveConfig, url: str, body: dict) -> dict:
+    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
+        async with session.patch(url, headers=headers(config),
+                                 json=body) as resp:
+            await _raise_for_status("PATCH", url, resp)
+            return await resp.json()
+
+
+async def graph_delete(config: OneDriveConfig, url: str) -> None:
+    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
+        async with session.delete(url, headers=headers(config)) as resp:
+            await _raise_for_status("DELETE", url, resp)
+
+
+async def graph_put_bytes(
+        config: OneDriveConfig,
+        url: str,
+        data: bytes,
+        content_type: str = "application/octet-stream") -> dict:
+    hdrs = headers(config)
+    hdrs["Content-Type"] = content_type
+    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
+        async with session.put(url, headers=hdrs, data=data) as resp:
+            await _raise_for_status("PUT", url, resp)
+            return await resp.json()
+
+
+async def upload_chunk(config: OneDriveConfig, upload_url: str, data: bytes,
+                       start: int, total: int) -> int:
+    end = start + len(data) - 1
+    hdrs = {"Content-Range": f"bytes {start}-{end}/{total}"}
+    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
+        async with session.put(upload_url, headers=hdrs, data=data) as resp:
+            await _raise_for_status("PUT", upload_url, resp)
+            return resp.status

--- a/python/mirage/core/onedrive/_client.py
+++ b/python/mirage/core/onedrive/_client.py
@@ -136,13 +136,15 @@ async def _request(config: OneDriveConfig,
                    json_body: dict | None = None,
                    data: bytes | None = None,
                    extra_headers: dict | None = None,
+                   auth: bool = True,
                    read: str = "json"):
     own = session is None
     sess = session or aiohttp.ClientSession(timeout=_timeout(config))
     try:
         attempt = 0
+        refreshed = False
         while True:
-            hdrs = headers(config)
+            hdrs = headers(config) if auth else {}
             if extra_headers:
                 hdrs.update(extra_headers)
             async with sess.request(method,
@@ -154,6 +156,10 @@ async def _request(config: OneDriveConfig,
                 if _should_retry(resp.status, attempt, config):
                     await asyncio.sleep(_retry_delay(resp, attempt))
                     attempt += 1
+                    continue
+                if (resp.status == 401 and auth and not refreshed
+                        and callable(config.access_token)):
+                    refreshed = True
                     continue
                 await _raise_for_status(method, url, resp)
                 if read == "bytes":
@@ -206,30 +212,33 @@ async def graph_list(
     return items
 
 
-async def graph_get_bytes(
-        config: OneDriveConfig,
-        url: str,
-        range_header: str | None = None,
-        session: aiohttp.ClientSession | None = None) -> bytes:
+async def graph_get_bytes(config: OneDriveConfig,
+                          url: str,
+                          range_header: str | None = None,
+                          session: aiohttp.ClientSession | None = None,
+                          auth: bool = True) -> bytes:
     extra = {"Range": range_header} if range_header else None
     return await _request(config,
                           "GET",
                           url,
                           extra_headers=extra,
                           session=session,
+                          auth=auth,
                           read="bytes")
 
 
 async def graph_stream(config: OneDriveConfig,
                        url: str,
                        chunk_size: int = 8192,
-                       session: aiohttp.ClientSession | None = None):
+                       session: aiohttp.ClientSession | None = None,
+                       auth: bool = True):
     own = session is None
     sess = session or aiohttp.ClientSession(timeout=_timeout(config))
     try:
         attempt = 0
         while True:
-            async with sess.get(url, headers=headers(config)) as resp:
+            hdrs = headers(config) if auth else {}
+            async with sess.get(url, headers=hdrs) as resp:
                 if _should_retry(resp.status, attempt, config):
                     await asyncio.sleep(_retry_delay(resp, attempt))
                     attempt += 1
@@ -318,7 +327,7 @@ async def poll_monitor(url: str,
 
 
 async def upload_chunk(config: OneDriveConfig, upload_url: str, data: bytes,
-                       start: int, total: int) -> int:
+                       start: int, total: int) -> dict:
     end = start + len(data) - 1
     hdrs = {"Content-Range": f"bytes {start}-{end}/{total}"}
     async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
@@ -331,4 +340,9 @@ async def upload_chunk(config: OneDriveConfig, upload_url: str, data: bytes,
                     attempt += 1
                     continue
                 await _raise_for_status("PUT", upload_url, resp)
-                return resp.status
+                if resp.status == 204 or resp.content_length == 0:
+                    return {}
+                try:
+                    return await resp.json()
+                except (aiohttp.ContentTypeError, ValueError):
+                    return {}

--- a/python/mirage/core/onedrive/_client.py
+++ b/python/mirage/core/onedrive/_client.py
@@ -32,7 +32,9 @@ def split_path(path: PathSpec | str) -> tuple[str, str]:
     prefix = path.prefix or ""
     raw = path.original
     if prefix and raw.startswith(prefix):
-        raw = raw[len(prefix):] or "/"
+        rest = raw[len(prefix):]
+        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
+            raw = rest or "/"
     return prefix, raw.strip("/")
 
 
@@ -127,6 +129,18 @@ def _should_retry(status: int, attempt: int, config: OneDriveConfig) -> bool:
     return status in RETRY_STATUSES and attempt < config.max_retries
 
 
+async def _retry_action(resp: aiohttp.ClientResponse, attempt: int,
+                        refreshed: bool, config: OneDriveConfig,
+                        auth: bool) -> str:
+    if _should_retry(resp.status, attempt, config):
+        await asyncio.sleep(_retry_delay(resp, attempt))
+        return "retry"
+    if (resp.status == 401 and auth and not refreshed
+            and callable(config.access_token)):
+        return "refresh"
+    return "ok"
+
+
 async def _request(config: OneDriveConfig,
                    method: str,
                    url: str,
@@ -153,12 +167,12 @@ async def _request(config: OneDriveConfig,
                                     params=params,
                                     json=json_body,
                                     data=data) as resp:
-                if _should_retry(resp.status, attempt, config):
-                    await asyncio.sleep(_retry_delay(resp, attempt))
+                action = await _retry_action(resp, attempt, refreshed, config,
+                                             auth)
+                if action == "retry":
                     attempt += 1
                     continue
-                if (resp.status == 401 and auth and not refreshed
-                        and callable(config.access_token)):
+                if action == "refresh":
                     refreshed = True
                     continue
                 await _raise_for_status(method, url, resp)
@@ -236,12 +250,17 @@ async def graph_stream(config: OneDriveConfig,
     sess = session or aiohttp.ClientSession(timeout=_timeout(config))
     try:
         attempt = 0
+        refreshed = False
         while True:
             hdrs = headers(config) if auth else {}
             async with sess.get(url, headers=hdrs) as resp:
-                if _should_retry(resp.status, attempt, config):
-                    await asyncio.sleep(_retry_delay(resp, attempt))
+                action = await _retry_action(resp, attempt, refreshed, config,
+                                             auth)
+                if action == "retry":
                     attempt += 1
+                    continue
+                if action == "refresh":
+                    refreshed = True
                     continue
                 await _raise_for_status("GET", url, resp)
                 async for chunk in resp.content.iter_chunked(chunk_size):

--- a/python/mirage/core/onedrive/_client.py
+++ b/python/mirage/core/onedrive/_client.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
 from urllib.parse import quote
 
 import aiohttp
@@ -21,6 +22,8 @@ from mirage.resource.secrets import reveal_secret
 from mirage.types import PathSpec
 
 GRAPH_API = "https://graph.microsoft.com/v1.0"
+RETRY_STATUSES = {429, 503, 504}
+MAX_BACKOFF = 30.0
 
 
 def split_path(path: PathSpec | str) -> tuple[str, str]:
@@ -75,15 +78,26 @@ def drive_ref_path(config: OneDriveConfig, folder: str = "") -> str:
     return f"{base}/root:"
 
 
+def _resolve_token(config: OneDriveConfig) -> str:
+    token = config.access_token
+    if callable(token):
+        token = token()
+    return reveal_secret(token)
+
+
 def headers(config: OneDriveConfig) -> dict[str, str]:
     return {
-        "Authorization": f"Bearer {reveal_secret(config.access_token)}",
+        "Authorization": f"Bearer {_resolve_token(config)}",
         "Content-Type": "application/json",
     }
 
 
 def _timeout(config: OneDriveConfig) -> aiohttp.ClientTimeout:
     return aiohttp.ClientTimeout(total=config.timeout)
+
+
+def new_session(config: OneDriveConfig) -> aiohttp.ClientSession:
+    return aiohttp.ClientSession(timeout=_timeout(config))
 
 
 async def _raise_for_status(method: str, url: str,
@@ -99,92 +113,208 @@ async def _raise_for_status(method: str, url: str,
                      err.get("message", f"{method} {url}"))
 
 
+def _retry_delay(resp: aiohttp.ClientResponse, attempt: int) -> float:
+    retry_after = resp.headers.get("Retry-After")
+    if retry_after:
+        try:
+            return float(retry_after)
+        except ValueError:
+            pass
+    return min(2.0**attempt, MAX_BACKOFF)
+
+
+def _should_retry(status: int, attempt: int, config: OneDriveConfig) -> bool:
+    return status in RETRY_STATUSES and attempt < config.max_retries
+
+
+async def _request(config: OneDriveConfig,
+                   method: str,
+                   url: str,
+                   *,
+                   session: aiohttp.ClientSession | None = None,
+                   params: dict | None = None,
+                   json_body: dict | None = None,
+                   data: bytes | None = None,
+                   extra_headers: dict | None = None,
+                   read: str = "json"):
+    own = session is None
+    sess = session or aiohttp.ClientSession(timeout=_timeout(config))
+    try:
+        attempt = 0
+        while True:
+            hdrs = headers(config)
+            if extra_headers:
+                hdrs.update(extra_headers)
+            async with sess.request(method,
+                                    url,
+                                    headers=hdrs,
+                                    params=params,
+                                    json=json_body,
+                                    data=data) as resp:
+                if _should_retry(resp.status, attempt, config):
+                    await asyncio.sleep(_retry_delay(resp, attempt))
+                    attempt += 1
+                    continue
+                await _raise_for_status(method, url, resp)
+                if read == "bytes":
+                    return await resp.read()
+                if read == "none":
+                    return None
+                if read == "location":
+                    return resp.headers.get("Location")
+                if resp.status == 204 or resp.content_length == 0:
+                    return {}
+                try:
+                    return await resp.json()
+                except (aiohttp.ContentTypeError, ValueError):
+                    return {}
+    finally:
+        if own:
+            await sess.close()
+
+
 async def graph_get(config: OneDriveConfig,
                     url: str,
-                    params: dict | None = None) -> dict:
-    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
-        async with session.get(url, headers=headers(config),
-                               params=params) as resp:
-            await _raise_for_status("GET", url, resp)
-            return await resp.json()
+                    params: dict | None = None,
+                    session: aiohttp.ClientSession | None = None) -> dict:
+    return await _request(config, "GET", url, params=params, session=session)
 
 
-async def graph_list(config: OneDriveConfig,
-                     url: str,
-                     params: dict | None = None) -> list[dict]:
+async def graph_list(
+        config: OneDriveConfig,
+        url: str,
+        params: dict | None = None,
+        session: aiohttp.ClientSession | None = None) -> list[dict]:
     items: list[dict] = []
     next_url: str | None = url
     next_params = params
-    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
+    own = session is None
+    sess = session or aiohttp.ClientSession(timeout=_timeout(config))
+    try:
         while next_url:
-            async with session.get(next_url,
-                                   headers=headers(config),
-                                   params=next_params) as resp:
-                await _raise_for_status("GET", next_url, resp)
-                data = await resp.json()
+            data = await _request(config,
+                                  "GET",
+                                  next_url,
+                                  params=next_params,
+                                  session=sess)
             items.extend(data.get("value", []))
             next_url = data.get("@odata.nextLink")
             next_params = None
+    finally:
+        if own:
+            await sess.close()
     return items
 
 
-async def graph_get_bytes(config: OneDriveConfig,
-                          url: str,
-                          range_header: str | None = None) -> bytes:
-    hdrs = headers(config)
-    if range_header:
-        hdrs["Range"] = range_header
-    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
-        async with session.get(url, headers=hdrs) as resp:
-            await _raise_for_status("GET", url, resp)
-            return await resp.read()
+async def graph_get_bytes(
+        config: OneDriveConfig,
+        url: str,
+        range_header: str | None = None,
+        session: aiohttp.ClientSession | None = None) -> bytes:
+    extra = {"Range": range_header} if range_header else None
+    return await _request(config,
+                          "GET",
+                          url,
+                          extra_headers=extra,
+                          session=session,
+                          read="bytes")
 
 
 async def graph_stream(config: OneDriveConfig,
                        url: str,
-                       chunk_size: int = 8192):
-    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
-        async with session.get(url, headers=headers(config)) as resp:
-            await _raise_for_status("GET", url, resp)
-            async for chunk in resp.content.iter_chunked(chunk_size):
-                yield chunk
+                       chunk_size: int = 8192,
+                       session: aiohttp.ClientSession | None = None):
+    own = session is None
+    sess = session or aiohttp.ClientSession(timeout=_timeout(config))
+    try:
+        attempt = 0
+        while True:
+            async with sess.get(url, headers=headers(config)) as resp:
+                if _should_retry(resp.status, attempt, config):
+                    await asyncio.sleep(_retry_delay(resp, attempt))
+                    attempt += 1
+                    continue
+                await _raise_for_status("GET", url, resp)
+                async for chunk in resp.content.iter_chunked(chunk_size):
+                    yield chunk
+                return
+    finally:
+        if own:
+            await sess.close()
 
 
 async def graph_post(config: OneDriveConfig,
                      url: str,
-                     body: dict | None = None) -> dict:
-    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
-        async with session.post(url, headers=headers(config), json=body
-                                or {}) as resp:
-            await _raise_for_status("POST", url, resp)
-            return await resp.json()
+                     body: dict | None = None,
+                     session: aiohttp.ClientSession | None = None) -> dict:
+    return await _request(config,
+                          "POST",
+                          url,
+                          json_body=body or {},
+                          session=session)
 
 
-async def graph_patch(config: OneDriveConfig, url: str, body: dict) -> dict:
-    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
-        async with session.patch(url, headers=headers(config),
-                                 json=body) as resp:
-            await _raise_for_status("PATCH", url, resp)
-            return await resp.json()
+async def graph_post_monitor(
+        config: OneDriveConfig,
+        url: str,
+        body: dict | None = None,
+        session: aiohttp.ClientSession | None = None) -> str | None:
+    return await _request(config,
+                          "POST",
+                          url,
+                          json_body=body or {},
+                          session=session,
+                          read="location")
 
 
-async def graph_delete(config: OneDriveConfig, url: str) -> None:
-    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
-        async with session.delete(url, headers=headers(config)) as resp:
-            await _raise_for_status("DELETE", url, resp)
+async def graph_patch(config: OneDriveConfig,
+                      url: str,
+                      body: dict,
+                      session: aiohttp.ClientSession | None = None) -> dict:
+    return await _request(config,
+                          "PATCH",
+                          url,
+                          json_body=body,
+                          session=session)
+
+
+async def graph_delete(config: OneDriveConfig,
+                       url: str,
+                       session: aiohttp.ClientSession | None = None) -> None:
+    await _request(config, "DELETE", url, session=session, read="none")
 
 
 async def graph_put_bytes(
         config: OneDriveConfig,
         url: str,
         data: bytes,
-        content_type: str = "application/octet-stream") -> dict:
-    hdrs = headers(config)
-    hdrs["Content-Type"] = content_type
-    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
-        async with session.put(url, headers=hdrs, data=data) as resp:
-            await _raise_for_status("PUT", url, resp)
-            return await resp.json()
+        content_type: str = "application/octet-stream",
+        session: aiohttp.ClientSession | None = None) -> dict:
+    return await _request(config,
+                          "PUT",
+                          url,
+                          data=data,
+                          extra_headers={"Content-Type": content_type},
+                          session=session)
+
+
+async def poll_monitor(url: str,
+                       timeout: float,
+                       interval: float = 1.0) -> dict:
+    waited = 0.0
+    async with aiohttp.ClientSession() as session:
+        while True:
+            async with session.get(url) as resp:
+                if resp.status >= 400:
+                    raise GraphError(resp.status, "monitorError", f"GET {url}")
+                payload = await resp.json()
+            status = payload.get("status")
+            if status in ("completed", "failed"):
+                return payload
+            if waited >= timeout:
+                return payload
+            await asyncio.sleep(interval)
+            waited += interval
 
 
 async def upload_chunk(config: OneDriveConfig, upload_url: str, data: bytes,
@@ -192,6 +322,13 @@ async def upload_chunk(config: OneDriveConfig, upload_url: str, data: bytes,
     end = start + len(data) - 1
     hdrs = {"Content-Range": f"bytes {start}-{end}/{total}"}
     async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
-        async with session.put(upload_url, headers=hdrs, data=data) as resp:
-            await _raise_for_status("PUT", upload_url, resp)
-            return resp.status
+        attempt = 0
+        while True:
+            async with session.put(upload_url, headers=hdrs,
+                                   data=data) as resp:
+                if _should_retry(resp.status, attempt, config):
+                    await asyncio.sleep(_retry_delay(resp, attempt))
+                    attempt += 1
+                    continue
+                await _raise_for_status("PUT", upload_url, resp)
+                return resp.status

--- a/python/mirage/core/onedrive/copy.py
+++ b/python/mirage/core/onedrive/copy.py
@@ -1,0 +1,36 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import posixpath
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive._client import (drive_ref_path, graph_post, item_url,
+                                          split_path)
+from mirage.types import PathSpec
+
+
+async def copy(accessor: OneDriveAccessor, src: PathSpec,
+               dst: PathSpec) -> None:
+    _, src_s = split_path(src)
+    _, dst_s = split_path(dst)
+    dst_parent = posixpath.dirname("/" + dst_s).strip("/")
+    name = posixpath.basename(dst_s)
+    url = item_url(accessor.config, "/" + src_s, action="/copy")
+    body = {
+        "name": name,
+        "parentReference": {
+            "path": drive_ref_path(accessor.config, dst_parent)
+        },
+    }
+    await graph_post(accessor.config, url, body)

--- a/python/mirage/core/onedrive/copy.py
+++ b/python/mirage/core/onedrive/copy.py
@@ -15,8 +15,9 @@
 import posixpath
 
 from mirage.accessor.onedrive import OneDriveAccessor
-from mirage.core.onedrive._client import (drive_ref_path, graph_post, item_url,
-                                          split_path)
+from mirage.core.onedrive._client import (GraphError, drive_ref_path,
+                                          graph_post_monitor, item_url,
+                                          poll_monitor, split_path)
 from mirage.types import PathSpec
 
 
@@ -33,4 +34,15 @@ async def copy(accessor: OneDriveAccessor, src: PathSpec,
             "path": drive_ref_path(accessor.config, dst_parent)
         },
     }
-    await graph_post(accessor.config, url, body)
+    monitor = await graph_post_monitor(accessor.config, url, body)
+    if not monitor:
+        return
+    result = await poll_monitor(monitor, timeout=accessor.config.timeout)
+    status = result.get("status")
+    if status == "failed":
+        err = result.get("error", {}) if isinstance(result, dict) else {}
+        raise GraphError(500, err.get("code", "copyFailed"),
+                         err.get("message", f"copy {src_s} -> {dst_s} failed"))
+    if status not in ("completed", None):
+        raise GraphError(504, "copyTimeout",
+                         f"copy {src_s} -> {dst_s} not confirmed complete")

--- a/python/mirage/core/onedrive/create.py
+++ b/python/mirage/core/onedrive/create.py
@@ -1,0 +1,23 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive._client import graph_put_bytes, item_url, split_path
+from mirage.types import PathSpec
+
+
+async def create(accessor: OneDriveAccessor, path: PathSpec) -> None:
+    _, stripped = split_path(path)
+    url = item_url(accessor.config, "/" + stripped, action="/content")
+    await graph_put_bytes(accessor.config, url, b"")

--- a/python/mirage/core/onedrive/du.py
+++ b/python/mirage/core/onedrive/du.py
@@ -1,0 +1,42 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive._client import split_path
+from mirage.core.onedrive.find import iter_tree
+from mirage.types import PathSpec
+
+
+async def du(accessor: OneDriveAccessor, path: PathSpec) -> int:
+    _, base = split_path(path)
+    total = 0
+    async for _rel, item, is_dir in iter_tree(accessor.config, base):
+        if not is_dir:
+            total += item.get("size", 0)
+    return total
+
+
+async def du_all(accessor: OneDriveAccessor,
+                 path: PathSpec) -> list[tuple[str, int]]:
+    _, base = split_path(path)
+    results: list[tuple[str, int]] = []
+    total = 0
+    async for rel, item, is_dir in iter_tree(accessor.config, base):
+        if is_dir:
+            continue
+        size = item.get("size", 0)
+        results.append(("/" + rel, size))
+        total += size
+    results.append(("/" + base if base else "/", total))
+    return results

--- a/python/mirage/core/onedrive/du.py
+++ b/python/mirage/core/onedrive/du.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.onedrive import OneDriveAccessor
-from mirage.core.onedrive._client import split_path
+from mirage.core.onedrive._client import new_session, split_path
 from mirage.core.onedrive.find import iter_tree
 from mirage.types import PathSpec
 
@@ -21,9 +21,12 @@ from mirage.types import PathSpec
 async def du(accessor: OneDriveAccessor, path: PathSpec) -> int:
     _, base = split_path(path)
     total = 0
-    async for _rel, item, is_dir in iter_tree(accessor.config, base):
-        if not is_dir:
-            total += item.get("size", 0)
+    async with new_session(accessor.config) as session:
+        async for _rel, item, is_dir in iter_tree(accessor.config,
+                                                  base,
+                                                  session=session):
+            if not is_dir:
+                total += item.get("size", 0)
     return total
 
 
@@ -32,11 +35,14 @@ async def du_all(accessor: OneDriveAccessor,
     _, base = split_path(path)
     results: list[tuple[str, int]] = []
     total = 0
-    async for rel, item, is_dir in iter_tree(accessor.config, base):
-        if is_dir:
-            continue
-        size = item.get("size", 0)
-        results.append(("/" + rel, size))
-        total += size
+    async with new_session(accessor.config) as session:
+        async for rel, item, is_dir in iter_tree(accessor.config,
+                                                 base,
+                                                 session=session):
+            if is_dir:
+                continue
+            size = item.get("size", 0)
+            results.append(("/" + rel, size))
+            total += size
     results.append(("/" + base if base else "/", total))
     return results

--- a/python/mirage/core/onedrive/exists.py
+++ b/python/mirage/core/onedrive/exists.py
@@ -1,0 +1,28 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.onedrive.stat import stat
+from mirage.types import PathSpec
+
+
+async def exists(accessor: OneDriveAccessor,
+                 path: PathSpec,
+                 index: IndexCacheStore = None) -> bool:
+    try:
+        await stat(accessor, path, index)
+        return True
+    except FileNotFoundError:
+        return False

--- a/python/mirage/core/onedrive/find.py
+++ b/python/mirage/core/onedrive/find.py
@@ -1,0 +1,87 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import fnmatch
+from collections.abc import AsyncIterator
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive._client import graph_list, item_url, split_path
+from mirage.types import PathSpec
+
+
+async def iter_tree(config,
+                    base: str) -> AsyncIterator[tuple[str, dict, bool]]:
+    url = item_url(config, "/" + base if base else "/", action="/children")
+    children = await graph_list(config, url)
+    for child in children:
+        cname = child.get("name", "")
+        rel = f"{base}/{cname}" if base else cname
+        is_dir = "folder" in child
+        yield rel, child, is_dir
+        if is_dir:
+            async for entry in iter_tree(config, rel):
+                yield entry
+
+
+async def find(
+    accessor: OneDriveAccessor,
+    path: PathSpec,
+    name: str | None = None,
+    type: str | None = None,
+    min_size: int | None = None,
+    max_size: int | None = None,
+    maxdepth: int | None = None,
+    name_exclude: str | None = None,
+    or_names: list[str] | None = None,
+    mtime_min: float | None = None,
+    mtime_max: float | None = None,
+    iname: str | None = None,
+    path_pattern: str | None = None,
+    mindepth: int | None = None,
+) -> list[str]:
+    _, base = split_path(path)
+    results: list[str] = []
+    async for rel, item, is_dir in iter_tree(accessor.config, base):
+        relative = rel[len(base):].lstrip("/") if base else rel
+        depth = relative.count("/") + 1
+        if maxdepth is not None and depth > maxdepth:
+            continue
+        if mindepth is not None and depth < mindepth:
+            continue
+        entry_name = rel.rsplit("/", 1)[-1]
+        if or_names:
+            if not any(fnmatch.fnmatch(entry_name, p) for p in or_names):
+                continue
+        elif name and not fnmatch.fnmatch(entry_name, name):
+            continue
+        if iname is not None and not fnmatch.fnmatch(entry_name.lower(),
+                                                     iname.lower()):
+            continue
+        full_path = "/" + rel
+        if path_pattern is not None and not fnmatch.fnmatch(
+                full_path, path_pattern):
+            continue
+        if name_exclude and fnmatch.fnmatch(entry_name, name_exclude):
+            continue
+        if type == "file" and is_dir:
+            continue
+        if type == "directory" and not is_dir:
+            continue
+        size = item.get("size", 0)
+        if min_size is not None and size < min_size:
+            continue
+        if max_size is not None and size > max_size:
+            continue
+        results.append(full_path)
+    return sorted(results)

--- a/python/mirage/core/onedrive/find.py
+++ b/python/mirage/core/onedrive/find.py
@@ -15,22 +15,28 @@
 import fnmatch
 from collections.abc import AsyncIterator
 
+import aiohttp
+
 from mirage.accessor.onedrive import OneDriveAccessor
-from mirage.core.onedrive._client import graph_list, item_url, split_path
+from mirage.core.onedrive._client import (graph_list, item_url, new_session,
+                                          split_path)
 from mirage.types import PathSpec
 
 
-async def iter_tree(config,
-                    base: str) -> AsyncIterator[tuple[str, dict, bool]]:
+async def iter_tree(
+    config,
+    base: str,
+    session: aiohttp.ClientSession | None = None,
+) -> AsyncIterator[tuple[str, dict, bool]]:
     url = item_url(config, "/" + base if base else "/", action="/children")
-    children = await graph_list(config, url)
+    children = await graph_list(config, url, session=session)
     for child in children:
         cname = child.get("name", "")
         rel = f"{base}/{cname}" if base else cname
         is_dir = "folder" in child
         yield rel, child, is_dir
         if is_dir:
-            async for entry in iter_tree(config, rel):
+            async for entry in iter_tree(config, rel, session=session):
                 yield entry
 
 
@@ -52,36 +58,39 @@ async def find(
 ) -> list[str]:
     _, base = split_path(path)
     results: list[str] = []
-    async for rel, item, is_dir in iter_tree(accessor.config, base):
-        relative = rel[len(base):].lstrip("/") if base else rel
-        depth = relative.count("/") + 1
-        if maxdepth is not None and depth > maxdepth:
-            continue
-        if mindepth is not None and depth < mindepth:
-            continue
-        entry_name = rel.rsplit("/", 1)[-1]
-        if or_names:
-            if not any(fnmatch.fnmatch(entry_name, p) for p in or_names):
+    async with new_session(accessor.config) as session:
+        async for rel, item, is_dir in iter_tree(accessor.config,
+                                                 base,
+                                                 session=session):
+            relative = rel[len(base):].lstrip("/") if base else rel
+            depth = relative.count("/") + 1
+            if maxdepth is not None and depth > maxdepth:
                 continue
-        elif name and not fnmatch.fnmatch(entry_name, name):
-            continue
-        if iname is not None and not fnmatch.fnmatch(entry_name.lower(),
-                                                     iname.lower()):
-            continue
-        full_path = "/" + rel
-        if path_pattern is not None and not fnmatch.fnmatch(
-                full_path, path_pattern):
-            continue
-        if name_exclude and fnmatch.fnmatch(entry_name, name_exclude):
-            continue
-        if type == "file" and is_dir:
-            continue
-        if type == "directory" and not is_dir:
-            continue
-        size = item.get("size", 0)
-        if min_size is not None and size < min_size:
-            continue
-        if max_size is not None and size > max_size:
-            continue
-        results.append(full_path)
+            if mindepth is not None and depth < mindepth:
+                continue
+            entry_name = rel.rsplit("/", 1)[-1]
+            if or_names:
+                if not any(fnmatch.fnmatch(entry_name, p) for p in or_names):
+                    continue
+            elif name and not fnmatch.fnmatch(entry_name, name):
+                continue
+            if iname is not None and not fnmatch.fnmatch(
+                    entry_name.lower(), iname.lower()):
+                continue
+            full_path = "/" + rel
+            if path_pattern is not None and not fnmatch.fnmatch(
+                    full_path, path_pattern):
+                continue
+            if name_exclude and fnmatch.fnmatch(entry_name, name_exclude):
+                continue
+            if type == "file" and is_dir:
+                continue
+            if type == "directory" and not is_dir:
+                continue
+            size = item.get("size", 0)
+            if min_size is not None and size < min_size:
+                continue
+            if max_size is not None and size > max_size:
+                continue
+            results.append(full_path)
     return sorted(results)

--- a/python/mirage/core/onedrive/glob.py
+++ b/python/mirage/core/onedrive/glob.py
@@ -1,0 +1,45 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import fnmatch
+import posixpath
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.onedrive.readdir import readdir
+from mirage.types import PathSpec
+
+
+async def resolve_glob(
+    accessor: OneDriveAccessor,
+    paths: list[PathSpec],
+    index: IndexCacheStore,
+) -> list[PathSpec]:
+    result: list[PathSpec] = []
+    for p in paths:
+        if isinstance(p, str):
+            result.append(PathSpec(original=p, directory=posixpath.dirname(p)))
+            continue
+        if p.resolved:
+            result.append(p)
+        elif p.pattern:
+            entries = await readdir(accessor, p.dir, index)
+            matched = [
+                PathSpec.from_str_path(e, p.prefix) for e in entries
+                if fnmatch.fnmatch(e.rsplit("/", 1)[-1], p.pattern)
+            ]
+            result.extend(matched)
+        else:
+            result.append(p)
+    return result

--- a/python/mirage/core/onedrive/mkdir.py
+++ b/python/mirage/core/onedrive/mkdir.py
@@ -1,0 +1,36 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import posixpath
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive._client import graph_post, item_url, split_path
+from mirage.types import PathSpec
+
+
+async def mkdir(accessor: OneDriveAccessor, path: PathSpec) -> None:
+    _, stripped = split_path(path)
+    if not stripped:
+        return
+    parent = posixpath.dirname("/" + stripped).strip("/")
+    name = posixpath.basename(stripped)
+    url = item_url(accessor.config,
+                   "/" + parent if parent else "/",
+                   action="/children")
+    body = {
+        "name": name,
+        "folder": {},
+        "@microsoft.graph.conflictBehavior": "replace",
+    }
+    await graph_post(accessor.config, url, body)

--- a/python/mirage/core/onedrive/read.py
+++ b/python/mirage/core/onedrive/read.py
@@ -1,0 +1,56 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import time
+from urllib.parse import quote
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.onedrive._client import (GraphError, graph_get_bytes,
+                                          item_url, split_path)
+from mirage.observe.context import record, revision_for
+from mirage.types import PathSpec
+
+
+def _range_header(offset: int, size: int | None) -> str | None:
+    if not offset and size is None:
+        return None
+    end = (offset + size - 1) if size is not None else ""
+    return f"bytes={offset}-{end}"
+
+
+async def read_bytes(accessor: OneDriveAccessor,
+                     path: PathSpec,
+                     index: IndexCacheStore = None,
+                     offset: int = 0,
+                     size: int | None = None) -> bytes:
+    virtual = path.original if isinstance(path, PathSpec) else path
+    prefix, stripped = split_path(path)
+    config = accessor.config
+    pinned = revision_for(virtual)
+    if pinned:
+        action = f"/versions/{quote(pinned, safe='')}/content"
+    else:
+        action = "/content"
+    url = item_url(config, "/" + stripped, action=action)
+    range_header = _range_header(offset, size)
+    start_ms = int(time.monotonic() * 1000)
+    try:
+        data = await graph_get_bytes(config, url, range_header)
+    except GraphError as exc:
+        if exc.status == 404:
+            raise FileNotFoundError(stripped)
+        raise
+    record("read", stripped, "onedrive", len(data), start_ms, revision=pinned)
+    return data

--- a/python/mirage/core/onedrive/read.py
+++ b/python/mirage/core/onedrive/read.py
@@ -19,7 +19,7 @@ from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.onedrive._client import (GraphError, graph_get_bytes,
                                           item_url, split_path)
-from mirage.core.onedrive.versions import current_fingerprint_revision
+from mirage.core.onedrive.versions import capture_metadata
 from mirage.observe.context import active_recorder, record, revision_for
 from mirage.types import PathSpec
 
@@ -40,24 +40,33 @@ async def read_bytes(accessor: OneDriveAccessor,
     prefix, stripped = split_path(path)
     config = accessor.config
     pinned = revision_for(virtual)
-    if pinned:
-        action = f"/versions/{quote(pinned, safe='')}/content"
-    else:
-        action = "/content"
-    url = item_url(config, "/" + stripped, action=action)
     range_header = _range_header(offset, size)
     start_ms = int(time.monotonic() * 1000)
+    fingerprint = None
+    revision = pinned
     try:
-        data = await graph_get_bytes(config, url, range_header)
+        if pinned:
+            action = f"/versions/{quote(pinned, safe='')}/content"
+            url = item_url(config, "/" + stripped, action=action)
+            data = await graph_get_bytes(config, url, range_header)
+        elif active_recorder() is not None:
+            fingerprint, revision, download_url = await capture_metadata(
+                accessor, path)
+            if download_url:
+                data = await graph_get_bytes(config,
+                                             download_url,
+                                             range_header,
+                                             auth=False)
+            else:
+                url = item_url(config, "/" + stripped, action="/content")
+                data = await graph_get_bytes(config, url, range_header)
+        else:
+            url = item_url(config, "/" + stripped, action="/content")
+            data = await graph_get_bytes(config, url, range_header)
     except GraphError as exc:
         if exc.status == 404:
             raise FileNotFoundError(stripped)
         raise
-    fingerprint = None
-    revision = pinned
-    if pinned is None and active_recorder() is not None:
-        fingerprint, revision = await current_fingerprint_revision(
-            accessor, path)
     record("read",
            stripped,
            "onedrive",

--- a/python/mirage/core/onedrive/read.py
+++ b/python/mirage/core/onedrive/read.py
@@ -19,7 +19,8 @@ from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.onedrive._client import (GraphError, graph_get_bytes,
                                           item_url, split_path)
-from mirage.observe.context import record, revision_for
+from mirage.core.onedrive.versions import current_fingerprint_revision
+from mirage.observe.context import active_recorder, record, revision_for
 from mirage.types import PathSpec
 
 
@@ -52,5 +53,16 @@ async def read_bytes(accessor: OneDriveAccessor,
         if exc.status == 404:
             raise FileNotFoundError(stripped)
         raise
-    record("read", stripped, "onedrive", len(data), start_ms, revision=pinned)
+    fingerprint = None
+    revision = pinned
+    if pinned is None and active_recorder() is not None:
+        fingerprint, revision = await current_fingerprint_revision(
+            accessor, path)
+    record("read",
+           stripped,
+           "onedrive",
+           len(data),
+           start_ms,
+           fingerprint=fingerprint,
+           revision=revision)
     return data

--- a/python/mirage/core/onedrive/readdir.py
+++ b/python/mirage/core/onedrive/readdir.py
@@ -1,0 +1,60 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore, IndexEntry
+from mirage.core.onedrive._client import graph_list, item_url
+from mirage.types import PathSpec
+
+
+async def readdir(accessor: OneDriveAccessor, path: PathSpec,
+                  index: IndexCacheStore) -> list[str]:
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    prefix = path.prefix or ""
+    raw = path.directory if path.pattern else path.original
+    if prefix and raw.startswith(prefix):
+        rest = raw[len(prefix):]
+        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
+            raw = rest or "/"
+    stripped = raw.strip("/")
+    virtual_key = (prefix + "/" + stripped if prefix else "/" + stripped) \
+        if stripped else (prefix or "/")
+    listing = await index.list_dir(virtual_key)
+    if listing.entries is not None:
+        return listing.entries
+
+    url = item_url(accessor.config,
+                   "/" + stripped if stripped else "/",
+                   action="/children")
+    children = await graph_list(accessor.config, url)
+    base = "/" + stripped if stripped else ""
+    names: list[str] = []
+    index_entries: list[tuple[str, IndexEntry]] = []
+    for child in children:
+        cname = child.get("name", "")
+        key = f"{base}/{cname}"
+        names.append(key)
+        if "folder" in child:
+            entry = IndexEntry(id=key, name=cname, resource_type="folder")
+        else:
+            entry = IndexEntry(id=key,
+                               name=cname,
+                               resource_type="file",
+                               size=child.get("size"))
+        index_entries.append((cname, entry))
+    names = sorted(names)
+    virtual_entries = sorted((prefix + e if prefix else e) for e in names)
+    await index.set_dir(virtual_key, index_entries)
+    return virtual_entries

--- a/python/mirage/core/onedrive/rename.py
+++ b/python/mirage/core/onedrive/rename.py
@@ -1,0 +1,36 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import posixpath
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive._client import (drive_ref_path, graph_patch,
+                                          item_url, split_path)
+from mirage.types import PathSpec
+
+
+async def rename(accessor: OneDriveAccessor, src: PathSpec,
+                 dst: PathSpec) -> None:
+    _, src_s = split_path(src)
+    _, dst_s = split_path(dst)
+    src_parent = posixpath.dirname("/" + src_s).strip("/")
+    dst_parent = posixpath.dirname("/" + dst_s).strip("/")
+    name = posixpath.basename(dst_s)
+    body: dict = {"name": name}
+    if dst_parent != src_parent:
+        body["parentReference"] = {
+            "path": drive_ref_path(accessor.config, dst_parent)
+        }
+    await graph_patch(accessor.config, item_url(accessor.config, "/" + src_s),
+                      body)

--- a/python/mirage/core/onedrive/rm.py
+++ b/python/mirage/core/onedrive/rm.py
@@ -1,0 +1,25 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive._client import graph_delete, item_url, split_path
+from mirage.types import PathSpec
+
+
+async def rm_r(accessor: OneDriveAccessor, path: PathSpec) -> None:
+    _, stripped = split_path(path)
+    if not stripped:
+        return
+    await graph_delete(accessor.config,
+                       item_url(accessor.config, "/" + stripped))

--- a/python/mirage/core/onedrive/rmdir.py
+++ b/python/mirage/core/onedrive/rmdir.py
@@ -1,0 +1,25 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive._client import graph_delete, item_url, split_path
+from mirage.types import PathSpec
+
+
+async def rmdir(accessor: OneDriveAccessor, path: PathSpec) -> None:
+    _, stripped = split_path(path)
+    if not stripped:
+        return
+    await graph_delete(accessor.config,
+                       item_url(accessor.config, "/" + stripped))

--- a/python/mirage/core/onedrive/stat.py
+++ b/python/mirage/core/onedrive/stat.py
@@ -1,0 +1,70 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.onedrive._client import (GraphError, graph_get, item_url,
+                                          split_path)
+from mirage.types import FileStat, FileType, PathSpec
+from mirage.utils.filetype import guess_type
+
+
+def _entry_stat(item: dict) -> FileStat:
+    name = item.get("name", "")
+    if "folder" in item:
+        return FileStat(name=name, type=FileType.DIRECTORY)
+    return FileStat(
+        name=name,
+        size=item.get("size"),
+        modified=item.get("lastModifiedDateTime"),
+        type=guess_type(name),
+        fingerprint=item.get("cTag"),
+        extra={
+            "id": item.get("id"),
+            "ctag": item.get("cTag"),
+            "etag": item.get("eTag"),
+        },
+    )
+
+
+async def stat(accessor: OneDriveAccessor,
+               path: PathSpec,
+               index: IndexCacheStore = None) -> FileStat:
+    prefix, stripped = split_path(path)
+    if not stripped:
+        return FileStat(name="/", type=FileType.DIRECTORY)
+
+    if index is not None:
+        virtual_key = (prefix + "/" + stripped if prefix else "/" + stripped)
+        lookup = await index.get(virtual_key)
+        if lookup.entry is not None:
+            entry = lookup.entry
+            if entry.resource_type == "folder":
+                return FileStat(name=entry.name, type=FileType.DIRECTORY)
+            return FileStat(name=entry.name,
+                            size=entry.size,
+                            type=guess_type(entry.name))
+        parent = virtual_key.rsplit("/", 1)[0] or "/"
+        parent_listing = await index.list_dir(parent)
+        if parent_listing.entries is not None:
+            raise FileNotFoundError(stripped)
+
+    try:
+        item = await graph_get(accessor.config,
+                               item_url(accessor.config, "/" + stripped))
+    except GraphError as exc:
+        if exc.status == 404:
+            raise FileNotFoundError(stripped)
+        raise
+    return _entry_stat(item)

--- a/python/mirage/core/onedrive/stream.py
+++ b/python/mirage/core/onedrive/stream.py
@@ -1,0 +1,52 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+from urllib.parse import quote
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.onedrive._client import graph_stream, item_url, split_path
+from mirage.core.onedrive.read import read_bytes
+from mirage.observe.context import record_stream, revision_for
+from mirage.types import PathSpec
+
+
+async def read_stream(
+    accessor: OneDriveAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+    chunk_size: int = 8192,
+) -> AsyncIterator[bytes]:
+    virtual = path.original if isinstance(path, PathSpec) else path
+    prefix, stripped = split_path(path)
+    config = accessor.config
+    pinned = revision_for(virtual)
+    if pinned:
+        action = f"/versions/{quote(pinned, safe='')}/content"
+    else:
+        action = "/content"
+    url = item_url(config, "/" + stripped, action=action)
+    rec = record_stream("read", stripped, "onedrive")
+    if rec is not None:
+        rec.revision = pinned
+    async for chunk in graph_stream(config, url, chunk_size):
+        if rec is not None:
+            rec.bytes += len(chunk)
+        yield chunk
+
+
+async def range_read(accessor: OneDriveAccessor, path: PathSpec, start: int,
+                     end: int) -> bytes:
+    return await read_bytes(accessor, path, offset=start, size=end - start)

--- a/python/mirage/core/onedrive/stream.py
+++ b/python/mirage/core/onedrive/stream.py
@@ -19,7 +19,7 @@ from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.onedrive._client import graph_stream, item_url, split_path
 from mirage.core.onedrive.read import read_bytes
-from mirage.core.onedrive.versions import current_fingerprint_revision
+from mirage.core.onedrive.versions import capture_metadata
 from mirage.observe.context import record_stream, revision_for
 from mirage.types import PathSpec
 
@@ -34,19 +34,21 @@ async def read_stream(
     prefix, stripped = split_path(path)
     config = accessor.config
     pinned = revision_for(virtual)
-    if pinned:
-        action = f"/versions/{quote(pinned, safe='')}/content"
-    else:
-        action = "/content"
-    url = item_url(config, "/" + stripped, action=action)
     rec = record_stream("read", stripped, "onedrive")
-    if rec is not None:
-        if pinned is not None:
+    url = item_url(config, "/" + stripped, action="/content")
+    auth = True
+    if pinned is not None:
+        action = f"/versions/{quote(pinned, safe='')}/content"
+        url = item_url(config, "/" + stripped, action=action)
+        if rec is not None:
             rec.revision = pinned
-        else:
-            rec.fingerprint, rec.revision = await current_fingerprint_revision(
-                accessor, path)
-    async for chunk in graph_stream(config, url, chunk_size):
+    elif rec is not None:
+        rec.fingerprint, rec.revision, download_url = await capture_metadata(
+            accessor, path)
+        if download_url:
+            url = download_url
+            auth = False
+    async for chunk in graph_stream(config, url, chunk_size, auth=auth):
         if rec is not None:
             rec.bytes += len(chunk)
         yield chunk

--- a/python/mirage/core/onedrive/stream.py
+++ b/python/mirage/core/onedrive/stream.py
@@ -17,7 +17,8 @@ from urllib.parse import quote
 
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.core.onedrive._client import graph_stream, item_url, split_path
+from mirage.core.onedrive._client import (GraphError, graph_stream, item_url,
+                                          split_path)
 from mirage.core.onedrive.read import read_bytes
 from mirage.core.onedrive.versions import capture_metadata
 from mirage.observe.context import record_stream, revision_for
@@ -48,10 +49,15 @@ async def read_stream(
         if download_url:
             url = download_url
             auth = False
-    async for chunk in graph_stream(config, url, chunk_size, auth=auth):
-        if rec is not None:
-            rec.bytes += len(chunk)
-        yield chunk
+    try:
+        async for chunk in graph_stream(config, url, chunk_size, auth=auth):
+            if rec is not None:
+                rec.bytes += len(chunk)
+            yield chunk
+    except GraphError as exc:
+        if exc.status == 404:
+            raise FileNotFoundError(stripped)
+        raise
 
 
 async def range_read(accessor: OneDriveAccessor, path: PathSpec, start: int,

--- a/python/mirage/core/onedrive/stream.py
+++ b/python/mirage/core/onedrive/stream.py
@@ -19,6 +19,7 @@ from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.onedrive._client import graph_stream, item_url, split_path
 from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.versions import current_fingerprint_revision
 from mirage.observe.context import record_stream, revision_for
 from mirage.types import PathSpec
 
@@ -40,7 +41,11 @@ async def read_stream(
     url = item_url(config, "/" + stripped, action=action)
     rec = record_stream("read", stripped, "onedrive")
     if rec is not None:
-        rec.revision = pinned
+        if pinned is not None:
+            rec.revision = pinned
+        else:
+            rec.fingerprint, rec.revision = await current_fingerprint_revision(
+                accessor, path)
     async for chunk in graph_stream(config, url, chunk_size):
         if rec is not None:
             rec.bytes += len(chunk)

--- a/python/mirage/core/onedrive/truncate.py
+++ b/python/mirage/core/onedrive/truncate.py
@@ -1,0 +1,31 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.write import write_bytes
+from mirage.types import PathSpec
+
+
+async def truncate(accessor: OneDriveAccessor, path: PathSpec,
+                   length: int) -> None:
+    try:
+        data = await read_bytes(accessor, path)
+    except FileNotFoundError:
+        data = b""
+    if length <= len(data):
+        new = data[:length]
+    else:
+        new = data + b"\x00" * (length - len(data))
+    await write_bytes(accessor, path, new)

--- a/python/mirage/core/onedrive/unlink.py
+++ b/python/mirage/core/onedrive/unlink.py
@@ -1,0 +1,29 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive._client import (GraphError, graph_delete, item_url,
+                                          split_path)
+from mirage.types import PathSpec
+
+
+async def unlink(accessor: OneDriveAccessor, path: PathSpec) -> None:
+    _, stripped = split_path(path)
+    try:
+        await graph_delete(accessor.config,
+                           item_url(accessor.config, "/" + stripped))
+    except GraphError as exc:
+        if exc.status == 404:
+            raise FileNotFoundError(stripped)
+        raise

--- a/python/mirage/core/onedrive/versions.py
+++ b/python/mirage/core/onedrive/versions.py
@@ -1,0 +1,43 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from urllib.parse import quote
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive._client import (graph_list, graph_post, item_url,
+                                          split_path)
+from mirage.types import PathSpec
+
+
+async def list_versions(accessor: OneDriveAccessor,
+                        path: PathSpec) -> list[dict]:
+    _, stripped = split_path(path)
+    url = item_url(accessor.config, "/" + stripped, action="/versions")
+    return await graph_list(accessor.config, url)
+
+
+async def current_version_id(accessor: OneDriveAccessor,
+                             path: PathSpec) -> str | None:
+    versions = await list_versions(accessor, path)
+    if not versions:
+        return None
+    return versions[0].get("id")
+
+
+async def restore_version(accessor: OneDriveAccessor, path: PathSpec,
+                          version_id: str) -> None:
+    _, stripped = split_path(path)
+    action = f"/versions/{quote(version_id, safe='')}/restoreVersion"
+    url = item_url(accessor.config, "/" + stripped, action=action)
+    await graph_post(accessor.config, url)

--- a/python/mirage/core/onedrive/versions.py
+++ b/python/mirage/core/onedrive/versions.py
@@ -40,15 +40,18 @@ async def current_version_id(accessor: OneDriveAccessor,
     return _current_version_id(versions)
 
 
-async def current_fingerprint_revision(
+async def capture_metadata(
         accessor: OneDriveAccessor,
-        path: PathSpec) -> tuple[str | None, str | None]:
+        path: PathSpec) -> tuple[str | None, str | None, str | None]:
     _, stripped = split_path(path)
     config = accessor.config
-    item = await graph_get(config, item_url(config, "/" + stripped))
-    versions = await graph_list(
-        config, item_url(config, "/" + stripped, action="/versions"))
-    return item.get("cTag"), _current_version_id(versions)
+    item = await graph_get(config,
+                           item_url(config, "/" + stripped),
+                           params={"$expand": "versions"})
+    fingerprint = item.get("cTag")
+    revision = _current_version_id(item.get("versions", []))
+    download_url = item.get("@microsoft.graph.downloadUrl")
+    return fingerprint, revision, download_url
 
 
 async def restore_version(accessor: OneDriveAccessor, path: PathSpec,

--- a/python/mirage/core/onedrive/versions.py
+++ b/python/mirage/core/onedrive/versions.py
@@ -15,9 +15,16 @@
 from urllib.parse import quote
 
 from mirage.accessor.onedrive import OneDriveAccessor
-from mirage.core.onedrive._client import (graph_list, graph_post, item_url,
-                                          split_path)
+from mirage.core.onedrive._client import (graph_get, graph_list, graph_post,
+                                          item_url, split_path)
 from mirage.types import PathSpec
+
+
+def _current_version_id(versions: list[dict]) -> str | None:
+    if not versions:
+        return None
+    current = max(versions, key=lambda v: v.get("lastModifiedDateTime") or "")
+    return current.get("id")
 
 
 async def list_versions(accessor: OneDriveAccessor,
@@ -30,9 +37,18 @@ async def list_versions(accessor: OneDriveAccessor,
 async def current_version_id(accessor: OneDriveAccessor,
                              path: PathSpec) -> str | None:
     versions = await list_versions(accessor, path)
-    if not versions:
-        return None
-    return versions[0].get("id")
+    return _current_version_id(versions)
+
+
+async def current_fingerprint_revision(
+        accessor: OneDriveAccessor,
+        path: PathSpec) -> tuple[str | None, str | None]:
+    _, stripped = split_path(path)
+    config = accessor.config
+    item = await graph_get(config, item_url(config, "/" + stripped))
+    versions = await graph_list(
+        config, item_url(config, "/" + stripped, action="/versions"))
+    return item.get("cTag"), _current_version_id(versions)
 
 
 async def restore_version(accessor: OneDriveAccessor, path: PathSpec,

--- a/python/mirage/core/onedrive/write.py
+++ b/python/mirage/core/onedrive/write.py
@@ -1,0 +1,53 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import time
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive._client import (graph_post, graph_put_bytes,
+                                          item_url, split_path, upload_chunk)
+from mirage.observe.context import record
+from mirage.types import PathSpec
+
+SIMPLE_UPLOAD_MAX = 4 * 1024 * 1024
+UPLOAD_CHUNK = 10 * 327680
+
+
+async def _upload_session(accessor: OneDriveAccessor, stripped: str,
+                          data: bytes) -> None:
+    config = accessor.config
+    session_url = item_url(config,
+                           "/" + stripped,
+                           action="/createUploadSession")
+    session = await graph_post(config, session_url)
+    upload_url = session["uploadUrl"]
+    total = len(data)
+    start = 0
+    while start < total:
+        chunk = data[start:start + UPLOAD_CHUNK]
+        await upload_chunk(config, upload_url, chunk, start, total)
+        start += len(chunk)
+
+
+async def write_bytes(accessor: OneDriveAccessor, path: PathSpec,
+                      data: bytes) -> None:
+    prefix, stripped = split_path(path)
+    config = accessor.config
+    start_ms = int(time.monotonic() * 1000)
+    if len(data) <= SIMPLE_UPLOAD_MAX:
+        url = item_url(config, "/" + stripped, action="/content")
+        await graph_put_bytes(config, url, data)
+    else:
+        await _upload_session(accessor, stripped, data)
+    record("write", stripped, "onedrive", len(data), start_ms)

--- a/python/mirage/core/onedrive/write.py
+++ b/python/mirage/core/onedrive/write.py
@@ -36,8 +36,12 @@ async def _upload_session(accessor: OneDriveAccessor, stripped: str,
     start = 0
     while start < total:
         chunk = data[start:start + UPLOAD_CHUNK]
-        await upload_chunk(config, upload_url, chunk, start, total)
-        start += len(chunk)
+        result = await upload_chunk(config, upload_url, chunk, start, total)
+        ranges = result.get("nextExpectedRanges") if result else None
+        if ranges:
+            start = int(ranges[0].split("-", 1)[0])
+        else:
+            start += len(chunk)
 
 
 async def write_bytes(accessor: OneDriveAccessor, path: PathSpec,

--- a/python/mirage/ops/onedrive/__init__.py
+++ b/python/mirage/ops/onedrive/__init__.py
@@ -1,0 +1,40 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.commands.optional import try_load_command
+from mirage.ops.onedrive.create import create
+from mirage.ops.onedrive.mkdir import mkdir
+from mirage.ops.onedrive.read.read import read
+from mirage.ops.onedrive.readdir import readdir
+from mirage.ops.onedrive.rename import rename
+from mirage.ops.onedrive.rmdir import rmdir
+from mirage.ops.onedrive.stat import stat
+from mirage.ops.onedrive.truncate import truncate
+from mirage.ops.onedrive.unlink import unlink
+from mirage.ops.onedrive.write import write as write_bytes
+
+read_feather = try_load_command("mirage.ops.onedrive.read.read_feather",
+                                "read_feather", "parquet")
+read_hdf5 = try_load_command("mirage.ops.onedrive.read.read_hdf5", "read_hdf5",
+                             "hdf5")
+read_orc = try_load_command("mirage.ops.onedrive.read.read_orc", "read_orc",
+                            "parquet")
+read_parquet = try_load_command("mirage.ops.onedrive.read.read_parquet",
+                                "read_parquet", "parquet")
+
+OPS = [
+    c for c in (create, mkdir, read, read_feather, read_hdf5, read_orc,
+                read_parquet, readdir, rename, rmdir, stat, truncate, unlink,
+                write_bytes) if c is not None
+]

--- a/python/mirage/ops/onedrive/create.py
+++ b/python/mirage/ops/onedrive/create.py
@@ -1,0 +1,23 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive.write import write_bytes
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("create", resource="onedrive", write=True)
+async def create(accessor: OneDriveAccessor, path: PathSpec, **kwargs) -> None:
+    await write_bytes(accessor, path, b"")

--- a/python/mirage/ops/onedrive/mkdir.py
+++ b/python/mirage/ops/onedrive/mkdir.py
@@ -1,0 +1,23 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive.mkdir import mkdir as mkdir_impl
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("mkdir", resource="onedrive", write=True)
+async def mkdir(accessor: OneDriveAccessor, path: PathSpec, **kwargs) -> None:
+    await mkdir_impl(accessor, path)

--- a/python/mirage/ops/onedrive/read/__init__.py
+++ b/python/mirage/ops/onedrive/read/__init__.py
@@ -1,0 +1,13 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========

--- a/python/mirage/ops/onedrive/read/read.py
+++ b/python/mirage/ops/onedrive/read/read.py
@@ -1,0 +1,24 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive.read import read_bytes
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("read", resource="onedrive")
+async def read(accessor: OneDriveAccessor, path: PathSpec, *, index,
+               **kwargs) -> bytes:
+    return await read_bytes(accessor, path, index)

--- a/python/mirage/ops/onedrive/read/read_feather.py
+++ b/python/mirage/ops/onedrive/read/read_feather.py
@@ -1,0 +1,26 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.filetype.feather import cat as feather_cat
+from mirage.core.onedrive.read import read_bytes
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("read", resource="onedrive", filetype=".feather")
+async def read_feather(accessor: OneDriveAccessor, path: PathSpec, *, index,
+                       **kwargs) -> bytes:
+    raw = await read_bytes(accessor, path, index)
+    return feather_cat(raw)

--- a/python/mirage/ops/onedrive/read/read_hdf5.py
+++ b/python/mirage/ops/onedrive/read/read_hdf5.py
@@ -1,0 +1,26 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.filetype.hdf5 import cat as hdf5_cat
+from mirage.core.onedrive.read import read_bytes
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("read", resource="onedrive", filetype=".hdf5")
+async def read_hdf5(accessor: OneDriveAccessor, path: PathSpec, *, index,
+                    **kwargs) -> bytes:
+    raw = await read_bytes(accessor, path, index)
+    return hdf5_cat(raw)

--- a/python/mirage/ops/onedrive/read/read_orc.py
+++ b/python/mirage/ops/onedrive/read/read_orc.py
@@ -1,0 +1,26 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.filetype.orc import cat as orc_cat
+from mirage.core.onedrive.read import read_bytes
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("read", resource="onedrive", filetype=".orc")
+async def read_orc(accessor: OneDriveAccessor, path: PathSpec, *, index,
+                   **kwargs) -> bytes:
+    raw = await read_bytes(accessor, path, index)
+    return orc_cat(raw)

--- a/python/mirage/ops/onedrive/read/read_parquet.py
+++ b/python/mirage/ops/onedrive/read/read_parquet.py
@@ -1,0 +1,26 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.filetype.parquet import cat as parquet_cat
+from mirage.core.onedrive.read import read_bytes
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("read", resource="onedrive", filetype=".parquet")
+async def read_parquet(accessor: OneDriveAccessor, path: PathSpec, *, index,
+                       **kwargs) -> bytes:
+    raw = await read_bytes(accessor, path, index)
+    return parquet_cat(raw)

--- a/python/mirage/ops/onedrive/readdir.py
+++ b/python/mirage/ops/onedrive/readdir.py
@@ -1,0 +1,24 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive.readdir import readdir as readdir_impl
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("readdir", resource="onedrive")
+async def readdir(accessor: OneDriveAccessor, path: PathSpec, *, index,
+                  **kwargs) -> list[str]:
+    return await readdir_impl(accessor, path, index)

--- a/python/mirage/ops/onedrive/rename.py
+++ b/python/mirage/ops/onedrive/rename.py
@@ -1,0 +1,24 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive.rename import rename as rename_impl
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("rename", resource="onedrive", write=True)
+async def rename(accessor: OneDriveAccessor, src: PathSpec, dst: PathSpec,
+                 **kwargs) -> None:
+    await rename_impl(accessor, src, dst)

--- a/python/mirage/ops/onedrive/rmdir.py
+++ b/python/mirage/ops/onedrive/rmdir.py
@@ -1,0 +1,23 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive.rmdir import rmdir as rmdir_impl
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("rmdir", resource="onedrive", write=True)
+async def rmdir(accessor: OneDriveAccessor, path: PathSpec, **kwargs) -> None:
+    await rmdir_impl(accessor, path)

--- a/python/mirage/ops/onedrive/stat.py
+++ b/python/mirage/ops/onedrive/stat.py
@@ -1,0 +1,24 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive.stat import stat as stat_impl
+from mirage.ops.registry import op
+from mirage.types import FileStat, PathSpec
+
+
+@op("stat", resource="onedrive")
+async def stat(accessor: OneDriveAccessor, path: PathSpec, *, index,
+               **kwargs) -> FileStat:
+    return await stat_impl(accessor, path, index)

--- a/python/mirage/ops/onedrive/truncate.py
+++ b/python/mirage/ops/onedrive/truncate.py
@@ -1,0 +1,24 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive.truncate import truncate as truncate_impl
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("truncate", resource="onedrive", write=True)
+async def truncate(accessor: OneDriveAccessor, path: PathSpec, length: int,
+                   **kwargs) -> None:
+    await truncate_impl(accessor, path, length)

--- a/python/mirage/ops/onedrive/unlink.py
+++ b/python/mirage/ops/onedrive/unlink.py
@@ -1,0 +1,23 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive.unlink import unlink as unlink_impl
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("unlink", resource="onedrive", write=True)
+async def unlink(accessor: OneDriveAccessor, path: PathSpec, **kwargs) -> None:
+    await unlink_impl(accessor, path)

--- a/python/mirage/ops/onedrive/write.py
+++ b/python/mirage/ops/onedrive/write.py
@@ -1,0 +1,24 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.onedrive.write import write_bytes
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("write", resource="onedrive", write=True)
+async def write(accessor: OneDriveAccessor, path: PathSpec, data: bytes,
+                **kwargs) -> None:
+    await write_bytes(accessor, path, data)

--- a/python/mirage/resource/onedrive/__init__.py
+++ b/python/mirage/resource/onedrive/__init__.py
@@ -1,0 +1,18 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.onedrive import OneDriveConfig
+from mirage.resource.onedrive.onedrive import OneDriveResource
+
+__all__ = ["OneDriveResource", "OneDriveConfig"]

--- a/python/mirage/resource/onedrive/onedrive.py
+++ b/python/mirage/resource/onedrive/onedrive.py
@@ -1,0 +1,101 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import dataclasses
+from typing import Any
+
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.commands.builtin.onedrive import COMMANDS as ONEDRIVE_COMMANDS
+from mirage.core.onedrive.copy import copy
+from mirage.core.onedrive.create import create
+from mirage.core.onedrive.du import du, du_all
+from mirage.core.onedrive.exists import exists
+from mirage.core.onedrive.find import find
+from mirage.core.onedrive.glob import resolve_glob as _resolve_glob
+from mirage.core.onedrive.mkdir import mkdir
+from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.readdir import readdir
+from mirage.core.onedrive.rename import rename
+from mirage.core.onedrive.rm import rm_r
+from mirage.core.onedrive.rmdir import rmdir
+from mirage.core.onedrive.stat import stat as onedrive_stat
+from mirage.core.onedrive.stream import range_read, read_stream
+from mirage.core.onedrive.truncate import truncate
+from mirage.core.onedrive.unlink import unlink
+from mirage.core.onedrive.write import write_bytes
+from mirage.ops.onedrive import OPS as ONEDRIVE_OPS
+from mirage.resource.base import BaseResource
+from mirage.resource.onedrive.prompt import PROMPT
+from mirage.types import PathSpec, ResourceName
+
+_ONEDRIVE_OPS = {
+    "read_bytes": read_bytes,
+    "write": write_bytes,
+    "readdir": readdir,
+    "stat": onedrive_stat,
+    "unlink": unlink,
+    "rmdir": rmdir,
+    "copy": copy,
+    "rename": rename,
+    "mkdir": mkdir,
+    "read_stream": read_stream,
+    "range_read": range_read,
+    "rm_recursive": rm_r,
+    "du_total": du,
+    "du_all": du_all,
+    "create": create,
+    "truncate": truncate,
+    "exists": exists,
+    "find_flat": find,
+}
+
+
+class OneDriveResource(BaseResource):
+
+    name: str = ResourceName.ONEDRIVE
+    is_remote: bool = True
+    _ops: dict[str, Any] = _ONEDRIVE_OPS
+    PROMPT: str = PROMPT
+    SUPPORTS_SNAPSHOT: bool = True
+
+    def __init__(self, config: OneDriveConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.accessor = OneDriveAccessor(self.config)
+        for fn in ONEDRIVE_COMMANDS:
+            self.register(fn)
+        for fn in ONEDRIVE_OPS:
+            self.register_op(fn)
+
+    async def resolve_glob(self, paths, prefix: str = ""):
+        if prefix:
+            paths = [
+                dataclasses.replace(p, prefix=prefix)
+                if isinstance(p, PathSpec) and not p.prefix else p
+                for p in paths
+            ]
+        return await _resolve_glob(self.accessor, paths, self._index)
+
+    async def fingerprint(self, path: str) -> str | None:
+        try:
+            remote = await onedrive_stat(self.accessor, path)
+            return remote.fingerprint
+        except FileNotFoundError:
+            return None
+
+    def get_state(self) -> dict:
+        return self.config_state(self.config)
+
+    def load_state(self, state: dict) -> None:
+        pass

--- a/python/mirage/resource/onedrive/prompt.py
+++ b/python/mirage/resource/onedrive/prompt.py
@@ -1,0 +1,23 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+PROMPT = """\
+{prefix}
+  Remote OneDrive / SharePoint document library. Maps driveItem paths to \
+virtual paths.
+  IMPORTANT: This is a remote mount. Prefer targeted reads (grep, head) \
+over full scans. Avoid cat on large files without piping to head/tail.
+  Supports: ls, cat, head, tail, grep, rg, wc, find, tree, jq, stat.
+  cat on .parquet/.orc/.feather returns a formatted table.
+  File versions are retained, snapshots pin and read prior versions."""

--- a/python/mirage/resource/registry.py
+++ b/python/mirage/resource/registry.py
@@ -86,6 +86,9 @@ REGISTRY: dict[str, ResourceEntry] = {
     "hf_spaces":
     ResourceEntry("mirage.resource.hf_spaces:HfSpacesResource",
                   "mirage.resource.hf_spaces:HfSpacesConfig"),
+    "onedrive":
+    ResourceEntry("mirage.resource.onedrive:OneDriveResource",
+                  "mirage.resource.onedrive:OneDriveConfig"),
     "github":
     ResourceEntry("mirage.resource.github:GitHubResource",
                   "mirage.resource.github:GitHubConfig"),

--- a/python/mirage/types.py
+++ b/python/mirage/types.py
@@ -185,6 +185,7 @@ class ResourceName(str, Enum):
     HF_SPACES = "hf_spaces"
     NEXTCLOUD = "nextcloud"
     LANCEDB = "lancedb"
+    ONEDRIVE = "onedrive"
 
 
 @dataclass(frozen=True)

--- a/python/tests/core/onedrive/test_client.py
+++ b/python/tests/core/onedrive/test_client.py
@@ -1,0 +1,116 @@
+import pytest
+from aioresponses import aioresponses
+
+from mirage.accessor.onedrive import OneDriveConfig
+from mirage.core.onedrive._client import (GraphError, drive_base, graph_get,
+                                          graph_get_bytes, graph_list, headers,
+                                          item_url)
+
+
+def _cfg(**kw) -> OneDriveConfig:
+    return OneDriveConfig(access_token="tok", **kw)
+
+
+def test_drive_base_defaults_to_me_drive():
+    assert drive_base(_cfg()) == "https://graph.microsoft.com/v1.0/me/drive"
+
+
+def test_drive_base_uses_drive_id():
+    base = drive_base(_cfg(drive_id="b!abc"))
+    assert base == "https://graph.microsoft.com/v1.0/drives/b!abc"
+
+
+def test_drive_base_uses_site_default_drive():
+    base = drive_base(_cfg(site_id="site123"))
+    assert base == "https://graph.microsoft.com/v1.0/sites/site123/drive"
+
+
+def test_item_url_root_children():
+    url = item_url(_cfg(), "/", action="/children")
+    assert url == "https://graph.microsoft.com/v1.0/me/drive/root/children"
+
+
+def test_item_url_nested_metadata_no_action():
+    url = item_url(_cfg(), "/Docs/report.docx")
+    assert url == (
+        "https://graph.microsoft.com/v1.0/me/drive/root:/Docs/report.docx")
+
+
+def test_item_url_nested_content():
+    url = item_url(_cfg(), "/Docs/report.docx", action="/content")
+    assert url == ("https://graph.microsoft.com/v1.0/me/drive"
+                   "/root:/Docs/report.docx:/content")
+
+
+def test_item_url_nested_children():
+    url = item_url(_cfg(), "/Docs", action="/children")
+    assert url == (
+        "https://graph.microsoft.com/v1.0/me/drive/root:/Docs:/children")
+
+
+def test_item_url_applies_key_prefix():
+    url = item_url(_cfg(key_prefix="team/files"), "/a.txt", action="/content")
+    assert url == ("https://graph.microsoft.com/v1.0/me/drive"
+                   "/root:/team/files/a.txt:/content")
+
+
+def test_item_url_quotes_spaces():
+    url = item_url(_cfg(), "/My Folder/a b.txt")
+    assert url == ("https://graph.microsoft.com/v1.0/me/drive"
+                   "/root:/My%20Folder/a%20b.txt")
+
+
+def test_headers_carry_bearer_token():
+    h = headers(_cfg())
+    assert h["Authorization"] == "Bearer tok"
+
+
+_ROOT = "https://graph.microsoft.com/v1.0/me/drive/root"
+
+
+@pytest.mark.asyncio
+async def test_graph_get_returns_parsed_json():
+    with aioresponses() as m:
+        m.get(_ROOT, payload={"id": "01ABC", "name": "root"})
+        result = await graph_get(_cfg(), _ROOT)
+    assert result["id"] == "01ABC"
+
+
+@pytest.mark.asyncio
+async def test_graph_get_raises_grapherror_with_status():
+    with aioresponses() as m:
+        m.get(_ROOT,
+              status=404,
+              payload={"error": {
+                  "code": "itemNotFound",
+                  "message": "nope"
+              }})
+        with pytest.raises(GraphError) as exc:
+            await graph_get(_cfg(), _ROOT)
+    assert exc.value.status == 404
+    assert exc.value.code == "itemNotFound"
+
+
+@pytest.mark.asyncio
+async def test_graph_list_follows_odata_nextlink():
+    page2 = _ROOT + "/children?$skiptoken=abc"
+    with aioresponses() as m:
+        m.get(_ROOT + "/children",
+              payload={
+                  "value": [{
+                      "id": "a"
+                  }],
+                  "@odata.nextLink": page2
+              })
+        m.get(page2, payload={"value": [{"id": "b"}]})
+        items = await graph_list(_cfg(), _ROOT + "/children")
+    assert [i["id"] for i in items] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_graph_get_bytes_returns_raw_content():
+    url = _ROOT + ":/a.txt:/content"
+    with aioresponses() as m:
+        m.get(url, body=b"hello bytes")
+        data = await graph_get_bytes(_cfg(), url)
+    assert data == b"hello bytes"

--- a/python/tests/core/onedrive/test_client.py
+++ b/python/tests/core/onedrive/test_client.py
@@ -138,3 +138,32 @@ async def test_request_gives_up_after_max_retries():
         with pytest.raises(GraphError) as exc:
             await graph_get(_cfg(max_retries=2), _ROOT)
     assert exc.value.status == 429
+
+
+@pytest.mark.asyncio
+async def test_401_refreshes_callable_token_once_then_succeeds():
+    calls = {"n": 0}
+
+    def provider():
+        calls["n"] += 1
+        return "fresh" if calls["n"] > 1 else "stale"
+
+    with aioresponses() as m:
+        m.get(_ROOT,
+              status=401,
+              payload={"error": {
+                  "code": "InvalidAuthenticationToken"
+              }})
+        m.get(_ROOT, payload={"id": "ok"})
+        result = await graph_get(OneDriveConfig(access_token=provider), _ROOT)
+    assert result["id"] == "ok"
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_401_with_static_token_does_not_retry():
+    with aioresponses() as m:
+        m.get(_ROOT, status=401, payload={"error": {"code": "x"}})
+        with pytest.raises(GraphError) as exc:
+            await graph_get(_cfg(), _ROOT)
+    assert exc.value.status == 401

--- a/python/tests/core/onedrive/test_client.py
+++ b/python/tests/core/onedrive/test_client.py
@@ -7,6 +7,11 @@ from mirage.core.onedrive._client import (GraphError, drive_base, graph_get,
                                           item_url)
 
 
+def test_headers_resolves_callable_token():
+    h = headers(OneDriveConfig(access_token=lambda: "live-token"))
+    assert h["Authorization"] == "Bearer live-token"
+
+
 def _cfg(**kw) -> OneDriveConfig:
     return OneDriveConfig(access_token="tok", **kw)
 
@@ -114,3 +119,22 @@ async def test_graph_get_bytes_returns_raw_content():
         m.get(url, body=b"hello bytes")
         data = await graph_get_bytes(_cfg(), url)
     assert data == b"hello bytes"
+
+
+@pytest.mark.asyncio
+async def test_request_retries_on_429_then_succeeds():
+    with aioresponses() as m:
+        m.get(_ROOT, status=429, headers={"Retry-After": "0"})
+        m.get(_ROOT, payload={"id": "ok"})
+        result = await graph_get(_cfg(), _ROOT)
+    assert result["id"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_request_gives_up_after_max_retries():
+    with aioresponses() as m:
+        for _ in range(3):
+            m.get(_ROOT, status=429, headers={"Retry-After": "0"})
+        with pytest.raises(GraphError) as exc:
+            await graph_get(_cfg(max_retries=2), _ROOT)
+    assert exc.value.status == 429

--- a/python/tests/core/onedrive/test_client.py
+++ b/python/tests/core/onedrive/test_client.py
@@ -4,7 +4,20 @@ from aioresponses import aioresponses
 from mirage.accessor.onedrive import OneDriveConfig
 from mirage.core.onedrive._client import (GraphError, drive_base, graph_get,
                                           graph_get_bytes, graph_list, headers,
-                                          item_url)
+                                          item_url, split_path)
+from mirage.types import PathSpec
+
+
+def test_split_path_strips_real_prefix():
+    p = PathSpec(original="/od/a.txt", directory="/od/a.txt", prefix="/od")
+    assert split_path(p) == ("/od", "a.txt")
+
+
+def test_split_path_does_not_strip_sibling_prefix_match():
+    p = PathSpec(original="database.txt",
+                 directory="database.txt",
+                 prefix="data")
+    assert split_path(p) == ("data", "database.txt")
 
 
 def test_headers_resolves_callable_token():

--- a/python/tests/core/onedrive/test_copy_truncate.py
+++ b/python/tests/core/onedrive/test_copy_truncate.py
@@ -1,0 +1,46 @@
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.core.onedrive.copy import copy
+from mirage.core.onedrive.truncate import truncate
+from mirage.types import PathSpec
+
+
+def _accessor(**kw) -> OneDriveAccessor:
+    return OneDriveAccessor(OneDriveConfig(access_token="tok", **kw))
+
+
+_BASE = "https://graph.microsoft.com/v1.0/me/drive"
+
+
+@pytest.mark.asyncio
+async def test_copy_posts_copy_action_with_name():
+    body = {}
+
+    def _cb(url, **kwargs):
+        body.update(kwargs.get("json") or {})
+        return CallbackResult(status=202, payload={})
+
+    with aioresponses() as m:
+        m.post(_BASE + "/root:/a.txt:/copy", callback=_cb)
+        await copy(_accessor(), PathSpec.from_str_path("/a.txt"),
+                   PathSpec.from_str_path("/sub/b.txt"))
+    assert body["name"] == "b.txt"
+    assert "/root:/sub" in body["parentReference"]["path"]
+
+
+@pytest.mark.asyncio
+async def test_truncate_shrinks_content():
+    captured = {}
+
+    def _put_cb(url, **kwargs):
+        captured["body"] = kwargs.get("data")
+        return CallbackResult(status=200, payload={"id": "X"})
+
+    content = _BASE + "/root:/a.txt:/content"
+    with aioresponses() as m:
+        m.get(content, body=b"hello")
+        m.put(content, callback=_put_cb)
+        await truncate(_accessor(), PathSpec.from_str_path("/a.txt"), 3)
+    assert captured["body"] == b"hel"

--- a/python/tests/core/onedrive/test_copy_truncate.py
+++ b/python/tests/core/onedrive/test_copy_truncate.py
@@ -2,6 +2,8 @@ import pytest
 from aioresponses import CallbackResult, aioresponses
 
 from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.commands.builtin.onedrive.cp import cp
+from mirage.core.onedrive._client import GraphError
 from mirage.core.onedrive.copy import copy
 from mirage.core.onedrive.truncate import truncate
 from mirage.types import PathSpec
@@ -28,6 +30,77 @@ async def test_copy_posts_copy_action_with_name():
                    PathSpec.from_str_path("/sub/b.txt"))
     assert body["name"] == "b.txt"
     assert "/root:/sub" in body["parentReference"]["path"]
+
+
+@pytest.mark.asyncio
+async def test_copy_polls_monitor_until_completed():
+    monitor = "https://monitor.example/op/123"
+    with aioresponses() as m:
+        m.post(_BASE + "/root:/a.txt:/copy",
+               status=202,
+               headers={"Location": monitor})
+        m.get(monitor, payload={"status": "completed"})
+        await copy(_accessor(), PathSpec.from_str_path("/a.txt"),
+                   PathSpec.from_str_path("/b.txt"))
+
+
+@pytest.mark.asyncio
+async def test_copy_raises_when_monitor_reports_failed():
+    monitor = "https://monitor.example/op/456"
+    with aioresponses() as m:
+        m.post(_BASE + "/root:/a.txt:/copy",
+               status=202,
+               headers={"Location": monitor})
+        m.get(monitor,
+              payload={
+                  "status": "failed",
+                  "error": {
+                      "code": "nameAlreadyExists",
+                      "message": "x"
+                  }
+              })
+        with pytest.raises(GraphError):
+            await copy(_accessor(), PathSpec.from_str_path("/a.txt"),
+                       PathSpec.from_str_path("/b.txt"))
+
+
+@pytest.mark.asyncio
+async def test_cp_recursive_uses_server_side_folder_copy():
+    src = PathSpec.from_str_path("/src")
+    dst = PathSpec.from_str_path("/dst")
+    with aioresponses() as m:
+        m.get(_BASE + "/root:/src:/children",
+              payload={
+                  "value": [
+                      {
+                          "id": "1",
+                          "name": "a.txt",
+                          "size": 3,
+                          "file": {}
+                      },
+                      {
+                          "id": "2",
+                          "name": "sub",
+                          "folder": {
+                              "childCount": 1
+                          }
+                      },
+                  ]
+              })
+        m.get(_BASE + "/root:/src/sub:/children",
+              payload={
+                  "value": [{
+                      "id": "3",
+                      "name": "b.txt",
+                      "size": 4,
+                      "file": {}
+                  }]
+              })
+        m.post(_BASE + "/root:/src:/copy", status=202, payload={})
+        _out, io = await cp.__wrapped__(_accessor(), [src, dst],
+                                        r=True,
+                                        index=None)
+    assert set(io.writes) == {"/dst/a.txt", "/dst/sub/b.txt"}
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/onedrive/test_find_du.py
+++ b/python/tests/core/onedrive/test_find_du.py
@@ -1,0 +1,86 @@
+import pytest
+from aioresponses import aioresponses
+
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.core.onedrive.du import du, du_all
+from mirage.core.onedrive.find import find
+from mirage.types import PathSpec
+
+
+def _accessor(**kw) -> OneDriveAccessor:
+    return OneDriveAccessor(OneDriveConfig(access_token="tok", **kw))
+
+
+_BASE = "https://graph.microsoft.com/v1.0/me/drive"
+
+
+def _tree(m):
+    m.get(_BASE + "/root/children",
+          payload={
+              "value": [
+                  {
+                      "id": "1",
+                      "name": "a.txt",
+                      "size": 3,
+                      "file": {}
+                  },
+                  {
+                      "id": "2",
+                      "name": "sub",
+                      "folder": {
+                          "childCount": 1
+                      }
+                  },
+              ]
+          })
+    m.get(_BASE + "/root:/sub:/children",
+          payload={
+              "value": [{
+                  "id": "3",
+                  "name": "b.txt",
+                  "size": 5,
+                  "file": {}
+              }]
+          })
+
+
+@pytest.mark.asyncio
+async def test_du_sums_all_files_recursively():
+    with aioresponses() as m:
+        _tree(m)
+        total = await du(_accessor(), PathSpec.from_str_path("/"))
+    assert total == 8
+
+
+@pytest.mark.asyncio
+async def test_du_all_lists_files_plus_total():
+    with aioresponses() as m:
+        _tree(m)
+        rows = await du_all(_accessor(), PathSpec.from_str_path("/"))
+    assert ("/a.txt", 3) in rows
+    assert ("/sub/b.txt", 5) in rows
+    assert rows[-1][1] == 8
+
+
+@pytest.mark.asyncio
+async def test_find_returns_files_and_folders():
+    with aioresponses() as m:
+        _tree(m)
+        out = await find(_accessor(), PathSpec.from_str_path("/"))
+    assert out == ["/a.txt", "/sub", "/sub/b.txt"]
+
+
+@pytest.mark.asyncio
+async def test_find_type_file_excludes_folders():
+    with aioresponses() as m:
+        _tree(m)
+        out = await find(_accessor(), PathSpec.from_str_path("/"), type="file")
+    assert out == ["/a.txt", "/sub/b.txt"]
+
+
+@pytest.mark.asyncio
+async def test_find_name_glob():
+    with aioresponses() as m:
+        _tree(m)
+        out = await find(_accessor(), PathSpec.from_str_path("/"), name="b.*")
+    assert out == ["/sub/b.txt"]

--- a/python/tests/core/onedrive/test_read.py
+++ b/python/tests/core/onedrive/test_read.py
@@ -1,0 +1,70 @@
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.core.onedrive.read import read_bytes
+from mirage.observe.context import push_revisions, reset_revisions
+from mirage.types import PathSpec
+
+
+def _accessor(**kw) -> OneDriveAccessor:
+    return OneDriveAccessor(OneDriveConfig(access_token="tok", **kw))
+
+
+_BASE = "https://graph.microsoft.com/v1.0/me/drive"
+_CONTENT = _BASE + "/root:/Docs/a.txt:/content"
+
+
+@pytest.mark.asyncio
+async def test_read_returns_current_content():
+    with aioresponses() as m:
+        m.get(_CONTENT, body=b"current bytes")
+        data = await read_bytes(_accessor(),
+                                PathSpec.from_str_path("/Docs/a.txt"))
+    assert data == b"current bytes"
+
+
+@pytest.mark.asyncio
+async def test_read_pinned_revision_hits_version_content():
+    version_url = _BASE + "/root:/Docs/a.txt:/versions/3.0/content"
+    token = push_revisions({"/Docs/a.txt": "3.0"})
+    try:
+        with aioresponses() as m:
+            m.get(version_url, body=b"old version bytes")
+            data = await read_bytes(_accessor(),
+                                    PathSpec.from_str_path("/Docs/a.txt"))
+    finally:
+        reset_revisions(token)
+    assert data == b"old version bytes"
+
+
+@pytest.mark.asyncio
+async def test_read_range_sends_range_header():
+    captured = {}
+
+    def _cb(url, **kwargs):
+        captured["range"] = kwargs["headers"].get("Range")
+        return CallbackResult(body=b"llo")
+
+    with aioresponses() as m:
+        m.get(_CONTENT, callback=_cb)
+        data = await read_bytes(_accessor(),
+                                PathSpec.from_str_path("/Docs/a.txt"),
+                                offset=2,
+                                size=3)
+    assert captured["range"] == "bytes=2-4"
+    assert data == b"llo"
+
+
+@pytest.mark.asyncio
+async def test_read_missing_raises_file_not_found():
+    with aioresponses() as m:
+        m.get(_CONTENT,
+              status=404,
+              payload={"error": {
+                  "code": "itemNotFound",
+                  "message": "no"
+              }})
+        with pytest.raises(FileNotFoundError):
+            await read_bytes(_accessor(),
+                             PathSpec.from_str_path("/Docs/a.txt"))

--- a/python/tests/core/onedrive/test_read.py
+++ b/python/tests/core/onedrive/test_read.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from aioresponses import CallbackResult, aioresponses
 
@@ -57,35 +59,62 @@ async def test_read_range_sends_range_header():
     assert data == b"llo"
 
 
+_META = re.compile(r".*/root:/Docs/a\.txt(\?.*)?$")
+_DOWNLOAD = "https://download.example/pinned-bytes"
+
+
+def _meta_payload():
+    return {
+        "id":
+        "01",
+        "cTag":
+        "ctag-xyz",
+        "@microsoft.graph.downloadUrl":
+        _DOWNLOAD,
+        "versions": [
+            {
+                "id": "1.0",
+                "lastModifiedDateTime": "2026-01-01T00:00:00Z"
+            },
+            {
+                "id": "2.0",
+                "lastModifiedDateTime": "2026-02-01T00:00:00Z"
+            },
+        ],
+    }
+
+
 @pytest.mark.asyncio
 async def test_read_captures_fingerprint_and_revision_when_recording():
-    meta = _BASE + "/root:/Docs/a.txt"
-    versions = _BASE + "/root:/Docs/a.txt:/versions"
     sink = start_recording()
     try:
         with aioresponses() as m:
-            m.get(_CONTENT, body=b"current bytes")
-            m.get(meta, payload={"id": "01", "cTag": "ctag-xyz"})
-            m.get(versions,
-                  payload={
-                      "value": [
-                          {
-                              "id": "1.0",
-                              "lastModifiedDateTime": "2026-01-01T00:00:00Z"
-                          },
-                          {
-                              "id": "2.0",
-                              "lastModifiedDateTime": "2026-02-01T00:00:00Z"
-                          },
-                      ]
-                  })
-            await read_bytes(_accessor(),
-                             PathSpec.from_str_path("/Docs/a.txt"))
+            m.get(_META, payload=_meta_payload())
+            m.get(_DOWNLOAD, body=b"old version bytes")
+            data = await read_bytes(_accessor(),
+                                    PathSpec.from_str_path("/Docs/a.txt"))
     finally:
         stop_recording()
     rec = sink[0]
     assert rec.fingerprint == "ctag-xyz"
     assert rec.revision == "2.0"
+    assert data == b"old version bytes"
+
+
+@pytest.mark.asyncio
+async def test_capture_reads_pinned_download_url_not_live_content():
+    sink = start_recording()
+    try:
+        with aioresponses() as m:
+            m.get(_META, payload=_meta_payload())
+            m.get(_DOWNLOAD, body=b"snapshot bytes")
+            m.get(_CONTENT, body=b"live mutated bytes")
+            data = await read_bytes(_accessor(),
+                                    PathSpec.from_str_path("/Docs/a.txt"))
+    finally:
+        stop_recording()
+    assert data == b"snapshot bytes"
+    assert sink[0].fingerprint == "ctag-xyz"
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/onedrive/test_read.py
+++ b/python/tests/core/onedrive/test_read.py
@@ -3,7 +3,8 @@ from aioresponses import CallbackResult, aioresponses
 
 from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
 from mirage.core.onedrive.read import read_bytes
-from mirage.observe.context import push_revisions, reset_revisions
+from mirage.observe.context import (push_revisions, reset_revisions,
+                                    start_recording, stop_recording)
 from mirage.types import PathSpec
 
 
@@ -54,6 +55,37 @@ async def test_read_range_sends_range_header():
                                 size=3)
     assert captured["range"] == "bytes=2-4"
     assert data == b"llo"
+
+
+@pytest.mark.asyncio
+async def test_read_captures_fingerprint_and_revision_when_recording():
+    meta = _BASE + "/root:/Docs/a.txt"
+    versions = _BASE + "/root:/Docs/a.txt:/versions"
+    sink = start_recording()
+    try:
+        with aioresponses() as m:
+            m.get(_CONTENT, body=b"current bytes")
+            m.get(meta, payload={"id": "01", "cTag": "ctag-xyz"})
+            m.get(versions,
+                  payload={
+                      "value": [
+                          {
+                              "id": "1.0",
+                              "lastModifiedDateTime": "2026-01-01T00:00:00Z"
+                          },
+                          {
+                              "id": "2.0",
+                              "lastModifiedDateTime": "2026-02-01T00:00:00Z"
+                          },
+                      ]
+                  })
+            await read_bytes(_accessor(),
+                             PathSpec.from_str_path("/Docs/a.txt"))
+    finally:
+        stop_recording()
+    rec = sink[0]
+    assert rec.fingerprint == "ctag-xyz"
+    assert rec.revision == "2.0"
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/onedrive/test_readdir.py
+++ b/python/tests/core/onedrive/test_readdir.py
@@ -1,0 +1,85 @@
+import pytest
+from aioresponses import aioresponses
+
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.cache.index import RAMIndexCacheStore
+from mirage.core.onedrive.readdir import readdir
+from mirage.types import PathSpec
+
+
+def _accessor(**kw) -> OneDriveAccessor:
+    return OneDriveAccessor(OneDriveConfig(access_token="tok", **kw))
+
+
+_BASE = "https://graph.microsoft.com/v1.0/me/drive"
+
+
+@pytest.mark.asyncio
+async def test_readdir_root_lists_children():
+    index = RAMIndexCacheStore()
+    with aioresponses() as m:
+        m.get(_BASE + "/root/children",
+              payload={
+                  "value": [
+                      {
+                          "id": "1",
+                          "name": "a.txt",
+                          "size": 10,
+                          "file": {}
+                      },
+                      {
+                          "id": "2",
+                          "name": "Docs",
+                          "folder": {
+                              "childCount": 0
+                          }
+                      },
+                  ]
+              })
+        names = await readdir(_accessor(), PathSpec.from_str_path("/"), index)
+    assert names == ["/Docs", "/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_readdir_folder_records_file_and_folder_entries():
+    index = RAMIndexCacheStore()
+    with aioresponses() as m:
+        m.get(_BASE + "/root:/Docs:/children",
+              payload={
+                  "value": [{
+                      "id": "9",
+                      "name": "report.docx",
+                      "size": 55,
+                      "file": {}
+                  }]
+              })
+        names = await readdir(_accessor(), PathSpec.from_str_path("/Docs"),
+                              index)
+    assert names == ["/Docs/report.docx"]
+    lookup = await index.get("/Docs/report.docx")
+    assert lookup.entry.resource_type == "file"
+    assert lookup.entry.size == 55
+
+
+@pytest.mark.asyncio
+async def test_readdir_paginates_nextlink():
+    index = RAMIndexCacheStore()
+    page2 = _BASE + "/root/children?$skiptoken=x"
+    with aioresponses() as m:
+        m.get(_BASE + "/root/children",
+              payload={
+                  "value": [{
+                      "id": "1",
+                      "name": "a.txt",
+                      "file": {}
+                  }],
+                  "@odata.nextLink": page2,
+              })
+        m.get(page2,
+              payload={"value": [{
+                  "id": "2",
+                  "name": "b.txt",
+                  "file": {}
+              }]})
+        names = await readdir(_accessor(), PathSpec.from_str_path("/"), index)
+    assert names == ["/a.txt", "/b.txt"]

--- a/python/tests/core/onedrive/test_snapshot_drift.py
+++ b/python/tests/core/onedrive/test_snapshot_drift.py
@@ -1,0 +1,57 @@
+import asyncio
+import re
+
+import pytest
+from aioresponses import aioresponses
+
+from mirage.accessor.onedrive import OneDriveConfig
+from mirage.resource.onedrive import OneDriveResource
+from mirage.types import MountMode
+from mirage.workspace import Workspace
+from mirage.workspace.snapshot.drift import ContentDriftError, check_drift
+
+_ITEM = re.compile(r".*/root:/a\.txt(\?.*)?$")
+
+
+def _ws() -> Workspace:
+    backend = OneDriveResource(OneDriveConfig(access_token="tok"))
+    return Workspace({"/od": (backend, MountMode.WRITE)}, mode=MountMode.WRITE)
+
+
+def test_drift_raises_when_live_ctag_differs():
+    with aioresponses() as m:
+        m.get(_ITEM,
+              payload={
+                  "name": "a.txt",
+                  "size": 3,
+                  "cTag": "live-ctag",
+                  "file": {}
+              })
+        with pytest.raises(ContentDriftError) as exc:
+            asyncio.run(check_drift(_ws(), "/od/a.txt", "snapshot-ctag"))
+    assert exc.value.path == "/od/a.txt"
+    assert exc.value.live_fingerprint == "live-ctag"
+
+
+def test_no_drift_when_ctag_matches():
+    with aioresponses() as m:
+        m.get(_ITEM,
+              payload={
+                  "name": "a.txt",
+                  "size": 3,
+                  "cTag": "same-ctag",
+                  "file": {}
+              })
+        asyncio.run(check_drift(_ws(), "/od/a.txt", "same-ctag"))
+
+
+def test_drift_raises_when_file_missing():
+    with aioresponses() as m:
+        m.get(_ITEM,
+              status=404,
+              payload={"error": {
+                  "code": "itemNotFound",
+                  "message": "no"
+              }})
+        with pytest.raises(ContentDriftError):
+            asyncio.run(check_drift(_ws(), "/od/a.txt", "snapshot-ctag"))

--- a/python/tests/core/onedrive/test_stat.py
+++ b/python/tests/core/onedrive/test_stat.py
@@ -1,0 +1,74 @@
+import pytest
+from aioresponses import aioresponses
+
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.core.onedrive.stat import stat
+from mirage.types import FileType, PathSpec
+
+
+def _accessor(**kw) -> OneDriveAccessor:
+    return OneDriveAccessor(OneDriveConfig(access_token="tok", **kw))
+
+
+_FILE_URL = ("https://graph.microsoft.com/v1.0/me/drive"
+             "/root:/Docs/report.docx")
+_DIR_URL = "https://graph.microsoft.com/v1.0/me/drive/root:/Docs"
+
+
+@pytest.mark.asyncio
+async def test_stat_root_is_directory():
+    result = await stat(_accessor(), PathSpec.from_str_path("/"))
+    assert result.type == FileType.DIRECTORY
+
+
+@pytest.mark.asyncio
+async def test_stat_file_carries_size_and_ctag_fingerprint():
+    with aioresponses() as m:
+        m.get(_FILE_URL,
+              payload={
+                  "id": "01ITEM",
+                  "name": "report.docx",
+                  "size": 1234,
+                  "lastModifiedDateTime": "2026-05-01T10:00:00Z",
+                  "cTag": "ctag-abc",
+                  "eTag": "etag-xyz",
+                  "file": {
+                      "mimeType": "application/vnd.openxml"
+                  },
+              })
+        result = await stat(_accessor(),
+                            PathSpec.from_str_path("/Docs/report.docx"))
+    assert result.name == "report.docx"
+    assert result.size == 1234
+    assert result.fingerprint == "ctag-abc"
+    assert result.extra["id"] == "01ITEM"
+
+
+@pytest.mark.asyncio
+async def test_stat_folder_is_directory():
+    with aioresponses() as m:
+        m.get(_DIR_URL,
+              payload={
+                  "id": "01FOLDER",
+                  "name": "Docs",
+                  "folder": {
+                      "childCount": 2
+                  },
+              })
+        result = await stat(_accessor(), PathSpec.from_str_path("/Docs"))
+    assert result.type == FileType.DIRECTORY
+    assert result.name == "Docs"
+
+
+@pytest.mark.asyncio
+async def test_stat_missing_raises_file_not_found():
+    with aioresponses() as m:
+        m.get(_FILE_URL,
+              status=404,
+              payload={"error": {
+                  "code": "itemNotFound",
+                  "message": "no"
+              }})
+        with pytest.raises(FileNotFoundError):
+            await stat(_accessor(),
+                       PathSpec.from_str_path("/Docs/report.docx"))

--- a/python/tests/core/onedrive/test_stream.py
+++ b/python/tests/core/onedrive/test_stream.py
@@ -1,0 +1,42 @@
+import pytest
+from aioresponses import aioresponses
+
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.core.onedrive.stream import range_read, read_stream
+from mirage.types import PathSpec
+
+
+def _accessor(**kw) -> OneDriveAccessor:
+    return OneDriveAccessor(OneDriveConfig(access_token="tok", **kw))
+
+
+_CONTENT = ("https://graph.microsoft.com/v1.0/me/drive"
+            "/root:/Docs/a.txt:/content")
+
+
+@pytest.mark.asyncio
+async def test_read_stream_yields_full_content():
+    with aioresponses() as m:
+        m.get(_CONTENT, body=b"abcdef")
+        chunks = []
+        async for chunk in read_stream(_accessor(),
+                                       PathSpec.from_str_path("/Docs/a.txt")):
+            chunks.append(chunk)
+    assert b"".join(chunks) == b"abcdef"
+
+
+@pytest.mark.asyncio
+async def test_range_read_returns_requested_bytes():
+    captured = {}
+
+    def _cb(url, **kwargs):
+        from aioresponses import CallbackResult
+        captured["range"] = kwargs["headers"].get("Range")
+        return CallbackResult(body=b"cde")
+
+    with aioresponses() as m:
+        m.get(_CONTENT, callback=_cb)
+        data = await range_read(_accessor(),
+                                PathSpec.from_str_path("/Docs/a.txt"), 2, 5)
+    assert data == b"cde"
+    assert captured["range"] == "bytes=2-4"

--- a/python/tests/core/onedrive/test_stream.py
+++ b/python/tests/core/onedrive/test_stream.py
@@ -26,6 +26,41 @@ async def test_read_stream_yields_full_content():
 
 
 @pytest.mark.asyncio
+async def test_read_stream_missing_raises_file_not_found():
+    with aioresponses() as m:
+        m.get(_CONTENT,
+              status=404,
+              payload={"error": {
+                  "code": "itemNotFound",
+                  "message": "no"
+              }})
+        with pytest.raises(FileNotFoundError):
+            async for _ in read_stream(_accessor(),
+                                       PathSpec.from_str_path("/Docs/a.txt")):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_read_stream_refreshes_callable_token_on_401():
+    calls = {"n": 0}
+
+    def provider():
+        calls["n"] += 1
+        return "fresh" if calls["n"] > 1 else "stale"
+
+    accessor = OneDriveAccessor(OneDriveConfig(access_token=provider))
+    with aioresponses() as m:
+        m.get(_CONTENT, status=401, payload={"error": {"code": "expired"}})
+        m.get(_CONTENT, body=b"abcdef")
+        chunks = [
+            c async for c in read_stream(accessor,
+                                         PathSpec.from_str_path("/Docs/a.txt"))
+        ]
+    assert b"".join(chunks) == b"abcdef"
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
 async def test_range_read_returns_requested_bytes():
     captured = {}
 

--- a/python/tests/core/onedrive/test_structural.py
+++ b/python/tests/core/onedrive/test_structural.py
@@ -1,0 +1,115 @@
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.core.onedrive.create import create
+from mirage.core.onedrive.exists import exists
+from mirage.core.onedrive.mkdir import mkdir
+from mirage.core.onedrive.rename import rename
+from mirage.core.onedrive.rm import rm_r
+from mirage.core.onedrive.rmdir import rmdir
+from mirage.core.onedrive.unlink import unlink
+from mirage.core.onedrive.versions import restore_version
+from mirage.types import PathSpec
+
+
+def _accessor(**kw) -> OneDriveAccessor:
+    return OneDriveAccessor(OneDriveConfig(access_token="tok", **kw))
+
+
+_BASE = "https://graph.microsoft.com/v1.0/me/drive"
+
+
+@pytest.mark.asyncio
+async def test_mkdir_posts_folder_to_parent_children():
+    body = {}
+
+    def _cb(url, **kwargs):
+        body.update(kwargs.get("json") or {})
+        return CallbackResult(status=201, payload={"id": "F"})
+
+    with aioresponses() as m:
+        m.post(_BASE + "/root:/a:/children", callback=_cb)
+        await mkdir(_accessor(), PathSpec.from_str_path("/a/b"))
+    assert body["name"] == "b"
+    assert "folder" in body
+
+
+@pytest.mark.asyncio
+async def test_create_puts_empty_content():
+    captured = {}
+
+    def _cb(url, **kwargs):
+        captured["body"] = kwargs.get("data")
+        return CallbackResult(status=201, payload={"id": "X"})
+
+    with aioresponses() as m:
+        m.put(_BASE + "/root:/a.txt:/content", callback=_cb)
+        await create(_accessor(), PathSpec.from_str_path("/a.txt"))
+    assert captured["body"] in (b"", None)
+
+
+@pytest.mark.asyncio
+async def test_unlink_deletes_item():
+    with aioresponses() as m:
+        m.delete(_BASE + "/root:/a.txt", status=204)
+        await unlink(_accessor(), PathSpec.from_str_path("/a.txt"))
+
+
+@pytest.mark.asyncio
+async def test_rmdir_deletes_folder():
+    with aioresponses() as m:
+        m.delete(_BASE + "/root:/docs", status=204)
+        await rmdir(_accessor(), PathSpec.from_str_path("/docs"))
+
+
+@pytest.mark.asyncio
+async def test_rm_r_deletes_tree():
+    with aioresponses() as m:
+        m.delete(_BASE + "/root:/docs", status=204)
+        await rm_r(_accessor(), PathSpec.from_str_path("/docs"))
+
+
+@pytest.mark.asyncio
+async def test_rename_patches_name():
+    body = {}
+
+    def _cb(url, **kwargs):
+        body.update(kwargs.get("json") or {})
+        return CallbackResult(status=200, payload={"id": "X", "name": "b.txt"})
+
+    with aioresponses() as m:
+        m.patch(_BASE + "/root:/a.txt", callback=_cb)
+        await rename(_accessor(), PathSpec.from_str_path("/a.txt"),
+                     PathSpec.from_str_path("/b.txt"))
+    assert body["name"] == "b.txt"
+
+
+@pytest.mark.asyncio
+async def test_restore_version_posts_action():
+    with aioresponses() as m:
+        m.post(_BASE + "/root:/a.txt:/versions/2.0/restoreVersion", status=204)
+        await restore_version(_accessor(), PathSpec.from_str_path("/a.txt"),
+                              "2.0")
+
+
+@pytest.mark.asyncio
+async def test_exists_true_and_false():
+    with aioresponses() as m:
+        m.get(_BASE + "/root:/a.txt",
+              payload={
+                  "id": "X",
+                  "name": "a.txt",
+                  "file": {}
+              })
+        assert await exists(_accessor(),
+                            PathSpec.from_str_path("/a.txt")) is True
+    with aioresponses() as m:
+        m.get(_BASE + "/root:/missing.txt",
+              status=404,
+              payload={"error": {
+                  "code": "itemNotFound",
+                  "message": "no"
+              }})
+        assert await exists(_accessor(),
+                            PathSpec.from_str_path("/missing.txt")) is False

--- a/python/tests/core/onedrive/test_write.py
+++ b/python/tests/core/onedrive/test_write.py
@@ -1,0 +1,57 @@
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+import mirage.core.onedrive.write as write_mod
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.core.onedrive.write import write_bytes
+from mirage.types import PathSpec
+
+
+def _accessor(**kw) -> OneDriveAccessor:
+    return OneDriveAccessor(OneDriveConfig(access_token="tok", **kw))
+
+
+_BASE = "https://graph.microsoft.com/v1.0/me/drive"
+_CONTENT = _BASE + "/root:/Docs/a.txt:/content"
+_SESSION = _BASE + "/root:/Docs/a.txt:/createUploadSession"
+
+
+@pytest.mark.asyncio
+async def test_write_small_file_puts_content():
+    captured = {}
+
+    def _cb(url, **kwargs):
+        captured["body"] = kwargs.get("data")
+        return CallbackResult(status=201, payload={"id": "X", "name": "a.txt"})
+
+    with aioresponses() as m:
+        m.put(_CONTENT, callback=_cb)
+        result = await write_bytes(_accessor(),
+                                   PathSpec.from_str_path("/Docs/a.txt"),
+                                   b"hello")
+    assert result is None
+    assert captured["body"] == b"hello"
+
+
+@pytest.mark.asyncio
+async def test_write_large_file_uses_upload_session(monkeypatch):
+    monkeypatch.setattr(write_mod, "SIMPLE_UPLOAD_MAX", 4)
+    monkeypatch.setattr(write_mod, "UPLOAD_CHUNK", 4)
+    ranges = []
+
+    def _chunk_cb(url, **kwargs):
+        ranges.append(kwargs["headers"]["Content-Range"])
+        return CallbackResult(status=202, payload={})
+
+    def _final_cb(url, **kwargs):
+        ranges.append(kwargs["headers"]["Content-Range"])
+        return CallbackResult(status=201, payload={"id": "X"})
+
+    upload_url = "https://upload.example/session1"
+    with aioresponses() as m:
+        m.post(_SESSION, payload={"uploadUrl": upload_url})
+        m.put(upload_url, callback=_chunk_cb)
+        m.put(upload_url, callback=_final_cb)
+        await write_bytes(_accessor(), PathSpec.from_str_path("/Docs/a.txt"),
+                          b"abcdef")
+    assert ranges == ["bytes 0-3/6", "bytes 4-5/6"]

--- a/python/tests/core/onedrive/test_write.py
+++ b/python/tests/core/onedrive/test_write.py
@@ -55,3 +55,28 @@ async def test_write_large_file_uses_upload_session(monkeypatch):
         await write_bytes(_accessor(), PathSpec.from_str_path("/Docs/a.txt"),
                           b"abcdef")
     assert ranges == ["bytes 0-3/6", "bytes 4-5/6"]
+
+
+@pytest.mark.asyncio
+async def test_upload_resumes_from_next_expected_ranges(monkeypatch):
+    monkeypatch.setattr(write_mod, "SIMPLE_UPLOAD_MAX", 4)
+    monkeypatch.setattr(write_mod, "UPLOAD_CHUNK", 4)
+    ranges = []
+
+    def _chunk_cb(url, **kwargs):
+        ranges.append(kwargs["headers"]["Content-Range"])
+        return CallbackResult(status=202,
+                              payload={"nextExpectedRanges": ["2-5"]})
+
+    def _final_cb(url, **kwargs):
+        ranges.append(kwargs["headers"]["Content-Range"])
+        return CallbackResult(status=201, payload={"id": "X"})
+
+    upload_url = "https://upload.example/session2"
+    with aioresponses() as m:
+        m.post(_SESSION, payload={"uploadUrl": upload_url})
+        m.put(upload_url, callback=_chunk_cb)
+        m.put(upload_url, callback=_final_cb)
+        await write_bytes(_accessor(), PathSpec.from_str_path("/Docs/a.txt"),
+                          b"abcdef")
+    assert ranges == ["bytes 0-3/6", "bytes 2-5/6"]

--- a/python/tests/resource/test_registry.py
+++ b/python/tests/resource/test_registry.py
@@ -61,6 +61,7 @@ EXPECTED_RESOURCES = {
     "nextcloud",
     "dify",
     "chroma",
+    "onedrive",
 }
 
 


### PR DESCRIPTION
## What

Adds a `onedrive` resource that mounts a OneDrive / SharePoint drive as a mirage filesystem over the Microsoft Graph API. Graph is a distinct protocol (not S3-compatible), so this is a full backend with its own `core/onedrive` and command surface, mirroring the S3 layout: full command set, snapshots with version-pinned reads + cTag drift detection, resumable uploads, and a refreshable token. Python only; TypeScript parity is a follow-up.

## Why

OneDrive / SharePoint is a common enterprise store. Hand-written on Graph rather than OpenDAL because OpenDAL's onedrive service lacks `read_with_version` and so cannot do the version-pinned reads snapshots need; Graph exposes it natively (`/versions/{id}/content`) — the same reason S3 stays on aioboto3.

## Changes

- **Core / ops / commands**: `core/onedrive` (Graph client with pagination, retry on 429/503/504 honoring `Retry-After`, and token refresh; version-pinned read; write + resumable upload session; monitor-polled copy; versions list/current/restore; find/du/glob), 14 ops, and the full builtin command surface delegating to the shared generic commands.
- **Resource / registry**: `resource/onedrive`, `ResourceName.ONEDRIVE`, registry entry, `SUPPORTS_SNAPSHOT=True`; files served as raw bytes (no Office-doc conversion).
- **Auth**: `OneDriveConfig.access_token` accepts a static bearer or a refreshable callable provider, plus optional `drive_id` / `site_id` / `key_prefix`.
- **Docs**: setup + resource pages under a new Microsoft nav group.

## Verification

- Scoped unit tests (aioresponses) green: core ops, snapshot capture / replay / drift, retry, token refresh, resumable upload, and multi-file commands; registry and multi-file guard pass; pre-commit clean.
- **Not yet run against a live drive** (needs a Files-scoped token): the `write → read → snapshot-pin → restoreVersion` round-trip and the Graph-shape-dependent paths (copy monitor, `$expand=versions`, downloadUrl) are mock-only.

Trade-offs: `mv` / cross-dir rename is copy+delete (not atomic).
