### PR TITLE
refactor(ts/discord): delegate cat/head/wc/ls/stat/tree to the generic layer

### DIFF
--- a/typescript/packages/core/src/commands/builtin/discord/cat.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/cat.ts
@@ -19,22 +19,24 @@ import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { numberLines } from '../cat_helper.ts'
+import { readStdinAsync, wrapBytes } from '../utils/stream.ts'
 import { fileReadProvision } from './_provision.ts'
 
 const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
 
-function numberLines(data: Uint8Array): Uint8Array {
-  const text = DEC.decode(data)
-  const lines = text.split('\n')
-  const trailing = text.endsWith('\n')
-  const limit = trailing ? lines.length - 1 : lines.length
-  const out: string[] = []
-  for (let i = 0; i < limit; i++) {
-    out.push(`     ${String(i + 1)}\t${lines[i] ?? ''}\n`)
+function concatBuffers(buffers: readonly Uint8Array[]): Uint8Array {
+  if (buffers.length === 0) return new Uint8Array(0)
+  if (buffers.length === 1) return buffers[0] ?? new Uint8Array(0)
+  let total = 0
+  for (const b of buffers) total += b.length
+  const out = new Uint8Array(total)
+  let off = 0
+  for (const b of buffers) {
+    out.set(b, off)
+    off += b.length
   }
-  return ENC.encode(out.join(''))
+  return out
 }
 
 async function catCommand(
@@ -46,21 +48,25 @@ async function catCommand(
   const nFlag = opts.flags.n === true
   if (paths.length > 0) {
     const resolved = await resolveDiscordGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const data = await discordRead(accessor, first, opts.index ?? undefined)
-    const out: ByteSource = nFlag ? numberLines(data) : data
-    const io = new IOResult({
-      reads: { [first.stripPrefix]: data },
-      cache: [first.stripPrefix],
-    })
-    return [out, io]
+    if (resolved.length === 0) return [null, new IOResult()]
+    const reads: Record<string, Uint8Array> = {}
+    const cache: string[] = []
+    const buffers: Uint8Array[] = []
+    for (const p of resolved) {
+      const data = await discordRead(accessor, p, opts.index ?? undefined)
+      reads[p.stripPrefix] = data
+      cache.push(p.stripPrefix)
+      buffers.push(data)
+    }
+    const merged = concatBuffers(buffers)
+    const out: ByteSource = nFlag ? numberLines(wrapBytes(merged)) : merged
+    return [out, new IOResult({ reads, cache })]
   }
   const raw = await readStdinAsync(opts.stdin)
   if (raw === null) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('cat: missing operand\n') })]
   }
-  const out: ByteSource = nFlag ? numberLines(raw) : raw
+  const out: ByteSource = nFlag ? numberLines(wrapBytes(raw)) : raw
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/core/src/commands/builtin/discord/head.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/head.ts
@@ -13,58 +13,39 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { DiscordAccessor } from '../../../accessor/discord.ts'
+import type { IndexCacheStore } from '../../../cache/index/index.ts'
 import { resolveDiscordGlob } from '../../../core/discord/glob.ts'
 import { read as discordRead } from '../../../core/discord/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stat as discordStat } from '../../../core/discord/stat.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { headGeneric } from '../generic/head.ts'
 import { fileReadProvision } from './_provision.ts'
 
-const ENC = new TextEncoder()
-
-function headBytes(data: Uint8Array, lines: number, bytesMode: number | null): Uint8Array {
-  if (bytesMode !== null) {
-    return data.slice(0, bytesMode)
-  }
-  let count = 0
-  let end = data.byteLength
-  for (let i = 0; i < data.byteLength; i++) {
-    if (data[i] === 0x0a) {
-      count += 1
-      if (count >= lines) {
-        end = i
-        break
-      }
-    }
-  }
-  return data.slice(0, end)
+async function* discordStream(
+  accessor: DiscordAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await discordRead(accessor, p, index)
 }
 
 async function headCommand(
   accessor: DiscordAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const nRaw = typeof opts.flags.n === 'string' ? opts.flags.n : null
-  const cRaw = typeof opts.flags.c === 'string' ? opts.flags.c : null
-  const lines = nRaw !== null ? Number.parseInt(nRaw, 10) : 10
-  const bytesMode = cRaw !== null ? Number.parseInt(cRaw, 10) : null
-  if (paths.length > 0) {
-    const resolved = await resolveDiscordGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const data = await discordRead(accessor, first, opts.index ?? undefined)
-    const out: ByteSource = headBytes(data, lines, bytesMode)
-    return [out, new IOResult()]
-  }
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('head: missing operand\n') })]
-  }
-  return [headBytes(raw, lines, bytesMode), new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveDiscordGlob(accessor, paths, opts.index ?? undefined) : []
+  return headGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => discordStat(accessor, p, opts.index ?? undefined),
+    (p) => discordStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const DISCORD_HEAD = command({

--- a/typescript/packages/core/src/commands/builtin/discord/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/ls.ts
@@ -16,93 +16,11 @@ import type { DiscordAccessor } from '../../../accessor/discord.ts'
 import { resolveDiscordGlob } from '../../../core/discord/glob.ts'
 import { readdir as discordReaddir } from '../../../core/discord/readdir.ts'
 import { stat as discordStat } from '../../../core/discord/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { humanSize } from '../utils/formatting.ts'
+import { lsGeneric } from '../generic/ls.ts'
 import { metadataProvision } from './_provision.ts'
-
-const ENC = new TextEncoder()
-
-async function lsEntries(
-  accessor: DiscordAccessor,
-  path: PathSpec,
-  allFiles: boolean,
-  sortBy: 'name' | 'size',
-  reverse: boolean,
-  recursive: boolean,
-  listDir: boolean,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<FileStat[]> {
-  if (listDir) {
-    const s = await discordStat(accessor, path, indexCache ?? undefined)
-    return [s]
-  }
-  let entries: string[]
-  try {
-    entries = await discordReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`ls: cannot access '${path.original}': ${msg}`)
-    return []
-  }
-  const stats: FileStat[] = []
-  for (const entry of entries) {
-    try {
-      const eSpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await discordStat(accessor, eSpec, indexCache ?? undefined)
-      if (!allFiles && s.name.startsWith('.')) continue
-      stats.push(s)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${entry}': ${msg}`)
-    }
-  }
-  if (sortBy === 'size') {
-    stats.sort((a, b) => (a.size ?? 0) - (b.size ?? 0))
-    if (!reverse) stats.reverse()
-  } else {
-    stats.sort((a, b) => a.name.localeCompare(b.name))
-    if (reverse) stats.reverse()
-  }
-  if (recursive) {
-    const subEntries: FileStat[] = []
-    for (const s of stats) {
-      subEntries.push(s)
-      if (s.type === FileType.DIRECTORY) {
-        const entryPath = path.child(s.name)
-        const entrySpec = new PathSpec({
-          original: entryPath,
-          directory: entryPath,
-          resolved: false,
-          prefix: path.prefix,
-        })
-        const sub = await lsEntries(
-          accessor,
-          entrySpec,
-          allFiles,
-          sortBy,
-          reverse,
-          recursive,
-          false,
-          warnings,
-          indexCache,
-        )
-        subEntries.push(...sub)
-      }
-    }
-    return subEntries
-  }
-  return stats
-}
 
 async function lsCommand(
   accessor: DiscordAccessor,
@@ -110,65 +28,24 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
-  const allFiles = opts.flags.a === true || opts.flags.A === true
-  const human = opts.flags.h === true
-  const reverse = opts.flags.r === true
-  const recursive = opts.flags.R === true
-  const listDir = opts.flags.d === true
-  const classify = opts.flags.F === true
-  const sortBy: 'name' | 'size' = opts.flags.S === true ? 'size' : 'name'
   let workingPaths: PathSpec[] = paths
   if (workingPaths.length === 0) {
-    const cwd = opts.cwd
     workingPaths = [
       new PathSpec({
-        original: cwd,
-        directory: cwd,
+        original: opts.cwd,
+        directory: opts.cwd,
         resolved: false,
         prefix: opts.mountPrefix ?? '',
       }),
     ]
   }
-  workingPaths = await resolveDiscordGlob(accessor, workingPaths, opts.index ?? undefined)
-  const warnings: string[] = []
-  const results: string[] = []
-  for (const p of workingPaths) {
-    let entries: FileStat[]
-    try {
-      entries = await lsEntries(
-        accessor,
-        p,
-        allFiles,
-        sortBy,
-        reverse,
-        recursive,
-        listDir,
-        warnings,
-        opts.index,
-      )
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${p.original}': ${msg}`)
-      continue
-    }
-    if (long) {
-      for (const e of entries) {
-        const sizeStr = human ? humanSize(e.size ?? 0) : String(e.size ?? 0)
-        results.push(`${e.type ?? '-'}\t${sizeStr}\t${e.modified ?? ''}\t${e.name}`)
-      }
-    } else {
-      for (const e of entries) {
-        const isDir = classify && e.type === FileType.DIRECTORY
-        const name = isDir ? e.name + '/' : e.name
-        results.push(name)
-      }
-    }
-  }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  return [out, new IOResult({ stderr, exitCode })]
+  const resolved = await resolveDiscordGlob(accessor, workingPaths, opts.index ?? undefined)
+  return lsGeneric(
+    resolved,
+    opts,
+    (p) => discordReaddir(accessor, p, opts.index ?? undefined),
+    (p) => discordStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const DISCORD_LS = command({

--- a/typescript/packages/core/src/commands/builtin/discord/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/stat.ts
@@ -15,32 +15,11 @@
 import type { DiscordAccessor } from '../../../accessor/discord.ts'
 import { resolveDiscordGlob } from '../../../core/discord/glob.ts'
 import { stat as discordStat } from '../../../core/discord/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { FileType, ResourceName, type FileStat, type PathSpec } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { statGeneric } from '../generic/stat.ts'
 import { metadataProvision } from './_provision.ts'
-
-const ENC = new TextEncoder()
-
-const TYPE_LABELS: Record<string, string> = {
-  [FileType.DIRECTORY]: 'directory',
-  [FileType.TEXT]: 'regular file',
-  [FileType.BINARY]: 'regular file',
-  [FileType.JSON]: 'regular file',
-  [FileType.CSV]: 'regular file',
-}
-
-function formatStat(fmt: string, s: FileStat): string {
-  return fmt.replace(/%(.)/g, (_, spec: string) => {
-    if (spec === 'n') return s.name
-    if (spec === 's') return String(s.size ?? 0)
-    if (spec === 'F')
-      return s.type !== null ? (TYPE_LABELS[s.type] ?? 'regular file') : 'regular file'
-    if (spec === 'y') return s.modified ?? ''
-    return '?'
-  })
-}
 
 async function statCommand(
   accessor: DiscordAccessor,
@@ -48,29 +27,9 @@ async function statCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('stat: missing operand\n') })]
-  }
-  const resolved = await resolveDiscordGlob(accessor, paths, opts.index ?? undefined)
-  const fmt =
-    typeof opts.flags.c === 'string'
-      ? opts.flags.c
-      : typeof opts.flags.f === 'string'
-        ? opts.flags.f
-        : null
-  const lines: string[] = []
-  for (const p of resolved) {
-    const s = await discordStat(accessor, p, opts.index ?? undefined)
-    if (fmt !== null) {
-      lines.push(formatStat(fmt, s))
-    } else {
-      lines.push(
-        `name=${s.name} size=${String(s.size)} modified=${String(s.modified)} type=${String(s.type)}`,
-      )
-    }
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveDiscordGlob(accessor, paths, opts.index ?? undefined) : []
+  return statGeneric(resolved, opts, (p) => discordStat(accessor, p, opts.index ?? undefined))
 }
 
 export const DISCORD_STAT = command({

--- a/typescript/packages/core/src/commands/builtin/discord/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/tree.ts
@@ -16,94 +16,10 @@ import type { DiscordAccessor } from '../../../accessor/discord.ts'
 import { resolveDiscordGlob } from '../../../core/discord/glob.ts'
 import { readdir as discordReaddir } from '../../../core/discord/readdir.ts'
 import { stat as discordStat } from '../../../core/discord/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function fnmatch(name: string, pattern: string): boolean {
-  const re = pattern
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\?/g, '.')
-    .replace(/\*/g, '.*')
-  return new RegExp(`^${re}$`).test(name)
-}
-
-interface TreeOpts {
-  maxDepth: number | null
-  showHidden: boolean
-  ignorePattern: string | null
-  dirsOnly: boolean
-  matchPattern: string | null
-}
-
-async function treeRecurse(
-  accessor: DiscordAccessor,
-  path: PathSpec,
-  prefix: string,
-  depth: number,
-  treeOpts: TreeOpts,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<string[]> {
-  const lines: string[] = []
-  let entries: string[]
-  try {
-    entries = await discordReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`tree: '${path.original}': ${msg}`)
-    return lines
-  }
-  const filtered: [PathSpec, FileStat][] = []
-  for (const entry of entries) {
-    try {
-      const entrySpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await discordStat(accessor, entrySpec, indexCache ?? undefined)
-      if (!treeOpts.showHidden && s.name.startsWith('.')) continue
-      if (treeOpts.ignorePattern !== null && fnmatch(s.name, treeOpts.ignorePattern)) continue
-      if (treeOpts.dirsOnly && s.type !== FileType.DIRECTORY) continue
-      const notDir = s.type !== FileType.DIRECTORY
-      if (treeOpts.matchPattern !== null && notDir && !fnmatch(s.name, treeOpts.matchPattern))
-        continue
-      filtered.push([entrySpec, s])
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`tree: '${entry}': ${msg}`)
-    }
-  }
-  for (let i = 0; i < filtered.length; i++) {
-    const pair = filtered[i]
-    if (pair === undefined) continue
-    const [entrySpec, s] = pair
-    const isLast = i === filtered.length - 1
-    const connector = isLast ? '\u2514\u2500\u2500 ' : '\u251c\u2500\u2500 '
-    lines.push(prefix + connector + s.name)
-    if (s.type === FileType.DIRECTORY) {
-      if (treeOpts.maxDepth !== null && depth >= treeOpts.maxDepth) continue
-      const extension = isLast ? '    ' : '\u2502   '
-      const sub = await treeRecurse(
-        accessor,
-        entrySpec,
-        prefix + extension,
-        depth + 1,
-        treeOpts,
-        warnings,
-        indexCache,
-      )
-      lines.push(...sub)
-    }
-  }
-  return lines
-}
+import { treeGeneric } from '../generic/tree.ts'
 
 async function treeCommand(
   accessor: DiscordAccessor,
@@ -112,27 +28,12 @@ async function treeCommand(
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const resolved = await resolveDiscordGlob(accessor, paths, opts.index ?? undefined)
-  const p0 =
-    resolved[0] ??
-    new PathSpec({
-      original: opts.cwd,
-      directory: opts.cwd,
-      resolved: false,
-      prefix: opts.mountPrefix ?? '',
-    })
-  const maxDepth = typeof opts.flags.L === 'string' ? Number.parseInt(opts.flags.L, 10) : null
-  const treeOpts: TreeOpts = {
-    maxDepth,
-    showHidden: opts.flags.a === true,
-    ignorePattern: typeof opts.flags.args_I === 'string' ? opts.flags.args_I : null,
-    dirsOnly: opts.flags.d === true,
-    matchPattern: typeof opts.flags.P === 'string' ? opts.flags.P : null,
-  }
-  const warnings: string[] = []
-  const results = await treeRecurse(accessor, p0, '', 0, treeOpts, warnings, opts.index)
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  return [out, new IOResult({ stderr })]
+  return treeGeneric(
+    resolved,
+    opts,
+    (p) => discordReaddir(accessor, p, opts.index ?? undefined),
+    (p) => discordStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const DISCORD_TREE = command({

--- a/typescript/packages/core/src/commands/builtin/discord/wc.test.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/wc.test.ts
@@ -75,8 +75,9 @@ describe('discord wc', () => {
       { index: idx, transport },
     )
     const parts = out.split('\t')
-    expect(parts).toHaveLength(3)
+    expect(parts).toHaveLength(4)
     expect(parts[0]).toBe('3')
+    expect(parts[3]).toBe('/mnt/discord/My Server__G1/channels/general__C1/2016-04-30/chat.jsonl')
   })
 
   it('supports -l flag (line count)', async () => {
@@ -106,6 +107,6 @@ describe('discord wc', () => {
       { args_l: true },
       { index: idx, transport },
     )
-    expect(out).toBe('2')
+    expect(out).toBe('2\t/mnt/discord/My Server__G1/channels/general__C1/2016-04-30/chat.jsonl')
   })
 })

--- a/typescript/packages/core/src/commands/builtin/discord/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/wc.ts
@@ -13,76 +13,34 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { DiscordAccessor } from '../../../accessor/discord.ts'
+import type { IndexCacheStore } from '../../../cache/index/index.ts'
 import { resolveDiscordGlob } from '../../../core/discord/glob.ts'
 import { read as discordRead } from '../../../core/discord/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { wcGeneric } from '../generic/wc.ts'
 import { fileReadProvision } from './_provision.ts'
 
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function countChar(text: string, ch: string): number {
-  let n = 0
-  for (const c of text) if (c === ch) n += 1
-  return n
-}
-
-function maxLineLength(text: string): number {
-  let max = 0
-  let current = 0
-  for (const c of text) {
-    if (c === '\n') {
-      if (current > max) max = current
-      current = 0
-    } else {
-      current += 1
-    }
-  }
-  if (current > max) max = current
-  return max
+async function* discordStream(
+  accessor: DiscordAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await discordRead(accessor, p, index)
 }
 
 async function wcCommand(
   accessor: DiscordAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const f = opts.flags
-  const lFlag = f.args_l === true
-  const wFlag = f.w === true
-  const cFlag = f.c === true
-  const mFlag = f.m === true
-  const LFlag = f.L === true
-  let data: Uint8Array | null
-  if (paths.length > 0) {
-    const resolved = await resolveDiscordGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    data = await discordRead(accessor, first, opts.index ?? undefined)
-  } else {
-    data = await readStdinAsync(opts.stdin)
-    if (data === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('wc: missing operand\n') })]
-    }
-  }
-  const text = DEC.decode(data)
-  const lineCount = countChar(text, '\n')
-  const wordCount = text.split(/\s+/).filter((s) => s !== '').length
-  const byteCount = data.byteLength
-  let payload: string
-  if (LFlag) payload = String(maxLineLength(text))
-  else if (lFlag) payload = String(lineCount)
-  else if (wFlag) payload = String(wordCount)
-  else if (mFlag) payload = String(text.length)
-  else if (cFlag) payload = String(byteCount)
-  else payload = `${String(lineCount)}\t${String(wordCount)}\t${String(byteCount)}`
-  const out: ByteSource = ENC.encode(payload)
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveDiscordGlob(accessor, paths, opts.index ?? undefined) : []
+  return wcGeneric(resolved, texts, opts, (p) =>
+    discordStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const DISCORD_WC = command({


### PR DESCRIPTION
Continues the generic-alignment work (after slack + s3) for the discord backend.

## What changed
Migrated the 6 read/structural commands discord still inlined to delegate to the shared generic layer: cat, head, wc, ls, stat, tree. tail, grep, rg already delegated. Matches Python's discord delegation profile (the only gap vs Python is basename/dirname/realpath, which TS discord does not register).

Each wrapper now resolves globs and calls the generic with discord's core readdir/stat/read injected, identical in shape to the slack pilot.

Two behavior alignments fall out (same as slack/s3):
- cat now concatenates multiple files (was single-file only)
- wc emits the filename label (coreutils/python parity); discord wc test updated for the extra column

## verification
- discord unit suite: 17 files / 43 tests pass
- full monorepo build + test: core 331, browser 44, node 154, server 19, agents 11, cli 4 all pass