### PR TITLE
fix: add provenance to dify search results

### DIFF
--- a/docs/python/resource/dify.mdx
+++ b/docs/python/resource/dify.mdx
@@ -133,6 +133,17 @@ Supported methods:
 
 `top-k` is capped at `100`. `threshold` must be between `0` and `1`.
 
+Results are emitted one retrieval hit per block:
+
+```text
+/knowledge/policies/refunds:0.82
+Refunds are allowed within 30 days.
+```
+
+Mirage uses the configured slug metadata field to derive the path, and falls
+back to the Dify document name when that metadata is missing. Multiple hits
+from the same document remain separate records.
+
 Scoped search uses Dify metadata filtering. Documents with the configured slug
 metadata field are filtered by that field; name-based documents are filtered by
 `document_name`, which requires Dify Built-in Fields to be enabled in dataset

--- a/integ/dify.py
+++ b/integ/dify.py
@@ -96,24 +96,64 @@ def _document_detail(doc: tuple) -> dict:
 
 
 def _retrieve_records(query: str) -> list[dict]:
+    def build_record(doc_id: str, content: str, score: float) -> dict:
+        doc = DOC_BY_ID[doc_id]
+        return {
+            "segment": {
+                "id": f"{doc_id}:{score:.2f}",
+                "document_id": doc_id,
+                "content": content,
+                "document": {
+                    "id": doc[0],
+                    "data_source_type": "upload_file",
+                    "name": doc[1],
+                    "doc_type": None,
+                    "doc_metadata": _document_summary(doc)["doc_metadata"],
+                },
+            },
+            "child_chunks": [],
+            "score": score,
+            "tsne_position": None,
+            "files": [],
+            "summary": None,
+        }
+
     lowered = query.lower()
     if "throttl" in lowered or "rate" in lowered or "429" in lowered:
-        contents = [
-            "Requests are rate limited to 100 calls per minute per token.",
-            "If you exceed the limit you receive HTTP 429 and must back off.",
+        return [
+            build_record(
+                "doc-auth",
+                "Requests are rate limited to 100 calls per minute per token.",
+                0.92,
+            ),
+            build_record(
+                "doc-auth",
+                "If you exceed the limit you receive HTTP 429 and must back off.",
+                0.88,
+            ),
         ]
     elif "refund" in lowered or "money" in lowered:
-        contents = [
-            "Refunds are available within 30 days of purchase.",
-            "Approved refunds are processed within five business days.",
+        return [
+            build_record(
+                "doc-refunds",
+                "Refunds are available within 30 days of purchase.",
+                0.91,
+            ),
+            build_record(
+                "doc-refunds",
+                "Approved refunds are processed within five business days.",
+                0.84,
+            ),
         ]
     elif "encrypt" in lowered or "privacy" in lowered:
-        contents = [
-            "Customer data is stored encrypted at rest and in transit."
+        return [
+            build_record(
+                "doc-privacy",
+                "Customer data is stored encrypted at rest and in transit.",
+                0.89,
+            )
         ]
-    else:
-        contents = []
-    return [{"segment": {"content": content}} for content in contents]
+    return []
 
 
 class DifyMockHandler(BaseHTTPRequestHandler):

--- a/integ/dify.py
+++ b/integ/dify.py
@@ -128,7 +128,8 @@ def _retrieve_records(query: str) -> list[dict]:
             ),
             build_record(
                 "doc-auth",
-                "If you exceed the limit you receive HTTP 429 and must back off.",
+                ("If you exceed the limit you receive HTTP 429 and must "
+                 "back off."),
                 0.88,
             ),
         ]

--- a/integ/dify.py
+++ b/integ/dify.py
@@ -95,38 +95,39 @@ def _document_detail(doc: tuple) -> dict:
     return detail
 
 
-def _retrieve_records(query: str) -> list[dict]:
-    def build_record(doc_id: str, content: str, score: float) -> dict:
-        doc = DOC_BY_ID[doc_id]
-        return {
-            "segment": {
-                "id": f"{doc_id}:{score:.2f}",
-                "document_id": doc_id,
-                "content": content,
-                "document": {
-                    "id": doc[0],
-                    "data_source_type": "upload_file",
-                    "name": doc[1],
-                    "doc_type": None,
-                    "doc_metadata": _document_summary(doc)["doc_metadata"],
-                },
+def _build_record(doc_id: str, content: str, score: float) -> dict:
+    doc = DOC_BY_ID[doc_id]
+    return {
+        "segment": {
+            "id": f"{doc_id}:{score:.2f}",
+            "document_id": doc_id,
+            "content": content,
+            "document": {
+                "id": doc[0],
+                "data_source_type": "upload_file",
+                "name": doc[1],
+                "doc_type": None,
+                "doc_metadata": _document_summary(doc)["doc_metadata"],
             },
-            "child_chunks": [],
-            "score": score,
-            "tsne_position": None,
-            "files": [],
-            "summary": None,
-        }
+        },
+        "child_chunks": [],
+        "score": score,
+        "tsne_position": None,
+        "files": [],
+        "summary": None,
+    }
 
+
+def _retrieve_records(query: str) -> list[dict]:
     lowered = query.lower()
     if "throttl" in lowered or "rate" in lowered or "429" in lowered:
         return [
-            build_record(
+            _build_record(
                 "doc-auth",
                 "Requests are rate limited to 100 calls per minute per token.",
                 0.92,
             ),
-            build_record(
+            _build_record(
                 "doc-auth",
                 ("If you exceed the limit you receive HTTP 429 and must "
                  "back off."),
@@ -135,12 +136,12 @@ def _retrieve_records(query: str) -> list[dict]:
         ]
     elif "refund" in lowered or "money" in lowered:
         return [
-            build_record(
+            _build_record(
                 "doc-refunds",
                 "Refunds are available within 30 days of purchase.",
                 0.91,
             ),
-            build_record(
+            _build_record(
                 "doc-refunds",
                 "Approved refunds are processed within five business days.",
                 0.84,
@@ -148,7 +149,7 @@ def _retrieve_records(query: str) -> list[dict]:
         ]
     elif "encrypt" in lowered or "privacy" in lowered:
         return [
-            build_record(
+            _build_record(
                 "doc-privacy",
                 "Customer data is stored encrypted at rest and in transit.",
                 0.89,

--- a/integ/truth_dify.txt
+++ b/integ/truth_dify.txt
@@ -51,12 +51,17 @@ If you exceed the limit you receive HTTP 429 and must back off.
 === pipe_sort_uniq_wc ===
 3
 === search_throttle ===
+/knowledge/guides/auth:0.92
 Requests are rate limited to 100 calls per minute per token.
+/knowledge/guides/auth:0.88
 If you exceed the limit you receive HTTP 429 and must back off.
 === search_scoped_refund ===
+/knowledge/policies/refunds:0.91
 Refunds are available within 30 days of purchase.
+/knowledge/policies/refunds:0.84
 Approved refunds are processed within five business days.
 === search_hybrid_encrypted ===
+/knowledge/policies/privacy:0.89
 Customer data is stored encrypted at rest and in transit.
 === calls_ls ===
 list=1 detail=1 segments=0 retrieve=0

--- a/python/mirage/commands/builtin/dify/search.py
+++ b/python/mirage/commands/builtin/dify/search.py
@@ -39,6 +39,7 @@ async def search(
     cwd = _extra.get("cwd")
     target_paths = default_paths(paths,
                                  cwd if isinstance(cwd, PathSpec) else None)
+    mount_prefix = target_paths[0].prefix if target_paths else ""
     if any(is_mount_root(path) for path in target_paths):
         resolved_paths: list[PathSpec] = []
     else:
@@ -49,5 +50,6 @@ async def search(
                                                index,
                                                method=method,
                                                top_k=int(top_k),
-                                               threshold=float(threshold))
+                                               threshold=float(threshold),
+                                               mount_prefix=mount_prefix)
     return output, IOResult()

--- a/python/mirage/core/dify/search.py
+++ b/python/mirage/core/dify/search.py
@@ -56,9 +56,9 @@ async def search_segments(
             "retrieval_model": retrieval_model
         },
     )
-    output = records_to_bytes(response.get("records") or [],
-                              accessor.config.slug_metadata_name,
-                              mount_prefix)
+    output = records_to_bytes(
+        response.get("records") or [], accessor.config.slug_metadata_name,
+        mount_prefix)
     if paths and has_name_based_target and output == b"":
         logger.debug(
             "Dify scoped search returned no records for name-based documents; "
@@ -154,7 +154,9 @@ def records_to_bytes(
             continue
         content = segment_content(segment)
         contents.append(f"{header}\n{content}")
-    return "\n".join(contents).encode()
+    if not contents:
+        return b""
+    return ("\n".join(contents) + "\n").encode()
 
 
 def format_record_header(
@@ -185,7 +187,12 @@ def record_path(
     raw_path = document_path(document, slug_metadata_name)
     if raw_path is None:
         return None
-    normalized = normalize_slug(raw_path)
+    try:
+        normalized = normalize_slug(raw_path)
+    except ValueError:
+        logger.debug("Skipping Dify record with invalid slug/name: %r",
+                     raw_path)
+        return None
     prefix = mount_prefix.rstrip("/")
     if not prefix:
         return normalized
@@ -203,7 +210,8 @@ def document_path(
                     and item.get("name") == slug_metadata_name
                     and item.get("value") is not None):
                 return str(item["value"])
-    if isinstance(metadata, dict) and metadata.get(slug_metadata_name) is not None:
+    if isinstance(metadata,
+                  dict) and metadata.get(slug_metadata_name) is not None:
         return str(metadata[slug_metadata_name])
     name = document.get("name")
     if name is None:
@@ -212,7 +220,7 @@ def document_path(
 
 
 def format_score(value: object) -> str | None:
-    if not isinstance(value, (int, float)):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
         return None
     return f"{value:.2f}"
 

--- a/python/mirage/core/dify/search.py
+++ b/python/mirage/core/dify/search.py
@@ -1,8 +1,10 @@
 import logging
+from typing import Any
 
 from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.core.dify._client import dify_post
 from mirage.core.dify.path import resolve_path
+from mirage.core.dify.tree import normalize_slug
 from mirage.core.dify.walk import walk
 from mirage.types import PathSpec
 
@@ -24,8 +26,11 @@ async def search_segments(
     method: str = "semantic",
     top_k: int = 10,
     threshold: float = 0.0,
+    mount_prefix: str = "",
 ) -> bytes:
     search_method = validate_args(query, method, top_k, threshold)
+    if not mount_prefix and paths:
+        mount_prefix = paths[0].prefix
     retrieval_model = {
         "search_method": search_method,
         "top_k": min(top_k, 100),
@@ -51,7 +56,9 @@ async def search_segments(
             "retrieval_model": retrieval_model
         },
     )
-    output = records_to_bytes(response.get("records") or [])
+    output = records_to_bytes(response.get("records") or [],
+                              accessor.config.slug_metadata_name,
+                              mount_prefix)
     if paths and has_name_based_target and output == b"":
         logger.debug(
             "Dify scoped search returned no records for name-based documents; "
@@ -132,17 +139,88 @@ async def target_entries(
     return targets
 
 
-def records_to_bytes(records: list[dict]) -> bytes:
-    contents = []
+def records_to_bytes(
+    records: list[dict[str, Any]],
+    slug_metadata_name: str,
+    mount_prefix: str,
+) -> bytes:
+    contents: list[str] = []
     for record in records:
         segment = record.get("segment")
         if not isinstance(segment, dict):
             continue
-        content = segment.get("content")
-        if content is None:
-            contents.append("")
-        elif isinstance(content, str):
-            contents.append(content)
-        else:
-            contents.append(str(content))
+        header = format_record_header(record, slug_metadata_name, mount_prefix)
+        if header is None:
+            continue
+        content = segment_content(segment)
+        contents.append(f"{header}\n{content}")
     return "\n".join(contents).encode()
+
+
+def format_record_header(
+    record: dict[str, Any],
+    slug_metadata_name: str,
+    mount_prefix: str,
+) -> str | None:
+    path = record_path(record, slug_metadata_name, mount_prefix)
+    if path is None:
+        return None
+    score = format_score(record.get("score"))
+    if score is None:
+        return path
+    return f"{path}:{score}"
+
+
+def record_path(
+    record: dict[str, Any],
+    slug_metadata_name: str,
+    mount_prefix: str,
+) -> str | None:
+    segment = record.get("segment")
+    if not isinstance(segment, dict):
+        return None
+    document = segment.get("document")
+    if not isinstance(document, dict):
+        return None
+    raw_path = document_path(document, slug_metadata_name)
+    if raw_path is None:
+        return None
+    normalized = normalize_slug(raw_path)
+    prefix = mount_prefix.rstrip("/")
+    if not prefix:
+        return normalized
+    return prefix + normalized
+
+
+def document_path(
+    document: dict[str, Any],
+    slug_metadata_name: str,
+) -> str | None:
+    metadata = document.get("doc_metadata")
+    if isinstance(metadata, list):
+        for item in metadata:
+            if (isinstance(item, dict)
+                    and item.get("name") == slug_metadata_name
+                    and item.get("value") is not None):
+                return str(item["value"])
+    if isinstance(metadata, dict) and metadata.get(slug_metadata_name) is not None:
+        return str(metadata[slug_metadata_name])
+    name = document.get("name")
+    if name is None:
+        return None
+    return str(name)
+
+
+def format_score(value: object) -> str | None:
+    if not isinstance(value, (int, float)):
+        return None
+    return f"{value:.2f}"
+
+
+def segment_content(segment: dict[str, Any]) -> str:
+    content = segment.get("content")
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    return str(content)

--- a/python/mirage/ops/dify/search.py
+++ b/python/mirage/ops/dify/search.py
@@ -6,5 +6,10 @@ from mirage.types import PathSpec
 @op("search", resource="dify")
 async def search(accessor, paths: list[PathSpec], query: str, *, index,
                  **kwargs) -> bytes:
-    return await search_core.search_segments(accessor, query, paths, index,
+    mount_prefix = paths[0].prefix if paths else kwargs.pop("mount_prefix", "")
+    return await search_core.search_segments(accessor,
+                                             query,
+                                             paths,
+                                             index,
+                                             mount_prefix=mount_prefix,
                                              **kwargs)

--- a/python/mirage/ops/dify/search.py
+++ b/python/mirage/ops/dify/search.py
@@ -6,7 +6,8 @@ from mirage.types import PathSpec
 @op("search", resource="dify")
 async def search(accessor, paths: list[PathSpec], query: str, *, index,
                  **kwargs) -> bytes:
-    mount_prefix = paths[0].prefix if paths else kwargs.pop("mount_prefix", "")
+    explicit_prefix = kwargs.pop("mount_prefix", "")
+    mount_prefix = paths[0].prefix if paths else explicit_prefix
     return await search_core.search_segments(accessor,
                                              query,
                                              paths,

--- a/python/mirage/resource/dify/prompt.py
+++ b/python/mirage/resource/dify/prompt.py
@@ -9,8 +9,10 @@ For semantic or relevance-based queries, use:
 search "<query>" [path ...] [--method semantic|fulltext|hybrid|keyword] [--top-k N] [--threshold F]
 
 Use grep for exact pattern or regex matching; use search when meaning matters.
-Search can target multiple files, folders, or globs. Results are matching
-segment contents joined by newlines, ranked by Dify relevance.
+Search can target multiple files, folders, or globs. Each result is returned as
+an absolute workspace path, optionally followed by the Dify relevance score,
+then the matched chunk content. Multiple hits from the same document stay as
+separate results.
 
 Scoped search requires documents with the configured slug metadata field
 (default: slug) or Dify Built-in Fields enabled for name-based documents.

--- a/python/tests/commands/builtin/dify/test_search.py
+++ b/python/tests/commands/builtin/dify/test_search.py
@@ -39,7 +39,7 @@ async def test_search_command_resolves_globs_and_passes_multiple_documents(
     from mirage.commands.builtin.dify import search as command_search
     from mirage.core.dify import search, tree
 
-    calls: list[list[PathSpec]] = []
+    calls: list[tuple[list[PathSpec], dict]] = []
 
     async def list_documents(config):
         return [
@@ -48,7 +48,7 @@ async def test_search_command_resolves_globs_and_passes_multiple_documents(
         ]
 
     async def search_segments(accessor, query, paths, index, **kwargs):
-        calls.append(paths)
+        calls.append((paths, kwargs))
         return b"api\nauth"
 
     monkeypatch.setattr(tree, "list_all_documents", list_documents)
@@ -70,10 +70,11 @@ async def test_search_command_resolves_globs_and_passes_multiple_documents(
     assert await materialize(stdout) == b"api\nauth"
     assert io.reads == {}
     assert io.cache == []
-    assert [path.original for path in calls[0]] == [
+    assert [path.original for path in calls[0][0]] == [
         "/knowledge/guides/api.md",
         "/knowledge/guides/auth.md",
     ]
+    assert calls[0][1]["mount_prefix"] == "/knowledge/"
 
 
 @pytest.mark.asyncio
@@ -81,10 +82,10 @@ async def test_search_command_root_searches_whole_dataset(monkeypatch):
     from mirage.commands.builtin.dify import search as command_search
     from mirage.core.dify import search
 
-    calls: list[list[PathSpec]] = []
+    calls: list[tuple[list[PathSpec], dict]] = []
 
     async def search_segments(accessor, query, paths, index, **kwargs):
-        calls.append(paths)
+        calls.append((paths, kwargs))
         return b"dataset"
 
     monkeypatch.setattr(search, "search_segments", search_segments)
@@ -97,4 +98,9 @@ async def test_search_command_root_searches_whole_dataset(monkeypatch):
                                      index=RAMIndexCacheStore())
 
     assert await materialize(stdout) == b"dataset"
-    assert calls == [[]]
+    assert calls == [([], {
+        "method": "semantic",
+        "top_k": 10,
+        "threshold": 0.0,
+        "mount_prefix": "/knowledge/"
+    })]

--- a/python/tests/core/dify/test_search.py
+++ b/python/tests/core/dify/test_search.py
@@ -73,12 +73,28 @@ async def test_search_segments_scopes_folder_to_all_documents(monkeypatch):
         return {
             "records": [{
                 "segment": {
-                    "content": "api segment"
-                }
+                    "content": "api segment",
+                    "document": {
+                        "name": "API",
+                        "doc_metadata": [{
+                            "name": "slug",
+                            "value": "guides/api"
+                        }],
+                    },
+                },
+                "score": 0.92,
             }, {
                 "segment": {
-                    "content": "auth segment"
-                }
+                    "content": "auth segment",
+                    "document": {
+                        "name": "Auth",
+                        "doc_metadata": [{
+                            "name": "slug",
+                            "value": "guides/auth"
+                        }],
+                    },
+                },
+                "score": 0.81,
             }]
         }
 
@@ -99,7 +115,10 @@ async def test_search_segments_scopes_folder_to_all_documents(monkeypatch):
         threshold=0.4,
     )
 
-    assert result == b"api segment\nauth segment"
+    assert result == (
+        b"/knowledge/guides/api:0.92\napi segment\n"
+        b"/knowledge/guides/auth:0.81\nauth segment"
+    )
     retrieval = bodies[0]["retrieval_model"]
     assert retrieval["search_method"] == "hybrid_search"
     assert retrieval["top_k"] == 2
@@ -205,15 +224,102 @@ async def test_search_segments_empty_paths_searches_whole_dataset(monkeypatch):
 
     async def dify_post(config, endpoint, body):
         bodies.append(body)
-        return {"records": [{"segment": {"content": "dataset match"}}]}
+        return {
+            "records": [{
+                "segment": {
+                    "content": "dataset match",
+                    "document": {
+                        "name": "README.md",
+                        "doc_metadata": None,
+                    },
+                },
+                "score": 0.77,
+            }]
+        }
 
     monkeypatch.setattr(search, "dify_post", dify_post)
 
-    result = await search.search_segments(accessor(), "anything", [],
-                                          RAMIndexCacheStore())
+    result = await search.search_segments(accessor(),
+                                          "anything", [],
+                                          RAMIndexCacheStore(),
+                                          mount_prefix="/knowledge/")
 
-    assert result == b"dataset match"
+    assert result == b"/knowledge/README.md:0.77\ndataset match"
     assert "metadata_filtering_conditions" not in bodies[0]["retrieval_model"]
+
+
+def test_records_to_bytes_formats_absolute_paths_and_scores():
+    from mirage.core.dify.search import records_to_bytes
+
+    result = records_to_bytes(
+        [{
+            "segment": {
+                "content": "api segment",
+                "document": {
+                    "name": "API",
+                    "doc_metadata": [{
+                        "name": "slug",
+                        "value": "guides/api"
+                    }],
+                },
+            },
+            "score": 0.92,
+        }, {
+            "segment": {
+                "content": "auth segment",
+                "document": {
+                    "name": "README.md",
+                    "doc_metadata": None,
+                },
+            },
+        }],
+        "slug",
+        "/knowledge/",
+    )
+
+    assert result == (
+        b"/knowledge/guides/api:0.92\napi segment\n"
+        b"/knowledge/README.md\nauth segment"
+    )
+
+
+def test_records_to_bytes_keeps_multiple_chunks_for_same_document():
+    from mirage.core.dify.search import records_to_bytes
+
+    result = records_to_bytes(
+        [{
+            "segment": {
+                "content": "first chunk",
+                "document": {
+                    "name": "refunds.md",
+                    "doc_metadata": [{
+                        "name": "slug",
+                        "value": "policies/refunds"
+                    }],
+                },
+            },
+            "score": 0.82,
+        }, {
+            "segment": {
+                "content": "second chunk",
+                "document": {
+                    "name": "refunds.md",
+                    "doc_metadata": [{
+                        "name": "slug",
+                        "value": "policies/refunds"
+                    }],
+                },
+            },
+            "score": 0.79,
+        }],
+        "slug",
+        "/knowledge/",
+    )
+
+    assert result == (
+        b"/knowledge/policies/refunds:0.82\nfirst chunk\n"
+        b"/knowledge/policies/refunds:0.79\nsecond chunk"
+    )
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/dify/test_search.py
+++ b/python/tests/core/dify/test_search.py
@@ -115,10 +115,8 @@ async def test_search_segments_scopes_folder_to_all_documents(monkeypatch):
         threshold=0.4,
     )
 
-    assert result == (
-        b"/knowledge/guides/api:0.92\napi segment\n"
-        b"/knowledge/guides/auth:0.81\nauth segment"
-    )
+    assert result == (b"/knowledge/guides/api:0.92\napi segment\n"
+                      b"/knowledge/guides/auth:0.81\nauth segment\n")
     retrieval = bodies[0]["retrieval_model"]
     assert retrieval["search_method"] == "hybrid_search"
     assert retrieval["top_k"] == 2
@@ -244,7 +242,7 @@ async def test_search_segments_empty_paths_searches_whole_dataset(monkeypatch):
                                           RAMIndexCacheStore(),
                                           mount_prefix="/knowledge/")
 
-    assert result == b"/knowledge/README.md:0.77\ndataset match"
+    assert result == b"/knowledge/README.md:0.77\ndataset match\n"
     assert "metadata_filtering_conditions" not in bodies[0]["retrieval_model"]
 
 
@@ -277,10 +275,8 @@ def test_records_to_bytes_formats_absolute_paths_and_scores():
         "/knowledge/",
     )
 
-    assert result == (
-        b"/knowledge/guides/api:0.92\napi segment\n"
-        b"/knowledge/README.md\nauth segment"
-    )
+    assert result == (b"/knowledge/guides/api:0.92\napi segment\n"
+                      b"/knowledge/README.md\nauth segment\n")
 
 
 def test_records_to_bytes_keeps_multiple_chunks_for_same_document():
@@ -291,7 +287,8 @@ def test_records_to_bytes_keeps_multiple_chunks_for_same_document():
             "segment": {
                 "content": "first chunk",
                 "document": {
-                    "name": "refunds.md",
+                    "name":
+                    "refunds.md",
                     "doc_metadata": [{
                         "name": "slug",
                         "value": "policies/refunds"
@@ -303,7 +300,8 @@ def test_records_to_bytes_keeps_multiple_chunks_for_same_document():
             "segment": {
                 "content": "second chunk",
                 "document": {
-                    "name": "refunds.md",
+                    "name":
+                    "refunds.md",
                     "doc_metadata": [{
                         "name": "slug",
                         "value": "policies/refunds"
@@ -316,10 +314,70 @@ def test_records_to_bytes_keeps_multiple_chunks_for_same_document():
         "/knowledge/",
     )
 
-    assert result == (
-        b"/knowledge/policies/refunds:0.82\nfirst chunk\n"
-        b"/knowledge/policies/refunds:0.79\nsecond chunk"
+    assert result == (b"/knowledge/policies/refunds:0.82\nfirst chunk\n"
+                      b"/knowledge/policies/refunds:0.79\nsecond chunk\n")
+
+
+def test_records_to_bytes_skips_records_with_invalid_slug():
+    from mirage.core.dify.search import records_to_bytes
+
+    result = records_to_bytes(
+        [{
+            "segment": {
+                "content": "bad chunk",
+                "document": {
+                    "name": "ok.md",
+                    "doc_metadata": [{
+                        "name": "slug",
+                        "value": ""
+                    }],
+                },
+            },
+            "score": 0.82,
+        }, {
+            "segment": {
+                "content": "good chunk",
+                "document": {
+                    "name":
+                    "refunds.md",
+                    "doc_metadata": [{
+                        "name": "slug",
+                        "value": "policies/refunds"
+                    }],
+                },
+            },
+            "score": 0.79,
+        }],
+        "slug",
+        "/knowledge/",
     )
+
+    assert result == b"/knowledge/policies/refunds:0.79\ngood chunk\n"
+
+
+def test_records_to_bytes_omits_score_for_non_numeric_values():
+    from mirage.core.dify.search import records_to_bytes
+
+    result = records_to_bytes(
+        [{
+            "segment": {
+                "content": "chunk",
+                "document": {
+                    "name":
+                    "refunds.md",
+                    "doc_metadata": [{
+                        "name": "slug",
+                        "value": "policies/refunds"
+                    }],
+                },
+            },
+            "score": True,
+        }],
+        "slug",
+        "/knowledge/",
+    )
+
+    assert result == b"/knowledge/policies/refunds\nchunk\n"
 
 
 @pytest.mark.asyncio

--- a/python/tests/ops/dify/test_search.py
+++ b/python/tests/ops/dify/test_search.py
@@ -27,4 +27,7 @@ async def test_search_op_delegates_to_core(monkeypatch):
                              method="keyword")
 
     assert result == b"result"
-    assert calls == [("query", paths, {"method": "keyword"})]
+    assert calls == [("query", paths, {
+        "method": "keyword",
+        "mount_prefix": ""
+    })]


### PR DESCRIPTION
# fix(py/dify): add provenance to search results

Partly fixed #143

## Summary

Update Dify `search` result formatting so each retrieval hit includes source provenance instead of emitting only raw segment content.

This change makes `search` return one block per Dify retrieval record in the format:

```text
/knowledge/path/to/doc:0.82
<chunk content>
```

The path is derived from the configured slug metadata field and falls back to the Dify document name when slug metadata is missing. Multiple hits from the same document remain separate records.

## Changes

- format Dify search results as `absolute_workspace_path[:score]\ncontent`
- propagate mount prefix through the Dify search command/op path so root searches still emit absolute workspace paths
- keep one output block per retrieval record instead of collapsing hits from the same document
- update tests to cover slug-based paths, document-name fallback, optional score formatting, and repeated hits for the same document
- update Dify prompt/docs to match the implemented output format

## Why

The previous implementation dropped document provenance and relevance score, which made search results unattributable and harder for an agent to follow up with commands like `cat`, `head`, or `grep`.

## Testing

```bash
cd python && uv run pytest tests/core/dify/test_search.py tests/commands/builtin/dify/test_search.py tests/ops/dify/test_search.py -v
```