### PR TITLE
refactor(ts): delegate gdrive/github/github_ci reads to generic

### DIFF
--- a/examples/typescript/gdrive/gdrive.ts
+++ b/examples/typescript/gdrive/gdrive.ts
@@ -85,21 +85,49 @@ async function main(): Promise<void> {
     const firstDoc = docFiles[0]
     if (firstDoc !== undefined && firstDoc !== '') {
       const jq = await run(ws, `cat "${firstDoc}" | jq ".title"`)
-      console.log(`=== cat ${firstDoc} | jq .title ===`)
-      console.log(`  ${jq.out.trim()}`)
+      printOut(`cat ${firstDoc} | jq .title`, jq.out, jq.err)
+
+      const head = await run(ws, `head -n 3 "${firstDoc}"`)
+      printOut(`head -n 3 ${firstDoc}`, head.out, head.err)
+
+      const wc = await run(ws, `wc "${firstDoc}"`)
+      printOut(`wc ${firstDoc}`, wc.out, wc.err)
+
+      const basename = await run(ws, `basename "${firstDoc}"`)
+      printOut(`basename ${firstDoc}`, basename.out, basename.err)
+
+      const dirname = await run(ws, `dirname "${firstDoc}"`)
+      printOut(`dirname ${firstDoc}`, dirname.out, dirname.err)
+
+      const tail = await run(ws, `tail -n 3 "${firstDoc}"`)
+      printOut(`tail -n 3 ${firstDoc}`, tail.out, tail.err)
+
+      const nl = await run(ws, `nl "${firstDoc}"`)
+      printOut(`nl ${firstDoc}`, nl.out, nl.err, 300)
+
+      const grep = await run(ws, `grep title "${firstDoc}"`)
+      printOut(`grep title ${firstDoc}`, grep.out, grep.err, 300)
+
+      const rg = await run(ws, `rg title "${firstDoc}"`)
+      printOut(`rg title ${firstDoc}`, rg.out, rg.err, 300)
+
+      const realpath = await run(ws, `realpath "${firstDoc}"`)
+      printOut(`realpath ${firstDoc}`, realpath.out, realpath.err)
     }
 
-    console.log('\n=== gws-docs-documents-create (registered under gdrive too) ===')
+    console.log('\n=== gws-docs-documents-create ===')
     const create = await run(
       ws,
-      "gws-docs-documents-create --json '{\"title\": \"MIRAGE Drive Cross-Resource Demo\"}'",
+      "gws-docs-documents-create --json '{\"title\": \"Test from MIRAGE gdrive\"}'",
     )
-    if (create.code === 0) {
-      const doc = JSON.parse(create.out) as { documentId?: string }
-      console.log(`Created via gdrive: ${doc.documentId ?? '(no id)'}`)
-    } else {
-      printOut('create', create.out, create.err)
-    }
+    printOut('gws-docs-documents-create', create.out, create.err, 300)
+
+    console.log('\n=== gws-sheets-spreadsheets-create ===')
+    const createSheet = await run(
+      ws,
+      "gws-sheets-spreadsheets-create --json '{\"properties\": {\"title\": \"Test Sheet from gdrive\"}}'",
+    )
+    printOut('gws-sheets-spreadsheets-create', createSheet.out, createSheet.err, 300)
   } finally {
     await ws.close()
   }

--- a/python/mirage/core/github_ci/read.py
+++ b/python/mirage/core/github_ci/read.py
@@ -78,7 +78,8 @@ async def read(
         for j in jobs:
             anns = await list_annotations(accessor.config, str(j["id"]))
             for a in anns:
-                lines.append(json.dumps(a, ensure_ascii=False))
+                lines.append(
+                    json.dumps(a, ensure_ascii=False, separators=(",", ":")))
         if lines:
             return ("\n".join(lines) + "\n").encode()
         return b""

--- a/typescript/packages/core/src/commands/builtin/gdrive/head.ts
+++ b/typescript/packages/core/src/commands/builtin/gdrive/head.ts
@@ -14,52 +14,29 @@
 
 import type { GDriveAccessor } from '../../../accessor/gdrive.ts'
 import { resolveGlob } from '../../../core/gdrive/glob.ts'
-import { read as gdriveRead } from '../../../core/gdrive/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as gdriveStream } from '../../../core/gdrive/read.ts'
+import { stat as gdriveStat } from '../../../core/gdrive/stat.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { headGeneric } from '../generic/head.ts'
 import { fileReadProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-function headBytes(data: Uint8Array, lines: number, bytesMode: number | null): Uint8Array {
-  if (bytesMode !== null) return data.slice(0, bytesMode)
-  let count = 0
-  let end = 0
-  for (let i = 0; i < data.byteLength && count < lines; i++) {
-    if (data[i] === 0x0a) {
-      count += 1
-      end = i + 1
-    }
-  }
-  if (count < lines) return data
-  return data.slice(0, end - 1)
-}
 
 async function headCommand(
   accessor: GDriveAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const lines = typeof opts.flags.n === 'string' ? Number.parseInt(opts.flags.n, 10) : 10
-  const bytesMode = typeof opts.flags.c === 'string' ? Number.parseInt(opts.flags.c, 10) : null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const data = await gdriveRead(accessor, first, opts.index ?? undefined)
-    const out: ByteSource = headBytes(data, lines, bytesMode)
-    return [out, new IOResult()]
-  }
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('head: missing operand\n') })]
-  }
-  const out: ByteSource = headBytes(raw, lines, bytesMode)
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return headGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => gdriveStat(accessor, p, opts.index ?? undefined),
+    (p) => gdriveStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GDRIVE_HEAD = command({

--- a/typescript/packages/core/src/commands/builtin/gdrive/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/gdrive/ls.ts
@@ -16,93 +16,11 @@ import type { GDriveAccessor } from '../../../accessor/gdrive.ts'
 import { resolveGlob } from '../../../core/gdrive/glob.ts'
 import { readdir as gdriveReaddir } from '../../../core/gdrive/readdir.ts'
 import { stat as gdriveStat } from '../../../core/gdrive/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { humanSize } from '../utils/formatting.ts'
+import { lsGeneric } from '../generic/ls.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-async function lsEntries(
-  accessor: GDriveAccessor,
-  path: PathSpec,
-  allFiles: boolean,
-  sortBy: 'name' | 'size',
-  reverse: boolean,
-  recursive: boolean,
-  listDir: boolean,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<FileStat[]> {
-  if (listDir) {
-    const s = await gdriveStat(accessor, path, indexCache ?? undefined)
-    return [s]
-  }
-  let entries: string[]
-  try {
-    entries = await gdriveReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`ls: cannot access '${path.original}': ${msg}`)
-    return []
-  }
-  const stats: FileStat[] = []
-  for (const entry of entries) {
-    try {
-      const eSpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await gdriveStat(accessor, eSpec, indexCache ?? undefined)
-      if (!allFiles && s.name.startsWith('.')) continue
-      stats.push(s)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${entry}': ${msg}`)
-    }
-  }
-  if (sortBy === 'size') {
-    stats.sort((a, b) => (a.size ?? 0) - (b.size ?? 0))
-    if (!reverse) stats.reverse()
-  } else {
-    stats.sort((a, b) => a.name.localeCompare(b.name))
-    if (reverse) stats.reverse()
-  }
-  if (recursive) {
-    const subEntries: FileStat[] = []
-    for (const s of stats) {
-      subEntries.push(s)
-      if (s.type === FileType.DIRECTORY) {
-        const childPath = path.child(s.name)
-        const childSpec = new PathSpec({
-          original: childPath,
-          directory: childPath,
-          resolved: false,
-          prefix: path.prefix,
-        })
-        const sub = await lsEntries(
-          accessor,
-          childSpec,
-          allFiles,
-          sortBy,
-          reverse,
-          recursive,
-          false,
-          warnings,
-          indexCache,
-        )
-        subEntries.push(...sub)
-      }
-    }
-    return subEntries
-  }
-  return stats
-}
 
 async function lsCommand(
   accessor: GDriveAccessor,
@@ -110,64 +28,24 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const targets: PathSpec[] =
-    resolved.length > 0
-      ? resolved
-      : [
-          new PathSpec({
-            original: opts.cwd,
-            directory: opts.cwd,
-            resolved: false,
-            prefix: opts.mountPrefix ?? '',
-          }),
-        ]
-  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
-  const allFiles = opts.flags.a === true || opts.flags.A === true
-  const human = opts.flags.h === true
-  const reverse = opts.flags.r === true
-  const recursive = opts.flags.R === true
-  const listDir = opts.flags.d === true
-  const classify = opts.flags.F === true
-  const sortBy: 'name' | 'size' = opts.flags.S === true ? 'size' : 'name'
-  const warnings: string[] = []
-  const results: string[] = []
-  for (const p of targets) {
-    let entries: FileStat[]
-    try {
-      entries = await lsEntries(
-        accessor,
-        p,
-        allFiles,
-        sortBy,
-        reverse,
-        recursive,
-        listDir,
-        warnings,
-        opts.index,
-      )
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${p.original}': ${msg}`)
-      continue
-    }
-    if (long) {
-      for (const e of entries) {
-        const sizeStr = human ? humanSize(e.size ?? 0) : String(e.size ?? 0)
-        results.push(`${e.type ?? '-'}\t${sizeStr}\t${e.modified ?? ''}\t${e.name}`)
-      }
-    } else {
-      for (const e of entries) {
-        const isDir = classify && e.type === FileType.DIRECTORY
-        const name = isDir ? e.name + '/' : e.name
-        results.push(name)
-      }
-    }
+  let workingPaths: PathSpec[] = paths
+  if (workingPaths.length === 0) {
+    workingPaths = [
+      new PathSpec({
+        original: opts.cwd,
+        directory: opts.cwd,
+        resolved: false,
+        prefix: opts.mountPrefix ?? '',
+      }),
+    ]
   }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  return [out, new IOResult({ stderr, exitCode })]
+  const resolved = await resolveGlob(accessor, workingPaths, opts.index ?? undefined)
+  return lsGeneric(
+    resolved,
+    opts,
+    (p) => gdriveReaddir(accessor, p, opts.index ?? undefined),
+    (p) => gdriveStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GDRIVE_LS = command({

--- a/typescript/packages/core/src/commands/builtin/gdrive/nl.ts
+++ b/typescript/packages/core/src/commands/builtin/gdrive/nl.ts
@@ -14,27 +14,12 @@
 
 import type { GDriveAccessor } from '../../../accessor/gdrive.ts'
 import { resolveGlob } from '../../../core/gdrive/glob.ts'
-import { read as gdriveRead } from '../../../core/gdrive/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as gdriveStream } from '../../../core/gdrive/read.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function shouldNumber(line: string, mode: string, pattern: RegExp | null): boolean {
-  if (mode === 'n') return false
-  if (mode === 'a') return true
-  if (mode === 'p' && pattern !== null) return pattern.test(line)
-  return line.trim() !== ''
-}
-
-function pad(n: number, width: number): string {
-  const s = String(n)
-  return s.length >= width ? s : ' '.repeat(width - s.length) + s
-}
+import { nlGeneric } from '../generic/nl.ts'
+import { fileReadProvision } from './provision.ts'
 
 async function nlCommand(
   accessor: GDriveAccessor,
@@ -42,43 +27,9 @@ async function nlCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const bRaw = typeof opts.flags.b === 'string' ? opts.flags.b : 't'
-  let mode = bRaw
-  let pattern: RegExp | null = null
-  if (bRaw.startsWith('p')) {
-    mode = 'p'
-    pattern = new RegExp(bRaw.slice(1))
-  }
-  const start = typeof opts.flags.v === 'string' ? Number.parseInt(opts.flags.v, 10) : 1
-  const increment = typeof opts.flags.i === 'string' ? Number.parseInt(opts.flags.i, 10) : 1
-  const width = typeof opts.flags.w === 'string' ? Number.parseInt(opts.flags.w, 10) : 6
-  const separator = typeof opts.flags.s === 'string' ? opts.flags.s : '\t'
-
-  let raw: Uint8Array | null = null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    raw = await gdriveRead(accessor, first, opts.index ?? undefined)
-  } else {
-    raw = await readStdinAsync(opts.stdin)
-    if (raw === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('nl: missing operand\n') })]
-    }
-  }
-
-  let num = start
-  const outLines: string[] = []
-  for (const line of DEC.decode(raw).split('\n')) {
-    if (shouldNumber(line, mode, pattern)) {
-      outLines.push(`${pad(num, width)}${separator}${line}`)
-      num += increment
-    } else {
-      outLines.push(`${' '.repeat(width)}${separator}${line}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(outLines.join('\n') + '\n')
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return nlGeneric(resolved, opts, (p) => gdriveStream(accessor, p, opts.index ?? undefined))
 }
 
 export const GDRIVE_NL = command({
@@ -86,4 +37,5 @@ export const GDRIVE_NL = command({
   resource: ResourceName.GDRIVE,
   spec: specOf('nl'),
   fn: nlCommand,
+  provision: fileReadProvision,
 })

--- a/typescript/packages/core/src/commands/builtin/gdrive/realpath.ts
+++ b/typescript/packages/core/src/commands/builtin/gdrive/realpath.ts
@@ -13,65 +13,24 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { GDriveAccessor } from '../../../accessor/gdrive.ts'
+import { resolveGlob } from '../../../core/gdrive/glob.ts'
 import { stat as gdriveStat } from '../../../core/gdrive/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function normalize(p: string): string {
-  const isAbs = p.startsWith('/')
-  const segments = p.split('/').filter((s) => s !== '' && s !== '.')
-  const out: string[] = []
-  for (const s of segments) {
-    if (s === '..') {
-      if (out.length > 0) out.pop()
-      else if (!isAbs) out.push('..')
-    } else {
-      out.push(s)
-    }
-  }
-  const joined = out.join('/')
-  return isAbs ? '/' + joined : joined === '' ? '.' : joined
-}
-
-async function exists(
-  accessor: GDriveAccessor,
-  path: string,
-  index: CommandOpts['index'],
-  prefix: string,
-): Promise<boolean> {
-  try {
-    const spec = new PathSpec({ original: path, directory: path, prefix })
-    await gdriveStat(accessor, spec, index ?? undefined)
-    return true
-  } catch {
-    return false
-  }
-}
+import { realpathGeneric } from '../generic/realpath.ts'
 
 async function realpathCommand(
   accessor: GDriveAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const prefix = opts.mountPrefix ?? ''
-  const e = opts.flags.e === true
-  const lines: string[] = []
-  for (const p of paths) {
-    const full = prefix !== '' ? prefix + p.original : p.original
-    const resolved = normalize(full)
-    if (e && !(await exists(accessor, resolved, opts.index, prefix))) {
-      const msg = `realpath: '${p.original}': No such file or directory\n`
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(msg) })]
-    }
-    lines.push(resolved)
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return realpathGeneric(resolved, texts, opts, (p) =>
+    gdriveStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GDRIVE_REALPATH = command({

--- a/typescript/packages/core/src/commands/builtin/gdrive/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/gdrive/stat.ts
@@ -15,32 +15,11 @@
 import type { GDriveAccessor } from '../../../accessor/gdrive.ts'
 import { resolveGlob } from '../../../core/gdrive/glob.ts'
 import { stat as gdriveStat } from '../../../core/gdrive/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { FileType, ResourceName, type FileStat, type PathSpec } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { statGeneric } from '../generic/stat.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-const TYPE_LABELS: Record<string, string> = {
-  [FileType.DIRECTORY]: 'directory',
-  [FileType.TEXT]: 'regular file',
-  [FileType.BINARY]: 'regular file',
-  [FileType.JSON]: 'regular file',
-  [FileType.CSV]: 'regular file',
-}
-
-function formatStat(fmt: string, s: FileStat): string {
-  return fmt.replace(/%(.)/g, (_, spec: string) => {
-    if (spec === 'n') return s.name
-    if (spec === 's') return String(s.size ?? 0)
-    if (spec === 'F')
-      return s.type !== null ? (TYPE_LABELS[s.type] ?? 'regular file') : 'regular file'
-    if (spec === 'y') return s.modified ?? ''
-    return '?'
-  })
-}
 
 async function statCommand(
   accessor: GDriveAccessor,
@@ -48,30 +27,9 @@ async function statCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('stat: missing operand\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const fmt =
-    typeof opts.flags.c === 'string'
-      ? opts.flags.c
-      : typeof opts.flags.f === 'string'
-        ? opts.flags.f
-        : null
-  const lines: string[] = []
-  for (const p of resolved) {
-    const s = await gdriveStat(accessor, p, opts.index ?? undefined)
-    if (fmt !== null) {
-      lines.push(formatStat(fmt, s))
-    } else {
-      const sizeStr = s.size === null ? 'None' : String(s.size)
-      const modStr = s.modified ?? 'None'
-      const typeStr = s.type ?? 'None'
-      lines.push(`name=${s.name} size=${sizeStr} modified=${modStr} type=${typeStr}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return statGeneric(resolved, opts, (p) => gdriveStat(accessor, p, opts.index ?? undefined))
 }
 
 export const GDRIVE_STAT = command({

--- a/typescript/packages/core/src/commands/builtin/gdrive/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/gdrive/tree.ts
@@ -16,94 +16,10 @@ import type { GDriveAccessor } from '../../../accessor/gdrive.ts'
 import { resolveGlob } from '../../../core/gdrive/glob.ts'
 import { readdir as gdriveReaddir } from '../../../core/gdrive/readdir.ts'
 import { stat as gdriveStat } from '../../../core/gdrive/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function fnmatch(name: string, pattern: string): boolean {
-  const re = pattern
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\?/g, '.')
-    .replace(/\*/g, '.*')
-  return new RegExp(`^${re}$`).test(name)
-}
-
-interface TreeOpts {
-  maxDepth: number | null
-  showHidden: boolean
-  ignorePattern: string | null
-  dirsOnly: boolean
-  matchPattern: string | null
-}
-
-async function treeRecurse(
-  accessor: GDriveAccessor,
-  path: PathSpec,
-  prefix: string,
-  depth: number,
-  treeOpts: TreeOpts,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<string[]> {
-  const lines: string[] = []
-  let entries: string[]
-  try {
-    entries = await gdriveReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`tree: '${path.original}': ${msg}`)
-    return lines
-  }
-  const filtered: [PathSpec, FileStat][] = []
-  for (const entry of entries) {
-    try {
-      const entrySpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await gdriveStat(accessor, entrySpec, indexCache ?? undefined)
-      if (!treeOpts.showHidden && s.name.startsWith('.')) continue
-      if (treeOpts.ignorePattern !== null && fnmatch(s.name, treeOpts.ignorePattern)) continue
-      if (treeOpts.dirsOnly && s.type !== FileType.DIRECTORY) continue
-      const notDir = s.type !== FileType.DIRECTORY
-      if (treeOpts.matchPattern !== null && notDir && !fnmatch(s.name, treeOpts.matchPattern))
-        continue
-      filtered.push([entrySpec, s])
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`tree: '${entry}': ${msg}`)
-    }
-  }
-  for (let i = 0; i < filtered.length; i++) {
-    const pair = filtered[i]
-    if (pair === undefined) continue
-    const [entrySpec, s] = pair
-    const isLast = i === filtered.length - 1
-    const connector = isLast ? '\u2514\u2500\u2500 ' : '\u251c\u2500\u2500 '
-    lines.push(prefix + connector + s.name)
-    if (s.type === FileType.DIRECTORY) {
-      if (treeOpts.maxDepth !== null && depth >= treeOpts.maxDepth) continue
-      const extension = isLast ? '    ' : '\u2502   '
-      const sub = await treeRecurse(
-        accessor,
-        entrySpec,
-        prefix + extension,
-        depth + 1,
-        treeOpts,
-        warnings,
-        indexCache,
-      )
-      lines.push(...sub)
-    }
-  }
-  return lines
-}
+import { treeGeneric } from '../generic/tree.ts'
 
 async function treeCommand(
   accessor: GDriveAccessor,
@@ -112,27 +28,12 @@ async function treeCommand(
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const p0 =
-    resolved[0] ??
-    new PathSpec({
-      original: opts.cwd,
-      directory: opts.cwd,
-      resolved: false,
-      prefix: opts.mountPrefix ?? '',
-    })
-  const maxDepth = typeof opts.flags.L === 'string' ? Number.parseInt(opts.flags.L, 10) : null
-  const treeOpts: TreeOpts = {
-    maxDepth,
-    showHidden: opts.flags.a === true,
-    ignorePattern: typeof opts.flags.args_I === 'string' ? opts.flags.args_I : null,
-    dirsOnly: opts.flags.d === true,
-    matchPattern: typeof opts.flags.P === 'string' ? opts.flags.P : null,
-  }
-  const warnings: string[] = []
-  const results = await treeRecurse(accessor, p0, '', 0, treeOpts, warnings, opts.index)
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  return [out, new IOResult({ stderr })]
+  return treeGeneric(
+    resolved,
+    opts,
+    (p) => gdriveReaddir(accessor, p, opts.index ?? undefined),
+    (p) => gdriveStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GDRIVE_TREE = command({

--- a/typescript/packages/core/src/commands/builtin/gdrive/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/gdrive/wc.ts
@@ -14,69 +14,22 @@
 
 import type { GDriveAccessor } from '../../../accessor/gdrive.ts'
 import { resolveGlob } from '../../../core/gdrive/glob.ts'
-import { read as gdriveRead } from '../../../core/gdrive/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as gdriveStream } from '../../../core/gdrive/read.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { wcGeneric } from '../generic/wc.ts'
 import { fileReadProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function countLines(text: string): number {
-  let n = 0
-  for (let i = 0; i < text.length; i++) if (text.charCodeAt(i) === 10) n += 1
-  return n
-}
-
-function countWords(text: string): number {
-  const trimmed = text.trim()
-  if (trimmed === '') return 0
-  return trimmed.split(/\s+/).length
-}
-
-function maxLineLen(text: string): number {
-  let max = 0
-  for (const line of text.split('\n')) if (line.length > max) max = line.length
-  return max
-}
 
 async function wcCommand(
   accessor: GDriveAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  let data: Uint8Array | null = null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    data = await gdriveRead(accessor, first, opts.index ?? undefined)
-  } else {
-    data = await readStdinAsync(opts.stdin)
-    if (data === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('wc: missing operand\n') })]
-    }
-  }
-  const text = DEC.decode(data)
-  const lineCount = countLines(text)
-  const wordCount = countWords(text)
-  const byteCount = data.byteLength
-  if (opts.flags.L === true) {
-    const out: ByteSource = ENC.encode(String(maxLineLen(text)))
-    return [out, new IOResult()]
-  }
-  if (opts.flags.args_l === true) return [ENC.encode(String(lineCount)), new IOResult()]
-  if (opts.flags.w === true) return [ENC.encode(String(wordCount)), new IOResult()]
-  if (opts.flags.m === true) return [ENC.encode(String(text.length)), new IOResult()]
-  if (opts.flags.c === true) return [ENC.encode(String(byteCount)), new IOResult()]
-  const out: ByteSource = ENC.encode(
-    `${String(lineCount)}\t${String(wordCount)}\t${String(byteCount)}`,
-  )
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return wcGeneric(resolved, texts, opts, (p) => gdriveStream(accessor, p, opts.index ?? undefined))
 }
 
 export const GDRIVE_WC = command({

--- a/typescript/packages/core/src/commands/builtin/generic/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.ts
@@ -64,7 +64,7 @@ function sortStats(
   const sorted = [...stats].sort((a, b) => {
     if (sortBy === 'time') return (b.modified ?? '').localeCompare(a.modified ?? '')
     if (sortBy === 'size') return (b.size ?? 0) - (a.size ?? 0)
-    return a.name.localeCompare(b.name)
+    return a.name < b.name ? -1 : a.name > b.name ? 1 : 0
   })
   if (reverse) sorted.reverse()
   return sorted

--- a/typescript/packages/core/src/commands/builtin/github/head.ts
+++ b/typescript/packages/core/src/commands/builtin/github/head.ts
@@ -13,42 +13,30 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { GitHubAccessor } from '../../../accessor/github.ts'
-import { headStream } from '../head_helper.ts'
 import { resolveGlob } from '../../../core/github/glob.ts'
 import { stream as githubStream } from '../../../core/github/read.ts'
-import { IOResult } from '../../../io/types.ts'
+import { stat as githubStat } from '../../../core/github/stat.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { resolveSource } from '../utils/stream.ts'
-import { headTailProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
+import { headGeneric } from '../generic/head.ts'
+import { fileReadProvision } from './provision.ts'
 
 async function headCommand(
   accessor: GitHubAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const nRaw = typeof opts.flags.n === 'string' ? opts.flags.n : null
-  const cRaw = typeof opts.flags.c === 'string' ? opts.flags.c : null
-  const lines = nRaw !== null ? Number.parseInt(nRaw, 10) : 10
-  const bytesMode = cRaw !== null ? Number.parseInt(cRaw, 10) : null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const source = githubStream(accessor, first, opts.index ?? undefined)
-    return [headStream(source, lines, bytesMode), new IOResult()]
-  }
-  try {
-    const source = resolveSource(opts.stdin, 'head: missing operand')
-    return [headStream(source, lines, bytesMode), new IOResult()]
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-  }
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return headGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => githubStat(accessor, p, opts.index ?? undefined),
+    (p) => githubStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GITHUB_HEAD = command({
@@ -56,5 +44,5 @@ export const GITHUB_HEAD = command({
   resource: ResourceName.GITHUB,
   spec: specOf('head'),
   fn: headCommand,
-  provision: headTailProvision,
+  provision: fileReadProvision,
 })

--- a/typescript/packages/core/src/commands/builtin/github/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/github/ls.ts
@@ -16,96 +16,11 @@ import type { GitHubAccessor } from '../../../accessor/github.ts'
 import { resolveGlob } from '../../../core/github/glob.ts'
 import { readdir as githubReaddir } from '../../../core/github/readdir.ts'
 import { stat as githubStat } from '../../../core/github/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { humanSize } from '../utils/formatting.ts'
+import { lsGeneric } from '../generic/ls.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-async function lsEntries(
-  accessor: GitHubAccessor,
-  path: PathSpec,
-  allFiles: boolean,
-  sortBy: 'name' | 'time' | 'size',
-  reverse: boolean,
-  recursive: boolean,
-  listDir: boolean,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<FileStat[]> {
-  if (listDir) {
-    const s = await githubStat(accessor, path, indexCache ?? undefined)
-    return [s]
-  }
-  let entries: string[]
-  try {
-    entries = await githubReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`ls: cannot access '${path.original}': ${msg}`)
-    return []
-  }
-  const stats: FileStat[] = []
-  for (const entry of entries) {
-    try {
-      const eSpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await githubStat(accessor, eSpec, indexCache ?? undefined)
-      if (!allFiles && s.name.startsWith('.')) continue
-      stats.push(s)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${entry}': ${msg}`)
-    }
-  }
-  if (sortBy === 'time') {
-    stats.sort((a, b) => (a.modified ?? '').localeCompare(b.modified ?? ''))
-    if (!reverse) stats.reverse()
-  } else if (sortBy === 'size') {
-    stats.sort((a, b) => (a.size ?? 0) - (b.size ?? 0))
-    if (!reverse) stats.reverse()
-  } else {
-    stats.sort((a, b) => a.name.localeCompare(b.name))
-    if (reverse) stats.reverse()
-  }
-  if (recursive) {
-    const subEntries: FileStat[] = []
-    for (const s of stats) {
-      subEntries.push(s)
-      if (s.type === FileType.DIRECTORY) {
-        const entryPath = path.child(s.name)
-        const entrySpec = new PathSpec({
-          original: entryPath,
-          directory: entryPath,
-          resolved: false,
-          prefix: path.prefix,
-        })
-        const sub = await lsEntries(
-          accessor,
-          entrySpec,
-          allFiles,
-          sortBy,
-          reverse,
-          recursive,
-          false,
-          warnings,
-          indexCache,
-        )
-        subEntries.push(...sub)
-      }
-    }
-    return subEntries
-  }
-  return stats
-}
 
 async function lsCommand(
   accessor: GitHubAccessor,
@@ -113,65 +28,24 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const targets: PathSpec[] =
-    resolved.length > 0
-      ? resolved
-      : [
-          new PathSpec({
-            original: opts.cwd,
-            directory: opts.cwd,
-            resolved: false,
-            prefix: opts.mountPrefix ?? '',
-          }),
-        ]
-  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
-  const allFiles = opts.flags.a === true || opts.flags.A === true
-  const human = opts.flags.h === true
-  const reverse = opts.flags.r === true
-  const recursive = opts.flags.R === true
-  const listDir = opts.flags.d === true
-  const classify = opts.flags.F === true
-  const sortBy: 'name' | 'time' | 'size' =
-    opts.flags.t === true ? 'time' : opts.flags.S === true ? 'size' : 'name'
-  const warnings: string[] = []
-  const results: string[] = []
-  for (const p of targets) {
-    let entries: FileStat[]
-    try {
-      entries = await lsEntries(
-        accessor,
-        p,
-        allFiles,
-        sortBy,
-        reverse,
-        recursive,
-        listDir,
-        warnings,
-        opts.index,
-      )
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${p.original}': ${msg}`)
-      continue
-    }
-    if (long) {
-      for (const e of entries) {
-        const sizeStr = human ? humanSize(e.size ?? 0) : String(e.size ?? 0)
-        results.push(`${e.type ?? '-'}\t${sizeStr}\t${e.modified ?? ''}\t${e.name}`)
-      }
-    } else {
-      for (const e of entries) {
-        const isDir = classify && e.type === FileType.DIRECTORY
-        const name = isDir ? e.name + '/' : e.name
-        results.push(name)
-      }
-    }
+  let workingPaths: PathSpec[] = paths
+  if (workingPaths.length === 0) {
+    workingPaths = [
+      new PathSpec({
+        original: opts.cwd,
+        directory: opts.cwd,
+        resolved: false,
+        prefix: opts.mountPrefix ?? '',
+      }),
+    ]
   }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  return [out, new IOResult({ stderr, exitCode })]
+  const resolved = await resolveGlob(accessor, workingPaths, opts.index ?? undefined)
+  return lsGeneric(
+    resolved,
+    opts,
+    (p) => githubReaddir(accessor, p, opts.index ?? undefined),
+    (p) => githubStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GITHUB_LS = command({

--- a/typescript/packages/core/src/commands/builtin/github/nl.ts
+++ b/typescript/packages/core/src/commands/builtin/github/nl.ts
@@ -15,72 +15,11 @@
 import type { GitHubAccessor } from '../../../accessor/github.ts'
 import { resolveGlob } from '../../../core/github/glob.ts'
 import { stream as githubStream } from '../../../core/github/read.ts'
-import { AsyncLineIterator } from '../../../io/async_line_iterator.ts'
-import { IOResult } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { resolveSource } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-interface NlOptions {
-  bodyNumbering: string
-  start: number
-  increment: number
-  width: number
-  separator: string
-  pattern: RegExp | null
-}
-
-function padLeft(value: string, width: number): string {
-  return value.length >= width ? value : ' '.repeat(width - value.length) + value
-}
-
-function shouldNumber(line: string, bodyNumbering: string, pattern: RegExp | null): boolean {
-  if (bodyNumbering === 'n') return false
-  if (bodyNumbering === 'a') return true
-  if (bodyNumbering === 'p' && pattern !== null) return pattern.test(line)
-  return line.trim() !== ''
-}
-
-async function* nlStream(
-  source: AsyncIterable<Uint8Array>,
-  opts: NlOptions,
-): AsyncIterable<Uint8Array> {
-  let num = opts.start
-  const iter = new AsyncLineIterator(source)
-  for await (const raw of iter) {
-    const line = DEC.decode(raw)
-    if (shouldNumber(line, opts.bodyNumbering, opts.pattern)) {
-      yield ENC.encode(`${padLeft(String(num), opts.width)}${opts.separator}${line}\n`)
-      num += opts.increment
-    } else {
-      yield ENC.encode(`${' '.repeat(opts.width)}${opts.separator}${line}\n`)
-    }
-  }
-}
-
-function parseOptions(flags: Record<string, string | boolean>): NlOptions {
-  const b = typeof flags.b === 'string' ? flags.b : 't'
-  let bodyNumbering = b
-  let pattern: RegExp | null = null
-  if (b.startsWith('p')) {
-    bodyNumbering = 'p'
-    pattern = new RegExp(b.slice(1))
-  }
-  const parseIntFlag = (key: 'v' | 'i' | 'w', fallback: number): number =>
-    typeof flags[key] === 'string' ? Number.parseInt(flags[key], 10) : fallback
-  return {
-    bodyNumbering,
-    start: parseIntFlag('v', 1),
-    increment: parseIntFlag('i', 1),
-    width: parseIntFlag('w', 6),
-    separator: typeof flags.s === 'string' ? flags.s : '\t',
-    pattern,
-  }
-}
+import { nlGeneric } from '../generic/nl.ts'
+import { fileReadProvision } from './provision.ts'
 
 async function nlCommand(
   accessor: GitHubAccessor,
@@ -88,23 +27,9 @@ async function nlCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const nlOpts = parseOptions(opts.flags)
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    return [
-      nlStream(githubStream(accessor, first, opts.index ?? undefined), nlOpts),
-      new IOResult(),
-    ]
-  }
-  try {
-    const source = resolveSource(opts.stdin, 'nl: missing operand')
-    return [nlStream(source, nlOpts), new IOResult()]
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-  }
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return nlGeneric(resolved, opts, (p) => githubStream(accessor, p, opts.index ?? undefined))
 }
 
 export const GITHUB_NL = command({
@@ -112,4 +37,5 @@ export const GITHUB_NL = command({
   resource: ResourceName.GITHUB,
   spec: specOf('nl'),
   fn: nlCommand,
+  provision: fileReadProvision,
 })

--- a/typescript/packages/core/src/commands/builtin/github/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/github/stat.ts
@@ -15,32 +15,11 @@
 import type { GitHubAccessor } from '../../../accessor/github.ts'
 import { resolveGlob } from '../../../core/github/glob.ts'
 import { stat as githubStat } from '../../../core/github/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { FileType, ResourceName, type FileStat, type PathSpec } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { statGeneric } from '../generic/stat.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-const TYPE_LABELS: Record<string, string> = {
-  [FileType.DIRECTORY]: 'directory',
-  [FileType.TEXT]: 'regular file',
-  [FileType.BINARY]: 'regular file',
-  [FileType.JSON]: 'regular file',
-  [FileType.CSV]: 'regular file',
-}
-
-function formatStat(fmt: string, s: FileStat): string {
-  return fmt.replace(/%(.)/g, (_, spec: string) => {
-    if (spec === 'n') return s.name
-    if (spec === 's') return String(s.size ?? 0)
-    if (spec === 'F')
-      return s.type !== null ? (TYPE_LABELS[s.type] ?? 'regular file') : 'regular file'
-    if (spec === 'y') return s.modified ?? ''
-    return '?'
-  })
-}
 
 async function statCommand(
   accessor: GitHubAccessor,
@@ -48,30 +27,9 @@ async function statCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('stat: missing operand\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const fmt =
-    typeof opts.flags.c === 'string'
-      ? opts.flags.c
-      : typeof opts.flags.f === 'string'
-        ? opts.flags.f
-        : null
-  const lines: string[] = []
-  for (const p of resolved) {
-    const s = await githubStat(accessor, p, opts.index ?? undefined)
-    if (fmt !== null) {
-      lines.push(formatStat(fmt, s))
-    } else {
-      const sizeStr = s.size === null ? 'None' : String(s.size)
-      const modStr = s.modified ?? 'None'
-      const typeStr = s.type ?? 'None'
-      lines.push(`name=${s.name} size=${sizeStr} modified=${modStr} type=${typeStr}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return statGeneric(resolved, opts, (p) => githubStat(accessor, p, opts.index ?? undefined))
 }
 
 export const GITHUB_STAT = command({

--- a/typescript/packages/core/src/commands/builtin/github/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/github/tree.ts
@@ -16,94 +16,10 @@ import type { GitHubAccessor } from '../../../accessor/github.ts'
 import { resolveGlob } from '../../../core/github/glob.ts'
 import { readdir as githubReaddir } from '../../../core/github/readdir.ts'
 import { stat as githubStat } from '../../../core/github/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function fnmatch(name: string, pattern: string): boolean {
-  const re = pattern
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\?/g, '.')
-    .replace(/\*/g, '.*')
-  return new RegExp(`^${re}$`).test(name)
-}
-
-interface TreeOpts {
-  maxDepth: number | null
-  showHidden: boolean
-  ignorePattern: string | null
-  dirsOnly: boolean
-  matchPattern: string | null
-}
-
-async function treeRecurse(
-  accessor: GitHubAccessor,
-  path: PathSpec,
-  prefix: string,
-  depth: number,
-  treeOpts: TreeOpts,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<string[]> {
-  const lines: string[] = []
-  let entries: string[]
-  try {
-    entries = await githubReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`tree: '${path.original}': ${msg}`)
-    return lines
-  }
-  const filtered: [PathSpec, FileStat][] = []
-  for (const entry of entries) {
-    try {
-      const entrySpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await githubStat(accessor, entrySpec, indexCache ?? undefined)
-      if (!treeOpts.showHidden && s.name.startsWith('.')) continue
-      if (treeOpts.ignorePattern !== null && fnmatch(s.name, treeOpts.ignorePattern)) continue
-      if (treeOpts.dirsOnly && s.type !== FileType.DIRECTORY) continue
-      const notDir = s.type !== FileType.DIRECTORY
-      if (treeOpts.matchPattern !== null && notDir && !fnmatch(s.name, treeOpts.matchPattern))
-        continue
-      filtered.push([entrySpec, s])
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`tree: '${entry}': ${msg}`)
-    }
-  }
-  for (let i = 0; i < filtered.length; i++) {
-    const pair = filtered[i]
-    if (pair === undefined) continue
-    const [entrySpec, s] = pair
-    const isLast = i === filtered.length - 1
-    const connector = isLast ? '\u2514\u2500\u2500 ' : '\u251c\u2500\u2500 '
-    lines.push(prefix + connector + s.name)
-    if (s.type === FileType.DIRECTORY) {
-      if (treeOpts.maxDepth !== null && depth >= treeOpts.maxDepth) continue
-      const extension = isLast ? '    ' : '\u2502   '
-      const sub = await treeRecurse(
-        accessor,
-        entrySpec,
-        prefix + extension,
-        depth + 1,
-        treeOpts,
-        warnings,
-        indexCache,
-      )
-      lines.push(...sub)
-    }
-  }
-  return lines
-}
+import { treeGeneric } from '../generic/tree.ts'
 
 async function treeCommand(
   accessor: GitHubAccessor,
@@ -112,27 +28,12 @@ async function treeCommand(
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const p0 =
-    resolved[0] ??
-    new PathSpec({
-      original: opts.cwd,
-      directory: opts.cwd,
-      resolved: false,
-      prefix: opts.mountPrefix ?? '',
-    })
-  const maxDepth = typeof opts.flags.L === 'string' ? Number.parseInt(opts.flags.L, 10) : null
-  const treeOpts: TreeOpts = {
-    maxDepth,
-    showHidden: opts.flags.a === true,
-    ignorePattern: typeof opts.flags.args_I === 'string' ? opts.flags.args_I : null,
-    dirsOnly: opts.flags.d === true,
-    matchPattern: typeof opts.flags.P === 'string' ? opts.flags.P : null,
-  }
-  const warnings: string[] = []
-  const results = await treeRecurse(accessor, p0, '', 0, treeOpts, warnings, opts.index)
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  return [out, new IOResult({ stderr })]
+  return treeGeneric(
+    resolved,
+    opts,
+    (p) => githubReaddir(accessor, p, opts.index ?? undefined),
+    (p) => githubStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GITHUB_TREE = command({

--- a/typescript/packages/core/src/commands/builtin/github/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/github/wc.ts
@@ -14,97 +14,22 @@
 
 import type { GitHubAccessor } from '../../../accessor/github.ts'
 import { resolveGlob } from '../../../core/github/glob.ts'
-import { read as githubRead } from '../../../core/github/read.ts'
-import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
+import { stream as githubStream } from '../../../core/github/read.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { resolveSource } from '../utils/stream.ts'
+import { wcGeneric } from '../generic/wc.ts'
 import { fileReadProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-async function* wcLinesStream(source: AsyncIterable<Uint8Array>): AsyncIterable<Uint8Array> {
-  let count = 0
-  for await (const chunk of source) {
-    for (let i = 0; i < chunk.byteLength; i++) if (chunk[i] === 0x0a) count += 1
-  }
-  yield ENC.encode(String(count))
-}
-
-function countChar(text: string, ch: string): number {
-  let n = 0
-  for (const c of text) if (c === ch) n += 1
-  return n
-}
-
-function maxLineLength(text: string): number {
-  let max = 0
-  let current = 0
-  for (const c of text) {
-    if (c === '\n') {
-      if (current > max) max = current
-      current = 0
-    } else {
-      current += 1
-    }
-  }
-  if (current > max) max = current
-  return max
-}
 
 async function wcCommand(
   accessor: GitHubAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const f = opts.flags
-  const lFlag = f.args_l === true
-  const wFlag = f.w === true
-  const cFlag = f.c === true
-  const mFlag = f.m === true
-  const LFlag = f.L === true
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const data = await githubRead(accessor, first, opts.index ?? undefined)
-    const text = DEC.decode(data)
-    const lineCount = countChar(text, '\n')
-    const wordCount = text.split(/\s+/).filter((s) => s !== '').length
-    const byteCount = data.byteLength
-    if (LFlag) return [ENC.encode(String(maxLineLength(text))), new IOResult()]
-    if (lFlag) return [ENC.encode(String(lineCount)), new IOResult()]
-    if (wFlag) return [ENC.encode(String(wordCount)), new IOResult()]
-    if (mFlag) return [ENC.encode(String(text.length)), new IOResult()]
-    if (cFlag) return [ENC.encode(String(byteCount)), new IOResult()]
-    const out = `${String(lineCount)}\t${String(wordCount)}\t${String(byteCount)}`
-    return [ENC.encode(out), new IOResult()]
-  }
-  let source: AsyncIterable<Uint8Array>
-  try {
-    source = resolveSource(opts.stdin, 'wc: missing operand')
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-  }
-  if (lFlag) {
-    const out: ByteSource = wcLinesStream(source)
-    return [out, new IOResult()]
-  }
-  const raw = await materialize(source)
-  const text = DEC.decode(raw)
-  const lc = countChar(text, '\n')
-  const wcVal = text.split(/\s+/).filter((s) => s !== '').length
-  const bc = raw.byteLength
-  const cc = text.length
-  if (LFlag) return [ENC.encode(String(maxLineLength(text))), new IOResult()]
-  if (wFlag) return [ENC.encode(String(wcVal)), new IOResult()]
-  if (mFlag) return [ENC.encode(String(cc)), new IOResult()]
-  if (cFlag) return [ENC.encode(String(bc)), new IOResult()]
-  return [ENC.encode(`${String(lc)}\t${String(wcVal)}\t${String(bc)}`), new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return wcGeneric(resolved, texts, opts, (p) => githubStream(accessor, p, opts.index ?? undefined))
 }
 
 export const GITHUB_WC = command({

--- a/typescript/packages/core/src/commands/builtin/github_ci/head.ts
+++ b/typescript/packages/core/src/commands/builtin/github_ci/head.ts
@@ -14,51 +14,29 @@
 
 import type { GitHubCIAccessor } from '../../../accessor/github_ci.ts'
 import { resolveGlob } from '../../../core/github_ci/glob.ts'
-import { read as ciRead } from '../../../core/github_ci/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as ciStream } from '../../../core/github_ci/read.ts'
+import { stat as ciStat } from '../../../core/github_ci/stat.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { headGeneric } from '../generic/head.ts'
 import { fileReadProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-function headBytes(data: Uint8Array, lines: number, bytesMode: number | null): Uint8Array {
-  if (bytesMode !== null) return data.slice(0, bytesMode)
-  let count = 0
-  for (let i = 0; i < data.byteLength; i++) {
-    if (data[i] === 0x0a) {
-      count += 1
-      if (count >= lines) return data.slice(0, i)
-    }
-  }
-  return data
-}
 
 async function headCommand(
   accessor: GitHubCIAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const nRaw = typeof opts.flags.n === 'string' ? opts.flags.n : null
-  const cRaw = typeof opts.flags.c === 'string' ? opts.flags.c : null
-  const lines = nRaw !== null ? Number.parseInt(nRaw, 10) : 10
-  const bytesMode = cRaw !== null ? Number.parseInt(cRaw, 10) : null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const data = await ciRead(accessor, first, opts.index ?? undefined)
-    const out: ByteSource = headBytes(data, lines, bytesMode)
-    return [out, new IOResult()]
-  }
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('head: missing operand\n') })]
-  }
-  return [headBytes(raw, lines, bytesMode), new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return headGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => ciStat(accessor, p, opts.index ?? undefined),
+    (p) => ciStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GITHUB_CI_HEAD = command({

--- a/typescript/packages/core/src/commands/builtin/github_ci/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/github_ci/ls.ts
@@ -16,93 +16,11 @@ import type { GitHubCIAccessor } from '../../../accessor/github_ci.ts'
 import { resolveGlob } from '../../../core/github_ci/glob.ts'
 import { readdir as ciReaddir } from '../../../core/github_ci/readdir.ts'
 import { stat as ciStat } from '../../../core/github_ci/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { humanSize } from '../utils/formatting.ts'
+import { lsGeneric } from '../generic/ls.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-async function lsEntries(
-  accessor: GitHubCIAccessor,
-  path: PathSpec,
-  allFiles: boolean,
-  sortBy: 'name' | 'size',
-  reverse: boolean,
-  recursive: boolean,
-  listDir: boolean,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<FileStat[]> {
-  if (listDir) {
-    const s = await ciStat(accessor, path, indexCache ?? undefined)
-    return [s]
-  }
-  let entries: string[]
-  try {
-    entries = await ciReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`ls: cannot access '${path.original}': ${msg}`)
-    return []
-  }
-  const stats: FileStat[] = []
-  for (const entry of entries) {
-    try {
-      const eSpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await ciStat(accessor, eSpec, indexCache ?? undefined)
-      if (!allFiles && s.name.startsWith('.')) continue
-      stats.push(s)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${entry}': ${msg}`)
-    }
-  }
-  if (sortBy === 'size') {
-    stats.sort((a, b) => (a.size ?? 0) - (b.size ?? 0))
-    if (!reverse) stats.reverse()
-  } else {
-    stats.sort((a, b) => a.name.localeCompare(b.name))
-    if (reverse) stats.reverse()
-  }
-  if (recursive) {
-    const subEntries: FileStat[] = []
-    for (const s of stats) {
-      subEntries.push(s)
-      if (s.type === FileType.DIRECTORY) {
-        const childPath = path.child(s.name)
-        const childSpec = new PathSpec({
-          original: childPath,
-          directory: childPath,
-          resolved: false,
-          prefix: path.prefix,
-        })
-        const sub = await lsEntries(
-          accessor,
-          childSpec,
-          allFiles,
-          sortBy,
-          reverse,
-          recursive,
-          false,
-          warnings,
-          indexCache,
-        )
-        subEntries.push(...sub)
-      }
-    }
-    return subEntries
-  }
-  return stats
-}
 
 async function lsCommand(
   accessor: GitHubCIAccessor,
@@ -110,64 +28,24 @@ async function lsCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const targets: PathSpec[] =
-    resolved.length > 0
-      ? resolved
-      : [
-          new PathSpec({
-            original: opts.cwd,
-            directory: opts.cwd,
-            resolved: false,
-            prefix: opts.mountPrefix ?? '',
-          }),
-        ]
-  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
-  const allFiles = opts.flags.a === true || opts.flags.A === true
-  const human = opts.flags.h === true
-  const reverse = opts.flags.r === true
-  const recursive = opts.flags.R === true
-  const listDir = opts.flags.d === true
-  const classify = opts.flags.F === true
-  const sortBy: 'name' | 'size' = opts.flags.S === true ? 'size' : 'name'
-  const warnings: string[] = []
-  const results: string[] = []
-  for (const p of targets) {
-    let entries: FileStat[]
-    try {
-      entries = await lsEntries(
-        accessor,
-        p,
-        allFiles,
-        sortBy,
-        reverse,
-        recursive,
-        listDir,
-        warnings,
-        opts.index,
-      )
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${p.original}': ${msg}`)
-      continue
-    }
-    if (long) {
-      for (const e of entries) {
-        const sizeStr = human ? humanSize(e.size ?? 0) : String(e.size ?? 0)
-        results.push(`${e.type ?? '-'}\t${sizeStr}\t${e.modified ?? ''}\t${e.name}`)
-      }
-    } else {
-      for (const e of entries) {
-        const isDir = classify && e.type === FileType.DIRECTORY
-        const name = isDir ? e.name + '/' : e.name
-        results.push(name)
-      }
-    }
+  let workingPaths: PathSpec[] = paths
+  if (workingPaths.length === 0) {
+    workingPaths = [
+      new PathSpec({
+        original: opts.cwd,
+        directory: opts.cwd,
+        resolved: false,
+        prefix: opts.mountPrefix ?? '',
+      }),
+    ]
   }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  return [out, new IOResult({ stderr, exitCode })]
+  const resolved = await resolveGlob(accessor, workingPaths, opts.index ?? undefined)
+  return lsGeneric(
+    resolved,
+    opts,
+    (p) => ciReaddir(accessor, p, opts.index ?? undefined),
+    (p) => ciStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GITHUB_CI_LS = command({

--- a/typescript/packages/core/src/commands/builtin/github_ci/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/github_ci/stat.ts
@@ -15,32 +15,11 @@
 import type { GitHubCIAccessor } from '../../../accessor/github_ci.ts'
 import { resolveGlob } from '../../../core/github_ci/glob.ts'
 import { stat as ciStat } from '../../../core/github_ci/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { FileType, ResourceName, type FileStat, type PathSpec } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { statGeneric } from '../generic/stat.ts'
 import { metadataProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-
-const TYPE_LABELS: Record<string, string> = {
-  [FileType.DIRECTORY]: 'directory',
-  [FileType.TEXT]: 'regular file',
-  [FileType.BINARY]: 'regular file',
-  [FileType.JSON]: 'regular file',
-  [FileType.CSV]: 'regular file',
-}
-
-function formatStat(fmt: string, s: FileStat): string {
-  return fmt.replace(/%(.)/g, (_, spec: string) => {
-    if (spec === 'n') return s.name
-    if (spec === 's') return String(s.size ?? 0)
-    if (spec === 'F')
-      return s.type !== null ? (TYPE_LABELS[s.type] ?? 'regular file') : 'regular file'
-    if (spec === 'y') return s.modified ?? ''
-    return '?'
-  })
-}
 
 async function statCommand(
   accessor: GitHubCIAccessor,
@@ -48,30 +27,9 @@ async function statCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('stat: missing operand\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const fmt =
-    typeof opts.flags.c === 'string'
-      ? opts.flags.c
-      : typeof opts.flags.f === 'string'
-        ? opts.flags.f
-        : null
-  const lines: string[] = []
-  for (const p of resolved) {
-    const s = await ciStat(accessor, p, opts.index ?? undefined)
-    if (fmt !== null) {
-      lines.push(formatStat(fmt, s))
-    } else {
-      const sizeStr = s.size === null ? 'None' : String(s.size)
-      const modStr = s.modified ?? 'None'
-      const typeStr = s.type ?? 'None'
-      lines.push(`name=${s.name} size=${sizeStr} modified=${modStr} type=${typeStr}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return statGeneric(resolved, opts, (p) => ciStat(accessor, p, opts.index ?? undefined))
 }
 
 export const GITHUB_CI_STAT = command({

--- a/typescript/packages/core/src/commands/builtin/github_ci/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/github_ci/tree.ts
@@ -16,94 +16,10 @@ import type { GitHubCIAccessor } from '../../../accessor/github_ci.ts'
 import { resolveGlob } from '../../../core/github_ci/glob.ts'
 import { readdir as ciReaddir } from '../../../core/github_ci/readdir.ts'
 import { stat as ciStat } from '../../../core/github_ci/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FileStat } from '../../../types.ts'
-import { FileType, PathSpec, ResourceName } from '../../../types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function fnmatch(name: string, pattern: string): boolean {
-  const re = pattern
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\?/g, '.')
-    .replace(/\*/g, '.*')
-  return new RegExp(`^${re}$`).test(name)
-}
-
-interface TreeOpts {
-  maxDepth: number | null
-  showHidden: boolean
-  ignorePattern: string | null
-  dirsOnly: boolean
-  matchPattern: string | null
-}
-
-async function treeRecurse(
-  accessor: GitHubCIAccessor,
-  path: PathSpec,
-  prefix: string,
-  depth: number,
-  treeOpts: TreeOpts,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<string[]> {
-  const lines: string[] = []
-  let entries: string[]
-  try {
-    entries = await ciReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`tree: '${path.original}': ${msg}`)
-    return lines
-  }
-  const filtered: [PathSpec, FileStat][] = []
-  for (const entry of entries) {
-    try {
-      const entrySpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await ciStat(accessor, entrySpec, indexCache ?? undefined)
-      if (!treeOpts.showHidden && s.name.startsWith('.')) continue
-      if (treeOpts.ignorePattern !== null && fnmatch(s.name, treeOpts.ignorePattern)) continue
-      if (treeOpts.dirsOnly && s.type !== FileType.DIRECTORY) continue
-      const notDir = s.type !== FileType.DIRECTORY
-      if (treeOpts.matchPattern !== null && notDir && !fnmatch(s.name, treeOpts.matchPattern))
-        continue
-      filtered.push([entrySpec, s])
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`tree: '${entry}': ${msg}`)
-    }
-  }
-  for (let i = 0; i < filtered.length; i++) {
-    const pair = filtered[i]
-    if (pair === undefined) continue
-    const [entrySpec, s] = pair
-    const isLast = i === filtered.length - 1
-    const connector = isLast ? '\u2514\u2500\u2500 ' : '\u251c\u2500\u2500 '
-    lines.push(prefix + connector + s.name)
-    if (s.type === FileType.DIRECTORY) {
-      if (treeOpts.maxDepth !== null && depth >= treeOpts.maxDepth) continue
-      const extension = isLast ? '    ' : '\u2502   '
-      const sub = await treeRecurse(
-        accessor,
-        entrySpec,
-        prefix + extension,
-        depth + 1,
-        treeOpts,
-        warnings,
-        indexCache,
-      )
-      lines.push(...sub)
-    }
-  }
-  return lines
-}
+import { treeGeneric } from '../generic/tree.ts'
 
 async function treeCommand(
   accessor: GitHubCIAccessor,
@@ -112,27 +28,12 @@ async function treeCommand(
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const p0 =
-    resolved[0] ??
-    new PathSpec({
-      original: opts.cwd,
-      directory: opts.cwd,
-      resolved: false,
-      prefix: opts.mountPrefix ?? '',
-    })
-  const maxDepth = typeof opts.flags.L === 'string' ? Number.parseInt(opts.flags.L, 10) : null
-  const treeOpts: TreeOpts = {
-    maxDepth,
-    showHidden: opts.flags.a === true,
-    ignorePattern: typeof opts.flags.args_I === 'string' ? opts.flags.args_I : null,
-    dirsOnly: opts.flags.d === true,
-    matchPattern: typeof opts.flags.P === 'string' ? opts.flags.P : null,
-  }
-  const warnings: string[] = []
-  const results = await treeRecurse(accessor, p0, '', 0, treeOpts, warnings, opts.index)
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  return [out, new IOResult({ stderr })]
+  return treeGeneric(
+    resolved,
+    opts,
+    (p) => ciReaddir(accessor, p, opts.index ?? undefined),
+    (p) => ciStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GITHUB_CI_TREE = command({

--- a/typescript/packages/core/src/commands/builtin/github_ci/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/github_ci/wc.ts
@@ -14,67 +14,22 @@
 
 import type { GitHubCIAccessor } from '../../../accessor/github_ci.ts'
 import { resolveGlob } from '../../../core/github_ci/glob.ts'
-import { read as ciRead } from '../../../core/github_ci/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as ciStream } from '../../../core/github_ci/read.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { wcGeneric } from '../generic/wc.ts'
 import { fileReadProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function countChar(text: string, ch: string): number {
-  let n = 0
-  for (const c of text) if (c === ch) n += 1
-  return n
-}
-
-function maxLineLength(text: string): number {
-  let max = 0
-  for (const ln of text.split('\n')) if (ln.length > max) max = ln.length
-  return max
-}
 
 async function wcCommand(
   accessor: GitHubCIAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const f = opts.flags
-  const lFlag = f.args_l === true
-  const wFlag = f.w === true
-  const cFlag = f.c === true
-  const mFlag = f.m === true
-  const LFlag = f.L === true
-  let data: Uint8Array
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    data = await ciRead(accessor, first, opts.index ?? undefined)
-  } else {
-    const raw = await readStdinAsync(opts.stdin)
-    if (raw === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('wc: missing operand\n') })]
-    }
-    data = raw
-  }
-  const text = DEC.decode(data)
-  const lineCount = countChar(text, '\n')
-  const wordCount = text.split(/\s+/).filter((s) => s !== '').length
-  const byteCount = data.byteLength
-  if (LFlag) return [ENC.encode(String(maxLineLength(text))), new IOResult()]
-  if (lFlag) return [ENC.encode(String(lineCount)), new IOResult()]
-  if (wFlag) return [ENC.encode(String(wordCount)), new IOResult()]
-  if (mFlag) return [ENC.encode(String(text.length)), new IOResult()]
-  if (cFlag) return [ENC.encode(String(byteCount)), new IOResult()]
-  const out: ByteSource = ENC.encode(
-    `${String(lineCount)}\t${String(wordCount)}\t${String(byteCount)}`,
-  )
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return wcGeneric(resolved, texts, opts, (p) => ciStream(accessor, p, opts.index ?? undefined))
 }
 
 export const GITHUB_CI_WC = command({


### PR DESCRIPTION
## What

Migrate the bespoke read commands in three more resources to the shared generic command layer, mirroring the Python side (continuing the work from #203 google and #204 slack/discord).

| resource | migrated to generic | left bespoke (matches Python) |
|---|---|---|
| **gdrive** | head, wc, ls, stat, tree, nl, realpath | find, jq |
| **github** | head, wc, ls, stat, tree, nl | find, grep, jq, realpath |
| **github_ci** | head, wc, ls, stat, tree | find |

## Why

These resources are remote, so warm reads go through the RAM cache (generic), but **cold reads (cache miss)** ran the bespoke per-resource commands, which omitted the `wc` filename label and double-prefixed `realpath`. Delegating makes cold == warm == Python.

## #200 JSON rendering

- **gdrive / github**: read raw file bytes (Drive files / repo file contents) — no JSON rendering, no divergence.
- **github_ci**: workflow/run/job render with `indent=2` on both sides (already match); the **annotation** site rendered single-line spaced in Python vs compact in TS — flipped it to compact separators.

## Verification (live, both languages, same paths)

| | TS | Python |
|---|---|---|
| gdrive `wc A16Z.gdoc.json` | `0 169 8453 <path>` | identical |
| gdrive `stat` / `realpath` | `size=1024` / `/gdrive/A16Z...` (no double-prefix) | identical |
| github `wc pyproject.toml` | `193 473 4696 <path>` | identical |
| github_ci `cat` (pretty) + `wc` | `11 23 567 <path>` | identical |

All TS package tests pass (core 331, node 154, browser 44, server 19, agents 11, cli 4); github_ci Python tests pass (21); `pre-commit` clean.