### PR TITLE
feat(ts): add Nowledge Mem resource

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -436,6 +436,13 @@
                 ]
               },
               {
+                "group": "Knowledge",
+                "icon": "brain",
+                "pages": [
+                  "typescript/setup/nowledge_mem"
+                ]
+              },
+              {
                 "group": "Notes",
                 "icon": "book",
                 "pages": [

--- a/docs/home/resource-matrix.mdx
+++ b/docs/home/resource-matrix.mdx
@@ -95,6 +95,7 @@ No external setup, these run locally or against a connection string you already 
 | Resource | Mount Mode | Setup | Docs | Notes |
 | --- | --- | --- | --- | --- |
 | Dify | read | [Dify](/home/setup/dify) | [<Icon icon="python" />](/python/resource/dify) | Knowledge documents and retrieval search |
+| Nowledge Mem | read | | [<Icon icon="node-js" />](/typescript/setup/nowledge_mem) [<Icon icon="globe" />](/typescript/setup/nowledge_mem) | API-backed knowledge tree: memories, threads, sources, wiki, feed, artifacts, and skills |
 
 ## Notes
 

--- a/docs/home/resource-matrix.mdx
+++ b/docs/home/resource-matrix.mdx
@@ -95,7 +95,7 @@ No external setup, these run locally or against a connection string you already 
 | Resource | Mount Mode | Setup | Docs | Notes |
 | --- | --- | --- | --- | --- |
 | Dify | read | [Dify](/home/setup/dify) | [<Icon icon="python" />](/python/resource/dify) | Knowledge documents and retrieval search |
-| Nowledge Mem | read | | [<Icon icon="node-js" />](/typescript/setup/nowledge_mem) [<Icon icon="globe" />](/typescript/setup/nowledge_mem) | API-backed knowledge tree: memories, threads, sources, wiki, feed, artifacts, and skills |
+| Nowledge Mem | read | | [<Icon icon="node-js" />](/typescript/setup/nowledge_mem) [<Icon icon="globe" />](/typescript/setup/nowledge_mem) | API-backed knowledge tree: memories, threads, sources, wiki, context, feed, artifacts, and skills |
 
 ## Notes
 

--- a/docs/typescript/setup/nowledge_mem.mdx
+++ b/docs/typescript/setup/nowledge_mem.mdx
@@ -1,0 +1,95 @@
+---
+title: Nowledge Mem
+icon: brain
+description: Mount Nowledge Mem as a read-only knowledge tree for memories, threads, sources, wiki pages, artifacts, and skills.
+---
+
+`NowledgeMemResource` connects to the Nowledge Mem API and exposes the Nowledge FS tree through Mirage. Agents can use familiar commands such as `ls`, `cat`, `find`, `grep`, and `recall` without shelling out to the `nmem` CLI.
+
+Nowledge FS is a projection of the whole knowledge workspace, not a folder of memory notes. The root includes memories, threads, parsed Library sources, wiki pages, Working Memory, feed events, artifacts, and active skills. Each path resolves back to Nowledge Mem; Mirage does not create a second datastore.
+
+This resource requires a Nowledge Mem server with the Nowledge FS API (`/fs/*`), available in Nowledge Mem 0.9.0 or newer.
+
+## Node
+
+```bash
+pnpm add @struktoai/mirage-node
+```
+
+```ts
+import {
+  MountMode,
+  NowledgeMemResource,
+  Workspace,
+} from "@struktoai/mirage-node";
+
+const mem = new NowledgeMemResource({
+  apiUrl: process.env.NMEM_API_URL ?? "http://127.0.0.1:14242",
+  apiKey: process.env.NMEM_API_KEY,
+});
+
+const ws = new Workspace({ "/mem": mem }, { mode: MountMode.READ });
+await ws.execute("ls /mem");
+await ws.execute('grep "JWT" /mem/threads');
+await ws.execute('recall "deployment decision" --in /mem/memories -k 5');
+```
+
+## Browser
+
+```bash
+pnpm add @struktoai/mirage-browser
+```
+
+For browser apps, point `apiUrl` at a same-origin proxy or a Nowledge Mem remote endpoint that allows your application origin. Do not ship a long-lived personal API key in client-side code; use a proxy or a short-lived token issued by your app.
+
+```ts
+import {
+  MountMode,
+  NowledgeMemResource,
+  Workspace,
+} from "@struktoai/mirage-browser";
+
+const mem = new NowledgeMemResource({
+  apiUrl: "/api/nowledge-mem",
+});
+
+const ws = new Workspace({ "/mem": mem }, { mode: MountMode.READ });
+await ws.execute('grep "JWT" /mem/memories');
+```
+
+## Commands
+
+| Command                                                               | Purpose                                                        |
+| --------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `ls /mem`                                                             | List the top-level knowledge namespaces.                       |
+| `cat /mem/wiki/entities/PostgreSQL.entity.md`                         | Read a projected wiki/entity/topic page.                       |
+| `cat --line 40 --lines 20 /mem/threads/codex/<thread>/messages.jsonl` | Read a small evidence window from a large thread/source/skill. |
+| `find /mem/memories --label security`                                 | Filter memory metadata.                                        |
+| `grep "JWT" /mem/threads`                                             | Search exact text across rendered content.                     |
+| `grep "JWT" /mem/sources`                                             | Search parsed Library source text.                             |
+| `recall "deployment decision" --in /mem/memories -k 5`                | Semantic recall through the Nowledge Mem API.                  |
+
+## Tree shape
+
+| Path                  | What it represents                                                  |
+| --------------------- | ------------------------------------------------------------------- |
+| `/mem/memories`       | Memories and crystals, including label/date/id projections.         |
+| `/mem/threads`        | Captured agent and chat threads with message files.                 |
+| `/mem/sources`        | Parsed Library documents such as PDFs, spreadsheets, and web pages. |
+| `/mem/wiki`           | Topic, entity, and crystal knowledge pages.                         |
+| `/mem/working-memory` | Current and archived Working Memory.                                |
+| `/mem/feed`           | Activity timeline events.                                           |
+| `/mem/artifacts`      | Reports, drafts, and generated knowledge artifacts.                 |
+| `/mem/skills`         | Active skills exposed as readable bundles.                          |
+
+## Config
+
+| Field          | Default                                    | Notes                                                                                                        |
+| -------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `apiUrl`       | `NMEM_API_URL` or `http://127.0.0.1:14242` | Nowledge Mem API base URL. Snake case `api_url` is also accepted.                                            |
+| `apiKey`       | `NMEM_API_KEY`                             | Optional bearer token for remote Nowledge Mem. Snake case `api_key` is also accepted. Redacted in snapshots. |
+| `defaultLimit` | none                                       | Optional default result limit for API-backed searches.                                                       |
+
+## Mount mode
+
+`read` only. Nowledge Mem remains the source of truth; Mirage provides a filesystem-shaped read surface over its API.

--- a/docs/typescript/setup/nowledge_mem.mdx
+++ b/docs/typescript/setup/nowledge_mem.mdx
@@ -1,12 +1,12 @@
 ---
 title: Nowledge Mem
 icon: brain
-description: Mount Nowledge Mem as a read-only knowledge tree for memories, threads, sources, wiki pages, artifacts, and skills.
+description: Mount Nowledge Mem as a read-only knowledge tree for memories, threads, sources, wiki pages, guidance context, artifacts, and skills.
 ---
 
 `NowledgeMemResource` connects to the Nowledge Mem API and exposes the Nowledge FS tree through Mirage. Agents can use familiar commands such as `ls`, `cat`, `find`, `grep`, and `recall` without shelling out to the `nmem` CLI.
 
-Nowledge FS is a projection of the whole knowledge workspace, not a folder of memory notes. The root includes memories, threads, parsed Library sources, wiki pages, Working Memory, feed events, artifacts, and active skills. Each path resolves back to Nowledge Mem; Mirage does not create a second datastore.
+Nowledge FS is a projection of the whole knowledge workspace, not a folder of memory notes. The root includes memories, threads, parsed Library sources, wiki pages, guidance context, Working Memory, feed events, artifacts, and active skills. Each path resolves back to Nowledge Mem; Mirage does not create a second datastore.
 
 This resource requires a Nowledge Mem server with the Nowledge FS API (`/fs/*`), available in Nowledge Mem 0.9.0 or newer.
 
@@ -77,6 +77,7 @@ await ws.execute('grep "JWT" /mem/memories');
 | `/mem/threads`        | Captured agent and chat threads with message files.                 |
 | `/mem/sources`        | Parsed Library documents such as PDFs, spreadsheets, and web pages. |
 | `/mem/wiki`           | Topic, entity, and crystal knowledge pages.                         |
+| `/mem/context`        | Context Bundle, guidance, profile, and policy-readable projections. |
 | `/mem/working-memory` | Current and archived Working Memory.                                |
 | `/mem/feed`           | Activity timeline events.                                           |
 | `/mem/artifacts`      | Reports, drafts, and generated knowledge artifacts.                 |

--- a/typescript/.changeset/nowledge-mem-resource.md
+++ b/typescript/.changeset/nowledge-mem-resource.md
@@ -1,0 +1,7 @@
+---
+'@struktoai/mirage-browser': patch
+'@struktoai/mirage-core': patch
+'@struktoai/mirage-node': patch
+---
+
+Add a read-only Nowledge Mem resource backed by the Knowledge Filesystem API.

--- a/typescript/packages/browser/src/resource/registry.test.ts
+++ b/typescript/packages/browser/src/resource/registry.test.ts
@@ -27,12 +27,21 @@ describe('browser resource registry', () => {
     expect(names).toContain('oci')
     expect(names).toContain('supabase')
     expect(names).toContain('slack')
+    expect(names).toContain('nowledge_mem')
     expect(names).toEqual([...names].sort())
   })
 
   it('builds RAM with no config', async () => {
     const r = await buildResource('ram', {})
     expect(r.kind).toBe('ram')
+  })
+
+  it('builds Nowledge Mem with API config', async () => {
+    const r = (await buildResource('nowledge_mem', {
+      api_url: 'https://mem.example',
+    })) as unknown as { kind: string; config: Record<string, unknown> }
+    expect(r.kind).toBe('nowledge_mem')
+    expect(r.config).toMatchObject({ apiUrl: 'https://mem.example' })
   })
 
   it('builds S3 with bucket and presignedUrlProvider', async () => {

--- a/typescript/packages/browser/src/resource/registry.ts
+++ b/typescript/packages/browser/src/resource/registry.ts
@@ -109,6 +109,10 @@ const REGISTRY: Record<string, ResourceFactory> = {
     const { RAMResource } = await import('@struktoai/mirage-core')
     return new RAMResource()
   },
+  nowledge_mem: async (config) => {
+    const { NowledgeMemResource } = await import('@struktoai/mirage-core')
+    return new NowledgeMemResource(config)
+  },
   opfs: async (config) => {
     const { OPFSResource } = await import('./opfs/opfs.ts')
     const norm = normalizeFields(config)

--- a/typescript/packages/core/src/accessor/nowledge_mem.ts
+++ b/typescript/packages/core/src/accessor/nowledge_mem.ts
@@ -12,6 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export { Accessor, NOOPAccessor } from './base.ts'
-export { NowledgeMemAccessor } from './nowledge_mem.ts'
-export { RAMAccessor } from './ram.ts'
+import { Accessor } from './base.ts'
+import type { NowledgeMemTransport } from '../core/nowledge_mem/client.ts'
+
+export class NowledgeMemAccessor extends Accessor {
+  constructor(
+    public readonly transport: NowledgeMemTransport,
+    public readonly defaultLimit?: number,
+  ) {
+    super()
+  }
+}

--- a/typescript/packages/core/src/commands/builtin/nowledge_mem/cat.ts
+++ b/typescript/packages/core/src/commands/builtin/nowledge_mem/cat.ts
@@ -18,10 +18,10 @@ import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { CommandSpec, Operand, OperandKind, Option } from '../../spec/types.ts'
+import { numberLines } from '../cat_helper.ts'
 import { readStdinAsync } from '../utils/stream.ts'
 
 const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
 
 const SPEC = new CommandSpec({
   options: [
@@ -32,14 +32,12 @@ const SPEC = new CommandSpec({
   rest: new Operand({ kind: OperandKind.PATH }),
 })
 
-function numberLines(data: Uint8Array): Uint8Array {
-  const text = DEC.decode(data)
-  const lines = text.split('\n')
-  const trailing = text.endsWith('\n')
-  const limit = trailing ? lines.length - 1 : lines.length
-  const out: string[] = []
-  for (let i = 0; i < limit; i++) out.push(`     ${String(i + 1)}\t${lines[i] ?? ''}\n`)
-  return ENC.encode(out.join(''))
+async function* chainBytes(chunks: readonly Uint8Array[]): AsyncIterable<Uint8Array> {
+  for (const chunk of chunks) yield chunk
+}
+
+function outputBytes(chunks: readonly Uint8Array[], number: boolean): ByteSource {
+  return number ? numberLines(chainBytes(chunks)) : chainBytes(chunks)
 }
 
 async function catCommand(
@@ -49,26 +47,30 @@ async function catCommand(
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const nFlag = opts.flags.n === true
-  const p = paths[0]
-  if (p !== undefined) {
-    const path = nowledgeMemPath(p.original, p.prefix)
+  if (paths.length > 0) {
     const line =
       typeof opts.flags.line === 'string' ? Number.parseInt(opts.flags.line, 10) : undefined
     const lines =
       typeof opts.flags.lines === 'string' ? Number.parseInt(opts.flags.lines, 10) : undefined
-    const data = await nowledgeMemRead(accessor, path, {
-      ...(line !== undefined && Number.isFinite(line) ? { line } : {}),
-      ...(lines !== undefined && Number.isFinite(lines) ? { lines } : {}),
-    })
-    const out: ByteSource = nFlag ? numberLines(data) : data
-    return [out, new IOResult({ reads: { [p.stripPrefix]: data }, cache: [p.stripPrefix] })]
+    const reads: Record<string, ByteSource> = {}
+    const cache: string[] = []
+    const chunks: Uint8Array[] = []
+    for (const p of paths) {
+      const data = await nowledgeMemRead(accessor, nowledgeMemPath(p.original, p.prefix), {
+        ...(line !== undefined && Number.isFinite(line) ? { line } : {}),
+        ...(lines !== undefined && Number.isFinite(lines) ? { lines } : {}),
+      })
+      reads[p.stripPrefix] = data
+      cache.push(p.stripPrefix)
+      chunks.push(data)
+    }
+    return [outputBytes(chunks, nFlag), new IOResult({ reads, cache })]
   }
   const raw = await readStdinAsync(opts.stdin)
   if (raw === null) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('cat: missing operand\n') })]
   }
-  const out: ByteSource = nFlag ? numberLines(raw) : raw
-  return [out, new IOResult()]
+  return [outputBytes([raw], nFlag), new IOResult()]
 }
 
 export const NOWLEDGE_MEM_CAT = command({

--- a/typescript/packages/core/src/commands/builtin/nowledge_mem/cat.ts
+++ b/typescript/packages/core/src/commands/builtin/nowledge_mem/cat.ts
@@ -1,0 +1,79 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { NowledgeMemAccessor } from '../../../accessor/nowledge_mem.ts'
+import { nowledgeMemPath, nowledgeMemRead } from '../../../core/nowledge_mem/client.ts'
+import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { CommandSpec, Operand, OperandKind, Option } from '../../spec/types.ts'
+import { readStdinAsync } from '../utils/stream.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder('utf-8', { fatal: false })
+
+const SPEC = new CommandSpec({
+  options: [
+    new Option({ short: '-n' }),
+    new Option({ long: '--line', valueKind: OperandKind.TEXT }),
+    new Option({ long: '--lines', valueKind: OperandKind.TEXT }),
+  ],
+  rest: new Operand({ kind: OperandKind.PATH }),
+})
+
+function numberLines(data: Uint8Array): Uint8Array {
+  const text = DEC.decode(data)
+  const lines = text.split('\n')
+  const trailing = text.endsWith('\n')
+  const limit = trailing ? lines.length - 1 : lines.length
+  const out: string[] = []
+  for (let i = 0; i < limit; i++) out.push(`     ${String(i + 1)}\t${lines[i] ?? ''}\n`)
+  return ENC.encode(out.join(''))
+}
+
+async function catCommand(
+  accessor: NowledgeMemAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const nFlag = opts.flags.n === true
+  const p = paths[0]
+  if (p !== undefined) {
+    const path = nowledgeMemPath(p.original, p.prefix)
+    const line =
+      typeof opts.flags.line === 'string' ? Number.parseInt(opts.flags.line, 10) : undefined
+    const lines =
+      typeof opts.flags.lines === 'string' ? Number.parseInt(opts.flags.lines, 10) : undefined
+    const data = await nowledgeMemRead(accessor, path, {
+      ...(line !== undefined && Number.isFinite(line) ? { line } : {}),
+      ...(lines !== undefined && Number.isFinite(lines) ? { lines } : {}),
+    })
+    const out: ByteSource = nFlag ? numberLines(data) : data
+    return [out, new IOResult({ reads: { [p.stripPrefix]: data }, cache: [p.stripPrefix] })]
+  }
+  const raw = await readStdinAsync(opts.stdin)
+  if (raw === null) {
+    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('cat: missing operand\n') })]
+  }
+  const out: ByteSource = nFlag ? numberLines(raw) : raw
+  return [out, new IOResult()]
+}
+
+export const NOWLEDGE_MEM_CAT = command({
+  name: 'cat',
+  resource: ResourceName.NOWLEDGE_MEM,
+  spec: SPEC,
+  fn: catCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/nowledge_mem/find.ts
+++ b/typescript/packages/core/src/commands/builtin/nowledge_mem/find.ts
@@ -1,0 +1,85 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { NowledgeMemAccessor } from '../../../accessor/nowledge_mem.ts'
+import { nowledgeMemFind, nowledgeMemPath } from '../../../core/nowledge_mem/client.ts'
+import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { CommandSpec, Operand, OperandKind, Option } from '../../spec/types.ts'
+
+const ENC = new TextEncoder()
+
+const SPEC = new CommandSpec({
+  options: [
+    new Option({ short: '-type', valueKind: OperandKind.TEXT }),
+    new Option({ short: '-label', valueKind: OperandKind.TEXT }),
+    new Option({ long: '--label', valueKind: OperandKind.TEXT }),
+    new Option({ short: '-since', valueKind: OperandKind.TEXT }),
+    new Option({ long: '--since', valueKind: OperandKind.TEXT }),
+    new Option({ short: '-until', valueKind: OperandKind.TEXT }),
+    new Option({ long: '--until', valueKind: OperandKind.TEXT }),
+    new Option({ short: '-mentions', valueKind: OperandKind.TEXT }),
+    new Option({ long: '--mentions', valueKind: OperandKind.TEXT }),
+    new Option({ long: '--limit', valueKind: OperandKind.TEXT }),
+  ],
+  rest: new Operand({ kind: OperandKind.PATH }),
+})
+
+function flagString(
+  flags: Record<string, string | boolean>,
+  ...names: string[]
+): string | undefined {
+  for (const name of names) {
+    const value = flags[name]
+    if (typeof value === 'string') return value
+  }
+  return undefined
+}
+
+async function findCommand(
+  accessor: NowledgeMemAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const p = paths[0]
+  const path = p !== undefined ? nowledgeMemPath(p.original, p.prefix) : '/memories'
+  const limitText = flagString(opts.flags, 'limit', '--limit')
+  const parsedLimit = limitText !== undefined ? Number.parseInt(limitText, 10) : undefined
+  const limit =
+    parsedLimit !== undefined && Number.isFinite(parsedLimit) ? parsedLimit : accessor.defaultLimit
+  const type = flagString(opts.flags, 'type', '-type')
+  const label = flagString(opts.flags, 'label', '-label', '--label')
+  const since = flagString(opts.flags, 'since', '-since', '--since')
+  const until = flagString(opts.flags, 'until', '-until', '--until')
+  const mentions = flagString(opts.flags, 'mentions', '-mentions', '--mentions')
+  const results = await nowledgeMemFind(accessor, path, {
+    ...(type !== undefined ? { type } : {}),
+    ...(label !== undefined ? { label } : {}),
+    ...(since !== undefined ? { since } : {}),
+    ...(until !== undefined ? { until } : {}),
+    ...(mentions !== undefined ? { mentions } : {}),
+    ...(limit !== undefined ? { limit } : {}),
+  })
+  const out: ByteSource = ENC.encode(results.join('\n'))
+  return [out, new IOResult()]
+}
+
+export const NOWLEDGE_MEM_FIND = command({
+  name: 'find',
+  resource: ResourceName.NOWLEDGE_MEM,
+  spec: SPEC,
+  fn: findCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/nowledge_mem/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/nowledge_mem/grep.ts
@@ -1,0 +1,70 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { NowledgeMemAccessor } from '../../../accessor/nowledge_mem.ts'
+import { nowledgeMemGrep, nowledgeMemPath } from '../../../core/nowledge_mem/client.ts'
+import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+
+const ENC = new TextEncoder()
+
+function getPattern(
+  texts: readonly string[],
+  flags: Record<string, string | boolean>,
+): string | null {
+  if (typeof flags.e === 'string') return flags.e
+  return texts[0] ?? null
+}
+
+async function grepCommand(
+  accessor: NowledgeMemAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const pattern = getPattern(texts, opts.flags)
+  if (pattern === null) {
+    return [null, new IOResult({ exitCode: 2, stderr: ENC.encode('grep: missing pattern\n') })]
+  }
+  const p = paths[0]
+  const path = p !== undefined ? nowledgeMemPath(p.original, p.prefix) : '/memories'
+  const parsedLimit =
+    typeof opts.flags.m === 'string' ? Number.parseInt(opts.flags.m, 10) : undefined
+  const limit =
+    parsedLimit !== undefined && Number.isFinite(parsedLimit) ? parsedLimit : accessor.defaultLimit
+  const matches = await nowledgeMemGrep(accessor, path, pattern, {
+    ...(limit !== undefined ? { limit } : {}),
+  })
+  const filesOnly = opts.flags.args_l === true || opts.flags.l === true
+  const lineNumbers = opts.flags.n === true
+  let lines: string[]
+  if (filesOnly) {
+    lines = [...new Set(matches.map((match) => match.path))]
+  } else {
+    lines = matches.map((match) =>
+      lineNumbers ? `${match.path}:${match.line}:${match.match}` : `${match.path}:${match.match}`,
+    )
+  }
+  const out: ByteSource = ENC.encode(lines.join('\n'))
+  return [out, new IOResult({ exitCode: lines.length === 0 ? 1 : 0 })]
+}
+
+export const NOWLEDGE_MEM_GREP = command({
+  name: 'grep',
+  resource: ResourceName.NOWLEDGE_MEM,
+  spec: specOf('grep'),
+  fn: grepCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/nowledge_mem/index.ts
+++ b/typescript/packages/core/src/commands/builtin/nowledge_mem/index.ts
@@ -12,6 +12,19 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export { Accessor, NOOPAccessor } from './base.ts'
-export { NowledgeMemAccessor } from './nowledge_mem.ts'
-export { RAMAccessor } from './ram.ts'
+import type { RegisteredCommand } from '../../config.ts'
+import { NOWLEDGE_MEM_CAT } from './cat.ts'
+import { NOWLEDGE_MEM_FIND } from './find.ts'
+import { NOWLEDGE_MEM_GREP } from './grep.ts'
+import { NOWLEDGE_MEM_LS } from './ls.ts'
+import { NOWLEDGE_MEM_RECALL } from './recall.ts'
+import { NOWLEDGE_MEM_STAT } from './stat.ts'
+
+export const NOWLEDGE_MEM_COMMANDS: readonly RegisteredCommand[] = [
+  ...NOWLEDGE_MEM_LS,
+  ...NOWLEDGE_MEM_CAT,
+  ...NOWLEDGE_MEM_STAT,
+  ...NOWLEDGE_MEM_FIND,
+  ...NOWLEDGE_MEM_GREP,
+  ...NOWLEDGE_MEM_RECALL,
+]

--- a/typescript/packages/core/src/commands/builtin/nowledge_mem/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/nowledge_mem/ls.ts
@@ -1,0 +1,62 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { NowledgeMemAccessor } from '../../../accessor/nowledge_mem.ts'
+import { nowledgeMemLsStats, nowledgeMemPath } from '../../../core/nowledge_mem/client.ts'
+import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { FileType, ResourceName, type FileStat, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { humanSize } from '../utils/formatting.ts'
+
+const ENC = new TextEncoder()
+
+function formatName(entry: FileStat, classify: boolean): string {
+  const path = typeof entry.extra.path === 'string' ? entry.extra.path : entry.name
+  const name = path.split('/').pop() ?? entry.name
+  return classify && entry.type === FileType.DIRECTORY ? `${name}/` : name
+}
+
+function formatLong(entry: FileStat, human: boolean): string {
+  const size = human ? humanSize(entry.size ?? 0) : String(entry.size ?? 0)
+  const path = typeof entry.extra.path === 'string' ? entry.extra.path : entry.name
+  const name = path.split('/').pop() ?? entry.name
+  return `${entry.type ?? '-'}\t${size}\t${entry.modified ?? ''}\t${name}`
+}
+
+async function lsCommand(
+  accessor: NowledgeMemAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
+  const human = opts.flags.h === true
+  const classify = opts.flags.F === true
+  const p = paths[0]
+  const path = p !== undefined ? nowledgeMemPath(p.original, p.prefix) : '/'
+  const entries = await nowledgeMemLsStats(accessor, path)
+  const lines = entries.map((entry) =>
+    long ? formatLong(entry, human) : formatName(entry, classify),
+  )
+  const out: ByteSource = ENC.encode(lines.join('\n'))
+  return [out, new IOResult()]
+}
+
+export const NOWLEDGE_MEM_LS = command({
+  name: 'ls',
+  resource: ResourceName.NOWLEDGE_MEM,
+  spec: specOf('ls'),
+  fn: lsCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/nowledge_mem/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/nowledge_mem/ls.ts
@@ -13,27 +13,15 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { NowledgeMemAccessor } from '../../../accessor/nowledge_mem.ts'
-import { nowledgeMemLsStats, nowledgeMemPath } from '../../../core/nowledge_mem/client.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { FileType, ResourceName, type FileStat, type PathSpec } from '../../../types.ts'
+import {
+  nowledgeMemPath,
+  nowledgeMemReaddir,
+  nowledgeMemStat,
+} from '../../../core/nowledge_mem/client.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { humanSize } from '../utils/formatting.ts'
-
-const ENC = new TextEncoder()
-
-function formatName(entry: FileStat, classify: boolean): string {
-  const path = typeof entry.extra.path === 'string' ? entry.extra.path : entry.name
-  const name = path.split('/').pop() ?? entry.name
-  return classify && entry.type === FileType.DIRECTORY ? `${name}/` : name
-}
-
-function formatLong(entry: FileStat, human: boolean): string {
-  const size = human ? humanSize(entry.size ?? 0) : String(entry.size ?? 0)
-  const path = typeof entry.extra.path === 'string' ? entry.extra.path : entry.name
-  const name = path.split('/').pop() ?? entry.name
-  return `${entry.type ?? '-'}\t${size}\t${entry.modified ?? ''}\t${name}`
-}
+import { lsGeneric } from '../generic/ls.ts'
 
 async function lsCommand(
   accessor: NowledgeMemAccessor,
@@ -41,17 +29,12 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
-  const human = opts.flags.h === true
-  const classify = opts.flags.F === true
-  const p = paths[0]
-  const path = p !== undefined ? nowledgeMemPath(p.original, p.prefix) : '/'
-  const entries = await nowledgeMemLsStats(accessor, path)
-  const lines = entries.map((entry) =>
-    long ? formatLong(entry, human) : formatName(entry, classify),
+  return lsGeneric(
+    paths,
+    opts,
+    (p) => nowledgeMemReaddir(accessor, nowledgeMemPath(p.original, p.prefix)),
+    (p) => nowledgeMemStat(accessor, nowledgeMemPath(p.original, p.prefix)),
   )
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
 }
 
 export const NOWLEDGE_MEM_LS = command({

--- a/typescript/packages/core/src/commands/builtin/nowledge_mem/recall.ts
+++ b/typescript/packages/core/src/commands/builtin/nowledge_mem/recall.ts
@@ -1,0 +1,68 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { NowledgeMemAccessor } from '../../../accessor/nowledge_mem.ts'
+import { nowledgeMemPath, nowledgeMemRecall } from '../../../core/nowledge_mem/client.ts'
+import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { CommandSpec, Operand, OperandKind, Option } from '../../spec/types.ts'
+
+const ENC = new TextEncoder()
+
+const SPEC = new CommandSpec({
+  options: [
+    new Option({ long: '--in', valueKind: OperandKind.PATH }),
+    new Option({ short: '-k', valueKind: OperandKind.TEXT }),
+    new Option({ long: '--limit', valueKind: OperandKind.TEXT }),
+  ],
+  positional: [new Operand({ kind: OperandKind.TEXT })],
+})
+
+async function recallCommand(
+  accessor: NowledgeMemAccessor,
+  _paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const query = texts[0]
+  if (query === undefined || query === '') {
+    return [null, new IOResult({ exitCode: 2, stderr: ENC.encode('recall: missing query\n') })]
+  }
+  const path =
+    typeof opts.flags.in === 'string'
+      ? nowledgeMemPath(opts.flags.in, opts.mountPrefix ?? '')
+      : undefined
+  const kText =
+    typeof opts.flags.k === 'string'
+      ? opts.flags.k
+      : typeof opts.flags.limit === 'string'
+        ? opts.flags.limit
+        : undefined
+  const parsedK = kText !== undefined ? Number.parseInt(kText, 10) : undefined
+  const k = parsedK !== undefined && Number.isFinite(parsedK) ? parsedK : accessor.defaultLimit
+  const results = await nowledgeMemRecall(accessor, query, {
+    ...(path !== undefined ? { path } : {}),
+    ...(k !== undefined ? { k } : {}),
+  })
+  const out: ByteSource = ENC.encode(results.join('\n'))
+  return [out, new IOResult({ exitCode: results.length === 0 ? 1 : 0 })]
+}
+
+export const NOWLEDGE_MEM_RECALL = command({
+  name: 'recall',
+  resource: ResourceName.NOWLEDGE_MEM,
+  spec: SPEC,
+  fn: recallCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/nowledge_mem/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/nowledge_mem/stat.ts
@@ -1,0 +1,79 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { NowledgeMemAccessor } from '../../../accessor/nowledge_mem.ts'
+import { nowledgeMemPath, nowledgeMemStat } from '../../../core/nowledge_mem/client.ts'
+import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { FileType, ResourceName, type FileStat, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+
+const ENC = new TextEncoder()
+
+const TYPE_LABELS: Record<string, string> = {
+  [FileType.DIRECTORY]: 'directory',
+  [FileType.TEXT]: 'regular file',
+  [FileType.BINARY]: 'regular file',
+  [FileType.JSON]: 'regular file',
+  [FileType.CSV]: 'regular file',
+  [FileType.PDF]: 'regular file',
+}
+
+function formatStat(fmt: string, stat: FileStat): string {
+  return fmt.replace(/%(.)/g, (_, spec: string) => {
+    if (spec === 'n') return stat.name
+    if (spec === 's') return String(stat.size ?? 0)
+    if (spec === 'F')
+      return stat.type !== null ? (TYPE_LABELS[stat.type] ?? 'regular file') : 'regular file'
+    if (spec === 'y') return stat.modified ?? ''
+    return '?'
+  })
+}
+
+async function statCommand(
+  accessor: NowledgeMemAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  if (paths.length === 0) {
+    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('stat: missing operand\n') })]
+  }
+  const fmt =
+    typeof opts.flags.c === 'string'
+      ? opts.flags.c
+      : typeof opts.flags.f === 'string'
+        ? opts.flags.f
+        : null
+  const lines: string[] = []
+  for (const p of paths) {
+    const stat = await nowledgeMemStat(accessor, nowledgeMemPath(p.original, p.prefix))
+    if (fmt !== null) {
+      lines.push(formatStat(fmt, stat))
+    } else {
+      lines.push(
+        `name=${stat.name} size=${String(stat.size)} modified=${String(stat.modified)} type=${String(stat.type)}`,
+      )
+    }
+  }
+  const out: ByteSource = ENC.encode(lines.join('\n'))
+  return [out, new IOResult()]
+}
+
+export const NOWLEDGE_MEM_STAT = command({
+  name: 'stat',
+  resource: ResourceName.NOWLEDGE_MEM,
+  spec: specOf('stat'),
+  fn: statCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/nowledge_mem/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/nowledge_mem/stat.ts
@@ -14,32 +14,10 @@
 
 import type { NowledgeMemAccessor } from '../../../accessor/nowledge_mem.ts'
 import { nowledgeMemPath, nowledgeMemStat } from '../../../core/nowledge_mem/client.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { FileType, ResourceName, type FileStat, type PathSpec } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-const TYPE_LABELS: Record<string, string> = {
-  [FileType.DIRECTORY]: 'directory',
-  [FileType.TEXT]: 'regular file',
-  [FileType.BINARY]: 'regular file',
-  [FileType.JSON]: 'regular file',
-  [FileType.CSV]: 'regular file',
-  [FileType.PDF]: 'regular file',
-}
-
-function formatStat(fmt: string, stat: FileStat): string {
-  return fmt.replace(/%(.)/g, (_, spec: string) => {
-    if (spec === 'n') return stat.name
-    if (spec === 's') return String(stat.size ?? 0)
-    if (spec === 'F')
-      return stat.type !== null ? (TYPE_LABELS[stat.type] ?? 'regular file') : 'regular file'
-    if (spec === 'y') return stat.modified ?? ''
-    return '?'
-  })
-}
+import { statGeneric } from '../generic/stat.ts'
 
 async function statCommand(
   accessor: NowledgeMemAccessor,
@@ -47,28 +25,9 @@ async function statCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('stat: missing operand\n') })]
-  }
-  const fmt =
-    typeof opts.flags.c === 'string'
-      ? opts.flags.c
-      : typeof opts.flags.f === 'string'
-        ? opts.flags.f
-        : null
-  const lines: string[] = []
-  for (const p of paths) {
-    const stat = await nowledgeMemStat(accessor, nowledgeMemPath(p.original, p.prefix))
-    if (fmt !== null) {
-      lines.push(formatStat(fmt, stat))
-    } else {
-      lines.push(
-        `name=${stat.name} size=${String(stat.size)} modified=${String(stat.modified)} type=${String(stat.type)}`,
-      )
-    }
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
+  return statGeneric(paths, opts, (p) =>
+    nowledgeMemStat(accessor, nowledgeMemPath(p.original, p.prefix)),
+  )
 }
 
 export const NOWLEDGE_MEM_STAT = command({

--- a/typescript/packages/core/src/core/nowledge_mem/client.ts
+++ b/typescript/packages/core/src/core/nowledge_mem/client.ts
@@ -182,7 +182,10 @@ export interface NowledgeMemAccessorLike {
 }
 
 function stripPrefix(path: string, prefix: string): string {
-  if (prefix !== '' && path.startsWith(prefix)) return path.slice(prefix.length) || '/'
+  if (prefix === '') return path
+  const cleanPrefix = prefix.replace(/\/+$/, '')
+  if (path === cleanPrefix) return '/'
+  if (path.startsWith(`${cleanPrefix}/`)) return path.slice(cleanPrefix.length) || '/'
   return path
 }
 

--- a/typescript/packages/core/src/core/nowledge_mem/client.ts
+++ b/typescript/packages/core/src/core/nowledge_mem/client.ts
@@ -1,0 +1,345 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { FileStat, FileType } from '../../types.ts'
+
+const ENC = new TextEncoder()
+
+function envValue(name: string): string | undefined {
+  const maybeProcess = globalThis as unknown as {
+    process?: { env?: Record<string, string | undefined> }
+  }
+  const value = maybeProcess.process?.env?.[name]
+  return typeof value === 'string' && value !== '' ? value : undefined
+}
+
+export interface NowledgeMemConfig {
+  apiUrl?: string
+  apiKey?: string
+  defaultLimit?: number
+}
+
+export interface NowledgeMemConfigRedacted {
+  apiUrl: string
+  apiKey?: string
+  defaultLimit?: number
+}
+
+export interface NowledgeMemTransport {
+  request<T>(
+    endpoint: string,
+    params?: Record<string, string | number | boolean | null>,
+  ): Promise<T>
+}
+
+interface WireEntry {
+  name: string
+  path: string
+  kind: 'file' | 'directory' | 'dir'
+  type?: string
+  ext?: string
+  id?: string
+  hint?: string
+  updated_at?: string | null
+  size_hint?: number | null
+}
+
+interface WireListResponse {
+  entries?: WireEntry[]
+  next_cursor?: string | null
+  nextCursor?: string | null
+}
+
+interface WireCatResponse {
+  path: string
+  body: string
+  frontmatter?: Record<string, unknown>
+  content_type?: string
+  sizeBytes?: number
+}
+
+interface WireStatResponse {
+  path: string
+  name?: string
+  kind: 'file' | 'directory' | 'dir'
+  type?: string
+  ext?: string
+  id?: string
+  sizeBytes?: number
+  updatedAt?: string
+  updated_at?: string
+  frontmatter?: Record<string, unknown>
+}
+
+interface WireSearchHit {
+  path: string
+  excerpt?: string
+  snippet?: string
+  score?: number
+}
+
+interface WireSearchResponse {
+  paths?: Array<string | WireSearchHit>
+  hits?: Array<string | WireSearchHit>
+  next_cursor?: string | null
+  nextCursor?: string | null
+}
+
+export interface NowledgeMemGrepMatch {
+  path: string
+  line: number
+  match: string
+}
+
+interface WireGrepResponse {
+  matches?: NowledgeMemGrepMatch[]
+  next_cursor?: string | null
+  nextCursor?: string | null
+}
+
+export function normalizeNowledgeMemConfig(
+  config: Record<string, unknown> = {},
+): NowledgeMemConfig {
+  const apiUrl =
+    typeof config.apiUrl === 'string'
+      ? config.apiUrl
+      : typeof config.api_url === 'string'
+        ? config.api_url
+        : (envValue('NMEM_API_URL') ?? 'http://127.0.0.1:14242')
+  const apiKey =
+    typeof config.apiKey === 'string'
+      ? config.apiKey
+      : typeof config.api_key === 'string'
+        ? config.api_key
+        : envValue('NMEM_API_KEY')
+  const defaultLimit =
+    typeof config.defaultLimit === 'number'
+      ? config.defaultLimit
+      : typeof config.default_limit === 'number'
+        ? config.default_limit
+        : undefined
+  return {
+    apiUrl,
+    ...(apiKey !== undefined && apiKey !== '' ? { apiKey } : {}),
+    ...(defaultLimit !== undefined ? { defaultLimit } : {}),
+  }
+}
+
+export function redactNowledgeMemConfig(config: NowledgeMemConfig): NowledgeMemConfigRedacted {
+  return {
+    apiUrl: config.apiUrl ?? 'http://127.0.0.1:14242',
+    ...(config.apiKey !== undefined ? { apiKey: '<redacted>' } : {}),
+    ...(config.defaultLimit !== undefined ? { defaultLimit: config.defaultLimit } : {}),
+  }
+}
+
+export class HttpNowledgeMemTransport implements NowledgeMemTransport {
+  readonly apiUrl: string
+  readonly apiKey?: string
+
+  constructor(config: NowledgeMemConfig = {}) {
+    this.apiUrl = (config.apiUrl ?? 'http://127.0.0.1:14242').replace(/\/+$/, '')
+    if (config.apiKey !== undefined && config.apiKey !== '') this.apiKey = config.apiKey
+  }
+
+  async request<T>(
+    endpoint: string,
+    params: Record<string, string | number | boolean | null> = {},
+  ): Promise<T> {
+    const query = new URLSearchParams()
+    for (const [key, value] of Object.entries(params)) {
+      if (value === null) continue
+      query.set(key, String(value))
+    }
+    const qs = query.toString()
+    const headers: Record<string, string> = { Accept: 'application/json' }
+    if (this.apiKey !== undefined) headers.Authorization = `Bearer ${this.apiKey}`
+    const res = await fetch(`${this.apiUrl}${endpoint}${qs !== '' ? `?${qs}` : ''}`, {
+      method: 'GET',
+      headers,
+    })
+    if (!res.ok) {
+      const body = await res.text()
+      throw new Error(`nowledge_mem: ${endpoint} failed (${res.status}): ${body}`)
+    }
+    return (await res.json()) as T
+  }
+}
+
+export interface NowledgeMemAccessorLike {
+  readonly transport: NowledgeMemTransport
+}
+
+function stripPrefix(path: string, prefix: string): string {
+  if (prefix !== '' && path.startsWith(prefix)) return path.slice(prefix.length) || '/'
+  return path
+}
+
+function basename(path: string): string {
+  const clean = path.replace(/\/+$/, '')
+  if (clean === '') return '/'
+  return clean.slice(clean.lastIndexOf('/') + 1) || '/'
+}
+
+function extFromPath(path: string): string {
+  const name = basename(path)
+  const compound = name.match(
+    /\.(memory|crystal|topic|entity|report|draft|thread|feed|chunk|summary)\.(md|jsonl)$/i,
+  )
+  if (compound !== null) return `${compound[1]?.toLowerCase()}.${compound[2]?.toLowerCase()}`
+  const source = name.match(/\.source\.([a-z0-9]+)$/i)
+  if (source !== null) return `source.${source[1]?.toLowerCase()}`
+  const idx = name.lastIndexOf('.')
+  return idx >= 0 ? name.slice(idx + 1).toLowerCase() : ''
+}
+
+function fileTypeFor(path: string, kind: string, contentType?: string): FileType {
+  if (kind !== 'file') return FileType.DIRECTORY
+  if (contentType === 'json' || contentType === 'application/json') return FileType.JSON
+  const ext = extFromPath(path)
+  if (ext.endsWith('jsonl') || ext === 'json') return FileType.JSON
+  if (ext === 'csv') return FileType.CSV
+  if (ext === 'pdf' || ext === 'source.pdf') return FileType.PDF
+  return FileType.TEXT
+}
+
+function statFromEntry(entry: WireEntry): FileStat {
+  return new FileStat({
+    name: entry.name,
+    type: fileTypeFor(entry.path, entry.kind),
+    size: entry.size_hint ?? null,
+    modified: entry.updated_at ?? null,
+    extra: {
+      path: entry.path,
+      ...(entry.id !== undefined ? { id: entry.id } : {}),
+      ...(entry.type !== undefined ? { type: entry.type } : {}),
+      ...(entry.ext !== undefined ? { ext: entry.ext } : {}),
+      ...(entry.hint !== undefined ? { hint: entry.hint } : {}),
+    },
+  })
+}
+
+function statFromWire(path: string, payload: WireStatResponse): FileStat {
+  const name = payload.name ?? basename(path)
+  return new FileStat({
+    name,
+    type: fileTypeFor(path, payload.kind, payload.type),
+    size: payload.sizeBytes ?? null,
+    modified: payload.updatedAt ?? payload.updated_at ?? null,
+    extra: {
+      path: payload.path,
+      ...(payload.id !== undefined ? { id: payload.id } : {}),
+      ...(payload.type !== undefined ? { type: payload.type } : {}),
+      ...(payload.ext !== undefined ? { ext: payload.ext } : {}),
+      ...(payload.frontmatter !== undefined ? { frontmatter: payload.frontmatter } : {}),
+    },
+  })
+}
+
+export async function nowledgeMemReaddir(
+  accessor: NowledgeMemAccessorLike,
+  path: string,
+): Promise<string[]> {
+  const payload = await accessor.transport.request<WireListResponse>('/fs/ls', { path })
+  return (payload.entries ?? []).map((entry) => entry.path)
+}
+
+export async function nowledgeMemRead(
+  accessor: NowledgeMemAccessorLike,
+  path: string,
+  opts: { line?: number; lines?: number } = {},
+): Promise<Uint8Array> {
+  const payload = await accessor.transport.request<WireCatResponse>('/fs/cat', {
+    path,
+    ...(opts.line !== undefined ? { line: opts.line } : {}),
+    ...(opts.lines !== undefined ? { lines: opts.lines } : {}),
+  })
+  return ENC.encode(payload.body)
+}
+
+export async function nowledgeMemStat(
+  accessor: NowledgeMemAccessorLike,
+  path: string,
+): Promise<FileStat> {
+  const payload = await accessor.transport.request<WireStatResponse>('/fs/stat', { path })
+  return statFromWire(path, payload)
+}
+
+export async function nowledgeMemFind(
+  accessor: NowledgeMemAccessorLike,
+  path: string,
+  opts: {
+    type?: string
+    label?: string
+    since?: string
+    until?: string
+    mentions?: string
+    limit?: number
+  } = {},
+): Promise<string[]> {
+  const payload = await accessor.transport.request<WireSearchResponse>('/fs/find', {
+    path,
+    ...(opts.type !== undefined ? { type: opts.type } : {}),
+    ...(opts.label !== undefined ? { label: opts.label } : {}),
+    ...(opts.since !== undefined ? { since: opts.since } : {}),
+    ...(opts.until !== undefined ? { until: opts.until } : {}),
+    ...(opts.mentions !== undefined ? { mentions: opts.mentions } : {}),
+    ...(opts.limit !== undefined ? { limit: opts.limit } : {}),
+  })
+  return normalizeSearchPaths(payload)
+}
+
+export async function nowledgeMemGrep(
+  accessor: NowledgeMemAccessorLike,
+  path: string,
+  query: string,
+  opts: { limit?: number } = {},
+): Promise<NowledgeMemGrepMatch[]> {
+  const payload = await accessor.transport.request<WireGrepResponse>('/fs/grep', {
+    path,
+    q: query,
+    ...(opts.limit !== undefined ? { limit: opts.limit } : {}),
+  })
+  return payload.matches ?? []
+}
+
+export async function nowledgeMemRecall(
+  accessor: NowledgeMemAccessorLike,
+  query: string,
+  opts: { path?: string; k?: number } = {},
+): Promise<string[]> {
+  const payload = await accessor.transport.request<WireSearchResponse>('/fs/recall', {
+    query,
+    ...(opts.path !== undefined ? { path: opts.path } : {}),
+    ...(opts.k !== undefined ? { k: opts.k } : {}),
+  })
+  return normalizeSearchPaths(payload)
+}
+
+export async function nowledgeMemLsStats(
+  accessor: NowledgeMemAccessorLike,
+  path: string,
+): Promise<FileStat[]> {
+  const payload = await accessor.transport.request<WireListResponse>('/fs/ls', { path })
+  return (payload.entries ?? []).map(statFromEntry)
+}
+
+export function nowledgeMemPath(path: string, prefix: string): string {
+  return stripPrefix(path, prefix)
+}
+
+function normalizeSearchPaths(payload: WireSearchResponse): string[] {
+  const rows = payload.paths ?? payload.hits ?? []
+  return rows.map((row) => (typeof row === 'string' ? row : row.path))
+}

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -48,6 +48,26 @@ export {
 } from './resource/secrets.ts'
 export { z } from 'zod'
 export { RAMResource } from './resource/ram/ram.ts'
+export { NowledgeMemResource, type NowledgeMemResourceState } from './resource/nowledge_mem/nowledge_mem.ts'
+export { NOWLEDGE_MEM_PROMPT } from './resource/nowledge_mem/prompt.ts'
+export { NowledgeMemAccessor } from './accessor/nowledge_mem.ts'
+export {
+  HttpNowledgeMemTransport,
+  normalizeNowledgeMemConfig,
+  nowledgeMemFind,
+  nowledgeMemGrep,
+  nowledgeMemLsStats,
+  nowledgeMemRead,
+  nowledgeMemReaddir,
+  nowledgeMemRecall,
+  nowledgeMemStat,
+  redactNowledgeMemConfig,
+  type NowledgeMemConfig,
+  type NowledgeMemConfigRedacted,
+  type NowledgeMemGrepMatch,
+  type NowledgeMemTransport,
+} from './core/nowledge_mem/client.ts'
+export { NOWLEDGE_MEM_COMMANDS } from './commands/builtin/nowledge_mem/index.ts'
 export { RAMStore } from './resource/ram/store.ts'
 export { DevResource } from './resource/dev/dev.ts'
 export { DevStore, DevFiles } from './resource/dev/store.ts'

--- a/typescript/packages/core/src/resource/nowledge_mem/nowledge_mem.test.ts
+++ b/typescript/packages/core/src/resource/nowledge_mem/nowledge_mem.test.ts
@@ -1,0 +1,223 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OpsRegistry } from '../../ops/registry.ts'
+import { FileType, MountMode, PathSpec, ResourceName } from '../../types.ts'
+import { Workspace } from '../../workspace/workspace.ts'
+import { getTestParser } from '../../workspace/fixtures/workspace_fixture.ts'
+import {
+  HttpNowledgeMemTransport,
+  normalizeNowledgeMemConfig,
+} from '../../core/nowledge_mem/client.ts'
+import { NowledgeMemResource } from './nowledge_mem.ts'
+
+const DEC = new TextDecoder()
+
+interface RequestRecord {
+  url: URL
+  headers: Headers
+}
+
+const originalFetch = globalThis.fetch
+let requests: RequestRecord[] = []
+const ROOT_NAMES = [
+  'memories',
+  'threads',
+  'sources',
+  'wiki',
+  'working-memory',
+  'feed',
+  'artifacts',
+  'skills',
+]
+const ROOT_ENTRIES = ROOT_NAMES.map((name) => ({
+  name,
+  path: `/${name}`,
+  kind: 'directory' as const,
+  type: 'directory',
+}))
+const ROOT_PATHS = ROOT_NAMES.map((name) => `/${name}`)
+const ROOT_LS_OUTPUT = ROOT_NAMES.join('\n')
+
+function mockFetch(handler: (url: URL) => unknown): void {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input))
+    requests.push({ url, headers: new Headers(init?.headers) })
+    return new Response(JSON.stringify(handler(url)), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }) as typeof fetch
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  requests = []
+  vi.restoreAllMocks()
+})
+
+describe('NowledgeMemResource', () => {
+  it('normalizes config without requiring the nmem CLI', () => {
+    expect(
+      normalizeNowledgeMemConfig({ api_url: 'https://mem.example/', api_key: 'secret' }),
+    ).toEqual({
+      apiUrl: 'https://mem.example/',
+      apiKey: 'secret',
+    })
+  })
+
+  it('mounts Nowledge Mem as an API-backed read-only resource', async () => {
+    mockFetch((url) => {
+      if (url.pathname === '/fs/ls') {
+        return {
+          entries: ROOT_ENTRIES,
+        }
+      }
+      if (url.pathname === '/fs/cat') {
+        return {
+          path: '/memories/by-id/m1.memory.md',
+          body: 'memory body',
+          content_type: 'markdown',
+        }
+      }
+      if (url.pathname === '/fs/stat') {
+        return {
+          path: '/memories',
+          name: 'memories',
+          kind: 'directory',
+          type: 'directory',
+        }
+      }
+      throw new Error(`unexpected endpoint ${url.pathname}`)
+    })
+
+    const resource = new NowledgeMemResource({
+      apiUrl: 'https://mem.example/',
+      apiKey: 'secret',
+    })
+
+    await expect(resource.readdir(PathSpec.fromStrPath('/mem', '/mem'))).resolves.toEqual(
+      ROOT_PATHS,
+    )
+    await expect(
+      resource.readFile(PathSpec.fromStrPath('/mem/memories/by-id/m1.memory.md', '/mem')),
+    ).resolves.toEqual(new TextEncoder().encode('memory body'))
+
+    const stat = await resource.stat(PathSpec.fromStrPath('/mem/memories', '/mem'))
+    expect(stat.name).toBe('memories')
+    expect(stat.type).toBe(FileType.DIRECTORY)
+    expect(resource.kind).toBe(ResourceName.NOWLEDGE_MEM)
+
+    expect(requests.map((r) => r.url.pathname)).toEqual(['/fs/ls', '/fs/cat', '/fs/stat'])
+    expect(requests[0]?.url.searchParams.get('path')).toBe('/')
+    expect(requests[1]?.url.searchParams.get('path')).toBe('/memories/by-id/m1.memory.md')
+    expect(requests[0]?.headers.get('authorization')).toBe('Bearer secret')
+  })
+
+  it('trims trailing slashes when building API URLs', async () => {
+    mockFetch((url) => {
+      expect(url.toString()).toBe('https://mem.example/fs/ls?path=%2F')
+      return { entries: [] }
+    })
+    const transport = new HttpNowledgeMemTransport({ apiUrl: 'https://mem.example///' })
+    await transport.request('/fs/ls', { path: '/' })
+  })
+
+  it('exposes ls, cat, grep, find, and recall commands over the API', async () => {
+    mockFetch((url) => {
+      if (url.pathname === '/fs/ls') {
+        expect(url.searchParams.get('path')).toBe('/')
+        return {
+          entries: ROOT_ENTRIES,
+        }
+      }
+      if (url.pathname === '/fs/cat') {
+        const path = url.searchParams.get('path')
+        if (path === '/threads/codex/release-planning/messages.jsonl') {
+          expect(url.searchParams.get('line')).toBe('40')
+          expect(url.searchParams.get('lines')).toBe('20')
+          return {
+            path,
+            body: '{"role":"assistant","content":"JWT rotation evidence"}',
+          }
+        }
+        expect(path).toBe('/memories/by-id/m1.memory.md')
+        return {
+          path: '/memories/by-id/m1.memory.md',
+          body: 'JWT rotation decision',
+        }
+      }
+      if (url.pathname === '/fs/grep') {
+        expect(url.searchParams.get('path')).toBe('/memories')
+        expect(url.searchParams.get('q')).toBe('JWT')
+        expect(url.searchParams.get('limit')).toBe('5')
+        return {
+          matches: [{ path: '/memories/by-id/m1.memory.md', line: 7, match: 'JWT rotation' }],
+        }
+      }
+      if (url.pathname === '/fs/find') {
+        expect(url.searchParams.get('path')).toBe('/memories')
+        expect(url.searchParams.get('label')).toBe('security')
+        expect(url.searchParams.get('limit')).toBe('5')
+        return { paths: ['/memories/by-id/m1.memory.md'] }
+      }
+      if (url.pathname === '/fs/recall') {
+        expect(url.searchParams.get('path')).toBe('/memories')
+        expect(url.searchParams.get('query')).toBe('jwt rotation')
+        expect(url.searchParams.get('k')).toBe('3')
+        return { paths: ['/memories/by-id/m1.memory.md'] }
+      }
+      throw new Error(`unexpected endpoint ${url.pathname}`)
+    })
+
+    const resource = new NowledgeMemResource({ apiUrl: 'https://mem.example', defaultLimit: 5 })
+    const registry = new OpsRegistry()
+    registry.registerResource(resource)
+    const ws = new Workspace(
+      { '/mem': resource },
+      { mode: MountMode.EXEC, ops: registry, shellParser: await getTestParser() },
+    )
+
+    const ls = await ws.execute('ls /mem')
+    expect(ls.exitCode).toBe(0)
+    expect(DEC.decode(ls.stdout)).toBe(ROOT_LS_OUTPUT)
+
+    const cat = await ws.execute('cat /mem/memories/by-id/m1.memory.md')
+    expect(cat.exitCode).toBe(0)
+    expect(DEC.decode(cat.stdout)).toBe('JWT rotation decision')
+
+    const threadWindow = await ws.execute(
+      'cat --line 40 --lines 20 /mem/threads/codex/release-planning/messages.jsonl',
+    )
+    expect(threadWindow.exitCode).toBe(0)
+    expect(DEC.decode(threadWindow.stdout)).toBe(
+      '{"role":"assistant","content":"JWT rotation evidence"}',
+    )
+
+    const grep = await ws.execute('grep -n JWT /mem/memories')
+    expect(grep.exitCode).toBe(0)
+    expect(DEC.decode(grep.stdout)).toBe('/memories/by-id/m1.memory.md:7:JWT rotation')
+
+    const find = await ws.execute('find /mem/memories --label security')
+    expect(find.exitCode).toBe(0)
+    expect(DEC.decode(find.stdout)).toBe('/memories/by-id/m1.memory.md')
+
+    const recall = await ws.execute('recall "jwt rotation" --in /mem/memories -k 3')
+    expect(recall.exitCode).toBe(0)
+    expect(DEC.decode(recall.stdout)).toBe('/memories/by-id/m1.memory.md')
+
+    await ws.close()
+  })
+})

--- a/typescript/packages/core/src/resource/nowledge_mem/nowledge_mem.test.ts
+++ b/typescript/packages/core/src/resource/nowledge_mem/nowledge_mem.test.ts
@@ -20,6 +20,7 @@ import { getTestParser } from '../../workspace/fixtures/workspace_fixture.ts'
 import {
   HttpNowledgeMemTransport,
   normalizeNowledgeMemConfig,
+  nowledgeMemPath,
 } from '../../core/nowledge_mem/client.ts'
 import { NowledgeMemResource } from './nowledge_mem.ts'
 
@@ -37,6 +38,7 @@ const ROOT_NAMES = [
   'threads',
   'sources',
   'wiki',
+  'context',
   'working-memory',
   'feed',
   'artifacts',
@@ -49,7 +51,7 @@ const ROOT_ENTRIES = ROOT_NAMES.map((name) => ({
   type: 'directory',
 }))
 const ROOT_PATHS = ROOT_NAMES.map((name) => `/${name}`)
-const ROOT_LS_OUTPUT = ROOT_NAMES.join('\n')
+const ROOT_LS_OUTPUT = [...ROOT_NAMES].sort((a, b) => a.localeCompare(b)).join('\n')
 
 function mockFetch(handler: (url: URL) => unknown): void {
   globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -76,6 +78,8 @@ describe('NowledgeMemResource', () => {
       apiUrl: 'https://mem.example/',
       apiKey: 'secret',
     })
+    expect(nowledgeMemPath('/mem/memories', '/mem')).toBe('/memories')
+    expect(nowledgeMemPath('/memories', '/mem')).toBe('/memories')
   })
 
   it('mounts Nowledge Mem as an API-backed read-only resource', async () => {
@@ -141,6 +145,17 @@ describe('NowledgeMemResource', () => {
         expect(url.searchParams.get('path')).toBe('/')
         return {
           entries: ROOT_ENTRIES,
+        }
+      }
+      if (url.pathname === '/fs/stat') {
+        const path = url.searchParams.get('path')
+        if (path !== null && ROOT_PATHS.includes(path)) {
+          return {
+            path,
+            name: path.split('/').pop(),
+            kind: 'directory',
+            type: 'directory',
+          }
         }
       }
       if (url.pathname === '/fs/cat') {

--- a/typescript/packages/core/src/resource/nowledge_mem/nowledge_mem.ts
+++ b/typescript/packages/core/src/resource/nowledge_mem/nowledge_mem.ts
@@ -1,0 +1,135 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { RegisteredCommand } from '../../commands/config.ts'
+import {
+  HttpNowledgeMemTransport,
+  normalizeNowledgeMemConfig,
+  nowledgeMemFind,
+  nowledgeMemGrep,
+  nowledgeMemPath,
+  nowledgeMemRead,
+  nowledgeMemReaddir,
+  nowledgeMemRecall,
+  nowledgeMemStat,
+  redactNowledgeMemConfig,
+  type NowledgeMemConfig,
+  type NowledgeMemConfigRedacted,
+} from '../../core/nowledge_mem/client.ts'
+import { BaseResource, type Resource } from '../base.ts'
+import { FileStat, PathSpec, ResourceName } from '../../types.ts'
+import { NowledgeMemAccessor } from '../../accessor/nowledge_mem.ts'
+import { NOWLEDGE_MEM_COMMANDS } from '../../commands/builtin/nowledge_mem/index.ts'
+import { NOWLEDGE_MEM_PROMPT } from './prompt.ts'
+
+export interface NowledgeMemResourceState {
+  type: string
+  config: NowledgeMemConfigRedacted
+}
+
+export class NowledgeMemResource extends BaseResource implements Resource {
+  readonly kind: string = ResourceName.NOWLEDGE_MEM
+  readonly isRemote: boolean = true
+  readonly indexTtl: number = 60
+  readonly prompt: string = NOWLEDGE_MEM_PROMPT
+  readonly config: NowledgeMemConfig
+  readonly accessor: NowledgeMemAccessor
+
+  constructor(config: Record<string, unknown> | NowledgeMemConfig = {}) {
+    super()
+    this.config = normalizeNowledgeMemConfig(config as Record<string, unknown>)
+    this.accessor = new NowledgeMemAccessor(
+      new HttpNowledgeMemTransport(this.config),
+      this.config.defaultLimit,
+    )
+  }
+
+  open(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  commands(): readonly RegisteredCommand[] {
+    return NOWLEDGE_MEM_COMMANDS
+  }
+
+  readFile(p: PathSpec): Promise<Uint8Array> {
+    return nowledgeMemRead(this.accessor, nowledgeMemPath(p.original, p.prefix))
+  }
+
+  readdir(p: PathSpec): Promise<string[]> {
+    return nowledgeMemReaddir(this.accessor, nowledgeMemPath(p.original, p.prefix))
+  }
+
+  stat(p: PathSpec): Promise<FileStat> {
+    return nowledgeMemStat(this.accessor, nowledgeMemPath(p.original, p.prefix))
+  }
+
+  find(p: PathSpec): Promise<string[]> {
+    return nowledgeMemFind(this.accessor, nowledgeMemPath(p.original, p.prefix), {
+      ...(this.config.defaultLimit !== undefined ? { limit: this.config.defaultLimit } : {}),
+    })
+  }
+
+  glob(paths: readonly PathSpec[], prefix = ''): Promise<PathSpec[]> {
+    return Promise.resolve(
+      paths.map((p) =>
+        p.prefix !== '' || prefix === ''
+          ? p
+          : new PathSpec({
+              original: p.original,
+              directory: p.directory,
+              ...(p.pattern !== null ? { pattern: p.pattern } : {}),
+              resolved: p.resolved,
+              prefix,
+            }),
+      ),
+    )
+  }
+
+  grep(path: string, query: string, limit?: number) {
+    return nowledgeMemGrep(this.accessor, path, query, {
+      ...(limit !== undefined
+        ? { limit }
+        : this.config.defaultLimit !== undefined
+          ? { limit: this.config.defaultLimit }
+          : {}),
+    })
+  }
+
+  recall(query: string, path?: string, k?: number) {
+    return nowledgeMemRecall(this.accessor, query, {
+      ...(path !== undefined ? { path } : {}),
+      ...(k !== undefined
+        ? { k }
+        : this.config.defaultLimit !== undefined
+          ? { k: this.config.defaultLimit }
+          : {}),
+    })
+  }
+
+  getState(): Promise<NowledgeMemResourceState> {
+    return Promise.resolve({
+      type: this.kind,
+      config: redactNowledgeMemConfig(this.config),
+    })
+  }
+
+  loadState(_state: NowledgeMemResourceState): Promise<void> {
+    return Promise.resolve()
+  }
+}

--- a/typescript/packages/core/src/resource/nowledge_mem/prompt.ts
+++ b/typescript/packages/core/src/resource/nowledge_mem/prompt.ts
@@ -15,10 +15,11 @@
 export const NOWLEDGE_MEM_PROMPT = `{prefix}
   Nowledge Mem is a remote knowledge filesystem, not just a memory list.
   Start with ls {prefix} to discover the tree: memories, threads, sources, wiki,
-  working-memory, feed, artifacts, and skills. Prefer targeted reads: use recall
-  for fuzzy memory questions, find for metadata filters, grep for exact phrases
-  across memories, threads, and parsed Library sources, stat before loading large
-  files, and cat --line/--lines when you only need an evidence window. Treat
-  paths as Nowledge FS identifiers, not local OS paths. This mount talks directly
-  to the Nowledge Mem /fs/* API and does not require the nmem CLI.
+  context, working-memory, feed, artifacts, and skills. Prefer targeted reads:
+  use recall for fuzzy memory questions, find for metadata filters, grep for
+  exact phrases across memories, threads, and parsed Library sources, stat
+  before loading large files, and cat --line/--lines when you only need an
+  evidence window. Treat paths as Nowledge FS identifiers, not local OS paths.
+  This mount talks directly to the Nowledge Mem /fs/* API and does not require
+  the nmem CLI.
 `.trim()

--- a/typescript/packages/core/src/resource/nowledge_mem/prompt.ts
+++ b/typescript/packages/core/src/resource/nowledge_mem/prompt.ts
@@ -12,6 +12,13 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export { Accessor, NOOPAccessor } from './base.ts'
-export { NowledgeMemAccessor } from './nowledge_mem.ts'
-export { RAMAccessor } from './ram.ts'
+export const NOWLEDGE_MEM_PROMPT = `{prefix}
+  Nowledge Mem is a remote knowledge filesystem, not just a memory list.
+  Start with ls {prefix} to discover the tree: memories, threads, sources, wiki,
+  working-memory, feed, artifacts, and skills. Prefer targeted reads: use recall
+  for fuzzy memory questions, find for metadata filters, grep for exact phrases
+  across memories, threads, and parsed Library sources, stat before loading large
+  files, and cat --line/--lines when you only need an evidence window. Treat
+  paths as Nowledge FS identifiers, not local OS paths. This mount talks directly
+  to the Nowledge Mem /fs/* API and does not require the nmem CLI.
+`.trim()

--- a/typescript/packages/core/src/types.test.ts
+++ b/typescript/packages/core/src/types.test.ts
@@ -48,7 +48,7 @@ describe('ConsistencyPolicy', () => {
 })
 
 describe('ResourceName', () => {
-  it('exposes the 24 documented backend kinds with matching string values', () => {
+  it('exposes documented backend kinds with matching string values', () => {
     expect(ResourceName.DISK).toBe('disk')
     expect(ResourceName.S3).toBe('s3')
     expect(ResourceName.RAM).toBe('ram')
@@ -74,10 +74,11 @@ describe('ResourceName', () => {
     expect(ResourceName.OPFS).toBe('opfs')
     expect(ResourceName.SUPABASE).toBe('supabase')
     expect(ResourceName.POSTGRES).toBe('postgres')
+    expect(ResourceName.NOWLEDGE_MEM).toBe('nowledge_mem')
   })
 
-  it('contains exactly 33 entries', () => {
-    expect(Object.keys(ResourceName)).toHaveLength(33)
+  it('contains exactly 34 entries', () => {
+    expect(Object.keys(ResourceName)).toHaveLength(34)
   })
 
   it('is frozen at runtime', () => {

--- a/typescript/packages/core/src/types.ts
+++ b/typescript/packages/core/src/types.ts
@@ -139,6 +139,7 @@ export const ResourceName = Object.freeze({
   SSCHOLAR_AUTHOR: 'sscholar-author',
   VERCEL: 'vercel',
   POSTHOG: 'posthog',
+  NOWLEDGE_MEM: 'nowledge_mem',
 } as const)
 
 export type ResourceName = (typeof ResourceName)[keyof typeof ResourceName]

--- a/typescript/packages/node/src/resource/registry.test.ts
+++ b/typescript/packages/node/src/resource/registry.test.ts
@@ -25,6 +25,7 @@ describe('node resource registry', () => {
     expect(names).toContain('s3')
     expect(names).toContain('postgres')
     expect(names).toContain('mongodb')
+    expect(names).toContain('nowledge_mem')
     expect(names).toEqual([...names].sort())
   })
 
@@ -51,6 +52,18 @@ describe('node resource registry', () => {
   it('builds RAM with no config', async () => {
     const r = await buildResource('ram', {})
     expect(r.kind).toBe('ram')
+  })
+
+  it('builds Nowledge Mem with API config', async () => {
+    const r = (await buildResource('nowledge_mem', {
+      api_url: 'https://mem.example',
+      api_key: 'secret',
+    })) as unknown as { kind: string; config: Record<string, unknown> }
+    expect(r.kind).toBe('nowledge_mem')
+    expect(r.config).toMatchObject({
+      apiUrl: 'https://mem.example',
+      apiKey: 'secret',
+    })
   })
 
   it('builds Disk with root', async () => {

--- a/typescript/packages/node/src/resource/registry.ts
+++ b/typescript/packages/node/src/resource/registry.ts
@@ -34,6 +34,10 @@ const REGISTRY: Record<string, ResourceFactory> = {
     const { RAMResource } = await import('@struktoai/mirage-core')
     return new RAMResource()
   },
+  nowledge_mem: async (config) => {
+    const { NowledgeMemResource } = await import('@struktoai/mirage-core')
+    return new NowledgeMemResource(config)
+  },
   disk: async (config) => {
     const { DiskResource } = await import('./disk/disk.ts')
     const norm = normalizeFields(config) as { root: string }


### PR DESCRIPTION
## Summary

Adds a read-only TypeScript resource for Nowledge Mem backed directly by the Nowledge FS API (`/fs/*`). Nowledge FS is a knowledge tree, not a memory-note folder: a Mirage workspace can mount it at `/mem` and browse memories, threads, parsed sources, wiki pages, guidance context, Working Memory, feed events, artifacts, and skills through familiar shell-shaped commands.

- `ls`, `cat`, and `stat` for tree discovery and targeted reads; `ls` and `stat` now delegate to Mirage's shared generic helpers.
- `cat --line/--lines` for small evidence windows from large thread/source files.
- `find` for Nowledge metadata filters.
- `grep` for exact text search across rendered content.
- `recall` for semantic recall through Nowledge Mem.

This is intentionally API-only. It does not shell out to the `nmem` CLI and does not require the CLI to be installed.

## Notes

- Requires a Nowledge Mem server that exposes the Nowledge FS API, expected in Nowledge Mem 0.9.0+.
- Rebased on the current TypeScript generic-command refactor in `main`.
- The resource is read-only; Nowledge Mem remains the source of truth.
- Browser docs recommend a same-origin proxy or short-lived token instead of embedding a long-lived personal API key.
- This PR is draft until the Nowledge Mem 0.9.0 `/fs/*` API is release-stable.

## Validation

Validated with Homebrew `node@22` (`v22.22.3`) because local Node 26 rejects Mirage's `--experimental-wasm-jspi` test flag.

- `pnpm --dir typescript --filter @struktoai/mirage-core exec vitest run src/resource/nowledge_mem/nowledge_mem.test.ts src/types.test.ts`
- `pnpm --dir typescript --filter @struktoai/mirage-core typecheck`
- `pnpm --dir typescript --filter @struktoai/mirage-node exec vitest run src/resource/registry.test.ts`
- `pnpm --dir typescript --filter @struktoai/mirage-browser exec vitest run src/resource/registry.test.ts`
- `pnpm --dir typescript --filter @struktoai/mirage-core build`
- `pnpm --dir typescript --filter @struktoai/mirage-node build`
- `pnpm --dir typescript --filter @struktoai/mirage-browser build`
- `git diff --check`
- Live local Nowledge Mem smoke against `http://127.0.0.1:14242` through built `@struktoai/mirage-node` output: `ls /mem`, `stat /mem/context`, and `recall "Nowledge Mem" --in /mem/memories -k 2`.
