### PR TITLE
refactor(ts/google): delegate gdocs/gsheets/gslides/gmail reads to generic

### DIFF
--- a/python/mirage/core/gdocs/read.py
+++ b/python/mirage/core/gdocs/read.py
@@ -25,7 +25,7 @@ from mirage.types import PathSpec
 async def read_doc(token_manager: TokenManager, doc_id: str) -> bytes:
     url = f"{DOCS_API_BASE}/documents/{doc_id}"
     data = await google_get(token_manager, url)
-    return json.dumps(data, ensure_ascii=False).encode()
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":")).encode()
 
 
 async def read(

--- a/python/mirage/core/gmail/read.py
+++ b/python/mirage/core/gmail/read.py
@@ -67,4 +67,5 @@ async def read(
                                     attachment_id)
     processed = await get_message_processed(accessor.token_manager,
                                             result.entry.id)
-    return json.dumps(processed, ensure_ascii=False).encode()
+    return json.dumps(processed, ensure_ascii=False,
+                      separators=(",", ":")).encode()

--- a/python/mirage/core/gsheets/read.py
+++ b/python/mirage/core/gsheets/read.py
@@ -36,7 +36,7 @@ async def read_spreadsheet(token_manager: TokenManager,
     """
     url = f"{SHEETS_API_BASE}/spreadsheets/{spreadsheet_id}"
     data = await google_get(token_manager, url)
-    return json.dumps(data, ensure_ascii=False).encode()
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":")).encode()
 
 
 async def read_values(token_manager: TokenManager, spreadsheet_id: str,
@@ -53,7 +53,7 @@ async def read_values(token_manager: TokenManager, spreadsheet_id: str,
     """
     url = f"{SHEETS_API_BASE}/spreadsheets/{spreadsheet_id}/values/{range_}"
     data = await google_get(token_manager, url)
-    return json.dumps(data, ensure_ascii=False).encode()
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":")).encode()
 
 
 async def fetch_sheet_names(

--- a/python/mirage/core/gslides/read.py
+++ b/python/mirage/core/gslides/read.py
@@ -27,7 +27,7 @@ async def read_presentation(token_manager: TokenManager,
                             presentation_id: str) -> bytes:
     url = f"{SLIDES_API_BASE}/presentations/{presentation_id}"
     data = await google_get(token_manager, url)
-    return json.dumps(data, ensure_ascii=False).encode()
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":")).encode()
 
 
 async def read(

--- a/typescript/packages/core/src/commands/builtin/gdocs/head.ts
+++ b/typescript/packages/core/src/commands/builtin/gdocs/head.ts
@@ -14,52 +14,29 @@
 
 import type { GDocsAccessor } from '../../../accessor/gdocs.ts'
 import { resolveGlob } from '../../../core/gdocs/glob.ts'
-import { read as gdocsRead } from '../../../core/gdocs/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as gdocsStream } from '../../../core/gdocs/read.ts'
+import { stat as gdocsStat } from '../../../core/gdocs/stat.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { headGeneric } from '../generic/head.ts'
 import { fileReadProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-function headBytes(data: Uint8Array, lines: number, bytesMode: number | null): Uint8Array {
-  if (bytesMode !== null) return data.slice(0, bytesMode)
-  let count = 0
-  let end = 0
-  for (let i = 0; i < data.byteLength && count < lines; i++) {
-    if (data[i] === 0x0a) {
-      count += 1
-      end = i + 1
-    }
-  }
-  if (count < lines) return data
-  return data.slice(0, end - 1)
-}
 
 async function headCommand(
   accessor: GDocsAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const lines = typeof opts.flags.n === 'string' ? Number.parseInt(opts.flags.n, 10) : 10
-  const bytesMode = typeof opts.flags.c === 'string' ? Number.parseInt(opts.flags.c, 10) : null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const data = await gdocsRead(accessor, first, opts.index ?? undefined)
-    const out: ByteSource = headBytes(data, lines, bytesMode)
-    return [out, new IOResult()]
-  }
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('head: missing operand\n') })]
-  }
-  const out: ByteSource = headBytes(raw, lines, bytesMode)
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return headGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => gdocsStat(accessor, p, opts.index ?? undefined),
+    (p) => gdocsStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GDOCS_HEAD = command({

--- a/typescript/packages/core/src/commands/builtin/gdocs/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/gdocs/ls.ts
@@ -16,93 +16,11 @@ import type { GDocsAccessor } from '../../../accessor/gdocs.ts'
 import { resolveGlob } from '../../../core/gdocs/glob.ts'
 import { readdir as gdocsReaddir } from '../../../core/gdocs/readdir.ts'
 import { stat as gdocsStat } from '../../../core/gdocs/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { humanSize } from '../utils/formatting.ts'
+import { lsGeneric } from '../generic/ls.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-async function lsEntries(
-  accessor: GDocsAccessor,
-  path: PathSpec,
-  allFiles: boolean,
-  sortBy: 'name' | 'size',
-  reverse: boolean,
-  recursive: boolean,
-  listDir: boolean,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<FileStat[]> {
-  if (listDir) {
-    const s = await gdocsStat(accessor, path, indexCache ?? undefined)
-    return [s]
-  }
-  let entries: string[]
-  try {
-    entries = await gdocsReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`ls: cannot access '${path.original}': ${msg}`)
-    return []
-  }
-  const stats: FileStat[] = []
-  for (const entry of entries) {
-    try {
-      const eSpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await gdocsStat(accessor, eSpec, indexCache ?? undefined)
-      if (!allFiles && s.name.startsWith('.')) continue
-      stats.push(s)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${entry}': ${msg}`)
-    }
-  }
-  if (sortBy === 'size') {
-    stats.sort((a, b) => (a.size ?? 0) - (b.size ?? 0))
-    if (!reverse) stats.reverse()
-  } else {
-    stats.sort((a, b) => a.name.localeCompare(b.name))
-    if (reverse) stats.reverse()
-  }
-  if (recursive) {
-    const subEntries: FileStat[] = []
-    for (const s of stats) {
-      subEntries.push(s)
-      if (s.type === FileType.DIRECTORY) {
-        const childPath = path.child(s.name)
-        const childSpec = new PathSpec({
-          original: childPath,
-          directory: childPath,
-          resolved: false,
-          prefix: path.prefix,
-        })
-        const sub = await lsEntries(
-          accessor,
-          childSpec,
-          allFiles,
-          sortBy,
-          reverse,
-          recursive,
-          false,
-          warnings,
-          indexCache,
-        )
-        subEntries.push(...sub)
-      }
-    }
-    return subEntries
-  }
-  return stats
-}
 
 async function lsCommand(
   accessor: GDocsAccessor,
@@ -110,64 +28,24 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const targets: PathSpec[] =
-    resolved.length > 0
-      ? resolved
-      : [
-          new PathSpec({
-            original: opts.cwd,
-            directory: opts.cwd,
-            resolved: false,
-            prefix: opts.mountPrefix ?? '',
-          }),
-        ]
-  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
-  const allFiles = opts.flags.a === true || opts.flags.A === true
-  const human = opts.flags.h === true
-  const reverse = opts.flags.r === true
-  const recursive = opts.flags.R === true
-  const listDir = opts.flags.d === true
-  const classify = opts.flags.F === true
-  const sortBy: 'name' | 'size' = opts.flags.S === true ? 'size' : 'name'
-  const warnings: string[] = []
-  const results: string[] = []
-  for (const p of targets) {
-    let entries: FileStat[]
-    try {
-      entries = await lsEntries(
-        accessor,
-        p,
-        allFiles,
-        sortBy,
-        reverse,
-        recursive,
-        listDir,
-        warnings,
-        opts.index,
-      )
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${p.original}': ${msg}`)
-      continue
-    }
-    if (long) {
-      for (const e of entries) {
-        const sizeStr = human ? humanSize(e.size ?? 0) : String(e.size ?? 0)
-        results.push(`${e.type ?? '-'}\t${sizeStr}\t${e.modified ?? ''}\t${e.name}`)
-      }
-    } else {
-      for (const e of entries) {
-        const isDir = classify && e.type === FileType.DIRECTORY
-        const name = isDir ? e.name + '/' : e.name
-        results.push(name)
-      }
-    }
+  let workingPaths: PathSpec[] = paths
+  if (workingPaths.length === 0) {
+    workingPaths = [
+      new PathSpec({
+        original: opts.cwd,
+        directory: opts.cwd,
+        resolved: false,
+        prefix: opts.mountPrefix ?? '',
+      }),
+    ]
   }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  return [out, new IOResult({ stderr, exitCode })]
+  const resolved = await resolveGlob(accessor, workingPaths, opts.index ?? undefined)
+  return lsGeneric(
+    resolved,
+    opts,
+    (p) => gdocsReaddir(accessor, p, opts.index ?? undefined),
+    (p) => gdocsStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GDOCS_LS = command({

--- a/typescript/packages/core/src/commands/builtin/gdocs/nl.ts
+++ b/typescript/packages/core/src/commands/builtin/gdocs/nl.ts
@@ -14,27 +14,12 @@
 
 import type { GDocsAccessor } from '../../../accessor/gdocs.ts'
 import { resolveGlob } from '../../../core/gdocs/glob.ts'
-import { read as gdocsRead } from '../../../core/gdocs/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as gdocsStream } from '../../../core/gdocs/read.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function shouldNumber(line: string, mode: string, pattern: RegExp | null): boolean {
-  if (mode === 'n') return false
-  if (mode === 'a') return true
-  if (mode === 'p' && pattern !== null) return pattern.test(line)
-  return line.trim() !== ''
-}
-
-function pad(n: number, width: number): string {
-  const s = String(n)
-  return s.length >= width ? s : ' '.repeat(width - s.length) + s
-}
+import { nlGeneric } from '../generic/nl.ts'
+import { fileReadProvision } from './provision.ts'
 
 async function nlCommand(
   accessor: GDocsAccessor,
@@ -42,43 +27,9 @@ async function nlCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const bRaw = typeof opts.flags.b === 'string' ? opts.flags.b : 't'
-  let mode = bRaw
-  let pattern: RegExp | null = null
-  if (bRaw.startsWith('p')) {
-    mode = 'p'
-    pattern = new RegExp(bRaw.slice(1))
-  }
-  const start = typeof opts.flags.v === 'string' ? Number.parseInt(opts.flags.v, 10) : 1
-  const increment = typeof opts.flags.i === 'string' ? Number.parseInt(opts.flags.i, 10) : 1
-  const width = typeof opts.flags.w === 'string' ? Number.parseInt(opts.flags.w, 10) : 6
-  const separator = typeof opts.flags.s === 'string' ? opts.flags.s : '\t'
-
-  let raw: Uint8Array | null = null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    raw = await gdocsRead(accessor, first, opts.index ?? undefined)
-  } else {
-    raw = await readStdinAsync(opts.stdin)
-    if (raw === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('nl: missing operand\n') })]
-    }
-  }
-
-  let num = start
-  const outLines: string[] = []
-  for (const line of DEC.decode(raw).split('\n')) {
-    if (shouldNumber(line, mode, pattern)) {
-      outLines.push(`${pad(num, width)}${separator}${line}`)
-      num += increment
-    } else {
-      outLines.push(`${' '.repeat(width)}${separator}${line}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(outLines.join('\n') + '\n')
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return nlGeneric(resolved, opts, (p) => gdocsStream(accessor, p, opts.index ?? undefined))
 }
 
 export const GDOCS_NL = command({
@@ -86,4 +37,5 @@ export const GDOCS_NL = command({
   resource: ResourceName.GDOCS,
   spec: specOf('nl'),
   fn: nlCommand,
+  provision: fileReadProvision,
 })

--- a/typescript/packages/core/src/commands/builtin/gdocs/realpath.ts
+++ b/typescript/packages/core/src/commands/builtin/gdocs/realpath.ts
@@ -13,65 +13,24 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { GDocsAccessor } from '../../../accessor/gdocs.ts'
+import { resolveGlob } from '../../../core/gdocs/glob.ts'
 import { stat as gdocsStat } from '../../../core/gdocs/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function normalize(p: string): string {
-  const isAbs = p.startsWith('/')
-  const segments = p.split('/').filter((s) => s !== '' && s !== '.')
-  const out: string[] = []
-  for (const s of segments) {
-    if (s === '..') {
-      if (out.length > 0) out.pop()
-      else if (!isAbs) out.push('..')
-    } else {
-      out.push(s)
-    }
-  }
-  const joined = out.join('/')
-  return isAbs ? '/' + joined : joined === '' ? '.' : joined
-}
-
-async function exists(
-  accessor: GDocsAccessor,
-  path: string,
-  index: CommandOpts['index'],
-  prefix: string,
-): Promise<boolean> {
-  try {
-    const spec = new PathSpec({ original: path, directory: path, prefix })
-    await gdocsStat(accessor, spec, index ?? undefined)
-    return true
-  } catch {
-    return false
-  }
-}
+import { realpathGeneric } from '../generic/realpath.ts'
 
 async function realpathCommand(
   accessor: GDocsAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const prefix = opts.mountPrefix ?? ''
-  const e = opts.flags.e === true
-  const lines: string[] = []
-  for (const p of paths) {
-    const full = prefix !== '' ? prefix + p.original : p.original
-    const resolved = normalize(full)
-    if (e && !(await exists(accessor, resolved, opts.index, prefix))) {
-      const msg = `realpath: '${p.original}': No such file or directory\n`
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(msg) })]
-    }
-    lines.push(resolved)
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return realpathGeneric(resolved, texts, opts, (p) =>
+    gdocsStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GDOCS_REALPATH = command({

--- a/typescript/packages/core/src/commands/builtin/gdocs/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/gdocs/stat.ts
@@ -15,32 +15,11 @@
 import type { GDocsAccessor } from '../../../accessor/gdocs.ts'
 import { resolveGlob } from '../../../core/gdocs/glob.ts'
 import { stat as gdocsStat } from '../../../core/gdocs/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { FileType, ResourceName, type FileStat, type PathSpec } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { statGeneric } from '../generic/stat.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-const TYPE_LABELS: Record<string, string> = {
-  [FileType.DIRECTORY]: 'directory',
-  [FileType.TEXT]: 'regular file',
-  [FileType.BINARY]: 'regular file',
-  [FileType.JSON]: 'regular file',
-  [FileType.CSV]: 'regular file',
-}
-
-function formatStat(fmt: string, s: FileStat): string {
-  return fmt.replace(/%(.)/g, (_, spec: string) => {
-    if (spec === 'n') return s.name
-    if (spec === 's') return String(s.size ?? 0)
-    if (spec === 'F')
-      return s.type !== null ? (TYPE_LABELS[s.type] ?? 'regular file') : 'regular file'
-    if (spec === 'y') return s.modified ?? ''
-    return '?'
-  })
-}
 
 async function statCommand(
   accessor: GDocsAccessor,
@@ -48,30 +27,9 @@ async function statCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('stat: missing operand\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const fmt =
-    typeof opts.flags.c === 'string'
-      ? opts.flags.c
-      : typeof opts.flags.f === 'string'
-        ? opts.flags.f
-        : null
-  const lines: string[] = []
-  for (const p of resolved) {
-    const s = await gdocsStat(accessor, p, opts.index ?? undefined)
-    if (fmt !== null) {
-      lines.push(formatStat(fmt, s))
-    } else {
-      const sizeStr = s.size === null ? 'None' : String(s.size)
-      const modStr = s.modified ?? 'None'
-      const typeStr = s.type ?? 'None'
-      lines.push(`name=${s.name} size=${sizeStr} modified=${modStr} type=${typeStr}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return statGeneric(resolved, opts, (p) => gdocsStat(accessor, p, opts.index ?? undefined))
 }
 
 export const GDOCS_STAT = command({

--- a/typescript/packages/core/src/commands/builtin/gdocs/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/gdocs/tree.ts
@@ -16,94 +16,10 @@ import type { GDocsAccessor } from '../../../accessor/gdocs.ts'
 import { resolveGlob } from '../../../core/gdocs/glob.ts'
 import { readdir as gdocsReaddir } from '../../../core/gdocs/readdir.ts'
 import { stat as gdocsStat } from '../../../core/gdocs/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function fnmatch(name: string, pattern: string): boolean {
-  const re = pattern
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\?/g, '.')
-    .replace(/\*/g, '.*')
-  return new RegExp(`^${re}$`).test(name)
-}
-
-interface TreeOpts {
-  maxDepth: number | null
-  showHidden: boolean
-  ignorePattern: string | null
-  dirsOnly: boolean
-  matchPattern: string | null
-}
-
-async function treeRecurse(
-  accessor: GDocsAccessor,
-  path: PathSpec,
-  prefix: string,
-  depth: number,
-  treeOpts: TreeOpts,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<string[]> {
-  const lines: string[] = []
-  let entries: string[]
-  try {
-    entries = await gdocsReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`tree: '${path.original}': ${msg}`)
-    return lines
-  }
-  const filtered: [PathSpec, FileStat][] = []
-  for (const entry of entries) {
-    try {
-      const entrySpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await gdocsStat(accessor, entrySpec, indexCache ?? undefined)
-      if (!treeOpts.showHidden && s.name.startsWith('.')) continue
-      if (treeOpts.ignorePattern !== null && fnmatch(s.name, treeOpts.ignorePattern)) continue
-      if (treeOpts.dirsOnly && s.type !== FileType.DIRECTORY) continue
-      const notDir = s.type !== FileType.DIRECTORY
-      if (treeOpts.matchPattern !== null && notDir && !fnmatch(s.name, treeOpts.matchPattern))
-        continue
-      filtered.push([entrySpec, s])
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`tree: '${entry}': ${msg}`)
-    }
-  }
-  for (let i = 0; i < filtered.length; i++) {
-    const pair = filtered[i]
-    if (pair === undefined) continue
-    const [entrySpec, s] = pair
-    const isLast = i === filtered.length - 1
-    const connector = isLast ? '\u2514\u2500\u2500 ' : '\u251c\u2500\u2500 '
-    lines.push(prefix + connector + s.name)
-    if (s.type === FileType.DIRECTORY) {
-      if (treeOpts.maxDepth !== null && depth >= treeOpts.maxDepth) continue
-      const extension = isLast ? '    ' : '\u2502   '
-      const sub = await treeRecurse(
-        accessor,
-        entrySpec,
-        prefix + extension,
-        depth + 1,
-        treeOpts,
-        warnings,
-        indexCache,
-      )
-      lines.push(...sub)
-    }
-  }
-  return lines
-}
+import { treeGeneric } from '../generic/tree.ts'
 
 async function treeCommand(
   accessor: GDocsAccessor,
@@ -112,27 +28,12 @@ async function treeCommand(
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const p0 =
-    resolved[0] ??
-    new PathSpec({
-      original: opts.cwd,
-      directory: opts.cwd,
-      resolved: false,
-      prefix: opts.mountPrefix ?? '',
-    })
-  const maxDepth = typeof opts.flags.L === 'string' ? Number.parseInt(opts.flags.L, 10) : null
-  const treeOpts: TreeOpts = {
-    maxDepth,
-    showHidden: opts.flags.a === true,
-    ignorePattern: typeof opts.flags.args_I === 'string' ? opts.flags.args_I : null,
-    dirsOnly: opts.flags.d === true,
-    matchPattern: typeof opts.flags.P === 'string' ? opts.flags.P : null,
-  }
-  const warnings: string[] = []
-  const results = await treeRecurse(accessor, p0, '', 0, treeOpts, warnings, opts.index)
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  return [out, new IOResult({ stderr })]
+  return treeGeneric(
+    resolved,
+    opts,
+    (p) => gdocsReaddir(accessor, p, opts.index ?? undefined),
+    (p) => gdocsStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GDOCS_TREE = command({

--- a/typescript/packages/core/src/commands/builtin/gdocs/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/gdocs/wc.ts
@@ -14,69 +14,22 @@
 
 import type { GDocsAccessor } from '../../../accessor/gdocs.ts'
 import { resolveGlob } from '../../../core/gdocs/glob.ts'
-import { read as gdocsRead } from '../../../core/gdocs/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as gdocsStream } from '../../../core/gdocs/read.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { wcGeneric } from '../generic/wc.ts'
 import { fileReadProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function countLines(text: string): number {
-  let n = 0
-  for (let i = 0; i < text.length; i++) if (text.charCodeAt(i) === 10) n += 1
-  return n
-}
-
-function countWords(text: string): number {
-  const trimmed = text.trim()
-  if (trimmed === '') return 0
-  return trimmed.split(/\s+/).length
-}
-
-function maxLineLen(text: string): number {
-  let max = 0
-  for (const line of text.split('\n')) if (line.length > max) max = line.length
-  return max
-}
 
 async function wcCommand(
   accessor: GDocsAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  let data: Uint8Array | null = null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    data = await gdocsRead(accessor, first, opts.index ?? undefined)
-  } else {
-    data = await readStdinAsync(opts.stdin)
-    if (data === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('wc: missing operand\n') })]
-    }
-  }
-  const text = DEC.decode(data)
-  const lineCount = countLines(text)
-  const wordCount = countWords(text)
-  const byteCount = data.byteLength
-  if (opts.flags.L === true) {
-    const out: ByteSource = ENC.encode(String(maxLineLen(text)))
-    return [out, new IOResult()]
-  }
-  if (opts.flags.args_l === true) return [ENC.encode(String(lineCount)), new IOResult()]
-  if (opts.flags.w === true) return [ENC.encode(String(wordCount)), new IOResult()]
-  if (opts.flags.m === true) return [ENC.encode(String(text.length)), new IOResult()]
-  if (opts.flags.c === true) return [ENC.encode(String(byteCount)), new IOResult()]
-  const out: ByteSource = ENC.encode(
-    `${String(lineCount)}\t${String(wordCount)}\t${String(byteCount)}`,
-  )
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return wcGeneric(resolved, texts, opts, (p) => gdocsStream(accessor, p, opts.index ?? undefined))
 }
 
 export const GDOCS_WC = command({

--- a/typescript/packages/core/src/commands/builtin/gmail/head.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/head.ts
@@ -13,53 +13,39 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { GmailAccessor } from '../../../accessor/gmail.ts'
+import type { IndexCacheStore } from '../../../cache/index/index.ts'
 import { resolveGlob } from '../../../core/gmail/glob.ts'
 import { read as gmailRead } from '../../../core/gmail/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stat as gmailStat } from '../../../core/gmail/stat.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { headGeneric } from '../generic/head.ts'
 import { fileReadProvision } from './provision.ts'
 
-const ENC = new TextEncoder()
-
-function headBytes(data: Uint8Array, lines: number, bytesMode: number | null): Uint8Array {
-  if (bytesMode !== null) return data.slice(0, bytesMode)
-  let count = 0
-  let end = 0
-  for (let i = 0; i < data.byteLength && count < lines; i++) {
-    if (data[i] === 0x0a) {
-      count += 1
-      end = i + 1
-    }
-  }
-  if (count < lines) return data
-  return data.slice(0, end - 1)
+async function* gmailStream(
+  accessor: GmailAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await gmailRead(accessor, p, index)
 }
 
 async function headCommand(
   accessor: GmailAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const lines = typeof opts.flags.n === 'string' ? Number.parseInt(opts.flags.n, 10) : 10
-  const bytesMode = typeof opts.flags.c === 'string' ? Number.parseInt(opts.flags.c, 10) : null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const data = await gmailRead(accessor, first, opts.index ?? undefined)
-    const out: ByteSource = headBytes(data, lines, bytesMode)
-    return [out, new IOResult()]
-  }
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('head: missing operand\n') })]
-  }
-  const out: ByteSource = headBytes(raw, lines, bytesMode)
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return headGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => gmailStat(accessor, p, opts.index ?? undefined),
+    (p) => gmailStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GMAIL_HEAD = command({

--- a/typescript/packages/core/src/commands/builtin/gmail/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/ls.ts
@@ -16,93 +16,11 @@ import type { GmailAccessor } from '../../../accessor/gmail.ts'
 import { resolveGlob } from '../../../core/gmail/glob.ts'
 import { readdir as gmailReaddir } from '../../../core/gmail/readdir.ts'
 import { stat as gmailStat } from '../../../core/gmail/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { humanSize } from '../utils/formatting.ts'
+import { lsGeneric } from '../generic/ls.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-async function lsEntries(
-  accessor: GmailAccessor,
-  path: PathSpec,
-  allFiles: boolean,
-  sortBy: 'name' | 'size',
-  reverse: boolean,
-  recursive: boolean,
-  listDir: boolean,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<FileStat[]> {
-  if (listDir) {
-    const s = await gmailStat(accessor, path, indexCache ?? undefined)
-    return [s]
-  }
-  let entries: string[]
-  try {
-    entries = await gmailReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`ls: cannot access '${path.original}': ${msg}`)
-    return []
-  }
-  const stats: FileStat[] = []
-  for (const entry of entries) {
-    try {
-      const eSpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await gmailStat(accessor, eSpec, indexCache ?? undefined)
-      if (!allFiles && s.name.startsWith('.')) continue
-      stats.push(s)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${entry}': ${msg}`)
-    }
-  }
-  if (sortBy === 'size') {
-    stats.sort((a, b) => (a.size ?? 0) - (b.size ?? 0))
-    if (!reverse) stats.reverse()
-  } else {
-    stats.sort((a, b) => a.name.localeCompare(b.name))
-    if (reverse) stats.reverse()
-  }
-  if (recursive) {
-    const subEntries: FileStat[] = []
-    for (const s of stats) {
-      subEntries.push(s)
-      if (s.type === FileType.DIRECTORY) {
-        const childPath = path.child(s.name)
-        const childSpec = new PathSpec({
-          original: childPath,
-          directory: childPath,
-          resolved: false,
-          prefix: path.prefix,
-        })
-        const sub = await lsEntries(
-          accessor,
-          childSpec,
-          allFiles,
-          sortBy,
-          reverse,
-          recursive,
-          false,
-          warnings,
-          indexCache,
-        )
-        subEntries.push(...sub)
-      }
-    }
-    return subEntries
-  }
-  return stats
-}
 
 async function lsCommand(
   accessor: GmailAccessor,
@@ -110,64 +28,24 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const targets: PathSpec[] =
-    resolved.length > 0
-      ? resolved
-      : [
-          new PathSpec({
-            original: opts.cwd,
-            directory: opts.cwd,
-            resolved: false,
-            prefix: opts.mountPrefix ?? '',
-          }),
-        ]
-  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
-  const allFiles = opts.flags.a === true || opts.flags.A === true
-  const human = opts.flags.h === true
-  const reverse = opts.flags.r === true
-  const recursive = opts.flags.R === true
-  const listDir = opts.flags.d === true
-  const classify = opts.flags.F === true
-  const sortBy: 'name' | 'size' = opts.flags.S === true ? 'size' : 'name'
-  const warnings: string[] = []
-  const results: string[] = []
-  for (const p of targets) {
-    let entries: FileStat[]
-    try {
-      entries = await lsEntries(
-        accessor,
-        p,
-        allFiles,
-        sortBy,
-        reverse,
-        recursive,
-        listDir,
-        warnings,
-        opts.index,
-      )
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${p.original}': ${msg}`)
-      continue
-    }
-    if (long) {
-      for (const e of entries) {
-        const sizeStr = human ? humanSize(e.size ?? 0) : String(e.size ?? 0)
-        results.push(`${e.type ?? '-'}\t${sizeStr}\t${e.modified ?? ''}\t${e.name}`)
-      }
-    } else {
-      for (const e of entries) {
-        const isDir = classify && e.type === FileType.DIRECTORY
-        const name = isDir ? e.name + '/' : e.name
-        results.push(name)
-      }
-    }
+  let workingPaths: PathSpec[] = paths
+  if (workingPaths.length === 0) {
+    workingPaths = [
+      new PathSpec({
+        original: opts.cwd,
+        directory: opts.cwd,
+        resolved: false,
+        prefix: opts.mountPrefix ?? '',
+      }),
+    ]
   }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  return [out, new IOResult({ stderr, exitCode })]
+  const resolved = await resolveGlob(accessor, workingPaths, opts.index ?? undefined)
+  return lsGeneric(
+    resolved,
+    opts,
+    (p) => gmailReaddir(accessor, p, opts.index ?? undefined),
+    (p) => gmailStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GMAIL_LS = command({

--- a/typescript/packages/core/src/commands/builtin/gmail/nl.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/nl.ts
@@ -13,27 +13,21 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { GmailAccessor } from '../../../accessor/gmail.ts'
+import type { IndexCacheStore } from '../../../cache/index/index.ts'
 import { resolveGlob } from '../../../core/gmail/glob.ts'
 import { read as gmailRead } from '../../../core/gmail/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { nlGeneric } from '../generic/nl.ts'
+import { fileReadProvision } from './provision.ts'
 
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function shouldNumber(line: string, mode: string, pattern: RegExp | null): boolean {
-  if (mode === 'n') return false
-  if (mode === 'a') return true
-  if (mode === 'p' && pattern !== null) return pattern.test(line)
-  return line.trim() !== ''
-}
-
-function pad(n: number, width: number): string {
-  const s = String(n)
-  return s.length >= width ? s : ' '.repeat(width - s.length) + s
+async function* gmailStream(
+  accessor: GmailAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await gmailRead(accessor, p, index)
 }
 
 async function nlCommand(
@@ -42,43 +36,9 @@ async function nlCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const bRaw = typeof opts.flags.b === 'string' ? opts.flags.b : 't'
-  let mode = bRaw
-  let pattern: RegExp | null = null
-  if (bRaw.startsWith('p')) {
-    mode = 'p'
-    pattern = new RegExp(bRaw.slice(1))
-  }
-  const start = typeof opts.flags.v === 'string' ? Number.parseInt(opts.flags.v, 10) : 1
-  const increment = typeof opts.flags.i === 'string' ? Number.parseInt(opts.flags.i, 10) : 1
-  const width = typeof opts.flags.w === 'string' ? Number.parseInt(opts.flags.w, 10) : 6
-  const separator = typeof opts.flags.s === 'string' ? opts.flags.s : '\t'
-
-  let raw: Uint8Array | null = null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    raw = await gmailRead(accessor, first, opts.index ?? undefined)
-  } else {
-    raw = await readStdinAsync(opts.stdin)
-    if (raw === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('nl: missing operand\n') })]
-    }
-  }
-
-  let num = start
-  const outLines: string[] = []
-  for (const line of DEC.decode(raw).split('\n')) {
-    if (shouldNumber(line, mode, pattern)) {
-      outLines.push(`${pad(num, width)}${separator}${line}`)
-      num += increment
-    } else {
-      outLines.push(`${' '.repeat(width)}${separator}${line}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(outLines.join('\n') + '\n')
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return nlGeneric(resolved, opts, (p) => gmailStream(accessor, p, opts.index ?? undefined))
 }
 
 export const GMAIL_NL = command({
@@ -86,4 +46,5 @@ export const GMAIL_NL = command({
   resource: ResourceName.GMAIL,
   spec: specOf('nl'),
   fn: nlCommand,
+  provision: fileReadProvision,
 })

--- a/typescript/packages/core/src/commands/builtin/gmail/realpath.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/realpath.ts
@@ -13,65 +13,24 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { GmailAccessor } from '../../../accessor/gmail.ts'
+import { resolveGlob } from '../../../core/gmail/glob.ts'
 import { stat as gmailStat } from '../../../core/gmail/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function normalize(p: string): string {
-  const isAbs = p.startsWith('/')
-  const segments = p.split('/').filter((s) => s !== '' && s !== '.')
-  const out: string[] = []
-  for (const s of segments) {
-    if (s === '..') {
-      if (out.length > 0) out.pop()
-      else if (!isAbs) out.push('..')
-    } else {
-      out.push(s)
-    }
-  }
-  const joined = out.join('/')
-  return isAbs ? '/' + joined : joined === '' ? '.' : joined
-}
-
-async function exists(
-  accessor: GmailAccessor,
-  path: string,
-  index: CommandOpts['index'],
-  prefix: string,
-): Promise<boolean> {
-  try {
-    const spec = new PathSpec({ original: path, directory: path, prefix })
-    await gmailStat(accessor, spec, index ?? undefined)
-    return true
-  } catch {
-    return false
-  }
-}
+import { realpathGeneric } from '../generic/realpath.ts'
 
 async function realpathCommand(
   accessor: GmailAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const prefix = opts.mountPrefix ?? ''
-  const e = opts.flags.e === true
-  const lines: string[] = []
-  for (const p of paths) {
-    const full = prefix !== '' ? prefix + p.original : p.original
-    const resolved = normalize(full)
-    if (e && !(await exists(accessor, resolved, opts.index, prefix))) {
-      const msg = `realpath: '${p.original}': No such file or directory\n`
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(msg) })]
-    }
-    lines.push(resolved)
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return realpathGeneric(resolved, texts, opts, (p) =>
+    gmailStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GMAIL_REALPATH = command({

--- a/typescript/packages/core/src/commands/builtin/gmail/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/stat.ts
@@ -15,32 +15,11 @@
 import type { GmailAccessor } from '../../../accessor/gmail.ts'
 import { resolveGlob } from '../../../core/gmail/glob.ts'
 import { stat as gmailStat } from '../../../core/gmail/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { FileType, ResourceName, type FileStat, type PathSpec } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { statGeneric } from '../generic/stat.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-const TYPE_LABELS: Record<string, string> = {
-  [FileType.DIRECTORY]: 'directory',
-  [FileType.TEXT]: 'regular file',
-  [FileType.BINARY]: 'regular file',
-  [FileType.JSON]: 'regular file',
-  [FileType.CSV]: 'regular file',
-}
-
-function formatStat(fmt: string, s: FileStat): string {
-  return fmt.replace(/%(.)/g, (_, spec: string) => {
-    if (spec === 'n') return s.name
-    if (spec === 's') return String(s.size ?? 0)
-    if (spec === 'F')
-      return s.type !== null ? (TYPE_LABELS[s.type] ?? 'regular file') : 'regular file'
-    if (spec === 'y') return s.modified ?? ''
-    return '?'
-  })
-}
 
 async function statCommand(
   accessor: GmailAccessor,
@@ -48,30 +27,9 @@ async function statCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('stat: missing operand\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const fmt =
-    typeof opts.flags.c === 'string'
-      ? opts.flags.c
-      : typeof opts.flags.f === 'string'
-        ? opts.flags.f
-        : null
-  const lines: string[] = []
-  for (const p of resolved) {
-    const s = await gmailStat(accessor, p, opts.index ?? undefined)
-    if (fmt !== null) {
-      lines.push(formatStat(fmt, s))
-    } else {
-      const sizeStr = s.size === null ? 'None' : String(s.size)
-      const modStr = s.modified ?? 'None'
-      const typeStr = s.type ?? 'None'
-      lines.push(`name=${s.name} size=${sizeStr} modified=${modStr} type=${typeStr}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return statGeneric(resolved, opts, (p) => gmailStat(accessor, p, opts.index ?? undefined))
 }
 
 export const GMAIL_STAT = command({

--- a/typescript/packages/core/src/commands/builtin/gmail/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/tree.ts
@@ -16,94 +16,10 @@ import type { GmailAccessor } from '../../../accessor/gmail.ts'
 import { resolveGlob } from '../../../core/gmail/glob.ts'
 import { readdir as gmailReaddir } from '../../../core/gmail/readdir.ts'
 import { stat as gmailStat } from '../../../core/gmail/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function fnmatch(name: string, pattern: string): boolean {
-  const re = pattern
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\?/g, '.')
-    .replace(/\*/g, '.*')
-  return new RegExp(`^${re}$`).test(name)
-}
-
-interface TreeOpts {
-  maxDepth: number | null
-  showHidden: boolean
-  ignorePattern: string | null
-  dirsOnly: boolean
-  matchPattern: string | null
-}
-
-async function treeRecurse(
-  accessor: GmailAccessor,
-  path: PathSpec,
-  prefix: string,
-  depth: number,
-  treeOpts: TreeOpts,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<string[]> {
-  const lines: string[] = []
-  let entries: string[]
-  try {
-    entries = await gmailReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`tree: '${path.original}': ${msg}`)
-    return lines
-  }
-  const filtered: [PathSpec, FileStat][] = []
-  for (const entry of entries) {
-    try {
-      const entrySpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await gmailStat(accessor, entrySpec, indexCache ?? undefined)
-      if (!treeOpts.showHidden && s.name.startsWith('.')) continue
-      if (treeOpts.ignorePattern !== null && fnmatch(s.name, treeOpts.ignorePattern)) continue
-      if (treeOpts.dirsOnly && s.type !== FileType.DIRECTORY) continue
-      const notDir = s.type !== FileType.DIRECTORY
-      if (treeOpts.matchPattern !== null && notDir && !fnmatch(s.name, treeOpts.matchPattern))
-        continue
-      filtered.push([entrySpec, s])
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`tree: '${entry}': ${msg}`)
-    }
-  }
-  for (let i = 0; i < filtered.length; i++) {
-    const pair = filtered[i]
-    if (pair === undefined) continue
-    const [entrySpec, s] = pair
-    const isLast = i === filtered.length - 1
-    const connector = isLast ? '\u2514\u2500\u2500 ' : '\u251c\u2500\u2500 '
-    lines.push(prefix + connector + s.name)
-    if (s.type === FileType.DIRECTORY) {
-      if (treeOpts.maxDepth !== null && depth >= treeOpts.maxDepth) continue
-      const extension = isLast ? '    ' : '\u2502   '
-      const sub = await treeRecurse(
-        accessor,
-        entrySpec,
-        prefix + extension,
-        depth + 1,
-        treeOpts,
-        warnings,
-        indexCache,
-      )
-      lines.push(...sub)
-    }
-  }
-  return lines
-}
+import { treeGeneric } from '../generic/tree.ts'
 
 async function treeCommand(
   accessor: GmailAccessor,
@@ -112,27 +28,12 @@ async function treeCommand(
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const p0 =
-    resolved[0] ??
-    new PathSpec({
-      original: opts.cwd,
-      directory: opts.cwd,
-      resolved: false,
-      prefix: opts.mountPrefix ?? '',
-    })
-  const maxDepth = typeof opts.flags.L === 'string' ? Number.parseInt(opts.flags.L, 10) : null
-  const treeOpts: TreeOpts = {
-    maxDepth,
-    showHidden: opts.flags.a === true,
-    ignorePattern: typeof opts.flags.args_I === 'string' ? opts.flags.args_I : null,
-    dirsOnly: opts.flags.d === true,
-    matchPattern: typeof opts.flags.P === 'string' ? opts.flags.P : null,
-  }
-  const warnings: string[] = []
-  const results = await treeRecurse(accessor, p0, '', 0, treeOpts, warnings, opts.index)
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  return [out, new IOResult({ stderr })]
+  return treeGeneric(
+    resolved,
+    opts,
+    (p) => gmailReaddir(accessor, p, opts.index ?? undefined),
+    (p) => gmailStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GMAIL_TREE = command({

--- a/typescript/packages/core/src/commands/builtin/gmail/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/wc.ts
@@ -13,70 +13,32 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { GmailAccessor } from '../../../accessor/gmail.ts'
+import type { IndexCacheStore } from '../../../cache/index/index.ts'
 import { resolveGlob } from '../../../core/gmail/glob.ts'
 import { read as gmailRead } from '../../../core/gmail/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { wcGeneric } from '../generic/wc.ts'
 import { fileReadProvision } from './provision.ts'
 
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function countLines(text: string): number {
-  let n = 0
-  for (let i = 0; i < text.length; i++) if (text.charCodeAt(i) === 10) n += 1
-  return n
-}
-
-function countWords(text: string): number {
-  const trimmed = text.trim()
-  if (trimmed === '') return 0
-  return trimmed.split(/\s+/).length
-}
-
-function maxLineLen(text: string): number {
-  let max = 0
-  for (const line of text.split('\n')) if (line.length > max) max = line.length
-  return max
+async function* gmailStream(
+  accessor: GmailAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await gmailRead(accessor, p, index)
 }
 
 async function wcCommand(
   accessor: GmailAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  let data: Uint8Array | null = null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    data = await gmailRead(accessor, first, opts.index ?? undefined)
-  } else {
-    data = await readStdinAsync(opts.stdin)
-    if (data === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('wc: missing operand\n') })]
-    }
-  }
-  const text = DEC.decode(data)
-  const lineCount = countLines(text)
-  const wordCount = countWords(text)
-  const byteCount = data.byteLength
-  if (opts.flags.L === true) {
-    const out: ByteSource = ENC.encode(String(maxLineLen(text)))
-    return [out, new IOResult()]
-  }
-  if (opts.flags.args_l === true) return [ENC.encode(String(lineCount)), new IOResult()]
-  if (opts.flags.w === true) return [ENC.encode(String(wordCount)), new IOResult()]
-  if (opts.flags.m === true) return [ENC.encode(String(text.length)), new IOResult()]
-  if (opts.flags.c === true) return [ENC.encode(String(byteCount)), new IOResult()]
-  const out: ByteSource = ENC.encode(
-    `${String(lineCount)}\t${String(wordCount)}\t${String(byteCount)}`,
-  )
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return wcGeneric(resolved, texts, opts, (p) => gmailStream(accessor, p, opts.index ?? undefined))
 }
 
 export const GMAIL_WC = command({

--- a/typescript/packages/core/src/commands/builtin/gsheets/head.ts
+++ b/typescript/packages/core/src/commands/builtin/gsheets/head.ts
@@ -14,52 +14,29 @@
 
 import type { GSheetsAccessor } from '../../../accessor/gsheets.ts'
 import { resolveGlob } from '../../../core/gsheets/glob.ts'
-import { read as gsheetsRead } from '../../../core/gsheets/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as gsheetsStream } from '../../../core/gsheets/read.ts'
+import { stat as gsheetsStat } from '../../../core/gsheets/stat.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { headGeneric } from '../generic/head.ts'
 import { fileReadProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-function headBytes(data: Uint8Array, lines: number, bytesMode: number | null): Uint8Array {
-  if (bytesMode !== null) return data.slice(0, bytesMode)
-  let count = 0
-  let end = 0
-  for (let i = 0; i < data.byteLength && count < lines; i++) {
-    if (data[i] === 0x0a) {
-      count += 1
-      end = i + 1
-    }
-  }
-  if (count < lines) return data
-  return data.slice(0, end - 1)
-}
 
 async function headCommand(
   accessor: GSheetsAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const lines = typeof opts.flags.n === 'string' ? Number.parseInt(opts.flags.n, 10) : 10
-  const bytesMode = typeof opts.flags.c === 'string' ? Number.parseInt(opts.flags.c, 10) : null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const data = await gsheetsRead(accessor, first, opts.index ?? undefined)
-    const out: ByteSource = headBytes(data, lines, bytesMode)
-    return [out, new IOResult()]
-  }
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('head: missing operand\n') })]
-  }
-  const out: ByteSource = headBytes(raw, lines, bytesMode)
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return headGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => gsheetsStat(accessor, p, opts.index ?? undefined),
+    (p) => gsheetsStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GSHEETS_HEAD = command({

--- a/typescript/packages/core/src/commands/builtin/gsheets/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/gsheets/ls.ts
@@ -16,93 +16,11 @@ import type { GSheetsAccessor } from '../../../accessor/gsheets.ts'
 import { resolveGlob } from '../../../core/gsheets/glob.ts'
 import { readdir as gsheetsReaddir } from '../../../core/gsheets/readdir.ts'
 import { stat as gsheetsStat } from '../../../core/gsheets/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { humanSize } from '../utils/formatting.ts'
+import { lsGeneric } from '../generic/ls.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-async function lsEntries(
-  accessor: GSheetsAccessor,
-  path: PathSpec,
-  allFiles: boolean,
-  sortBy: 'name' | 'size',
-  reverse: boolean,
-  recursive: boolean,
-  listDir: boolean,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<FileStat[]> {
-  if (listDir) {
-    const s = await gsheetsStat(accessor, path, indexCache ?? undefined)
-    return [s]
-  }
-  let entries: string[]
-  try {
-    entries = await gsheetsReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`ls: cannot access '${path.original}': ${msg}`)
-    return []
-  }
-  const stats: FileStat[] = []
-  for (const entry of entries) {
-    try {
-      const eSpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await gsheetsStat(accessor, eSpec, indexCache ?? undefined)
-      if (!allFiles && s.name.startsWith('.')) continue
-      stats.push(s)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${entry}': ${msg}`)
-    }
-  }
-  if (sortBy === 'size') {
-    stats.sort((a, b) => (a.size ?? 0) - (b.size ?? 0))
-    if (!reverse) stats.reverse()
-  } else {
-    stats.sort((a, b) => a.name.localeCompare(b.name))
-    if (reverse) stats.reverse()
-  }
-  if (recursive) {
-    const subEntries: FileStat[] = []
-    for (const s of stats) {
-      subEntries.push(s)
-      if (s.type === FileType.DIRECTORY) {
-        const childPath = path.child(s.name)
-        const childSpec = new PathSpec({
-          original: childPath,
-          directory: childPath,
-          resolved: false,
-          prefix: path.prefix,
-        })
-        const sub = await lsEntries(
-          accessor,
-          childSpec,
-          allFiles,
-          sortBy,
-          reverse,
-          recursive,
-          false,
-          warnings,
-          indexCache,
-        )
-        subEntries.push(...sub)
-      }
-    }
-    return subEntries
-  }
-  return stats
-}
 
 async function lsCommand(
   accessor: GSheetsAccessor,
@@ -110,64 +28,24 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const targets: PathSpec[] =
-    resolved.length > 0
-      ? resolved
-      : [
-          new PathSpec({
-            original: opts.cwd,
-            directory: opts.cwd,
-            resolved: false,
-            prefix: opts.mountPrefix ?? '',
-          }),
-        ]
-  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
-  const allFiles = opts.flags.a === true || opts.flags.A === true
-  const human = opts.flags.h === true
-  const reverse = opts.flags.r === true
-  const recursive = opts.flags.R === true
-  const listDir = opts.flags.d === true
-  const classify = opts.flags.F === true
-  const sortBy: 'name' | 'size' = opts.flags.S === true ? 'size' : 'name'
-  const warnings: string[] = []
-  const results: string[] = []
-  for (const p of targets) {
-    let entries: FileStat[]
-    try {
-      entries = await lsEntries(
-        accessor,
-        p,
-        allFiles,
-        sortBy,
-        reverse,
-        recursive,
-        listDir,
-        warnings,
-        opts.index,
-      )
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${p.original}': ${msg}`)
-      continue
-    }
-    if (long) {
-      for (const e of entries) {
-        const sizeStr = human ? humanSize(e.size ?? 0) : String(e.size ?? 0)
-        results.push(`${e.type ?? '-'}\t${sizeStr}\t${e.modified ?? ''}\t${e.name}`)
-      }
-    } else {
-      for (const e of entries) {
-        const isDir = classify && e.type === FileType.DIRECTORY
-        const name = isDir ? e.name + '/' : e.name
-        results.push(name)
-      }
-    }
+  let workingPaths: PathSpec[] = paths
+  if (workingPaths.length === 0) {
+    workingPaths = [
+      new PathSpec({
+        original: opts.cwd,
+        directory: opts.cwd,
+        resolved: false,
+        prefix: opts.mountPrefix ?? '',
+      }),
+    ]
   }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  return [out, new IOResult({ stderr, exitCode })]
+  const resolved = await resolveGlob(accessor, workingPaths, opts.index ?? undefined)
+  return lsGeneric(
+    resolved,
+    opts,
+    (p) => gsheetsReaddir(accessor, p, opts.index ?? undefined),
+    (p) => gsheetsStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GSHEETS_LS = command({

--- a/typescript/packages/core/src/commands/builtin/gsheets/nl.ts
+++ b/typescript/packages/core/src/commands/builtin/gsheets/nl.ts
@@ -14,27 +14,12 @@
 
 import type { GSheetsAccessor } from '../../../accessor/gsheets.ts'
 import { resolveGlob } from '../../../core/gsheets/glob.ts'
-import { read as gsheetsRead } from '../../../core/gsheets/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as gsheetsStream } from '../../../core/gsheets/read.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function shouldNumber(line: string, mode: string, pattern: RegExp | null): boolean {
-  if (mode === 'n') return false
-  if (mode === 'a') return true
-  if (mode === 'p' && pattern !== null) return pattern.test(line)
-  return line.trim() !== ''
-}
-
-function pad(n: number, width: number): string {
-  const s = String(n)
-  return s.length >= width ? s : ' '.repeat(width - s.length) + s
-}
+import { nlGeneric } from '../generic/nl.ts'
+import { fileReadProvision } from './provision.ts'
 
 async function nlCommand(
   accessor: GSheetsAccessor,
@@ -42,43 +27,9 @@ async function nlCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const bRaw = typeof opts.flags.b === 'string' ? opts.flags.b : 't'
-  let mode = bRaw
-  let pattern: RegExp | null = null
-  if (bRaw.startsWith('p')) {
-    mode = 'p'
-    pattern = new RegExp(bRaw.slice(1))
-  }
-  const start = typeof opts.flags.v === 'string' ? Number.parseInt(opts.flags.v, 10) : 1
-  const increment = typeof opts.flags.i === 'string' ? Number.parseInt(opts.flags.i, 10) : 1
-  const width = typeof opts.flags.w === 'string' ? Number.parseInt(opts.flags.w, 10) : 6
-  const separator = typeof opts.flags.s === 'string' ? opts.flags.s : '\t'
-
-  let raw: Uint8Array | null = null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    raw = await gsheetsRead(accessor, first, opts.index ?? undefined)
-  } else {
-    raw = await readStdinAsync(opts.stdin)
-    if (raw === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('nl: missing operand\n') })]
-    }
-  }
-
-  let num = start
-  const outLines: string[] = []
-  for (const line of DEC.decode(raw).split('\n')) {
-    if (shouldNumber(line, mode, pattern)) {
-      outLines.push(`${pad(num, width)}${separator}${line}`)
-      num += increment
-    } else {
-      outLines.push(`${' '.repeat(width)}${separator}${line}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(outLines.join('\n') + '\n')
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return nlGeneric(resolved, opts, (p) => gsheetsStream(accessor, p, opts.index ?? undefined))
 }
 
 export const GSHEETS_NL = command({
@@ -86,4 +37,5 @@ export const GSHEETS_NL = command({
   resource: ResourceName.GSHEETS,
   spec: specOf('nl'),
   fn: nlCommand,
+  provision: fileReadProvision,
 })

--- a/typescript/packages/core/src/commands/builtin/gsheets/realpath.ts
+++ b/typescript/packages/core/src/commands/builtin/gsheets/realpath.ts
@@ -13,65 +13,24 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { GSheetsAccessor } from '../../../accessor/gsheets.ts'
+import { resolveGlob } from '../../../core/gsheets/glob.ts'
 import { stat as gsheetsStat } from '../../../core/gsheets/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function normalize(p: string): string {
-  const isAbs = p.startsWith('/')
-  const segments = p.split('/').filter((s) => s !== '' && s !== '.')
-  const out: string[] = []
-  for (const s of segments) {
-    if (s === '..') {
-      if (out.length > 0) out.pop()
-      else if (!isAbs) out.push('..')
-    } else {
-      out.push(s)
-    }
-  }
-  const joined = out.join('/')
-  return isAbs ? '/' + joined : joined === '' ? '.' : joined
-}
-
-async function exists(
-  accessor: GSheetsAccessor,
-  path: string,
-  index: CommandOpts['index'],
-  prefix: string,
-): Promise<boolean> {
-  try {
-    const spec = new PathSpec({ original: path, directory: path, prefix })
-    await gsheetsStat(accessor, spec, index ?? undefined)
-    return true
-  } catch {
-    return false
-  }
-}
+import { realpathGeneric } from '../generic/realpath.ts'
 
 async function realpathCommand(
   accessor: GSheetsAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const prefix = opts.mountPrefix ?? ''
-  const e = opts.flags.e === true
-  const lines: string[] = []
-  for (const p of paths) {
-    const full = prefix !== '' ? prefix + p.original : p.original
-    const resolved = normalize(full)
-    if (e && !(await exists(accessor, resolved, opts.index, prefix))) {
-      const msg = `realpath: '${p.original}': No such file or directory\n`
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(msg) })]
-    }
-    lines.push(resolved)
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return realpathGeneric(resolved, texts, opts, (p) =>
+    gsheetsStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GSHEETS_REALPATH = command({

--- a/typescript/packages/core/src/commands/builtin/gsheets/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/gsheets/stat.ts
@@ -15,32 +15,11 @@
 import type { GSheetsAccessor } from '../../../accessor/gsheets.ts'
 import { resolveGlob } from '../../../core/gsheets/glob.ts'
 import { stat as gsheetsStat } from '../../../core/gsheets/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { FileType, ResourceName, type FileStat, type PathSpec } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { statGeneric } from '../generic/stat.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-const TYPE_LABELS: Record<string, string> = {
-  [FileType.DIRECTORY]: 'directory',
-  [FileType.TEXT]: 'regular file',
-  [FileType.BINARY]: 'regular file',
-  [FileType.JSON]: 'regular file',
-  [FileType.CSV]: 'regular file',
-}
-
-function formatStat(fmt: string, s: FileStat): string {
-  return fmt.replace(/%(.)/g, (_, spec: string) => {
-    if (spec === 'n') return s.name
-    if (spec === 's') return String(s.size ?? 0)
-    if (spec === 'F')
-      return s.type !== null ? (TYPE_LABELS[s.type] ?? 'regular file') : 'regular file'
-    if (spec === 'y') return s.modified ?? ''
-    return '?'
-  })
-}
 
 async function statCommand(
   accessor: GSheetsAccessor,
@@ -48,30 +27,9 @@ async function statCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('stat: missing operand\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const fmt =
-    typeof opts.flags.c === 'string'
-      ? opts.flags.c
-      : typeof opts.flags.f === 'string'
-        ? opts.flags.f
-        : null
-  const lines: string[] = []
-  for (const p of resolved) {
-    const s = await gsheetsStat(accessor, p, opts.index ?? undefined)
-    if (fmt !== null) {
-      lines.push(formatStat(fmt, s))
-    } else {
-      const sizeStr = s.size === null ? 'None' : String(s.size)
-      const modStr = s.modified ?? 'None'
-      const typeStr = s.type ?? 'None'
-      lines.push(`name=${s.name} size=${sizeStr} modified=${modStr} type=${typeStr}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return statGeneric(resolved, opts, (p) => gsheetsStat(accessor, p, opts.index ?? undefined))
 }
 
 export const GSHEETS_STAT = command({

--- a/typescript/packages/core/src/commands/builtin/gsheets/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/gsheets/tree.ts
@@ -16,94 +16,10 @@ import type { GSheetsAccessor } from '../../../accessor/gsheets.ts'
 import { resolveGlob } from '../../../core/gsheets/glob.ts'
 import { readdir as gsheetsReaddir } from '../../../core/gsheets/readdir.ts'
 import { stat as gsheetsStat } from '../../../core/gsheets/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function fnmatch(name: string, pattern: string): boolean {
-  const re = pattern
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\?/g, '.')
-    .replace(/\*/g, '.*')
-  return new RegExp(`^${re}$`).test(name)
-}
-
-interface TreeOpts {
-  maxDepth: number | null
-  showHidden: boolean
-  ignorePattern: string | null
-  dirsOnly: boolean
-  matchPattern: string | null
-}
-
-async function treeRecurse(
-  accessor: GSheetsAccessor,
-  path: PathSpec,
-  prefix: string,
-  depth: number,
-  treeOpts: TreeOpts,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<string[]> {
-  const lines: string[] = []
-  let entries: string[]
-  try {
-    entries = await gsheetsReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`tree: '${path.original}': ${msg}`)
-    return lines
-  }
-  const filtered: [PathSpec, FileStat][] = []
-  for (const entry of entries) {
-    try {
-      const entrySpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await gsheetsStat(accessor, entrySpec, indexCache ?? undefined)
-      if (!treeOpts.showHidden && s.name.startsWith('.')) continue
-      if (treeOpts.ignorePattern !== null && fnmatch(s.name, treeOpts.ignorePattern)) continue
-      if (treeOpts.dirsOnly && s.type !== FileType.DIRECTORY) continue
-      const notDir = s.type !== FileType.DIRECTORY
-      if (treeOpts.matchPattern !== null && notDir && !fnmatch(s.name, treeOpts.matchPattern))
-        continue
-      filtered.push([entrySpec, s])
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`tree: '${entry}': ${msg}`)
-    }
-  }
-  for (let i = 0; i < filtered.length; i++) {
-    const pair = filtered[i]
-    if (pair === undefined) continue
-    const [entrySpec, s] = pair
-    const isLast = i === filtered.length - 1
-    const connector = isLast ? '\u2514\u2500\u2500 ' : '\u251c\u2500\u2500 '
-    lines.push(prefix + connector + s.name)
-    if (s.type === FileType.DIRECTORY) {
-      if (treeOpts.maxDepth !== null && depth >= treeOpts.maxDepth) continue
-      const extension = isLast ? '    ' : '\u2502   '
-      const sub = await treeRecurse(
-        accessor,
-        entrySpec,
-        prefix + extension,
-        depth + 1,
-        treeOpts,
-        warnings,
-        indexCache,
-      )
-      lines.push(...sub)
-    }
-  }
-  return lines
-}
+import { treeGeneric } from '../generic/tree.ts'
 
 async function treeCommand(
   accessor: GSheetsAccessor,
@@ -112,27 +28,12 @@ async function treeCommand(
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const p0 =
-    resolved[0] ??
-    new PathSpec({
-      original: opts.cwd,
-      directory: opts.cwd,
-      resolved: false,
-      prefix: opts.mountPrefix ?? '',
-    })
-  const maxDepth = typeof opts.flags.L === 'string' ? Number.parseInt(opts.flags.L, 10) : null
-  const treeOpts: TreeOpts = {
-    maxDepth,
-    showHidden: opts.flags.a === true,
-    ignorePattern: typeof opts.flags.args_I === 'string' ? opts.flags.args_I : null,
-    dirsOnly: opts.flags.d === true,
-    matchPattern: typeof opts.flags.P === 'string' ? opts.flags.P : null,
-  }
-  const warnings: string[] = []
-  const results = await treeRecurse(accessor, p0, '', 0, treeOpts, warnings, opts.index)
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  return [out, new IOResult({ stderr })]
+  return treeGeneric(
+    resolved,
+    opts,
+    (p) => gsheetsReaddir(accessor, p, opts.index ?? undefined),
+    (p) => gsheetsStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GSHEETS_TREE = command({

--- a/typescript/packages/core/src/commands/builtin/gsheets/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/gsheets/wc.ts
@@ -14,69 +14,24 @@
 
 import type { GSheetsAccessor } from '../../../accessor/gsheets.ts'
 import { resolveGlob } from '../../../core/gsheets/glob.ts'
-import { read as gsheetsRead } from '../../../core/gsheets/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as gsheetsStream } from '../../../core/gsheets/read.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { wcGeneric } from '../generic/wc.ts'
 import { fileReadProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function countLines(text: string): number {
-  let n = 0
-  for (let i = 0; i < text.length; i++) if (text.charCodeAt(i) === 10) n += 1
-  return n
-}
-
-function countWords(text: string): number {
-  const trimmed = text.trim()
-  if (trimmed === '') return 0
-  return trimmed.split(/\s+/).length
-}
-
-function maxLineLen(text: string): number {
-  let max = 0
-  for (const line of text.split('\n')) if (line.length > max) max = line.length
-  return max
-}
 
 async function wcCommand(
   accessor: GSheetsAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  let data: Uint8Array | null = null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    data = await gsheetsRead(accessor, first, opts.index ?? undefined)
-  } else {
-    data = await readStdinAsync(opts.stdin)
-    if (data === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('wc: missing operand\n') })]
-    }
-  }
-  const text = DEC.decode(data)
-  const lineCount = countLines(text)
-  const wordCount = countWords(text)
-  const byteCount = data.byteLength
-  if (opts.flags.L === true) {
-    const out: ByteSource = ENC.encode(String(maxLineLen(text)))
-    return [out, new IOResult()]
-  }
-  if (opts.flags.args_l === true) return [ENC.encode(String(lineCount)), new IOResult()]
-  if (opts.flags.w === true) return [ENC.encode(String(wordCount)), new IOResult()]
-  if (opts.flags.m === true) return [ENC.encode(String(text.length)), new IOResult()]
-  if (opts.flags.c === true) return [ENC.encode(String(byteCount)), new IOResult()]
-  const out: ByteSource = ENC.encode(
-    `${String(lineCount)}\t${String(wordCount)}\t${String(byteCount)}`,
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return wcGeneric(resolved, texts, opts, (p) =>
+    gsheetsStream(accessor, p, opts.index ?? undefined),
   )
-  return [out, new IOResult()]
 }
 
 export const GSHEETS_WC = command({

--- a/typescript/packages/core/src/commands/builtin/gslides/head.ts
+++ b/typescript/packages/core/src/commands/builtin/gslides/head.ts
@@ -14,52 +14,29 @@
 
 import type { GSlidesAccessor } from '../../../accessor/gslides.ts'
 import { resolveGlob } from '../../../core/gslides/glob.ts'
-import { read as gslidesRead } from '../../../core/gslides/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as gslidesStream } from '../../../core/gslides/read.ts'
+import { stat as gslidesStat } from '../../../core/gslides/stat.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { headGeneric } from '../generic/head.ts'
 import { fileReadProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-function headBytes(data: Uint8Array, lines: number, bytesMode: number | null): Uint8Array {
-  if (bytesMode !== null) return data.slice(0, bytesMode)
-  let count = 0
-  let end = 0
-  for (let i = 0; i < data.byteLength && count < lines; i++) {
-    if (data[i] === 0x0a) {
-      count += 1
-      end = i + 1
-    }
-  }
-  if (count < lines) return data
-  return data.slice(0, end - 1)
-}
 
 async function headCommand(
   accessor: GSlidesAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const lines = typeof opts.flags.n === 'string' ? Number.parseInt(opts.flags.n, 10) : 10
-  const bytesMode = typeof opts.flags.c === 'string' ? Number.parseInt(opts.flags.c, 10) : null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const data = await gslidesRead(accessor, first, opts.index ?? undefined)
-    const out: ByteSource = headBytes(data, lines, bytesMode)
-    return [out, new IOResult()]
-  }
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('head: missing operand\n') })]
-  }
-  const out: ByteSource = headBytes(raw, lines, bytesMode)
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return headGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => gslidesStat(accessor, p, opts.index ?? undefined),
+    (p) => gslidesStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GSLIDES_HEAD = command({

--- a/typescript/packages/core/src/commands/builtin/gslides/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/gslides/ls.ts
@@ -16,93 +16,11 @@ import type { GSlidesAccessor } from '../../../accessor/gslides.ts'
 import { resolveGlob } from '../../../core/gslides/glob.ts'
 import { readdir as gslidesReaddir } from '../../../core/gslides/readdir.ts'
 import { stat as gslidesStat } from '../../../core/gslides/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { humanSize } from '../utils/formatting.ts'
+import { lsGeneric } from '../generic/ls.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-async function lsEntries(
-  accessor: GSlidesAccessor,
-  path: PathSpec,
-  allFiles: boolean,
-  sortBy: 'name' | 'size',
-  reverse: boolean,
-  recursive: boolean,
-  listDir: boolean,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<FileStat[]> {
-  if (listDir) {
-    const s = await gslidesStat(accessor, path, indexCache ?? undefined)
-    return [s]
-  }
-  let entries: string[]
-  try {
-    entries = await gslidesReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`ls: cannot access '${path.original}': ${msg}`)
-    return []
-  }
-  const stats: FileStat[] = []
-  for (const entry of entries) {
-    try {
-      const eSpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await gslidesStat(accessor, eSpec, indexCache ?? undefined)
-      if (!allFiles && s.name.startsWith('.')) continue
-      stats.push(s)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${entry}': ${msg}`)
-    }
-  }
-  if (sortBy === 'size') {
-    stats.sort((a, b) => (a.size ?? 0) - (b.size ?? 0))
-    if (!reverse) stats.reverse()
-  } else {
-    stats.sort((a, b) => a.name.localeCompare(b.name))
-    if (reverse) stats.reverse()
-  }
-  if (recursive) {
-    const subEntries: FileStat[] = []
-    for (const s of stats) {
-      subEntries.push(s)
-      if (s.type === FileType.DIRECTORY) {
-        const childPath = path.child(s.name)
-        const childSpec = new PathSpec({
-          original: childPath,
-          directory: childPath,
-          resolved: false,
-          prefix: path.prefix,
-        })
-        const sub = await lsEntries(
-          accessor,
-          childSpec,
-          allFiles,
-          sortBy,
-          reverse,
-          recursive,
-          false,
-          warnings,
-          indexCache,
-        )
-        subEntries.push(...sub)
-      }
-    }
-    return subEntries
-  }
-  return stats
-}
 
 async function lsCommand(
   accessor: GSlidesAccessor,
@@ -110,64 +28,24 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const targets: PathSpec[] =
-    resolved.length > 0
-      ? resolved
-      : [
-          new PathSpec({
-            original: opts.cwd,
-            directory: opts.cwd,
-            resolved: false,
-            prefix: opts.mountPrefix ?? '',
-          }),
-        ]
-  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
-  const allFiles = opts.flags.a === true || opts.flags.A === true
-  const human = opts.flags.h === true
-  const reverse = opts.flags.r === true
-  const recursive = opts.flags.R === true
-  const listDir = opts.flags.d === true
-  const classify = opts.flags.F === true
-  const sortBy: 'name' | 'size' = opts.flags.S === true ? 'size' : 'name'
-  const warnings: string[] = []
-  const results: string[] = []
-  for (const p of targets) {
-    let entries: FileStat[]
-    try {
-      entries = await lsEntries(
-        accessor,
-        p,
-        allFiles,
-        sortBy,
-        reverse,
-        recursive,
-        listDir,
-        warnings,
-        opts.index,
-      )
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${p.original}': ${msg}`)
-      continue
-    }
-    if (long) {
-      for (const e of entries) {
-        const sizeStr = human ? humanSize(e.size ?? 0) : String(e.size ?? 0)
-        results.push(`${e.type ?? '-'}\t${sizeStr}\t${e.modified ?? ''}\t${e.name}`)
-      }
-    } else {
-      for (const e of entries) {
-        const isDir = classify && e.type === FileType.DIRECTORY
-        const name = isDir ? e.name + '/' : e.name
-        results.push(name)
-      }
-    }
+  let workingPaths: PathSpec[] = paths
+  if (workingPaths.length === 0) {
+    workingPaths = [
+      new PathSpec({
+        original: opts.cwd,
+        directory: opts.cwd,
+        resolved: false,
+        prefix: opts.mountPrefix ?? '',
+      }),
+    ]
   }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  return [out, new IOResult({ stderr, exitCode })]
+  const resolved = await resolveGlob(accessor, workingPaths, opts.index ?? undefined)
+  return lsGeneric(
+    resolved,
+    opts,
+    (p) => gslidesReaddir(accessor, p, opts.index ?? undefined),
+    (p) => gslidesStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GSLIDES_LS = command({

--- a/typescript/packages/core/src/commands/builtin/gslides/nl.ts
+++ b/typescript/packages/core/src/commands/builtin/gslides/nl.ts
@@ -14,27 +14,12 @@
 
 import type { GSlidesAccessor } from '../../../accessor/gslides.ts'
 import { resolveGlob } from '../../../core/gslides/glob.ts'
-import { read as gslidesRead } from '../../../core/gslides/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as gslidesStream } from '../../../core/gslides/read.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function shouldNumber(line: string, mode: string, pattern: RegExp | null): boolean {
-  if (mode === 'n') return false
-  if (mode === 'a') return true
-  if (mode === 'p' && pattern !== null) return pattern.test(line)
-  return line.trim() !== ''
-}
-
-function pad(n: number, width: number): string {
-  const s = String(n)
-  return s.length >= width ? s : ' '.repeat(width - s.length) + s
-}
+import { nlGeneric } from '../generic/nl.ts'
+import { fileReadProvision } from './provision.ts'
 
 async function nlCommand(
   accessor: GSlidesAccessor,
@@ -42,43 +27,9 @@ async function nlCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const bRaw = typeof opts.flags.b === 'string' ? opts.flags.b : 't'
-  let mode = bRaw
-  let pattern: RegExp | null = null
-  if (bRaw.startsWith('p')) {
-    mode = 'p'
-    pattern = new RegExp(bRaw.slice(1))
-  }
-  const start = typeof opts.flags.v === 'string' ? Number.parseInt(opts.flags.v, 10) : 1
-  const increment = typeof opts.flags.i === 'string' ? Number.parseInt(opts.flags.i, 10) : 1
-  const width = typeof opts.flags.w === 'string' ? Number.parseInt(opts.flags.w, 10) : 6
-  const separator = typeof opts.flags.s === 'string' ? opts.flags.s : '\t'
-
-  let raw: Uint8Array | null = null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    raw = await gslidesRead(accessor, first, opts.index ?? undefined)
-  } else {
-    raw = await readStdinAsync(opts.stdin)
-    if (raw === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('nl: missing operand\n') })]
-    }
-  }
-
-  let num = start
-  const outLines: string[] = []
-  for (const line of DEC.decode(raw).split('\n')) {
-    if (shouldNumber(line, mode, pattern)) {
-      outLines.push(`${pad(num, width)}${separator}${line}`)
-      num += increment
-    } else {
-      outLines.push(`${' '.repeat(width)}${separator}${line}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(outLines.join('\n') + '\n')
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return nlGeneric(resolved, opts, (p) => gslidesStream(accessor, p, opts.index ?? undefined))
 }
 
 export const GSLIDES_NL = command({
@@ -86,4 +37,5 @@ export const GSLIDES_NL = command({
   resource: ResourceName.GSLIDES,
   spec: specOf('nl'),
   fn: nlCommand,
+  provision: fileReadProvision,
 })

--- a/typescript/packages/core/src/commands/builtin/gslides/realpath.ts
+++ b/typescript/packages/core/src/commands/builtin/gslides/realpath.ts
@@ -13,65 +13,24 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { GSlidesAccessor } from '../../../accessor/gslides.ts'
+import { resolveGlob } from '../../../core/gslides/glob.ts'
 import { stat as gslidesStat } from '../../../core/gslides/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function normalize(p: string): string {
-  const isAbs = p.startsWith('/')
-  const segments = p.split('/').filter((s) => s !== '' && s !== '.')
-  const out: string[] = []
-  for (const s of segments) {
-    if (s === '..') {
-      if (out.length > 0) out.pop()
-      else if (!isAbs) out.push('..')
-    } else {
-      out.push(s)
-    }
-  }
-  const joined = out.join('/')
-  return isAbs ? '/' + joined : joined === '' ? '.' : joined
-}
-
-async function exists(
-  accessor: GSlidesAccessor,
-  path: string,
-  index: CommandOpts['index'],
-  prefix: string,
-): Promise<boolean> {
-  try {
-    const spec = new PathSpec({ original: path, directory: path, prefix })
-    await gslidesStat(accessor, spec, index ?? undefined)
-    return true
-  } catch {
-    return false
-  }
-}
+import { realpathGeneric } from '../generic/realpath.ts'
 
 async function realpathCommand(
   accessor: GSlidesAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const prefix = opts.mountPrefix ?? ''
-  const e = opts.flags.e === true
-  const lines: string[] = []
-  for (const p of paths) {
-    const full = prefix !== '' ? prefix + p.original : p.original
-    const resolved = normalize(full)
-    if (e && !(await exists(accessor, resolved, opts.index, prefix))) {
-      const msg = `realpath: '${p.original}': No such file or directory\n`
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(msg) })]
-    }
-    lines.push(resolved)
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return realpathGeneric(resolved, texts, opts, (p) =>
+    gslidesStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GSLIDES_REALPATH = command({

--- a/typescript/packages/core/src/commands/builtin/gslides/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/gslides/stat.ts
@@ -15,32 +15,11 @@
 import type { GSlidesAccessor } from '../../../accessor/gslides.ts'
 import { resolveGlob } from '../../../core/gslides/glob.ts'
 import { stat as gslidesStat } from '../../../core/gslides/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { FileType, ResourceName, type FileStat, type PathSpec } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { statGeneric } from '../generic/stat.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-const TYPE_LABELS: Record<string, string> = {
-  [FileType.DIRECTORY]: 'directory',
-  [FileType.TEXT]: 'regular file',
-  [FileType.BINARY]: 'regular file',
-  [FileType.JSON]: 'regular file',
-  [FileType.CSV]: 'regular file',
-}
-
-function formatStat(fmt: string, s: FileStat): string {
-  return fmt.replace(/%(.)/g, (_, spec: string) => {
-    if (spec === 'n') return s.name
-    if (spec === 's') return String(s.size ?? 0)
-    if (spec === 'F')
-      return s.type !== null ? (TYPE_LABELS[s.type] ?? 'regular file') : 'regular file'
-    if (spec === 'y') return s.modified ?? ''
-    return '?'
-  })
-}
 
 async function statCommand(
   accessor: GSlidesAccessor,
@@ -48,30 +27,9 @@ async function statCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('stat: missing operand\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const fmt =
-    typeof opts.flags.c === 'string'
-      ? opts.flags.c
-      : typeof opts.flags.f === 'string'
-        ? opts.flags.f
-        : null
-  const lines: string[] = []
-  for (const p of resolved) {
-    const s = await gslidesStat(accessor, p, opts.index ?? undefined)
-    if (fmt !== null) {
-      lines.push(formatStat(fmt, s))
-    } else {
-      const sizeStr = s.size === null ? 'None' : String(s.size)
-      const modStr = s.modified ?? 'None'
-      const typeStr = s.type ?? 'None'
-      lines.push(`name=${s.name} size=${sizeStr} modified=${modStr} type=${typeStr}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return statGeneric(resolved, opts, (p) => gslidesStat(accessor, p, opts.index ?? undefined))
 }
 
 export const GSLIDES_STAT = command({

--- a/typescript/packages/core/src/commands/builtin/gslides/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/gslides/tree.ts
@@ -16,94 +16,10 @@ import type { GSlidesAccessor } from '../../../accessor/gslides.ts'
 import { resolveGlob } from '../../../core/gslides/glob.ts'
 import { readdir as gslidesReaddir } from '../../../core/gslides/readdir.ts'
 import { stat as gslidesStat } from '../../../core/gslides/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function fnmatch(name: string, pattern: string): boolean {
-  const re = pattern
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\?/g, '.')
-    .replace(/\*/g, '.*')
-  return new RegExp(`^${re}$`).test(name)
-}
-
-interface TreeOpts {
-  maxDepth: number | null
-  showHidden: boolean
-  ignorePattern: string | null
-  dirsOnly: boolean
-  matchPattern: string | null
-}
-
-async function treeRecurse(
-  accessor: GSlidesAccessor,
-  path: PathSpec,
-  prefix: string,
-  depth: number,
-  treeOpts: TreeOpts,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<string[]> {
-  const lines: string[] = []
-  let entries: string[]
-  try {
-    entries = await gslidesReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`tree: '${path.original}': ${msg}`)
-    return lines
-  }
-  const filtered: [PathSpec, FileStat][] = []
-  for (const entry of entries) {
-    try {
-      const entrySpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await gslidesStat(accessor, entrySpec, indexCache ?? undefined)
-      if (!treeOpts.showHidden && s.name.startsWith('.')) continue
-      if (treeOpts.ignorePattern !== null && fnmatch(s.name, treeOpts.ignorePattern)) continue
-      if (treeOpts.dirsOnly && s.type !== FileType.DIRECTORY) continue
-      const notDir = s.type !== FileType.DIRECTORY
-      if (treeOpts.matchPattern !== null && notDir && !fnmatch(s.name, treeOpts.matchPattern))
-        continue
-      filtered.push([entrySpec, s])
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`tree: '${entry}': ${msg}`)
-    }
-  }
-  for (let i = 0; i < filtered.length; i++) {
-    const pair = filtered[i]
-    if (pair === undefined) continue
-    const [entrySpec, s] = pair
-    const isLast = i === filtered.length - 1
-    const connector = isLast ? '\u2514\u2500\u2500 ' : '\u251c\u2500\u2500 '
-    lines.push(prefix + connector + s.name)
-    if (s.type === FileType.DIRECTORY) {
-      if (treeOpts.maxDepth !== null && depth >= treeOpts.maxDepth) continue
-      const extension = isLast ? '    ' : '\u2502   '
-      const sub = await treeRecurse(
-        accessor,
-        entrySpec,
-        prefix + extension,
-        depth + 1,
-        treeOpts,
-        warnings,
-        indexCache,
-      )
-      lines.push(...sub)
-    }
-  }
-  return lines
-}
+import { treeGeneric } from '../generic/tree.ts'
 
 async function treeCommand(
   accessor: GSlidesAccessor,
@@ -112,27 +28,12 @@ async function treeCommand(
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const p0 =
-    resolved[0] ??
-    new PathSpec({
-      original: opts.cwd,
-      directory: opts.cwd,
-      resolved: false,
-      prefix: opts.mountPrefix ?? '',
-    })
-  const maxDepth = typeof opts.flags.L === 'string' ? Number.parseInt(opts.flags.L, 10) : null
-  const treeOpts: TreeOpts = {
-    maxDepth,
-    showHidden: opts.flags.a === true,
-    ignorePattern: typeof opts.flags.args_I === 'string' ? opts.flags.args_I : null,
-    dirsOnly: opts.flags.d === true,
-    matchPattern: typeof opts.flags.P === 'string' ? opts.flags.P : null,
-  }
-  const warnings: string[] = []
-  const results = await treeRecurse(accessor, p0, '', 0, treeOpts, warnings, opts.index)
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  return [out, new IOResult({ stderr })]
+  return treeGeneric(
+    resolved,
+    opts,
+    (p) => gslidesReaddir(accessor, p, opts.index ?? undefined),
+    (p) => gslidesStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GSLIDES_TREE = command({

--- a/typescript/packages/core/src/commands/builtin/gslides/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/gslides/wc.ts
@@ -14,69 +14,24 @@
 
 import type { GSlidesAccessor } from '../../../accessor/gslides.ts'
 import { resolveGlob } from '../../../core/gslides/glob.ts'
-import { read as gslidesRead } from '../../../core/gslides/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as gslidesStream } from '../../../core/gslides/read.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { wcGeneric } from '../generic/wc.ts'
 import { fileReadProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function countLines(text: string): number {
-  let n = 0
-  for (let i = 0; i < text.length; i++) if (text.charCodeAt(i) === 10) n += 1
-  return n
-}
-
-function countWords(text: string): number {
-  const trimmed = text.trim()
-  if (trimmed === '') return 0
-  return trimmed.split(/\s+/).length
-}
-
-function maxLineLen(text: string): number {
-  let max = 0
-  for (const line of text.split('\n')) if (line.length > max) max = line.length
-  return max
-}
 
 async function wcCommand(
   accessor: GSlidesAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  let data: Uint8Array | null = null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    data = await gslidesRead(accessor, first, opts.index ?? undefined)
-  } else {
-    data = await readStdinAsync(opts.stdin)
-    if (data === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('wc: missing operand\n') })]
-    }
-  }
-  const text = DEC.decode(data)
-  const lineCount = countLines(text)
-  const wordCount = countWords(text)
-  const byteCount = data.byteLength
-  if (opts.flags.L === true) {
-    const out: ByteSource = ENC.encode(String(maxLineLen(text)))
-    return [out, new IOResult()]
-  }
-  if (opts.flags.args_l === true) return [ENC.encode(String(lineCount)), new IOResult()]
-  if (opts.flags.w === true) return [ENC.encode(String(wordCount)), new IOResult()]
-  if (opts.flags.m === true) return [ENC.encode(String(text.length)), new IOResult()]
-  if (opts.flags.c === true) return [ENC.encode(String(byteCount)), new IOResult()]
-  const out: ByteSource = ENC.encode(
-    `${String(lineCount)}\t${String(wordCount)}\t${String(byteCount)}`,
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return wcGeneric(resolved, texts, opts, (p) =>
+    gslidesStream(accessor, p, opts.index ?? undefined),
   )
-  return [out, new IOResult()]
 }
 
 export const GSLIDES_WC = command({

--- a/typescript/packages/core/src/core/gmail/messages.ts
+++ b/typescript/packages/core/src/core/gmail/messages.ts
@@ -63,6 +63,14 @@ export interface GmailAddress {
   email: string
 }
 
+export interface GmailProcessedAttachment {
+  id: string
+  filename: string
+  path: string
+  mime_type: string
+  size: number
+}
+
 export interface GmailMessageProcessed {
   id: string
   thread_id: string
@@ -74,6 +82,7 @@ export interface GmailMessageProcessed {
   body_text: string
   snippet: string
   labels: string[]
+  attachments: GmailProcessedAttachment[]
 }
 
 export interface ListMessagesOptions {
@@ -192,6 +201,42 @@ export function extractAttachments(payload: GmailPayload | undefined): GmailAtta
   return attachments
 }
 
+function extractProcessedAttachments(
+  payload: GmailPayload | undefined,
+): GmailProcessedAttachment[] {
+  if (payload === undefined) return []
+  const result: GmailProcessedAttachment[] = []
+  for (const part of payload.parts ?? []) {
+    const filename = part.filename ?? ''
+    const body = part.body ?? {}
+    const attachmentId = body.attachmentId ?? ''
+    if (filename !== '' && attachmentId !== '') {
+      result.push({
+        id: attachmentId,
+        filename,
+        path: `attachments/${attachmentId}_${filename}`,
+        mime_type: part.mimeType ?? '',
+        size: body.size ?? 0,
+      })
+    }
+    for (const sub of part.parts ?? []) {
+      const fn = sub.filename ?? ''
+      const bd = sub.body ?? {}
+      const aid = bd.attachmentId ?? ''
+      if (fn !== '' && aid !== '') {
+        result.push({
+          id: aid,
+          filename: fn,
+          path: `attachments/${aid}_${fn}`,
+          mime_type: sub.mimeType ?? '',
+          size: bd.size ?? 0,
+        })
+      }
+    }
+  }
+  return result
+}
+
 export async function getMessageProcessed(
   tokenManager: TokenManager,
   messageId: string,
@@ -210,5 +255,6 @@ export async function getMessageProcessed(
     body_text: bodyText,
     snippet: raw.snippet ?? '',
     labels: raw.labelIds ?? [],
+    attachments: extractProcessedAttachments(raw.payload),
   }
 }


### PR DESCRIPTION
## What

Migrate the bespoke read commands in the four Google resources (gdocs, gsheets, gslides, gmail) to the shared generic command layer, mirroring the Python side, and align cross-language JSON output so `cat`/`wc`/`stat` are byte-for-byte identical.

## Why

Google resources are remote, so cached reads are served by the RAM cache mount (generic layer), but **cold reads (cache miss)** went through the bespoke per-resource commands. Those diverged from both the generic/warm path and Python:

- `wc` / `wc -c` / `wc -l`: omitted the filename label and multi-file totals
- `realpath`: double-prefixed the path (`/gdocs/gdocs/owned/...`)
- `head`: single-file only (no multi-file headers)

## Changes

- **TS (28 files):** `head/wc/ls/stat/tree/nl/realpath` in gdocs/gsheets/gslides/gmail now delegate to the generic layer (`cat/tail/grep/rg` already did; `jq/find` left as-is, already aligned). gmail wraps `read` in a generator since it has no core `stream`.
- **Python (4 files, issue #200, google subset):** flip the google read render sites to compact separators (`json.dumps(..., separators=(",", ":"))`) to match TS `JSON.stringify`.
- **TS gmail (1 file):** add the missing `attachments` field to the processed message to match Python's structure.

## Verification

- Cold-path probes + live examples for all four resources: `cat`/`wc`/`stat` now byte-for-byte identical between TS and Python (e.g. gmail `cat` 2639 == 2639, `diff` clean).
- All TS package tests pass (core 2714, node 1290, browser 162, server 131, agents 123, cli 51).
- Google Python tests pass (core + commands + resource).
- `pre-commit run` clean.