### PR TITLE
fix(databricks-volume): prevent mv/cp onto same path from deleting the file (#127)

### DIFF
--- a/python/mirage/commands/builtin/databricks_volume/_helpers.py
+++ b/python/mirage/commands/builtin/databricks_volume/_helpers.py
@@ -19,6 +19,7 @@ from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.utils.wrap import (call_read_bytes,
                                                 call_read_stream)
+from mirage.core.databricks_volume.path import backend_path
 from mirage.core.databricks_volume.read import read_bytes as _read_bytes
 from mirage.core.databricks_volume.stat import stat as _stat
 from mirage.core.databricks_volume.stream import read_stream as _read_stream
@@ -57,6 +58,11 @@ async def path_exists(accessor: DatabricksVolumeAccessor,
 def child_path(parent: PathSpec, name: str) -> PathSpec:
     base = parent.original.rstrip("/")
     return PathSpec.from_str_path(f"{base}/{name}", parent.prefix)
+
+
+def same_backend_file(accessor: DatabricksVolumeAccessor, a: PathSpec,
+                      b: PathSpec) -> bool:
+    return backend_path(accessor.config, a) == backend_path(accessor.config, b)
 
 
 def read_bytes_with_index(index: IndexCacheStore | None,

--- a/python/mirage/commands/builtin/databricks_volume/cp.py
+++ b/python/mirage/commands/builtin/databricks_volume/cp.py
@@ -14,9 +14,8 @@
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.databricks_volume._helpers import (child_path,
-                                                                is_directory,
-                                                                path_exists)
+from mirage.commands.builtin.databricks_volume._helpers import (
+    child_path, is_directory, path_exists, same_backend_file)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.copy import copy as copy_core
@@ -48,11 +47,16 @@ async def cp(
     dst_is_dir = await is_directory(accessor, dst, index)
     writes: dict[str, bytes] = {}
     lines: list[str] = []
+    errors: list[str] = []
     for src in sources:
         target = dst
         if dst_is_dir:
             name = src.strip_prefix.rstrip("/").rsplit("/", 1)[-1]
             target = child_path(dst, name)
+        if same_backend_file(accessor, src, target):
+            errors.append(f"cp: '{src.original}' and '{target.original}' "
+                          "are the same file")
+            continue
         if n and await path_exists(accessor, target, index):
             continue
         await copy_core(accessor, src, target, index, recursive=recursive)
@@ -60,4 +64,7 @@ async def cp(
         if v:
             lines.append(f"'{src.original}' -> '{target.original}'")
     output = ("\n".join(lines) + "\n").encode() if lines else None
-    return output, IOResult(writes=writes)
+    stderr = ("\n".join(errors) + "\n").encode() if errors else None
+    return output, IOResult(writes=writes,
+                            stderr=stderr,
+                            exit_code=1 if errors else 0)

--- a/python/mirage/commands/builtin/databricks_volume/mv.py
+++ b/python/mirage/commands/builtin/databricks_volume/mv.py
@@ -14,9 +14,8 @@
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.databricks_volume._helpers import (child_path,
-                                                                is_directory,
-                                                                path_exists)
+from mirage.commands.builtin.databricks_volume._helpers import (
+    child_path, is_directory, path_exists, same_backend_file)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
@@ -44,11 +43,16 @@ async def mv(
     dst_is_dir = await is_directory(accessor, dst, index)
     writes: dict[str, bytes] = {}
     lines: list[str] = []
+    errors: list[str] = []
     for src in sources:
         target = dst
         if dst_is_dir:
             name = src.strip_prefix.rstrip("/").rsplit("/", 1)[-1]
             target = child_path(dst, name)
+        if same_backend_file(accessor, src, target):
+            errors.append(f"mv: '{src.original}' and '{target.original}' "
+                          "are the same file")
+            continue
         if n and await path_exists(accessor, target, index):
             continue
         await rename_core(accessor, src, target, index)
@@ -57,4 +61,7 @@ async def mv(
         if v:
             lines.append(f"'{src.original}' -> '{target.original}'")
     output = ("\n".join(lines) + "\n").encode() if lines else None
-    return output, IOResult(writes=writes)
+    stderr = ("\n".join(errors) + "\n").encode() if errors else None
+    return output, IOResult(writes=writes,
+                            stderr=stderr,
+                            exit_code=1 if errors else 0)

--- a/python/mirage/core/databricks_volume/copy.py
+++ b/python/mirage/core/databricks_volume/copy.py
@@ -84,13 +84,22 @@ async def copy(
     src = ensure_path_spec(src)
     dst = ensure_path_spec(dst)
     src_stat = await stat(accessor, src, index)
+    # Same-path guard runs after stat (and the non-recursive directory check)
+    # so a missing source or `cp` of a directory still raises.
+    same_path = backend_path(accessor.config,
+                             src) == backend_path(accessor.config, dst)
     if src_stat.type == FileType.DIRECTORY:
         if not recursive:
             raise IsADirectoryError(src.strip_prefix)
+        if same_path:
+            return
         remote_src = backend_path(accessor.config, src)
         remote_dst = backend_path(accessor.config, dst)
         await asyncio.to_thread(_copy_tree_sync, accessor, remote_src,
                                 remote_dst)
+        return
+    if same_path:
+        # Copying a file onto itself would re-upload it; skip.
         return
     data = await read_bytes(accessor, src, index)
     await write_bytes(accessor, dst, data, index)

--- a/python/mirage/core/databricks_volume/rename.py
+++ b/python/mirage/core/databricks_volume/rename.py
@@ -16,6 +16,7 @@ from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.databricks_volume._helpers import ensure_path_spec
 from mirage.core.databricks_volume.copy import copy
+from mirage.core.databricks_volume.path import backend_path
 from mirage.core.databricks_volume.rm import rm_recursive
 from mirage.core.databricks_volume.stat import stat
 from mirage.core.databricks_volume.unlink import unlink
@@ -33,6 +34,12 @@ async def rename(
     src = ensure_path_spec(src)
     dst = ensure_path_spec(dst)
     src_stat = await stat(accessor, src, index)
+    if backend_path(accessor.config,
+                    src) == backend_path(accessor.config, dst):
+        # rename(2) onto the same path is a no-op; copy + unlink here would
+        # upload the file onto itself then delete it, destroying the data.
+        # Guard runs after stat so a missing source still raises.
+        return
     if src_stat.type == FileType.DIRECTORY:
         await copy(accessor, src, dst, index, recursive=True)
         await rm_recursive(accessor, src, index)

--- a/python/tests/commands/builtin/databricks_volume/test_cp.py
+++ b/python/tests/commands/builtin/databricks_volume/test_cp.py
@@ -73,3 +73,13 @@ async def test_cp_read_only_mount_rejected(read_ws, dbx_files):
     assert io.exit_code != 0
     assert b"read-only" in io.stderr
     assert f"{ROOT}/dst.txt" not in dbx_files.downloads
+
+
+@pytest.mark.asyncio
+async def test_cp_onto_same_path_errors_and_preserves_file(
+        write_ws, dbx_files):
+    io = await write_ws.execute("cp /dbx/src.txt /dbx/src.txt")
+
+    assert io.exit_code != 0
+    assert b"are the same file" in io.stderr
+    assert dbx_files.downloads[f"{ROOT}/src.txt"] == b"hello"

--- a/python/tests/commands/builtin/databricks_volume/test_mv.py
+++ b/python/tests/commands/builtin/databricks_volume/test_mv.py
@@ -85,3 +85,32 @@ async def test_ops_rename(write_ws, dbx_files):
 
     assert dbx_files.downloads[f"{ROOT}/renamed.txt"] == b"data"
     assert f"{ROOT}/src.txt" not in dbx_files.downloads
+
+
+@pytest.mark.asyncio
+async def test_mv_onto_same_path_errors_and_preserves_file(
+        write_ws, dbx_files):
+    io = await write_ws.execute("mv /dbx/src.txt /dbx/src.txt")
+
+    assert io.exit_code != 0
+    assert b"are the same file" in io.stderr
+    assert dbx_files.downloads[f"{ROOT}/src.txt"] == b"data"
+    assert f"{ROOT}/src.txt" not in dbx_files.delete_calls
+
+
+@pytest.mark.asyncio
+async def test_mv_into_dir_where_file_already_lives_errors_and_preserves_file(
+        write_ws, dbx_files):
+    io = await write_ws.execute("mv /dbx/src.txt /dbx/")
+
+    assert io.exit_code != 0
+    assert b"are the same file" in io.stderr
+    assert dbx_files.downloads[f"{ROOT}/src.txt"] == b"data"
+
+
+@pytest.mark.asyncio
+async def test_ops_rename_onto_same_path_is_noop(write_ws, dbx_files):
+    await write_ws.ops.rename("/dbx/src.txt", "/dbx/src.txt")
+
+    assert dbx_files.downloads[f"{ROOT}/src.txt"] == b"data"
+    assert f"{ROOT}/src.txt" not in dbx_files.delete_calls

--- a/python/tests/core/databricks_volume/test_copy.py
+++ b/python/tests/core/databricks_volume/test_copy.py
@@ -83,6 +83,36 @@ async def test_copy_directory_without_recursive_fails(accessor, files,
 
 
 @pytest.mark.asyncio
+async def test_copy_same_path_is_noop(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_file(files, f"{remote_root}/src.txt", b"hello")
+
+    await copy(accessor, _path("/dbx/src.txt"), _path("/dbx/src.txt"), index)
+
+    assert files.downloads[f"{remote_root}/src.txt"] == b"hello"
+
+
+@pytest.mark.asyncio
+async def test_copy_same_missing_path_fails(accessor, files, remote_root,
+                                            index):
+    _seed_directory(files, remote_root)
+
+    with pytest.raises(FileNotFoundError):
+        await copy(accessor, _path("/dbx/missing.txt"),
+                   _path("/dbx/missing.txt"), index)
+
+
+@pytest.mark.asyncio
+async def test_copy_same_dir_without_recursive_fails(accessor, files,
+                                                     remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_directory(files, f"{remote_root}/d")
+
+    with pytest.raises(IsADirectoryError):
+        await copy(accessor, _path("/dbx/d"), _path("/dbx/d"), index)
+
+
+@pytest.mark.asyncio
 async def test_copy_recursive_tree(accessor, files, remote_root, index):
     _seed_directory(files, remote_root)
     _seed_directory(files, f"{remote_root}/d")

--- a/python/tests/core/databricks_volume/test_rename.py
+++ b/python/tests/core/databricks_volume/test_rename.py
@@ -64,6 +64,27 @@ async def test_rename_missing_source_fails(accessor, files, remote_root,
 
 
 @pytest.mark.asyncio
+async def test_rename_same_path_is_noop(accessor, files, remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_file(files, f"{remote_root}/src.txt", b"data")
+
+    await rename(accessor, _path("/dbx/src.txt"), _path("/dbx/src.txt"), index)
+
+    assert files.downloads[f"{remote_root}/src.txt"] == b"data"
+    assert f"{remote_root}/src.txt" not in files.delete_calls
+
+
+@pytest.mark.asyncio
+async def test_rename_same_missing_path_fails(accessor, files, remote_root,
+                                              index):
+    _seed_directory(files, remote_root)
+
+    with pytest.raises(FileNotFoundError):
+        await rename(accessor, _path("/dbx/missing.txt"),
+                     _path("/dbx/missing.txt"), index)
+
+
+@pytest.mark.asyncio
 async def test_rename_directory_moves_tree(accessor, files, remote_root,
                                            index):
     _seed_directory(files, remote_root)


### PR DESCRIPTION
## Summary
Fixes #127.

Bug: Moving a path onto itself uploaded the file onto itself and then deleted it. 

New issue detected in #141: recursive `cp -r/mv dir dir` into its own subtree (`target = dir/dir`) bypasses the exact-key guard.

## Tests
- Command: same-path `mv`/`cp` error + preserve file; `mv a dir/` variant.
- Core/ops: `rename`/`copy` same-path no-op; same-path **missing** source raises `FileNotFoundError`; non-recursive same-dir raises `IsADirectoryError`.
- Full `tests/{commands/builtin,core}/databricks_volume` suite (124 tests) passes; isort/flake8/ruff/yapf clean.
