### PR TITLE
fix(du,file): handle multiple files across remote backends

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -202,6 +202,8 @@ CASES: list[tuple[str, str]] = [
     ("wc_l_multi", "wc -l /data/a.txt /data/b.txt"),
     ("cat_multi3", "cat /data/a.txt /data/b.txt /data/dup.txt"),
     ("md5_multi3", "md5 /data/a.txt /data/b.txt /data/dup.txt"),
+    ("du_multi", "du /data/a.txt /data/b.txt"),
+    ("file_multi", "file /data/a.txt /data/user.json"),
 
     # ----- pipelines -----
     ("grep_pipe_wc", "grep world /data/a.txt | wc -l"),

--- a/integ/nextcloud.py
+++ b/integ/nextcloud.py
@@ -72,6 +72,8 @@ PER_MOUNT_CASES: list[tuple[str, str]] = [
     ("file_parquet", "file {m}/data/example.parquet"),
     ("file_orc", "file {m}/data/example.orc"),
     ("file_feather", "file {m}/data/example.feather"),
+    ("du_multi", "du {m}/data/example.json {m}/data/example.jsonl"),
+    ("file_multi", "file {m}/data/example.json {m}/data/example.jsonl"),
 
     # ----- safeguard: per-mount cap on cat (set to 20 lines below) -----
     ("safeguard_cat_truncates", "cat {m}/data/example.jsonl"),

--- a/integ/s3.py
+++ b/integ/s3.py
@@ -94,6 +94,8 @@ PER_MOUNT_CASES: list[tuple[str, str]] = [
     ("file_parquet", "file {m}/data/example.parquet"),
     ("file_orc", "file {m}/data/example.orc"),
     ("file_feather", "file {m}/data/example.feather"),
+    ("du_multi", "du {m}/data/example.json {m}/data/example.jsonl"),
+    ("file_multi", "file {m}/data/example.json {m}/data/example.jsonl"),
 
     # ----- safeguard: per-mount cap on cat (set to 20 lines below) -----
     ("safeguard_cat_truncates", "cat {m}/data/example.jsonl"),

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -474,6 +474,12 @@ c
 191c53e00627438f88824862472a3f59  /data/a.txt
 c0710d6b4f15dfa88f600b0e6b624077  /data/b.txt
 aa824302994c716187326457c48e125e  /data/dup.txt
+=== du_multi ===
+24	/data/a.txt
+6	/data/b.txt
+=== file_multi ===
+/data/a.txt: text
+/data/user.json: json
 === grep_pipe_wc ===
 1
 === sort_uniq ===

--- a/integ/truth_s3.txt
+++ b/integ/truth_s3.txt
@@ -94,6 +94,12 @@ parquet, 10 rows, 3 columns (id: int64, value: double, label: large_string)
 orc, 10 rows, 3 columns, 1 stripes (id: int64, value: double, label: string)
 === s3:file_feather ===
 feather, 10 rows, 3 columns (id: int64, value: double, label: large_string)
+=== s3:du_multi ===
+15533	/s3/data/example.json
+10414430	/s3/data/example.jsonl
+=== s3:file_multi ===
+/s3/data/example.json: json
+/s3/data/example.jsonl: json
 === s3:safeguard_cat_truncates ===
 {"type":"queue-operation","operation":"enqueue","timestamp":"2026-03-17T13:35:35.319Z","sessionId":"664396f7-55a4-4604-8289-aa7142480db4"}
 {"type":"queue-operation","operation":"dequeue","timestamp":"2026-03-17T13:35:35.320Z","sessionId":"664396f7-55a4-4604-8289-aa7142480db4"}
@@ -214,6 +220,12 @@ parquet, 10 rows, 3 columns (id: int64, value: double, label: large_string)
 orc, 10 rows, 3 columns, 1 stripes (id: int64, value: double, label: string)
 === gcs:file_feather ===
 feather, 10 rows, 3 columns (id: int64, value: double, label: large_string)
+=== gcs:du_multi ===
+15533	/gcs/data/example.json
+10414430	/gcs/data/example.jsonl
+=== gcs:file_multi ===
+/gcs/data/example.json: json
+/gcs/data/example.jsonl: json
 === gcs:safeguard_cat_truncates ===
 {"type":"queue-operation","operation":"enqueue","timestamp":"2026-03-17T13:35:35.319Z","sessionId":"664396f7-55a4-4604-8289-aa7142480db4"}
 {"type":"queue-operation","operation":"dequeue","timestamp":"2026-03-17T13:35:35.320Z","sessionId":"664396f7-55a4-4604-8289-aa7142480db4"}
@@ -334,6 +346,12 @@ parquet, 10 rows, 3 columns (id: int64, value: double, label: large_string)
 orc, 10 rows, 3 columns, 1 stripes (id: int64, value: double, label: string)
 === minio:file_feather ===
 feather, 10 rows, 3 columns (id: int64, value: double, label: large_string)
+=== minio:du_multi ===
+15533	/minio/data/example.json
+10414430	/minio/data/example.jsonl
+=== minio:file_multi ===
+/minio/data/example.json: json
+/minio/data/example.jsonl: json
 === minio:safeguard_cat_truncates ===
 {"type":"queue-operation","operation":"enqueue","timestamp":"2026-03-17T13:35:35.319Z","sessionId":"664396f7-55a4-4604-8289-aa7142480db4"}
 {"type":"queue-operation","operation":"dequeue","timestamp":"2026-03-17T13:35:35.320Z","sessionId":"664396f7-55a4-4604-8289-aa7142480db4"}

--- a/python/mirage/commands/builtin/gdrive/du.py
+++ b/python/mirage/commands/builtin/gdrive/du.py
@@ -12,10 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.gdrive._provision import metadata_provision
-from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.commands.builtin.generic.du import du_multi
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdrive.glob import resolve_glob
@@ -24,10 +26,6 @@ from mirage.core.gdrive.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import FileType, PathSpec
-
-
-def _format_size(size: int, human: bool) -> str:
-    return _human_size(size) if human else str(size)
 
 
 async def _du_walk(
@@ -83,15 +81,12 @@ async def du(
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     paths = await resolve_glob(accessor, paths, index)
-    p0 = paths[0]
-    total = await _du_walk(accessor, p0, index)
-    if s:
-        output = _format_size(total, h) + "\t" + p0.original
-        if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
-    lines: list[str] = []
-    lines.append(_format_size(total, h) + "\t" + p0.original)
-    if c:
-        lines.append(_format_size(total, h) + "\ttotal")
-    return "\n".join(lines).encode(), IOResult()
+    out = await du_multi(
+        paths,
+        compute_total=partial(_du_walk, accessor, index=index),
+        h=h,
+        s=s,
+        a=a,
+        c=c,
+    )
+    return out, IOResult()

--- a/python/mirage/commands/builtin/gdrive/file.py
+++ b/python/mirage/commands/builtin/gdrive/file.py
@@ -12,47 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.file_helper import _detect
+from mirage.commands.builtin.generic.file import file_cmd as generic_file
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdrive.glob import resolve_glob
 from mirage.core.gdrive.read import read as gdrive_read
 from mirage.core.gdrive.stat import stat as stat_impl
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
-
-_MIME_MAP: dict[str, str] = {
-    "text": "text/plain; charset=us-ascii",
-    "json": "application/json; charset=us-ascii",
-    "csv": "text/csv; charset=us-ascii",
-    "directory": "inode/directory",
-    "binary": "application/octet-stream",
-    "image/png": "image/png",
-    "image/jpeg": "image/jpeg",
-    "image/gif": "image/gif",
-    "application/zip": "application/zip",
-    "application/gzip": "application/gzip",
-    "application/pdf": "application/pdf",
-    "parquet": "application/octet-stream",
-    "orc": "application/octet-stream",
-    "feather": "application/octet-stream",
-    "hdf5": "application/octet-stream",
-}
-
-
-def _format_file_result(
-    path: str,
-    result: FileType | str,
-    brief: bool,
-    mime: bool,
-) -> str:
-    key = result.value if isinstance(result, FileType) else str(result)
-    desc = _MIME_MAP.get(key, key) if mime else key
-    if brief:
-        return desc
-    return f"{path}: {desc}"
+from mirage.types import PathSpec
 
 
 @command("file", resource="gdrive", spec=SPECS["file"])
@@ -69,15 +40,9 @@ async def file(
     if not paths:
         raise ValueError("file: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    p = paths[0]
-    s = await stat_impl(accessor, p, index)
-    if s.type == FileType.DIRECTORY:
-        result = FileType.DIRECTORY
-    else:
-        try:
-            data = await gdrive_read(accessor, p, index)
-            header = data[:512]
-        except Exception:
-            header = b""
-        result = _detect(p.original, header, s)
-    return _format_file_result(p.original, result, b, i).encode(), IOResult()
+    return await generic_file(paths,
+                              read_bytes=partial(gdrive_read, index=index),
+                              stat_fn=partial(stat_impl, index=index),
+                              accessor=accessor,
+                              b=b,
+                              i=i)

--- a/python/mirage/commands/builtin/generic/du.py
+++ b/python/mirage/commands/builtin/generic/du.py
@@ -84,3 +84,61 @@ async def du(
         grand = sum(totals)
         out += "\n" + _format_size(grand, h) + "\ttotal"
     return out
+
+
+async def _du_block(
+    p0: PathSpec,
+    compute_total: Callable[[PathSpec], Awaitable[int]],
+    compute_all: Callable[[PathSpec], Awaitable[list[tuple[str, int]]]] | None,
+    *,
+    s: bool,
+    a: bool,
+    h: bool,
+    max_depth: int | None,
+) -> tuple[list[str], int]:
+    if s or compute_all is None:
+        total = await compute_total(p0)
+        return [_format_size(total, h) + "\t" + p0.original], total
+    all_entries = await compute_all(p0)
+    if not all_entries:
+        total = await compute_total(p0)
+        return [_format_size(total, h) + "\t" + p0.original], total
+    if not a:
+        all_entries = [(p, sz) for p, sz in all_entries if p == p0.original]
+    if max_depth is not None:
+        all_entries = [(p, sz) for p, sz in all_entries
+                       if _depth(p, p0.original) <= max_depth]
+    if not all_entries:
+        total = await compute_total(p0)
+        return [_format_size(total, h) + "\t" + p0.original], total
+    lines = [_format_size(sz, h) + "\t" + p for p, sz in all_entries]
+    return lines, sum(sz for _, sz in all_entries)
+
+
+async def du_multi(
+    paths: list[PathSpec],
+    *,
+    compute_total: Callable[[PathSpec], Awaitable[int]],
+    compute_all: Callable[[PathSpec], Awaitable[list[tuple[str, int]]]]
+    | None = None,
+    h: bool = False,
+    s: bool = False,
+    a: bool = False,
+    max_depth: int | None = None,
+    c: bool = False,
+) -> bytes:
+    lines: list[str] = []
+    totals: list[int] = []
+    for p0 in paths:
+        block, total = await _du_block(p0,
+                                       compute_total,
+                                       compute_all,
+                                       s=s,
+                                       a=a,
+                                       h=h,
+                                       max_depth=max_depth)
+        lines.extend(block)
+        totals.append(total)
+    if c:
+        lines.append(_format_size(sum(totals), h) + "\ttotal")
+    return "\n".join(lines).encode()

--- a/python/mirage/commands/builtin/github/du.py
+++ b/python/mirage/commands/builtin/github/du.py
@@ -12,10 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.du import du_multi
 from mirage.commands.builtin.github._provision import metadata_provision
-from mirage.commands.builtin.utils.formatting import _human_size
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github.glob import resolve_glob
@@ -24,8 +26,14 @@ from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
 
 
-def _format_size(size: int, human: bool) -> str:
-    return _human_size(size) if human else str(size)
+async def _du_total(index: IndexCacheStore, path: PathSpec) -> int:
+    key = path.original
+    du_prefix = key + "/" if key else ""
+    total = 0
+    for ep, entry in index._entries.items():
+        if (ep == key or ep.startswith(du_prefix)) and entry.size is not None:
+            total += entry.size
+    return total
 
 
 async def du_provision(
@@ -56,22 +64,12 @@ async def du(
     if index is None:
         raise ValueError("du: no tree loaded")
     paths = await resolve_glob(accessor, paths, index)
-    p = paths[0]
-    path = p.original
-    key = path
-    du_prefix = key + "/" if key else ""
-    total = 0
-    for ep, entry in index._entries.items():
-        if ep == key or ep.startswith(du_prefix):
-            if entry.size is not None:
-                total += entry.size
-    if s:
-        output = _format_size(total, h) + "\t" + path
-        if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
-    lines: list[str] = []
-    lines.append(_format_size(total, h) + "\t" + path)
-    if c:
-        lines.append(_format_size(total, h) + "\ttotal")
-    return "\n".join(lines).encode(), IOResult()
+    out = await du_multi(
+        paths,
+        compute_total=partial(_du_total, index),
+        h=h,
+        s=s,
+        a=a,
+        c=c,
+    )
+    return out, IOResult()

--- a/python/mirage/commands/builtin/github/file.py
+++ b/python/mirage/commands/builtin/github/file.py
@@ -12,47 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.file_helper import _detect
+from mirage.commands.builtin.generic.file import file_cmd as generic_file
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github.glob import resolve_glob
 from mirage.core.github.read import read as github_read
 from mirage.core.github.stat import stat as stat_impl
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
-
-_MIME_MAP: dict[str, str] = {
-    "text": "text/plain; charset=us-ascii",
-    "json": "application/json; charset=us-ascii",
-    "csv": "text/csv; charset=us-ascii",
-    "directory": "inode/directory",
-    "binary": "application/octet-stream",
-    "image/png": "image/png",
-    "image/jpeg": "image/jpeg",
-    "image/gif": "image/gif",
-    "application/zip": "application/zip",
-    "application/gzip": "application/gzip",
-    "application/pdf": "application/pdf",
-    "parquet": "application/octet-stream",
-    "orc": "application/octet-stream",
-    "feather": "application/octet-stream",
-    "hdf5": "application/octet-stream",
-}
-
-
-def _format_file_result(
-    path: str,
-    result: FileType | str,
-    brief: bool,
-    mime: bool,
-) -> str:
-    key = result.value if isinstance(result, FileType) else str(result)
-    desc = _MIME_MAP.get(key, key) if mime else key
-    if brief:
-        return desc
-    return f"{path}: {desc}"
+from mirage.types import PathSpec
 
 
 @command("file", resource="github", spec=SPECS["file"])
@@ -69,15 +40,9 @@ async def file(
     if index is None or not paths:
         raise ValueError("file: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    p = paths[0]
-    s = await stat_impl(accessor, p, index)
-    if s.type == FileType.DIRECTORY:
-        result = FileType.DIRECTORY
-    else:
-        try:
-            data = await github_read(accessor, p, index)
-            header = data[:512]
-        except Exception:
-            header = b""
-        result = _detect(p.original, header, s)
-    return _format_file_result(p.original, result, b, i).encode(), IOResult()
+    return await generic_file(paths,
+                              read_bytes=partial(github_read, index=index),
+                              stat_fn=partial(stat_impl, index=index),
+                              accessor=accessor,
+                              b=b,
+                              i=i)

--- a/python/mirage/commands/builtin/github/md5.py
+++ b/python/mirage/commands/builtin/github/md5.py
@@ -12,10 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import hashlib
+from functools import partial
 
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.md5 import md5 as generic_md5
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github.glob import resolve_glob
@@ -36,7 +37,7 @@ async def md5(
     if index is None or not paths:
         raise ValueError("md5: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    p = paths[0]
-    data = await github_read(accessor, p, index)
-    result = hashlib.md5(data).hexdigest()
-    return result.encode(), IOResult()
+    return await generic_md5(paths,
+                             read_bytes=partial(github_read, index=index),
+                             accessor=accessor,
+                             stdin=stdin)

--- a/python/mirage/commands/builtin/github/nl.py
+++ b/python/mirage/commands/builtin/github/nl.py
@@ -12,29 +12,19 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import re
 from collections.abc import AsyncIterator
+from functools import partial
 
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.generic.nl import nl as generic_nl
+from mirage.commands.builtin.utils.wrap import stream_from_bytes
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github.glob import resolve_glob
 from mirage.core.github.read import read as github_read
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-def _should_number(line: str, body_numbering: str,
-                   pattern: re.Pattern[str] | None) -> bool:
-    if body_numbering == "n":
-        return False
-    if body_numbering == "a":
-        return True
-    if body_numbering == "p" and pattern is not None:
-        return pattern.search(line) is not None
-    return bool(line.strip())
 
 
 @command("nl", resource="github", spec=SPECS["nl"])
@@ -51,33 +41,18 @@ async def nl(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    body_numbering_raw = b if b is not None else "t"
-    pattern: re.Pattern[str] | None = None
-    if body_numbering_raw.startswith("p"):
-        body_numbering = "p"
-        pattern = re.compile(body_numbering_raw[1:])
-    else:
-        body_numbering = body_numbering_raw
-    start = int(v) if v is not None else 1
-    increment = int(i) if i is not None else 1
-    width = int(w) if w is not None else 6
-    separator = s if s is not None else "\t"
-
     if paths and index is not None:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        raw = await github_read(accessor, p, index)
     else:
-        raw = await _read_stdin_async(stdin)
-        if raw is None:
-            raise ValueError("nl: missing operand")
-
-    num = start
-    out_lines: list[str] = []
-    for line in raw.decode(errors="replace").splitlines():
-        if _should_number(line, body_numbering, pattern):
-            out_lines.append(f"{num:{width}d}{separator}{line}")
-            num += increment
-        else:
-            out_lines.append(f"{' ' * width}{separator}{line}")
-    return ("\n".join(out_lines) + "\n").encode(), IOResult()
+        paths = []
+    return await generic_nl(
+        paths,
+        read_stream=partial(stream_from_bytes, github_read, index=index),
+        accessor=accessor,
+        stdin=stdin,
+        body_numbering_raw=b,
+        start_raw=v,
+        increment_raw=i,
+        width_raw=w,
+        separator=s,
+    )

--- a/python/mirage/commands/builtin/hf_buckets/du.py
+++ b/python/mirage/commands/builtin/hf_buckets/du.py
@@ -12,10 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor._hf import HF_RESOURCES
 from mirage.accessor.hf_buckets import HfBucketsAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.commands.builtin.generic.du import du_multi
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.hf_buckets.du import du as du_impl
@@ -23,18 +25,6 @@ from mirage.core.hf_buckets.du import du_all as du_all_impl
 from mirage.core.hf_buckets.glob import resolve_glob
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-def _format_size(size: int, human: bool) -> str:
-    return _human_size(size) if human else str(size)
-
-
-def _depth(entry_path: str, base_path: str) -> int:
-    base = base_path.rstrip("/")
-    rel = entry_path.rstrip("/")[len(base):]
-    if not rel:
-        return 0
-    return rel.strip("/").count("/") + 1
 
 
 @command("du", resource=HF_RESOURCES, spec=SPECS["du"])
@@ -52,39 +42,14 @@ async def du(
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     paths = await resolve_glob(accessor, paths, index)
-    p0 = paths[0]
-    path = p0
-    if s:
-        total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
-        if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
-    all_entries = await du_all_impl(accessor, path)
-    if not all_entries:
-        total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
-        if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
-    if not a:
-        dir_entries: list[tuple[str, int]] = []
-        for p, sz in all_entries:
-            if p == p0.original:
-                dir_entries.append((p, sz))
-        all_entries = dir_entries
-    if max_depth is not None:
-        md = int(max_depth)
-        all_entries = [(p, sz) for p, sz in all_entries
-                       if _depth(p, p0.original) <= md]
-    if not all_entries:
-        total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
-        if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
-    lines = [_format_size(sz, h) + "\t" + p for p, sz in all_entries]
-    if c:
-        grand = sum(sz for _, sz in all_entries)
-        lines.append(_format_size(grand, h) + "\ttotal")
-    return "\n".join(lines).encode(), IOResult()
+    out = await du_multi(
+        paths,
+        compute_total=partial(du_impl, accessor),
+        compute_all=partial(du_all_impl, accessor),
+        h=h,
+        s=s,
+        a=a,
+        max_depth=int(max_depth) if max_depth is not None else None,
+        c=c,
+    )
+    return out, IOResult()

--- a/python/mirage/commands/builtin/hf_buckets/file.py
+++ b/python/mirage/commands/builtin/hf_buckets/file.py
@@ -12,48 +12,19 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor._hf import HF_RESOURCES
 from mirage.accessor.hf_buckets import HfBucketsAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.file_helper import _detect
+from mirage.commands.builtin.generic.file import file_cmd as generic_file
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.hf_buckets.glob import resolve_glob
 from mirage.core.hf_buckets.read import read_bytes
 from mirage.core.hf_buckets.stat import stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
-
-_MIME_MAP: dict[str, str] = {
-    "text": "text/plain; charset=us-ascii",
-    "json": "application/json; charset=us-ascii",
-    "csv": "text/csv; charset=us-ascii",
-    "directory": "inode/directory",
-    "binary": "application/octet-stream",
-    "image/png": "image/png",
-    "image/jpeg": "image/jpeg",
-    "image/gif": "image/gif",
-    "application/zip": "application/zip",
-    "application/gzip": "application/gzip",
-    "application/pdf": "application/pdf",
-    "parquet": "application/octet-stream",
-    "orc": "application/octet-stream",
-    "feather": "application/octet-stream",
-    "hdf5": "application/octet-stream",
-}
-
-
-def _format_file_result(
-    path: str,
-    result: FileType | str,
-    brief: bool,
-    mime: bool,
-) -> str:
-    key = result.value if isinstance(result, FileType) else str(result)
-    desc = _MIME_MAP.get(key, key) if mime else key
-    if brief:
-        return desc
-    return f"{path}: {desc}"
+from mirage.types import PathSpec
 
 
 @command("file", resource=HF_RESOURCES, spec=SPECS["file"])
@@ -70,15 +41,9 @@ async def file(
     if not paths:
         raise ValueError("file: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    s = await stat(accessor, paths[0], index)
-    if s.type == FileType.DIRECTORY:
-        result = FileType.DIRECTORY
-    else:
-        try:
-            data = await read_bytes(accessor, paths[0])
-            header = data[:512]
-        except Exception:
-            header = b""
-        result = _detect(paths[0].original, header, s)
-    return _format_file_result(paths[0].original, result, b,
-                               i).encode(), IOResult()
+    return await generic_file(paths,
+                              read_bytes=partial(read_bytes, index=index),
+                              stat_fn=partial(stat, index=index),
+                              accessor=accessor,
+                              b=b,
+                              i=i)

--- a/python/mirage/commands/builtin/nextcloud/du.py
+++ b/python/mirage/commands/builtin/nextcloud/du.py
@@ -12,9 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.commands.builtin.generic.du import du_multi
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.nextcloud.du import du as du_impl
@@ -22,18 +24,6 @@ from mirage.core.nextcloud.du import du_all as du_all_impl
 from mirage.core.nextcloud.glob import resolve_glob
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-def _format_size(size: int, human: bool) -> str:
-    return _human_size(size) if human else str(size)
-
-
-def _depth(entry_path: str, base_path: str) -> int:
-    base = base_path.rstrip("/")
-    rel = entry_path.rstrip("/")[len(base):]
-    if not rel:
-        return 0
-    return rel.strip("/").count("/") + 1
 
 
 @command("du", resource="nextcloud", spec=SPECS["du"])
@@ -51,39 +41,14 @@ async def du(
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     paths = await resolve_glob(accessor, paths, index)
-    p0 = paths[0]
-    path = p0
-    if s:
-        total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
-        if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
-    all_entries = await du_all_impl(accessor, path)
-    if not all_entries:
-        total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
-        if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
-    if not a:
-        dir_entries: list[tuple[str, int]] = []
-        for p, sz in all_entries:
-            if p == p0.original:
-                dir_entries.append((p, sz))
-        all_entries = dir_entries
-    if max_depth is not None:
-        md = int(max_depth)
-        all_entries = [(p, sz) for p, sz in all_entries
-                       if _depth(p, p0.original) <= md]
-    if not all_entries:
-        total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
-        if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
-    lines = [_format_size(sz, h) + "\t" + p for p, sz in all_entries]
-    if c:
-        grand = sum(sz for _, sz in all_entries)
-        lines.append(_format_size(grand, h) + "\ttotal")
-    return "\n".join(lines).encode(), IOResult()
+    out = await du_multi(
+        paths,
+        compute_total=partial(du_impl, accessor),
+        compute_all=partial(du_all_impl, accessor),
+        h=h,
+        s=s,
+        a=a,
+        max_depth=int(max_depth) if max_depth is not None else None,
+        c=c,
+    )
+    return out, IOResult()

--- a/python/mirage/commands/builtin/nextcloud/file.py
+++ b/python/mirage/commands/builtin/nextcloud/file.py
@@ -12,47 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.file_helper import _detect
+from mirage.commands.builtin.generic.file import file_cmd as generic_file
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.nextcloud.glob import resolve_glob
 from mirage.core.nextcloud.read import read_bytes
 from mirage.core.nextcloud.stat import stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
-
-_MIME_MAP: dict[str, str] = {
-    "text": "text/plain; charset=us-ascii",
-    "json": "application/json; charset=us-ascii",
-    "csv": "text/csv; charset=us-ascii",
-    "directory": "inode/directory",
-    "binary": "application/octet-stream",
-    "image/png": "image/png",
-    "image/jpeg": "image/jpeg",
-    "image/gif": "image/gif",
-    "application/zip": "application/zip",
-    "application/gzip": "application/gzip",
-    "application/pdf": "application/pdf",
-    "parquet": "application/octet-stream",
-    "orc": "application/octet-stream",
-    "feather": "application/octet-stream",
-    "hdf5": "application/octet-stream",
-}
-
-
-def _format_file_result(
-    path: str,
-    result: FileType | str,
-    brief: bool,
-    mime: bool,
-) -> str:
-    key = result.value if isinstance(result, FileType) else str(result)
-    desc = _MIME_MAP.get(key, key) if mime else key
-    if brief:
-        return desc
-    return f"{path}: {desc}"
+from mirage.types import PathSpec
 
 
 @command("file", resource="nextcloud", spec=SPECS["file"])
@@ -69,15 +40,9 @@ async def file(
     if not paths:
         raise ValueError("file: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    s = await stat(accessor, paths[0], index)
-    if s.type == FileType.DIRECTORY:
-        result = FileType.DIRECTORY
-    else:
-        try:
-            data = await read_bytes(accessor, paths[0])
-            header = data[:512]
-        except Exception:
-            header = b""
-        result = _detect(paths[0].original, header, s)
-    return _format_file_result(paths[0].original, result, b,
-                               i).encode(), IOResult()
+    return await generic_file(paths,
+                              read_bytes=partial(read_bytes, index=index),
+                              stat_fn=partial(stat, index=index),
+                              accessor=accessor,
+                              b=b,
+                              i=i)

--- a/python/mirage/commands/builtin/s3/du.py
+++ b/python/mirage/commands/builtin/s3/du.py
@@ -12,9 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.commands.builtin.generic.du import du_multi
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.s3.du import du as du_impl
@@ -22,18 +24,6 @@ from mirage.core.s3.du import du_all as du_all_impl
 from mirage.core.s3.glob import resolve_glob
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-def _format_size(size: int, human: bool) -> str:
-    return _human_size(size) if human else str(size)
-
-
-def _depth(entry_path: str, base_path: str) -> int:
-    base = base_path.rstrip("/")
-    rel = entry_path.rstrip("/")[len(base):]
-    if not rel:
-        return 0
-    return rel.strip("/").count("/") + 1
 
 
 @command("du", resource="s3", spec=SPECS["du"])
@@ -51,39 +41,14 @@ async def du(
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     paths = await resolve_glob(accessor, paths, index)
-    p0 = paths[0]
-    path = p0
-    if s:
-        total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
-        if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
-    all_entries = await du_all_impl(accessor, path)
-    if not all_entries:
-        total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
-        if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
-    if not a:
-        dir_entries: list[tuple[str, int]] = []
-        for p, sz in all_entries:
-            if p == p0.original:
-                dir_entries.append((p, sz))
-        all_entries = dir_entries
-    if max_depth is not None:
-        md = int(max_depth)
-        all_entries = [(p, sz) for p, sz in all_entries
-                       if _depth(p, p0.original) <= md]
-    if not all_entries:
-        total = await du_impl(accessor, path)
-        output = _format_size(total, h) + "\t" + p0.original
-        if c:
-            output += "\n" + _format_size(total, h) + "\ttotal"
-        return output.encode(), IOResult()
-    lines = [_format_size(sz, h) + "\t" + p for p, sz in all_entries]
-    if c:
-        grand = sum(sz for _, sz in all_entries)
-        lines.append(_format_size(grand, h) + "\ttotal")
-    return "\n".join(lines).encode(), IOResult()
+    out = await du_multi(
+        paths,
+        compute_total=partial(du_impl, accessor),
+        compute_all=partial(du_all_impl, accessor),
+        h=h,
+        s=s,
+        a=a,
+        max_depth=int(max_depth) if max_depth is not None else None,
+        c=c,
+    )
+    return out, IOResult()

--- a/python/mirage/commands/builtin/s3/file.py
+++ b/python/mirage/commands/builtin/s3/file.py
@@ -12,47 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.file_helper import _detect
+from mirage.commands.builtin.generic.file import file_cmd as generic_file
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.s3.glob import resolve_glob
 from mirage.core.s3.read import read_bytes
 from mirage.core.s3.stat import stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
-
-_MIME_MAP: dict[str, str] = {
-    "text": "text/plain; charset=us-ascii",
-    "json": "application/json; charset=us-ascii",
-    "csv": "text/csv; charset=us-ascii",
-    "directory": "inode/directory",
-    "binary": "application/octet-stream",
-    "image/png": "image/png",
-    "image/jpeg": "image/jpeg",
-    "image/gif": "image/gif",
-    "application/zip": "application/zip",
-    "application/gzip": "application/gzip",
-    "application/pdf": "application/pdf",
-    "parquet": "application/octet-stream",
-    "orc": "application/octet-stream",
-    "feather": "application/octet-stream",
-    "hdf5": "application/octet-stream",
-}
-
-
-def _format_file_result(
-    path: str,
-    result: FileType | str,
-    brief: bool,
-    mime: bool,
-) -> str:
-    key = result.value if isinstance(result, FileType) else str(result)
-    desc = _MIME_MAP.get(key, key) if mime else key
-    if brief:
-        return desc
-    return f"{path}: {desc}"
+from mirage.types import PathSpec
 
 
 @command("file", resource="s3", spec=SPECS["file"])
@@ -69,15 +40,9 @@ async def file(
     if not paths:
         raise ValueError("file: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    s = await stat(accessor, paths[0], index)
-    if s.type == FileType.DIRECTORY:
-        result = FileType.DIRECTORY
-    else:
-        try:
-            data = await read_bytes(accessor, paths[0])
-            header = data[:512]
-        except Exception:
-            header = b""
-        result = _detect(paths[0].original, header, s)
-    return _format_file_result(paths[0].original, result, b,
-                               i).encode(), IOResult()
+    return await generic_file(paths,
+                              read_bytes=partial(read_bytes, index=index),
+                              stat_fn=partial(stat, index=index),
+                              accessor=accessor,
+                              b=b,
+                              i=i)

--- a/python/tests/commands/builtin/generic/test_du.py
+++ b/python/tests/commands/builtin/generic/test_du.py
@@ -1,11 +1,37 @@
 import pytest
 
-from mirage.commands.builtin.generic.du import _depth, du
+from mirage.commands.builtin.generic.du import _depth, du, du_multi
 from mirage.types import PathSpec
 
 
 def _spec(path: str) -> PathSpec:
     return PathSpec(original=path, directory=path)
+
+
+def _make_list_backend(tree: dict[str, int]):
+    """Build (compute_total, compute_all) where compute_all returns a flat
+    list (NOT a (list, total) tuple), matching the backend `du_all` contract
+    consumed by `du_multi`. Directory targets include a trailing
+    (dirpath, total) entry, mirroring the real backends."""
+
+    async def compute_total(p: PathSpec) -> int:
+        prefix = p.original.rstrip("/") + "/"
+        return sum(size for path, size in tree.items()
+                   if path == p.original or path.startswith(prefix))
+
+    async def compute_all(p: PathSpec) -> list[tuple[str, int]]:
+        prefix = p.original.rstrip("/") + "/"
+        entries: list[tuple[str, int]] = []
+        total = 0
+        for path, size in sorted(tree.items()):
+            if path == p.original or path.startswith(prefix):
+                entries.append((path, size))
+                total += size
+        if p.original not in dict(entries):
+            entries.append((p.original, total))
+        return entries
+
+    return compute_total, compute_all
 
 
 def _make_backend(tree: dict[str, int]):
@@ -177,6 +203,60 @@ async def test_du_empty_target_returns_zero_with_path():
                    compute_total=compute_total,
                    compute_all=compute_all)
     assert out == "0\t/nothing"
+
+
+@pytest.mark.asyncio
+async def test_du_multi_independent_outputs_bytes():
+    compute_total, compute_all = _make_list_backend({"/a.txt": 3, "/b.txt": 7})
+    out = await du_multi([_spec("/a.txt"), _spec("/b.txt")],
+                         compute_total=compute_total,
+                         compute_all=compute_all)
+    assert out == b"3\t/a.txt\n7\t/b.txt"
+
+
+@pytest.mark.asyncio
+async def test_du_multi_c_grand_total_sums_all_paths():
+    compute_total, compute_all = _make_list_backend({"/a.txt": 3, "/b.txt": 7})
+    out = await du_multi([_spec("/a.txt"), _spec("/b.txt")],
+                         compute_total=compute_total,
+                         compute_all=compute_all,
+                         c=True)
+    assert out.decode().splitlines()[-1] == "10\ttotal"
+
+
+@pytest.mark.asyncio
+async def test_du_multi_directory_collapses_when_not_a():
+    tree = {"/dir/a.txt": 3, "/dir/b.txt": 2}
+    compute_total, compute_all = _make_list_backend(tree)
+    out = await du_multi([_spec("/dir")],
+                         compute_total=compute_total,
+                         compute_all=compute_all)
+    assert out == b"5\t/dir"
+
+
+@pytest.mark.asyncio
+async def test_du_multi_a_lists_files():
+    tree = {"/dir/a.txt": 3, "/dir/b.txt": 2}
+    compute_total, compute_all = _make_list_backend(tree)
+    out = await du_multi([_spec("/dir")],
+                         compute_total=compute_total,
+                         compute_all=compute_all,
+                         a=True)
+    lines = out.decode().splitlines()
+    assert "3\t/dir/a.txt" in lines
+    assert "2\t/dir/b.txt" in lines
+
+
+@pytest.mark.asyncio
+async def test_du_multi_compute_all_none_emits_total_only():
+    """Walk-only backends (gdrive, github) pass compute_all=None: each path
+    yields a single total line; -c still sums across paths."""
+    compute_total, _ = _make_list_backend({"/x/a": 4, "/x/b": 6, "/y/c": 5})
+    out = await du_multi([_spec("/x"), _spec("/y")],
+                         compute_total=compute_total,
+                         compute_all=None,
+                         c=True)
+    assert out.decode().splitlines() == ["10\t/x", "5\t/y", "15\ttotal"]
 
 
 def test_depth_helper_root_is_zero():

--- a/python/tests/commands/builtin/generic/test_file.py
+++ b/python/tests/commands/builtin/generic/test_file.py
@@ -1,0 +1,77 @@
+import pytest
+
+from mirage.commands.builtin.generic.file import file_cmd
+from mirage.types import FileStat, FileType, PathSpec
+
+
+def _spec(path: str) -> PathSpec:
+    return PathSpec(original=path, directory=path)
+
+
+def _make_backend(files: dict[str, tuple[bytes, FileType]], dirs: set[str]):
+
+    async def stat_fn(accessor: object, p: PathSpec) -> FileStat:
+        if p.original in dirs:
+            return FileStat(name=p.original, type=FileType.DIRECTORY, size=0)
+        if p.original in files:
+            data, ftype = files[p.original]
+            return FileStat(name=p.original, type=ftype, size=len(data))
+        raise FileNotFoundError(p.original)
+
+    async def read_bytes(accessor: object, p: PathSpec) -> bytes:
+        return files[p.original][0]
+
+    return stat_fn, read_bytes
+
+
+@pytest.mark.asyncio
+async def test_file_single_text():
+    stat_fn, read_bytes = _make_backend(
+        {"/a.txt": (b"hello world\n", FileType.TEXT)}, set())
+    out, io = await file_cmd([_spec("/a.txt")],
+                             read_bytes=read_bytes,
+                             stat_fn=stat_fn)
+    assert out == b"/a.txt: text"
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_file_multiple_paths_one_line_each():
+    stat_fn, read_bytes = _make_backend(
+        {
+            "/a.txt": (b"hello\n", FileType.TEXT),
+            "/b.json": (b'{"k": 1}\n', FileType.JSON),
+        }, set())
+    out, _io = await file_cmd(
+        [_spec("/a.txt"), _spec("/b.json")],
+        read_bytes=read_bytes,
+        stat_fn=stat_fn)
+    lines = out.decode().splitlines()
+    assert lines == ["/a.txt: text", "/b.json: json"]
+
+
+@pytest.mark.asyncio
+async def test_file_directory_reported_without_read():
+    stat_fn, read_bytes = _make_backend({}, {"/d"})
+    out, _io = await file_cmd([_spec("/d")],
+                              read_bytes=read_bytes,
+                              stat_fn=stat_fn)
+    assert out == b"/d: directory"
+
+
+@pytest.mark.asyncio
+async def test_file_brief_drops_path_prefix():
+    stat_fn, read_bytes = _make_backend(
+        {"/a.txt": (b"hello\n", FileType.TEXT)}, set())
+    out, _io = await file_cmd([_spec("/a.txt")],
+                              read_bytes=read_bytes,
+                              stat_fn=stat_fn,
+                              b=True)
+    assert out == b"text"
+
+
+@pytest.mark.asyncio
+async def test_file_missing_operand_raises():
+    stat_fn, read_bytes = _make_backend({}, set())
+    with pytest.raises(ValueError):
+        await file_cmd([], read_bytes=read_bytes, stat_fn=stat_fn)

--- a/python/tests/commands/builtin/github/test_md5.py
+++ b/python/tests/commands/builtin/github/test_md5.py
@@ -1,0 +1,71 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import hashlib
+
+import pytest
+
+from mirage.commands.builtin.github.md5 import md5
+from mirage.io.types import materialize
+from mirage.types import PathSpec
+from tests.fixtures.github_mock import MOCK_BLOBS
+
+
+@pytest.fixture(autouse=True)
+def _patch_read(monkeypatch):
+
+    async def _read_bytes(config, owner, repo, sha):
+        return MOCK_BLOBS[sha]
+
+    monkeypatch.setattr("mirage.core.github.read.read_bytes", _read_bytes)
+
+
+def _scope(path: str) -> PathSpec:
+    norm = "/" + path.lstrip("/")
+    directory = norm.rsplit("/", 1)[0] + "/"
+    return PathSpec(original=norm, directory=directory, resolved=True)
+
+
+async def _run(accessor, index, paths):
+    stdout, io = await md5(accessor, [_scope(p) for p in paths], index=index)
+    return (await materialize(stdout)).decode(), io
+
+
+def _digest(sha: str) -> str:
+    return hashlib.md5(MOCK_BLOBS[sha]).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_md5_single_file_gnu_format(mock_github_api, github_env):
+    accessor, index = github_env
+    text, io = await _run(accessor, index, ["README.md"])
+    assert io.exit_code == 0
+    assert text == f"{_digest('aaa111')}  /README.md"
+
+
+@pytest.mark.asyncio
+async def test_md5_multiple_files_one_hash_each(mock_github_api, github_env):
+    accessor, index = github_env
+    text, _io = await _run(accessor, index, ["README.md", "src/config.py"])
+    assert text.splitlines() == [
+        f"{_digest('aaa111')}  /README.md",
+        f"{_digest('bbb444')}  /src/config.py",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_md5_missing_operand_raises(mock_github_api, github_env):
+    accessor, index = github_env
+    with pytest.raises(ValueError):
+        await md5(accessor, [], index=index)

--- a/python/tests/commands/builtin/github/test_nl.py
+++ b/python/tests/commands/builtin/github/test_nl.py
@@ -1,0 +1,71 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.commands.builtin.github.nl import nl
+from mirage.io.types import materialize
+from mirage.types import PathSpec
+from tests.fixtures.github_mock import MOCK_BLOBS
+
+
+@pytest.fixture(autouse=True)
+def _patch_read(monkeypatch):
+
+    async def _read_bytes(config, owner, repo, sha):
+        return MOCK_BLOBS[sha]
+
+    monkeypatch.setattr("mirage.core.github.read.read_bytes", _read_bytes)
+
+
+def _scope(path: str) -> PathSpec:
+    norm = "/" + path.lstrip("/")
+    directory = norm.rsplit("/", 1)[0] + "/"
+    return PathSpec(original=norm, directory=directory, resolved=True)
+
+
+async def _run(accessor, index, paths, **kwargs):
+    stdout, io = await nl(accessor, [_scope(p) for p in paths],
+                          index=index,
+                          **kwargs)
+    return (await materialize(stdout)).decode(), io
+
+
+@pytest.mark.asyncio
+async def test_nl_single_file_numbers_nonblank_lines(mock_github_api,
+                                                     github_env):
+    accessor, index = github_env
+    text, io = await _run(accessor, index, ["README.md"])
+    assert io.exit_code == 0
+    lines = text.splitlines()
+    # README.md = "# Mock Repo\n\nA test repository.\n": two non-blank lines
+    # numbered 1 and 2, the blank line unnumbered.
+    assert lines[0].endswith("# Mock Repo")
+    assert lines[0].lstrip().startswith("1")
+    assert lines[-1].lstrip().startswith("2")
+    assert "A test repository." in lines[-1]
+
+
+@pytest.mark.asyncio
+async def test_nl_multiple_files_includes_all(mock_github_api, github_env):
+    accessor, index = github_env
+    text, _io = await _run(accessor, index, ["README.md", "src/config.py"])
+    # Both files must be present (the bug dropped everything after the first).
+    assert "# Mock Repo" in text
+    assert 'DB_URL = "localhost"' in text
+    assert "DEBUG = True" in text
+    # Numbering restarts per file (matches the generic nl contract): the
+    # config file's first line is renumbered from 1.
+    cfg_line = next(ln for ln in text.splitlines() if "DB_URL" in ln)
+    assert cfg_line.lstrip().startswith("1")

--- a/python/tests/commands/builtin/test_multifile_guard.py
+++ b/python/tests/commands/builtin/test_multifile_guard.py
@@ -20,7 +20,7 @@ import pytest
 BUILTIN = pathlib.Path(
     __file__).resolve().parents[3] / "mirage" / "commands" / "builtin"
 
-GUARDED_COMMANDS = ("cat", "head", "tail", "wc", "du", "file")
+GUARDED_COMMANDS = ("cat", "head", "tail", "wc", "du", "file", "nl", "md5")
 
 # Backends whose command genuinely operates on a single resource and rejects
 # or has no multi-file semantics. Each entry needs a one-line reason so the
@@ -82,7 +82,8 @@ def _loops_paths(func: ast.AST) -> bool:
 
 
 _MULTI_HELPERS = ("format_multi", "generic_grep", "generic_rg", "grep", "rg",
-                  "generic_du", "generic_file", "file_cmd", "du_multi")
+                  "generic_du", "generic_file", "file_cmd", "du_multi",
+                  "generic_nl", "generic_md5")
 
 
 def _passes_full_list(func: ast.AST) -> bool:

--- a/python/tests/commands/builtin/test_multifile_guard.py
+++ b/python/tests/commands/builtin/test_multifile_guard.py
@@ -20,7 +20,7 @@ import pytest
 BUILTIN = pathlib.Path(
     __file__).resolve().parents[3] / "mirage" / "commands" / "builtin"
 
-GUARDED_COMMANDS = ("cat", "head", "tail", "wc")
+GUARDED_COMMANDS = ("cat", "head", "tail", "wc", "du", "file")
 
 # Backends whose command genuinely operates on a single resource and rejects
 # or has no multi-file semantics. Each entry needs a one-line reason so the
@@ -81,26 +81,28 @@ def _loops_paths(func: ast.AST) -> bool:
     return False
 
 
+_MULTI_HELPERS = ("format_multi", "generic_grep", "generic_rg", "grep", "rg",
+                  "generic_du", "generic_file", "file_cmd", "du_multi")
+
+
 def _passes_full_list(func: ast.AST) -> bool:
     """Heuristic: the resolved list is handed to a *_multi / generic helper.
 
     Covers backends that delegate multi-file handling to a generic routine
-    (head_multi, tail_multi, format_multi, generic_grep, generic_rg) by
-    passing the whole ``paths``/``resolved`` list as the first argument.
+    (head_multi, tail_multi, format_multi, du_multi, file_cmd, generic_grep,
+    generic_rg) by passing the whole ``paths``/``resolved`` list as the first
+    argument.
     """
-    helper_suffixes = ("_multi", "generic_grep", "generic_rg", "format_multi")
     for node in ast.walk(func):
         if not isinstance(node, ast.Call):
             continue
         target = node.func
         name = getattr(target, "id", getattr(target, "attr", "")) or ""
-        if name.endswith("_multi") or name in ("format_multi", "generic_grep",
-                                               "generic_rg", "grep", "rg"):
+        if name.endswith("_multi") or name in _MULTI_HELPERS:
             for arg in node.args:
                 if isinstance(arg,
                               ast.Name) and arg.id in ("paths", "resolved"):
                     return True
-    _ = helper_suffixes
     return False
 
 


### PR DESCRIPTION
Follow-up to #145. Closes the remaining instances of the multi-file bug (`resolve_glob` then only `paths[0]`).

**du / file** — same bug as cat/head/tail across s3, nextcloud, hf_buckets, gdrive, github:
- `du`: added `du_multi` to `generic/du.py`; routed all five backends through it.
- `file`: routed all five through the existing `generic.file_cmd`.

**github/nl, github/md5** — github inlined single-file bodies while every other backend delegates to the looping generic:
- `nl` → `generic_nl` (via `stream_from_bytes`).
- `md5` → `generic_md5` (now emits GNU `<digest>  <name>` format, matching ram/disk/s3).

**Guard + tests:**
- AST multi-file guard extended to cover du, file, nl, md5 (now guards 8 commands across every backend).
- Unit tests: `du_multi`, new `generic/test_file.py`, github `test_nl.py` + `test_md5.py`.
- Integ: `du_multi`/`file_multi` cases added to cross-backend (disk/ram/redis, truth.txt) and s3/gcs/minio (truth_s3.txt exact-diff); nextcloud mirrors for parity.

Stacked on #145 (base `fix/python-cat-multifile`); retarget to `main` after #145 merges.