### PR TITLE
fix(py): emit UTC timestamps with Z suffix across all resources

### DIFF
--- a/python/mirage/cache/index/ram.py
+++ b/python/mirage/cache/index/ram.py
@@ -18,6 +18,7 @@ from mirage.cache.index.config import (IndexConfig, IndexEntry, ListResult,
                                        LookupResult, LookupStatus)
 from mirage.cache.index.store import IndexCacheStore
 from mirage.cache.lock import KeyLockMixin
+from mirage.core.timeutil import to_iso_z
 
 
 class RAMIndexCacheStore(IndexCacheStore, KeyLockMixin):
@@ -45,7 +46,7 @@ class RAMIndexCacheStore(IndexCacheStore, KeyLockMixin):
             if not entry.index_time:
                 entry = entry.model_copy(
                     update={
-                        "index_time": datetime.now(timezone.utc).isoformat()
+                        "index_time": to_iso_z(datetime.now(timezone.utc))
                     })
             self._entries[resource_path] = entry
 
@@ -67,7 +68,7 @@ class RAMIndexCacheStore(IndexCacheStore, KeyLockMixin):
         async with self._lock_for(resource_path):
             now = datetime.now(timezone.utc)
             exp = expired_at or (now + timedelta(seconds=self._ttl))
-            now_iso = now.isoformat()
+            now_iso = to_iso_z(now)
             prefix = "/" if resource_path == "/" else resource_path + "/"
             child_keys: list[str] = []
             for name, entry in entries:

--- a/python/mirage/cache/index/redis.py
+++ b/python/mirage/cache/index/redis.py
@@ -23,6 +23,7 @@ except ImportError as _err:
 from mirage.cache.index.config import (IndexConfig, IndexEntry, ListResult,
                                        LookupResult, LookupStatus)
 from mirage.cache.index.store import IndexCacheStore
+from mirage.core.timeutil import to_iso_z
 
 ENTRY_PREFIX = "mirage:idx:entry:"
 CHILDREN_PREFIX = "mirage:idx:children:"
@@ -86,7 +87,7 @@ class RedisIndexCacheStore(IndexCacheStore):
     async def put(self, resource_path: str, entry: IndexEntry) -> None:
         if not entry.index_time:
             entry = entry.model_copy(
-                update={"index_time": datetime.now(timezone.utc).isoformat()})
+                update={"index_time": to_iso_z(datetime.now(timezone.utc))})
         await self._client.set(self._entry_key(resource_path),
                                entry.model_dump_json())
 
@@ -108,7 +109,7 @@ class RedisIndexCacheStore(IndexCacheStore):
         expired_at: datetime | None = None,
     ) -> None:
         now = datetime.now(timezone.utc)
-        now_iso = now.isoformat()
+        now_iso = to_iso_z(now)
         prefix = "/" if resource_path == "/" else resource_path + "/"
 
         pipe = self._client.pipeline()

--- a/python/mirage/core/disk/stat.py
+++ b/python/mirage/core/disk/stat.py
@@ -20,6 +20,7 @@ from aiofiles.os import path as aio_path
 
 from mirage.accessor.disk import DiskAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.core.timeutil import to_iso_z
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.filetype import guess_type
 
@@ -48,7 +49,7 @@ async def stat(accessor: DiskAccessor,
     if not await aio_path.exists(p):
         raise FileNotFoundError(str(p))
     st = await aiofiles.os.stat(p)
-    modified = datetime.fromtimestamp(st.st_mtime, tz=timezone.utc).isoformat()
+    modified = to_iso_z(datetime.fromtimestamp(st.st_mtime, tz=timezone.utc))
     if await aio_path.isdir(p):
         return FileStat(name=p.name,
                         size=None,

--- a/python/mirage/core/ram/append.py
+++ b/python/mirage/core/ram/append.py
@@ -13,9 +13,9 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import time
-from datetime import datetime, timezone
 
 from mirage.accessor.ram import RAMAccessor
+from mirage.core.timeutil import now_iso
 from mirage.observe.context import record
 from mirage.types import PathSpec
 
@@ -37,5 +37,5 @@ async def append_bytes(accessor: RAMAccessor, path: PathSpec,
         store.files[p] += data
     else:
         store.files[p] = data
-    store.modified[p] = datetime.now(timezone.utc).isoformat()
+    store.modified[p] = now_iso()
     record("append", path, "ram", len(data), start_ms)

--- a/python/mirage/core/ram/copy.py
+++ b/python/mirage/core/ram/copy.py
@@ -12,9 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import datetime, timezone
-
 from mirage.accessor.ram import RAMAccessor
+from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
 
 
@@ -36,4 +35,4 @@ async def copy(accessor: RAMAccessor, src: PathSpec, dst: PathSpec) -> None:
     if s not in store.files:
         raise FileNotFoundError(s)
     store.files[d] = store.files[s]
-    store.modified[d] = datetime.now(timezone.utc).isoformat()
+    store.modified[d] = now_iso()

--- a/python/mirage/core/ram/create.py
+++ b/python/mirage/core/ram/create.py
@@ -12,9 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import datetime, timezone
-
 from mirage.accessor.ram import RAMAccessor
+from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
 
 
@@ -26,4 +25,4 @@ async def create(accessor: RAMAccessor, path: PathSpec) -> None:
     store = accessor.store
     p = _norm(path)
     store.files[p] = b""
-    store.modified[p] = datetime.now(timezone.utc).isoformat()
+    store.modified[p] = now_iso()

--- a/python/mirage/core/ram/mkdir.py
+++ b/python/mirage/core/ram/mkdir.py
@@ -12,9 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import datetime, timezone
-
 from mirage.accessor.ram import RAMAccessor
+from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
 
 
@@ -39,7 +38,7 @@ async def mkdir(accessor: RAMAccessor,
     if parents:
         parts = p.strip("/").split("/")
         current = ""
-        now = datetime.now(timezone.utc).isoformat()
+        now = now_iso()
         for part in parts:
             current += "/" + part
             store.dirs.add(current)
@@ -50,4 +49,4 @@ async def mkdir(accessor: RAMAccessor,
     if parent != "/" and parent not in store.dirs:
         raise FileNotFoundError(f"parent directory does not exist: {parent}")
     store.dirs.add(p)
-    store.modified[p] = datetime.now(timezone.utc).isoformat()
+    store.modified[p] = now_iso()

--- a/python/mirage/core/ram/mkdir_p.py
+++ b/python/mirage/core/ram/mkdir_p.py
@@ -12,9 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import datetime, timezone
-
 from mirage.accessor.ram import RAMAccessor
+from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
 
 
@@ -27,7 +26,7 @@ async def mkdir_p(accessor: RAMAccessor, path: PathSpec) -> None:
     p = _norm(path)
     parts = p.strip("/").split("/")
     current = ""
-    now = datetime.now(timezone.utc).isoformat()
+    now = now_iso()
     for part in parts:
         current += "/" + part
         store.dirs.add(current)

--- a/python/mirage/core/ram/rename.py
+++ b/python/mirage/core/ram/rename.py
@@ -12,9 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import datetime, timezone
-
 from mirage.accessor.ram import RAMAccessor
+from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
 
 
@@ -33,7 +32,7 @@ async def rename(accessor: RAMAccessor, src: PathSpec, dst: PathSpec) -> None:
         dst = dst.strip_prefix
     store = accessor.store
     s, d = _norm(src), _norm(dst)
-    now = datetime.now(timezone.utc).isoformat()
+    now = now_iso()
     if s in store.files:
         store.files[d] = store.files.pop(s)
         store.modified[d] = store.modified.pop(s, now)

--- a/python/mirage/core/ram/write.py
+++ b/python/mirage/core/ram/write.py
@@ -13,9 +13,9 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import time
-from datetime import datetime, timezone
 
 from mirage.accessor.ram import RAMAccessor
+from mirage.core.timeutil import now_iso
 from mirage.observe.context import record
 from mirage.types import PathSpec
 
@@ -42,5 +42,5 @@ async def write_bytes(accessor: RAMAccessor, path: PathSpec,
     if parent != "/" and parent not in store.dirs:
         raise FileNotFoundError(f"parent directory does not exist: {parent}")
     store.files[p] = data
-    store.modified[p] = datetime.now(timezone.utc).isoformat()
+    store.modified[p] = now_iso()
     record("write", path, "ram", len(data), start_ms)

--- a/python/mirage/core/redis/append.py
+++ b/python/mirage/core/redis/append.py
@@ -13,9 +13,9 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import time
-from datetime import datetime, timezone
 
 from mirage.accessor.redis import RedisAccessor
+from mirage.core.timeutil import now_iso
 from mirage.observe.context import record
 from mirage.types import PathSpec
 
@@ -41,5 +41,5 @@ async def append_bytes(
         await store.set_file(p, existing + data)
     else:
         await store.set_file(p, data)
-    await store.set_modified(p, datetime.now(timezone.utc).isoformat())
+    await store.set_modified(p, now_iso())
     record("append", path, "redis", len(data), start_ms)

--- a/python/mirage/core/redis/copy.py
+++ b/python/mirage/core/redis/copy.py
@@ -12,9 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import datetime, timezone
-
 from mirage.accessor.redis import RedisAccessor
+from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
 
 
@@ -41,4 +40,4 @@ async def copy(
     if data is None:
         raise FileNotFoundError(s)
     await store.set_file(d, data)
-    await store.set_modified(d, datetime.now(timezone.utc).isoformat())
+    await store.set_modified(d, now_iso())

--- a/python/mirage/core/redis/create.py
+++ b/python/mirage/core/redis/create.py
@@ -12,9 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import datetime, timezone
-
 from mirage.accessor.redis import RedisAccessor
+from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
 
 
@@ -26,4 +25,4 @@ async def create(accessor: RedisAccessor, path: PathSpec) -> None:
     store = accessor.store
     p = _norm(path)
     await store.set_file(p, b"")
-    await store.set_modified(p, datetime.now(timezone.utc).isoformat())
+    await store.set_modified(p, now_iso())

--- a/python/mirage/core/redis/mkdir.py
+++ b/python/mirage/core/redis/mkdir.py
@@ -12,9 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import datetime, timezone
-
 from mirage.accessor.redis import RedisAccessor
+from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
 
 
@@ -41,7 +40,7 @@ async def mkdir(
     if parents:
         parts = p.strip("/").split("/")
         current = ""
-        now = datetime.now(timezone.utc).isoformat()
+        now = now_iso()
         for part in parts:
             current += "/" + part
             await store.add_dir(current)
@@ -53,4 +52,4 @@ async def mkdir(
     if parent != "/" and not await store.has_dir(parent):
         raise FileNotFoundError(f"parent directory does not exist: {parent}")
     await store.add_dir(p)
-    await store.set_modified(p, datetime.now(timezone.utc).isoformat())
+    await store.set_modified(p, now_iso())

--- a/python/mirage/core/redis/mkdir_p.py
+++ b/python/mirage/core/redis/mkdir_p.py
@@ -12,9 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import datetime, timezone
-
 from mirage.accessor.redis import RedisAccessor
+from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
 
 
@@ -27,7 +26,7 @@ async def mkdir_p(accessor: RedisAccessor, path: PathSpec) -> None:
     p = _norm(path)
     parts = p.strip("/").split("/")
     current = ""
-    now = datetime.now(timezone.utc).isoformat()
+    now = now_iso()
     for part in parts:
         current += "/" + part
         await store.add_dir(current)

--- a/python/mirage/core/redis/rename.py
+++ b/python/mirage/core/redis/rename.py
@@ -12,9 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import datetime, timezone
-
 from mirage.accessor.redis import RedisAccessor
+from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
 
 
@@ -37,7 +36,7 @@ async def rename(
         dst = dst.strip_prefix
     store = accessor.store
     s, d = _norm(src), _norm(dst)
-    now = datetime.now(timezone.utc).isoformat()
+    now = now_iso()
     if await store.has_file(s):
         data = await store.get_file(s)
         mod = await store.get_modified(s)

--- a/python/mirage/core/redis/truncate.py
+++ b/python/mirage/core/redis/truncate.py
@@ -12,9 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import datetime, timezone
-
 from mirage.accessor.redis import RedisAccessor
+from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
 
 
@@ -30,4 +29,4 @@ async def truncate(accessor: RedisAccessor, path: PathSpec,
     if data is None:
         data = b""
     await store.set_file(p, data[:length].ljust(length, b"\0"))
-    await store.set_modified(p, datetime.now(timezone.utc).isoformat())
+    await store.set_modified(p, now_iso())

--- a/python/mirage/core/redis/write.py
+++ b/python/mirage/core/redis/write.py
@@ -13,9 +13,9 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import time
-from datetime import datetime, timezone
 
 from mirage.accessor.redis import RedisAccessor
+from mirage.core.timeutil import now_iso
 from mirage.observe.context import record
 from mirage.types import PathSpec
 
@@ -45,5 +45,5 @@ async def write_bytes(
     if parent != "/" and not await store.has_dir(parent):
         raise FileNotFoundError(f"parent directory does not exist: {parent}")
     await store.set_file(p, data)
-    await store.set_modified(p, datetime.now(timezone.utc).isoformat())
+    await store.set_modified(p, now_iso())
     record("write", path, "redis", len(data), start_ms)

--- a/python/mirage/core/s3/entry.py
+++ b/python/mirage/core/s3/entry.py
@@ -15,6 +15,7 @@
 from enum import Enum
 
 from mirage.cache.index.config import IndexEntry
+from mirage.core.timeutil import to_iso_z
 
 
 class S3ResourceType(str, Enum):
@@ -49,7 +50,7 @@ class S3IndexEntry(IndexEntry):
             resource_type=S3ResourceType.FILE,
             vfs_name=name,
             size=obj.get("Size"),
-            remote_time=modified.isoformat() if modified else "",
+            remote_time=to_iso_z(modified) if modified else "",
             etag=obj.get("ETag", ""),
         )
 

--- a/python/mirage/core/s3/stat.py
+++ b/python/mirage/core/s3/stat.py
@@ -12,11 +12,10 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from datetime import timezone
-
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.s3._client import _client_kwargs, _key, async_session
+from mirage.core.timeutil import to_iso_z
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.filetype import guess_type
 
@@ -81,8 +80,7 @@ async def stat(accessor: S3Accessor,
         # Try head_object first — works for files.
         try:
             resp = await client.head_object(Bucket=config.bucket, Key=key)
-            modified = resp["LastModified"].astimezone(
-                timezone.utc).isoformat()
+            modified = to_iso_z(resp["LastModified"])
             etag_raw = resp.get("ETag", "").strip('"')
             vid_raw = resp.get("VersionId")
             if vid_raw == "null":

--- a/python/mirage/core/ssh/stat.py
+++ b/python/mirage/core/ssh/stat.py
@@ -19,6 +19,7 @@ import asyncssh
 from mirage.accessor.ssh import SSHAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.ssh._client import _abs
+from mirage.core.timeutil import to_iso_z
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.filetype import guess_type
 
@@ -44,8 +45,8 @@ async def stat(accessor: SSHAccessor,
         name = path.rstrip("/").rsplit("/", 1)[-1] or "/"
         mod_str = ""
         if attrs.mtime is not None:
-            mod_str = datetime.fromtimestamp(attrs.mtime,
-                                             tz=timezone.utc).isoformat()
+            mod_str = to_iso_z(
+                datetime.fromtimestamp(attrs.mtime, tz=timezone.utc))
         return FileStat(
             name=name,
             size=attrs.size or 0,

--- a/python/mirage/core/timeutil.py
+++ b/python/mirage/core/timeutil.py
@@ -12,21 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.accessor.ram import RAMAccessor
-from mirage.core.timeutil import now_iso
-from mirage.types import PathSpec
+from datetime import datetime, timezone
 
 
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+def to_iso_z(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
-async def truncate(accessor: RAMAccessor, path: PathSpec, length: int) -> None:
-    store = accessor.store
-    p = _norm(path)
-    if p in store.files:
-        data = store.files[p]
-    else:
-        data = b""
-    store.files[p] = data[:length].ljust(length, b"\0")
-    store.modified[p] = now_iso()
+def now_iso() -> str:
+    return to_iso_z(datetime.now(timezone.utc))

--- a/python/mirage/resource/redis/store.py
+++ b/python/mirage/resource/redis/store.py
@@ -120,7 +120,7 @@ class RedisStore:
         return val.decode() if isinstance(val, bytes) else val
 
     async def set_modified(self, path: str, ts: str) -> None:
-        await self._client.set(self._mk(path), ts)
+        await self._client.set(self._mk(path), ts.replace("+00:00", "Z"))
 
     async def del_modified(self, path: str) -> None:
         await self._client.delete(self._mk(path))

--- a/python/mirage/resource/redis/store.py
+++ b/python/mirage/resource/redis/store.py
@@ -120,7 +120,7 @@ class RedisStore:
         return val.decode() if isinstance(val, bytes) else val
 
     async def set_modified(self, path: str, ts: str) -> None:
-        await self._client.set(self._mk(path), ts.replace("+00:00", "Z"))
+        await self._client.set(self._mk(path), ts)
 
     async def del_modified(self, path: str) -> None:
         await self._client.delete(self._mk(path))

--- a/python/tests/core/disk/test_stat.py
+++ b/python/tests/core/disk/test_stat.py
@@ -32,6 +32,8 @@ async def test_stat_file(tmp_path):
     assert result.name == "hello.txt"
     assert result.size == 5
     assert result.modified is not None
+    assert result.modified.endswith("Z")
+    assert "+00:00" not in result.modified
     assert result.type != FileType.DIRECTORY
 
 

--- a/python/tests/core/ram/test_write.py
+++ b/python/tests/core/ram/test_write.py
@@ -36,6 +36,8 @@ async def test_write_bytes(store):
                       b"hello")
     assert store.store.files["/hello.txt"] == b"hello"
     assert "/hello.txt" in store.store.modified
+    assert store.store.modified["/hello.txt"].endswith("Z")
+    assert "+00:00" not in store.store.modified["/hello.txt"]
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/redis/test_write.py
+++ b/python/tests/core/redis/test_write.py
@@ -104,3 +104,14 @@ async def test_write_bytes_sets_modified(accessor):
                       PathSpec(original="/file.txt", directory="/file.txt"),
                       b"data")
     assert await accessor.store.get_modified("/file.txt") is not None
+
+
+@pytest.mark.asyncio
+async def test_write_bytes_modified_uses_z_suffix(accessor):
+    await write_bytes(accessor,
+                      PathSpec(original="/file.txt", directory="/file.txt"),
+                      b"data")
+    modified = await accessor.store.get_modified("/file.txt")
+    assert modified is not None
+    assert modified.endswith("Z")
+    assert "+00:00" not in modified

--- a/python/tests/core/test_timeutil.py
+++ b/python/tests/core/test_timeutil.py
@@ -12,21 +12,23 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.accessor.ram import RAMAccessor
-from mirage.core.timeutil import now_iso
-from mirage.types import PathSpec
+from datetime import datetime, timedelta, timezone
+
+from mirage.core.timeutil import now_iso, to_iso_z
 
 
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+def test_to_iso_z_converts_utc_offset_to_z():
+    dt = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    assert to_iso_z(dt) == "2026-01-02T03:04:05Z"
 
 
-async def truncate(accessor: RAMAccessor, path: PathSpec, length: int) -> None:
-    store = accessor.store
-    p = _norm(path)
-    if p in store.files:
-        data = store.files[p]
-    else:
-        data = b""
-    store.files[p] = data[:length].ljust(length, b"\0")
-    store.modified[p] = now_iso()
+def test_to_iso_z_normalizes_non_utc_to_z():
+    tz = timezone(timedelta(hours=5))
+    dt = datetime(2026, 1, 2, 8, 4, 5, tzinfo=tz)
+    assert to_iso_z(dt) == "2026-01-02T03:04:05Z"
+
+
+def test_now_iso_uses_z_suffix():
+    s = now_iso()
+    assert s.endswith("Z")
+    assert "+00:00" not in s


### PR DESCRIPTION
Closes #162.

Python emitted UTC timestamps as `datetime...isoformat()` → `...+00:00`, while TS uses `Date.toISOString()` → `...Z`. This diverged `stat`/`index_time` output between the two implementations.

Added `mirage.core.timeutil.now_iso()` / `to_iso_z(dt)` (mirrors TS's `nowIso()`) and applied it at every site that generates or formats a UTC timestamp:

- **Generated:** RAM (8 ops), redis (8 ops, replacing the earlier `set_modified` sink normalization)
- **Backend-derived mtime:** disk, s3 (stat + entry), ssh
- **Index cache:** RAM + redis `index_time`

Backends with **no TS twin** (nextcloud, hf_buckets, databricks_volume, dify) keep their external-API timestamp formats — nothing to align to.

```
before: name=hello.txt size=12 modified=2026-06-05T17:44:26.394393+00:00 type=text
after:  name=hello.txt size=12 modified=2026-06-05T22:37:56.865830Z       type=text
```

Tests: unit tests for `to_iso_z`/`now_iso`; Z-suffix assertions for RAM, redis, and disk. Verified PY integ truths (ram/disk/redis + variants) still pass.