### PR TITLE
fix(py/slack,discord): compact JSON separators for read content (#200)

### DIFF
--- a/python/mirage/commands/builtin/discord/head.py
+++ b/python/mirage/commands/builtin/discord/head.py
@@ -78,8 +78,9 @@ async def head(
                 },
             )
             msgs.sort(key=lambda m: int(m["id"]))
-            jsonl = "\n".join(json.dumps(m, ensure_ascii=False)
-                              for m in msgs) + "\n"
+            jsonl = "\n".join(
+                json.dumps(m, ensure_ascii=False, separators=(",", ":"))
+                for m in msgs) + "\n"
             return generic_head(jsonl.encode(), n=lines), IOResult()
 
         paths = await resolve_glob(accessor, paths, index)

--- a/python/mirage/core/discord/history.py
+++ b/python/mirage/core/discord/history.py
@@ -118,5 +118,8 @@ async def get_history_jsonl(
         bytes: JSONL-encoded messages.
     """
     messages = await list_messages_for_day(config, channel_id, date_str)
-    lines = [json.dumps(m, ensure_ascii=False) for m in messages]
+    lines = [
+        json.dumps(m, ensure_ascii=False, separators=(",", ":"))
+        for m in messages
+    ]
     return ("\n".join(lines) + "\n").encode() if lines else b""

--- a/python/mirage/core/discord/read.py
+++ b/python/mirage/core/discord/read.py
@@ -105,7 +105,8 @@ async def read(
         for m in members:
             user = m.get("user", {})
             if user.get("id") == entry_lookup.entry.id:
-                return json.dumps(m, ensure_ascii=False).encode()
+                return json.dumps(m, ensure_ascii=False,
+                                  separators=(",", ":")).encode()
         raise FileNotFoundError(key)
 
     raise FileNotFoundError(key)

--- a/python/mirage/core/slack/history.py
+++ b/python/mirage/core/slack/history.py
@@ -98,7 +98,10 @@ async def get_history_jsonl(
         bytes: JSONL-encoded messages.
     """
     messages = await fetch_messages_for_day(config, channel_id, date_str)
-    lines = [json.dumps(m, ensure_ascii=False) for m in messages]
+    lines = [
+        json.dumps(m, ensure_ascii=False, separators=(",", ":"))
+        for m in messages
+    ]
     return ("\n".join(lines) + "\n").encode() if lines else b""
 
 

--- a/python/mirage/core/slack/read.py
+++ b/python/mirage/core/slack/read.py
@@ -70,6 +70,7 @@ async def read(
         if lookup.entry is None:
             raise FileNotFoundError(key)
         user = await get_user_profile(accessor.config, lookup.entry.id)
-        return json.dumps(user, ensure_ascii=False).encode()
+        return json.dumps(user, ensure_ascii=False,
+                          separators=(",", ":")).encode()
 
     raise FileNotFoundError(key)

--- a/python/mirage/core/slack/search.py
+++ b/python/mirage/core/slack/search.py
@@ -52,7 +52,7 @@ async def search_messages(
         "search.messages",
         params=params,
     )
-    return json.dumps(data, ensure_ascii=False).encode()
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":")).encode()
 
 
 def search_messages_stream(
@@ -117,7 +117,7 @@ async def search_files(
         "search.files",
         params=params,
     )
-    return json.dumps(data, ensure_ascii=False).encode()
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":")).encode()
 
 
 def search_files_stream(


### PR DESCRIPTION
## What

Flip the slack and discord **content read** render sites to compact `json.dumps(..., separators=(",", ":"))` to match the TypeScript `JSON.stringify` output. This is the slack/discord portion of issue #200 (the google portion shipped in #203).

## Sites changed (6)

- slack: `core/slack/read.py` (user profile), `core/slack/history.py` (chat.jsonl), `core/slack/search.py` (×2 search results)
- discord: `core/discord/read.py` (member), `core/discord/history.py` (chat.jsonl), `commands/builtin/discord/head.py` (live head)

Action commands (slack_post_message, slack_get_users, discord_send_message, etc.) are left as-is, matching how the google `gws_*` commands were handled.

## Why

slack/discord were already migrated to the generic command layer (#164, #199), but Python still rendered read content with spaced JSON while TS used compact. That made `cat` differ and any byte-size op (`stat`, `wc -c`, `md5`, `sha256sum`) diverge.

## Verification

Live examples, both languages, `cat`/`stat` now byte-for-byte identical:

| | before (PY spaced) | after (PY compact) | TS |
|---|---|---|---|
| slack `stat chat.jsonl` | 6226 | **5933** | 5933 |
| discord `stat chat.jsonl` | (spaced) | **1867** | 1867 |

`cat` content is compact on both sides; `wc -l`/`grep`/`jq`/`ls` already matched. slack+discord Python tests pass (227); `pre-commit` clean.