### PR TITLE
refactor(ts): delegate slack + s3 commands to the generic layer

### DIFF
--- a/.github/workflows/test_integ_ts.yml
+++ b/.github/workflows/test_integ_ts.yml
@@ -115,11 +115,8 @@ jobs:
           pnpm exec tsx safeguard.ts > /tmp/ts-safeguard.out
           diff truth_safeguard.txt /tmp/ts-safeguard.out
 
-      # S3 is not yet on the shared generic layer, so its output still diverges
-      # from truth.txt (find newline, dir trailing-slash, grep -r on dirs).
-      # Smoke-run it against MinIO for now; re-enable the truth diff once the
-      # s3 backend is converted to delegate to the generic commands.
-      - name: Run S3 (MinIO) backend (smoke)
+      - name: Run S3 (MinIO) backend and diff against truth
         working-directory: integ
         run: |
           pnpm exec tsx s3.ts > /tmp/ts-s3.out
+          diff truth.txt /tmp/ts-s3.out

--- a/typescript/packages/browser/src/resource/s3/s3.ts
+++ b/typescript/packages/browser/src/resource/s3/s3.ts
@@ -208,7 +208,7 @@ export class S3Resource implements Resource {
 
   // Ignored — duAll is not yet on the public Resource interface, but keeping
   // it around matches the node-side S3Resource.opsMap hook for completeness.
-  _duAll(p: PathSpec): Promise<[string, number][]> {
+  _duAll(p: PathSpec): Promise<[[string, number][], number]> {
     return duAllCore(this.accessor, p)
   }
 

--- a/typescript/packages/core/src/commands/builtin/s3/base64_cmd.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/base64_cmd.ts
@@ -15,39 +15,10 @@
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
 import { stream as s3Stream } from '../../../core/s3/stream.ts'
-import { IOResult, materialize } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
-import { decodeBase64, encodeBase64 } from '../../../utils/base64.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { resolveSource } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-async function* base64EncodeStream(
-  source: AsyncIterable<Uint8Array>,
-  wrap: number | null,
-): AsyncIterable<Uint8Array> {
-  const buf = await materialize(source)
-  const encoded = encodeBase64(buf)
-  if (wrap !== null && wrap === 0) {
-    yield ENC.encode(encoded + '\n')
-    return
-  }
-  const lineLen = wrap ?? 76
-  const lines: string[] = []
-  for (let i = 0; i < encoded.length; i += lineLen) {
-    lines.push(encoded.slice(i, i + lineLen))
-  }
-  yield ENC.encode(lines.join('\n') + '\n')
-}
-
-async function* base64DecodeStream(source: AsyncIterable<Uint8Array>): AsyncIterable<Uint8Array> {
-  const buf = await materialize(source)
-  const text = DEC.decode(buf).replace(/[\r\n ]/g, '')
-  yield decodeBase64(text)
-}
+import { base64Generic } from '../generic/base64_cmd.ts'
 
 async function base64Command(
   accessor: S3Accessor,
@@ -55,26 +26,9 @@ async function base64Command(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const decode = opts.flags.d === true || opts.flags.D === true
-  const wrap = typeof opts.flags.w === 'string' ? Number.parseInt(opts.flags.w, 10) : null
-  const cache: string[] = []
-  let source: AsyncIterable<Uint8Array>
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    source = s3Stream(accessor, first)
-    cache.push(first.original)
-  } else {
-    try {
-      source = resolveSource(opts.stdin, 'base64: missing input')
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-    }
-  }
-  const out = decode ? base64DecodeStream(source) : base64EncodeStream(source, wrap)
-  return [out, new IOResult({ cache })]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return base64Generic(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_BASE64 = command({

--- a/typescript/packages/core/src/commands/builtin/s3/cmp.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/cmp.ts
@@ -14,23 +14,11 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function octal(n: number): string {
-  return '0o' + n.toString(8)
-}
-
-function arraysEqual(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.byteLength !== b.byteLength) return false
-  for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false
-  return true
-}
+import { cmpGeneric } from '../generic/cmp.ts'
 
 async function cmpCommand(
   accessor: S3Accessor,
@@ -38,52 +26,9 @@ async function cmpCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length < 2) {
-    return [null, new IOResult({ exitCode: 2, stderr: ENC.encode('cmp: requires two paths\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const p0 = resolved[0]
-  const p1 = resolved[1]
-  if (p0 === undefined || p1 === undefined) return [null, new IOResult()]
-  let data1 = await s3Read(accessor, p0, opts.index ?? undefined)
-  let data2 = await s3Read(accessor, p1, opts.index ?? undefined)
-  if (typeof opts.flags.i === 'string') {
-    const skip = Number.parseInt(opts.flags.i, 10)
-    data1 = data1.slice(skip)
-    data2 = data2.slice(skip)
-  }
-  if (typeof opts.flags.n === 'string') {
-    const limit = Number.parseInt(opts.flags.n, 10)
-    data1 = data1.slice(0, limit)
-    data2 = data2.slice(0, limit)
-  }
-  if (arraysEqual(data1, data2)) return [null, new IOResult()]
-  if (opts.flags.s === true) return [null, new IOResult({ exitCode: 1 })]
-  if (opts.flags.args_l === true) {
-    const outLines: string[] = []
-    const limit = Math.min(data1.byteLength, data2.byteLength)
-    for (let idx = 0; idx < limit; idx++) {
-      if (data1[idx] !== data2[idx]) {
-        outLines.push(`${String(idx + 1)} ${octal(data1[idx] ?? 0)} ${octal(data2[idx] ?? 0)}`)
-      }
-    }
-    const out: ByteSource = ENC.encode(outLines.join('\n'))
-    return [out, new IOResult({ exitCode: 1 })]
-  }
-  const limit = Math.min(data1.byteLength, data2.byteLength)
-  for (let idx = 0; idx < limit; idx++) {
-    if (data1[idx] !== data2[idx]) {
-      let line = 1
-      for (let k = 0; k < idx; k++) if (data1[k] === 0x0a) line += 1
-      let msg = `${p0.original} ${p1.original} differ: char ${String(idx + 1)}, line ${String(line)}`
-      if (opts.flags.b === true) {
-        msg += ` is ${octal(data1[idx] ?? 0)} ${String.fromCharCode(data1[idx] ?? 0)} ${octal(data2[idx] ?? 0)} ${String.fromCharCode(data2[idx] ?? 0)}`
-      }
-      return [ENC.encode(msg), new IOResult({ exitCode: 1 })]
-    }
-  }
-  const shorter = data1.byteLength < data2.byteLength ? p0 : p1
-  return [ENC.encode(`cmp: EOF on ${shorter.original}`), new IOResult({ exitCode: 1 })]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return cmpGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_CMP = command({

--- a/typescript/packages/core/src/commands/builtin/s3/column.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/column.ts
@@ -14,61 +14,11 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function padRight(s: string, width: number): string {
-  if (s.length >= width) return s
-  return s + ' '.repeat(width - s.length)
-}
-
-function splitLinesNoTrailing(text: string): string[] {
-  const stripped = text.endsWith('\n') ? text.slice(0, -1) : text
-  return stripped === '' ? [] : stripped.split('\n')
-}
-
-function tableFormat(text: string, separator: string | null, outputSep: string): string {
-  const lines = splitLinesNoTrailing(text)
-  if (lines.length === 0) return ''
-  const rows: string[][] = []
-  for (const line of lines) {
-    if (separator !== null && separator !== '') {
-      rows.push(line.split(separator))
-    } else {
-      rows.push(line.split(/\s+/).filter((s) => s !== ''))
-    }
-  }
-  if (rows.length === 0) return ''
-  let maxCols = 0
-  for (const r of rows) {
-    if (r.length > maxCols) maxCols = r.length
-  }
-  const widths = new Array(maxCols).fill(0) as number[]
-  for (const row of rows) {
-    for (let idx = 0; idx < row.length; idx++) {
-      const cell = row[idx] ?? ''
-      if (cell.length > (widths[idx] ?? 0)) widths[idx] = cell.length
-    }
-  }
-  const out: string[] = []
-  for (const row of rows) {
-    const parts: string[] = []
-    for (let idx = 0; idx < row.length; idx++) {
-      const cell = row[idx] ?? ''
-      if (idx < row.length - 1) parts.push(padRight(cell, widths[idx] ?? 0))
-      else parts.push(cell)
-    }
-    out.push(parts.join(outputSep))
-  }
-  return out.join('\n') + '\n'
-}
+import { columnGeneric } from '../generic/column.ts'
 
 async function columnCommand(
   accessor: S3Accessor,
@@ -76,26 +26,9 @@ async function columnCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const tMode = opts.flags.t === true
-  const sFlag = typeof opts.flags.s === 'string' ? opts.flags.s : null
-  const oFlag = typeof opts.flags.o === 'string' ? opts.flags.o : '  '
-  let raw: Uint8Array
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    raw = await s3Read(accessor, first, opts.index ?? undefined)
-  } else {
-    const stdinData = await readStdinAsync(opts.stdin)
-    if (stdinData === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('column: missing input\n') })]
-    }
-    raw = stdinData
-  }
-  const text = DEC.decode(raw)
-  const output = tMode ? tableFormat(text, sFlag, oFlag) : text
-  const result: ByteSource = ENC.encode(output)
-  return [result, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return columnGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_COLUMN = command({

--- a/typescript/packages/core/src/commands/builtin/s3/comm.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/comm.ts
@@ -13,82 +13,12 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function splitLinesNoTrailing(text: string): string[] {
-  const stripped = text.endsWith('\n') ? text.slice(0, -1) : text
-  return stripped === '' ? [] : stripped.split('\n')
-}
-
-type MergeEntry = [number, string]
-
-function commMerge(lines1: readonly string[], lines2: readonly string[]): MergeEntry[] {
-  const result: MergeEntry[] = []
-  let i = 0
-  let j = 0
-  while (i < lines1.length && j < lines2.length) {
-    const a = lines1[i] ?? ''
-    const b = lines2[j] ?? ''
-    if (a < b) {
-      result.push([1, a])
-      i += 1
-    } else if (a > b) {
-      result.push([2, b])
-      j += 1
-    } else {
-      result.push([3, a])
-      i += 1
-      j += 1
-    }
-  }
-  while (i < lines1.length) {
-    result.push([1, lines1[i] ?? ''])
-    i += 1
-  }
-  while (j < lines2.length) {
-    result.push([2, lines2[j] ?? ''])
-    j += 1
-  }
-  return result
-}
-
-function formatComm(
-  merged: readonly MergeEntry[],
-  suppress1: boolean,
-  suppress2: boolean,
-  suppress3: boolean,
-): string {
-  const out: string[] = []
-  for (const [col, text] of merged) {
-    if (col === 1 && !suppress1) {
-      out.push(text)
-    } else if (col === 2 && !suppress2) {
-      const prefix = suppress1 ? '' : '\t'
-      out.push(prefix + text)
-    } else if (col === 3 && !suppress3) {
-      let prefix = ''
-      if (!suppress1) prefix += '\t'
-      if (!suppress2) prefix += '\t'
-      out.push(prefix + text)
-    }
-  }
-  return out.length > 0 ? out.join('\n') + '\n' : ''
-}
-
-function isSorted(lines: readonly string[]): boolean {
-  for (let i = 1; i < lines.length; i++) {
-    if ((lines[i - 1] ?? '') > (lines[i] ?? '')) return false
-  }
-  return true
-}
+import { commGeneric } from '../generic/comm.ts'
 
 async function commCommand(
   accessor: S3Accessor,
@@ -96,29 +26,9 @@ async function commCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length < 2) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('comm: requires two paths\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const p1 = resolved[0]
-  const p2 = resolved[1]
-  if (p1 === undefined || p2 === undefined) return [null, new IOResult()]
-  const data1 = DEC.decode(await s3Read(accessor, p1))
-  const data2 = DEC.decode(await s3Read(accessor, p2))
-  const lines1 = splitLinesNoTrailing(data1)
-  const lines2 = splitLinesNoTrailing(data2)
-  let stderr = ''
-  if (opts.flags['check-order'] === true || opts.flags.check_order === true) {
-    if (!isSorted(lines1)) stderr = 'comm: file 1 is not in sorted order\n'
-    else if (!isSorted(lines2)) stderr = 'comm: file 2 is not in sorted order\n'
-  }
-  const suppress1 = opts.flags.args_1 === true
-  const suppress2 = opts.flags['2'] === true
-  const suppress3 = opts.flags['3'] === true
-  const merged = commMerge(lines1, lines2)
-  const output = formatComm(merged, suppress1, suppress2, suppress3)
-  const result: ByteSource = ENC.encode(output)
-  return [result, new IOResult({ stderr: stderr !== '' ? ENC.encode(stderr) : null })]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return commGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_COMM = command({

--- a/typescript/packages/core/src/commands/builtin/s3/du.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/du.ts
@@ -15,24 +15,10 @@
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { du as s3Du, duAll as s3DuAll } from '../../../core/s3/du.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { humanSize } from '../utils/formatting.ts'
-
-const ENC = new TextEncoder()
-
-function formatSize(size: number, human: boolean): string {
-  return human ? humanSize(size) : String(size)
-}
-
-function depth(entryPath: string, basePath: string): number {
-  const base = basePath.replace(/\/+$/, '')
-  const rel = entryPath.replace(/\/+$/, '').slice(base.length)
-  if (rel === '') return 0
-  return (rel.replace(/^\/+|\/+$/g, '').match(/\//g) ?? []).length + 1
-}
+import { duGeneric } from '../generic/du.ts'
 
 async function duCommand(
   accessor: S3Accessor,
@@ -40,59 +26,14 @@ async function duCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const p0 =
-    resolved[0] ??
-    new PathSpec({
-      original: '/',
-      directory: '/',
-      resolved: false,
-      prefix: opts.mountPrefix ?? '',
-    })
-  const human = opts.flags.h === true
-  const summarize = opts.flags.s === true
-  const all = opts.flags.a === true
-  const cumulate = opts.flags.c === true
-  const maxDepthFlag =
-    typeof opts.flags.max_depth === 'string'
-      ? opts.flags.max_depth
-      : typeof opts.flags['max-depth'] === 'string'
-        ? opts.flags['max-depth']
-        : null
-
-  if (summarize) {
-    const total = await s3Du(accessor, p0)
-    let output = formatSize(total, human) + '\t' + p0.original
-    if (cumulate) output += '\n' + formatSize(total, human) + '\ttotal'
-    return [ENC.encode(output), new IOResult()]
-  }
-  let allEntries = await s3DuAll(accessor, p0)
-  if (allEntries.length === 0) {
-    const total = await s3Du(accessor, p0)
-    let output = formatSize(total, human) + '\t' + p0.original
-    if (cumulate) output += '\n' + formatSize(total, human) + '\ttotal'
-    return [ENC.encode(output), new IOResult()]
-  }
-  if (!all) {
-    allEntries = allEntries.filter(([p]) => p === p0.original)
-  }
-  if (maxDepthFlag !== null) {
-    const md = Number.parseInt(maxDepthFlag, 10)
-    allEntries = allEntries.filter(([p]) => depth(p, p0.original) <= md)
-  }
-  if (allEntries.length === 0) {
-    const total = await s3Du(accessor, p0)
-    let output = formatSize(total, human) + '\t' + p0.original
-    if (cumulate) output += '\n' + formatSize(total, human) + '\ttotal'
-    return [ENC.encode(output), new IOResult()]
-  }
-  const lines = allEntries.map(([p, sz]) => formatSize(sz, human) + '\t' + p)
-  if (cumulate) {
-    const grand = allEntries.reduce((sum, [, sz]) => sum + sz, 0)
-    lines.push(formatSize(grand, human) + '\ttotal')
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return duGeneric(
+    resolved,
+    opts,
+    (p) => s3Du(accessor, p),
+    (p) => s3DuAll(accessor, p),
+  )
 }
 
 export const S3_DU = command({

--- a/typescript/packages/core/src/commands/builtin/s3/expand.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/expand.ts
@@ -14,51 +14,11 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function expandTabs(text: string, tabsize: number): string {
-  const out: string[] = []
-  let col = 0
-  for (const ch of text) {
-    if (ch === '\t') {
-      const spaces = tabsize - (col % tabsize)
-      out.push(' '.repeat(spaces))
-      col += spaces
-    } else if (ch === '\n') {
-      out.push(ch)
-      col = 0
-    } else {
-      out.push(ch)
-      col += 1
-    }
-  }
-  return out.join('')
-}
-
-function expandLeadingTabs(text: string, tabsize: number): string {
-  const lines = text.split('\n')
-  const result: string[] = []
-  for (const line of lines) {
-    let i = 0
-    while (i < line.length && line[i] === '\t') i += 1
-    if (i === 0) {
-      result.push(line)
-    } else {
-      const leading = line.slice(0, i)
-      const rest = line.slice(i)
-      result.push(expandTabs(leading, tabsize) + rest)
-    }
-  }
-  return result.join('\n')
-}
+import { expandGeneric } from '../generic/expand.ts'
 
 async function expandCommand(
   accessor: S3Accessor,
@@ -66,27 +26,9 @@ async function expandCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const tabsize = typeof opts.flags.t === 'string' ? Number.parseInt(opts.flags.t, 10) : 8
-  const leadingOnly = opts.flags.i === true
-  const expander = (txt: string): string =>
-    leadingOnly ? expandLeadingTabs(txt, tabsize) : expandTabs(txt, tabsize)
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const parts: string[] = []
-    for (const p of resolved) {
-      const data = DEC.decode(await s3Read(accessor, p, opts.index ?? undefined))
-      parts.push(expander(data))
-    }
-    const result: ByteSource = ENC.encode(parts.join(''))
-    return [result, new IOResult()]
-  }
-  const stdinData = await readStdinAsync(opts.stdin)
-  if (stdinData === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('expand: missing operand\n') })]
-  }
-  const text = DEC.decode(stdinData)
-  const result: ByteSource = ENC.encode(expander(text))
-  return [result, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return expandGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_EXPAND = command({

--- a/typescript/packages/core/src/commands/builtin/s3/file.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/file.ts
@@ -16,13 +16,10 @@ import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
 import { read as s3Read } from '../../../core/s3/read.ts'
 import { stat as s3Stat } from '../../../core/s3/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { FileType, ResourceName, type PathSpec } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
-import { detectFileType, formatFileResult } from '../file_helper.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
+import { fileGeneric } from '../generic/file.ts'
 
 async function fileCommand(
   accessor: S3Accessor,
@@ -30,31 +27,14 @@ async function fileCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('file: missing operand\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const first = resolved[0]
-  if (first === undefined) return [null, new IOResult()]
-  const brief = opts.flags.b === true
-  const mime = opts.flags.i === true
-  const s = await s3Stat(accessor, first, opts.index ?? undefined)
-  let result: FileType
-  if (s.type === FileType.DIRECTORY) {
-    result = FileType.DIRECTORY
-  } else {
-    let header: Uint8Array
-    try {
-      const data = await s3Read(accessor, first, opts.index ?? undefined)
-      header = data.subarray(0, 512)
-    } catch {
-      header = new Uint8Array(0)
-    }
-    result = detectFileType(header, s)
-  }
-  const line = formatFileResult(first.original, result, brief, mime)
-  const out: ByteSource = ENC.encode(line)
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return fileGeneric(
+    resolved,
+    opts,
+    (p) => s3Stat(accessor, p, opts.index ?? undefined),
+    (p) => s3Read(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const S3_FILE = command({

--- a/typescript/packages/core/src/commands/builtin/s3/find.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/find.ts
@@ -14,122 +14,17 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { find as s3Find } from '../../../core/s3/find.ts'
-import { resolveGlob } from '../../../core/s3/glob.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
-import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { ResourceName } from '../../../types.ts'
+import { command } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { findGeneric } from '../generic/find.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-function parseSize(spec: string): [number | null, number | null] {
-  const suffixes: Record<string, number> = { c: 1, k: 1024, M: 1024 ** 2, G: 1024 ** 3 }
-  const sign = spec.startsWith('+') ? '+' : spec.startsWith('-') ? '-' : ''
-  const raw = sign === '' ? spec : spec.slice(1)
-  const lastChar = raw.slice(-1)
-  const mult = suffixes[lastChar] ?? 1
-  const numPart = lastChar in suffixes ? raw.slice(0, -1) : raw
-  const num = Number.parseInt(numPart, 10) * mult
-  if (sign === '+') return [num, null]
-  if (sign === '-') return [null, num]
-  return [num, num]
-}
-
-function parseMtime(spec: string): [number | null, number | null] {
-  const now = Date.now() / 1000
-  const day = 86_400
-  const n = Number.parseInt(spec.replace(/^[+-]/, ''), 10)
-  if (spec.startsWith('+')) return [null, now - n * day]
-  if (spec.startsWith('-')) return [now - n * day, null]
-  return [now - (n + 1) * day, now - n * day]
-}
-
-function extractNotName(texts: readonly string[]): string | null {
-  for (let i = 0; i < texts.length; i++) {
-    const pat = texts[i + 2]
-    if (texts[i] === '-not' && texts[i + 1] === '-name' && pat !== undefined) {
-      return pat
-    }
-  }
-  return null
-}
-
-function extractOrNames(name: string | null, texts: readonly string[]): string[] {
-  const names: string[] = []
-  if (name !== null) names.push(name)
-  let i = 0
-  while (i < texts.length) {
-    const pat = texts[i + 2]
-    if (
-      (texts[i] === '-or' || texts[i] === '-o') &&
-      texts[i + 1] === '-name' &&
-      pat !== undefined
-    ) {
-      names.push(pat)
-      i += 3
-    } else {
-      i += 1
-    }
-  }
-  return names
-}
-
-async function findCommand(
-  accessor: S3Accessor,
-  paths: PathSpec[],
-  texts: string[],
-  opts: CommandOpts,
-): Promise<CommandFnResult> {
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const p0 =
-    resolved[0] ??
-    new PathSpec({ original: '/', directory: '/', resolved: false, prefix: opts.mountPrefix ?? '' })
-  const nameFlag = typeof opts.flags.name === 'string' ? opts.flags.name : null
-  const inameFlag = typeof opts.flags.iname === 'string' ? opts.flags.iname : null
-  const typeFlag = typeof opts.flags.type === 'string' ? opts.flags.type : null
-  const pathFlag = typeof opts.flags.path === 'string' ? opts.flags.path : null
-  const maxDepthFlag = typeof opts.flags.maxdepth === 'string' ? opts.flags.maxdepth : null
-  const minDepthFlag = typeof opts.flags.mindepth === 'string' ? opts.flags.mindepth : null
-  const sizeFlag = typeof opts.flags.size === 'string' ? opts.flags.size : null
-  const mtimeFlag = typeof opts.flags.mtime === 'string' ? opts.flags.mtime : null
-  const findType: 'f' | 'd' | null = typeFlag === 'f' ? 'f' : typeFlag === 'd' ? 'd' : null
-  const maxDepth = maxDepthFlag !== null ? Number.parseInt(maxDepthFlag, 10) : null
-  const minDepth = minDepthFlag !== null ? Number.parseInt(minDepthFlag, 10) : null
-  const [minSize, maxSize] = sizeFlag !== null ? parseSize(sizeFlag) : [null, null]
-  const [mtimeMin, mtimeMax] = mtimeFlag !== null ? parseMtime(mtimeFlag) : [null, null]
-  const nameExclude = extractNotName(texts)
-  const orNames = extractOrNames(nameFlag, texts)
-  let results: string[]
-  try {
-    results = await s3Find(accessor, p0, {
-      name: nameFlag,
-      iname: inameFlag,
-      type: findType,
-      ...(maxDepth !== null ? { maxDepth } : {}),
-      ...(minDepth !== null ? { minDepth } : {}),
-      ...(minSize !== null ? { minSize } : {}),
-      ...(maxSize !== null ? { maxSize } : {}),
-      ...(mtimeMin !== null ? { mtimeMin } : {}),
-      ...(mtimeMax !== null ? { mtimeMax } : {}),
-      ...(nameExclude !== null ? { nameExclude } : {}),
-      ...(pathFlag !== null ? { pathPattern: pathFlag } : {}),
-      ...(orNames.length > 1 ? { orNames } : {}),
-    })
-  } catch {
-    results = []
-  }
-  if (p0.prefix !== '') {
-    results = results.map((r) => p0.prefix + '/' + r.replace(/^\/+/, ''))
-  }
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  return [out, new IOResult()]
-}
 
 export const S3_FIND = command({
   name: 'find',
   resource: ResourceName.S3,
   spec: specOf('find'),
-  fn: findCommand,
+  fn: (accessor: S3Accessor, paths, texts, opts) =>
+    findGeneric(paths, texts, opts, (root, options) => s3Find(accessor, root, options)),
   provision: metadataProvision,
 })

--- a/typescript/packages/core/src/commands/builtin/s3/fold.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/fold.ts
@@ -14,43 +14,11 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function splitLinesNoTrailing(text: string): string[] {
-  const stripped = text.endsWith('\n') ? text.slice(0, -1) : text
-  return stripped === '' ? [] : stripped.split('\n')
-}
-
-function foldLine(line: string, width: number, breakSpaces: boolean): string {
-  if (line.length <= width) return line
-  const parts: string[] = []
-  let rest = line
-  while (rest.length > width) {
-    if (breakSpaces) {
-      const idx = rest.lastIndexOf(' ', width - 1)
-      if (idx > 0) {
-        parts.push(rest.slice(0, idx + 1))
-        rest = rest.slice(idx + 1)
-      } else {
-        parts.push(rest.slice(0, width))
-        rest = rest.slice(width)
-      }
-    } else {
-      parts.push(rest.slice(0, width))
-      rest = rest.slice(width)
-    }
-  }
-  if (rest !== '') parts.push(rest)
-  return parts.join('\n')
-}
+import { foldGeneric } from '../generic/fold.ts'
 
 async function foldCommand(
   accessor: S3Accessor,
@@ -58,29 +26,9 @@ async function foldCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const width = typeof opts.flags.w === 'string' ? Number.parseInt(opts.flags.w, 10) : 80
-  const breakSpaces = opts.flags.s === true
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const allLines: string[] = []
-    for (const p of resolved) {
-      const data = DEC.decode(await s3Read(accessor, p, opts.index ?? undefined))
-      for (const line of splitLinesNoTrailing(data)) {
-        allLines.push(foldLine(line, width, breakSpaces))
-      }
-    }
-    const result: ByteSource = ENC.encode(allLines.join('\n') + '\n')
-    return [result, new IOResult()]
-  }
-  const stdinData = await readStdinAsync(opts.stdin)
-  if (stdinData === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('fold: missing operand\n') })]
-  }
-  const lines = splitLinesNoTrailing(DEC.decode(stdinData))
-  const result: ByteSource = ENC.encode(
-    lines.map((ln) => foldLine(ln, width, breakSpaces)).join('\n') + '\n',
-  )
-  return [result, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return foldGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_FOLD = command({

--- a/typescript/packages/core/src/commands/builtin/s3/join.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/join.ts
@@ -14,135 +14,11 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { type PathSpec, ResourceName } from '../../../types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function splitLinesNoTrailing(text: string): string[] {
-  const stripped = text.endsWith('\n') ? text.slice(0, -1) : text
-  return stripped === '' ? [] : stripped.split('\n')
-}
-
-function splitFields(line: string, delimiter: string | null): string[] {
-  if (delimiter !== null && delimiter !== '') return line.split(delimiter)
-  return line.split(/\s+/).filter((s) => s !== '')
-}
-
-function buildJoinMap(
-  lines: readonly string[],
-  fieldIdx: number,
-  delimiter: string | null,
-): Map<string, string[][]> {
-  const result = new Map<string, string[][]>()
-  for (const line of lines) {
-    const parts = splitFields(line, delimiter)
-    if (fieldIdx < parts.length) {
-      const key = parts[fieldIdx] ?? ''
-      const rest = parts.slice(0, fieldIdx).concat(parts.slice(fieldIdx + 1))
-      const list = result.get(key)
-      if (list === undefined) result.set(key, [rest])
-      else list.push(rest)
-    }
-  }
-  return result
-}
-
-function formatRow(
-  key: string,
-  rest1: readonly string[],
-  rest2: readonly string[],
-  oFmt: string | null,
-  outSep: string,
-): string {
-  if (oFmt === null) return [key, ...rest1, ...rest2].join(outSep)
-  const fields: string[] = []
-  for (const spec of oFmt.split(',')) {
-    const trimmed = spec.trim()
-    if (trimmed === '0') {
-      fields.push(key)
-    } else {
-      const parts = trimmed.split('.')
-      const fileN = Number.parseInt(parts[0] ?? '', 10)
-      const fieldM = Number.parseInt(parts[1] ?? '', 10) - 1
-      const src = fileN === 1 ? rest1 : rest2
-      if (fieldM >= 0 && fieldM < src.length) fields.push(src[fieldM] ?? '')
-      else fields.push('')
-    }
-  }
-  return fields.join(outSep)
-}
-
-function firstValue<K, V>(map: Map<K, V>): V | undefined {
-  for (const v of map.values()) return v
-  return undefined
-}
-
-function joinLines(
-  lines1: readonly string[],
-  lines2: readonly string[],
-  field1: number,
-  field2: number,
-  sep: string | null,
-  aFlag: string | null,
-  vFlag: string | null,
-  eFlag: string | null,
-  oFlag: string | null,
-): string[] {
-  const map1 = buildJoinMap(lines1, field1, sep)
-  const map2 = buildJoinMap(lines2, field2, sep)
-  const outSep = sep !== null && sep !== '' ? sep : ' '
-  const outLines: string[] = []
-  const matchedKeys2 = new Set<string>()
-
-  for (const line of lines1) {
-    const parts = splitFields(line, sep)
-    if (field1 >= parts.length) continue
-    const key = parts[field1] ?? ''
-    const rest1 = parts.slice(0, field1).concat(parts.slice(field1 + 1))
-    const hit = map2.get(key)
-    if (hit !== undefined) {
-      matchedKeys2.add(key)
-      if (vFlag === null) {
-        for (const rest2 of hit) {
-          outLines.push(formatRow(key, rest1, rest2, oFlag, outSep))
-        }
-      }
-    } else {
-      if (vFlag === '1' || aFlag === '1') {
-        let placeholder: string[] = []
-        if (oFlag !== null && eFlag !== null && map2.size > 0) {
-          const sample = firstValue(map2)?.[0]
-          if (sample !== undefined) placeholder = sample.map(() => eFlag)
-        }
-        outLines.push(formatRow(key, rest1, placeholder, oFlag, outSep))
-      }
-    }
-  }
-
-  if (aFlag === '2' || vFlag === '2') {
-    for (const line of lines2) {
-      const parts = splitFields(line, sep)
-      if (field2 >= parts.length) continue
-      const key = parts[field2] ?? ''
-      if (!matchedKeys2.has(key)) {
-        const rest2 = parts.slice(0, field2).concat(parts.slice(field2 + 1))
-        let placeholder: string[] = []
-        if (oFlag !== null && eFlag !== null && map1.size > 0) {
-          const sample = firstValue(map1)?.[0]
-          if (sample !== undefined) placeholder = sample.map(() => eFlag)
-        }
-        outLines.push(formatRow(key, placeholder, rest2, oFlag, outSep))
-      }
-    }
-  }
-
-  return outLines
-}
+import { joinGeneric } from '../generic/join.ts'
 
 async function joinCommand(
   accessor: S3Accessor,
@@ -150,30 +26,9 @@ async function joinCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length < 2) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('join: requires two paths\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const p1 = resolved[0]
-  const p2 = resolved[1]
-  if (p1 === undefined || p2 === undefined) return [null, new IOResult()]
-  const field1 =
-    (typeof opts.flags.args_1 === 'string' ? Number.parseInt(opts.flags.args_1, 10) : 1) - 1
-  const field2 =
-    (typeof opts.flags['2'] === 'string' ? Number.parseInt(opts.flags['2'], 10) : 1) - 1
-  const sep = typeof opts.flags.t === 'string' ? opts.flags.t : null
-  const aFlag = typeof opts.flags.a === 'string' ? opts.flags.a : null
-  const vFlag = typeof opts.flags.v === 'string' ? opts.flags.v : null
-  const eFlag = typeof opts.flags.e === 'string' ? opts.flags.e : null
-  const oFlag = typeof opts.flags.o === 'string' ? opts.flags.o : null
-  const data1 = DEC.decode(await s3Read(accessor, p1, opts.index ?? undefined))
-  const data2 = DEC.decode(await s3Read(accessor, p2, opts.index ?? undefined))
-  const lines1 = splitLinesNoTrailing(data1)
-  const lines2 = splitLinesNoTrailing(data2)
-  const out = joinLines(lines1, lines2, field1, field2, sep, aFlag, vFlag, eFlag, oFlag)
-  if (out.length === 0) return [null, new IOResult()]
-  const result: ByteSource = ENC.encode(out.join('\n') + '\n')
-  return [result, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return joinGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_JOIN = command({

--- a/typescript/packages/core/src/commands/builtin/s3/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/jq.ts
@@ -13,28 +13,15 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
 import { stat as s3Stat } from '../../../core/s3/stat.ts'
 import { stream as s3Stream } from '../../../core/s3/stream.ts'
-import {
-  concatBytes,
-  evalJsonlStream,
-  formatJqOutput,
-  isJsonlPath,
-  isStreamableJsonlExpr,
-  jqEval,
-  parseJsonAuto,
-  parseJsonPath,
-} from '../../../core/jq/index.ts'
+import { isJsonlPath, isStreamableJsonlExpr } from '../../../core/jq/index.ts'
 import { Precision, ProvisionResult } from '../../../provision/types.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
+import { jqGeneric } from '../generic/jq.ts'
 
 export async function jqProvision(
   accessor: S3Accessor,
@@ -75,51 +62,9 @@ async function jqCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const expression = texts[0]
-  if (expression === undefined) {
-    return [
-      null,
-      new IOResult({ exitCode: 1, stderr: ENC.encode('jq: usage: jq EXPRESSION [path]\n') }),
-    ]
-  }
-  const raw = opts.flags.r === true
-  const compact = opts.flags.c === true
-  const slurp = opts.flags.s === true
-
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    if (isJsonlPath(first.original) && isStreamableJsonlExpr(expression)) {
-      return [evalJsonlStream(s3Stream(accessor, first), expression), new IOResult()]
-    }
-    const outputs: Uint8Array[] = []
-    const spread = expression.includes('[]')
-    for (const p of resolved) {
-      const bytes = await s3Read(accessor, p)
-      let data = parseJsonPath(bytes, p.original)
-      if (isJsonlPath(p.original) && Array.isArray(data) && !slurp) {
-        for (const item of data) {
-          const result = await jqEval(item, expression.trim())
-          outputs.push(formatJqOutput(result, raw, compact, spread))
-        }
-        continue
-      }
-      if (slurp && !Array.isArray(data)) data = [data]
-      const result = await jqEval(data, expression.trim())
-      outputs.push(formatJqOutput(result, raw, compact, spread))
-    }
-    const out: ByteSource = concatBytes(outputs)
-    return [out, new IOResult()]
-  }
-
-  const stdinBytes = await readStdinAsync(opts.stdin)
-  if (stdinBytes === null) return [null, new IOResult()]
-  let stdinData = parseJsonAuto(stdinBytes)
-  if (slurp && !Array.isArray(stdinData)) stdinData = [stdinData]
-  const stdinResult = await jqEval(stdinData, expression.trim())
-  const stdinSpread = expression.includes('[]')
-  return [formatJqOutput(stdinResult, raw, compact, stdinSpread), new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return jqGeneric(resolved, texts, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_JQ = command({

--- a/typescript/packages/core/src/commands/builtin/s3/look.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/look.ts
@@ -13,21 +13,12 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function splitLinesNoTrailing(text: string): string[] {
-  const stripped = text.endsWith('\n') ? text.slice(0, -1) : text
-  return stripped === '' ? [] : stripped.split('\n')
-}
+import { lookGeneric } from '../generic/look.ts'
 
 async function lookCommand(
   accessor: S3Accessor,
@@ -35,34 +26,9 @@ async function lookCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (texts.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('look: missing prefix\n') })]
-  }
-  const prefix = texts[0] ?? ''
-  const caseInsensitive = opts.flags.f === true
-  let raw: Uint8Array
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    raw = await s3Read(accessor, first)
-  } else {
-    const stdinData = await readStdinAsync(opts.stdin)
-    if (stdinData === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('look: missing input\n') })]
-    }
-    raw = stdinData
-  }
-  const lines = splitLinesNoTrailing(DEC.decode(raw))
-  const cmpPrefix = caseInsensitive ? prefix.toLowerCase() : prefix
-  const matched: string[] = []
-  for (const line of lines) {
-    const cmpLine = caseInsensitive ? line.toLowerCase() : line
-    if (cmpLine.startsWith(cmpPrefix)) matched.push(line)
-  }
-  if (matched.length === 0) return [null, new IOResult({ exitCode: 1 })]
-  const result: ByteSource = ENC.encode(matched.join('\n') + '\n')
-  return [result, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return lookGeneric(resolved, texts, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_LOOK = command({

--- a/typescript/packages/core/src/commands/builtin/s3/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/ls.ts
@@ -16,132 +16,11 @@ import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
 import { readdir as s3Readdir } from '../../../core/s3/readdir.ts'
 import { stat as s3Stat } from '../../../core/s3/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { humanSize } from '../utils/formatting.ts'
+import { lsGeneric } from '../generic/ls.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-async function lsEntries(
-  accessor: S3Accessor,
-  path: PathSpec,
-  allFiles: boolean,
-  sortBy: 'name' | 'time' | 'size',
-  reverse: boolean,
-  listDir: boolean,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<FileStat[]> {
-  if (listDir) {
-    const s = await s3Stat(accessor, path, indexCache ?? undefined)
-    return [s]
-  }
-  let entries: string[]
-  try {
-    entries = await s3Readdir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`ls: cannot access '${path.original}': ${msg}`)
-    return []
-  }
-  const stats: FileStat[] = []
-  for (const entry of entries) {
-    try {
-      const eSpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await s3Stat(accessor, eSpec, indexCache ?? undefined)
-      if (!allFiles && s.name.startsWith('.')) continue
-      stats.push(s)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${entry}': ${msg}`)
-    }
-  }
-  if (sortBy === 'time') {
-    stats.sort((a, b) => (a.modified ?? '').localeCompare(b.modified ?? ''))
-    if (!reverse) stats.reverse()
-  } else if (sortBy === 'size') {
-    stats.sort((a, b) => (a.size ?? 0) - (b.size ?? 0))
-    if (!reverse) stats.reverse()
-  } else {
-    stats.sort((a, b) => a.name.localeCompare(b.name))
-    if (reverse) stats.reverse()
-  }
-  return stats
-}
-
-async function walkGrouped(
-  accessor: S3Accessor,
-  path: PathSpec,
-  allFiles: boolean,
-  sortBy: 'name' | 'time' | 'size',
-  reverse: boolean,
-  groups: [PathSpec, FileStat[]][],
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<void> {
-  const here = await lsEntries(
-    accessor,
-    path,
-    allFiles,
-    sortBy,
-    reverse,
-    false,
-    warnings,
-    indexCache,
-  )
-  groups.push([path, here])
-  for (const s of here) {
-    if (s.type === FileType.DIRECTORY) {
-      const entryPath = path.child(s.name)
-      const entrySpec = new PathSpec({
-        original: entryPath,
-        directory: entryPath,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      await walkGrouped(
-        accessor,
-        entrySpec,
-        allFiles,
-        sortBy,
-        reverse,
-        groups,
-        warnings,
-        indexCache,
-      )
-    }
-  }
-}
-
-function formatEntries(
-  entries: readonly FileStat[],
-  results: string[],
-  long: boolean,
-  human: boolean,
-  classify: boolean,
-): void {
-  if (long) {
-    for (const e of entries) {
-      const sizeStr = human ? humanSize(e.size ?? 0) : String(e.size ?? 0)
-      results.push(`${e.type ?? '-'}\t${sizeStr}\t${e.modified ?? ''}\t${e.name}`)
-    }
-  } else {
-    for (const e of entries) {
-      const isDir = classify && e.type === FileType.DIRECTORY
-      const name = isDir ? e.name + '/' : e.name
-      results.push(name)
-    }
-  }
-}
 
 async function lsCommand(
   accessor: S3Accessor,
@@ -149,68 +28,14 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const targets: PathSpec[] =
-    resolved.length > 0
-      ? resolved
-      : [
-          new PathSpec({
-            original: opts.cwd,
-            directory: opts.cwd,
-            resolved: false,
-            prefix: opts.mountPrefix ?? '',
-          }),
-        ]
-  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
-  const allFiles = opts.flags.a === true || opts.flags.A === true
-  const human = opts.flags.h === true
-  const reverse = opts.flags.r === true
-  const recursive = opts.flags.R === true
-  const listDir = opts.flags.d === true
-  const classify = opts.flags.F === true
-  const sortBy: 'name' | 'time' | 'size' =
-    opts.flags.t === true ? 'time' : opts.flags.S === true ? 'size' : 'name'
-  const warnings: string[] = []
-  const results: string[] = []
-  if (recursive && !listDir) {
-    const groups: [PathSpec, FileStat[]][] = []
-    for (const p of targets) {
-      await walkGrouped(accessor, p, allFiles, sortBy, reverse, groups, warnings, opts.index)
-    }
-    for (let i = 0; i < groups.length; i++) {
-      const group = groups[i]
-      if (group === undefined) continue
-      const [dirSpec, entries] = group
-      if (i > 0) results.push('')
-      results.push(`${dirSpec.original}:`)
-      formatEntries(entries, results, long, human, classify)
-    }
-  } else {
-    for (const p of targets) {
-      let entries: FileStat[]
-      try {
-        entries = await lsEntries(
-          accessor,
-          p,
-          allFiles,
-          sortBy,
-          reverse,
-          listDir,
-          warnings,
-          opts.index,
-        )
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err)
-        warnings.push(`ls: cannot access '${p.original}': ${msg}`)
-        continue
-      }
-      formatEntries(entries, results, long, human, classify)
-    }
-  }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  return [out, new IOResult({ stderr, exitCode })]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return lsGeneric(
+    resolved,
+    opts,
+    (p) => s3Readdir(accessor, p, opts.index ?? undefined),
+    (p) => s3Stat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const S3_LS = command({

--- a/typescript/packages/core/src/commands/builtin/s3/md5.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/md5.ts
@@ -13,14 +13,12 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
+import { resolveGlob } from '../../../core/s3/glob.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
-import { md5Hex } from '../../../utils/hash.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
+import { md5Generic } from '../generic/md5.ts'
 
 async function md5Command(
   accessor: S3Accessor,
@@ -28,20 +26,9 @@ async function md5Command(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const lines: string[] = []
-  if (paths.length > 0) {
-    for (const p of paths) {
-      const data = await s3Read(accessor, p, opts.index ?? undefined)
-      lines.push(`${md5Hex(data)}  ${p.original}`)
-    }
-  } else if (opts.stdin !== null) {
-    const data = await materialize(opts.stdin)
-    lines.push(`${md5Hex(data)}  -`)
-  } else {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('md5: missing operand\n') })]
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return md5Generic(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_MD5 = command({

--- a/typescript/packages/core/src/commands/builtin/s3/nl.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/nl.ts
@@ -15,72 +15,10 @@
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
 import { stream as s3Stream } from '../../../core/s3/stream.ts'
-import { AsyncLineIterator } from '../../../io/async_line_iterator.ts'
-import { IOResult } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { resolveSource } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-interface NlOptions {
-  bodyNumbering: string
-  start: number
-  increment: number
-  width: number
-  separator: string
-  pattern: RegExp | null
-}
-
-function padLeft(value: string, width: number): string {
-  return value.length >= width ? value : ' '.repeat(width - value.length) + value
-}
-
-function shouldNumber(line: string, bodyNumbering: string, pattern: RegExp | null): boolean {
-  if (bodyNumbering === 'n') return false
-  if (bodyNumbering === 'a') return true
-  if (bodyNumbering === 'p' && pattern !== null) return pattern.test(line)
-  return line.trim() !== ''
-}
-
-async function* nlStream(
-  source: AsyncIterable<Uint8Array>,
-  opts: NlOptions,
-): AsyncIterable<Uint8Array> {
-  let num = opts.start
-  const iter = new AsyncLineIterator(source)
-  for await (const raw of iter) {
-    const line = DEC.decode(raw)
-    if (shouldNumber(line, opts.bodyNumbering, opts.pattern)) {
-      yield ENC.encode(`${padLeft(String(num), opts.width)}${opts.separator}${line}\n`)
-      num += opts.increment
-    } else {
-      yield ENC.encode(`${' '.repeat(opts.width)}${opts.separator}${line}\n`)
-    }
-  }
-}
-
-function parseOptions(flags: Record<string, string | boolean>): NlOptions {
-  const b = typeof flags.b === 'string' ? flags.b : 't'
-  let bodyNumbering = b
-  let pattern: RegExp | null = null
-  if (b.startsWith('p')) {
-    bodyNumbering = 'p'
-    pattern = new RegExp(b.slice(1))
-  }
-  const parseIntFlag = (key: 'v' | 'i' | 'w', fallback: number): number =>
-    typeof flags[key] === 'string' ? Number.parseInt(flags[key], 10) : fallback
-  return {
-    bodyNumbering,
-    start: parseIntFlag('v', 1),
-    increment: parseIntFlag('i', 1),
-    width: parseIntFlag('w', 6),
-    separator: typeof flags.s === 'string' ? flags.s : '\t',
-    pattern,
-  }
-}
+import { nlGeneric } from '../generic/nl.ts'
 
 async function nlCommand(
   accessor: S3Accessor,
@@ -88,20 +26,9 @@ async function nlCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const nlOpts = parseOptions(opts.flags)
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    return [nlStream(s3Stream(accessor, first), nlOpts), new IOResult()]
-  }
-  try {
-    const source = resolveSource(opts.stdin, 'nl: missing operand')
-    return [nlStream(source, nlOpts), new IOResult()]
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-  }
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return nlGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_NL = command({

--- a/typescript/packages/core/src/commands/builtin/s3/paste.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/paste.ts
@@ -13,21 +13,12 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function splitLinesNoEnds(text: string): string[] {
-  const stripped = text.endsWith('\n') ? text.slice(0, -1) : text
-  return stripped === '' ? [] : stripped.split('\n')
-}
+import { pasteGeneric } from '../generic/paste.ts'
 
 async function pasteCommand(
   accessor: S3Accessor,
@@ -35,41 +26,9 @@ async function pasteCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const delimiter = typeof opts.flags.d === 'string' ? opts.flags.d : '\t'
-  const serial = opts.flags.s === true
   const resolved =
-    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : paths
-  const fileLines: string[][] = []
-  let stdinConsumed = false
-  for (const p of resolved) {
-    if (p.original === '-') {
-      const raw = stdinConsumed ? null : await readStdinAsync(opts.stdin)
-      stdinConsumed = true
-      fileLines.push(splitLinesNoEnds(raw !== null ? DEC.decode(raw) : ''))
-    } else {
-      const data = await s3Read(accessor, p)
-      fileLines.push(splitLinesNoEnds(DEC.decode(data)))
-    }
-  }
-  if (fileLines.length === 0 && !stdinConsumed) {
-    const raw = await readStdinAsync(opts.stdin)
-    if (raw !== null) fileLines.push(splitLinesNoEnds(DEC.decode(raw)))
-  }
-  if (fileLines.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('paste: missing operand\n') })]
-  }
-  let outLines: string[]
-  if (serial) {
-    outLines = fileLines.map((lines) => lines.join(delimiter))
-  } else {
-    const maxLen = Math.max(...fileLines.map((l) => l.length))
-    outLines = []
-    for (let i = 0; i < maxLen; i++) {
-      outLines.push(fileLines.map((lines) => lines[i] ?? '').join(delimiter))
-    }
-  }
-  const out: ByteSource = ENC.encode(outLines.join('\n') + '\n')
-  return [out, new IOResult()]
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return pasteGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_PASTE = command({

--- a/typescript/packages/core/src/commands/builtin/s3/readlink.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/readlink.ts
@@ -12,66 +12,15 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { S3Accessor } from '../../../accessor/s3.ts'
-import { resolveGlob } from '../../../core/s3/glob.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { ResourceName, type PathSpec } from '../../../types.ts'
-import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import type { Accessor } from '../../../accessor/base.ts'
+import { ResourceName } from '../../../types.ts'
+import { command } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function posixNormpath(p: string): string {
-  const isAbs = p.startsWith('/')
-  const parts = p.split('/')
-  const out: string[] = []
-  for (const seg of parts) {
-    if (seg === '' || seg === '.') continue
-    if (seg === '..') {
-      if (out.length > 0 && out[out.length - 1] !== '..') {
-        out.pop()
-      } else if (!isAbs) {
-        out.push('..')
-      }
-      continue
-    }
-    out.push(seg)
-  }
-  const joined = out.join('/')
-  if (isAbs) return '/' + joined
-  return joined === '' ? '.' : joined
-}
-
-async function readlinkCommand(
-  accessor: S3Accessor,
-  paths: PathSpec[],
-  _texts: string[],
-  opts: CommandOpts,
-): Promise<CommandFnResult> {
-  if (paths.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('readlink: missing operand\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const fFlag = opts.flags.f === true
-  const eFlag = opts.flags.e === true
-  const mFlag = opts.flags.m === true
-  const nFlag = opts.flags.n === true
-  const normalize = fFlag || eFlag || mFlag
-  const results: string[] = []
-  for (const p of resolved) {
-    let vp = p.original
-    if (normalize) vp = posixNormpath(vp)
-    results.push(vp)
-  }
-  let text = results.join('\n')
-  if (!nFlag) text += '\n'
-  const out: ByteSource = ENC.encode(text)
-  return [out, new IOResult()]
-}
+import { readlinkGeneric } from '../generic/readlink.ts'
 
 export const S3_READLINK = command({
   name: 'readlink',
   resource: ResourceName.S3,
   spec: specOf('readlink'),
-  fn: readlinkCommand,
+  fn: (_accessor: Accessor, paths, texts, opts) => readlinkGeneric(paths, texts, opts),
 })

--- a/typescript/packages/core/src/commands/builtin/s3/realpath.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/realpath.ts
@@ -13,79 +13,16 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
-import { resolveGlob } from '../../../core/s3/glob.ts'
 import { stat as s3Stat } from '../../../core/s3/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
-import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { ResourceName } from '../../../types.ts'
+import { command } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function posixNormpath(p: string): string {
-  const isAbs = p.startsWith('/')
-  const parts = p.split('/')
-  const out: string[] = []
-  for (const seg of parts) {
-    if (seg === '' || seg === '.') continue
-    if (seg === '..') {
-      if (out.length > 0 && out[out.length - 1] !== '..') {
-        out.pop()
-      } else if (!isAbs) {
-        out.push('..')
-      }
-      continue
-    }
-    out.push(seg)
-  }
-  const joined = out.join('/')
-  if (isAbs) return '/' + joined
-  return joined === '' ? '.' : joined
-}
-
-async function existsPath(accessor: S3Accessor, path: PathSpec): Promise<boolean> {
-  try {
-    await s3Stat(accessor, path)
-    return true
-  } catch {
-    return false
-  }
-}
-
-async function realpathCommand(
-  accessor: S3Accessor,
-  paths: PathSpec[],
-  _texts: string[],
-  opts: CommandOpts,
-): Promise<CommandFnResult> {
-  const resolved =
-    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
-  const eFlag = opts.flags.e === true
-  const mountPrefix = resolved[0]?.prefix ?? ''
-  const lines: string[] = []
-  for (const p of resolved) {
-    const normalized = posixNormpath(p.original)
-    if (eFlag) {
-      const probe = new PathSpec({
-        original: normalized,
-        directory: normalized,
-        resolved: false,
-        prefix: mountPrefix,
-      })
-      if (!(await existsPath(accessor, probe))) {
-        const msg = `realpath: '${p.original}': No such file or directory\n`
-        return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(msg) })]
-      }
-    }
-    lines.push(normalized)
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
-  return [out, new IOResult()]
-}
+import { realpathGeneric } from '../generic/realpath.ts'
 
 export const S3_REALPATH = command({
   name: 'realpath',
   resource: ResourceName.S3,
   spec: specOf('realpath'),
-  fn: realpathCommand,
+  fn: (accessor: S3Accessor, paths, texts, opts) =>
+    realpathGeneric(paths, texts, opts, (p) => s3Stat(accessor, p, opts.index ?? undefined)),
 })

--- a/typescript/packages/core/src/commands/builtin/s3/rev.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/rev.ts
@@ -14,19 +14,11 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function reverseString(s: string): string {
-  return Array.from(s).reverse().join('')
-}
+import { revGeneric } from '../generic/rev.ts'
 
 async function revCommand(
   accessor: S3Accessor,
@@ -34,36 +26,9 @@ async function revCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const allLines: string[] = []
-    for (const p of resolved) {
-      const data = DEC.decode(await s3Read(accessor, p, opts.index ?? undefined))
-      for (const line of data.split('\n')) {
-        // Python's splitlines drops a single trailing empty line.
-        allLines.push(line)
-      }
-      // Match Python splitlines(): drop trailing empty if data ended with \n
-      if (data.endsWith('\n') && allLines[allLines.length - 1] === '') {
-        allLines.pop()
-      }
-    }
-    const reversedLines = allLines.map(reverseString)
-    const out: ByteSource = ENC.encode(reversedLines.join('\n') + '\n')
-    return [out, new IOResult()]
-  }
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('rev: missing operand\n') })]
-  }
-  const text = DEC.decode(raw)
-  const lines = text.split('\n')
-  if (text.endsWith('\n') && lines[lines.length - 1] === '') {
-    lines.pop()
-  }
-  const reversedLines = lines.map(reverseString)
-  const out: ByteSource = ENC.encode(reversedLines.join('\n') + '\n')
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return revGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_REV = command({

--- a/typescript/packages/core/src/commands/builtin/s3/sha256sum.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/sha256sum.ts
@@ -14,68 +14,11 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
 import { stream as s3Stream } from '../../../core/s3/stream.ts'
-import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
-import { sha256Hex } from '../../../utils/hash.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { resolveSource } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-async function hashOfStream(source: AsyncIterable<Uint8Array>): Promise<string> {
-  const data = await materialize(source)
-  return sha256Hex(data)
-}
-
-async function* sha256SingleStream(
-  source: AsyncIterable<Uint8Array>,
-  label: string,
-): AsyncIterable<Uint8Array> {
-  const digest = await hashOfStream(source)
-  yield ENC.encode(`${digest}  ${label}\n`)
-}
-
-async function* sha256Multi(
-  accessor: S3Accessor,
-  paths: readonly PathSpec[],
-): AsyncIterable<Uint8Array> {
-  for (const p of paths) {
-    const digest = await hashOfStream(s3Stream(accessor, p))
-    yield ENC.encode(`${digest}  ${p.stripPrefix}\n`)
-  }
-}
-
-async function sha256Check(accessor: S3Accessor, p: PathSpec): Promise<[Uint8Array, number]> {
-  const data = DEC.decode(await s3Read(accessor, p))
-  const lines: string[] = []
-  let failed = false
-  const mountPrefix = p.prefix
-  for (const line of data.split('\n')) {
-    if (line.trim() === '') continue
-    const idx = line.indexOf('  ')
-    if (idx < 0) continue
-    const expected = line.slice(0, idx)
-    const filename = line.slice(idx + 2)
-    const spec = new PathSpec({
-      original: filename,
-      directory: filename,
-      resolved: false,
-      prefix: mountPrefix,
-    })
-    const digest = await hashOfStream(s3Stream(accessor, spec))
-    if (digest === expected) {
-      lines.push(`${filename}: OK`)
-    } else {
-      lines.push(`${filename}: FAILED`)
-      failed = true
-    }
-  }
-  return [ENC.encode(lines.join('\n') + '\n'), failed ? 1 : 0]
-}
+import { sha256sumGeneric } from '../generic/sha256sum.ts'
 
 async function sha256sumCommand(
   accessor: S3Accessor,
@@ -83,30 +26,9 @@ async function sha256sumCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const check = opts.flags.c === true
   const resolved =
     paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
-  if (check && resolved.length > 0) {
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const [out, exitCode] = await sha256Check(accessor, first)
-    const result: ByteSource = out
-    return [result, new IOResult({ exitCode })]
-  }
-  if (resolved.length > 0) {
-    return [
-      sha256Multi(accessor, resolved),
-      new IOResult({ cache: resolved.map((p) => p.original) }),
-    ]
-  }
-  let source: AsyncIterable<Uint8Array>
-  try {
-    source = resolveSource(opts.stdin, 'sha256sum: missing input')
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-  }
-  return [sha256SingleStream(source, '-'), new IOResult()]
+  return sha256sumGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_SHA256SUM = command({

--- a/typescript/packages/core/src/commands/builtin/s3/shuf.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/shuf.ts
@@ -14,38 +14,11 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function splitLinesNoTrailing(text: string): string[] {
-  const stripped = text.endsWith('\n') ? text.slice(0, -1) : text
-  return stripped === '' ? [] : stripped.split('\n')
-}
-
-function shuffleInPlace(arr: string[]): void {
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1))
-    const tmp = arr[i] ?? ''
-    arr[i] = arr[j] ?? ''
-    arr[j] = tmp
-  }
-}
-
-function choicesWithReplacement(items: readonly string[], k: number): string[] {
-  if (items.length === 0) return []
-  const out: string[] = []
-  for (let i = 0; i < k; i++) {
-    out.push(items[Math.floor(Math.random() * items.length)] ?? '')
-  }
-  return out
-}
+import { shufGeneric } from '../generic/shuf.ts'
 
 async function shufCommand(
   accessor: S3Accessor,
@@ -53,53 +26,9 @@ async function shufCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const nFlag = typeof opts.flags.n === 'string' ? Number.parseInt(opts.flags.n, 10) : null
-  const echoMode = opts.flags.e === true
-  const zeroSep = opts.flags.z === true
-  const repeat = opts.flags.r === true
-  const sep = zeroSep ? '\x00' : '\n'
-
   const resolved =
-    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : paths
-
-  const processItems = (items: string[]): string[] => {
-    if (repeat) {
-      const count = nFlag ?? items.length
-      return choicesWithReplacement(items, count)
-    }
-    shuffleInPlace(items)
-    if (nFlag !== null) return items.slice(0, nFlag)
-    return items
-  }
-
-  if (echoMode) {
-    const base = resolved.length > 0 ? resolved.map((p) => p.stripPrefix) : [...texts]
-    const out = processItems(base)
-    const result: ByteSource = ENC.encode(out.join(sep) + sep)
-    return [result, new IOResult()]
-  }
-
-  if (resolved.length > 0) {
-    const allLines: string[] = []
-    for (const p of resolved) {
-      const data = DEC.decode(await s3Read(accessor, p, opts.index ?? undefined))
-      if (zeroSep) for (const l of data.split('\x00')) allLines.push(l)
-      else for (const l of splitLinesNoTrailing(data)) allLines.push(l)
-    }
-    const out = processItems(allLines)
-    const result: ByteSource = ENC.encode(out.join(sep) + sep)
-    return [result, new IOResult()]
-  }
-
-  const stdinData = await readStdinAsync(opts.stdin)
-  if (stdinData === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('shuf: missing operand\n') })]
-  }
-  const text = DEC.decode(stdinData)
-  const lines = zeroSep ? text.split('\x00') : splitLinesNoTrailing(text)
-  const out = processItems(lines)
-  const result: ByteSource = ENC.encode(out.join(sep) + sep)
-  return [result, new IOResult()]
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return shufGeneric(resolved, texts, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_SHUF = command({

--- a/typescript/packages/core/src/commands/builtin/s3/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/stat.ts
@@ -15,32 +15,11 @@
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
 import { stat as s3Stat } from '../../../core/s3/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { FileType, ResourceName, type FileStat, type PathSpec } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { statGeneric } from '../generic/stat.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-const TYPE_LABELS: Record<string, string> = {
-  [FileType.DIRECTORY]: 'directory',
-  [FileType.TEXT]: 'regular file',
-  [FileType.BINARY]: 'regular file',
-  [FileType.JSON]: 'regular file',
-  [FileType.CSV]: 'regular file',
-}
-
-function formatStat(fmt: string, s: FileStat): string {
-  return fmt.replace(/%(.)/g, (_, spec: string) => {
-    if (spec === 'n') return s.name
-    if (spec === 's') return String(s.size ?? 0)
-    if (spec === 'F')
-      return s.type !== null ? (TYPE_LABELS[s.type] ?? 'regular file') : 'regular file'
-    if (spec === 'y') return s.modified ?? ''
-    return '?'
-  })
-}
 
 async function statCommand(
   accessor: S3Accessor,
@@ -48,30 +27,9 @@ async function statCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('stat: missing operand\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const fmt =
-    typeof opts.flags.c === 'string'
-      ? opts.flags.c
-      : typeof opts.flags.f === 'string'
-        ? opts.flags.f
-        : null
-  const lines: string[] = []
-  for (const p of resolved) {
-    const s = await s3Stat(accessor, p, opts.index ?? undefined)
-    if (fmt !== null) {
-      lines.push(formatStat(fmt, s))
-    } else {
-      const sizeStr = s.size === null ? 'None' : String(s.size)
-      const modStr = s.modified ?? 'None'
-      const typeStr = s.type ?? 'None'
-      lines.push(`name=${s.name} size=${sizeStr} modified=${modStr} type=${typeStr}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return statGeneric(resolved, opts, (p) => s3Stat(accessor, p, opts.index ?? undefined))
 }
 
 export const S3_STAT = command({

--- a/typescript/packages/core/src/commands/builtin/s3/strings.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/strings.ts
@@ -14,34 +14,11 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-
-function extractStrings(data: Uint8Array, minLen: number): string[] {
-  const out: string[] = []
-  let current: number[] = []
-  for (let i = 0; i < data.byteLength; i++) {
-    const b = data[i] ?? 0
-    if (b >= 0x20 && b <= 0x7e) {
-      current.push(b)
-    } else {
-      if (current.length >= minLen) {
-        out.push(String.fromCharCode(...current))
-      }
-      current = []
-    }
-  }
-  if (current.length >= minLen) {
-    out.push(String.fromCharCode(...current))
-  }
-  return out
-}
+import { stringsGeneric } from '../generic/strings.ts'
 
 async function stringsCommand(
   accessor: S3Accessor,
@@ -49,24 +26,9 @@ async function stringsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const minLen = typeof opts.flags.n === 'string' ? Number.parseInt(opts.flags.n, 10) : 4
-  let raw: Uint8Array
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    raw = await s3Read(accessor, first, opts.index ?? undefined)
-  } else {
-    const stdinData = await readStdinAsync(opts.stdin)
-    if (stdinData === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('strings: missing input\n') })]
-    }
-    raw = stdinData
-  }
-  const matches = extractStrings(raw, minLen)
-  const output = matches.length > 0 ? matches.join('\n') + '\n' : ''
-  const result: ByteSource = ENC.encode(output)
-  return [result, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return stringsGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_STRINGS = command({

--- a/typescript/packages/core/src/commands/builtin/s3/tac.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/tac.ts
@@ -15,21 +15,10 @@
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
 import { stream as s3Stream } from '../../../core/s3/stream.ts'
-import { AsyncLineIterator } from '../../../io/async_line_iterator.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { resolveSource } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-
-async function collectLines(source: AsyncIterable<Uint8Array>): Promise<Uint8Array[]> {
-  const lines: Uint8Array[] = []
-  const iter = new AsyncLineIterator(source)
-  for await (const line of iter) lines.push(line)
-  return lines
-}
+import { tacGeneric } from '../generic/tac.ts'
 
 async function tacCommand(
   accessor: S3Accessor,
@@ -37,36 +26,9 @@ async function tacCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const cache: string[] = []
-  let source: AsyncIterable<Uint8Array>
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    source = s3Stream(accessor, first)
-    cache.push(first.original)
-  } else {
-    try {
-      source = resolveSource(opts.stdin, 'tac: missing input')
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-    }
-  }
-  const lines = await collectLines(source)
-  lines.reverse()
-  let total = 0
-  for (const l of lines) total += l.byteLength + 1
-  const out = new Uint8Array(total)
-  let offset = 0
-  for (const l of lines) {
-    out.set(l, offset)
-    offset += l.byteLength
-    out[offset] = 0x0a
-    offset += 1
-  }
-  const result: ByteSource = out
-  return [result, new IOResult({ cache })]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return tacGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_TAC = command({

--- a/typescript/packages/core/src/commands/builtin/s3/tr.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/tr.ts
@@ -15,116 +15,10 @@
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
 import { stream as s3Stream } from '../../../core/s3/stream.ts'
-import { IOResult } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { interpretEscapes } from '../utils/escapes.ts'
-import { resolveSource } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function expandRanges(s: string): string {
-  let out = ''
-  let i = 0
-  while (i < s.length) {
-    if (i + 2 < s.length && s[i + 1] === '-') {
-      const start = s.charCodeAt(i)
-      const end = s.charCodeAt(i + 2)
-      for (let c = start; c <= end; c++) out += String.fromCharCode(c)
-      i += 3
-    } else {
-      out += s[i] ?? ''
-      i += 1
-    }
-  }
-  return out
-}
-
-interface TrOptions {
-  set1: string
-  set2: string
-  del: boolean
-  squeeze: boolean
-  table: Map<string, string> | null
-}
-
-async function* trStream(
-  source: AsyncIterable<Uint8Array>,
-  opts: TrOptions,
-): AsyncIterable<Uint8Array> {
-  const squeezeSet: Set<string> =
-    opts.squeeze && opts.set2 !== ''
-      ? new Set(opts.set2)
-      : opts.squeeze
-        ? new Set(opts.set1)
-        : new Set()
-  let prevChar = ''
-  for await (const chunk of source) {
-    const text = DEC.decode(chunk)
-    let result: string
-    if (opts.del) {
-      const set1Set = new Set(opts.set1)
-      result = Array.from(text)
-        .filter((c) => !set1Set.has(c))
-        .join('')
-    } else if (opts.table !== null) {
-      result = Array.from(text)
-        .map((c) => opts.table?.get(c) ?? c)
-        .join('')
-    } else {
-      result = text
-    }
-    if (squeezeSet.size > 0) {
-      const squeezed: string[] = []
-      for (const c of result) {
-        if (squeezeSet.has(c) && c === prevChar) continue
-        squeezed.push(c)
-        prevChar = c
-      }
-      result = squeezed.join('')
-    } else if (result.length > 0) {
-      prevChar = result[result.length - 1] ?? ''
-    }
-    yield ENC.encode(result)
-  }
-}
-
-function buildOptions(
-  texts: readonly string[],
-  flags: Record<string, string | boolean>,
-): TrOptions {
-  if (texts.length === 0) throw new Error('tr: usage: tr [-d] [-s] [-c] set1 [set2] [path]')
-  let set1 = expandRanges(interpretEscapes(texts[0] ?? ''))
-  if (flags.c === true) {
-    let allChars = ''
-    for (let i = 0; i < 128; i++) allChars += String.fromCharCode(i)
-    const s1 = new Set(set1)
-    set1 = Array.from(allChars)
-      .filter((c) => !s1.has(c))
-      .join('')
-  }
-  let set2 = texts.length >= 2 ? expandRanges(interpretEscapes(texts[1] ?? '')) : ''
-  if (set2 !== '' && set2.length < set1.length) {
-    const last = set2[set2.length - 1] ?? ''
-    set2 = set2 + last.repeat(set1.length - set2.length)
-  }
-  const del = flags.d === true
-  const squeeze = flags.s === true
-  let table: Map<string, string> | null = null
-  if (!del && set2 !== '') {
-    table = new Map<string, string>()
-    for (let i = 0; i < set1.length; i++) {
-      const from = set1[i]
-      const to = set2[i]
-      if (from !== undefined && to !== undefined) table.set(from, to)
-    }
-  } else if (!del && set2 === '' && !squeeze) {
-    throw new Error('tr: usage: tr set1 set2')
-  }
-  return { set1, set2, del, squeeze, table }
-}
+import { trGeneric } from '../generic/tr.ts'
 
 async function trCommand(
   accessor: S3Accessor,
@@ -132,30 +26,9 @@ async function trCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  let trOpts: TrOptions
-  try {
-    trOpts = buildOptions(texts, opts.flags)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-  }
-  const cache: string[] = []
-  let source: AsyncIterable<Uint8Array>
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    source = s3Stream(accessor, first)
-    cache.push(first.original)
-  } else {
-    try {
-      source = resolveSource(opts.stdin, 'tr: missing input')
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-    }
-  }
-  return [trStream(source, trOpts), new IOResult({ cache })]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return trGeneric(resolved, texts, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_TR = command({

--- a/typescript/packages/core/src/commands/builtin/s3/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/tree.ts
@@ -16,94 +16,10 @@ import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
 import { readdir as s3Readdir } from '../../../core/s3/readdir.ts'
 import { stat as s3Stat } from '../../../core/s3/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function fnmatch(name: string, pattern: string): boolean {
-  const re = pattern
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\?/g, '.')
-    .replace(/\*/g, '.*')
-  return new RegExp(`^${re}$`).test(name)
-}
-
-interface TreeOpts {
-  maxDepth: number | null
-  showHidden: boolean
-  ignorePattern: string | null
-  dirsOnly: boolean
-  matchPattern: string | null
-}
-
-async function treeRecurse(
-  accessor: S3Accessor,
-  path: PathSpec,
-  prefix: string,
-  depth: number,
-  treeOpts: TreeOpts,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<string[]> {
-  const lines: string[] = []
-  let entries: string[]
-  try {
-    entries = await s3Readdir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`tree: '${path.original}': ${msg}`)
-    return lines
-  }
-  const filtered: [PathSpec, FileStat][] = []
-  for (const entry of entries) {
-    try {
-      const entrySpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await s3Stat(accessor, entrySpec, indexCache ?? undefined)
-      if (!treeOpts.showHidden && s.name.startsWith('.')) continue
-      if (treeOpts.ignorePattern !== null && fnmatch(s.name, treeOpts.ignorePattern)) continue
-      if (treeOpts.dirsOnly && s.type !== FileType.DIRECTORY) continue
-      const notDir = s.type !== FileType.DIRECTORY
-      if (treeOpts.matchPattern !== null && notDir && !fnmatch(s.name, treeOpts.matchPattern))
-        continue
-      filtered.push([entrySpec, s])
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`tree: '${entry}': ${msg}`)
-    }
-  }
-  for (let i = 0; i < filtered.length; i++) {
-    const pair = filtered[i]
-    if (pair === undefined) continue
-    const [entrySpec, s] = pair
-    const isLast = i === filtered.length - 1
-    const connector = isLast ? '\u2514\u2500\u2500 ' : '\u251c\u2500\u2500 '
-    lines.push(prefix + connector + s.name)
-    if (s.type === FileType.DIRECTORY) {
-      if (treeOpts.maxDepth !== null && depth >= treeOpts.maxDepth) continue
-      const extension = isLast ? '    ' : '\u2502   '
-      const sub = await treeRecurse(
-        accessor,
-        entrySpec,
-        prefix + extension,
-        depth + 1,
-        treeOpts,
-        warnings,
-        indexCache,
-      )
-      lines.push(...sub)
-    }
-  }
-  return lines
-}
+import { treeGeneric } from '../generic/tree.ts'
 
 async function treeCommand(
   accessor: S3Accessor,
@@ -112,27 +28,12 @@ async function treeCommand(
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const p0 =
-    resolved[0] ??
-    new PathSpec({
-      original: opts.cwd,
-      directory: opts.cwd,
-      resolved: false,
-      prefix: opts.mountPrefix ?? '',
-    })
-  const maxDepth = typeof opts.flags.L === 'string' ? Number.parseInt(opts.flags.L, 10) : null
-  const treeOpts: TreeOpts = {
-    maxDepth,
-    showHidden: opts.flags.a === true,
-    ignorePattern: typeof opts.flags.args_I === 'string' ? opts.flags.args_I : null,
-    dirsOnly: opts.flags.d === true,
-    matchPattern: typeof opts.flags.P === 'string' ? opts.flags.P : null,
-  }
-  const warnings: string[] = []
-  const results = await treeRecurse(accessor, p0, '', 0, treeOpts, warnings, opts.index)
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  return [out, new IOResult({ stderr })]
+  return treeGeneric(
+    resolved,
+    opts,
+    (p) => s3Readdir(accessor, p, opts.index ?? undefined),
+    (p) => s3Stat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const S3_TREE = command({

--- a/typescript/packages/core/src/commands/builtin/s3/tsort.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/tsort.ts
@@ -14,55 +14,11 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function topologicalSort(pairs: readonly (readonly [string, string])[]): [string[], boolean] {
-  const graph = new Map<string, Set<string>>()
-  const inDegree = new Map<string, number>()
-  const getOrCreate = (node: string): Set<string> => {
-    const existing = graph.get(node)
-    if (existing !== undefined) return existing
-    const created = new Set<string>()
-    graph.set(node, created)
-    inDegree.set(node, 0)
-    return created
-  }
-  for (const [a, b] of pairs) {
-    const adj = getOrCreate(a)
-    getOrCreate(b)
-    if (!adj.has(b)) {
-      adj.add(b)
-      inDegree.set(b, (inDegree.get(b) ?? 0) + 1)
-    }
-  }
-  const queue: string[] = []
-  for (const [node, deg] of inDegree) {
-    if (deg === 0) queue.push(node)
-  }
-  const result: string[] = []
-  let head = 0
-  while (head < queue.length) {
-    const node = queue[head] ?? ''
-    head += 1
-    result.push(node)
-    const neighbors = [...(graph.get(node) ?? new Set<string>())].sort()
-    for (const nb of neighbors) {
-      const d = (inDegree.get(nb) ?? 0) - 1
-      inDegree.set(nb, d)
-      if (d === 0) queue.push(nb)
-    }
-  }
-  const hasCycle = result.length !== graph.size
-  return [result, hasCycle]
-}
+import { tsortGeneric } from '../generic/tsort.ts'
 
 async function tsortCommand(
   accessor: S3Accessor,
@@ -70,36 +26,9 @@ async function tsortCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  let raw: Uint8Array
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    raw = await s3Read(accessor, first, opts.index ?? undefined)
-  } else {
-    const stdinData = await readStdinAsync(opts.stdin)
-    if (stdinData === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('tsort: missing input\n') })]
-    }
-    raw = stdinData
-  }
-  const text = DEC.decode(raw)
-  const tokens = text.split(/\s+/).filter((s) => s !== '')
-  if (tokens.length % 2 !== 0) {
-    const out: ByteSource = ENC.encode('tsort: odd number of tokens\n')
-    return [out, new IOResult({ exitCode: 1 })]
-  }
-  const pairs: [string, string][] = []
-  for (let i = 0; i < tokens.length; i += 2) {
-    pairs.push([tokens[i] ?? '', tokens[i + 1] ?? ''])
-  }
-  const [sorted, hasCycle] = topologicalSort(pairs)
-  if (hasCycle) {
-    const out: ByteSource = ENC.encode('tsort: cycle detected\n')
-    return [out, new IOResult({ exitCode: 1 })]
-  }
-  const result: ByteSource = ENC.encode(sorted.join('\n') + '\n')
-  return [result, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return tsortGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_TSORT = command({

--- a/typescript/packages/core/src/commands/builtin/s3/unexpand.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/unexpand.ts
@@ -14,60 +14,11 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function splitLinesKeepEnds(text: string): string[] {
-  const lines: string[] = []
-  let start = 0
-  for (let i = 0; i < text.length; i++) {
-    if (text[i] === '\n') {
-      lines.push(text.slice(start, i + 1))
-      start = i + 1
-    }
-  }
-  if (start < text.length) lines.push(text.slice(start))
-  return lines
-}
-
-function unexpandLine(line: string, tabsize: number, allSpaces: boolean): string {
-  if (allSpaces) {
-    const result: string[] = []
-    let i = 0
-    while (i < line.length) {
-      let count = 0
-      while (i + count < line.length && line[i + count] === ' ') count += 1
-      if (count >= tabsize) {
-        const tabs = Math.floor(count / tabsize)
-        const remainder = count % tabsize
-        result.push('\t'.repeat(tabs) + ' '.repeat(remainder))
-        i += count
-      } else if (count > 0) {
-        result.push(' '.repeat(count))
-        i += count
-      } else {
-        result.push(line[i] ?? '')
-        i += 1
-      }
-    }
-    return result.join('')
-  }
-  let leading = 0
-  while (leading < line.length && line[leading] === ' ') leading += 1
-  if (leading >= tabsize) {
-    const tabs = Math.floor(leading / tabsize)
-    const remainder = leading % tabsize
-    return '\t'.repeat(tabs) + ' '.repeat(remainder) + line.slice(leading)
-  }
-  return line
-}
+import { unexpandGeneric } from '../generic/unexpand.ts'
 
 async function unexpandCommand(
   accessor: S3Accessor,
@@ -75,28 +26,9 @@ async function unexpandCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const tabsize = typeof opts.flags.t === 'string' ? Number.parseInt(opts.flags.t, 10) : 8
-  const allSpaces = opts.flags.a === true
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const parts: string[] = []
-    for (const p of resolved) {
-      const data = DEC.decode(await s3Read(accessor, p, opts.index ?? undefined))
-      for (const ln of splitLinesKeepEnds(data)) parts.push(unexpandLine(ln, tabsize, allSpaces))
-    }
-    const result: ByteSource = ENC.encode(parts.join(''))
-    return [result, new IOResult()]
-  }
-  const stdinData = await readStdinAsync(opts.stdin)
-  if (stdinData === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('unexpand: missing operand\n') })]
-  }
-  const text = DEC.decode(stdinData)
-  const lines = splitLinesKeepEnds(text)
-  const result: ByteSource = ENC.encode(
-    lines.map((ln) => unexpandLine(ln, tabsize, allSpaces)).join(''),
-  )
-  return [result, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return unexpandGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_UNEXPAND = command({

--- a/typescript/packages/core/src/commands/builtin/s3/uniq.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/uniq.ts
@@ -15,101 +15,10 @@
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
 import { stream as s3Stream } from '../../../core/s3/stream.ts'
-import { AsyncLineIterator } from '../../../io/async_line_iterator.ts'
-import { IOResult } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { resolveSource } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-interface UniqOptions {
-  count: boolean
-  duplicatesOnly: boolean
-  uniqueOnly: boolean
-  skipFields: number
-  skipChars: number
-  checkChars: number
-  ignoreCase: boolean
-}
-
-function comparisonKey(line: Uint8Array, opts: UniqOptions): string {
-  let text = DEC.decode(line)
-  if (opts.skipFields > 0) {
-    const parts = text.split(/\s+/).filter((s) => s !== '')
-    const remaining = opts.skipFields < parts.length ? parts.slice(opts.skipFields) : []
-    text = remaining.join(' ')
-  }
-  if (opts.skipChars > 0) text = text.slice(opts.skipChars)
-  if (opts.checkChars > 0) text = text.slice(0, opts.checkChars)
-  if (opts.ignoreCase) text = text.toLowerCase()
-  return text
-}
-
-function padLeft(value: string, width: number): string {
-  return value.length >= width ? value : ' '.repeat(width - value.length) + value
-}
-
-function emitLine(line: Uint8Array, count: number, opts: UniqOptions): Uint8Array | null {
-  if (opts.duplicatesOnly && count === 1) return null
-  if (opts.uniqueOnly && count > 1) return null
-  if (opts.count) {
-    const prefix = ENC.encode(`${padLeft(String(count), 7)} `)
-    const out = new Uint8Array(prefix.byteLength + line.byteLength + 1)
-    out.set(prefix, 0)
-    out.set(line, prefix.byteLength)
-    out[out.byteLength - 1] = 0x0a
-    return out
-  }
-  const out = new Uint8Array(line.byteLength + 1)
-  out.set(line, 0)
-  out[line.byteLength] = 0x0a
-  return out
-}
-
-async function* uniqStream(
-  source: AsyncIterable<Uint8Array>,
-  opts: UniqOptions,
-): AsyncIterable<Uint8Array> {
-  let prevLine: Uint8Array | null = null
-  let prevKey: string | null = null
-  let prevCount = 0
-  const iter = new AsyncLineIterator(source)
-  for await (const rawLine of iter) {
-    const key = comparisonKey(rawLine, opts)
-    if (key === prevKey) {
-      prevCount += 1
-    } else {
-      if (prevLine !== null) {
-        const chunk = emitLine(prevLine, prevCount, opts)
-        if (chunk !== null) yield chunk
-      }
-      prevLine = rawLine
-      prevKey = key
-      prevCount = 1
-    }
-  }
-  if (prevLine !== null) {
-    const chunk = emitLine(prevLine, prevCount, opts)
-    if (chunk !== null) yield chunk
-  }
-}
-
-function parseOptions(flags: Record<string, string | boolean>): UniqOptions {
-  const intFlag = (key: 'f' | 's' | 'w'): number =>
-    typeof flags[key] === 'string' ? Number.parseInt(flags[key], 10) : 0
-  return {
-    count: flags.c === true,
-    duplicatesOnly: flags.d === true,
-    uniqueOnly: flags.u === true,
-    skipFields: intFlag('f'),
-    skipChars: intFlag('s'),
-    checkChars: intFlag('w'),
-    ignoreCase: flags.i === true,
-  }
-}
+import { uniqGeneric } from '../generic/uniq.ts'
 
 async function uniqCommand(
   accessor: S3Accessor,
@@ -117,23 +26,9 @@ async function uniqCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const uniqOpts = parseOptions(opts.flags)
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    return [
-      uniqStream(s3Stream(accessor, first), uniqOpts),
-      new IOResult({ cache: [first.stripPrefix] }),
-    ]
-  }
-  try {
-    const source = resolveSource(opts.stdin, 'uniq: missing operand')
-    return [uniqStream(source, uniqOpts), new IOResult()]
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-  }
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return uniqGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_UNIQ = command({

--- a/typescript/packages/core/src/commands/builtin/s3/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/wc.ts
@@ -14,97 +14,22 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { resolveSource } from '../utils/stream.ts'
+import { wcGeneric } from '../generic/wc.ts'
 import { fileReadProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-async function* wcLinesStream(source: AsyncIterable<Uint8Array>): AsyncIterable<Uint8Array> {
-  let count = 0
-  for await (const chunk of source) {
-    for (let i = 0; i < chunk.byteLength; i++) if (chunk[i] === 0x0a) count += 1
-  }
-  yield ENC.encode(String(count))
-}
-
-function countChar(text: string, ch: string): number {
-  let n = 0
-  for (const c of text) if (c === ch) n += 1
-  return n
-}
-
-function maxLineLength(text: string): number {
-  let max = 0
-  let current = 0
-  for (const c of text) {
-    if (c === '\n') {
-      if (current > max) max = current
-      current = 0
-    } else {
-      current += 1
-    }
-  }
-  if (current > max) max = current
-  return max
-}
 
 async function wcCommand(
   accessor: S3Accessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const f = opts.flags
-  const lFlag = f.args_l === true
-  const wFlag = f.w === true
-  const cFlag = f.c === true
-  const mFlag = f.m === true
-  const LFlag = f.L === true
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const data = await s3Read(accessor, first, opts.index ?? undefined)
-    const text = DEC.decode(data)
-    const lineCount = countChar(text, '\n')
-    const wordCount = text.split(/\s+/).filter((s) => s !== '').length
-    const byteCount = data.byteLength
-    if (LFlag) return [ENC.encode(String(maxLineLength(text))), new IOResult()]
-    if (lFlag) return [ENC.encode(String(lineCount)), new IOResult()]
-    if (wFlag) return [ENC.encode(String(wordCount)), new IOResult()]
-    if (mFlag) return [ENC.encode(String(text.length)), new IOResult()]
-    if (cFlag) return [ENC.encode(String(byteCount)), new IOResult()]
-    const out = `${String(lineCount)}\t${String(wordCount)}\t${String(byteCount)}`
-    return [ENC.encode(out), new IOResult()]
-  }
-  let source: AsyncIterable<Uint8Array>
-  try {
-    source = resolveSource(opts.stdin, 'wc: missing operand')
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-  }
-  if (lFlag) {
-    const out: ByteSource = wcLinesStream(source)
-    return [out, new IOResult()]
-  }
-  const raw = await materialize(source)
-  const text = DEC.decode(raw)
-  const lc = countChar(text, '\n')
-  const wcVal = text.split(/\s+/).filter((s) => s !== '').length
-  const bc = raw.byteLength
-  const cc = text.length
-  if (LFlag) return [ENC.encode(String(maxLineLength(text))), new IOResult()]
-  if (wFlag) return [ENC.encode(String(wcVal)), new IOResult()]
-  if (mFlag) return [ENC.encode(String(cc)), new IOResult()]
-  if (cFlag) return [ENC.encode(String(bc)), new IOResult()]
-  return [ENC.encode(`${String(lc)}\t${String(wcVal)}\t${String(bc)}`), new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return wcGeneric(resolved, texts, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_WC = command({

--- a/typescript/packages/core/src/commands/builtin/s3/xxd.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/xxd.ts
@@ -15,133 +15,10 @@
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
 import { stream as s3Stream } from '../../../core/s3/stream.ts'
-import { IOResult } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { resolveSource } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function padRight(s: string, width: number): string {
-  return s.length >= width ? s : s + ' '.repeat(width - s.length)
-}
-
-function hexByte(b: number, uppercase: boolean): string {
-  const h = b.toString(16).padStart(2, '0')
-  return uppercase ? h.toUpperCase() : h
-}
-
-function hexOffset(offset: number, uppercase: boolean): string {
-  const h = offset.toString(16).padStart(8, '0')
-  return uppercase ? h.toUpperCase() : h
-}
-
-async function* xxdDumpStream(
-  source: AsyncIterable<Uint8Array>,
-  cols: number,
-  group: number,
-  uppercase: boolean,
-): AsyncIterable<Uint8Array> {
-  let offset = 0
-  let leftover = new Uint8Array(0)
-  const hexColumnWidth = cols * 2 + Math.floor(cols / group) - 1
-  const emitRow = (row: Uint8Array): Uint8Array => {
-    const hexParts: string[] = []
-    for (let g = 0; g < row.byteLength; g += group) {
-      let seg = ''
-      const end = Math.min(g + group, row.byteLength)
-      for (let k = g; k < end; k++) seg += hexByte(row[k] ?? 0, uppercase)
-      hexParts.push(seg)
-    }
-    const hexPart = hexParts.join(' ')
-    let asciiPart = ''
-    for (const b of row) asciiPart += b >= 32 && b < 127 ? String.fromCharCode(b) : '.'
-    const line = `${hexOffset(offset, uppercase)}: ${padRight(hexPart, hexColumnWidth)}  ${asciiPart}\n`
-    return ENC.encode(line)
-  }
-  for await (const chunk of source) {
-    const merged = new Uint8Array(leftover.byteLength + chunk.byteLength)
-    merged.set(leftover, 0)
-    merged.set(chunk, leftover.byteLength)
-    let i = 0
-    while (i + cols <= merged.byteLength) {
-      yield emitRow(merged.subarray(i, i + cols))
-      offset += cols
-      i += cols
-    }
-    leftover = merged.subarray(i)
-  }
-  if (leftover.byteLength > 0) {
-    yield emitRow(leftover)
-  }
-}
-
-async function* xxdPlainStream(
-  source: AsyncIterable<Uint8Array>,
-  uppercase: boolean,
-): AsyncIterable<Uint8Array> {
-  for await (const chunk of source) {
-    let hex = ''
-    for (const b of chunk) hex += hexByte(b, uppercase)
-    yield ENC.encode(hex)
-  }
-  yield ENC.encode('\n')
-}
-
-async function* xxdReverseStream(source: AsyncIterable<Uint8Array>): AsyncIterable<Uint8Array> {
-  const chunks: Uint8Array[] = []
-  for await (const c of source) chunks.push(c)
-  let total = 0
-  for (const c of chunks) total += c.byteLength
-  const buf = new Uint8Array(total)
-  let off = 0
-  for (const c of chunks) {
-    buf.set(c, off)
-    off += c.byteLength
-  }
-  const text = DEC.decode(buf)
-  const hexParts: string[] = []
-  for (const rawLine of text.split('\n')) {
-    if (rawLine === '') continue
-    let line = rawLine
-    const colon = line.indexOf(':')
-    if (colon !== -1) line = line.slice(colon + 1)
-    const twoSpace = line.indexOf('  ')
-    if (twoSpace !== -1) line = line.slice(0, twoSpace)
-    hexParts.push(line.replace(/\s+/g, ''))
-  }
-  const hex = hexParts.join('')
-  const out = new Uint8Array(Math.floor(hex.length / 2))
-  for (let i = 0; i < out.byteLength; i++) out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16)
-  yield out
-}
-
-async function* applyLimits(
-  source: AsyncIterable<Uint8Array>,
-  skip: number,
-  limit: number,
-): AsyncIterable<Uint8Array> {
-  let pos = 0
-  let remaining = limit
-  for await (let chunk of source) {
-    const len = chunk.byteLength
-    if (pos + len <= skip) {
-      pos += len
-      continue
-    }
-    if (pos < skip) {
-      chunk = chunk.subarray(skip - pos)
-      pos = skip
-    }
-    if (remaining <= 0) break
-    if (chunk.byteLength > remaining) chunk = chunk.subarray(0, remaining)
-    yield chunk
-    remaining -= chunk.byteLength
-    pos += chunk.byteLength
-  }
-}
+import { xxdGeneric } from '../generic/xxd.ts'
 
 async function xxdCommand(
   accessor: S3Accessor,
@@ -149,36 +26,9 @@ async function xxdCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const cache: string[] = []
-  let source: AsyncIterable<Uint8Array>
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    source = s3Stream(accessor, first)
-    cache.push(first.original)
-  } else {
-    try {
-      source = resolveSource(opts.stdin, 'xxd: missing input')
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-    }
-  }
-  const toInt = (v: string | boolean | undefined): number =>
-    typeof v === 'string' ? Number.parseInt(v, 10) : 0
-  const skip = toInt(opts.flags.s)
-  const limitFlag = toInt(opts.flags.l)
-  if (skip > 0 || limitFlag > 0) {
-    const limit = limitFlag > 0 ? limitFlag : Number.MAX_SAFE_INTEGER
-    source = applyLimits(source, skip, limit)
-  }
-  const uppercase = opts.flags.u === true
-  if (opts.flags.r === true) return [xxdReverseStream(source), new IOResult({ cache })]
-  if (opts.flags.p === true) return [xxdPlainStream(source, uppercase), new IOResult({ cache })]
-  const cols = toInt(opts.flags.c) > 0 ? toInt(opts.flags.c) : 16
-  const group = toInt(opts.flags.g) > 0 ? toInt(opts.flags.g) : 2
-  return [xxdDumpStream(source, cols, group, uppercase), new IOResult({ cache })]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return xxdGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_XXD = command({

--- a/typescript/packages/core/src/commands/builtin/s3/zcat.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/zcat.ts
@@ -14,15 +14,11 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { type PathSpec, ResourceName } from '../../../types.ts'
-import { gunzip } from '../../../utils/compress.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
+import { zcatGeneric } from '../generic/zcat.ts'
 
 async function zcatCommand(
   accessor: S3Accessor,
@@ -30,24 +26,9 @@ async function zcatCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  let raw: Uint8Array
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('zcat: missing input\n') })]
-    }
-    raw = await s3Read(accessor, first, opts.index ?? undefined)
-  } else {
-    const stdinBytes = await readStdinAsync(opts.stdin)
-    if (stdinBytes === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('zcat: missing input\n') })]
-    }
-    raw = stdinBytes
-  }
-  const out = await gunzip(raw)
-  const result: ByteSource = out
-  return [result, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return zcatGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_ZCAT = command({

--- a/typescript/packages/core/src/commands/builtin/slack/cat.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/cat.ts
@@ -19,23 +19,11 @@ import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { numberLines } from '../cat_helper.ts'
+import { readStdinAsync, wrapBytes } from '../utils/stream.ts'
 import { fileReadProvision } from './_provision.ts'
 
 const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function numberLines(data: Uint8Array): Uint8Array {
-  const text = DEC.decode(data)
-  const lines = text.split('\n')
-  const trailing = text.endsWith('\n')
-  const limit = trailing ? lines.length - 1 : lines.length
-  const out: string[] = []
-  for (let i = 0; i < limit; i++) {
-    out.push(`     ${String(i + 1)}\t${lines[i] ?? ''}\n`)
-  }
-  return ENC.encode(out.join(''))
-}
 
 function concatBuffers(buffers: readonly Uint8Array[]): Uint8Array {
   if (buffers.length === 0) return new Uint8Array(0)
@@ -71,14 +59,14 @@ async function catCommand(
       buffers.push(data)
     }
     const merged = concatBuffers(buffers)
-    const out: ByteSource = nFlag ? numberLines(merged) : merged
+    const out: ByteSource = nFlag ? numberLines(wrapBytes(merged)) : merged
     return [out, new IOResult({ reads, cache })]
   }
   const raw = await readStdinAsync(opts.stdin)
   if (raw === null) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('cat: missing operand\n') })]
   }
-  const out: ByteSource = nFlag ? numberLines(raw) : raw
+  const out: ByteSource = nFlag ? numberLines(wrapBytes(raw)) : raw
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/core/src/commands/builtin/slack/head.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/head.ts
@@ -13,58 +13,39 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { SlackAccessor } from '../../../accessor/slack.ts'
+import type { IndexCacheStore } from '../../../cache/index/index.ts'
 import { resolveSlackGlob } from '../../../core/slack/glob.ts'
 import { read as slackRead } from '../../../core/slack/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stat as slackStat } from '../../../core/slack/stat.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { headGeneric } from '../generic/head.ts'
 import { fileReadProvision } from './_provision.ts'
 
-const ENC = new TextEncoder()
-
-function headBytes(data: Uint8Array, lines: number, bytesMode: number | null): Uint8Array {
-  if (bytesMode !== null) {
-    return data.slice(0, bytesMode)
-  }
-  let count = 0
-  let end = data.byteLength
-  for (let i = 0; i < data.byteLength; i++) {
-    if (data[i] === 0x0a) {
-      count += 1
-      if (count >= lines) {
-        end = i
-        break
-      }
-    }
-  }
-  return data.slice(0, end)
+async function* slackStream(
+  accessor: SlackAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await slackRead(accessor, p, index)
 }
 
 async function headCommand(
   accessor: SlackAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const nRaw = typeof opts.flags.n === 'string' ? opts.flags.n : null
-  const cRaw = typeof opts.flags.c === 'string' ? opts.flags.c : null
-  const lines = nRaw !== null ? Number.parseInt(nRaw, 10) : 10
-  const bytesMode = cRaw !== null ? Number.parseInt(cRaw, 10) : null
-  if (paths.length > 0) {
-    const resolved = await resolveSlackGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const data = await slackRead(accessor, first, opts.index ?? undefined)
-    const out: ByteSource = headBytes(data, lines, bytesMode)
-    return [out, new IOResult()]
-  }
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('head: missing operand\n') })]
-  }
-  return [headBytes(raw, lines, bytesMode), new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveSlackGlob(accessor, paths, opts.index ?? undefined) : []
+  return headGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => slackStat(accessor, p, opts.index ?? undefined),
+    (p) => slackStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const SLACK_HEAD = command({

--- a/typescript/packages/core/src/commands/builtin/slack/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/ls.ts
@@ -16,93 +16,11 @@ import type { SlackAccessor } from '../../../accessor/slack.ts'
 import { resolveSlackGlob } from '../../../core/slack/glob.ts'
 import { readdir as slackReaddir } from '../../../core/slack/readdir.ts'
 import { stat as slackStat } from '../../../core/slack/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { humanSize } from '../utils/formatting.ts'
+import { lsGeneric } from '../generic/ls.ts'
 import { metadataProvision } from './_provision.ts'
-
-const ENC = new TextEncoder()
-
-async function lsEntries(
-  accessor: SlackAccessor,
-  path: PathSpec,
-  allFiles: boolean,
-  sortBy: 'name' | 'size',
-  reverse: boolean,
-  recursive: boolean,
-  listDir: boolean,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<FileStat[]> {
-  if (listDir) {
-    const s = await slackStat(accessor, path, indexCache ?? undefined)
-    return [s]
-  }
-  let entries: string[]
-  try {
-    entries = await slackReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`ls: cannot access '${path.original}': ${msg}`)
-    return []
-  }
-  const stats: FileStat[] = []
-  for (const entry of entries) {
-    try {
-      const eSpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await slackStat(accessor, eSpec, indexCache ?? undefined)
-      if (!allFiles && s.name.startsWith('.')) continue
-      stats.push(s)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${entry}': ${msg}`)
-    }
-  }
-  if (sortBy === 'size') {
-    stats.sort((a, b) => (a.size ?? 0) - (b.size ?? 0))
-    if (!reverse) stats.reverse()
-  } else {
-    stats.sort((a, b) => a.name.localeCompare(b.name))
-    if (reverse) stats.reverse()
-  }
-  if (recursive) {
-    const subEntries: FileStat[] = []
-    for (const s of stats) {
-      subEntries.push(s)
-      if (s.type === FileType.DIRECTORY) {
-        const entryPath = path.child(s.name)
-        const entrySpec = new PathSpec({
-          original: entryPath,
-          directory: entryPath,
-          resolved: false,
-          prefix: path.prefix,
-        })
-        const sub = await lsEntries(
-          accessor,
-          entrySpec,
-          allFiles,
-          sortBy,
-          reverse,
-          recursive,
-          false,
-          warnings,
-          indexCache,
-        )
-        subEntries.push(...sub)
-      }
-    }
-    return subEntries
-  }
-  return stats
-}
 
 async function lsCommand(
   accessor: SlackAccessor,
@@ -110,65 +28,24 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
-  const allFiles = opts.flags.a === true || opts.flags.A === true
-  const human = opts.flags.h === true
-  const reverse = opts.flags.r === true
-  const recursive = opts.flags.R === true
-  const listDir = opts.flags.d === true
-  const classify = opts.flags.F === true
-  const sortBy: 'name' | 'size' = opts.flags.S === true ? 'size' : 'name'
   let workingPaths: PathSpec[] = paths
   if (workingPaths.length === 0) {
-    const cwd = opts.cwd
     workingPaths = [
       new PathSpec({
-        original: cwd,
-        directory: cwd,
+        original: opts.cwd,
+        directory: opts.cwd,
         resolved: false,
         prefix: opts.mountPrefix ?? '',
       }),
     ]
   }
-  workingPaths = await resolveSlackGlob(accessor, workingPaths, opts.index ?? undefined)
-  const warnings: string[] = []
-  const results: string[] = []
-  for (const p of workingPaths) {
-    let entries: FileStat[]
-    try {
-      entries = await lsEntries(
-        accessor,
-        p,
-        allFiles,
-        sortBy,
-        reverse,
-        recursive,
-        listDir,
-        warnings,
-        opts.index,
-      )
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${p.original}': ${msg}`)
-      continue
-    }
-    if (long) {
-      for (const e of entries) {
-        const sizeStr = human ? humanSize(e.size ?? 0) : String(e.size ?? 0)
-        results.push(`${e.type ?? '-'}\t${sizeStr}\t${e.modified ?? ''}\t${e.name}`)
-      }
-    } else {
-      for (const e of entries) {
-        const isDir = classify && e.type === FileType.DIRECTORY
-        const name = isDir ? e.name + '/' : e.name
-        results.push(name)
-      }
-    }
-  }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  return [out, new IOResult({ stderr, exitCode })]
+  const resolved = await resolveSlackGlob(accessor, workingPaths, opts.index ?? undefined)
+  return lsGeneric(
+    resolved,
+    opts,
+    (p) => slackReaddir(accessor, p, opts.index ?? undefined),
+    (p) => slackStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const SLACK_LS = command({

--- a/typescript/packages/core/src/commands/builtin/slack/realpath.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/realpath.ts
@@ -15,72 +15,22 @@
 import type { SlackAccessor } from '../../../accessor/slack.ts'
 import { resolveSlackGlob } from '../../../core/slack/glob.ts'
 import { stat as slackStat } from '../../../core/slack/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function posixNormpath(p: string): string {
-  const isAbs = p.startsWith('/')
-  const parts = p.split('/')
-  const out: string[] = []
-  for (const seg of parts) {
-    if (seg === '' || seg === '.') continue
-    if (seg === '..') {
-      if (out.length > 0 && out[out.length - 1] !== '..') {
-        out.pop()
-      } else if (!isAbs) {
-        out.push('..')
-      }
-      continue
-    }
-    out.push(seg)
-  }
-  const joined = out.join('/')
-  if (isAbs) return '/' + joined
-  return joined === '' ? '.' : joined
-}
-
-async function existsPath(accessor: SlackAccessor, path: PathSpec): Promise<boolean> {
-  try {
-    await slackStat(accessor, path)
-    return true
-  } catch {
-    return false
-  }
-}
+import { realpathGeneric } from '../generic/realpath.ts'
 
 async function realpathCommand(
   accessor: SlackAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const resolved =
     paths.length > 0 ? await resolveSlackGlob(accessor, paths, opts.index ?? undefined) : []
-  const eFlag = opts.flags.e === true
-  const mountPrefix = resolved[0]?.prefix ?? ''
-  const lines: string[] = []
-  for (const p of resolved) {
-    const normalized = posixNormpath(p.original)
-    if (eFlag) {
-      const probe = new PathSpec({
-        original: normalized,
-        directory: normalized,
-        resolved: false,
-        prefix: mountPrefix,
-      })
-      if (!(await existsPath(accessor, probe))) {
-        const msg = `realpath: '${p.original}': No such file or directory\n`
-        return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(msg) })]
-      }
-    }
-    lines.push(normalized)
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
-  return [out, new IOResult()]
+  return realpathGeneric(resolved, texts, opts, (p) =>
+    slackStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const SLACK_REALPATH = command({

--- a/typescript/packages/core/src/commands/builtin/slack/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/stat.ts
@@ -15,32 +15,11 @@
 import type { SlackAccessor } from '../../../accessor/slack.ts'
 import { resolveSlackGlob } from '../../../core/slack/glob.ts'
 import { stat as slackStat } from '../../../core/slack/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { FileType, ResourceName, type FileStat, type PathSpec } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { statGeneric } from '../generic/stat.ts'
 import { metadataProvision } from './_provision.ts'
-
-const ENC = new TextEncoder()
-
-const TYPE_LABELS: Record<string, string> = {
-  [FileType.DIRECTORY]: 'directory',
-  [FileType.TEXT]: 'regular file',
-  [FileType.BINARY]: 'regular file',
-  [FileType.JSON]: 'regular file',
-  [FileType.CSV]: 'regular file',
-}
-
-function formatStat(fmt: string, s: FileStat): string {
-  return fmt.replace(/%(.)/g, (_, spec: string) => {
-    if (spec === 'n') return s.name
-    if (spec === 's') return String(s.size ?? 0)
-    if (spec === 'F')
-      return s.type !== null ? (TYPE_LABELS[s.type] ?? 'regular file') : 'regular file'
-    if (spec === 'y') return s.modified ?? ''
-    return '?'
-  })
-}
 
 async function statCommand(
   accessor: SlackAccessor,
@@ -48,29 +27,9 @@ async function statCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('stat: missing operand\n') })]
-  }
-  const resolved = await resolveSlackGlob(accessor, paths, opts.index ?? undefined)
-  const fmt =
-    typeof opts.flags.c === 'string'
-      ? opts.flags.c
-      : typeof opts.flags.f === 'string'
-        ? opts.flags.f
-        : null
-  const lines: string[] = []
-  for (const p of resolved) {
-    const s = await slackStat(accessor, p, opts.index ?? undefined)
-    if (fmt !== null) {
-      lines.push(formatStat(fmt, s))
-    } else {
-      lines.push(
-        `name=${s.name} size=${String(s.size)} modified=${String(s.modified)} type=${String(s.type)}`,
-      )
-    }
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveSlackGlob(accessor, paths, opts.index ?? undefined) : []
+  return statGeneric(resolved, opts, (p) => slackStat(accessor, p, opts.index ?? undefined))
 }
 
 export const SLACK_STAT = command({

--- a/typescript/packages/core/src/commands/builtin/slack/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/tree.ts
@@ -16,94 +16,10 @@ import type { SlackAccessor } from '../../../accessor/slack.ts'
 import { resolveSlackGlob } from '../../../core/slack/glob.ts'
 import { readdir as slackReaddir } from '../../../core/slack/readdir.ts'
 import { stat as slackStat } from '../../../core/slack/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function fnmatch(name: string, pattern: string): boolean {
-  const re = pattern
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\?/g, '.')
-    .replace(/\*/g, '.*')
-  return new RegExp(`^${re}$`).test(name)
-}
-
-interface TreeOpts {
-  maxDepth: number | null
-  showHidden: boolean
-  ignorePattern: string | null
-  dirsOnly: boolean
-  matchPattern: string | null
-}
-
-async function treeRecurse(
-  accessor: SlackAccessor,
-  path: PathSpec,
-  prefix: string,
-  depth: number,
-  treeOpts: TreeOpts,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<string[]> {
-  const lines: string[] = []
-  let entries: string[]
-  try {
-    entries = await slackReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`tree: '${path.original}': ${msg}`)
-    return lines
-  }
-  const filtered: [PathSpec, FileStat][] = []
-  for (const entry of entries) {
-    try {
-      const entrySpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await slackStat(accessor, entrySpec, indexCache ?? undefined)
-      if (!treeOpts.showHidden && s.name.startsWith('.')) continue
-      if (treeOpts.ignorePattern !== null && fnmatch(s.name, treeOpts.ignorePattern)) continue
-      if (treeOpts.dirsOnly && s.type !== FileType.DIRECTORY) continue
-      const notDir = s.type !== FileType.DIRECTORY
-      if (treeOpts.matchPattern !== null && notDir && !fnmatch(s.name, treeOpts.matchPattern))
-        continue
-      filtered.push([entrySpec, s])
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`tree: '${entry}': ${msg}`)
-    }
-  }
-  for (let i = 0; i < filtered.length; i++) {
-    const pair = filtered[i]
-    if (pair === undefined) continue
-    const [entrySpec, s] = pair
-    const isLast = i === filtered.length - 1
-    const connector = isLast ? '\u2514\u2500\u2500 ' : '\u251c\u2500\u2500 '
-    lines.push(prefix + connector + s.name)
-    if (s.type === FileType.DIRECTORY) {
-      if (treeOpts.maxDepth !== null && depth >= treeOpts.maxDepth) continue
-      const extension = isLast ? '    ' : '\u2502   '
-      const sub = await treeRecurse(
-        accessor,
-        entrySpec,
-        prefix + extension,
-        depth + 1,
-        treeOpts,
-        warnings,
-        indexCache,
-      )
-      lines.push(...sub)
-    }
-  }
-  return lines
-}
+import { treeGeneric } from '../generic/tree.ts'
 
 async function treeCommand(
   accessor: SlackAccessor,
@@ -112,27 +28,12 @@ async function treeCommand(
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const resolved = await resolveSlackGlob(accessor, paths, opts.index ?? undefined)
-  const p0 =
-    resolved[0] ??
-    new PathSpec({
-      original: opts.cwd,
-      directory: opts.cwd,
-      resolved: false,
-      prefix: opts.mountPrefix ?? '',
-    })
-  const maxDepth = typeof opts.flags.L === 'string' ? Number.parseInt(opts.flags.L, 10) : null
-  const treeOpts: TreeOpts = {
-    maxDepth,
-    showHidden: opts.flags.a === true,
-    ignorePattern: typeof opts.flags.args_I === 'string' ? opts.flags.args_I : null,
-    dirsOnly: opts.flags.d === true,
-    matchPattern: typeof opts.flags.P === 'string' ? opts.flags.P : null,
-  }
-  const warnings: string[] = []
-  const results = await treeRecurse(accessor, p0, '', 0, treeOpts, warnings, opts.index)
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  return [out, new IOResult({ stderr })]
+  return treeGeneric(
+    resolved,
+    opts,
+    (p) => slackReaddir(accessor, p, opts.index ?? undefined),
+    (p) => slackStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const SLACK_TREE = command({

--- a/typescript/packages/core/src/commands/builtin/slack/wc.test.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/wc.test.ts
@@ -75,8 +75,9 @@ describe('slack wc', () => {
       { index: idx, transport },
     )
     const parts = out.split('\t')
-    expect(parts).toHaveLength(3)
+    expect(parts).toHaveLength(4)
     expect(parts[0]).toBe('3')
+    expect(parts[3]).toBe('/mnt/slack/channels/general__C1/2024-01-01/chat.jsonl')
   })
 
   it('supports -l flag (line count)', async () => {
@@ -106,6 +107,6 @@ describe('slack wc', () => {
       { args_l: true },
       { index: idx, transport },
     )
-    expect(out).toBe('2')
+    expect(out).toBe('2\t/mnt/slack/channels/general__C1/2024-01-01/chat.jsonl')
   })
 })

--- a/typescript/packages/core/src/commands/builtin/slack/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/wc.ts
@@ -13,76 +13,32 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { SlackAccessor } from '../../../accessor/slack.ts'
+import type { IndexCacheStore } from '../../../cache/index/index.ts'
 import { resolveSlackGlob } from '../../../core/slack/glob.ts'
 import { read as slackRead } from '../../../core/slack/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { wcGeneric } from '../generic/wc.ts'
 import { fileReadProvision } from './_provision.ts'
 
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function countChar(text: string, ch: string): number {
-  let n = 0
-  for (const c of text) if (c === ch) n += 1
-  return n
-}
-
-function maxLineLength(text: string): number {
-  let max = 0
-  let current = 0
-  for (const c of text) {
-    if (c === '\n') {
-      if (current > max) max = current
-      current = 0
-    } else {
-      current += 1
-    }
-  }
-  if (current > max) max = current
-  return max
+async function* slackStream(
+  accessor: SlackAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await slackRead(accessor, p, index)
 }
 
 async function wcCommand(
   accessor: SlackAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const f = opts.flags
-  const lFlag = f.args_l === true
-  const wFlag = f.w === true
-  const cFlag = f.c === true
-  const mFlag = f.m === true
-  const LFlag = f.L === true
-  let data: Uint8Array | null
-  if (paths.length > 0) {
-    const resolved = await resolveSlackGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    data = await slackRead(accessor, first, opts.index ?? undefined)
-  } else {
-    data = await readStdinAsync(opts.stdin)
-    if (data === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('wc: missing operand\n') })]
-    }
-  }
-  const text = DEC.decode(data)
-  const lineCount = countChar(text, '\n')
-  const wordCount = text.split(/\s+/).filter((s) => s !== '').length
-  const byteCount = data.byteLength
-  let payload: string
-  if (LFlag) payload = String(maxLineLength(text))
-  else if (lFlag) payload = String(lineCount)
-  else if (wFlag) payload = String(wordCount)
-  else if (mFlag) payload = String(text.length)
-  else if (cFlag) payload = String(byteCount)
-  else payload = `${String(lineCount)}\t${String(wordCount)}\t${String(byteCount)}`
-  const out: ByteSource = ENC.encode(payload)
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveSlackGlob(accessor, paths, opts.index ?? undefined) : []
+  return wcGeneric(resolved, texts, opts, (p) => slackStream(accessor, p, opts.index ?? undefined))
 }
 
 export const SLACK_WC = command({

--- a/typescript/packages/core/src/core/s3/du.ts
+++ b/typescript/packages/core/src/core/s3/du.ts
@@ -14,7 +14,7 @@
 
 import type { PathSpec } from '../../types.ts'
 import type { S3Accessor } from '../../accessor/s3.ts'
-import { loadS3Module, rawPathOf, s3Prefix, withClient } from './_client.ts'
+import { loadS3Module, rawPathOf, s3Prefix, stripKeyPrefix, withClient } from './_client.ts'
 
 export async function du(accessor: S3Accessor, path: PathSpec): Promise<number> {
   const { ListObjectsV2Command } = await loadS3Module(accessor.config)
@@ -47,7 +47,10 @@ export async function du(accessor: S3Accessor, path: PathSpec): Promise<number> 
  * Return `[path, size]` pairs for every object under the prefix plus a trailing
  * entry with the total — mirrors Python's `du_all` used by `du -a`.
  */
-export async function duAll(accessor: S3Accessor, path: PathSpec): Promise<[string, number][]> {
+export async function duAll(
+  accessor: S3Accessor,
+  path: PathSpec,
+): Promise<[[string, number][], number]> {
   const { ListObjectsV2Command } = await loadS3Module(accessor.config)
   const raw = rawPathOf(path)
   const pfx = s3Prefix(raw, accessor.config)
@@ -70,13 +73,12 @@ export async function duAll(accessor: S3Accessor, path: PathSpec): Promise<[stri
         const key = obj.Key
         if (key === undefined) continue
         const size = obj.Size ?? 0
-        const entry = '/' + key.replace(/^\/+/, '')
+        const entry = '/' + stripKeyPrefix(key, accessor.config)
         entries.push([entry, size])
         total += size
       }
       continuationToken = resp.IsTruncated === true ? resp.NextContinuationToken : undefined
     } while (continuationToken !== undefined)
   })
-  entries.push([raw, total])
-  return entries
+  return [entries, total]
 }

--- a/typescript/packages/core/src/core/s3/find.ts
+++ b/typescript/packages/core/src/core/s3/find.ts
@@ -78,7 +78,7 @@ export async function find(
         if (options.iname !== null && options.iname !== undefined) {
           if (!fnmatch(entryName.toLowerCase(), options.iname.toLowerCase())) continue
         }
-        const fullPath = '/' + stripKeyPrefix(key, accessor.config)
+        const fullPath = ('/' + stripKeyPrefix(key, accessor.config)).replace(/\/+$/, '') || '/'
         if (options.pathPattern !== null && options.pathPattern !== undefined) {
           if (!fnmatch(fullPath, options.pathPattern)) continue
         }
@@ -87,12 +87,14 @@ export async function find(
         }
         if (options.type === 'f' && key.endsWith('/')) continue
         if (options.type === 'd' && !key.endsWith('/')) continue
-        const size = obj.Size ?? 0
-        if (options.minSize !== null && options.minSize !== undefined && size < options.minSize) {
-          continue
-        }
-        if (options.maxSize !== null && options.maxSize !== undefined && size > options.maxSize) {
-          continue
+        if (!key.endsWith('/')) {
+          const size = obj.Size ?? 0
+          if (options.minSize !== null && options.minSize !== undefined && size < options.minSize) {
+            continue
+          }
+          if (options.maxSize !== null && options.maxSize !== undefined && size > options.maxSize) {
+            continue
+          }
         }
         results.push(fullPath)
       }

--- a/typescript/packages/node/src/resource/s3/s3_complex.test.ts
+++ b/typescript/packages/node/src/resource/s3/s3_complex.test.ts
@@ -163,8 +163,8 @@ describe('S3 complex scenarios (mocked)', () => {
     const jsonlBytes = objects['data/example.jsonl']
     if (jsonBytes === undefined || jsonlBytes === undefined) throw new Error('missing fixture')
     expect(lines).toEqual([
-      `/s3/data/example.json ${jsonBytes.byteLength.toString()}`,
-      `/s3/data/example.jsonl ${jsonlBytes.byteLength.toString()}`,
+      `/s3/data/example.json ${jsonBytes.byteLength.toString()}\t/s3/data/example.json`,
+      `/s3/data/example.jsonl ${jsonlBytes.byteLength.toString()}\t/s3/data/example.jsonl`,
     ])
   })
 


### PR DESCRIPTION
Aligns the TypeScript slack and s3 backends with the shared generic command layer, matching how Python already delegates. No command was added or removed; only internal wiring moved onto the generics.

## slack (pilot)
Migrated the 7 commands Python's slack delegates but TS still inlined: ls, stat, wc, tree, head, cat, realpath. find and jq stay inline (Python parity). Verified by the existing slack unit suite (24 files / 63 tests).

## s3
- Delegation went from 13/63 to 46/63, matching Python's s3.
- Fixed three genuine divergences in the process: wc (missing filename column), file (multi-file dropped all but the first path), find (trailing newline -> correct pipe counts).
- core/s3/find: strip trailing slash on dir keys and skip the size filter for directories, to match the generic contract the shared truth encodes.
- core/s3/duAll: return [entries, total] and strip the key prefix, matching the generic du contract.
- fmt stays inline (no generic/fmt.ts exists; ram inlines it too).

## integ test
Re-enabled the s3 truth diff in test_integ_ts.yml (was a smoke-only run). integ/s3.ts now diffs clean against the shared truth.txt, the same truth ram/disk/redis pass.

## verification
- integ s3.ts vs truth.txt: diff = 0 (via moto)
- full core unit suite: 331 files / 2714 tests pass
- typecheck, prettier, eslint clean