### PR TITLE
fix: correct rg count fallbacks

### DIFF
--- a/python/mirage/commands/builtin/discord/rg.py
+++ b/python/mirage/commands/builtin/discord/rg.py
@@ -17,9 +17,8 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.discord import DiscordAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
+from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.utils.output import format_records
-from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.discord.channels import list_channels
@@ -30,32 +29,11 @@ from mirage.core.discord.read import read as discord_read
 from mirage.core.discord.readdir import readdir as _readdir
 from mirage.core.discord.scope import coalesce_scopes, detect_scope
 from mirage.core.discord.search import search_guild
+from mirage.core.discord.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
 logger = logging.getLogger(__name__)
-
-
-async def _collect_files(
-    accessor: DiscordAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-) -> list[str]:
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    files: list[str] = []
-    for child in children:
-        if child.endswith(".json") or child.endswith(".jsonl"):
-            files.append(child)
-        else:
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            files.extend(await _collect_files(accessor, child_spec, index))
-    return files
 
 
 @command("rg", resource="discord", spec=SPECS["rg"])
@@ -87,7 +65,8 @@ async def rg(
         raise ValueError("rg: usage: rg [flags] pattern [path]")
     pattern_str = texts[0]
     max_count = int(m) if m is not None else None
-    pat = compile_pattern(pattern_str, i, F, w)
+    after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
+    before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
 
     pushdown_warnings: list[str] = []
     if paths:
@@ -138,73 +117,32 @@ async def rg(
                     "falling back to per-file scan", exc)
 
         paths = await resolve_glob(accessor, paths, index=index)
-        blob_paths: list[str] = []
-        file_prefix = paths[0].prefix if paths else ""
-        for path_item in paths:
-            blob_paths.extend(await _collect_files(accessor, path_item, index))
-        blob_paths = sorted(set(blob_paths))
-        all_results: list[str] = []
-        any_match = False
-        for bp in blob_paths:
-            if not hidden and any(
-                    part.startswith(".") for part in bp.split("/")):
-                continue
-            try:
-                bp_spec = PathSpec(original=bp,
-                                   directory=bp,
-                                   resolved=True,
-                                   prefix=file_prefix)
-                data = await discord_read(accessor, bp_spec, index)
-            except (FileNotFoundError, IsADirectoryError, RuntimeError):
-                continue
-            text = data.decode(errors="replace")
-            if not text:
-                continue
-            lines = text.splitlines()
-            matched = grep_lines(bp,
-                                 lines,
-                                 pat,
-                                 invert=v,
-                                 line_numbers=n,
-                                 count_only=c,
-                                 files_only=args_l,
-                                 only_matching=o,
-                                 max_count=max_count)
-            if not matched:
-                continue
-            any_match = True
-            if args_l:
-                all_results.append(bp)
-                continue
-            if c:
-                all_results.append(f"{bp}:{len(matched)}")
-                continue
-            for line in matched:
-                all_results.append(f"{bp}:{line}")
-        stderr = (("\n".join(pushdown_warnings) +
-                   "\n").encode() if pushdown_warnings else None)
-        if not any_match:
-            return b"", IOResult(exit_code=1, stderr=stderr)
-        return format_records(all_results), IOResult(stderr=stderr)
 
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("rg: usage: rg [flags] pattern path")
-    lines = raw.decode(errors="replace").splitlines()
-    matched = grep_lines("<stdin>",
-                         lines,
-                         pat,
-                         invert=v,
-                         line_numbers=n,
-                         count_only=c,
-                         files_only=args_l,
-                         only_matching=o,
-                         max_count=max_count)
-    if not matched:
-        return b"", IOResult(exit_code=1)
-    if c:
-        return str(len(matched)).encode() + b"\n", IOResult()
-    result_lines: list[str] = []
-    for line in matched:
-        result_lines.append(line)
-    return format_records(result_lines), IOResult()
+    stdout, io = await generic_rg(
+        paths,
+        pattern=pattern_str,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=discord_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        max_count=max_count,
+        context_before=before_ctx,
+        context_after=after_ctx,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
+    )
+    if pushdown_warnings:
+        io.stderr = ("\n".join(pushdown_warnings) + "\n").encode()
+    return stdout, io

--- a/python/mirage/commands/builtin/email/grep.py
+++ b/python/mirage/commands/builtin/email/grep.py
@@ -19,6 +19,7 @@ from mirage.accessor.email import EmailAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.email._provision import file_read_provision
 from mirage.commands.builtin.grep_helper import (compile_pattern,
+                                                 grep_count_has_matches,
                                                  grep_files_only, grep_lines,
                                                  grep_stream)
 from mirage.commands.builtin.utils.output import (format_optional_records,
@@ -249,18 +250,22 @@ async def _grep_server_side(
                              files_only=args_l,
                              only_matching=o,
                              max_count=max_count)
+        if c:
+            all_results.append(f"{vfs_path}:{matched[0]}")
+            if grep_count_has_matches(matched):
+                any_match = True
+            continue
         if not matched:
             continue
         any_match = True
         if args_l:
             all_results.append(vfs_path)
             continue
-        if c:
-            all_results.append(f"{vfs_path}:{len(matched)}")
-            continue
         for line in matched:
             all_results.append(f"{vfs_path}:{line}")
 
     if not any_match:
+        if all_results:
+            return format_records(all_results), IOResult(exit_code=1)
         return b"", IOResult(exit_code=1)
     return format_records(all_results), IOResult()

--- a/python/mirage/commands/builtin/email/rg.py
+++ b/python/mirage/commands/builtin/email/rg.py
@@ -17,14 +17,19 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.email import EmailAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
+from mirage.commands.builtin.generic.rg import rg as generic_rg
+from mirage.commands.builtin.grep_helper import (compile_pattern,
+                                                 grep_count_has_matches,
+                                                 grep_lines)
 from mirage.commands.builtin.utils.output import format_records
-from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.email._client import fetch_message
+from mirage.core.email.read import read as email_read
+from mirage.core.email.readdir import readdir as _readdir
 from mirage.core.email.scope import extract_folder
 from mirage.core.email.search import _build_vfs_path, search_messages
+from mirage.core.email.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -59,6 +64,8 @@ async def rg(
     pattern_str = texts[0]
     max_count = int(m) if m is not None else None
     pat = compile_pattern(pattern_str, i, F, w)
+    after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
+    before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
 
     if paths:
         folder = extract_folder(paths)
@@ -89,14 +96,17 @@ async def rg(
                                  files_only=args_l,
                                  only_matching=o,
                                  max_count=max_count)
+            if c:
+                if not grep_count_has_matches(matched):
+                    continue
+                any_match = True
+                all_results.append(f"{vfs_path}:{matched[0]}")
+                continue
             if not matched:
                 continue
             any_match = True
             if args_l:
                 all_results.append(vfs_path)
-                continue
-            if c:
-                all_results.append(f"{vfs_path}:{len(matched)}")
                 continue
             for line in matched:
                 all_results.append(f"{vfs_path}:{line}")
@@ -104,21 +114,28 @@ async def rg(
             return b"", IOResult(exit_code=1)
         return format_records(all_results), IOResult()
 
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("rg: usage: rg [flags] pattern path")
-    lines = raw.decode(errors="replace").splitlines()
-    matched = grep_lines("<stdin>",
-                         lines,
-                         pat,
-                         invert=v,
-                         line_numbers=n,
-                         count_only=c,
-                         files_only=args_l,
-                         only_matching=o,
-                         max_count=max_count)
-    if not matched:
-        return b"", IOResult(exit_code=1)
-    if c:
-        return str(len(matched)).encode() + b"\n", IOResult()
-    return format_records(matched), IOResult()
+    return await generic_rg(
+        [],
+        pattern=pattern_str,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=email_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        max_count=max_count,
+        context_before=before_ctx,
+        context_after=after_ctx,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/generic/grep.py
+++ b/python/mirage/commands/builtin/generic/grep.py
@@ -43,6 +43,42 @@ async def grep(
     scope_check: Callable[..., Awaitable[str | None]] | None = None,
     index: IndexCacheStore | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
+    """Run grep-style fallback search over backend paths or stdin.
+
+    Args:
+        paths (list[PathSpec]): Backend paths to search. Empty paths consume
+            stdin.
+        pattern (str): Pattern text from CLI arguments.
+        readdir (Callable[..., Awaitable[list[str]]]): Directory reader.
+        stat (Callable[[PathSpec], Awaitable[FileStat]]): Backend stat reader.
+        read_bytes (Callable[..., Awaitable[bytes]]): Whole-file reader.
+        read_stream (Callable[..., AsyncIterator[bytes]] | None): Optional
+            stream reader.
+        accessor (object): Backend accessor passed through wrapper helpers.
+        stdin (AsyncIterator[bytes] | bytes | None): Input used when paths is
+            empty.
+        pattern_via_e (bool): True when the pattern came from `-e`.
+        ignore_case (bool): `-i`, case-insensitive matching.
+        invert (bool): `-v`, select non-matching lines.
+        line_numbers (bool): `-n`, prefix line numbers.
+        count_only (bool): `-c`, output match counts.
+        files_only (bool): `-l`, output only matching file paths.
+        whole_word (bool): `-w`, match whole words.
+        fixed_string (bool): `-F`, treat pattern as a literal string.
+        only_matching (bool): `-o`, output only matched text.
+        quiet (bool): `-q`, suppress stdout and use exit status only.
+        recursive (bool): `-r`, descend into directories.
+        max_count (int | None): `-m`, stop after this many matching lines.
+        after_context (int): `-A`, trailing context lines.
+        before_context (int): `-B`, leading context lines.
+        scope_check (Callable[..., Awaitable[str | None]] | None): Optional
+            backend warning hook.
+        index (IndexCacheStore | None): Optional cache index for wrapped
+            backend calls.
+
+    Returns:
+        tuple[ByteSource | None, IOResult]: Output stream and exit metadata.
+    """
     if paths:
         mount_prefix = paths[0].prefix
         rd = partial(call_readdir,

--- a/python/mirage/commands/builtin/generic/rg.py
+++ b/python/mirage/commands/builtin/generic/rg.py
@@ -2,8 +2,10 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from functools import partial
 
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import (compile_pattern, grep_lines,
-                                                 grep_stream)
+from mirage.commands.builtin.grep_helper import (compile_pattern,
+                                                 grep_count_has_matches,
+                                                 grep_lines, grep_stream,
+                                                 nonzero_count_stream)
 from mirage.commands.builtin.rg_helper import rg_full
 from mirage.commands.builtin.utils.lines import split_lines
 from mirage.commands.builtin.utils.output import (format_optional_records,
@@ -120,7 +122,7 @@ async def rg(
                                   count_only, files_only, only_matching,
                                   max_count)
                 if count_only:
-                    if hits:
+                    if grep_count_has_matches(hits):
                         all_results.append(f"{p.original}:{hits[0]}")
                 elif files_only:
                     all_results.extend(hits)
@@ -144,6 +146,8 @@ async def rg(
             max_count=max_count,
             count_only=count_only,
         )
+        if count_only:
+            stream = nonzero_count_stream(stream)
         io = IOResult()
         return exit_on_empty(stream, io), io
 
@@ -158,6 +162,8 @@ async def rg(
         max_count=max_count,
         count_only=count_only,
     )
+    if count_only:
+        stream = nonzero_count_stream(stream)
     io = IOResult()
     return exit_on_empty(stream, io), io
 

--- a/python/mirage/commands/builtin/generic/rg.py
+++ b/python/mirage/commands/builtin/generic/rg.py
@@ -45,6 +45,42 @@ async def rg(
     scope_check: Callable[..., Awaitable[str | None]] | None = None,
     index: IndexCacheStore | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
+    """Run ripgrep-style fallback search over backend paths or stdin.
+
+    Args:
+        paths (list[PathSpec]): Backend paths to search. Empty paths consume
+            stdin.
+        pattern (str): Pattern text from CLI arguments.
+        readdir (Callable[..., Awaitable[list[str]]]): Directory reader.
+        stat (Callable[[PathSpec], Awaitable[FileStat]]): Backend stat reader.
+        read_bytes (Callable[..., Awaitable[bytes]]): Whole-file reader.
+        read_stream (Callable[..., AsyncIterator[bytes]] | None): Optional
+            stream reader.
+        accessor (object): Backend accessor passed through wrapper helpers.
+        stdin (AsyncIterator[bytes] | bytes | None): Input used when paths is
+            empty.
+        ignore_case (bool): `-i`, case-insensitive matching.
+        invert (bool): `-v`, select non-matching lines.
+        line_numbers (bool): `-n`, prefix line numbers.
+        count_only (bool): `-c`, output counts and omit zero-count files.
+        files_only (bool): `-l`, output only matching file paths.
+        whole_word (bool): `-w`, match whole words.
+        fixed_string (bool): `-F`, treat pattern as a literal string.
+        only_matching (bool): `-o`, output only matched text.
+        max_count (int | None): `-m`, stop after this many matching lines.
+        context_before (int): `-B`, leading context lines.
+        context_after (int): `-A`, trailing context lines.
+        hidden (bool): Include hidden files while scanning directories.
+        file_type (str | None): `--type`, filter directory scan by file type.
+        glob_pattern (str | None): `--glob`, filter directory scan by glob.
+        scope_check (Callable[..., Awaitable[str | None]] | None): Optional
+            backend warning hook.
+        index (IndexCacheStore | None): Optional cache index for wrapped
+            backend calls.
+
+    Returns:
+        tuple[ByteSource | None, IOResult]: Output stream and exit metadata.
+    """
     if paths:
         mount_prefix = paths[0].prefix
         rd = partial(call_readdir,

--- a/python/mirage/commands/builtin/github/grep.py
+++ b/python/mirage/commands/builtin/github/grep.py
@@ -27,10 +27,12 @@ from mirage.commands.builtin.utils.output import (format_optional_records,
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
+from mirage.core.github.constants import SCOPE_ERROR, SCOPE_WARN
 from mirage.core.github.glob import resolve_glob
 from mirage.core.github.read import read as github_read
 from mirage.core.github.readdir import readdir as _readdir
-from mirage.core.github.scope import should_use_search
+from mirage.core.github.scope import (count_scope_files, is_repo_root,
+                                      scope_relative_key, should_use_search)
 from mirage.core.github.search import narrow_paths
 from mirage.core.github.stat import stat as _stat
 from mirage.io.stream import exit_on_empty, quiet_match
@@ -160,19 +162,27 @@ async def grep(
         st = partial(_st, accessor, index, mount_prefix)
         rb = partial(_rb, accessor, index, mount_prefix)
 
+        key = scope_relative_key(paths[0])
+        file_count = count_scope_files(index._entries, key)
         pt = classify_pattern(pattern, F)
-        use_search = should_use_search(
+        use_search = (should_use_search(
             is_regex=(pt == PatternType.REGEX),
             recursive=(r or R),
             on_default_branch=(accessor.ref == accessor.default_branch),
-        )
+        ) and is_repo_root(key) and file_count > SCOPE_WARN)
         if use_search:
             narrowed = await narrow_paths(accessor.config, accessor.owner,
                                           accessor.repo, pattern, paths)
-            paths = (narrowed if narrowed else await resolve_glob(
-                accessor, paths, index))
+            if narrowed:
+                paths = narrowed
+                file_count = len(narrowed)
+            else:
+                paths = await resolve_glob(accessor, paths, index)
         else:
             paths = await resolve_glob(accessor, paths, index)
+        if file_count > SCOPE_ERROR:
+            msg = f"grep: {file_count} files in scope, narrow the path\n"
+            return b"", IOResult(exit_code=1, stderr=msg.encode())
 
         multi = len(paths) > 1 or r or R
 

--- a/python/mirage/commands/builtin/github/rg.py
+++ b/python/mirage/commands/builtin/github/rg.py
@@ -16,12 +16,18 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.constants import PatternType
 from mirage.commands.builtin.generic.rg import rg as generic_rg
+from mirage.commands.builtin.grep_helper import classify_pattern
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
+from mirage.core.github.constants import SCOPE_ERROR, SCOPE_WARN
 from mirage.core.github.glob import resolve_glob
 from mirage.core.github.read import read as github_read
 from mirage.core.github.readdir import readdir as _readdir
+from mirage.core.github.scope import (count_scope_files, is_repo_root,
+                                      scope_relative_key, should_use_search)
+from mirage.core.github.search import narrow_paths
 from mirage.core.github.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -61,7 +67,27 @@ async def rg(
     if paths and index is None:
         return b"", IOResult(exit_code=1)
     if paths:
-        paths = await resolve_glob(accessor, paths, index)
+        key = scope_relative_key(paths[0])
+        file_count = count_scope_files(index._entries, key)
+        pt = classify_pattern(pattern_str, F)
+        use_search = (should_use_search(
+            is_regex=(pt == PatternType.REGEX),
+            recursive=True,
+            on_default_branch=(accessor.ref == accessor.default_branch),
+        ) and is_repo_root(key) and file_count > SCOPE_WARN)
+        if use_search:
+            narrowed = await narrow_paths(accessor.config, accessor.owner,
+                                          accessor.repo, pattern_str, paths)
+            if narrowed:
+                paths = narrowed
+                file_count = len(narrowed)
+            else:
+                paths = await resolve_glob(accessor, paths, index)
+        else:
+            paths = await resolve_glob(accessor, paths, index)
+        if file_count > SCOPE_ERROR:
+            msg = f"rg: {file_count} files in scope, narrow the path\n"
+            return b"", IOResult(exit_code=1, stderr=msg.encode())
 
     return await generic_rg(
         paths,

--- a/python/mirage/commands/builtin/github/rg.py
+++ b/python/mirage/commands/builtin/github/rg.py
@@ -16,44 +16,15 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.constants import PatternType
-from mirage.commands.builtin.grep_helper import (classify_pattern,
-                                                 compile_pattern, grep_lines)
-from mirage.commands.builtin.utils.output import format_records
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
-from mirage.core.github.constants import SCOPE_ERROR, SCOPE_WARN
 from mirage.core.github.glob import resolve_glob
 from mirage.core.github.read import read as github_read
-from mirage.core.github.scope import should_use_search
-from mirage.core.github.search import search_code
+from mirage.core.github.readdir import readdir as _readdir
+from mirage.core.github.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-def _rg_tree_search(
-    index,
-    search_path: str,
-    pattern: str,
-    ignore_case: bool,
-    invert: bool,
-    line_numbers: bool,
-    count_only: bool,
-    files_only: bool,
-    only_matching: bool,
-    max_count: int | None,
-    fixed_string: bool,
-    whole_word: bool,
-    hidden: bool,
-) -> list[str]:
-    compile_pattern(pattern, ignore_case, fixed_string, whole_word)
-    key = search_path
-    prefix = key + "/" if key else ""
-    blob_paths = sorted(p for p, e in index._entries.items()
-                        if e.resource_type == "file" and (
-                            not key or p.startswith(prefix) or p == key))
-    return blob_paths
 
 
 @command("rg", resource="github", spec=SPECS["rg"])
@@ -84,115 +55,36 @@ async def rg(
         raise ValueError("rg: usage: rg [flags] pattern [path]")
     pattern_str = texts[0]
     max_count = int(m) if m is not None else None
-    pat = compile_pattern(pattern_str, i, F, w)
+    after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
+    before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
 
-    mount_prefix = paths[0].prefix if paths else ""
-    if paths and index is not None:
-        blob_set: set[str] = set()
-        for path_item in paths:
-            p_prefix = (path_item.prefix
-                        if isinstance(path_item, PathSpec) else "")
-            key = (path_item.original
-                   if isinstance(path_item, PathSpec) else path_item)
-            if p_prefix and key.startswith(p_prefix):
-                key = key[len(p_prefix):] or "/"
-            search_prefix = key + "/" if key else ""
-            for p, e in index._entries.items():
-                if e.resource_type == "file" and (
-                        not key or p.startswith(search_prefix) or p == key):
-                    blob_set.add(p)
-        blob_paths = sorted(blob_set)
-
-        first_p = paths[0]
-        first_prefix = first_p.prefix if isinstance(first_p, PathSpec) else ""
-        first_key = first_p.original if isinstance(first_p,
-                                                   PathSpec) else first_p
-        if first_prefix and first_key.startswith(first_prefix):
-            first_key = first_key[len(first_prefix):] or "/"
-        pt = classify_pattern(pattern_str, F)
-        use_search = (should_use_search(
-            is_regex=(pt == PatternType.REGEX),
-            recursive=True,
-            on_default_branch=(accessor.ref == accessor.default_branch),
-        ) and len(blob_paths) > SCOPE_WARN)
-        if use_search:
-            try:
-                results = await search_code(accessor.config,
-                                            accessor.owner,
-                                            accessor.repo,
-                                            query=pattern_str,
-                                            path_filter=first_key or None)
-                if results:
-                    api_paths = {r.path for r in results}
-                    blob_paths = [p for p in blob_paths if p in api_paths]
-            except Exception:
-                pass
-        if len(blob_paths) > SCOPE_ERROR:
-            msg = (f"rg: {len(blob_paths)} files in scope,"
-                   f" narrow the path\n")
-            return b"", IOResult(exit_code=1, stderr=msg.encode())
-
-        all_results: list[str] = []
-        any_match = False
-        for bp in blob_paths:
-            if not hidden and any(
-                    part.startswith(".") for part in bp.split("/")):
-                continue
-            try:
-                data = await github_read(accessor, bp, index)
-            except (FileNotFoundError, IsADirectoryError):
-                continue
-            text = data.decode(errors="replace")
-            lines = text.splitlines()
-            matched = grep_lines(bp,
-                                 lines,
-                                 pat,
-                                 invert=v,
-                                 line_numbers=n,
-                                 count_only=c,
-                                 files_only=args_l,
-                                 only_matching=o,
-                                 max_count=max_count)
-            if not matched:
-                continue
-            any_match = True
-            if args_l:
-                display = mount_prefix + "/" + bp.lstrip(
-                    "/") if mount_prefix else bp
-                all_results.append(display)
-                continue
-            if c:
-                display = mount_prefix + "/" + bp.lstrip(
-                    "/") if mount_prefix else bp
-                all_results.append(f"{display}:{len(matched)}")
-                continue
-            for line in matched:
-                display = mount_prefix + "/" + bp.lstrip(
-                    "/") if mount_prefix else bp
-                all_results.append(f"{display}:{line}")
-        if not any_match:
-            return b"", IOResult(exit_code=1)
-        return format_records(all_results), IOResult()
-
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("rg: usage: rg [flags] pattern path")
-    paths = await resolve_glob(accessor, paths, index)
-    lines = raw.decode(errors="replace").splitlines()
-    matched = grep_lines("<stdin>",
-                         lines,
-                         pat,
-                         invert=v,
-                         line_numbers=n,
-                         count_only=c,
-                         files_only=args_l,
-                         only_matching=o,
-                         max_count=max_count)
-    if not matched:
+    if paths and index is None:
         return b"", IOResult(exit_code=1)
-    if c:
-        return str(len(matched)).encode() + b"\n", IOResult()
-    result_lines: list[str] = []
-    for line in matched:
-        result_lines.append(line)
-    return format_records(result_lines), IOResult()
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+
+    return await generic_rg(
+        paths,
+        pattern=pattern_str,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=github_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        max_count=max_count,
+        context_before=before_ctx,
+        context_after=after_ctx,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/gmail/rg.py
+++ b/python/mirage/commands/builtin/gmail/rg.py
@@ -16,9 +16,8 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.gmail import GmailAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
+from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.utils.output import format_records
-from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gmail.glob import resolve_glob
@@ -26,32 +25,9 @@ from mirage.core.gmail.read import read as gmail_read
 from mirage.core.gmail.readdir import readdir as _readdir
 from mirage.core.gmail.scope import detect_scope
 from mirage.core.gmail.search import format_grep_results, search_messages
+from mirage.core.gmail.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _collect_files(
-    accessor: GmailAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-) -> list[str]:
-    if path.endswith(".json") or path.endswith(".jsonl"):
-        return [path]
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    files: list[str] = []
-    for child in children:
-        if child.endswith(".gmail.json"):
-            files.append(child)
-        else:
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            files.extend(await _collect_files(accessor, child_spec, index))
-    return files
 
 
 @command("rg", resource="gmail", spec=SPECS["rg"])
@@ -83,8 +59,8 @@ async def rg(
         raise ValueError("rg: usage: rg [flags] pattern [path]")
     pattern_str = texts[0]
     max_count = int(m) if m is not None else None
-    pat = compile_pattern(pattern_str, i, F, w)
-    index = index
+    after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
+    before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
 
     if paths:
         scope = detect_scope(paths[0])
@@ -103,71 +79,29 @@ async def rg(
             return format_records(lines), IOResult()
 
         paths = await resolve_glob(accessor, paths, index)
-        blob_paths: list[str] = []
-        file_prefix = paths[0].prefix if paths else ""
-        for path_item in paths:
-            blob_paths.extend(await _collect_files(accessor, path_item, index))
-        blob_paths = sorted(set(blob_paths))
-        all_results: list[str] = []
-        any_match = False
-        for bp in blob_paths:
-            if not hidden and any(
-                    part.startswith(".") for part in bp.split("/")):
-                continue
-            try:
-                bp_spec = PathSpec(original=bp,
-                                   directory=bp,
-                                   resolved=True,
-                                   prefix=file_prefix)
-                data = await gmail_read(accessor, bp_spec, index)
-            except (FileNotFoundError, IsADirectoryError, RuntimeError):
-                continue
-            text = data.decode(errors="replace")
-            if not text:
-                continue
-            lines = text.splitlines()
-            matched = grep_lines(bp,
-                                 lines,
-                                 pat,
-                                 invert=v,
-                                 line_numbers=n,
-                                 count_only=c,
-                                 files_only=args_l,
-                                 only_matching=o,
-                                 max_count=max_count)
-            if not matched:
-                continue
-            any_match = True
-            if args_l:
-                all_results.append(bp)
-                continue
-            if c:
-                all_results.append(f"{bp}:{len(matched)}")
-                continue
-            for line in matched:
-                all_results.append(f"{bp}:{line}")
-        if not any_match:
-            return b"", IOResult(exit_code=1)
-        return format_records(all_results), IOResult()
 
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("rg: usage: rg [flags] pattern path")
-    lines = raw.decode(errors="replace").splitlines()
-    matched = grep_lines("<stdin>",
-                         lines,
-                         pat,
-                         invert=v,
-                         line_numbers=n,
-                         count_only=c,
-                         files_only=args_l,
-                         only_matching=o,
-                         max_count=max_count)
-    if not matched:
-        return b"", IOResult(exit_code=1)
-    if c:
-        return str(len(matched)).encode() + b"\n", IOResult()
-    result_lines: list[str] = []
-    for line in matched:
-        result_lines.append(line)
-    return format_records(result_lines), IOResult()
+    return await generic_rg(
+        paths,
+        pattern=pattern_str,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=gmail_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        max_count=max_count,
+        context_before=before_ctx,
+        context_after=after_ctx,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/grep_helper.py
+++ b/python/mirage/commands/builtin/grep_helper.py
@@ -113,6 +113,25 @@ def grep_lines(
     return results
 
 
+def grep_count_value(results: list[str]) -> int:
+    if not results:
+        return 0
+    return int(results[0])
+
+
+def grep_count_has_matches(results: list[str]) -> bool:
+    return grep_count_value(results) > 0
+
+
+async def nonzero_count_stream(
+    source: AsyncIterator[bytes],
+) -> AsyncIterator[bytes]:
+    async for chunk in source:
+        count = int(chunk.decode(errors="replace").strip() or "0")
+        if count > 0:
+            yield chunk
+
+
 async def grep_stream(
     source: AsyncIterator[bytes],
     pat: re.Pattern[str],

--- a/python/mirage/commands/builtin/grep_helper.py
+++ b/python/mirage/commands/builtin/grep_helper.py
@@ -114,18 +114,41 @@ def grep_lines(
 
 
 def grep_count_value(results: list[str]) -> int:
+    """Return the numeric value from count-only grep results.
+
+    Args:
+        results (list[str]): `grep_lines(..., count_only=True)` output.
+
+    Returns:
+        int: The parsed match count, or zero when the result is empty.
+    """
     if not results:
         return 0
     return int(results[0])
 
 
 def grep_count_has_matches(results: list[str]) -> bool:
+    """Return whether count-only grep results contain any matches.
+
+    Args:
+        results (list[str]): `grep_lines(..., count_only=True)` output.
+
+    Returns:
+        bool: True when the parsed count is greater than zero.
+    """
     return grep_count_value(results) > 0
 
 
 async def nonzero_count_stream(
-    source: AsyncIterator[bytes],
-) -> AsyncIterator[bytes]:
+        source: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
+    """Drop zero-count chunks for `rg -c` fallback streams.
+
+    Args:
+        source (AsyncIterator[bytes]): Count-only grep stream.
+
+    Yields:
+        bytes: Count chunks whose parsed value is greater than zero.
+    """
     async for chunk in source:
         count = int(chunk.decode(errors="replace").strip() or "0")
         if count > 0:

--- a/python/mirage/commands/builtin/langfuse/rg.py
+++ b/python/mirage/commands/builtin/langfuse/rg.py
@@ -22,7 +22,6 @@ from mirage.commands.builtin.langfuse.grep import (_filter_traces,
                                                    _format_dataset_results,
                                                    _format_prompt_results,
                                                    _format_session_results)
-from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.langfuse._client import (fetch_datasets, fetch_prompts,

--- a/python/mirage/commands/builtin/langfuse/rg.py
+++ b/python/mirage/commands/builtin/langfuse/rg.py
@@ -16,13 +16,13 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.langfuse import LangfuseAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
+from mirage.commands.builtin.generic.rg import rg as generic_rg
+from mirage.commands.builtin.grep_helper import compile_pattern
 from mirage.commands.builtin.langfuse.grep import (_filter_traces,
                                                    _format_dataset_results,
                                                    _format_prompt_results,
                                                    _format_session_results)
 from mirage.commands.builtin.utils.output import format_records
-from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.langfuse._client import (fetch_datasets, fetch_prompts,
@@ -31,30 +31,9 @@ from mirage.core.langfuse.glob import resolve_glob
 from mirage.core.langfuse.read import read as langfuse_read
 from mirage.core.langfuse.readdir import readdir as _readdir
 from mirage.core.langfuse.scope import detect_scope
+from mirage.core.langfuse.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _collect_files(
-    accessor: LangfuseAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-) -> list[str]:
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    files: list[str] = []
-    for child in children:
-        if child.endswith(".json") or child.endswith(".jsonl"):
-            files.append(child)
-        else:
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            files.extend(await _collect_files(accessor, child_spec, index))
-    return files
 
 
 @command("rg", resource="langfuse", spec=SPECS["rg"])
@@ -87,6 +66,8 @@ async def rg(
     pattern_str = texts[0]
     max_count = int(m) if m is not None else None
     pat = compile_pattern(pattern_str, i, F, w)
+    after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
+    before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
 
     config = accessor.config
     limit = config.default_search_limit
@@ -117,71 +98,29 @@ async def rg(
             return _format_dataset_results(datasets, pat)
 
         paths = await resolve_glob(accessor, paths, index=index)
-        blob_paths: list[str] = []
-        file_prefix = paths[0].prefix if paths else ""
-        for path_item in paths:
-            blob_paths.extend(await _collect_files(accessor, path_item, index))
-        blob_paths = sorted(set(blob_paths))
-        all_results: list[str] = []
-        any_match = False
-        for bp in blob_paths:
-            if not hidden and any(
-                    part.startswith(".") for part in bp.split("/")):
-                continue
-            try:
-                bp_spec = PathSpec(original=bp,
-                                   directory=bp,
-                                   resolved=True,
-                                   prefix=file_prefix)
-                data = await langfuse_read(accessor, bp_spec, index)
-            except (FileNotFoundError, IsADirectoryError, RuntimeError):
-                continue
-            text = data.decode(errors="replace")
-            if not text:
-                continue
-            lines = text.splitlines()
-            matched = grep_lines(bp,
-                                 lines,
-                                 pat,
-                                 invert=v,
-                                 line_numbers=n,
-                                 count_only=c,
-                                 files_only=args_l,
-                                 only_matching=o,
-                                 max_count=max_count)
-            if not matched:
-                continue
-            any_match = True
-            if args_l:
-                all_results.append(bp)
-                continue
-            if c:
-                all_results.append(f"{bp}:{len(matched)}")
-                continue
-            for line in matched:
-                all_results.append(f"{bp}:{line}")
-        if not any_match:
-            return b"", IOResult(exit_code=1)
-        return format_records(all_results), IOResult()
 
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("rg: usage: rg [flags] pattern path")
-    lines = raw.decode(errors="replace").splitlines()
-    matched = grep_lines("<stdin>",
-                         lines,
-                         pat,
-                         invert=v,
-                         line_numbers=n,
-                         count_only=c,
-                         files_only=args_l,
-                         only_matching=o,
-                         max_count=max_count)
-    if not matched:
-        return b"", IOResult(exit_code=1)
-    if c:
-        return str(len(matched)).encode() + b"\n", IOResult()
-    result_lines: list[str] = []
-    for line in matched:
-        result_lines.append(line)
-    return format_records(result_lines), IOResult()
+    return await generic_rg(
+        paths,
+        pattern=pattern_str,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=langfuse_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        max_count=max_count,
+        context_before=before_ctx,
+        context_after=after_ctx,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/mongodb/rg.py
+++ b/python/mirage/commands/builtin/mongodb/rg.py
@@ -16,9 +16,8 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.mongodb import MongoDBAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
+from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.utils.output import format_records
-from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.mongodb._client import list_databases
@@ -28,31 +27,10 @@ from mirage.core.mongodb.readdir import readdir as _readdir
 from mirage.core.mongodb.scope import detect_scope
 from mirage.core.mongodb.search import (format_grep_results, search_collection,
                                         search_database)
+from mirage.core.mongodb.stat import stat as _stat
 from mirage.core.mongodb.types import ScopeLevel
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _collect_files(
-    accessor: MongoDBAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-) -> list[str]:
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    files: list[str] = []
-    for child in children:
-        if child.endswith(".json") or child.endswith(".jsonl"):
-            files.append(child)
-        else:
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            files.extend(await _collect_files(accessor, child_spec, index))
-    return files
 
 
 @command("rg", resource="mongodb", spec=SPECS["rg"])
@@ -84,7 +62,8 @@ async def rg(
         raise ValueError("rg: usage: rg [flags] pattern [path]")
     pattern_str = texts[0]
     max_count = int(m) if m is not None else None
-    pat = compile_pattern(pattern_str, i, F, w)
+    after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
+    before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
 
     config = accessor.config
     limit = config.default_search_limit
@@ -129,71 +108,29 @@ async def rg(
             return format_records(all_lines), IOResult()
 
         paths = await resolve_glob(accessor, paths, index=index)
-        blob_paths: list[str] = []
-        file_prefix = paths[0].prefix if paths else ""
-        for path_item in paths:
-            blob_paths.extend(await _collect_files(accessor, path_item, index))
-        blob_paths = sorted(set(blob_paths))
-        all_results: list[str] = []
-        any_match = False
-        for bp in blob_paths:
-            if not hidden and any(
-                    part.startswith(".") for part in bp.split("/")):
-                continue
-            try:
-                bp_spec = PathSpec(original=bp,
-                                   directory=bp,
-                                   resolved=True,
-                                   prefix=file_prefix)
-                data = await mongodb_read(accessor, bp_spec, index)
-            except (FileNotFoundError, IsADirectoryError, RuntimeError):
-                continue
-            text = data.decode(errors="replace")
-            if not text:
-                continue
-            lines = text.splitlines()
-            matched = grep_lines(bp,
-                                 lines,
-                                 pat,
-                                 invert=v,
-                                 line_numbers=n,
-                                 count_only=c,
-                                 files_only=args_l,
-                                 only_matching=o,
-                                 max_count=max_count)
-            if not matched:
-                continue
-            any_match = True
-            if args_l:
-                all_results.append(bp)
-                continue
-            if c:
-                all_results.append(f"{bp}:{len(matched)}")
-                continue
-            for line in matched:
-                all_results.append(f"{bp}:{line}")
-        if not any_match:
-            return b"", IOResult(exit_code=1)
-        return format_records(all_results), IOResult()
 
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("rg: usage: rg [flags] pattern path")
-    lines = raw.decode(errors="replace").splitlines()
-    matched = grep_lines("<stdin>",
-                         lines,
-                         pat,
-                         invert=v,
-                         line_numbers=n,
-                         count_only=c,
-                         files_only=args_l,
-                         only_matching=o,
-                         max_count=max_count)
-    if not matched:
-        return b"", IOResult(exit_code=1)
-    if c:
-        return str(len(matched)).encode() + b"\n", IOResult()
-    result_lines: list[str] = []
-    for line in matched:
-        result_lines.append(line)
-    return format_records(result_lines), IOResult()
+    return await generic_rg(
+        paths,
+        pattern=pattern_str,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=mongodb_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        max_count=max_count,
+        context_before=before_ctx,
+        context_after=after_ctx,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/postgres/rg.py
+++ b/python/mirage/commands/builtin/postgres/rg.py
@@ -16,9 +16,8 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.postgres import PostgresAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
+from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.utils.output import format_records
-from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.postgres.glob import resolve_glob
@@ -28,30 +27,9 @@ from mirage.core.postgres.scope import detect_scope
 from mirage.core.postgres.search import (format_grep_results, search_database,
                                          search_entity, search_kind,
                                          search_schema)
+from mirage.core.postgres.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _collect_files(
-    accessor: PostgresAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-) -> list[str]:
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    files: list[str] = []
-    for child in children:
-        if child.endswith(".json") or child.endswith(".jsonl"):
-            files.append(child)
-        else:
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            files.extend(await _collect_files(accessor, child_spec, index))
-    return files
 
 
 @command("rg", resource="postgres", spec=SPECS["rg"])
@@ -83,7 +61,8 @@ async def rg(
         raise ValueError("rg: usage: rg [flags] pattern [path]")
     pattern_str = texts[0]
     max_count = int(m) if m is not None else None
-    pat = compile_pattern(pattern_str, i, F, w)
+    after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
+    before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
 
     config = accessor.config
     limit = config.default_search_limit
@@ -124,72 +103,29 @@ async def rg(
             return format_records(all_lines), IOResult()
 
         paths = await resolve_glob(accessor, paths, index=index)
-        blob_paths: list[str] = []
-        file_prefix = paths[0].prefix if paths else ""
-        for path_item in paths:
-            blob_paths.extend(await _collect_files(accessor, path_item, index))
-        blob_paths = sorted(set(blob_paths))
-        all_results: list[str] = []
-        any_match = False
-        for bp in blob_paths:
-            if not hidden and any(
-                    part.startswith(".") for part in bp.split("/")):
-                continue
-            try:
-                bp_spec = PathSpec(original=bp,
-                                   directory=bp,
-                                   resolved=True,
-                                   prefix=file_prefix)
-                data = await postgres_read(accessor, bp_spec, index)
-            except (FileNotFoundError, IsADirectoryError, RuntimeError,
-                    ValueError):
-                continue
-            text = data.decode(errors="replace")
-            if not text:
-                continue
-            lines = text.splitlines()
-            matched = grep_lines(bp,
-                                 lines,
-                                 pat,
-                                 invert=v,
-                                 line_numbers=n,
-                                 count_only=c,
-                                 files_only=args_l,
-                                 only_matching=o,
-                                 max_count=max_count)
-            if not matched:
-                continue
-            any_match = True
-            if args_l:
-                all_results.append(bp)
-                continue
-            if c:
-                all_results.append(f"{bp}:{len(matched)}")
-                continue
-            for line in matched:
-                all_results.append(f"{bp}:{line}")
-        if not any_match:
-            return b"", IOResult(exit_code=1)
-        return format_records(all_results), IOResult()
 
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("rg: usage: rg [flags] pattern path")
-    lines = raw.decode(errors="replace").splitlines()
-    matched = grep_lines("<stdin>",
-                         lines,
-                         pat,
-                         invert=v,
-                         line_numbers=n,
-                         count_only=c,
-                         files_only=args_l,
-                         only_matching=o,
-                         max_count=max_count)
-    if not matched:
-        return b"", IOResult(exit_code=1)
-    if c:
-        return str(len(matched)).encode() + b"\n", IOResult()
-    result_lines: list[str] = []
-    for line in matched:
-        result_lines.append(line)
-    return format_records(result_lines), IOResult()
+    return await generic_rg(
+        paths,
+        pattern=pattern_str,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=postgres_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        max_count=max_count,
+        context_before=before_ctx,
+        context_after=after_ctx,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/rg_helper.py
+++ b/python/mirage/commands/builtin/rg_helper.py
@@ -18,7 +18,9 @@ import re
 
 from mirage.commands.builtin.grep_helper import (BINARY_EXTENSIONS,
                                                  compile_pattern,
-                                                 get_extension, grep_lines)
+                                                 get_extension,
+                                                 grep_count_has_matches,
+                                                 grep_lines)
 from mirage.commands.builtin.utils.types import (_AsyncReadBytes,
                                                  _AsyncReaddir, _AsyncStat,
                                                  _ReadBytes)
@@ -101,6 +103,8 @@ def rg_search_file(
             only_matching,
             max_count,
         )
+        if count_only and not grep_count_has_matches(lines):
+            return []
         if prefix_path and not count_only and not files_only:
             return [f"{entry}:{ln}" for ln in lines]
         return lines
@@ -118,7 +122,7 @@ def rg_search_file(
                 break
 
     if count_only:
-        return [str(count)]
+        return [str(count)] if count > 0 else []
     if files_only:
         return [entry] if count > 0 else []
 
@@ -216,16 +220,19 @@ async def rg_folder(
         try:
             raw = await read_bytes_fn(entry)
             text_lines = raw.decode(errors="replace").splitlines()
+            file_count = 0
             for i_line, line in enumerate(text_lines, 1):
                 m = pat.search(line)
                 matched = bool(m) != invert
                 if not matched:
                     continue
+                file_count += 1
                 if files_only:
                     results.append(entry)
                     break
                 elif count_only:
-                    pass
+                    if max_count is not None and file_count >= max_count:
+                        break
                 elif only_matching and m and not invert:
                     pfx = (f"{i_line}:{m.group()}"
                            if line_numbers else m.group())
@@ -233,6 +240,8 @@ async def rg_folder(
                 else:
                     pfx = f"{i_line}:{line}" if line_numbers else line
                     results.append(f"{entry}:{pfx}")
+            if count_only and file_count > 0:
+                results.append(f"{entry}:{file_count}")
         except Exception as exc:
             if warnings is not None:
                 warnings.append(f"rg: {entry}: {exc}")
@@ -304,7 +313,7 @@ async def rg_full(
             if max_count is not None and count >= max_count:
                 break
         if count_only:
-            return [str(count)]
+            return [str(count)] if count > 0 else []
         return results
 
     results = []
@@ -357,20 +366,28 @@ async def rg_full(
             try:
                 data = (await read_bytes_fn(entry)).decode(
                     errors="replace").splitlines()
+                file_count = 0
                 for i_ln, line in enumerate(data, 1):
                     m = compiled.search(line)
                     matched = bool(m) != invert
                     if not matched:
                         continue
+                    file_count += 1
                     if files_only:
                         results.append(entry)
                         break
+                    if count_only:
+                        if max_count is not None and file_count >= max_count:
+                            break
+                        continue
                     if only_matching and m and not invert:
                         text = m.group(0)
                     else:
                         text = line
                     pfx = f"{i_ln}:{text}" if line_numbers else text
                     results.append(f"{entry}:{pfx}")
+                if count_only and file_count > 0:
+                    results.append(f"{entry}:{file_count}")
             except Exception as exc:
                 if warnings is not None:
                     warnings.append(f"rg: {entry}: {exc}")

--- a/python/mirage/commands/builtin/slack/grep.py
+++ b/python/mirage/commands/builtin/slack/grep.py
@@ -105,7 +105,8 @@ async def grep(
         if not scope.use_native:
             scope = coalesce_scopes(paths) or scope
 
-        if scope.use_native and search_available(accessor.config):
+        if (scope.use_native and getattr(scope, "target", None) != "files"
+                and search_available(accessor.config)):
             file_prefix = paths[0].prefix or ""
             query = build_query(pattern, scope)
             target = getattr(scope, "target", None)

--- a/python/mirage/commands/builtin/slack/rg.py
+++ b/python/mirage/commands/builtin/slack/rg.py
@@ -74,7 +74,8 @@ async def rg(
         if not scope.use_native:
             scope = coalesce_scopes(paths) or scope
 
-        if scope.use_native and search_available(accessor.config):
+        if (scope.use_native and getattr(scope, "target", None) != "files"
+                and search_available(accessor.config)):
             file_prefix = paths[0].prefix or ""
             query = build_query(pattern_str, scope)
             target = getattr(scope, "target", None)

--- a/python/mirage/commands/builtin/slack/rg.py
+++ b/python/mirage/commands/builtin/slack/rg.py
@@ -17,9 +17,8 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.slack import SlackAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import compile_pattern, grep_lines
+from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.utils.output import format_records
-from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.slack.formatters import (build_query,
@@ -31,32 +30,11 @@ from mirage.core.slack.readdir import readdir as _readdir
 from mirage.core.slack.scope import coalesce_scopes, detect_scope
 from mirage.core.slack.search import (search_available, search_files,
                                       search_messages)
+from mirage.core.slack.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
 logger = logging.getLogger(__name__)
-
-
-async def _collect_files(
-    accessor: SlackAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-) -> list[str]:
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    files: list[str] = []
-    for child in children:
-        if child.endswith(".json") or child.endswith(".jsonl"):
-            files.append(child)
-        else:
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            files.extend(await _collect_files(accessor, child_spec, index))
-    return files
 
 
 @command("rg", resource="slack", spec=SPECS["rg"])
@@ -88,7 +66,8 @@ async def rg(
         raise ValueError("rg: usage: rg [flags] pattern [path]")
     pattern_str = texts[0]
     max_count = int(m) if m is not None else None
-    pat = compile_pattern(pattern_str, i, F, w)
+    after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
+    before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
 
     if paths:
         scope = detect_scope(paths[0])
@@ -127,71 +106,29 @@ async def rg(
                 "falling back to per-file scan", err)
 
         paths = await resolve_glob(accessor, paths, index)
-        blob_paths: list[str] = []
-        file_prefix = paths[0].prefix if paths else ""
-        for path_item in paths:
-            blob_paths.extend(await _collect_files(accessor, path_item, index))
-        blob_paths = sorted(set(blob_paths))
-        all_results: list[str] = []
-        any_match = False
-        for bp in blob_paths:
-            if not hidden and any(
-                    part.startswith(".") for part in bp.split("/")):
-                continue
-            try:
-                bp_spec = PathSpec(original=bp,
-                                   directory=bp,
-                                   resolved=True,
-                                   prefix=file_prefix)
-                data = await slack_read(accessor, bp_spec, index)
-            except (FileNotFoundError, IsADirectoryError, RuntimeError):
-                continue
-            text = data.decode(errors="replace")
-            if not text:
-                continue
-            lines = text.splitlines()
-            matched = grep_lines(bp,
-                                 lines,
-                                 pat,
-                                 invert=v,
-                                 line_numbers=n,
-                                 count_only=c,
-                                 files_only=args_l,
-                                 only_matching=o,
-                                 max_count=max_count)
-            if not matched:
-                continue
-            any_match = True
-            if args_l:
-                all_results.append(bp)
-                continue
-            if c:
-                all_results.append(f"{bp}:{len(matched)}")
-                continue
-            for line in matched:
-                all_results.append(f"{bp}:{line}")
-        if not any_match:
-            return b"", IOResult(exit_code=1)
-        return format_records(all_results), IOResult()
 
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("rg: usage: rg [flags] pattern path")
-    lines = raw.decode(errors="replace").splitlines()
-    matched = grep_lines("<stdin>",
-                         lines,
-                         pat,
-                         invert=v,
-                         line_numbers=n,
-                         count_only=c,
-                         files_only=args_l,
-                         only_matching=o,
-                         max_count=max_count)
-    if not matched:
-        return b"", IOResult(exit_code=1)
-    if c:
-        return str(len(matched)).encode() + b"\n", IOResult()
-    result_lines: list[str] = []
-    for line in matched:
-        result_lines.append(line)
-    return format_records(result_lines), IOResult()
+    return await generic_rg(
+        paths,
+        pattern=pattern_str,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=slack_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        max_count=max_count,
+        context_before=before_ctx,
+        context_after=after_ctx,
+        hidden=hidden,
+        file_type=type,
+        glob_pattern=glob,
+        index=index,
+    )

--- a/python/mirage/core/github/scope.py
+++ b/python/mirage/core/github/scope.py
@@ -14,7 +14,57 @@
 
 import fnmatch
 
+from mirage.cache.index import IndexEntry
 from mirage.core.github.tree_entry import TreeEntry
+from mirage.types import PathSpec
+
+
+def scope_relative_key(path: PathSpec | str) -> str:
+    """Strip the mount prefix from a path to get its repo-relative key.
+
+    Args:
+        path (PathSpec | str): Scope path, possibly mount-prefixed.
+
+    Returns:
+        str: Repo-relative key with a leading slash; ``/`` for the root.
+    """
+    prefix = path.prefix if isinstance(path, PathSpec) else ""
+    key = path.original if isinstance(path, PathSpec) else str(path)
+    if prefix and key.startswith(prefix):
+        key = key[len(prefix):] or "/"
+    return key
+
+
+def is_repo_root(key: str) -> bool:
+    """Return whether a repo-relative key points at the repository root.
+
+    Args:
+        key (str): Repo-relative key from :func:`scope_relative_key`.
+
+    Returns:
+        bool: True for ``""`` or ``"/"``.
+    """
+    return key in ("", "/")
+
+
+def count_scope_files(entries: dict[str, IndexEntry], key: str) -> int:
+    """Count indexed files under a repo-relative scope key.
+
+    Args:
+        entries (dict[str, IndexEntry]): Index entries keyed by repo-relative
+            path with a leading slash.
+        key (str): Repo-relative scope key from :func:`scope_relative_key`.
+
+    Returns:
+        int: Number of file entries at or below the scope.
+    """
+    if is_repo_root(key):
+        return sum(1 for e in entries.values() if e.resource_type == "file")
+    norm = "/" + key.strip("/")
+    prefix = norm + "/"
+    return sum(
+        1 for p, e in entries.items()
+        if e.resource_type == "file" and (p == norm or p.startswith(prefix)))
 
 
 def should_use_search(

--- a/python/mirage/core/github/search.py
+++ b/python/mirage/core/github/search.py
@@ -12,11 +12,15 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import logging
 from dataclasses import dataclass
 
 from mirage.core.github._client import github_get
 from mirage.core.github.config import GitHubConfig
+from mirage.core.github.scope import scope_relative_key
 from mirage.types import PathSpec
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -51,15 +55,23 @@ async def narrow_paths(
 ) -> list[PathSpec]:
     """Use GitHub code search to narrow paths for grep/rg.
 
-    Returns narrowed PathSpecs (one per matching file). Empty list means
-    search returned no results.
+    Args:
+        config (GitHubConfig): GitHub API config.
+        owner (str): Repository owner.
+        repo (str): Repository name.
+        pattern (str): Literal search pattern.
+        paths (list[PathSpec]): Scope paths, possibly mount-prefixed.
+
+    Returns:
+        list[PathSpec]: One PathSpec per matching file, repo-relative with a
+        leading slash and the original mount prefix. Empty when search
+        returned nothing.
     """
+    mount_prefix = (paths[0].prefix
+                    if paths and isinstance(paths[0], PathSpec) else "")
     narrowed: list[str] = []
     for p in paths:
-        p_prefix = p.prefix if isinstance(p, PathSpec) else ""
-        path_filter = p.original if isinstance(p, PathSpec) else p
-        if p_prefix and path_filter.startswith(p_prefix):
-            path_filter = path_filter[len(p_prefix):] or "/"
+        path_filter = scope_relative_key(p).strip("/")
         try:
             results = await search_code(
                 config,
@@ -68,7 +80,15 @@ async def narrow_paths(
                 query=pattern,
                 path_filter=path_filter or None,
             )
-            narrowed.extend(r.path for r in results)
-        except Exception:
-            pass
-    return [PathSpec(original=n, directory="") for n in narrowed]
+        except Exception as exc:
+            logger.warning(
+                "github code search failed (%s); "
+                "falling back to per-file scan", exc)
+            continue
+        narrowed.extend(r.path for r in results)
+    return [
+        PathSpec(original="/" + n.lstrip("/"),
+                 directory="",
+                 prefix=mount_prefix,
+                 resolved=True) for n in narrowed
+    ]

--- a/python/mirage/core/github/search.py
+++ b/python/mirage/core/github/search.py
@@ -87,7 +87,7 @@ async def narrow_paths(
             continue
         narrowed.extend(r.path for r in results)
     return [
-        PathSpec(original="/" + n.lstrip("/"),
+        PathSpec(original=mount_prefix + "/" + n.lstrip("/"),
                  directory="",
                  prefix=mount_prefix,
                  resolved=True) for n in narrowed

--- a/python/tests/commands/builtin/discord/test_search_pushdown_fallback.py
+++ b/python/tests/commands/builtin/discord/test_search_pushdown_fallback.py
@@ -18,6 +18,7 @@ import pytest
 
 from mirage.commands.builtin.discord.grep import grep
 from mirage.commands.builtin.discord.rg import rg
+from mirage.io.types import IOResult
 from mirage.types import PathSpec
 
 
@@ -79,8 +80,8 @@ async def test_rg_emits_warning_on_rate_limit():
             "mirage.commands.builtin.discord.rg.resolve_glob",
             new=AsyncMock(return_value=paths),
     ), patch(
-            "mirage.commands.builtin.discord.rg._collect_files",
-            new=AsyncMock(return_value=[]),
+            "mirage.commands.builtin.discord.rg.generic_rg",
+            new=AsyncMock(return_value=(b"", IOResult(exit_code=1))),
     ):
         _out, io = await rg(accessor, paths, "hi", index=_fake_index())
     stderr = (io.stderr or b"").decode()

--- a/python/tests/commands/builtin/email/test_grep.py
+++ b/python/tests/commands/builtin/email/test_grep.py
@@ -1,18 +1,24 @@
+import importlib
 import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from mirage.io.stream import materialize
+from mirage.types import PathSpec
+
 sys.modules.setdefault(
     "aioimaplib",
     SimpleNamespace(IMAP4=object, IMAP4_SSL=object),
 )
-sys.modules.setdefault("aiosmtplib", SimpleNamespace(SMTP=object))
+sys.modules.setdefault(
+    "aiosmtplib",
+    SimpleNamespace(SMTP=object, send=AsyncMock()),
+)
 
-from mirage.commands.builtin.email.grep import _grep_server_side
-from mirage.io.stream import materialize
-from mirage.types import PathSpec
+_grep_server_side = importlib.import_module(
+    "mirage.commands.builtin.email.grep")._grep_server_side
 
 
 @pytest.mark.asyncio
@@ -37,7 +43,6 @@ async def test_grep_server_side_count_uses_real_count():
             ],
             c=True,
         )
-    assert await materialize(stdout) == (
-        b"/email/INBOX/msg1.email.json:2\n"
-        b"/email/INBOX/msg2.email.json:0\n")
+    assert await materialize(stdout) == (b"/email/INBOX/msg1.email.json:2\n"
+                                         b"/email/INBOX/msg2.email.json:0\n")
     assert io.exit_code == 0

--- a/python/tests/commands/builtin/email/test_grep.py
+++ b/python/tests/commands/builtin/email/test_grep.py
@@ -1,0 +1,43 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.modules.setdefault(
+    "aioimaplib",
+    SimpleNamespace(IMAP4=object, IMAP4_SSL=object),
+)
+sys.modules.setdefault("aiosmtplib", SimpleNamespace(SMTP=object))
+
+from mirage.commands.builtin.email.grep import _grep_server_side
+from mirage.io.stream import materialize
+from mirage.types import PathSpec
+
+
+@pytest.mark.asyncio
+async def test_grep_server_side_count_uses_real_count():
+    accessor = SimpleNamespace(config=SimpleNamespace(max_messages=10))
+    pairs = [
+        ("/email/INBOX/msg1.email.json", "foo foo\nfoo bar\nbaz\n"),
+        ("/email/INBOX/msg2.email.json", "bar\nbaz\n"),
+    ]
+    with patch(
+            "mirage.commands.builtin.email.grep.search_and_format",
+            new=AsyncMock(return_value=pairs),
+    ):
+        stdout, io = await _grep_server_side(
+            accessor,
+            "INBOX",
+            "foo",
+            [
+                PathSpec(original="/email/INBOX",
+                         directory="/email/INBOX",
+                         prefix="/email")
+            ],
+            c=True,
+        )
+    assert await materialize(stdout) == (
+        b"/email/INBOX/msg1.email.json:2\n"
+        b"/email/INBOX/msg2.email.json:0\n")
+    assert io.exit_code == 0

--- a/python/tests/commands/builtin/generic/test_rg.py
+++ b/python/tests/commands/builtin/generic/test_rg.py
@@ -93,6 +93,40 @@ async def test_rg_stdin_basic():
 
 
 @pytest.mark.asyncio
+async def test_rg_count_stdin_uses_match_count():
+    readdir, stat, rb, rs = _make_backend({})
+    output, io = await rg(
+        [],
+        pattern="foo",
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+        stdin=b"foo foo\nfoo bar\nbaz\n",
+        count_only=True,
+    )
+    assert (await _drain_async(output)) == b"2\n"
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_rg_count_stdin_zero_exits_1_without_output():
+    readdir, stat, rb, rs = _make_backend({})
+    output, io = await rg(
+        [],
+        pattern="foo",
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+        stdin=b"bar\nbaz\n",
+        count_only=True,
+    )
+    assert await _drain_async(output) == b""
+    assert io.exit_code == 1
+
+
+@pytest.mark.asyncio
 async def test_rg_file_basic():
     readdir, stat, rb, rs = _make_backend({
         "/a.txt":
@@ -146,6 +180,27 @@ async def test_rg_dir_auto_recursive():
     decoded = (await _drain_async(output)).decode()
     assert "apple" in decoded
     assert "apricot" in decoded
+
+
+@pytest.mark.asyncio
+async def test_rg_count_dir_skips_zero_count_files():
+    readdir, stat, rb, rs = _make_backend({
+        "/dir/a.txt": b"foo\nbar\nfoo\n",
+        "/dir/b.txt": b"bar\nbaz\n",
+    })
+    output, io = await rg(
+        [_spec("/dir")],
+        pattern="foo",
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+        count_only=True,
+    )
+    decoded = (await _drain_async(output)).decode()
+    assert "/dir/a.txt:2" in decoded
+    assert "/dir/b.txt" not in decoded
+    assert io.exit_code == 0
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/builtin/github/test_commands.py
+++ b/python/tests/commands/builtin/github/test_commands.py
@@ -372,4 +372,20 @@ async def test_rg_count_stdin_terminates_newline(github_env):
     )
     data = await materialize(stdout)
     assert io.exit_code == 0
-    assert data and data.endswith(b"\n")
+    assert data == b"2\n"
+
+
+@pytest.mark.asyncio
+async def test_rg_count_stdin_zero_exits_1(github_env):
+    accessor, index = github_env
+    stdout, io = await rg(
+        accessor,
+        [],
+        "foo",
+        stdin=b"bar\nbaz\n",
+        c=True,
+        index=index,
+    )
+    data = await materialize(stdout)
+    assert data == b""
+    assert io.exit_code == 1

--- a/python/tests/commands/builtin/github/test_grep_search.py
+++ b/python/tests/commands/builtin/github/test_grep_search.py
@@ -1,0 +1,87 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mirage.commands.builtin.github.grep import grep
+from mirage.types import PathSpec
+from tests.fixtures.github_mock import MOCK_BLOBS
+
+_GLOBALS = grep.__wrapped__.__globals__
+
+
+@pytest.fixture(autouse=True)
+def _patch_read(monkeypatch):
+
+    async def _read_bytes(config, owner, repo, sha):
+        return MOCK_BLOBS[sha]
+
+    monkeypatch.setattr("mirage.core.github.read.read_bytes", _read_bytes)
+
+
+def _root() -> PathSpec:
+    return PathSpec(original="/", directory="/", prefix="", resolved=False)
+
+
+def _subdir() -> PathSpec:
+    return PathSpec(original="/src", directory="/src", prefix="",
+                    resolved=False)
+
+
+@pytest.mark.asyncio
+async def test_grep_root_large_tree_uses_search(mock_github_api, github_env,
+                                                monkeypatch):
+    accessor, index = github_env
+    narrowed = [
+        PathSpec(original="/src/main.py", directory="", prefix="",
+                 resolved=True),
+    ]
+    spy = AsyncMock(return_value=narrowed)
+    monkeypatch.setitem(_GLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_GLOBALS, "narrow_paths", spy)
+    await grep(accessor, [_root()], "import", r=True, index=index)
+    spy.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_grep_subdir_skips_search(mock_github_api, github_env,
+                                        monkeypatch):
+    accessor, index = github_env
+    spy = AsyncMock(return_value=[])
+    monkeypatch.setitem(_GLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_GLOBALS, "narrow_paths", spy)
+    await grep(accessor, [_subdir()], "import", r=True, index=index)
+    spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_grep_small_tree_skips_search(mock_github_api, github_env,
+                                            monkeypatch):
+    accessor, index = github_env
+    spy = AsyncMock(return_value=[])
+    monkeypatch.setitem(_GLOBALS, "narrow_paths", spy)
+    await grep(accessor, [_root()], "import", r=True, index=index)
+    spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_grep_scope_error_when_too_many_files(mock_github_api,
+                                                    github_env, monkeypatch):
+    accessor, index = github_env
+    monkeypatch.setitem(_GLOBALS, "SCOPE_ERROR", 1)
+    stdout, io = await grep(accessor, [_root()], "import", r=True, index=index)
+    assert io.exit_code == 1
+    assert b"narrow the path" in (io.stderr or b"")

--- a/python/tests/commands/builtin/github/test_grep_search.py
+++ b/python/tests/commands/builtin/github/test_grep_search.py
@@ -37,7 +37,9 @@ def _root() -> PathSpec:
 
 
 def _subdir() -> PathSpec:
-    return PathSpec(original="/src", directory="/src", prefix="",
+    return PathSpec(original="/src",
+                    directory="/src",
+                    prefix="",
                     resolved=False)
 
 
@@ -46,7 +48,9 @@ async def test_grep_root_large_tree_uses_search(mock_github_api, github_env,
                                                 monkeypatch):
     accessor, index = github_env
     narrowed = [
-        PathSpec(original="/src/main.py", directory="", prefix="",
+        PathSpec(original="/src/main.py",
+                 directory="",
+                 prefix="",
                  resolved=True),
     ]
     spy = AsyncMock(return_value=narrowed)

--- a/python/tests/commands/builtin/github/test_rg_search.py
+++ b/python/tests/commands/builtin/github/test_rg_search.py
@@ -1,0 +1,104 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mirage.commands.builtin.github.rg import rg
+from mirage.io.stream import materialize
+from mirage.types import PathSpec
+from tests.fixtures.github_mock import MOCK_BLOBS
+
+_GLOBALS = rg.__wrapped__.__globals__
+
+
+@pytest.fixture(autouse=True)
+def _patch_read(monkeypatch):
+
+    async def _read_bytes(config, owner, repo, sha):
+        return MOCK_BLOBS[sha]
+
+    monkeypatch.setattr("mirage.core.github.read.read_bytes", _read_bytes)
+
+
+def _root() -> PathSpec:
+    return PathSpec(original="/", directory="/", prefix="", resolved=False)
+
+
+def _subdir() -> PathSpec:
+    return PathSpec(original="/src", directory="/src", prefix="",
+                    resolved=False)
+
+
+@pytest.mark.asyncio
+async def test_rg_root_large_tree_uses_search(mock_github_api, github_env,
+                                              monkeypatch):
+    accessor, index = github_env
+    narrowed = [
+        PathSpec(original="/src/main.py", directory="", prefix="",
+                 resolved=True),
+        PathSpec(original="/src/utils.py", directory="", prefix="",
+                 resolved=True),
+    ]
+    spy = AsyncMock(return_value=narrowed)
+    monkeypatch.setitem(_GLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_GLOBALS, "narrow_paths", spy)
+    stdout, io = await rg(accessor, [_root()], "import", c=True, index=index)
+    spy.assert_awaited_once()
+    text = (await materialize(stdout)).decode()
+    assert io.exit_code == 0
+    assert "/src/main.py:3" in text
+    assert "/src/utils.py:1" in text
+
+
+@pytest.mark.asyncio
+async def test_rg_subdir_skips_search(mock_github_api, github_env,
+                                      monkeypatch):
+    accessor, index = github_env
+    spy = AsyncMock(return_value=[])
+    monkeypatch.setitem(_GLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_GLOBALS, "narrow_paths", spy)
+    await rg(accessor, [_subdir()], "import", index=index)
+    spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rg_regex_skips_search(mock_github_api, github_env, monkeypatch):
+    accessor, index = github_env
+    spy = AsyncMock(return_value=[])
+    monkeypatch.setitem(_GLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_GLOBALS, "narrow_paths", spy)
+    await rg(accessor, [_root()], "imp.*rt", index=index)
+    spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rg_small_tree_skips_search(mock_github_api, github_env,
+                                          monkeypatch):
+    accessor, index = github_env
+    spy = AsyncMock(return_value=[])
+    monkeypatch.setitem(_GLOBALS, "narrow_paths", spy)
+    await rg(accessor, [_root()], "import", index=index)
+    spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rg_scope_error_when_too_many_files(mock_github_api, github_env,
+                                                  monkeypatch):
+    accessor, index = github_env
+    monkeypatch.setitem(_GLOBALS, "SCOPE_ERROR", 1)
+    stdout, io = await rg(accessor, [_root()], "import", index=index)
+    assert io.exit_code == 1
+    assert b"narrow the path" in (io.stderr or b"")

--- a/python/tests/commands/builtin/github/test_rg_search.py
+++ b/python/tests/commands/builtin/github/test_rg_search.py
@@ -38,7 +38,9 @@ def _root() -> PathSpec:
 
 
 def _subdir() -> PathSpec:
-    return PathSpec(original="/src", directory="/src", prefix="",
+    return PathSpec(original="/src",
+                    directory="/src",
+                    prefix="",
                     resolved=False)
 
 
@@ -47,9 +49,13 @@ async def test_rg_root_large_tree_uses_search(mock_github_api, github_env,
                                               monkeypatch):
     accessor, index = github_env
     narrowed = [
-        PathSpec(original="/src/main.py", directory="", prefix="",
+        PathSpec(original="/src/main.py",
+                 directory="",
+                 prefix="",
                  resolved=True),
-        PathSpec(original="/src/utils.py", directory="", prefix="",
+        PathSpec(original="/src/utils.py",
+                 directory="",
+                 prefix="",
                  resolved=True),
     ]
     spy = AsyncMock(return_value=narrowed)

--- a/python/tests/commands/builtin/helpers/test_rg_helper.py
+++ b/python/tests/commands/builtin/helpers/test_rg_helper.py
@@ -195,7 +195,7 @@ class TestCountOnly:
     async def test_count_only_zero(self, backend):
         await _write(backend, "/tmp/a.txt", "bar\nbaz")
         result = await rg(backend, "/tmp/a.txt", "foo", count_only=True)
-        assert result == ["0"]
+        assert result == []
 
 
 class TestFilesOnly:

--- a/python/tests/commands/builtin/slack/test_rg_files.py
+++ b/python/tests/commands/builtin/slack/test_rg_files.py
@@ -19,6 +19,7 @@ import pytest
 from mirage.accessor.slack import SlackAccessor
 from mirage.cache.index import RAMIndexCacheStore
 from mirage.commands.builtin.slack.rg import rg
+from mirage.io.stream import materialize
 from mirage.resource.slack.config import SlackConfig
 from mirage.types import PathSpec
 
@@ -60,14 +61,15 @@ async def test_rg_messages_only_when_chat_jsonl(accessor, index):
 
 
 @pytest.mark.asyncio
-async def test_rg_files_only_when_files_dir(accessor, index):
-    files_payload = b'{"files":{"matches":[]}}'
+async def test_rg_files_dir_redirects_to_generic_scan(accessor, index):
     with (
             patch("mirage.commands.builtin.slack.rg.search_messages",
                   new_callable=AsyncMock) as mock_msgs,
             patch("mirage.commands.builtin.slack.rg.search_files",
+                  new_callable=AsyncMock) as mock_files,
+            patch("mirage.commands.builtin.slack.rg.generic_rg",
                   new_callable=AsyncMock,
-                  return_value=files_payload) as mock_files,
+                  return_value=(b"", None)) as mock_generic,
     ):
         await rg(
             accessor,
@@ -82,7 +84,8 @@ async def test_rg_files_only_when_files_dir(accessor, index):
             index=index,
         )
     assert mock_msgs.await_count == 0
-    assert mock_files.await_count == 1
+    assert mock_files.await_count == 0
+    assert mock_generic.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -141,17 +144,26 @@ async def test_grep_messages_only_when_chat_jsonl(accessor, index):
 
 
 @pytest.mark.asyncio
-async def test_grep_files_only_when_files_dir(accessor, index):
-    files_payload = b'{"files":{"matches":[]}}'
+async def test_grep_files_dir_redirects_to_per_file_scan(accessor, index):
+    blob = PathSpec(
+        original="/channels/general__C001/2026-04-10/files/report.txt",
+        directory="/channels/general__C001/2026-04-10/files/report.txt",
+        prefix="",
+    )
     with (
             patch("mirage.commands.builtin.slack.grep.search_messages",
                   new_callable=AsyncMock) as mock_msgs,
             patch("mirage.commands.builtin.slack.grep.search_files",
+                  new_callable=AsyncMock) as mock_files,
+            patch("mirage.commands.builtin.slack.grep.resolve_glob",
                   new_callable=AsyncMock,
-                  return_value=files_payload) as mock_files,
+                  return_value=[blob]),
+            patch("mirage.commands.builtin.slack.grep.slack_read",
+                  new_callable=AsyncMock,
+                  return_value=b"foo line\nbar\n") as mock_read,
     ):
         from mirage.commands.builtin.slack.grep import grep
-        await grep(
+        out, io = await grep(
             accessor,
             [
                 PathSpec(
@@ -164,4 +176,6 @@ async def test_grep_files_only_when_files_dir(accessor, index):
             index=index,
         )
     assert mock_msgs.await_count == 0
-    assert mock_files.await_count == 1
+    assert mock_files.await_count == 0
+    assert mock_read.await_count >= 1
+    assert b"foo line" in await materialize(out)

--- a/python/tests/core/github/test_scope.py
+++ b/python/tests/core/github/test_scope.py
@@ -12,10 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from types import SimpleNamespace
+
 import pytest
 
-from mirage.core.github.scope import estimate_scope
+from mirage.core.github.scope import (count_scope_files, estimate_scope,
+                                      is_repo_root, scope_relative_key)
 from mirage.core.github.tree_entry import TreeEntry
+from mirage.types import PathSpec
 
 
 @pytest.fixture
@@ -60,3 +64,54 @@ async def test_estimate_scope_empty_directory(tree):
     count, total = await estimate_scope(tree, "nonexistent", "*")
     assert count == 0
     assert total == 0
+
+
+@pytest.fixture
+def entries():
+
+    def _f():
+        return SimpleNamespace(resource_type="file")
+
+    def _d():
+        return SimpleNamespace(resource_type="folder")
+
+    return {
+        "/README.md": _f(),
+        "/src": _d(),
+        "/src/main.py": _f(),
+        "/src/utils.py": _f(),
+        "/src/models": _d(),
+        "/src/models/user.py": _f(),
+    }
+
+
+def test_scope_relative_key_strips_mount_prefix():
+    path = PathSpec(original="/gh/src", directory="/gh/src", prefix="/gh")
+    assert scope_relative_key(path) == "/src"
+
+
+def test_scope_relative_key_root_becomes_slash():
+    path = PathSpec(original="/gh", directory="/gh", prefix="/gh")
+    assert scope_relative_key(path) == "/"
+
+
+def test_is_repo_root():
+    assert is_repo_root("/")
+    assert is_repo_root("")
+    assert not is_repo_root("/src")
+
+
+def test_count_scope_files_root_counts_all(entries):
+    assert count_scope_files(entries, "/") == 4
+
+
+def test_count_scope_files_subdir(entries):
+    assert count_scope_files(entries, "/src") == 3
+
+
+def test_count_scope_files_single_file(entries):
+    assert count_scope_files(entries, "/src/main.py") == 1
+
+
+def test_count_scope_files_missing(entries):
+    assert count_scope_files(entries, "/nope") == 0

--- a/python/tests/core/github/test_search.py
+++ b/python/tests/core/github/test_search.py
@@ -17,7 +17,8 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from mirage.core.github.config import GitHubConfig
-from mirage.core.github.search import SearchResult, search_code
+from mirage.core.github.search import SearchResult, narrow_paths, search_code
+from mirage.types import PathSpec
 
 
 @pytest.fixture
@@ -65,3 +66,47 @@ async def test_search_code_with_path_filter(mock_get, config):
         config.token,
         "/search/code",
         params={"q": "import os repo:acme/proj path:src/"})
+
+
+@pytest.mark.asyncio
+@patch("mirage.core.github.search.search_code", new_callable=AsyncMock)
+async def test_narrow_paths_strips_leading_slash_in_filter(
+        mock_search, config):
+    mock_search.return_value = [SearchResult(path="src/main.py", sha="aaa")]
+    paths = [PathSpec(original="/src", directory="/src", prefix="")]
+    await narrow_paths(config, "acme", "proj", "import", paths)
+    _, kwargs = mock_search.await_args
+    assert kwargs["path_filter"] == "src"
+
+
+@pytest.mark.asyncio
+@patch("mirage.core.github.search.search_code", new_callable=AsyncMock)
+async def test_narrow_paths_root_uses_no_filter(mock_search, config):
+    mock_search.return_value = [SearchResult(path="src/main.py", sha="aaa")]
+    paths = [PathSpec(original="/", directory="/", prefix="")]
+    await narrow_paths(config, "acme", "proj", "import", paths)
+    _, kwargs = mock_search.await_args
+    assert kwargs["path_filter"] is None
+
+
+@pytest.mark.asyncio
+@patch("mirage.core.github.search.search_code", new_callable=AsyncMock)
+async def test_narrow_paths_normalizes_results_with_leading_slash(
+        mock_search, config):
+    mock_search.return_value = [
+        SearchResult(path="src/main.py", sha="aaa"),
+        SearchResult(path="src/utils.py", sha="bbb"),
+    ]
+    paths = [PathSpec(original="/gh", directory="/gh", prefix="/gh")]
+    out = await narrow_paths(config, "acme", "proj", "import", paths)
+    assert [p.original for p in out] == ["/src/main.py", "/src/utils.py"]
+    assert all(p.prefix == "/gh" for p in out)
+
+
+@pytest.mark.asyncio
+@patch("mirage.core.github.search.search_code", new_callable=AsyncMock)
+async def test_narrow_paths_logs_and_continues_on_error(mock_search, config):
+    mock_search.side_effect = RuntimeError("boom")
+    paths = [PathSpec(original="/src", directory="/src", prefix="")]
+    out = await narrow_paths(config, "acme", "proj", "import", paths)
+    assert out == []

--- a/python/tests/core/github/test_search.py
+++ b/python/tests/core/github/test_search.py
@@ -99,7 +99,7 @@ async def test_narrow_paths_normalizes_results_with_leading_slash(
     ]
     paths = [PathSpec(original="/gh", directory="/gh", prefix="/gh")]
     out = await narrow_paths(config, "acme", "proj", "import", paths)
-    assert [p.original for p in out] == ["/src/main.py", "/src/utils.py"]
+    assert [p.original for p in out] == ["/gh/src/main.py", "/gh/src/utils.py"]
     assert all(p.prefix == "/gh" for p in out)
 
 


### PR DESCRIPTION
## Summary

Fixes #149.

- Fix fallback `rg -c` semantics so zero-count files are omitted, and stdin no-match exits 1 with no output.
- Add shared count helpers so generic and backend fallback paths parse count output consistently.
- Route backend fallback/stdin `rg` behavior through generic `rg` instead of duplicated implementations.
- Fix email server-side count mode to report actual match counts.

## Testing

- `pytest tests/commands/builtin/generic/test_rg.py tests/commands/builtin/helpers/test_rg_helper.py tests/commands/builtin/github/test_commands.py tests/commands/builtin/email/test_grep.py`
