### PR TITLE
fix(commands): enforce cp and mv destination semantics

### DIFF
--- a/python/mirage/commands/builtin/databricks_volume/cp.py
+++ b/python/mirage/commands/builtin/databricks_volume/cp.py
@@ -45,6 +45,9 @@ async def cp(
     recursive = r or R or a
     *sources, dst = paths
     dst_is_dir = await is_directory(accessor, dst, index)
+    # POSIX multi-source form requires the final operand to be a directory.
+    if len(sources) > 1 and not dst_is_dir:
+        raise NotADirectoryError(f"target '{dst.original}' is not a directory")
     writes: dict[str, bytes] = {}
     lines: list[str] = []
     errors: list[str] = []

--- a/python/mirage/commands/builtin/databricks_volume/mv.py
+++ b/python/mirage/commands/builtin/databricks_volume/mv.py
@@ -41,6 +41,9 @@ async def mv(
     paths = await resolve_glob(accessor, paths, index)
     *sources, dst = paths
     dst_is_dir = await is_directory(accessor, dst, index)
+    # POSIX multi-source form requires the final operand to be a directory.
+    if len(sources) > 1 and not dst_is_dir:
+        raise NotADirectoryError(f"target '{dst.original}' is not a directory")
     writes: dict[str, bytes] = {}
     lines: list[str] = []
     errors: list[str] = []

--- a/python/mirage/workspace/executor/command.py
+++ b/python/mirage/workspace/executor/command.py
@@ -16,7 +16,8 @@ from collections.abc import Callable
 
 from mirage.commands.builtin.utils.safeguard import maybe_with_timeout
 from mirage.commands.safeguard import resolve_across_mounts, resolve_safeguard
-from mirage.commands.spec import OperandKind, parse_command, parse_to_kwargs
+from mirage.commands.spec import (SPECS, OperandKind, parse_command,
+                                  parse_to_kwargs)
 from mirage.io import IOResult
 from mirage.io.stream import async_chain, materialize, wrap_cachable_streams
 from mirage.io.types import ByteSource
@@ -260,8 +261,15 @@ async def handle_command(
                                   stderr=msg.encode())
 
     if is_cross_mount(cmd_name, path_scopes, registry):
+        flag_kwargs = {}
+        # Cross-mount execution bypasses a resource command handler. Parse
+        # against the shared spec so flags do not depend on the source mount.
+        command_spec = SPECS.get(cmd_name)
+        if command_spec is not None:
+            parsed = parse_command(command_spec, raw_argv, cwd=session.cwd)
+            flag_kwargs = parse_to_kwargs(parsed)
         stdout, io, exec_node = await handle_cross_mount(
-            cmd_name, path_scopes, text_only, dispatch, cmd_str)
+            cmd_name, path_scopes, text_only, flag_kwargs, dispatch, cmd_str)
         if io.safeguard is None:
             mounts = []
             for s in path_scopes:

--- a/python/mirage/workspace/executor/cross_mount.py
+++ b/python/mirage/workspace/executor/cross_mount.py
@@ -16,7 +16,7 @@ import re
 
 from mirage.io import IOResult
 from mirage.io.types import ByteSource
-from mirage.types import PathSpec
+from mirage.types import FileType, PathSpec
 from mirage.workspace.types import ExecutionNode
 
 _CROSS_COMMANDS = frozenset({"cp", "mv", "diff", "cmp"})
@@ -40,15 +40,43 @@ async def handle_cross_mount(
     cmd_name: str,
     scopes: list[PathSpec],
     text_args: list[str],
+    flag_kwargs: dict,
     dispatch,
     cmd_str: str,
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
-    """Handle commands that span multiple mounts."""
+    """Execute a supported command whose path operands span mounts.
+
+    Copy and move follow POSIX operand semantics: every path except the final
+    path is a source, and the final path is the destination. An existing
+    destination directory maps each source to ``destination/basename``;
+    multiple sources require that directory form. Source data is read before
+    mutation so validation or read failures do not partially modify targets.
+
+    Examples:
+        ``cp /ram/a.txt /disk/a.txt`` produces scopes
+        ``[/ram/a.txt, /disk/a.txt]``.
+        ``cp -n /ram/a.txt /disk/dir`` additionally receives
+        ``flag_kwargs={"n": True}``.
+        ``mv /ram/a.txt /s3/b.txt /disk/dir`` treats the first two scopes as
+        sources and the final scope as the destination directory.
+
+    Args:
+        cmd_name (str): Command name, such as ``cp``, ``mv``, or ``cat``.
+        scopes (list[PathSpec]): Path operands in command-line order.
+        text_args (list[str]): Original non-path command arguments.
+        flag_kwargs (dict): Flags parsed from the shared command spec.
+        dispatch (Callable): Workspace operation dispatcher.
+        cmd_str (str): Original command text for the execution record.
+
+    Returns:
+        tuple[ByteSource | None, IOResult, ExecutionNode]: Command output,
+        I/O metadata, and execution record.
+    """
     try:
         if cmd_name == "cp":
-            return await _cross_cp(scopes, dispatch, cmd_str)
+            return await _cross_cp(scopes, flag_kwargs, dispatch, cmd_str)
         if cmd_name == "mv":
-            return await _cross_mv(scopes, dispatch, cmd_str)
+            return await _cross_mv(scopes, flag_kwargs, dispatch, cmd_str)
         if cmd_name == "diff":
             return await _cross_diff(scopes, dispatch, cmd_str)
         if cmd_name == "cmp":
@@ -56,7 +84,7 @@ async def handle_cross_mount(
         if cmd_name in _MULTI_READ_COMMANDS:
             return await _cross_multi_read(cmd_name, scopes, text_args,
                                            dispatch, cmd_str)
-    except (FileNotFoundError, PermissionError) as exc:
+    except (FileNotFoundError, NotADirectoryError, PermissionError) as exc:
         err = f"{cmd_name}: {exc}\n".encode()
         return None, IOResult(exit_code=1,
                               stderr=err), ExecutionNode(command=cmd_str,
@@ -69,18 +97,70 @@ async def handle_cross_mount(
                                                      exit_code=1)
 
 
-async def _cross_cp(scopes, dispatch, cmd_str):
-    src, dst = scopes[0], scopes[1]
-    data, _ = await dispatch("read", src)
-    await dispatch("write", dst, data=data)
+def _child_path(parent: PathSpec, source: PathSpec) -> PathSpec:
+    name = source.original.rstrip("/").rsplit("/", 1)[-1]
+    return PathSpec.from_str_path(parent.child(name), parent.prefix)
+
+
+async def _cross_targets(scopes, dispatch):
+    # Resolve the complete source-to-target mapping before any mutation.
+    *sources, dst = scopes
+    try:
+        dst_stat, _ = await dispatch("stat", dst)
+        dst_is_dir = dst_stat.type == FileType.DIRECTORY
+    except FileNotFoundError:
+        dst_is_dir = False
+    if len(sources) > 1 and not dst_is_dir:
+        raise NotADirectoryError(f"target '{dst.original}' is not a directory")
+    targets = ([_child_path(dst, src)
+                for src in sources] if dst_is_dir else [dst])
+    return sources, targets
+
+
+async def _read_cross_sources(sources, dispatch):
+    # Pre-read all sources so a later read failure cannot leave partial writes.
+    source_data = []
+    for src in sources:
+        data, _ = await dispatch("read", src)
+        source_data.append(data)
+    return source_data
+
+
+async def _cross_target_exists(target: PathSpec, dispatch) -> bool:
+    try:
+        await dispatch("stat", target)
+    except FileNotFoundError:
+        return False
+    return True
+
+
+async def _cross_cp(scopes, flag_kwargs, dispatch, cmd_str):
+    sources, targets = await _cross_targets(scopes, dispatch)
+    source_data = await _read_cross_sources(sources, dispatch)
+    no_clobber = flag_kwargs.get("n") is True
+    for target, data in zip(targets, source_data):
+        # Check immediately before writing: earlier sources may share this
+        # basename and create the target during the same command.
+        if no_clobber and await _cross_target_exists(target, dispatch):
+            continue
+        await dispatch("write", target, data=data)
     return None, IOResult(), ExecutionNode(command=cmd_str, exit_code=0)
 
 
-async def _cross_mv(scopes, dispatch, cmd_str):
-    src, dst = scopes[0], scopes[1]
-    data, _ = await dispatch("read", src)
-    await dispatch("write", dst, data=data)
-    await dispatch("unlink", src)
+async def _cross_mv(scopes, flag_kwargs, dispatch, cmd_str):
+    sources, targets = await _cross_targets(scopes, dispatch)
+    source_data = await _read_cross_sources(sources, dispatch)
+    no_clobber = flag_kwargs.get("n") is True
+    moved_sources = []
+    for src, target, data in zip(sources, targets, source_data):
+        # A skipped no-clobber target must also preserve its source.
+        if no_clobber and await _cross_target_exists(target, dispatch):
+            continue
+        await dispatch("write", target, data=data)
+        moved_sources.append(src)
+    # Delete only sources whose destination write completed.
+    for src in moved_sources:
+        await dispatch("unlink", src)
     return None, IOResult(), ExecutionNode(command=cmd_str, exit_code=0)
 
 

--- a/python/tests/commands/builtin/databricks_volume/test_cp.py
+++ b/python/tests/commands/builtin/databricks_volume/test_cp.py
@@ -83,3 +83,18 @@ async def test_cp_onto_same_path_errors_and_preserves_file(
     assert io.exit_code != 0
     assert b"are the same file" in io.stderr
     assert dbx_files.downloads[f"{ROOT}/src.txt"] == b"hello"
+
+
+@pytest.mark.asyncio
+async def test_cp_multiple_sources_require_directory(write_ws, dbx_files):
+    seed_file(dbx_files, f"{ROOT}/a.txt", b"AAA")
+    seed_file(dbx_files, f"{ROOT}/b.txt", b"BBB")
+    seed_file(dbx_files, f"{ROOT}/target.txt", b"target")
+
+    io = await write_ws.execute("cp /dbx/a.txt /dbx/b.txt /dbx/target.txt")
+
+    assert io.exit_code != 0
+    assert b"not a directory" in io.stderr
+    assert dbx_files.downloads[f"{ROOT}/a.txt"] == b"AAA"
+    assert dbx_files.downloads[f"{ROOT}/b.txt"] == b"BBB"
+    assert dbx_files.downloads[f"{ROOT}/target.txt"] == b"target"

--- a/python/tests/commands/builtin/databricks_volume/test_mv.py
+++ b/python/tests/commands/builtin/databricks_volume/test_mv.py
@@ -114,3 +114,20 @@ async def test_ops_rename_onto_same_path_is_noop(write_ws, dbx_files):
 
     assert dbx_files.downloads[f"{ROOT}/src.txt"] == b"data"
     assert f"{ROOT}/src.txt" not in dbx_files.delete_calls
+
+
+@pytest.mark.asyncio
+async def test_mv_multiple_sources_require_directory(write_ws, dbx_files):
+    seed_file(dbx_files, f"{ROOT}/a.txt", b"AAA")
+    seed_file(dbx_files, f"{ROOT}/b.txt", b"BBB")
+    seed_file(dbx_files, f"{ROOT}/target.txt", b"target")
+
+    io = await write_ws.execute("mv /dbx/a.txt /dbx/b.txt /dbx/target.txt")
+
+    assert io.exit_code != 0
+    assert b"not a directory" in io.stderr
+    assert dbx_files.downloads[f"{ROOT}/a.txt"] == b"AAA"
+    assert dbx_files.downloads[f"{ROOT}/b.txt"] == b"BBB"
+    assert dbx_files.downloads[f"{ROOT}/target.txt"] == b"target"
+    assert f"{ROOT}/a.txt" not in dbx_files.delete_calls
+    assert f"{ROOT}/b.txt" not in dbx_files.delete_calls

--- a/python/tests/workspace/test_workspace.py
+++ b/python/tests/workspace/test_workspace.py
@@ -1512,6 +1512,159 @@ def test_cross_mount_mv():
     assert io.exit_code == 1
 
 
+def test_cross_mount_cp_into_directory():
+    ws = _ws()
+    _exec(ws, "echo source > /ram/source.txt")
+    _exec(ws, "mkdir /disk/target")
+
+    io = _exec(ws, "cp /ram/source.txt /disk/target")
+
+    assert io.exit_code == 0
+    assert _stdout(_exec(ws, "cat /disk/target/source.txt")) == b"source\n"
+    assert _stdout(_exec(ws, "cat /ram/source.txt")) == b"source\n"
+
+
+def test_cross_mount_mv_into_directory():
+    ws = _ws()
+    _exec(ws, "echo source > /ram/source.txt")
+    _exec(ws, "mkdir /disk/target")
+
+    io = _exec(ws, "mv /ram/source.txt /disk/target")
+
+    assert io.exit_code == 0
+    assert _stdout(_exec(ws, "cat /disk/target/source.txt")) == b"source\n"
+    assert _exec(ws, "cat /ram/source.txt").exit_code != 0
+
+
+def test_cross_mount_cp_no_clobber_into_directory():
+    ws = _ws()
+    _exec(ws, "echo source > /ram/source.txt")
+    _exec(ws, "mkdir /disk/target")
+    _exec(ws, "echo existing > /disk/target/source.txt")
+
+    io = _exec(ws, "cp -vn /ram/source.txt /disk/target")
+
+    assert io.exit_code == 0
+    assert _stdout(_exec(ws, "cat /disk/target/source.txt")) == b"existing\n"
+    assert _stdout(_exec(ws, "cat /ram/source.txt")) == b"source\n"
+
+
+def test_cross_mount_mv_no_clobber_into_directory():
+    ws = _ws()
+    _exec(ws, "echo source > /ram/source.txt")
+    _exec(ws, "mkdir /disk/target")
+    _exec(ws, "echo existing > /disk/target/source.txt")
+
+    io = _exec(ws, "mv -vn /ram/source.txt /disk/target")
+
+    assert io.exit_code == 0
+    assert _stdout(_exec(ws, "cat /disk/target/source.txt")) == b"existing\n"
+    assert _stdout(_exec(ws, "cat /ram/source.txt")) == b"source\n"
+
+
+def test_cross_mount_cp_no_clobber_duplicate_basenames():
+    ws = _ws()
+    _exec(ws, "echo first > /ram/shared.txt")
+    _exec(ws, "echo second > /s3/shared.txt")
+    _exec(ws, "mkdir /disk/target")
+
+    io = _exec(ws, "cp -n /ram/shared.txt /s3/shared.txt /disk/target")
+
+    assert io.exit_code == 0
+    assert _stdout(_exec(ws, "cat /disk/target/shared.txt")) == b"first\n"
+    assert _stdout(_exec(ws, "cat /ram/shared.txt")) == b"first\n"
+    assert _stdout(_exec(ws, "cat /s3/shared.txt")) == b"second\n"
+
+
+def test_cross_mount_no_clobber_uses_shared_command_spec():
+    ws = _ws()
+    source_mount = ws._registry.mount_for("/ram/source.txt")
+    source_mount._cmds.pop(("cp", None))
+    source_mount._cmd_specs.pop("cp")
+    _exec(ws, "echo source > /ram/source.txt")
+    _exec(ws, "echo existing > /disk/target.txt")
+
+    io = _exec(ws, "cp -n /ram/source.txt /disk/target.txt")
+
+    assert io.exit_code == 0
+    assert _stdout(_exec(ws, "cat /disk/target.txt")) == b"existing\n"
+    assert _stdout(_exec(ws, "cat /ram/source.txt")) == b"source\n"
+
+
+def test_cross_mount_mv_no_clobber_duplicate_basenames():
+    ws = _ws()
+    _exec(ws, "echo first > /ram/shared.txt")
+    _exec(ws, "echo second > /s3/shared.txt")
+    _exec(ws, "mkdir /disk/target")
+
+    io = _exec(ws, "mv -n /ram/shared.txt /s3/shared.txt /disk/target")
+
+    assert io.exit_code == 0
+    assert _stdout(_exec(ws, "cat /disk/target/shared.txt")) == b"first\n"
+    assert _exec(ws, "cat /ram/shared.txt").exit_code != 0
+    assert _stdout(_exec(ws, "cat /s3/shared.txt")) == b"second\n"
+
+
+def test_cross_mount_cp_multiple_sources_require_directory():
+    ws = _ws()
+    _exec(ws, "echo first > /ram/a.txt")
+    _exec(ws, "echo second > /ram/b.txt")
+    _exec(ws, "echo target > /disk/target.txt")
+
+    io = _exec(ws, "cp /ram/a.txt /ram/b.txt /disk/target.txt")
+
+    assert io.exit_code != 0
+    assert b"not a directory" in io.stderr
+    assert _stdout(_exec(ws, "cat /ram/a.txt")) == b"first\n"
+    assert _stdout(_exec(ws, "cat /ram/b.txt")) == b"second\n"
+    assert _stdout(_exec(ws, "cat /disk/target.txt")) == b"target\n"
+
+
+def test_cross_mount_mv_multiple_sources_require_directory():
+    ws = _ws()
+    _exec(ws, "echo first > /ram/a.txt")
+    _exec(ws, "echo second > /ram/b.txt")
+    _exec(ws, "echo target > /disk/target.txt")
+
+    io = _exec(ws, "mv /ram/a.txt /ram/b.txt /disk/target.txt")
+
+    assert io.exit_code != 0
+    assert b"not a directory" in io.stderr
+    assert _stdout(_exec(ws, "cat /ram/a.txt")) == b"first\n"
+    assert _stdout(_exec(ws, "cat /ram/b.txt")) == b"second\n"
+    assert _stdout(_exec(ws, "cat /disk/target.txt")) == b"target\n"
+
+
+def test_cross_mount_cp_multiple_sources_into_directory():
+    ws = _ws()
+    _exec(ws, "echo first > /ram/a.txt")
+    _exec(ws, "echo second > /ram/b.txt")
+    _exec(ws, "mkdir /disk/target")
+
+    io = _exec(ws, "cp /ram/a.txt /ram/b.txt /disk/target")
+
+    assert io.exit_code == 0
+    assert _stdout(_exec(ws, "cat /disk/target/a.txt")) == b"first\n"
+    assert _stdout(_exec(ws, "cat /disk/target/b.txt")) == b"second\n"
+    assert _stdout(_exec(ws, "cat /ram/a.txt")) == b"first\n"
+    assert _stdout(_exec(ws, "cat /ram/b.txt")) == b"second\n"
+
+
+def test_cross_mount_mv_multiple_sources_into_directory():
+    ws = _ws()
+    _exec(ws, "echo first > /ram/a.txt")
+    _exec(ws, "echo second > /ram/b.txt")
+    _exec(ws, "mkdir /disk/target")
+
+    io = _exec(ws, "mv /ram/a.txt /ram/b.txt /disk/target")
+
+    assert io.exit_code == 0
+    assert _stdout(_exec(ws, "cat /disk/target/a.txt")) == b"first\n"
+    assert _stdout(_exec(ws, "cat /disk/target/b.txt")) == b"second\n"
+    assert _exec(ws, "cat /ram/a.txt").exit_code != 0
+    assert _exec(ws, "cat /ram/b.txt").exit_code != 0
+
+
 def test_cross_mount_diff_same():
     ws = _ws()
     _exec(ws, "echo same > /disk/a.txt")


### PR DESCRIPTION
## Summary

Fix `cp` and `mv` destination handling for multi-source Databricks Volume commands and cross-mount operations.

Fixes #128.  
Partially addresses #130 by adding move/copy-into-directory semantics. Recursive cross-mount operations and parent directory creation remain out of scope.

## Changes

- Require an existing directory destination for multi-source Databricks Volume `cp` and `mv`.
- Treat the final cross-mount operand as the destination and all preceding operands as sources.
- Copy or move sources into an existing destination directory using their basenames.
- Validate and read all sources before performing mutations.
- Preserve `-n` no-clobber behavior, including bundled flags and duplicate basenames.
- Delete only sources whose cross-mount destination writes completed.
- Parse cross-mount flags using the shared command specification.

## Tests

Added regression tests for:
- Multi-source operations targeting a non-directory.
- Single and multiple sources targeting a directory.
- Cross-mount operand selection.
- No-clobber behavior and bundled flags.
- Multiple sources with duplicate basenames.
- Source and destination preservation after rejected or skipped operations.
