### PR TITLE
fix(commands): terminate generated record output with newlines

### DIFF
--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -488,7 +488,7 @@ world
       2 b
       1 c
 === find_pipe_wc ===
-18
+19
 === jq_pipe_wc ===
 3
 === cat_tr_sort ===

--- a/python/mirage/commands/builtin/databricks_volume/find.py
+++ b/python/mirage/commands/builtin/databricks_volume/find.py
@@ -16,6 +16,7 @@ import fnmatch
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
@@ -101,4 +102,4 @@ async def find(
     depth = int(maxdepth) if maxdepth is not None else None
     results = await _find_recurse(accessor, path, name, type_filter, depth, 0,
                                   index)
-    return "\n".join(results).encode(), IOResult()
+    return format_records(results), IOResult()

--- a/python/mirage/commands/builtin/databricks_volume/grep.py
+++ b/python/mirage/commands/builtin/databricks_volume/grep.py
@@ -20,6 +20,8 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.grep_helper import (compile_pattern,
                                                  grep_files_only, grep_lines,
                                                  grep_recursive, grep_stream)
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.builtin.utils.wrap import (call_read_bytes,
                                                 call_read_stream, call_readdir,
@@ -167,10 +169,10 @@ async def grep(
                                        index=index,
                                        prefix=mount_prefix),
             )
-            stderr = "\n".join(warnings_l).encode() if warnings_l else None
+            stderr = format_optional_records(warnings_l)
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            return "\n".join(results).encode(), IOResult(stderr=stderr)
+            return format_records(results), IOResult(stderr=stderr)
 
         if r or R:
             compiled = compile_pattern(pattern, i, F, w)
@@ -211,10 +213,10 @@ async def grep(
                         all_results.extend(
                             f"{path.original}:{line}" if len(paths) >
                             1 else line for line in hits)
-            stderr = ("\n".join(warnings_r).encode() if warnings_r else None)
+            stderr = format_optional_records(warnings_r)
             if not all_results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            return "\n".join(all_results).encode(), IOResult(stderr=stderr)
+            return format_records(all_results), IOResult(stderr=stderr)
 
         compiled = compile_pattern(pattern, i, F, w)
 
@@ -236,7 +238,7 @@ async def grep(
                                        for line in hits)
             if not all_results:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
+            return format_records(all_results), IOResult()
 
         source = read_stream(accessor, paths[0], index)
         stream = grep_stream(

--- a/python/mirage/commands/builtin/databricks_volume/ls.py
+++ b/python/mirage/commands/builtin/databricks_volume/ls.py
@@ -15,6 +15,8 @@
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
@@ -164,9 +166,9 @@ async def ls(
             for entry in entries:
                 is_dir = F and entry.type == FileType.DIRECTORY
                 results.append(entry.name + ("/" if is_dir else ""))
-    stderr = "\n".join(warnings).encode() if warnings else None
+    stderr = format_optional_records(warnings)
     exit_code = 1 if warnings and not results else 0
-    return "\n".join(results).encode(), IOResult(
+    return format_records(results), IOResult(
         stderr=stderr,
         exit_code=exit_code,
     )

--- a/python/mirage/commands/builtin/databricks_volume/rg.py
+++ b/python/mirage/commands/builtin/databricks_volume/rg.py
@@ -20,6 +20,8 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.grep_helper import (compile_pattern, grep_lines,
                                                  grep_stream)
 from mirage.commands.builtin.rg_helper import rg_full
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
                                                 call_stat)
@@ -125,12 +127,12 @@ async def rg(
                 hidden=hidden,
                 warnings=warnings_f,
             )
-            stderr = "\n".join(warnings_f).encode() if warnings_f else None
+            stderr = format_optional_records(warnings_f)
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
             if mount_prefix and args_l:
                 results = [mount_prefix + "/" + r.lstrip("/") for r in results]
-            return "\n".join(results).encode(), IOResult(stderr=stderr)
+            return format_records(results), IOResult(stderr=stderr)
 
         compiled = compile_pattern(pattern, i, F, w)
 
@@ -157,7 +159,7 @@ async def rg(
                     mount_prefix + "/" + result.lstrip("/")
                     for result in all_results
                 ]
-            return "\n".join(all_results).encode(), IOResult()
+            return format_records(all_results), IOResult()
 
         source = read_stream(accessor, paths[0], index)
         stream = grep_stream(

--- a/python/mirage/commands/builtin/databricks_volume/rm.py
+++ b/python/mirage/commands/builtin/databricks_volume/rm.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_optional_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
@@ -67,5 +68,5 @@ async def rm(
             removed[path.strip_prefix] = b""
         if v:
             verbose_parts.append(f"removed '{path.original}'")
-    output = "\n".join(verbose_parts).encode() if v else None
+    output = format_optional_records(verbose_parts) if v else None
     return output, IOResult(writes=removed)

--- a/python/mirage/commands/builtin/databricks_volume/stat.py
+++ b/python/mirage/commands/builtin/databricks_volume/stat.py
@@ -17,6 +17,7 @@ from functools import partial
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
@@ -82,4 +83,4 @@ async def stat(
             type_value = file_stat.type.value if file_stat.type else None
             lines.append(f"name={file_stat.name} size={file_stat.size}"
                          f" modified={file_stat.modified} type={type_value}")
-    return "\n".join(lines).encode(), IOResult()
+    return format_records(lines), IOResult()

--- a/python/mirage/commands/builtin/databricks_volume/tree.py
+++ b/python/mirage/commands/builtin/databricks_volume/tree.py
@@ -14,6 +14,8 @@
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
@@ -108,5 +110,5 @@ async def tree(
         warnings=warnings,
         index=index,
     )
-    stderr = "\n".join(warnings).encode() if warnings else None
-    return "\n".join(results).encode(), IOResult(stderr=stderr)
+    stderr = format_optional_records(warnings)
+    return format_records(results), IOResult(stderr=stderr)

--- a/python/mirage/commands/builtin/dify/find.py
+++ b/python/mirage/commands/builtin/dify/find.py
@@ -3,6 +3,7 @@ from functools import partial
 
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.find import find as generic_find
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.dify.find import find as find_core
@@ -47,7 +48,7 @@ async def _normalize_find_output(
     root = search_path.prefix.rstrip("/") or "/"
     lines = data.decode().splitlines()
     normalized = [root if line == root + "/" else line for line in lines]
-    return "\n".join(normalized).encode()
+    return format_records(normalized)
 
 
 @command("find", resource="dify", spec=SPECS["find"])

--- a/python/mirage/commands/builtin/dify/wc.py
+++ b/python/mirage/commands/builtin/dify/wc.py
@@ -1,6 +1,7 @@
 from mirage.commands.builtin.aggregators import wc_aggregate
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.dify.glob import resolve_glob
@@ -43,4 +44,4 @@ async def wc(
         output.append(
             format_wc(totals, args_l=args_l, w=w, c=c, m=m, L=L,
                       label="total"))
-    return "\n".join(output).encode(), IOResult(reads=reads, cache=list(reads))
+    return format_records(output), IOResult(reads=reads, cache=list(reads))

--- a/python/mirage/commands/builtin/discord/find.py
+++ b/python/mirage/commands/builtin/discord/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.discord import DiscordAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.discord._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.discord.glob import resolve_glob
@@ -111,5 +112,5 @@ async def find(
         if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
             continue
         results.append(p)
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/discord/grep.py
+++ b/python/mirage/commands/builtin/discord/grep.py
@@ -22,6 +22,7 @@ from mirage.commands.builtin.discord._provision import file_read_provision
 from mirage.commands.builtin.grep_helper import (compile_pattern,
                                                  grep_files_only, grep_lines,
                                                  grep_stream)
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
                                                 call_stat)
@@ -129,7 +130,7 @@ async def grep(
                                             channel_map)
                 if not lines:
                     return b"", IOResult(exit_code=1)
-                return "\n".join(lines).encode(), IOResult()
+                return format_records(lines), IOResult()
             except Exception as exc:
                 msg = str(exc)
                 pushdown_warnings.append(
@@ -191,7 +192,7 @@ async def grep(
             stderr = _stderr_from(warnings)
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            return ("\n".join(results).encode(), IOResult(stderr=stderr))
+            return (format_records(results), IOResult(stderr=stderr))
 
         pat = compile_pattern(pattern, i, F, w)
 
@@ -212,7 +213,7 @@ async def grep(
             stderr = _stderr_from()
             if not all_results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            return "\n".join(all_results).encode(), IOResult(stderr=stderr)
+            return format_records(all_results), IOResult(stderr=stderr)
 
         data = await rb(paths[0].original)
         source = yield_bytes(data)

--- a/python/mirage/commands/builtin/discord/grep.py
+++ b/python/mirage/commands/builtin/discord/grep.py
@@ -22,7 +22,8 @@ from mirage.commands.builtin.discord._provision import file_read_provision
 from mirage.commands.builtin.grep_helper import (compile_pattern,
                                                  grep_files_only, grep_lines,
                                                  grep_stream)
-from mirage.commands.builtin.utils.output import format_records
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
                                                 call_stat)
@@ -168,7 +169,7 @@ async def grep(
             joined: list[str] = list(pushdown_warnings)
             for w in extra:
                 joined.extend(w)
-            return ("\n".join(joined) + "\n").encode() if joined else None
+            return format_optional_records(joined)
 
         if args_l:
             warnings: list[str] = []

--- a/python/mirage/commands/builtin/discord/ls.py
+++ b/python/mirage/commands/builtin/discord/ls.py
@@ -84,5 +84,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/discord/rg.py
+++ b/python/mirage/commands/builtin/discord/rg.py
@@ -18,6 +18,7 @@ from collections.abc import AsyncIterator
 from mirage.accessor.discord import DiscordAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -120,7 +121,7 @@ async def rg(
                                             channel_map)
                 if not lines:
                     return b"", IOResult(exit_code=1)
-                return "\n".join(lines).encode(), IOResult()
+                return format_records(lines), IOResult()
             except Exception as exc:
                 msg = str(exc)
                 pushdown_warnings.append(
@@ -184,7 +185,7 @@ async def rg(
                    "\n").encode() if pushdown_warnings else None)
         if not any_match:
             return b"", IOResult(exit_code=1, stderr=stderr)
-        return "\n".join(all_results).encode(), IOResult(stderr=stderr)
+        return format_records(all_results), IOResult(stderr=stderr)
 
     raw = await _read_stdin_async(stdin)
     if raw is None:
@@ -206,4 +207,4 @@ async def rg(
     result_lines: list[str] = []
     for line in matched:
         result_lines.append(line)
-    return "\n".join(result_lines).encode(), IOResult()
+    return format_records(result_lines), IOResult()

--- a/python/mirage/commands/builtin/discord/rg.py
+++ b/python/mirage/commands/builtin/discord/rg.py
@@ -203,7 +203,7 @@ async def rg(
     if not matched:
         return b"", IOResult(exit_code=1)
     if c:
-        return str(len(matched)).encode(), IOResult()
+        return str(len(matched)).encode() + b"\n", IOResult()
     result_lines: list[str] = []
     for line in matched:
         result_lines.append(line)

--- a/python/mirage/commands/builtin/discord/wc.py
+++ b/python/mirage/commands/builtin/discord/wc.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.discord._provision import file_read_provision
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -80,10 +81,10 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
     data = await _read_stdin_async(stdin)
     if data is None:
         raise ValueError("wc: missing operand")
     counts = await generic_wc(data)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/disk/rm.py
+++ b/python/mirage/commands/builtin/disk/rm.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.disk import DiskAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_optional_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.disk.glob import resolve_glob
@@ -65,5 +66,5 @@ async def rm(
         removed[p.strip_prefix] = b""
         if v:
             verbose_parts.append(f"removed '{p.original}'")
-    output = "\n".join(verbose_parts).encode() if v else None
+    output = format_optional_records(verbose_parts) if v else None
     return output, IOResult(writes=removed)

--- a/python/mirage/commands/builtin/email/find.py
+++ b/python/mirage/commands/builtin/email/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.email import EmailAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.email._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.email._client import fetch_headers
@@ -128,7 +129,7 @@ async def find(
         if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
             continue
         results.append(p)
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()
 
 
@@ -167,5 +168,5 @@ async def _find_server_side(
                                 if p)
             results.append(vfs_path)
 
-    output = "\n".join(sorted(results)).encode()
+    output = format_records(sorted(results))
     return output, IOResult()

--- a/python/mirage/commands/builtin/email/grep.py
+++ b/python/mirage/commands/builtin/email/grep.py
@@ -21,6 +21,8 @@ from mirage.commands.builtin.email._provision import file_read_provision
 from mirage.commands.builtin.grep_helper import (compile_pattern,
                                                  grep_files_only, grep_lines,
                                                  grep_stream)
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
                                                 call_stat)
@@ -147,10 +149,10 @@ async def grep(
                                             max_count=max_count,
                                             whole_word=w,
                                             warnings=warnings)
-            stderr = ("\n".join(warnings).encode() if warnings else None)
+            stderr = format_optional_records(warnings)
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            return ("\n".join(results).encode(), IOResult(stderr=stderr))
+            return (format_records(results), IOResult(stderr=stderr))
 
         pat = compile_pattern(pattern, i, F, w)
 
@@ -170,7 +172,7 @@ async def grep(
                     all_results.extend(f"{p.original}:{r_}" for r_ in hits)
             if not all_results:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
+            return format_records(all_results), IOResult()
 
         data = await rb(paths[0].original)
         source = yield_bytes(data)
@@ -261,4 +263,4 @@ async def _grep_server_side(
 
     if not any_match:
         return b"", IOResult(exit_code=1)
-    return "\n".join(all_results).encode(), IOResult()
+    return format_records(all_results), IOResult()

--- a/python/mirage/commands/builtin/email/ls.py
+++ b/python/mirage/commands/builtin/email/ls.py
@@ -84,5 +84,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/email/rg.py
+++ b/python/mirage/commands/builtin/email/rg.py
@@ -18,6 +18,7 @@ from collections.abc import AsyncIterator
 from mirage.accessor.email import EmailAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -101,7 +102,7 @@ async def rg(
                 all_results.append(f"{vfs_path}:{line}")
         if not any_match:
             return b"", IOResult(exit_code=1)
-        return "\n".join(all_results).encode(), IOResult()
+        return format_records(all_results), IOResult()
 
     raw = await _read_stdin_async(stdin)
     if raw is None:
@@ -120,4 +121,4 @@ async def rg(
         return b"", IOResult(exit_code=1)
     if c:
         return str(len(matched)).encode(), IOResult()
-    return "\n".join(matched).encode(), IOResult()
+    return format_records(matched), IOResult()

--- a/python/mirage/commands/builtin/email/rg.py
+++ b/python/mirage/commands/builtin/email/rg.py
@@ -120,5 +120,5 @@ async def rg(
     if not matched:
         return b"", IOResult(exit_code=1)
     if c:
-        return str(len(matched)).encode(), IOResult()
+        return str(len(matched)).encode() + b"\n", IOResult()
     return format_records(matched), IOResult()

--- a/python/mirage/commands/builtin/email/wc.py
+++ b/python/mirage/commands/builtin/email/wc.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.email._provision import file_read_provision
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -83,10 +84,10 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
     data = await _read_stdin_async(stdin)
     if data is None:
         raise ValueError("wc: missing operand")
     counts = await generic_wc(data)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/gdocs/find.py
+++ b/python/mirage/commands/builtin/gdocs/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.gdocs import GDocsAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.gdocs._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdocs.glob import resolve_glob
@@ -114,5 +115,5 @@ async def find(
         if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
             continue
         results.append(p)
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/gdocs/ls.py
+++ b/python/mirage/commands/builtin/gdocs/ls.py
@@ -87,5 +87,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/gdocs/rm.py
+++ b/python/mirage/commands/builtin/gdocs/rm.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.gdocs import GDocsAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_optional_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdocs.glob import resolve_glob
@@ -47,5 +48,5 @@ async def rm(
         removed[p.strip_prefix] = b""
         if v:
             verbose_parts.append(f"removed '{p.original}'")
-    output = "\n".join(verbose_parts).encode() if v else None
+    output = format_optional_records(verbose_parts) if v else None
     return output, IOResult(writes=removed)

--- a/python/mirage/commands/builtin/gdocs/wc.py
+++ b/python/mirage/commands/builtin/gdocs/wc.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.gdocs._provision import file_read_provision
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -83,10 +84,10 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
     data = await _read_stdin_async(stdin)
     if data is None:
         raise ValueError("wc: missing operand")
     counts = await generic_wc(data)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/gdrive/du.py
+++ b/python/mirage/commands/builtin/gdrive/du.py
@@ -16,6 +16,7 @@ from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.gdrive._provision import metadata_provision
 from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdrive.glob import resolve_glob
@@ -89,9 +90,9 @@ async def du(
         output = _format_size(total, h) + "\t" + p0.original
         if c:
             output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
+        return format_records(output.splitlines()), IOResult()
     lines: list[str] = []
     lines.append(_format_size(total, h) + "\t" + p0.original)
     if c:
         lines.append(_format_size(total, h) + "\ttotal")
-    return "\n".join(lines).encode(), IOResult()
+    return format_records(lines), IOResult()

--- a/python/mirage/commands/builtin/gdrive/du.py
+++ b/python/mirage/commands/builtin/gdrive/du.py
@@ -87,10 +87,10 @@ async def du(
     p0 = paths[0]
     total = await _du_walk(accessor, p0, index)
     if s:
-        output = _format_size(total, h) + "\t" + p0.original
+        lines = [_format_size(total, h) + "\t" + p0.original]
         if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return format_records(output.splitlines()), IOResult()
+            lines.append(_format_size(total, h) + "\ttotal")
+        return format_records(lines), IOResult()
     lines: list[str] = []
     lines.append(_format_size(total, h) + "\t" + p0.original)
     if c:

--- a/python/mirage/commands/builtin/gdrive/find.py
+++ b/python/mirage/commands/builtin/gdrive/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.gdrive._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdrive.glob import resolve_glob
@@ -114,5 +115,5 @@ async def find(
         if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
             continue
         results.append(p)
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/gdrive/ls.py
+++ b/python/mirage/commands/builtin/gdrive/ls.py
@@ -87,5 +87,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/gdrive/wc.py
+++ b/python/mirage/commands/builtin/gdrive/wc.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.gdrive._provision import file_read_provision
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -83,10 +84,10 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
     data = await _read_stdin_async(stdin)
     if data is None:
         raise ValueError("wc: missing operand")
     counts = await generic_wc(data)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/general/grep.py
+++ b/python/mirage/commands/builtin/general/grep.py
@@ -16,6 +16,7 @@ import re
 from collections.abc import AsyncIterator
 
 from mirage.commands.builtin.grep_context import grep_context_lines
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.stream import exit_on_empty, quiet_match
@@ -155,7 +156,7 @@ async def grep(
                 return b"", IOResult(exit_code=1)
             if prefix:
                 results = [prefix + "/" + r.lstrip("/") for r in results]
-            return "\n".join(results).encode(), IOResult()
+            return format_records(results), IOResult()
 
         pat = _compile_pattern(pattern, i, F, w)
         source = ops["read_stream"](paths[0])

--- a/python/mirage/commands/builtin/general/grep.py
+++ b/python/mirage/commands/builtin/general/grep.py
@@ -83,7 +83,7 @@ async def _grep_stream(
                     yield m.group().encode() + b"\n"
                 if max_count and match_count >= max_count:
                     if count_only:
-                        yield str(match_count).encode()
+                        yield str(match_count).encode() + b"\n"
                     return
         else:
             match_count += 1
@@ -94,10 +94,10 @@ async def _grep_stream(
                     yield raw_line + b"\n"
             if max_count and match_count >= max_count:
                 if count_only:
-                    yield str(match_count).encode()
+                    yield str(match_count).encode() + b"\n"
                 return
     if count_only:
-        yield str(match_count).encode()
+        yield str(match_count).encode() + b"\n"
 
 
 async def grep(

--- a/python/mirage/commands/builtin/generic/cmp.py
+++ b/python/mirage/commands/builtin/generic/cmp.py
@@ -1,5 +1,6 @@
 from collections.abc import Awaitable, Callable
 
+from mirage.commands.builtin.utils.output import format_records
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -36,7 +37,7 @@ async def cmp_cmd(
             if data1[idx] != data2[idx]:
                 out_lines.append(
                     f"{idx + 1} {oct(data1[idx])} {oct(data2[idx])}")
-        return "\n".join(out_lines).encode(), IOResult(exit_code=1)
+        return format_records(out_lines), IOResult(exit_code=1)
     for idx in range(min(len(data1), len(data2))):
         if data1[idx] != data2[idx]:
             line = 1 + data1[:idx].count(ord(b"\n"))
@@ -45,10 +46,10 @@ async def cmp_cmd(
             if print_bytes:
                 msg += (f" is {oct(data1[idx])} {chr(data1[idx])}"
                         f" {oct(data2[idx])} {chr(data2[idx])}")
-            return msg.encode(), IOResult(exit_code=1)
+            return format_records([msg]), IOResult(exit_code=1)
     shorter = p0.original if len(data1) < len(data2) else p1.original
     msg = f"cmp: EOF on {shorter}"
-    return msg.encode(), IOResult(exit_code=1)
+    return format_records([msg]), IOResult(exit_code=1)
 
 
 __all__ = ["cmp_cmd"]

--- a/python/mirage/commands/builtin/generic/du.py
+++ b/python/mirage/commands/builtin/generic/du.py
@@ -1,6 +1,7 @@
 from collections.abc import Awaitable, Callable
 
 from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.commands.builtin.utils.output import format_record_text
 from mirage.types import PathSpec
 
 
@@ -50,7 +51,7 @@ async def _du_one(
 
     lines = [_format_size(sz, h) + "\t" + p for p, sz in entries]
     display_total = sum(sz for _, sz in entries)
-    return "\n".join(lines), display_total
+    return format_record_text(lines).rstrip("\n"), display_total
 
 
 async def du(
@@ -79,8 +80,8 @@ async def du(
         )
         sub_texts.append(text)
         totals.append(total)
-    out = "\n".join(sub_texts)
+    out = format_record_text(sub_texts)
     if c:
         grand = sum(totals)
-        out += "\n" + _format_size(grand, h) + "\ttotal"
+        out += _format_size(grand, h) + "\ttotal\n"
     return out

--- a/python/mirage/commands/builtin/generic/du.py
+++ b/python/mirage/commands/builtin/generic/du.py
@@ -51,7 +51,7 @@ async def _du_one(
 
     lines = [_format_size(sz, h) + "\t" + p for p, sz in entries]
     display_total = sum(sz for _, sz in entries)
-    return format_record_text(lines).rstrip("\n"), display_total
+    return "\n".join(lines), display_total
 
 
 async def du(

--- a/python/mirage/commands/builtin/generic/file.py
+++ b/python/mirage/commands/builtin/generic/file.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Awaitable, Callable
 
 from mirage.commands.builtin.file_helper import _detect
+from mirage.commands.builtin.utils.output import format_records
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import FileStat, FileType, PathSpec
 
@@ -65,7 +66,7 @@ async def file_cmd(
             header = b""
         result = _detect(p.original, header, s)
         lines.append(_format_file_result(p.original, result, b, i))
-    return "\n".join(lines).encode(), IOResult()
+    return format_records(lines), IOResult()
 
 
 __all__ = ["file_cmd"]

--- a/python/mirage/commands/builtin/generic/find.py
+++ b/python/mirage/commands/builtin/generic/find.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from mirage.commands.builtin.find_helper import (_extract_not_name,
                                                  _extract_or_names,
                                                  _parse_mtime, _parse_size)
+from mirage.commands.builtin.utils.output import format_records
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import FileStat, FindType, PathSpec
 
@@ -156,4 +157,4 @@ async def find(
                                            stat=stat,
                                            mount_prefix=search_path.prefix)
     results = apply_mount_prefix(results, search_path.prefix)
-    return "\n".join(results).encode(), IOResult()
+    return format_records(results), IOResult()

--- a/python/mirage/commands/builtin/generic/grep.py
+++ b/python/mirage/commands/builtin/generic/grep.py
@@ -6,6 +6,8 @@ from mirage.commands.builtin.grep_helper import (compile_pattern,
                                                  grep_files_only, grep_lines,
                                                  grep_recursive, grep_stream)
 from mirage.commands.builtin.utils.lines import split_lines
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
                                                 call_stat)
@@ -88,10 +90,10 @@ async def grep(
                     read_stream_fn=None,
                 )
                 results.extend(hits)
-            stderr = "\n".join(warnings).encode() if warnings else None
+            stderr = format_optional_records(warnings)
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            return "\n".join(results).encode(), IOResult(stderr=stderr)
+            return format_records(results), IOResult(stderr=stderr)
 
         if recursive:
             pat = compile_pattern(pattern, ignore_case, fixed_string,
@@ -131,10 +133,10 @@ async def grep(
                         all_results.extend(
                             f"{p.original}:{rl}" if len(paths) > 1 else rl
                             for rl in hits)
-            stderr = "\n".join(warnings).encode() if warnings else None
+            stderr = format_optional_records(warnings)
             if not all_results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            return "\n".join(all_results).encode(), IOResult(stderr=stderr)
+            return format_records(all_results), IOResult(stderr=stderr)
 
         pat = compile_pattern(pattern, ignore_case, fixed_string, whole_word)
 
@@ -155,7 +157,7 @@ async def grep(
                     all_results.extend(f"{p.original}:{r}" for r in hits)
             if not all_results:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
+            return format_records(all_results), IOResult()
 
         if read_stream is not None:
             source: AsyncIterator[bytes] = read_stream(accessor, paths[0])

--- a/python/mirage/commands/builtin/generic/ls.py
+++ b/python/mirage/commands/builtin/generic/ls.py
@@ -2,6 +2,8 @@ from collections.abc import Awaitable, Callable
 
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.utils.formatting import format_ls_long
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.io.types import IOResult
 from mirage.types import FileStat, FileType, LsSortBy, PathSpec
 
@@ -195,7 +197,6 @@ async def ls(
     list_dir: bool = False,
     classify: bool = False,
     index: IndexCacheStore | None = None,
-    trailing_newline: bool = False,
 ) -> tuple[bytes, IOResult]:
     results: list[str] = []
     warnings: list[str] = []
@@ -239,11 +240,8 @@ async def ls(
                           human=human,
                           classify=classify)
 
-    body = "\n".join(results)
-    if trailing_newline and results:
-        body += "\n"
-    output = body.encode() if results else b""
-    stderr = "\n".join(warnings).encode() if warnings else None
+    output = format_records(results)
+    stderr = format_optional_records(warnings)
     exit_code = 1 if warnings and not results else 0
     return output, IOResult(stderr=stderr, exit_code=exit_code)
 

--- a/python/mirage/commands/builtin/generic/md5.py
+++ b/python/mirage/commands/builtin/generic/md5.py
@@ -1,6 +1,7 @@
 import hashlib
 from collections.abc import AsyncIterator, Awaitable, Callable
 
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -24,7 +25,7 @@ async def md5(
         data = await read_bytes(accessor, p)
         digest = hashlib.md5(data).hexdigest()
         outputs.append(f"{digest}  {p.original}")
-    return "\n".join(outputs).encode(), IOResult()
+    return format_records(outputs), IOResult()
 
 
 __all__ = ["md5"]

--- a/python/mirage/commands/builtin/generic/rg.py
+++ b/python/mirage/commands/builtin/generic/rg.py
@@ -6,6 +6,8 @@ from mirage.commands.builtin.grep_helper import (compile_pattern, grep_lines,
                                                  grep_stream)
 from mirage.commands.builtin.rg_helper import rg_full
 from mirage.commands.builtin.utils.lines import split_lines
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
                                                 call_stat)
@@ -102,10 +104,10 @@ async def rg(
                 hidden=hidden,
                 warnings=warnings_f,
             )
-            stderr = "\n".join(warnings_f).encode() if warnings_f else None
+            stderr = format_optional_records(warnings_f)
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            return "\n".join(results).encode(), IOResult(stderr=stderr)
+            return format_records(results), IOResult(stderr=stderr)
 
         pat = compile_pattern(pattern, ignore_case, fixed_string, whole_word)
 
@@ -126,7 +128,7 @@ async def rg(
                     all_results.extend(f"{p.original}:{r}" for r in hits)
             if not all_results:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
+            return format_records(all_results), IOResult()
 
         if read_stream is not None:
             source: AsyncIterator[bytes] = read_stream(accessor, paths[0])

--- a/python/mirage/commands/builtin/generic/stat.py
+++ b/python/mirage/commands/builtin/generic/stat.py
@@ -2,6 +2,7 @@ import re
 from collections.abc import Awaitable, Callable
 
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_records
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import FileStat, FileType, PathSpec
 
@@ -54,7 +55,7 @@ async def stat(
             lines.append(f"name={s.name} size={s.size}"
                          f" modified={s.modified}"
                          f" type={s.type.value if s.type else None}")
-    return "\n".join(lines).encode(), IOResult()
+    return format_records(lines), IOResult()
 
 
 __all__ = ["stat"]

--- a/python/mirage/commands/builtin/generic/tree.py
+++ b/python/mirage/commands/builtin/generic/tree.py
@@ -2,6 +2,8 @@ import fnmatch
 from collections.abc import Awaitable, Callable
 
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.io.types import IOResult
 from mirage.types import FileStat, FileType, PathSpec
 
@@ -108,8 +110,8 @@ async def tree(
                         match_pattern=match_pattern,
                         warnings=warnings,
                         index=index)
-    output = "\n".join(lines).encode()
-    stderr = "\n".join(warnings).encode() if warnings else None
+    output = format_records(lines)
+    stderr = format_optional_records(warnings)
     return output, IOResult(stderr=stderr)
 
 

--- a/python/mirage/commands/builtin/generic/wc.py
+++ b/python/mirage/commands/builtin/generic/wc.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, Callable
 
+from mirage.commands.builtin.utils.output import format_records
 from mirage.types import PathSpec
 from mirage.utils.stream import ensure_stream
 
@@ -176,4 +177,4 @@ async def format_multi(
                       label="total"))
     if not outputs:
         return b""
-    return ("\n".join(outputs) + "\n").encode()
+    return format_records(outputs)

--- a/python/mirage/commands/builtin/github/du.py
+++ b/python/mirage/commands/builtin/github/du.py
@@ -67,10 +67,10 @@ async def du(
             if entry.size is not None:
                 total += entry.size
     if s:
-        output = _format_size(total, h) + "\t" + path
+        lines = [_format_size(total, h) + "\t" + path]
         if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return format_records(output.splitlines()), IOResult()
+            lines.append(_format_size(total, h) + "\ttotal")
+        return format_records(lines), IOResult()
     lines: list[str] = []
     lines.append(_format_size(total, h) + "\t" + path)
     if c:

--- a/python/mirage/commands/builtin/github/du.py
+++ b/python/mirage/commands/builtin/github/du.py
@@ -16,6 +16,7 @@ from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.github._provision import metadata_provision
 from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github.glob import resolve_glob
@@ -69,9 +70,9 @@ async def du(
         output = _format_size(total, h) + "\t" + path
         if c:
             output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
+        return format_records(output.splitlines()), IOResult()
     lines: list[str] = []
     lines.append(_format_size(total, h) + "\t" + path)
     if c:
         lines.append(_format_size(total, h) + "\ttotal")
-    return "\n".join(lines).encode(), IOResult()
+    return format_records(lines), IOResult()

--- a/python/mirage/commands/builtin/github/find.py
+++ b/python/mirage/commands/builtin/github/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.github._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github.glob import resolve_glob
@@ -113,5 +114,5 @@ async def find(
             results.append(ep)
     if mount_prefix:
         results = [mount_prefix + "/" + r.lstrip("/") for r in results]
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/github/grep.py
+++ b/python/mirage/commands/builtin/github/grep.py
@@ -22,6 +22,8 @@ from mirage.commands.builtin.grep_helper import (classify_pattern,
                                                  compile_pattern,
                                                  grep_files_only, grep_lines,
                                                  grep_recursive, grep_stream)
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -221,10 +223,10 @@ async def grep(
                     warnings=warnings_l,
                 )
                 all_results.extend(res)
-            stderr = "\n".join(warnings_l).encode() if warnings_l else None
+            stderr = format_optional_records(warnings_l)
             if not all_results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            return "\n".join(all_results).encode(), IOResult(stderr=stderr)
+            return format_records(all_results), IOResult(stderr=stderr)
 
         pat = compile_pattern(pattern, i, F, w)
         all_results = []
@@ -275,10 +277,10 @@ async def grep(
                                        for line in file_lines)
             else:
                 all_results.extend(file_lines)
-        stderr = "\n".join(warnings_g).encode() if warnings_g else None
+        stderr = format_optional_records(warnings_g)
         if not all_results:
             return b"", IOResult(exit_code=1, stderr=stderr)
-        return "\n".join(all_results).encode(), IOResult(stderr=stderr)
+        return format_records(all_results), IOResult(stderr=stderr)
 
     source = _resolve_source(stdin, "grep: usage: grep [flags] pattern [path]")
     pat = compile_pattern(pattern, i, F, w)

--- a/python/mirage/commands/builtin/github/rg.py
+++ b/python/mirage/commands/builtin/github/rg.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.constants import PatternType
 from mirage.commands.builtin.grep_helper import (classify_pattern,
                                                  compile_pattern, grep_lines)
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -171,7 +172,7 @@ async def rg(
                 all_results.append(f"{display}:{line}")
         if not any_match:
             return b"", IOResult(exit_code=1)
-        return "\n".join(all_results).encode(), IOResult()
+        return format_records(all_results), IOResult()
 
     raw = await _read_stdin_async(stdin)
     if raw is None:
@@ -194,4 +195,4 @@ async def rg(
     result_lines: list[str] = []
     for line in matched:
         result_lines.append(line)
-    return "\n".join(result_lines).encode(), IOResult()
+    return format_records(result_lines), IOResult()

--- a/python/mirage/commands/builtin/github/rg.py
+++ b/python/mirage/commands/builtin/github/rg.py
@@ -191,7 +191,7 @@ async def rg(
     if not matched:
         return b"", IOResult(exit_code=1)
     if c:
-        return str(len(matched)).encode(), IOResult()
+        return str(len(matched)).encode() + b"\n", IOResult()
     result_lines: list[str] = []
     for line in matched:
         result_lines.append(line)

--- a/python/mirage/commands/builtin/github/wc.py
+++ b/python/mirage/commands/builtin/github/wc.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.github._provision import file_read_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -81,10 +82,10 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
     data = await _read_stdin_async(stdin)
     if data is None:
         raise ValueError("wc: missing operand")
     counts = await generic_wc(data)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/github_ci/find.py
+++ b/python/mirage/commands/builtin/github_ci/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.github_ci import GitHubCIAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.github_ci._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github_ci.glob import is_cross_run_root, resolve_glob
@@ -115,5 +116,5 @@ async def find(
         if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
             continue
         results.append(p)
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/github_ci/wc.py
+++ b/python/mirage/commands/builtin/github_ci/wc.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.github_ci._provision import file_read_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -80,10 +81,10 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
     data = await _read_stdin_async(stdin)
     if data is None:
         raise ValueError("wc: missing operand")
     counts = await generic_wc(data)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/gmail/find.py
+++ b/python/mirage/commands/builtin/gmail/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.gmail import GmailAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.gmail._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gmail.glob import resolve_glob
@@ -115,5 +116,5 @@ async def find(
         if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
             continue
         results.append(p)
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/gmail/grep.py
+++ b/python/mirage/commands/builtin/gmail/grep.py
@@ -110,7 +110,7 @@ async def grep(
             lines = format_grep_results(rows, scope, file_prefix, pattern)
             if not lines:
                 return b"", IOResult(exit_code=1)
-            return ("\n".join(lines) + "\n").encode(), IOResult()
+            return format_records(lines), IOResult()
 
         paths = await resolve_glob(accessor, paths, index)
         file_prefix = paths[0].prefix if paths else ""

--- a/python/mirage/commands/builtin/gmail/grep.py
+++ b/python/mirage/commands/builtin/gmail/grep.py
@@ -21,6 +21,8 @@ from mirage.commands.builtin.gmail._provision import file_read_provision
 from mirage.commands.builtin.grep_helper import (compile_pattern,
                                                  grep_files_only, grep_lines,
                                                  grep_stream)
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
                                                 call_stat)
@@ -147,10 +149,10 @@ async def grep(
                 whole_word=w,
                 warnings=warnings,
             )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
+            stderr = format_optional_records(warnings)
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            return ("\n".join(results).encode(), IOResult(stderr=stderr))
+            return (format_records(results), IOResult(stderr=stderr))
 
         pat = compile_pattern(pattern, i, F, w)
 
@@ -170,7 +172,7 @@ async def grep(
                     all_results.extend(f"{p.original}:{r_}" for r_ in hits)
             if not all_results:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
+            return format_records(all_results), IOResult()
 
         data = await rb(paths[0].original)
         source = yield_bytes(data)

--- a/python/mirage/commands/builtin/gmail/ls.py
+++ b/python/mirage/commands/builtin/gmail/ls.py
@@ -87,5 +87,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/gmail/rg.py
+++ b/python/mirage/commands/builtin/gmail/rg.py
@@ -100,7 +100,7 @@ async def rg(
             lines = format_grep_results(rows, scope, file_prefix, pattern_str)
             if not lines:
                 return b"", IOResult(exit_code=1)
-            return ("\n".join(lines) + "\n").encode(), IOResult()
+            return format_records(lines), IOResult()
 
         paths = await resolve_glob(accessor, paths, index)
         blob_paths: list[str] = []

--- a/python/mirage/commands/builtin/gmail/rg.py
+++ b/python/mirage/commands/builtin/gmail/rg.py
@@ -17,6 +17,7 @@ from collections.abc import AsyncIterator
 from mirage.accessor.gmail import GmailAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -147,7 +148,7 @@ async def rg(
                 all_results.append(f"{bp}:{line}")
         if not any_match:
             return b"", IOResult(exit_code=1)
-        return "\n".join(all_results).encode(), IOResult()
+        return format_records(all_results), IOResult()
 
     raw = await _read_stdin_async(stdin)
     if raw is None:
@@ -169,4 +170,4 @@ async def rg(
     result_lines: list[str] = []
     for line in matched:
         result_lines.append(line)
-    return "\n".join(result_lines).encode(), IOResult()
+    return format_records(result_lines), IOResult()

--- a/python/mirage/commands/builtin/gmail/rg.py
+++ b/python/mirage/commands/builtin/gmail/rg.py
@@ -166,7 +166,7 @@ async def rg(
     if not matched:
         return b"", IOResult(exit_code=1)
     if c:
-        return str(len(matched)).encode(), IOResult()
+        return str(len(matched)).encode() + b"\n", IOResult()
     result_lines: list[str] = []
     for line in matched:
         result_lines.append(line)

--- a/python/mirage/commands/builtin/gmail/rm.py
+++ b/python/mirage/commands/builtin/gmail/rm.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.gmail import GmailAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_optional_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gmail.glob import resolve_glob
@@ -47,5 +48,5 @@ async def rm(
         removed[p.strip_prefix] = b""
         if v:
             verbose_parts.append(f"removed '{p.original}'")
-    output = "\n".join(verbose_parts).encode() if v else None
+    output = format_optional_records(verbose_parts) if v else None
     return output, IOResult(writes=removed)

--- a/python/mirage/commands/builtin/gmail/wc.py
+++ b/python/mirage/commands/builtin/gmail/wc.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.gmail._provision import file_read_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -83,10 +84,10 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
     data = await _read_stdin_async(stdin)
     if data is None:
         raise ValueError("wc: missing operand")
     counts = await generic_wc(data)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/gsheets/find.py
+++ b/python/mirage/commands/builtin/gsheets/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.gsheets import GSheetsAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.gsheets._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gsheets.glob import resolve_glob
@@ -115,5 +116,5 @@ async def find(
         if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
             continue
         results.append(p)
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/gsheets/ls.py
+++ b/python/mirage/commands/builtin/gsheets/ls.py
@@ -87,5 +87,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/gsheets/rm.py
+++ b/python/mirage/commands/builtin/gsheets/rm.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.gsheets import GSheetsAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_optional_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gsheets.glob import resolve_glob
@@ -47,5 +48,5 @@ async def rm(
         removed[p.strip_prefix] = b""
         if v:
             verbose_parts.append(f"removed '{p.original}'")
-    output = "\n".join(verbose_parts).encode() if v else None
+    output = format_optional_records(verbose_parts) if v else None
     return output, IOResult(writes=removed)

--- a/python/mirage/commands/builtin/gsheets/wc.py
+++ b/python/mirage/commands/builtin/gsheets/wc.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.gsheets._provision import file_read_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -83,10 +84,10 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
     data = await _read_stdin_async(stdin)
     if data is None:
         raise ValueError("wc: missing operand")
     counts = await generic_wc(data)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/gslides/find.py
+++ b/python/mirage/commands/builtin/gslides/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.gslides import GSlidesAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.gslides._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gslides.glob import resolve_glob
@@ -115,5 +116,5 @@ async def find(
         if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
             continue
         results.append(p)
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/gslides/ls.py
+++ b/python/mirage/commands/builtin/gslides/ls.py
@@ -87,5 +87,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/gslides/rm.py
+++ b/python/mirage/commands/builtin/gslides/rm.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.gslides import GSlidesAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_optional_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gslides.glob import resolve_glob
@@ -47,5 +48,5 @@ async def rm(
         removed[p.strip_prefix] = b""
         if v:
             verbose_parts.append(f"removed '{p.original}'")
-    output = "\n".join(verbose_parts).encode() if v else None
+    output = format_optional_records(verbose_parts) if v else None
     return output, IOResult(writes=removed)

--- a/python/mirage/commands/builtin/gslides/wc.py
+++ b/python/mirage/commands/builtin/gslides/wc.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.gslides._provision import file_read_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -83,10 +84,10 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
     data = await _read_stdin_async(stdin)
     if data is None:
         raise ValueError("wc: missing operand")
     counts = await generic_wc(data)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/hf_buckets/du.py
+++ b/python/mirage/commands/builtin/hf_buckets/du.py
@@ -57,17 +57,17 @@ async def du(
     path = p0
     if s:
         total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
+        lines = [_format_size(total, h) + "\t" + p0.original]
         if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return format_records(output.splitlines()), IOResult()
+            lines.append(_format_size(total, h) + "\ttotal")
+        return format_records(lines), IOResult()
     all_entries = await du_all_impl(accessor, path)
     if not all_entries:
         total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
+        lines = [_format_size(total, h) + "\t" + p0.original]
         if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return format_records(output.splitlines()), IOResult()
+            lines.append(_format_size(total, h) + "\ttotal")
+        return format_records(lines), IOResult()
     if not a:
         dir_entries: list[tuple[str, int]] = []
         for p, sz in all_entries:
@@ -80,10 +80,10 @@ async def du(
                        if _depth(p, p0.original) <= md]
     if not all_entries:
         total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
+        lines = [_format_size(total, h) + "\t" + p0.original]
         if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return format_records(output.splitlines()), IOResult()
+            lines.append(_format_size(total, h) + "\ttotal")
+        return format_records(lines), IOResult()
     lines = [_format_size(sz, h) + "\t" + p for p, sz in all_entries]
     if c:
         grand = sum(sz for _, sz in all_entries)

--- a/python/mirage/commands/builtin/hf_buckets/du.py
+++ b/python/mirage/commands/builtin/hf_buckets/du.py
@@ -16,6 +16,7 @@ from mirage.accessor._hf import HF_RESOURCES
 from mirage.accessor.hf_buckets import HfBucketsAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.hf_buckets.du import du as du_impl
@@ -59,14 +60,14 @@ async def du(
         output = _format_size(total, h) + "\t" + p0.original
         if c:
             output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
+        return format_records(output.splitlines()), IOResult()
     all_entries = await du_all_impl(accessor, path)
     if not all_entries:
         total = await du_impl(accessor, path)
         output = _format_size(total, h) + "\t" + p0.original
         if c:
             output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
+        return format_records(output.splitlines()), IOResult()
     if not a:
         dir_entries: list[tuple[str, int]] = []
         for p, sz in all_entries:
@@ -82,9 +83,9 @@ async def du(
         output = _format_size(total, h) + "\t" + p0.original
         if c:
             output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
+        return format_records(output.splitlines()), IOResult()
     lines = [_format_size(sz, h) + "\t" + p for p, sz in all_entries]
     if c:
         grand = sum(sz for _, sz in all_entries)
         lines.append(_format_size(grand, h) + "\ttotal")
-    return "\n".join(lines).encode(), IOResult()
+    return format_records(lines), IOResult()

--- a/python/mirage/commands/builtin/hf_buckets/find.py
+++ b/python/mirage/commands/builtin/hf_buckets/find.py
@@ -19,6 +19,7 @@ from mirage.commands.builtin.find_helper import (_extract_not_name,
                                                  _extract_or_names,
                                                  _parse_mtime, _parse_size)
 from mirage.commands.builtin.hf_buckets._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.hf_buckets.find import find as find_impl
@@ -87,5 +88,5 @@ async def find(
     )
     if p0.prefix:
         results = [p0.prefix + "/" + r.lstrip("/") for r in results]
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/hf_buckets/ls.py
+++ b/python/mirage/commands/builtin/hf_buckets/ls.py
@@ -77,5 +77,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/hf_buckets/rm.py
+++ b/python/mirage/commands/builtin/hf_buckets/rm.py
@@ -15,6 +15,7 @@
 from mirage.accessor._hf import HF_RESOURCES
 from mirage.accessor.hf_buckets import HfBucketsAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_optional_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.hf_buckets.glob import resolve_glob
@@ -59,5 +60,5 @@ async def rm(
         removed[path.strip_prefix] = b""
         if v:
             verbose_parts.append(f"removed '{path.original}'")
-    output = "\n".join(verbose_parts).encode() if v else None
+    output = format_optional_records(verbose_parts) if v else None
     return output, IOResult(writes=removed)

--- a/python/mirage/commands/builtin/langfuse/find.py
+++ b/python/mirage/commands/builtin/langfuse/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.langfuse import LangfuseAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.langfuse._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.langfuse.glob import resolve_glob
@@ -111,5 +112,5 @@ async def find(
         if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
             continue
         results.append(p)
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/langfuse/grep.py
+++ b/python/mirage/commands/builtin/langfuse/grep.py
@@ -23,6 +23,8 @@ from mirage.commands.builtin.grep_helper import (compile_pattern,
                                                  grep_files_only, grep_lines,
                                                  grep_stream)
 from mirage.commands.builtin.langfuse._provision import file_read_provision
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
                                                 call_stat)
@@ -55,7 +57,7 @@ def _filter_traces(
         lines.append(line)
     if not lines:
         return b"", IOResult(exit_code=1)
-    return "\n".join(lines).encode(), IOResult()
+    return format_records(lines), IOResult()
 
 
 def _format_session_results(
@@ -72,7 +74,7 @@ def _format_session_results(
         lines.append(line)
     if not lines:
         return b"", IOResult(exit_code=1)
-    return "\n".join(lines).encode(), IOResult()
+    return format_records(lines), IOResult()
 
 
 def _format_prompt_results(
@@ -93,7 +95,7 @@ def _format_prompt_results(
         lines.append(line)
     if not lines:
         return b"", IOResult(exit_code=1)
-    return "\n".join(lines).encode(), IOResult()
+    return format_records(lines), IOResult()
 
 
 def _format_dataset_results(
@@ -110,7 +112,7 @@ def _format_dataset_results(
         lines.append(line)
     if not lines:
         return b"", IOResult(exit_code=1)
-    return "\n".join(lines).encode(), IOResult()
+    return format_records(lines), IOResult()
 
 
 async def grep_provision(
@@ -235,10 +237,10 @@ async def grep(
                 whole_word=w,
                 warnings=warnings,
             )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
+            stderr = format_optional_records(warnings)
             if not results_l:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            return ("\n".join(results_l).encode(), IOResult(stderr=stderr))
+            return (format_records(results_l), IOResult(stderr=stderr))
 
         pat = compile_pattern(pattern, i, F, w)
 
@@ -258,7 +260,7 @@ async def grep(
                     all_results.extend(f"{p.original}:{r_}" for r_ in hits)
             if not all_results:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
+            return format_records(all_results), IOResult()
 
         data = await rb(paths[0].original)
         source = yield_bytes(data)

--- a/python/mirage/commands/builtin/langfuse/ls.py
+++ b/python/mirage/commands/builtin/langfuse/ls.py
@@ -84,5 +84,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/langfuse/rg.py
+++ b/python/mirage/commands/builtin/langfuse/rg.py
@@ -180,7 +180,7 @@ async def rg(
     if not matched:
         return b"", IOResult(exit_code=1)
     if c:
-        return str(len(matched)).encode(), IOResult()
+        return str(len(matched)).encode() + b"\n", IOResult()
     result_lines: list[str] = []
     for line in matched:
         result_lines.append(line)

--- a/python/mirage/commands/builtin/langfuse/rg.py
+++ b/python/mirage/commands/builtin/langfuse/rg.py
@@ -21,6 +21,7 @@ from mirage.commands.builtin.langfuse.grep import (_filter_traces,
                                                    _format_dataset_results,
                                                    _format_prompt_results,
                                                    _format_session_results)
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -161,7 +162,7 @@ async def rg(
                 all_results.append(f"{bp}:{line}")
         if not any_match:
             return b"", IOResult(exit_code=1)
-        return "\n".join(all_results).encode(), IOResult()
+        return format_records(all_results), IOResult()
 
     raw = await _read_stdin_async(stdin)
     if raw is None:
@@ -183,4 +184,4 @@ async def rg(
     result_lines: list[str] = []
     for line in matched:
         result_lines.append(line)
-    return "\n".join(result_lines).encode(), IOResult()
+    return format_records(result_lines), IOResult()

--- a/python/mirage/commands/builtin/langfuse/wc.py
+++ b/python/mirage/commands/builtin/langfuse/wc.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.langfuse._provision import file_read_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -80,10 +81,10 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
     data = await _read_stdin_async(stdin)
     if data is None:
         raise ValueError("wc: missing operand")
     counts = await generic_wc(data)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/linear/find.py
+++ b/python/mirage/commands/builtin/linear/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.linear import LinearAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.linear._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.linear.glob import resolve_glob
@@ -123,4 +124,4 @@ async def find(
         else:
             value = entry_path
         results.append(value)
-    return "\n".join(results).encode(), IOResult()
+    return format_records(results), IOResult()

--- a/python/mirage/commands/builtin/linear/ls.py
+++ b/python/mirage/commands/builtin/linear/ls.py
@@ -84,5 +84,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/linear/wc.py
+++ b/python/mirage/commands/builtin/linear/wc.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.linear._provision import file_read_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -80,10 +81,10 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
     data = await _read_stdin_async(stdin)
     if data is None:
         raise ValueError("wc: missing operand")
     counts = await generic_wc(data)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/mongodb/find.py
+++ b/python/mirage/commands/builtin/mongodb/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.mongodb._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.mongodb.glob import resolve_glob
@@ -111,5 +112,5 @@ async def find(
         if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
             continue
         results.append(p)
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/mongodb/grep.py
+++ b/python/mirage/commands/builtin/mongodb/grep.py
@@ -22,6 +22,8 @@ from mirage.commands.builtin.grep_helper import (compile_pattern,
                                                  grep_files_only, grep_lines,
                                                  grep_stream)
 from mirage.commands.builtin.mongodb._provision import file_read_provision
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
                                                 call_stat)
@@ -143,7 +145,7 @@ async def grep(
             all_lines = format_grep_results(results)
             if not all_lines:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_lines).encode(), IOResult()
+            return format_records(all_lines), IOResult()
 
         paths = await resolve_glob(accessor, paths, index=index)
         file_prefix = paths[0].prefix if paths else ""
@@ -182,10 +184,10 @@ async def grep(
                 whole_word=w,
                 warnings=warnings,
             )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
+            stderr = format_optional_records(warnings)
             if not results_l:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            return ("\n".join(results_l).encode(), IOResult(stderr=stderr))
+            return (format_records(results_l), IOResult(stderr=stderr))
 
         pat = compile_pattern(pattern, i, F, w)
 
@@ -205,7 +207,7 @@ async def grep(
                     all_results.extend(f"{p.original}:{r_}" for r_ in hits)
             if not all_results:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
+            return format_records(all_results), IOResult()
 
         source = read_stream(accessor, paths[0], index)
         stream = grep_stream(

--- a/python/mirage/commands/builtin/mongodb/rg.py
+++ b/python/mirage/commands/builtin/mongodb/rg.py
@@ -17,6 +17,7 @@ from collections.abc import AsyncIterator
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -125,7 +126,7 @@ async def rg(
             all_lines = format_grep_results(results)
             if not all_lines:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_lines).encode(), IOResult()
+            return format_records(all_lines), IOResult()
 
         paths = await resolve_glob(accessor, paths, index=index)
         blob_paths: list[str] = []
@@ -173,7 +174,7 @@ async def rg(
                 all_results.append(f"{bp}:{line}")
         if not any_match:
             return b"", IOResult(exit_code=1)
-        return "\n".join(all_results).encode(), IOResult()
+        return format_records(all_results), IOResult()
 
     raw = await _read_stdin_async(stdin)
     if raw is None:
@@ -195,4 +196,4 @@ async def rg(
     result_lines: list[str] = []
     for line in matched:
         result_lines.append(line)
-    return "\n".join(result_lines).encode(), IOResult()
+    return format_records(result_lines), IOResult()

--- a/python/mirage/commands/builtin/mongodb/rg.py
+++ b/python/mirage/commands/builtin/mongodb/rg.py
@@ -192,7 +192,7 @@ async def rg(
     if not matched:
         return b"", IOResult(exit_code=1)
     if c:
-        return str(len(matched)).encode(), IOResult()
+        return str(len(matched)).encode() + b"\n", IOResult()
     result_lines: list[str] = []
     for line in matched:
         result_lines.append(line)

--- a/python/mirage/commands/builtin/mongodb/wc.py
+++ b/python/mirage/commands/builtin/mongodb/wc.py
@@ -75,12 +75,12 @@ async def wc(
                 paths[0],
                 index,
             )
-            return str(len(data)).encode(), IOResult()
+            return str(len(data)).encode() + b"\n", IOResult()
         count = await count_documents(
             accessor.client,
             scope.database,
             scope.name,
         )
-        return str(count).encode(), IOResult()
+        return str(count).encode() + b"\n", IOResult()
 
     raise ValueError("wc: path must target documents.jsonl")

--- a/python/mirage/commands/builtin/nextcloud/du.py
+++ b/python/mirage/commands/builtin/nextcloud/du.py
@@ -56,17 +56,17 @@ async def du(
     path = p0
     if s:
         total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
+        lines = [_format_size(total, h) + "\t" + p0.original]
         if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return format_records(output.splitlines()), IOResult()
+            lines.append(_format_size(total, h) + "\ttotal")
+        return format_records(lines), IOResult()
     all_entries = await du_all_impl(accessor, path)
     if not all_entries:
         total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
+        lines = [_format_size(total, h) + "\t" + p0.original]
         if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return format_records(output.splitlines()), IOResult()
+            lines.append(_format_size(total, h) + "\ttotal")
+        return format_records(lines), IOResult()
     if not a:
         dir_entries: list[tuple[str, int]] = []
         for p, sz in all_entries:
@@ -79,10 +79,10 @@ async def du(
                        if _depth(p, p0.original) <= md]
     if not all_entries:
         total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
+        lines = [_format_size(total, h) + "\t" + p0.original]
         if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return format_records(output.splitlines()), IOResult()
+            lines.append(_format_size(total, h) + "\ttotal")
+        return format_records(lines), IOResult()
     lines = [_format_size(sz, h) + "\t" + p for p, sz in all_entries]
     if c:
         grand = sum(sz for _, sz in all_entries)

--- a/python/mirage/commands/builtin/nextcloud/du.py
+++ b/python/mirage/commands/builtin/nextcloud/du.py
@@ -15,6 +15,7 @@
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.nextcloud.du import du as du_impl
@@ -58,14 +59,14 @@ async def du(
         output = _format_size(total, h) + "\t" + p0.original
         if c:
             output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
+        return format_records(output.splitlines()), IOResult()
     all_entries = await du_all_impl(accessor, path)
     if not all_entries:
         total = await du_impl(accessor, path)
         output = _format_size(total, h) + "\t" + p0.original
         if c:
             output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
+        return format_records(output.splitlines()), IOResult()
     if not a:
         dir_entries: list[tuple[str, int]] = []
         for p, sz in all_entries:
@@ -81,9 +82,9 @@ async def du(
         output = _format_size(total, h) + "\t" + p0.original
         if c:
             output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
+        return format_records(output.splitlines()), IOResult()
     lines = [_format_size(sz, h) + "\t" + p for p, sz in all_entries]
     if c:
         grand = sum(sz for _, sz in all_entries)
         lines.append(_format_size(grand, h) + "\ttotal")
-    return "\n".join(lines).encode(), IOResult()
+    return format_records(lines), IOResult()

--- a/python/mirage/commands/builtin/nextcloud/find.py
+++ b/python/mirage/commands/builtin/nextcloud/find.py
@@ -18,6 +18,7 @@ from mirage.commands.builtin.find_helper import (_extract_not_name,
                                                  _extract_or_names,
                                                  _parse_mtime, _parse_size)
 from mirage.commands.builtin.nextcloud._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.nextcloud.find import find as find_impl
@@ -86,5 +87,5 @@ async def find(
     )
     if p0.prefix:
         results = [p0.prefix + "/" + r.lstrip("/") for r in results]
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/nextcloud/ls.py
+++ b/python/mirage/commands/builtin/nextcloud/ls.py
@@ -76,5 +76,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/nextcloud/rm.py
+++ b/python/mirage/commands/builtin/nextcloud/rm.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_optional_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.nextcloud.glob import resolve_glob
@@ -85,5 +86,5 @@ async def rm(
         removed[p.strip_prefix] = b""
         if v:
             verbose_parts.append(f"removed '{p.original}'")
-    output = "\n".join(verbose_parts).encode() if v else None
+    output = format_optional_records(verbose_parts) if v else None
     return output, IOResult(writes=removed)

--- a/python/mirage/commands/builtin/notion/grep.py
+++ b/python/mirage/commands/builtin/notion/grep.py
@@ -18,6 +18,7 @@ from mirage.accessor.notion import NotionAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.builtin.notion._provision import file_read_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.notion.glob import resolve_glob
@@ -95,7 +96,7 @@ async def grep(
             lines = format_grep_results(results, file_prefix)
             if not lines:
                 return b"", IOResult(exit_code=1)
-            return ("\n".join(lines) + "\n").encode(), IOResult()
+            return format_records(lines), IOResult()
 
     resolved = await resolve_glob(accessor, paths, index) if paths else []
     return await generic_grep(

--- a/python/mirage/commands/builtin/notion/rg.py
+++ b/python/mirage/commands/builtin/notion/rg.py
@@ -18,6 +18,7 @@ from mirage.accessor.notion import NotionAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.notion._provision import file_read_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.notion.glob import resolve_glob
@@ -87,7 +88,7 @@ async def rg(
             lines = format_grep_results(results, file_prefix)
             if not lines:
                 return b"", IOResult(exit_code=1)
-            return ("\n".join(lines) + "\n").encode(), IOResult()
+            return format_records(lines), IOResult()
 
     resolved = await resolve_glob(accessor, paths, index) if paths else []
     return await generic_rg(

--- a/python/mirage/commands/builtin/postgres/find.py
+++ b/python/mirage/commands/builtin/postgres/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.postgres import PostgresAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.postgres._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.postgres.glob import resolve_glob
@@ -111,5 +112,5 @@ async def find(
         if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
             continue
         results.append(p)
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/postgres/grep.py
+++ b/python/mirage/commands/builtin/postgres/grep.py
@@ -21,6 +21,8 @@ from mirage.commands.builtin.grep_helper import (compile_pattern,
                                                  grep_files_only, grep_lines,
                                                  grep_stream)
 from mirage.commands.builtin.postgres._provision import file_read_provision
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
                                                 call_stat)
@@ -104,7 +106,7 @@ async def grep(
             all_lines = format_grep_results(results)
             if not all_lines:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_lines).encode(), IOResult()
+            return format_records(all_lines), IOResult()
 
         if scope.level == "schema":
             results = await search_schema(accessor, scope.schema, pattern,
@@ -112,7 +114,7 @@ async def grep(
             all_lines = format_grep_results(results)
             if not all_lines:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_lines).encode(), IOResult()
+            return format_records(all_lines), IOResult()
 
         if scope.level == "kind":
             results = await search_kind(accessor, scope.schema, scope.kind,
@@ -120,7 +122,7 @@ async def grep(
             all_lines = format_grep_results(results)
             if not all_lines:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_lines).encode(), IOResult()
+            return format_records(all_lines), IOResult()
 
         if scope.level in ("entity", "entity_rows"):
             rows = await search_entity(accessor, scope.schema, scope.kind,
@@ -129,7 +131,7 @@ async def grep(
                 return b"", IOResult(exit_code=1)
             results = [(scope.schema, scope.kind, scope.entity, rows)]
             all_lines = format_grep_results(results)
-            return "\n".join(all_lines).encode(), IOResult()
+            return format_records(all_lines), IOResult()
 
         paths = await resolve_glob(accessor, paths, index=index)
         file_prefix = paths[0].prefix if paths else ""
@@ -168,10 +170,10 @@ async def grep(
                 whole_word=w,
                 warnings=warnings,
             )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
+            stderr = format_optional_records(warnings)
             if not results_l:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            return ("\n".join(results_l).encode(), IOResult(stderr=stderr))
+            return (format_records(results_l), IOResult(stderr=stderr))
 
         pat = compile_pattern(pattern, i, F, w)
 
@@ -191,7 +193,7 @@ async def grep(
                     all_results.extend(f"{p.original}:{r_}" for r_ in hits)
             if not all_results:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
+            return format_records(all_results), IOResult()
 
         data = await rb(paths[0].original)
         source = yield_bytes(data)

--- a/python/mirage/commands/builtin/postgres/ls.py
+++ b/python/mirage/commands/builtin/postgres/ls.py
@@ -84,5 +84,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/postgres/rg.py
+++ b/python/mirage/commands/builtin/postgres/rg.py
@@ -17,6 +17,7 @@ from collections.abc import AsyncIterator
 from mirage.accessor.postgres import PostgresAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -95,7 +96,7 @@ async def rg(
             all_lines = format_grep_results(results)
             if not all_lines:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_lines).encode(), IOResult()
+            return format_records(all_lines), IOResult()
 
         if scope.level == "schema":
             results = await search_schema(accessor, scope.schema, pattern_str,
@@ -103,7 +104,7 @@ async def rg(
             all_lines = format_grep_results(results)
             if not all_lines:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_lines).encode(), IOResult()
+            return format_records(all_lines), IOResult()
 
         if scope.level == "kind":
             results = await search_kind(accessor, scope.schema, scope.kind,
@@ -111,7 +112,7 @@ async def rg(
             all_lines = format_grep_results(results)
             if not all_lines:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_lines).encode(), IOResult()
+            return format_records(all_lines), IOResult()
 
         if scope.level in ("entity", "entity_rows"):
             rows = await search_entity(accessor, scope.schema, scope.kind,
@@ -120,7 +121,7 @@ async def rg(
                 return b"", IOResult(exit_code=1)
             results = [(scope.schema, scope.kind, scope.entity, rows)]
             all_lines = format_grep_results(results)
-            return "\n".join(all_lines).encode(), IOResult()
+            return format_records(all_lines), IOResult()
 
         paths = await resolve_glob(accessor, paths, index=index)
         blob_paths: list[str] = []
@@ -169,7 +170,7 @@ async def rg(
                 all_results.append(f"{bp}:{line}")
         if not any_match:
             return b"", IOResult(exit_code=1)
-        return "\n".join(all_results).encode(), IOResult()
+        return format_records(all_results), IOResult()
 
     raw = await _read_stdin_async(stdin)
     if raw is None:
@@ -191,4 +192,4 @@ async def rg(
     result_lines: list[str] = []
     for line in matched:
         result_lines.append(line)
-    return "\n".join(result_lines).encode(), IOResult()
+    return format_records(result_lines), IOResult()

--- a/python/mirage/commands/builtin/postgres/rg.py
+++ b/python/mirage/commands/builtin/postgres/rg.py
@@ -188,7 +188,7 @@ async def rg(
     if not matched:
         return b"", IOResult(exit_code=1)
     if c:
-        return str(len(matched)).encode(), IOResult()
+        return str(len(matched)).encode() + b"\n", IOResult()
     result_lines: list[str] = []
     for line in matched:
         result_lines.append(line)

--- a/python/mirage/commands/builtin/postgres/wc.py
+++ b/python/mirage/commands/builtin/postgres/wc.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.postgres._provision import file_read_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -80,10 +81,10 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
     data = await _read_stdin_async(stdin)
     if data is None:
         raise ValueError("wc: missing operand")
     counts = await generic_wc(data)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/ram/ls.py
+++ b/python/mirage/commands/builtin/ram/ls.py
@@ -74,5 +74,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/ram/rm.py
+++ b/python/mirage/commands/builtin/ram/rm.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_optional_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.ram.glob import resolve_glob
@@ -65,5 +66,5 @@ async def rm(
         removed[p.strip_prefix] = b""
         if v:
             verbose_parts.append(f"removed '{p.original}'")
-    output = "\n".join(verbose_parts).encode() if v else None
+    output = format_optional_records(verbose_parts) if v else None
     return output, IOResult(writes=removed)

--- a/python/mirage/commands/builtin/ram/wc.py
+++ b/python/mirage/commands/builtin/ram/wc.py
@@ -17,7 +17,7 @@ from collections.abc import AsyncIterator
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.aggregators import wc_aggregate
-from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import format_multi, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.generic.wc import wc_lines as generic_wc_lines
 from mirage.commands.builtin.utils.stream import _resolve_source
@@ -45,35 +45,21 @@ async def wc(
 ) -> tuple[ByteSource | None, IOResult]:
     if paths and accessor.store is not None:
         paths = await resolve_glob(accessor, paths, index)
-        outputs: list[str] = []
-        totals = WCCounts()
-        for p in paths:
-            counts = await generic_wc(_stream_core(accessor, p))
-            outputs.append(
-                format_wc(counts,
-                          args_l=args_l,
-                          w=w,
-                          c=c,
-                          m=m,
-                          L=L,
-                          label=p.original))
-            totals.merge(counts)
-        if len(paths) > 1:
-            outputs.append(
-                format_wc(totals,
-                          args_l=args_l,
-                          w=w,
-                          c=c,
-                          m=m,
-                          L=L,
-                          label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        body = await format_multi(paths,
+                                  read=_stream_core,
+                                  accessor=accessor,
+                                  args_l=args_l,
+                                  w=w,
+                                  c=c,
+                                  m=m,
+                                  L=L)
+        return body, IOResult()
 
     source: AsyncIterator[bytes] = _resolve_source(stdin,
                                                    "wc: missing operand")
     if args_l and not (L or w or c or m):
         line_count = await generic_wc_lines(source)
-        return str(line_count).encode(), IOResult()
+        return str(line_count).encode() + b"\n", IOResult()
     counts = await generic_wc(source)
-    return format_wc(counts, args_l=args_l, w=w, c=c, m=m, L=L).encode(), \
-        IOResult()
+    return (format_wc(counts, args_l=args_l, w=w, c=c, m=m, L=L).encode() +
+            b"\n", IOResult())

--- a/python/mirage/commands/builtin/redis/rm.py
+++ b/python/mirage/commands/builtin/redis/rm.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.redis import RedisAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_optional_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.redis.glob import resolve_glob
@@ -65,5 +66,5 @@ async def rm(
         removed[p.strip_prefix] = b""
         if v:
             verbose_parts.append(f"removed '{p.original}'")
-    output = "\n".join(verbose_parts).encode() if v else None
+    output = format_optional_records(verbose_parts) if v else None
     return output, IOResult(writes=removed)

--- a/python/mirage/commands/builtin/redis/wc.py
+++ b/python/mirage/commands/builtin/redis/wc.py
@@ -17,7 +17,7 @@ from collections.abc import AsyncIterator
 from mirage.accessor.redis import RedisAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.aggregators import wc_aggregate
-from mirage.commands.builtin.generic.wc import WCCounts, format_wc
+from mirage.commands.builtin.generic.wc import format_multi, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.generic.wc import wc_lines as generic_wc_lines
 from mirage.commands.builtin.redis._provision import file_read_provision
@@ -50,35 +50,21 @@ async def wc(
 ) -> tuple[ByteSource | None, IOResult]:
     if paths and accessor.store is not None:
         paths = await resolve_glob(accessor, paths, index)
-        outputs: list[str] = []
-        totals = WCCounts()
-        for p in paths:
-            counts = await generic_wc(_stream_core(accessor, p))
-            outputs.append(
-                format_wc(counts,
-                          args_l=args_l,
-                          w=w,
-                          c=c,
-                          m=m,
-                          L=L,
-                          label=p.original))
-            totals.merge(counts)
-        if len(paths) > 1:
-            outputs.append(
-                format_wc(totals,
-                          args_l=args_l,
-                          w=w,
-                          c=c,
-                          m=m,
-                          L=L,
-                          label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        body = await format_multi(paths,
+                                  read=_stream_core,
+                                  accessor=accessor,
+                                  args_l=args_l,
+                                  w=w,
+                                  c=c,
+                                  m=m,
+                                  L=L)
+        return body, IOResult()
 
     source: AsyncIterator[bytes] = _resolve_source(stdin,
                                                    "wc: missing operand")
     if args_l and not (L or w or c or m):
         line_count = await generic_wc_lines(source)
-        return str(line_count).encode(), IOResult()
+        return str(line_count).encode() + b"\n", IOResult()
     counts = await generic_wc(source)
-    return format_wc(counts, args_l=args_l, w=w, c=c, m=m, L=L).encode(), \
-        IOResult()
+    return (format_wc(counts, args_l=args_l, w=w, c=c, m=m, L=L).encode() +
+            b"\n", IOResult())

--- a/python/mirage/commands/builtin/s3/du.py
+++ b/python/mirage/commands/builtin/s3/du.py
@@ -56,17 +56,17 @@ async def du(
     path = p0
     if s:
         total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
+        lines = [_format_size(total, h) + "\t" + p0.original]
         if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return format_records(output.splitlines()), IOResult()
+            lines.append(_format_size(total, h) + "\ttotal")
+        return format_records(lines), IOResult()
     all_entries = await du_all_impl(accessor, path)
     if not all_entries:
         total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
+        lines = [_format_size(total, h) + "\t" + p0.original]
         if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return format_records(output.splitlines()), IOResult()
+            lines.append(_format_size(total, h) + "\ttotal")
+        return format_records(lines), IOResult()
     if not a:
         dir_entries: list[tuple[str, int]] = []
         for p, sz in all_entries:
@@ -79,10 +79,10 @@ async def du(
                        if _depth(p, p0.original) <= md]
     if not all_entries:
         total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
+        lines = [_format_size(total, h) + "\t" + p0.original]
         if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return format_records(output.splitlines()), IOResult()
+            lines.append(_format_size(total, h) + "\ttotal")
+        return format_records(lines), IOResult()
     lines = [_format_size(sz, h) + "\t" + p for p, sz in all_entries]
     if c:
         grand = sum(sz for _, sz in all_entries)

--- a/python/mirage/commands/builtin/s3/du.py
+++ b/python/mirage/commands/builtin/s3/du.py
@@ -15,6 +15,7 @@
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.s3.du import du as du_impl
@@ -58,14 +59,14 @@ async def du(
         output = _format_size(total, h) + "\t" + p0.original
         if c:
             output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
+        return format_records(output.splitlines()), IOResult()
     all_entries = await du_all_impl(accessor, path)
     if not all_entries:
         total = await du_impl(accessor, path)
         output = _format_size(total, h) + "\t" + p0.original
         if c:
             output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
+        return format_records(output.splitlines()), IOResult()
     if not a:
         dir_entries: list[tuple[str, int]] = []
         for p, sz in all_entries:
@@ -81,9 +82,9 @@ async def du(
         output = _format_size(total, h) + "\t" + p0.original
         if c:
             output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
+        return format_records(output.splitlines()), IOResult()
     lines = [_format_size(sz, h) + "\t" + p for p, sz in all_entries]
     if c:
         grand = sum(sz for _, sz in all_entries)
         lines.append(_format_size(grand, h) + "\ttotal")
-    return "\n".join(lines).encode(), IOResult()
+    return format_records(lines), IOResult()

--- a/python/mirage/commands/builtin/s3/find.py
+++ b/python/mirage/commands/builtin/s3/find.py
@@ -18,6 +18,7 @@ from mirage.commands.builtin.find_helper import (_extract_not_name,
                                                  _extract_or_names,
                                                  _parse_mtime, _parse_size)
 from mirage.commands.builtin.s3._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.s3.find import find as find_impl
@@ -86,5 +87,5 @@ async def find(
     )
     if p0.prefix:
         results = [p0.prefix + "/" + r.lstrip("/") for r in results]
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/s3/ls.py
+++ b/python/mirage/commands/builtin/s3/ls.py
@@ -73,5 +73,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/s3/rm.py
+++ b/python/mirage/commands/builtin/s3/rm.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_optional_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.s3.glob import resolve_glob
@@ -85,5 +86,5 @@ async def rm(
         removed[p.strip_prefix] = b""
         if v:
             verbose_parts.append(f"removed '{p.original}'")
-    output = "\n".join(verbose_parts).encode() if v else None
+    output = format_optional_records(verbose_parts) if v else None
     return output, IOResult(writes=removed)

--- a/python/mirage/commands/builtin/slack/find.py
+++ b/python/mirage/commands/builtin/slack/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.slack import SlackAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.slack._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.slack.glob import resolve_glob
@@ -111,5 +112,5 @@ async def find(
         if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
             continue
         results.append(p)
-    output = "\n".join(results).encode()
+    output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/slack/grep.py
+++ b/python/mirage/commands/builtin/slack/grep.py
@@ -22,6 +22,8 @@ from mirage.commands.builtin.grep_helper import (compile_pattern,
                                                  grep_files_only, grep_lines,
                                                  grep_stream)
 from mirage.commands.builtin.slack._provision import file_read_provision
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_records)
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
                                                 call_stat)
@@ -171,10 +173,10 @@ async def grep(
                 whole_word=w,
                 warnings=warnings,
             )
-            stderr = ("\n".join(warnings).encode() if warnings else None)
+            stderr = format_optional_records(warnings)
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            return ("\n".join(results).encode(), IOResult(stderr=stderr))
+            return (format_records(results), IOResult(stderr=stderr))
 
         pat = compile_pattern(pattern, i, F, w)
 
@@ -194,7 +196,7 @@ async def grep(
                     all_results.extend(f"{p.original}:{r}" for r in hits)
             if not all_results:
                 return b"", IOResult(exit_code=1)
-            return "\n".join(all_results).encode(), IOResult()
+            return format_records(all_results), IOResult()
 
         data = await rb(paths[0].original)
         source = yield_bytes(data)

--- a/python/mirage/commands/builtin/slack/grep.py
+++ b/python/mirage/commands/builtin/slack/grep.py
@@ -131,7 +131,7 @@ async def grep(
             if err is None:
                 if not native_lines:
                     return b"", IOResult(exit_code=1)
-                return ("\n".join(native_lines) + "\n").encode(), IOResult()
+                return format_records(native_lines), IOResult()
             logger.warning(
                 "slack search push-down failed (%s); "
                 "falling back to per-file scan", err)

--- a/python/mirage/commands/builtin/slack/ls.py
+++ b/python/mirage/commands/builtin/slack/ls.py
@@ -84,5 +84,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/slack/rg.py
+++ b/python/mirage/commands/builtin/slack/rg.py
@@ -190,7 +190,7 @@ async def rg(
     if not matched:
         return b"", IOResult(exit_code=1)
     if c:
-        return str(len(matched)).encode(), IOResult()
+        return str(len(matched)).encode() + b"\n", IOResult()
     result_lines: list[str] = []
     for line in matched:
         result_lines.append(line)

--- a/python/mirage/commands/builtin/slack/rg.py
+++ b/python/mirage/commands/builtin/slack/rg.py
@@ -18,6 +18,7 @@ from collections.abc import AsyncIterator
 from mirage.accessor.slack import SlackAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -171,7 +172,7 @@ async def rg(
                 all_results.append(f"{bp}:{line}")
         if not any_match:
             return b"", IOResult(exit_code=1)
-        return "\n".join(all_results).encode(), IOResult()
+        return format_records(all_results), IOResult()
 
     raw = await _read_stdin_async(stdin)
     if raw is None:
@@ -193,4 +194,4 @@ async def rg(
     result_lines: list[str] = []
     for line in matched:
         result_lines.append(line)
-    return "\n".join(result_lines).encode(), IOResult()
+    return format_records(result_lines), IOResult()

--- a/python/mirage/commands/builtin/slack/rg.py
+++ b/python/mirage/commands/builtin/slack/rg.py
@@ -121,7 +121,7 @@ async def rg(
             if err is None:
                 if not native_lines:
                     return b"", IOResult(exit_code=1)
-                return ("\n".join(native_lines) + "\n").encode(), IOResult()
+                return format_records(native_lines), IOResult()
             logger.warning(
                 "slack search push-down failed (%s); "
                 "falling back to per-file scan", err)

--- a/python/mirage/commands/builtin/slack/wc.py
+++ b/python/mirage/commands/builtin/slack/wc.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.slack._provision import file_read_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -80,10 +81,10 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
     data = await _read_stdin_async(stdin)
     if data is None:
         raise ValueError("wc: missing operand")
     counts = await generic_wc(data)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/ssh/rm.py
+++ b/python/mirage/commands/builtin/ssh/rm.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.ssh import SSHAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.output import format_optional_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.ssh.glob import resolve_glob
@@ -85,5 +86,5 @@ async def rm(
         removed[p.strip_prefix] = b""
         if v:
             verbose_parts.append(f"removed '{p.original}'")
-    output = "\n".join(verbose_parts).encode() if v else None
+    output = format_optional_records(verbose_parts) if v else None
     return output, IOResult(writes=removed)

--- a/python/mirage/commands/builtin/ssh/wc.py
+++ b/python/mirage/commands/builtin/ssh/wc.py
@@ -20,6 +20,7 @@ from mirage.commands.builtin.aggregators import wc_aggregate
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.generic.wc import wc_lines as generic_wc_lines
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -67,13 +68,13 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
 
     source: AsyncIterator[bytes] = _resolve_source(stdin,
                                                    "wc: missing operand")
     if args_l and not (L or w or c or m):
         line_count = await generic_wc_lines(source)
-        return str(line_count).encode(), IOResult()
+        return str(line_count).encode() + b"\n", IOResult()
     counts = await generic_wc(source)
-    return format_wc(counts, args_l=args_l, w=w, c=c, m=m, L=L).encode(), \
-        IOResult()
+    return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/trello/find.py
+++ b/python/mirage/commands/builtin/trello/find.py
@@ -17,6 +17,7 @@ import fnmatch
 from mirage.accessor.trello import TrelloAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.trello._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.trello.glob import resolve_glob
@@ -123,4 +124,4 @@ async def find(
         else:
             value = entry_path
         results.append(value)
-    return "\n".join(results).encode(), IOResult()
+    return format_records(results), IOResult()

--- a/python/mirage/commands/builtin/trello/wc.py
+++ b/python/mirage/commands/builtin/trello/wc.py
@@ -19,6 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.wc import WCCounts, format_wc
 from mirage.commands.builtin.generic.wc import wc as generic_wc
 from mirage.commands.builtin.trello._provision import file_read_provision
+from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -79,10 +80,10 @@ async def wc(
                           m=m,
                           L=L,
                           label="total"))
-        return "\n".join(outputs).encode(), IOResult()
+        return format_records(outputs), IOResult()
     data = await _read_stdin_async(stdin)
     if data is None:
         raise ValueError("wc: missing operand")
     counts = await generic_wc(data)
     return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
-                     L=L).encode(), IOResult()
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/commands/builtin/utils/output.py
+++ b/python/mirage/commands/builtin/utils/output.py
@@ -1,3 +1,17 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
 from collections.abc import Sequence
 
 

--- a/python/mirage/commands/builtin/utils/output.py
+++ b/python/mirage/commands/builtin/utils/output.py
@@ -1,0 +1,21 @@
+from collections.abc import Sequence
+
+
+def format_records(records: Sequence[str]) -> bytes:
+    if not records:
+        return b""
+    return ("\n".join(records) + "\n").encode()
+
+
+def format_optional_records(records: Sequence[str]) -> bytes | None:
+    output = format_records(records)
+    return output if output else None
+
+
+def format_record_text(records: Sequence[str]) -> str:
+    if not records:
+        return ""
+    return "\n".join(records) + "\n"
+
+
+__all__ = ["format_optional_records", "format_record_text", "format_records"]

--- a/python/tests/commands/builtin/dify/test_find.py
+++ b/python/tests/commands/builtin/dify/test_find.py
@@ -32,7 +32,7 @@ async def test_find_matches_name_pattern(monkeypatch, dify_accessor,
                            "quick*.md",
                            index=dify_index)
 
-    assert await materialize(stdout) == b"/knowledge/guides/quickstart.md"
+    assert await materialize(stdout) == b"/knowledge/guides/quickstart.md\n"
 
 
 @pytest.mark.asyncio
@@ -45,13 +45,14 @@ async def test_find_handles_file_missing_and_maxdepth(monkeypatch,
 
     file_stdout, file_io = await find(dify_accessor, [guide_path],
                                       index=dify_index)
-    assert await materialize(file_stdout) == b"/knowledge/guides/quickstart.md"
+    assert await materialize(file_stdout
+                             ) == b"/knowledge/guides/quickstart.md\n"
     assert file_io.exit_code == 0
 
     maxdepth_stdout, maxdepth_io = await find(dify_accessor, [knowledge_root],
                                               maxdepth="0",
                                               index=dify_index)
-    assert await materialize(maxdepth_stdout) == b"/knowledge"
+    assert await materialize(maxdepth_stdout) == b"/knowledge\n"
     assert maxdepth_io.exit_code == 0
 
     missing = PathSpec.from_str_path("/knowledge/missing.md", "/knowledge/")
@@ -73,7 +74,7 @@ async def test_find_uses_cwd_when_path_missing(monkeypatch, dify_accessor,
                             cwd=guides_path,
                             index=dify_index)
 
-    assert await materialize(stdout) == b"/knowledge/guides/quickstart.md"
+    assert await materialize(stdout) == b"/knowledge/guides/quickstart.md\n"
     assert io.exit_code == 0
 
 
@@ -89,5 +90,5 @@ async def test_find_resolves_glob_patterns(monkeypatch, dify_accessor,
 
     stdout, io = await find(dify_accessor, [path], index=dify_index)
 
-    assert await materialize(stdout) == b"/knowledge/guides/quickstart.md"
+    assert await materialize(stdout) == b"/knowledge/guides/quickstart.md\n"
     assert io.exit_code == 0

--- a/python/tests/commands/builtin/dify/test_grep.py
+++ b/python/tests/commands/builtin/dify/test_grep.py
@@ -89,7 +89,8 @@ async def test_grep_supports_standard_flags(monkeypatch, dify_accessor,
                                  "alpha",
                                  args_l=True,
                                  index=dify_index)
-    assert await materialize(files_stdout) == guide_path.original.encode()
+    assert await materialize(files_stdout
+                             ) == guide_path.original.encode() + b"\n"
 
     fixed_stdout, _ = await grep(dify_accessor, [guide_path],
                                  "alpha beta",

--- a/python/tests/commands/builtin/dify/test_ls.py
+++ b/python/tests/commands/builtin/dify/test_ls.py
@@ -49,7 +49,7 @@ async def test_ls_lists_virtual_tree(monkeypatch, dify_accessor, dify_index,
 
     stdout, _ = await ls(dify_accessor, [knowledge_root], index=dify_index)
 
-    assert await materialize(stdout) == b"README.md\nguides"
+    assert await materialize(stdout) == b"README.md\nguides\n"
 
 
 @pytest.mark.asyncio
@@ -61,13 +61,13 @@ async def test_ls_uses_cwd_and_supports_list_dir(monkeypatch, dify_accessor,
     cwd_stdout, cwd_io = await ls(dify_accessor, [],
                                   index=dify_index,
                                   cwd=guides_path)
-    assert await materialize(cwd_stdout) == b"quickstart.md"
+    assert await materialize(cwd_stdout) == b"quickstart.md\n"
     assert cwd_io.exit_code == 0
 
     dir_stdout, dir_io = await ls(dify_accessor, [guides_path],
                                   d=True,
                                   index=dify_index)
-    assert await materialize(dir_stdout) == b"guides"
+    assert await materialize(dir_stdout) == b"guides\n"
     assert dir_io.exit_code == 0
 
 
@@ -84,5 +84,5 @@ async def test_ls_resolves_glob_patterns(monkeypatch, dify_accessor,
 
     stdout, io = await ls(dify_accessor, [path], d=True, index=dify_index)
 
-    assert await materialize(stdout) == b"README.md"
+    assert await materialize(stdout) == b"README.md\n"
     assert io.exit_code == 0

--- a/python/tests/commands/builtin/dify/test_rg.py
+++ b/python/tests/commands/builtin/dify/test_rg.py
@@ -64,4 +64,4 @@ async def test_rg_supports_line_numbers_and_files_only(monkeypatch,
                                index=dify_index)
     assert await materialize(files_stdout) == (
         b"/knowledge/guides/api.md\n"
-        b"/knowledge/guides/quickstart.md")
+        b"/knowledge/guides/quickstart.md\n")

--- a/python/tests/commands/builtin/dify/test_stat.py
+++ b/python/tests/commands/builtin/dify/test_stat.py
@@ -36,7 +36,7 @@ async def test_stat_prints_dify_metadata(monkeypatch, dify_accessor,
 
     assert await materialize(stdout) == (
         b"name=quickstart.md size=17 modified=2024-05-21T10:00:00Z "
-        b"type=text")
+        b"type=text\n")
     assert io.exit_code == 0
 
 
@@ -50,4 +50,4 @@ async def test_stat_supports_format(monkeypatch, dify_accessor, dify_index,
                            c="%n %s %F",
                            index=dify_index)
 
-    assert await materialize(stdout) == b"quickstart.md 17 regular file"
+    assert await materialize(stdout) == b"quickstart.md 17 regular file\n"

--- a/python/tests/commands/builtin/dify/test_tree.py
+++ b/python/tests/commands/builtin/dify/test_tree.py
@@ -28,7 +28,7 @@ async def test_tree_renders_nested_dify_tree(monkeypatch, dify_accessor,
         "\u2514\u2500\u2500 guides\n"
         "    \u251c\u2500\u2500 deep\n"
         "    \u2502   \u2514\u2500\u2500 note.md\n"
-        "    \u2514\u2500\u2500 quickstart.md")
+        "    \u2514\u2500\u2500 quickstart.md\n")
     assert io.exit_code == 0
 
 
@@ -45,4 +45,4 @@ async def test_tree_uses_cwd_and_depth(monkeypatch, dify_accessor, dify_index,
     assert (await materialize(stdout)).decode() == (
         "\u251c\u2500\u2500 deep\n"
         "\u2502   \u2514\u2500\u2500 note.md\n"
-        "\u2514\u2500\u2500 quickstart.md")
+        "\u2514\u2500\u2500 quickstart.md\n")

--- a/python/tests/commands/builtin/dify/test_wc.py
+++ b/python/tests/commands/builtin/dify/test_wc.py
@@ -28,7 +28,7 @@ async def test_wc_counts_document(monkeypatch, dify_accessor, dify_index,
     stdout, io = await wc(dify_accessor, [guide_path], index=dify_index)
 
     assert await materialize(stdout) == (
-        b"2\t3\t16\t/knowledge/guides/quickstart.md")
+        b"2\t3\t16\t/knowledge/guides/quickstart.md\n")
     assert io.cache == [guide_path.original]
 
 
@@ -43,10 +43,10 @@ async def test_wc_supports_chars_and_max_line_length(monkeypatch,
                                m=True,
                                index=dify_index)
     assert await materialize(chars_stdout) == (
-        b"17\t/knowledge/guides/quickstart.md")
+        b"17\t/knowledge/guides/quickstart.md\n")
 
     max_line_stdout, _ = await wc(dify_accessor, [guide_path],
                                   L=True,
                                   index=dify_index)
     assert await materialize(max_line_stdout) == (
-        b"7\t/knowledge/guides/quickstart.md")
+        b"7\t/knowledge/guides/quickstart.md\n")

--- a/python/tests/commands/builtin/discord/test_grep_pushdown.py
+++ b/python/tests/commands/builtin/discord/test_grep_pushdown.py
@@ -80,6 +80,7 @@ async def test_discord_grep_with_many_concrete_paths_uses_native_search():
     assert fake_search.await_count == 1
     assert io.exit_code == 0
     assert b"hello" in out
+    assert out.endswith(b"\n")
     assert (b"/discord/myguild/channels/general__ch_456/"
             b"2026-01-15/chat.jsonl:") in out
 
@@ -162,5 +163,6 @@ async def test_discord_rg_with_many_concrete_paths_uses_native_search():
     assert fake_search.await_count == 1
     assert io.exit_code == 0
     assert b"hello" in out
+    assert out.endswith(b"\n")
     assert (b"/discord/myguild/channels/general__ch_456/"
             b"2026-01-15/chat.jsonl:") in out

--- a/python/tests/commands/builtin/discord/test_read_commands.py
+++ b/python/tests/commands/builtin/discord/test_read_commands.py
@@ -257,7 +257,7 @@ async def test_wc(accessor):
     ):
         stream, io = await wc(accessor, _make_glob(ABS_FILE), args_l=True)
     data = await _collect(stream)
-    assert data == b"3\t" + ABS_FILE.encode()
+    assert data == b"3\t" + ABS_FILE.encode() + b"\n"
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/builtin/disk/test_rm.py
+++ b/python/tests/commands/builtin/disk/test_rm.py
@@ -1,0 +1,33 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import DiskResource, MountMode, Workspace
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    return Workspace({"/": DiskResource(root=str(tmp_path))},
+                     mode=MountMode.WRITE)
+
+
+@pytest.mark.asyncio
+async def test_rm_v_terminates_verbose_output(workspace):
+    await workspace.ops.write("/a.txt", b"a")
+
+    io = await workspace.execute("rm -v /a.txt", session_id="default")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"removed '/a.txt'\n"

--- a/python/tests/commands/builtin/generic/test_du.py
+++ b/python/tests/commands/builtin/generic/test_du.py
@@ -43,7 +43,7 @@ async def test_du_single_file_default():
     out = await du([_spec("/f.txt")],
                    compute_total=compute_total,
                    compute_all=compute_all)
-    assert out == "5\t/f.txt"
+    assert out == "5\t/f.txt\n"
 
 
 @pytest.mark.asyncio
@@ -54,7 +54,7 @@ async def test_du_directory_collapses_to_root_when_not_a():
     out = await du([_spec("/dir")],
                    compute_total=compute_total,
                    compute_all=compute_all)
-    assert out == "5\t/dir"
+    assert out == "5\t/dir\n"
 
 
 @pytest.mark.asyncio
@@ -78,7 +78,7 @@ async def test_du_s_summary_single_line():
                    compute_total=compute_total,
                    compute_all=compute_all,
                    s=True)
-    assert out == "5\t/dir"
+    assert out == "5\t/dir\n"
 
 
 @pytest.mark.asyncio
@@ -93,7 +93,7 @@ async def test_du_max_depth_zero_in_a_mode_drops_everything_below():
                    compute_all=compute_all,
                    a=True,
                    max_depth=0)
-    assert out == "5\t/dir"
+    assert out == "5\t/dir\n"
 
 
 @pytest.mark.asyncio
@@ -140,7 +140,7 @@ async def test_du_multi_path_independent_outputs():
     out = await du([_spec("/a.txt"), _spec("/b.txt")],
                    compute_total=compute_total,
                    compute_all=compute_all)
-    assert out == "3\t/a.txt\n7\t/b.txt"
+    assert out == "3\t/a.txt\n7\t/b.txt\n"
 
 
 @pytest.mark.asyncio
@@ -176,7 +176,7 @@ async def test_du_empty_target_returns_zero_with_path():
     out = await du([_spec("/nothing")],
                    compute_total=compute_total,
                    compute_all=compute_all)
-    assert out == "0\t/nothing"
+    assert out == "0\t/nothing\n"
 
 
 def test_depth_helper_root_is_zero():

--- a/python/tests/commands/builtin/generic/test_ls.py
+++ b/python/tests/commands/builtin/generic/test_ls.py
@@ -186,23 +186,12 @@ async def test_walk_missing_path_collects_warning():
 
 
 @pytest.mark.asyncio
-async def test_ls_short_output_no_trailing_newline_by_default():
+async def test_ls_short_output_terminates_record():
     tree = {"/dir": _dir("dir"), "/dir/a.txt": _file("a.txt")}
     readdir, stat = _make_fs_backend(tree)
     output, io = await ls([_spec("/dir")], readdir=readdir, stat=stat)
-    assert output == b"a.txt"
-    assert io.exit_code == 0
-
-
-@pytest.mark.asyncio
-async def test_ls_trailing_newline_when_requested():
-    tree = {"/dir": _dir("dir"), "/dir/a.txt": _file("a.txt")}
-    readdir, stat = _make_fs_backend(tree)
-    output, _ = await ls([_spec("/dir")],
-                         readdir=readdir,
-                         stat=stat,
-                         trailing_newline=True)
     assert output == b"a.txt\n"
+    assert io.exit_code == 0
 
 
 @pytest.mark.asyncio
@@ -233,7 +222,7 @@ async def test_ls_one_per_line_overrides_long():
                            stat=stat,
                            long=True,
                            one_per_line=True)
-    assert out_long == b"a.txt"
+    assert out_long == b"a.txt\n"
 
 
 @pytest.mark.asyncio
@@ -307,7 +296,7 @@ async def test_ls_file_argument_lists_the_file():
     tree = {"/dir/a.json": _file("a.json", 5)}
     readdir, stat = _make_fs_backend(tree)
     output, io = await ls([_spec("/dir/a.json")], readdir=readdir, stat=stat)
-    assert output == b"a.json"
+    assert output == b"a.json\n"
     assert io.exit_code == 0
 
 

--- a/python/tests/commands/builtin/generic/test_phase_o.py
+++ b/python/tests/commands/builtin/generic/test_phase_o.py
@@ -132,9 +132,7 @@ async def test_cmp_differing_reports_first_byte():
     rb, _ = _make_backend({"/a.txt": b"hello", "/b.txt": b"hallo"})
     output, io = await cmp_cmd(
         [_spec("/a.txt"), _spec("/b.txt")], read_bytes=rb)
-    decoded = output.decode()
-    assert "differ" in decoded
-    assert "char 2" in decoded
+    assert output == b"/a.txt /b.txt differ: char 2, line 1\n"
     assert io.exit_code == 1
 
 
@@ -177,5 +175,5 @@ async def test_cmp_eof_on_shorter():
     rb, _ = _make_backend({"/a.txt": b"abc", "/b.txt": b"abcdef"})
     output, io = await cmp_cmd(
         [_spec("/a.txt"), _spec("/b.txt")], read_bytes=rb)
-    assert b"EOF" in output
+    assert output == b"cmp: EOF on /a.txt\n"
     assert io.exit_code == 1

--- a/python/tests/commands/builtin/generic/test_phase_r.py
+++ b/python/tests/commands/builtin/generic/test_phase_r.py
@@ -111,7 +111,7 @@ async def test_stat_custom_format():
         return FileStat(name="foo", size=10, type=FileType.TEXT)
 
     out, _ = await generic_stat([_spec("foo")], stat_fn=stat_fn, c="%n=%s")
-    assert out == b"foo=10"
+    assert out == b"foo=10\n"
 
 
 @pytest.mark.asyncio
@@ -121,7 +121,7 @@ async def test_stat_format_F_directory():
         return FileStat(name="d", type=FileType.DIRECTORY)
 
     out, _ = await generic_stat([_spec("d")], stat_fn=stat_fn, c="%F")
-    assert out == b"directory"
+    assert out == b"directory\n"
 
 
 @pytest.mark.asyncio
@@ -131,7 +131,7 @@ async def test_stat_format_F_regular():
         return FileStat(name="x", type=FileType.JSON)
 
     out, _ = await generic_stat([_spec("x")], stat_fn=stat_fn, f="%F")
-    assert out == b"regular file"
+    assert out == b"regular file\n"
 
 
 @pytest.mark.asyncio
@@ -143,7 +143,7 @@ async def test_stat_multiple_paths():
     out, _ = await generic_stat([_spec("a"), _spec("b")],
                                 stat_fn=stat_fn,
                                 c="%n")
-    assert out == b"a\nb"
+    assert out == b"a\nb\n"
 
 
 @pytest.mark.asyncio
@@ -216,7 +216,7 @@ async def test_file_directory():
     out, _ = await file_cmd([_spec("d")],
                             read_bytes=read_bytes,
                             stat_fn=stat_fn)
-    assert b"d: directory" == out
+    assert b"d: directory\n" == out
 
 
 @pytest.mark.asyncio
@@ -233,7 +233,7 @@ async def test_file_multiple_paths():
                             stat_fn=stat_fn)
     assert b"a:" in out
     assert b"b:" in out
-    assert out.count(b"\n") == 1
+    assert out.count(b"\n") == 2
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/builtin/github/test_commands.py
+++ b/python/tests/commands/builtin/github/test_commands.py
@@ -357,3 +357,19 @@ async def test_rg_with_prefix(github_env):
     text = data.decode()
     assert io.exit_code == 0
     assert "import" in text
+
+
+@pytest.mark.asyncio
+async def test_rg_count_stdin_terminates_newline(github_env):
+    accessor, index = github_env
+    stdout, io = await rg(
+        accessor,
+        [],
+        "foo",
+        stdin=b"foo foo\nfoo bar\nbaz\n",
+        c=True,
+        index=index,
+    )
+    data = await materialize(stdout)
+    assert io.exit_code == 0
+    assert data and data.endswith(b"\n")

--- a/python/tests/commands/builtin/github/test_commands.py
+++ b/python/tests/commands/builtin/github/test_commands.py
@@ -109,7 +109,7 @@ async def test_wc_full(github_env):
     )
     data = await materialize(stdout)
     text = data.decode()
-    parts = text.split("\t")
+    parts = text.rstrip("\n").split("\t")
     assert len(parts) == 4
     line_count, word_count, byte_count = int(parts[0]), int(parts[1]), int(
         parts[2])

--- a/python/tests/commands/builtin/notion/test_generic_wiring.py
+++ b/python/tests/commands/builtin/notion/test_generic_wiring.py
@@ -135,7 +135,7 @@ def _paths(*originals: str) -> list[PathSpec]:
 @pytest.mark.asyncio
 async def test_ls_lists_entries_and_hides_dotfiles():
     out = await _collect(await ls_mod.ls(_ACCESSOR, _paths("/db")))
-    names = set(out.decode().split("\n"))
+    names = set(out.decode().splitlines())
     assert names == {
         "notes.md", "data.json", "sub", "log.jsonl", "empty.jsonl"
     }
@@ -236,7 +236,7 @@ async def test_find_type_file():
     out = await _collect(await find_mod.find(_ACCESSOR,
                                              _paths("/db"),
                                              type="f"))
-    found = set(out.decode().split("\n"))
+    found = set(out.decode().splitlines())
     assert "/db/notes.md" in found
     assert "/db/sub/page.md" in found
     assert "/db" not in found
@@ -247,7 +247,7 @@ async def test_find_name_glob():
     out = await _collect(await find_mod.find(_ACCESSOR,
                                              _paths("/db"),
                                              name="*.md"))
-    found = set(out.decode().split("\n"))
+    found = set(out.decode().splitlines())
     assert found == {"/db/notes.md", "/db/sub/page.md"}
 
 

--- a/python/tests/commands/builtin/ram/test_rm.py
+++ b/python/tests/commands/builtin/ram/test_rm.py
@@ -1,0 +1,32 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, RAMResource, Workspace
+
+
+@pytest.fixture
+def workspace():
+    return Workspace({"/": RAMResource()}, mode=MountMode.WRITE)
+
+
+@pytest.mark.asyncio
+async def test_rm_v_terminates_verbose_output(workspace):
+    await workspace.ops.write("/a.txt", b"a")
+
+    io = await workspace.execute("rm -v /a.txt", session_id="default")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"removed '/a.txt'\n"

--- a/python/tests/commands/builtin/ram/wc/test_wc.py
+++ b/python/tests/commands/builtin/ram/wc/test_wc.py
@@ -31,7 +31,7 @@ async def test_wc_default(workspace):
     assert parts[0] == "2"
     assert parts[1] == "4"
     assert parts[2] == "20"
-    assert parts[3] == "/f.txt"
+    assert parts[3] == "/f.txt\n"
 
 
 @pytest.mark.asyncio
@@ -90,7 +90,7 @@ async def test_wc_l_stdin(workspace):
                                  session_id="default",
                                  stdin=b"a\nb\nc\n")
     assert io.exit_code == 0
-    assert io.stdout.decode().strip() == "3"
+    assert io.stdout == b"3\n"
 
 
 @pytest.mark.asyncio
@@ -134,6 +134,7 @@ async def test_wc_multi_file_emits_total(workspace):
     await workspace.ops.write("/b.txt", b"world\nfoo\n")
     io = await workspace.execute("wc /a.txt /b.txt", session_id="default")
     assert io.exit_code == 0
+    assert io.stdout.endswith(b"\n")
     lines = io.stdout.decode().splitlines()
     assert any(line.endswith("/a.txt") for line in lines)
     assert any(line.endswith("/b.txt") for line in lines)

--- a/python/tests/commands/builtin/redis/test_rm.py
+++ b/python/tests/commands/builtin/redis/test_rm.py
@@ -1,0 +1,44 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import os
+
+import pytest
+import pytest_asyncio
+
+from mirage import MountMode, Workspace
+from mirage.resource.redis import RedisResource
+
+REDIS_URL = os.environ.get("REDIS_URL", "")
+pytestmark = pytest.mark.skipif(not REDIS_URL, reason="REDIS_URL not set")
+
+
+@pytest_asyncio.fixture()
+async def workspace():
+    resource = RedisResource(url=REDIS_URL, key_prefix="test:rm:")
+    await resource._store.clear()
+    ws = Workspace({"/": resource}, mode=MountMode.WRITE)
+    yield ws
+    await resource._store.clear()
+    await resource._store.close()
+
+
+@pytest.mark.asyncio
+async def test_rm_v_terminates_verbose_output(workspace):
+    await workspace.ops.write("/a.txt", b"a")
+
+    io = await workspace.execute("rm -v /a.txt", session_id="default")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"removed '/a.txt'\n"

--- a/python/tests/commands/builtin/redis/wc/test_wc.py
+++ b/python/tests/commands/builtin/redis/wc/test_wc.py
@@ -67,5 +67,6 @@ async def test_wc_multi_file_emits_total(workspace):
     await workspace.ops.write("/b.txt", b"world\nfoo\n")
     io = await workspace.execute("wc /a.txt /b.txt", session_id="default")
     assert io.exit_code == 0
+    assert io.stdout.endswith(b"\n")
     lines = io.stdout.decode().splitlines()
     assert lines[-1].endswith("total")

--- a/python/tests/commands/builtin/utils/test_output.py
+++ b/python/tests/commands/builtin/utils/test_output.py
@@ -1,0 +1,23 @@
+from mirage.commands.builtin.utils.output import (format_optional_records,
+                                                  format_record_text,
+                                                  format_records)
+
+
+def test_format_records_empty_returns_empty_bytes():
+    assert format_records([]) == b""
+
+
+def test_format_records_single_record_terminates_line():
+    assert format_records(["a"]) == b"a\n"
+
+
+def test_format_records_multiple_records_terminates_last_line():
+    assert format_records(["a", "b"]) == b"a\nb\n"
+
+
+def test_format_optional_records_empty_returns_none():
+    assert format_optional_records([]) is None
+
+
+def test_format_record_text_multiple_records_terminates_last_line():
+    assert format_record_text(["a", "b"]) == "a\nb\n"

--- a/python/tests/integration/test_s3_complex.py
+++ b/python/tests/integration/test_s3_complex.py
@@ -306,5 +306,6 @@ async def test_grep_then_jq_with_and_or_list(ws):
             "cat /tmp/search_report.txt")
         assert (await io.stdout_str()).strip().splitlines() == [
             "/s3/data/example.jsonl",
+            "",
             '"Strukto"',
         ]

--- a/python/tests/workspace/test_dify_resource.py
+++ b/python/tests/workspace/test_dify_resource.py
@@ -63,4 +63,4 @@ async def test_workspace_executes_dify_ls(monkeypatch):
     result = await workspace.execute("ls /knowledge")
 
     assert result.exit_code == 0
-    assert await result.stdout_str() == "guides"
+    assert await result.stdout_str() == "guides\n"


### PR DESCRIPTION
Closes #137 

Detected an out-scope issue and created #149 for it.

## Problem

  Many builtin commands built stdout with `"\n".join(records).encode()` — `\n` as a
  **separator**, not a **terminator** — so the last line had no trailing newline (unlike
  POSIX coreutils, where every line including the last ends in `\n`):

  - `find /s3 -type f | wc -l` undercounted by one (last path had no newline to count).
  - `while read` / `tail` / `awk` could drop the final record.

  Systemic across `find/grep/rg/du/stat/ls/tree/md5/cmp/file/wc` in essentially every backend.

## Fix

  Add shared record-output helpers in `commands/builtin/utils/output.py` and apply it uniformly across backends.
  
  Byte-preserving commands (`cat`, `sed`, `diff`, `head`, `tail`, `awk`) untouched.
  This keeps byte-preserving commands untouched while making generated command records end with POSIX-style trailing newlines. 

  ## Tests

  - Updated generic, RAM/Redis, and disk `rm` tests for the new contract.
  - Updated per-backend exact-output assertions (dify, discord, github, notion, s3, workspace) which delegates to generic layer.
  - `integ/truth.txt` `find_pipe_wc` `18 → 19`: the old missing terminator made `wc -l` undercount by one; the new value matches real coreutils.
  - Affected suites: 93 passed, 0 failed. pre-commit (yapf/isort/flake8) clean.