### PR TITLE
feat(workspace): land copy-on-write ws.fork() substrate (F1, #167)

### DIFF
--- a/python/mirage/cache/file/ram.py
+++ b/python/mirage/cache/file/ram.py
@@ -45,6 +45,25 @@ class RAMFileCacheStore(RAMResource, FileCacheMixin, KeyLockMixin):
         self._clear_lock: asyncio.Lock = asyncio.Lock()
         self.max_drain_bytes: int | None = max_drain_bytes
 
+    def fork(self) -> "RAMFileCacheStore":
+        """Cheap copy-on-write fork of the cache.
+
+        Shares cached byte payloads by reference (``bytes`` is
+        immutable) while giving the child its own key index, LRU
+        metadata, and size counter, so the child's sets/removals never
+        affect the parent. In-flight drain tasks and per-key locks are
+        NOT inherited — the child starts with fresh ones and re-fetches
+        any stream that was still draining at fork time.
+        """
+        child = RAMFileCacheStore(cache_limit=self._cache_limit,
+                                  max_drain_bytes=self.max_drain_bytes)
+        child._store.files = dict(self._store.files)
+        child._store.dirs = set(self._store.dirs)
+        child._store.modified = dict(self._store.modified)
+        child._entries = OrderedDict(self._entries)
+        child._cache_size = self._cache_size
+        return child
+
     async def get(self, key: str) -> bytes | None:
         async with self._lock_for(key):
             entry = self._entries.get(key)

--- a/python/mirage/cache/file/ram.py
+++ b/python/mirage/cache/file/ram.py
@@ -49,20 +49,20 @@ class RAMFileCacheStore(RAMResource, FileCacheMixin, KeyLockMixin):
         """Cheap copy-on-write fork of the cache.
 
         Shares cached byte payloads by reference (``bytes`` is
-        immutable) while giving the child its own key index, LRU
-        metadata, and size counter, so the child's sets/removals never
-        affect the parent. In-flight drain tasks and per-key locks are
-        NOT inherited — the child starts with fresh ones and re-fetches
-        any stream that was still draining at fork time.
+        immutable) while giving the staged copy its own key index, LRU
+        metadata, and size counter, so the staged copy's sets/removals
+        never affect live. In-flight drain tasks and per-key locks are
+        NOT inherited — the staged copy starts with fresh ones and
+        re-fetches any stream that was still draining at fork time.
         """
-        child = RAMFileCacheStore(cache_limit=self._cache_limit,
-                                  max_drain_bytes=self.max_drain_bytes)
-        child._store.files = dict(self._store.files)
-        child._store.dirs = set(self._store.dirs)
-        child._store.modified = dict(self._store.modified)
-        child._entries = OrderedDict(self._entries)
-        child._cache_size = self._cache_size
-        return child
+        staged = RAMFileCacheStore(cache_limit=self._cache_limit,
+                                   max_drain_bytes=self.max_drain_bytes)
+        staged._store.files = dict(self._store.files)
+        staged._store.dirs = set(self._store.dirs)
+        staged._store.modified = dict(self._store.modified)
+        staged._entries = OrderedDict(self._entries)
+        staged._cache_size = self._cache_size
+        return staged
 
     async def get(self, key: str) -> bytes | None:
         async with self._lock_for(key):

--- a/python/mirage/cache/file/redis.py
+++ b/python/mirage/cache/file/redis.py
@@ -35,6 +35,11 @@ class RedisFileCacheStore(RedisResource, FileCacheMixin):
         self._meta_prefix = f"{key_prefix}meta:"
         self.max_drain_bytes: int | None = max_drain_bytes
 
+    def fork(self) -> "RedisFileCacheStore":
+        raise NotImplementedError(
+            "RedisFileCacheStore cannot be forked: its state lives outside "
+            "the process. Workspace.fork() requires the default RAM cache.")
+
     async def get(self, key: str) -> bytes | None:
         return await self._cache_client.get(f"{self._data_prefix}{key}")
 

--- a/python/mirage/resource/base.py
+++ b/python/mirage/resource/base.py
@@ -127,3 +127,14 @@ class BaseResource:
 
     def load_state(self, state: dict) -> None:
         pass
+
+    def fork(self) -> "BaseResource":
+        """Return the resource to use in a forked workspace.
+
+        Default is share-by-reference: a live, externally-owned backend
+        (S3, Slack, GDrive, a Redis mount, ...) is the same object in
+        parent and child, so a write the child sends to it is real and
+        visible to both. In-process content backends override this to
+        return an isolated copy (RAM: copy-on-write; Disk: eager copy).
+        """
+        return self

--- a/python/mirage/resource/base.py
+++ b/python/mirage/resource/base.py
@@ -136,6 +136,7 @@ class BaseResource:
         both the original (live) workspace and its staged fork, so a
         write the staged side sends to it is real and visible to both.
         In-process content backends override this to return an isolated
-        copy (RAM: copy-on-write; Disk: eager copy).
+        copy (RAM: copy-on-write). Disk is not yet forkable (raises
+        NotImplementedError — deferred to Lane C, #178).
         """
         return self

--- a/python/mirage/resource/base.py
+++ b/python/mirage/resource/base.py
@@ -133,8 +133,9 @@ class BaseResource:
 
         Default is share-by-reference: a live, externally-owned backend
         (S3, Slack, GDrive, a Redis mount, ...) is the same object in
-        parent and child, so a write the child sends to it is real and
-        visible to both. In-process content backends override this to
-        return an isolated copy (RAM: copy-on-write; Disk: eager copy).
+        both the original (live) workspace and its staged fork, so a
+        write the staged side sends to it is real and visible to both.
+        In-process content backends override this to return an isolated
+        copy (RAM: copy-on-write; Disk: eager copy).
         """
         return self

--- a/python/mirage/resource/disk/disk.py
+++ b/python/mirage/resource/disk/disk.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import dataclasses
+import tempfile
 from pathlib import Path
 
 from mirage.accessor.disk import DiskAccessor
@@ -104,3 +105,14 @@ class DiskResource(BaseResource):
             target = self.root / rel
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(data)
+
+    def fork(self) -> "DiskResource":
+        """Fork by eager content copy into a fresh temp root.
+
+        Correct but not yet copy-on-write: the child's bytes are
+        duplicated on disk. A cheap copy-up overlay for disk mounts is a
+        follow-up.
+        """
+        child = DiskResource(root=tempfile.mkdtemp(prefix="mirage-disk-"))
+        child.load_state(self.get_state())
+        return child

--- a/python/mirage/resource/disk/disk.py
+++ b/python/mirage/resource/disk/disk.py
@@ -13,7 +13,6 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import dataclasses
-import tempfile
 from pathlib import Path
 
 from mirage.accessor.disk import DiskAccessor
@@ -107,12 +106,7 @@ class DiskResource(BaseResource):
             target.write_bytes(data)
 
     def fork(self) -> "DiskResource":
-        """Fork by eager content copy into a fresh temp root.
-
-        Correct but not yet copy-on-write: the child's bytes are
-        duplicated on disk. A cheap copy-up overlay for disk mounts is a
-        follow-up.
-        """
-        child = DiskResource(root=tempfile.mkdtemp(prefix="mirage-disk-"))
-        child.load_state(self.get_state())
-        return child
+        raise NotImplementedError(
+            "DiskResource.fork() is not supported yet: disk isolation is "
+            "owned by Lane C (#178). Forking a workspace that has a disk "
+            "mount fails until the copy-up overlay lands.")

--- a/python/mirage/resource/ram/ram.py
+++ b/python/mirage/resource/ram/ram.py
@@ -99,3 +99,15 @@ class RAMResource(BaseResource):
         self._store.files = dict(state.get("files", {}))
         self._store.dirs = set(state.get("dirs", ["/"]))
         self._store.modified = dict(state.get("modified", {}))
+
+    def fork(self) -> "RAMResource":
+        """Copy-on-write fork sharing this resource's byte payloads.
+
+        The child gets a forked :class:`RAMStore` (shared contents, own
+        key index) and a fresh empty index cache (directory listings are
+        derived and re-built on demand).
+        """
+        child = RAMResource()
+        child._store = self._store.fork()
+        child.accessor = RAMAccessor(child._store)
+        return child

--- a/python/mirage/resource/ram/ram.py
+++ b/python/mirage/resource/ram/ram.py
@@ -103,11 +103,11 @@ class RAMResource(BaseResource):
     def fork(self) -> "RAMResource":
         """Copy-on-write fork sharing this resource's byte payloads.
 
-        The child gets a forked :class:`RAMStore` (shared contents, own
+        The staged copy gets a forked :class:`RAMStore` (shared contents, own
         key index) and a fresh empty index cache (directory listings are
         derived and re-built on demand).
         """
-        child = RAMResource()
-        child._store = self._store.fork()
-        child.accessor = RAMAccessor(child._store)
-        return child
+        staged = RAMResource()
+        staged._store = self._store.fork()
+        staged.accessor = RAMAccessor(staged._store)
+        return staged

--- a/python/mirage/resource/ram/store.py
+++ b/python/mirage/resource/ram/store.py
@@ -20,3 +20,17 @@ class RAMStore:
     files: dict[str, bytes] = field(default_factory=dict)
     dirs: set[str] = field(default_factory=lambda: {"/"})
     modified: dict[str, str] = field(default_factory=dict)
+
+    def fork(self) -> "RAMStore":
+        """Cheap copy-on-write fork.
+
+        File *contents* are ``bytes`` (immutable), so they are shared by
+        reference; only the lightweight key index (the dicts/set) is
+        copied. A write rebinds one key in the child; a delete pops one
+        key from the child. Neither touches the parent.
+        """
+        return RAMStore(
+            files=dict(self.files),
+            dirs=set(self.dirs),
+            modified=dict(self.modified),
+        )

--- a/python/mirage/resource/ram/store.py
+++ b/python/mirage/resource/ram/store.py
@@ -26,8 +26,8 @@ class RAMStore:
 
         File *contents* are ``bytes`` (immutable), so they are shared by
         reference; only the lightweight key index (the dicts/set) is
-        copied. A write rebinds one key in the child; a delete pops one
-        key from the child. Neither touches the parent.
+        copied. A write rebinds one key in the staged copy; a delete pops
+        one key from the staged copy. Neither touches live.
         """
         return RAMStore(
             files=dict(self.files),

--- a/python/mirage/workspace/fork.py
+++ b/python/mirage/workspace/fork.py
@@ -1,0 +1,126 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+try:
+    from mirage.cache.file.redis import RedisFileCacheStore
+except ImportError:
+    RedisFileCacheStore = None  # type: ignore[misc, assignment]
+
+try:
+    from mirage.cache.index import RedisIndexCacheStore
+except ImportError:
+    RedisIndexCacheStore = None  # type: ignore[misc, assignment]
+
+DEV_PREFIX = "/dev/"
+
+
+def _norm_prefix(prefix: str) -> str:
+    stripped = prefix.strip("/")
+    return "/" + stripped + "/" if stripped else "/"
+
+
+def _assert_forkable(ws) -> None:
+    if ws._closed:
+        raise RuntimeError("Workspace is closed")
+    if RedisFileCacheStore is not None and isinstance(ws._cache,
+                                                      RedisFileCacheStore):
+        raise NotImplementedError(
+            "Workspace.fork() requires the default RAM cache: a Redis-backed "
+            "cache lives outside the process and cannot be cheaply forked "
+            "(an empty child would silently lose default-mount scratch).")
+    if RedisIndexCacheStore is not None:
+        for m in ws._registry.mounts():
+            if isinstance(m.resource.index, RedisIndexCacheStore):
+                raise NotImplementedError(
+                    f"Workspace.fork() does not support the Redis-backed "
+                    f"index on mount {m.prefix!r}: its state lives outside "
+                    "the process and cannot be cheaply forked.")
+
+
+def _auto_prefixes(ws) -> set[str]:
+    prefixes = {DEV_PREFIX}
+    if ws.observer is not None:
+        prefixes.add(_norm_prefix(ws.observer.prefix))
+    return prefixes
+
+
+def _fork_resources(ws) -> dict:
+    auto = _auto_prefixes(ws)
+    resources: dict = {}
+    for m in ws._registry.mounts():
+        if m.prefix in auto:
+            continue
+        resources[m.prefix] = (m.resource.fork(), m.mode)
+    return resources
+
+
+def _copy_sessions(ws, child) -> None:
+    mgr = child._session_mgr
+    for sess in ws._session_mgr.list():
+        mgr._sessions[sess.session_id] = sess.fork()
+        if sess.session_id not in mgr._locks:
+            mgr._locks[sess.session_id] = asyncio.Lock()
+
+
+def _copy_history(ws, child) -> None:
+    if ws.history is None or child.history is None:
+        return
+    for rec in ws.history.entries():
+        child.history.append(rec)
+
+
+def _copy_revisions(ws, child) -> None:
+    for cm in child._registry.mounts():
+        try:
+            pm = ws._registry.mount_for_prefix(cm.prefix)
+        except ValueError:
+            continue
+        if pm.revisions:
+            cm.revisions = dict(pm.revisions)
+
+
+def _history_limit(ws) -> int | None:
+    if ws.history is None:
+        return None
+    return ws.history._buffer.maxlen
+
+
+async def fork_workspace(ws):
+    """Build a copy-on-write child of ``ws``.
+
+    Constructed via ``type(ws)`` so this module never imports Workspace
+    (avoids a cycle). Remote backends are shared by reference; RAM-backed
+    mounts and the cache are forked copy-on-write; disk mounts are copied
+    eagerly; sessions, history, and revision pins are copied by value.
+
+    Args:
+        ws: the parent Workspace to fork.
+    """
+    _assert_forkable(ws)
+    child = type(ws)(
+        _fork_resources(ws),
+        consistency=ws._consistency,
+        session_id=ws._default_session_id,
+        agent_id=ws._default_agent_id,
+        history=_history_limit(ws),
+        observe_prefix=ws.observer.prefix,
+        _cache_store=ws._cache.fork(),
+    )
+    child._current_agent_id = ws._current_agent_id
+    _copy_sessions(ws, child)
+    _copy_history(ws, child)
+    _copy_revisions(ws, child)
+    return child

--- a/python/mirage/workspace/fork.py
+++ b/python/mirage/workspace/fork.py
@@ -14,6 +14,9 @@
 
 import asyncio
 
+from mirage.resource.disk.disk import DiskResource
+from mirage.workspace.snapshot.utils import norm_mount_prefix
+
 try:
     from mirage.cache.file.redis import RedisFileCacheStore
 except ImportError:
@@ -27,11 +30,6 @@ except ImportError:
 DEV_PREFIX = "/dev/"
 
 
-def _norm_prefix(prefix: str) -> str:
-    stripped = prefix.strip("/")
-    return "/" + stripped + "/" if stripped else "/"
-
-
 def _assert_forkable(ws) -> None:
     if ws._closed:
         raise RuntimeError("Workspace is closed")
@@ -42,19 +40,23 @@ def _assert_forkable(ws) -> None:
             "cache lives outside the process and cannot be cheaply forked "
             "(an empty staged workspace would silently lose "
             "default-mount scratch).")
-    if RedisIndexCacheStore is not None:
-        for m in ws._registry.mounts():
-            if isinstance(m.resource.index, RedisIndexCacheStore):
-                raise NotImplementedError(
-                    f"Workspace.fork() does not support the Redis-backed "
-                    f"index on mount {m.prefix!r}: its state lives outside "
-                    "the process and cannot be cheaply forked.")
+    for m in ws._registry.mounts():
+        if isinstance(m.resource, DiskResource):
+            raise NotImplementedError(
+                f"Workspace.fork() does not yet support the disk mount at "
+                f"{m.prefix!r}: disk isolation is owned by Lane C (#178).")
+        if (RedisIndexCacheStore is not None
+                and isinstance(m.resource.index, RedisIndexCacheStore)):
+            raise NotImplementedError(
+                f"Workspace.fork() does not support the Redis-backed index "
+                f"on mount {m.prefix!r}: its state lives outside the "
+                "process and cannot be cheaply forked.")
 
 
 def _auto_prefixes(ws) -> set[str]:
     prefixes = {DEV_PREFIX}
     if ws.observer is not None:
-        prefixes.add(_norm_prefix(ws.observer.prefix))
+        prefixes.add(norm_mount_prefix(ws.observer.prefix))
     return prefixes
 
 
@@ -116,6 +118,9 @@ async def fork_workspace(ws):
         ws: the live Workspace to fork.
     """
     _assert_forkable(ws)
+    # Intentional asymmetry: history entries are copied by value, but
+    # history_path + observer are rebuilt fresh (no double-persist of
+    # inherited records, no writes to the live audit sink).
     staged = type(ws)(
         _fork_resources(ws),
         consistency=ws._consistency,

--- a/python/mirage/workspace/fork.py
+++ b/python/mirage/workspace/fork.py
@@ -40,7 +40,8 @@ def _assert_forkable(ws) -> None:
         raise NotImplementedError(
             "Workspace.fork() requires the default RAM cache: a Redis-backed "
             "cache lives outside the process and cannot be cheaply forked "
-            "(an empty child would silently lose default-mount scratch).")
+            "(an empty staged workspace would silently lose "
+            "default-mount scratch).")
     if RedisIndexCacheStore is not None:
         for m in ws._registry.mounts():
             if isinstance(m.resource.index, RedisIndexCacheStore):
@@ -63,27 +64,31 @@ def _fork_resources(ws) -> dict:
     for m in ws._registry.mounts():
         if m.prefix in auto:
             continue
-        resources[m.prefix] = (m.resource.fork(), m.mode)
+        resources[m.prefix] = (
+            m.resource.fork(),
+            m.mode,
+            dict(m.command_safeguards),
+        )
     return resources
 
 
-def _copy_sessions(ws, child) -> None:
-    mgr = child._session_mgr
+def _copy_sessions(ws, staged) -> None:
+    mgr = staged._session_mgr
     for sess in ws._session_mgr.list():
         mgr._sessions[sess.session_id] = sess.fork()
         if sess.session_id not in mgr._locks:
             mgr._locks[sess.session_id] = asyncio.Lock()
 
 
-def _copy_history(ws, child) -> None:
-    if ws.history is None or child.history is None:
+def _copy_history(ws, staged) -> None:
+    if ws.history is None or staged.history is None:
         return
     for rec in ws.history.entries():
-        child.history.append(rec)
+        staged.history.append(rec)
 
 
-def _copy_revisions(ws, child) -> None:
-    for cm in child._registry.mounts():
+def _copy_revisions(ws, staged) -> None:
+    for cm in staged._registry.mounts():
         try:
             pm = ws._registry.mount_for_prefix(cm.prefix)
         except ValueError:
@@ -99,7 +104,7 @@ def _history_limit(ws) -> int | None:
 
 
 async def fork_workspace(ws):
-    """Build a copy-on-write child of ``ws``.
+    """Build a copy-on-write staged fork of ``ws`` (the live workspace).
 
     Constructed via ``type(ws)`` so this module never imports Workspace
     (avoids a cycle). Remote backends are shared by reference; RAM-backed
@@ -107,10 +112,10 @@ async def fork_workspace(ws):
     eagerly; sessions, history, and revision pins are copied by value.
 
     Args:
-        ws: the parent Workspace to fork.
+        ws: the live Workspace to fork.
     """
     _assert_forkable(ws)
-    child = type(ws)(
+    staged = type(ws)(
         _fork_resources(ws),
         consistency=ws._consistency,
         session_id=ws._default_session_id,
@@ -119,8 +124,8 @@ async def fork_workspace(ws):
         observe_prefix=ws.observer.prefix,
         _cache_store=ws._cache.fork(),
     )
-    child._current_agent_id = ws._current_agent_id
-    _copy_sessions(ws, child)
-    _copy_history(ws, child)
-    _copy_revisions(ws, child)
-    return child
+    staged._current_agent_id = ws._current_agent_id
+    _copy_sessions(ws, staged)
+    _copy_history(ws, staged)
+    _copy_revisions(ws, staged)
+    return staged

--- a/python/mirage/workspace/fork.py
+++ b/python/mirage/workspace/fork.py
@@ -108,8 +108,9 @@ async def fork_workspace(ws):
 
     Constructed via ``type(ws)`` so this module never imports Workspace
     (avoids a cycle). Remote backends are shared by reference; RAM-backed
-    mounts and the cache are forked copy-on-write; disk mounts are copied
-    eagerly; sessions, history, and revision pins are copied by value.
+    mounts and the cache are forked copy-on-write; disk mounts are not
+    yet forkable (raise ``NotImplementedError`` — deferred to Lane C,
+    #178); sessions, history, and revision pins are copied by value.
 
     Args:
         ws: the live Workspace to fork.

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -22,6 +22,7 @@ from functools import partial
 from typing import Any
 
 from mirage.cache.file.config import CacheConfig, RedisCacheConfig
+from mirage.cache.file.mixin import FileCacheMixin
 from mirage.cache.file.ram import RAMFileCacheStore
 from mirage.cache.index import IndexConfig
 from mirage.commands.builtin.general import HISTORY_COMMANDS
@@ -51,6 +52,7 @@ from mirage.types import (DEFAULT_AGENT_ID, DEFAULT_SESSION_ID,
 from mirage.workspace.abort import MirageAbortError
 from mirage.workspace.dispatcher import Dispatcher
 from mirage.workspace.file_prompt import build_file_prompt
+from mirage.workspace.fork import fork_workspace
 from mirage.workspace.fuse import FuseManager
 from mirage.workspace.history import ExecutionHistory
 from mirage.workspace.mount import Mount, MountRegistry
@@ -93,9 +95,12 @@ class Workspace:
         native: bool = False,
         observe: BaseResource | None = None,
         observe_prefix: str = "/.sessions",
+        _cache_store: FileCacheMixin | None = None,
     ) -> None:
         self._registry = MountRegistry()
-        if isinstance(cache, RedisCacheConfig):
+        if _cache_store is not None:
+            self._cache = _cache_store
+        elif isinstance(cache, RedisCacheConfig):
             if RedisFileCacheStore is None:
                 raise ImportError(
                     "RedisCacheConfig requires the 'redis' extra. "
@@ -430,6 +435,35 @@ class Workspace:
             and m["prefix"] in prefix_to_resource
         }
         return type(self)._from_state(state, resources=resources)
+
+    async def fork(self) -> "Workspace":
+        """Cheap copy-on-write fork of this workspace.
+
+        Returns a child Workspace that isolates *internal* state from the
+        parent. The read/scratch cache and RAM-backed mounts are forked
+        copy-on-write: file *contents* (immutable bytes) are shared by
+        reference and only the lightweight key index is copied, so a
+        write or delete in the child never touches the parent and vice
+        versa. Sessions (cwd/env), history, and revision pins are copied
+        by value. Disk mounts are copied eagerly (correct, not yet
+        cheap). The child gets its own observer and job table.
+
+        Remote backends (S3, Slack, GDrive, ...) are **shared by
+        reference**: a write the child sends to them is real and visible
+        to the parent and the outside world. Forking isolates agent
+        state, not the external world — staged/reversible external writes
+        are a separate layer.
+
+        Call between operations, not concurrently with an in-flight
+        ``execute()`` on the same workspace.
+
+        Raises:
+            NotImplementedError: if the cache or any mount index is
+                Redis-backed (out-of-process state cannot be cheaply
+                forked).
+            RuntimeError: if the workspace is closed.
+        """
+        return await fork_workspace(self)
 
     @classmethod
     def _from_state(cls,

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -439,18 +439,19 @@ class Workspace:
     async def fork(self) -> "Workspace":
         """Cheap copy-on-write fork of this workspace.
 
-        Returns a child Workspace that isolates *internal* state from the
-        parent. The read/scratch cache and RAM-backed mounts are forked
-        copy-on-write: file *contents* (immutable bytes) are shared by
-        reference and only the lightweight key index is copied, so a
-        write or delete in the child never touches the parent and vice
-        versa. Sessions (cwd/env), history, and revision pins are copied
-        by value. Disk mounts are copied eagerly (correct, not yet
-        cheap). The child gets its own observer and job table.
+        Returns a *staged* Workspace that isolates *internal* state from
+        this *live* workspace. The read/scratch cache and RAM-backed
+        mounts are forked copy-on-write: file *contents* (immutable
+        bytes) are shared by reference and only the lightweight key index
+        is copied, so a write or delete in the staged workspace never
+        touches live and vice versa. Sessions (cwd/env), history, and
+        revision pins are copied by value. Disk mounts are copied eagerly
+        (correct, not yet cheap). The staged workspace gets its own
+        observer and job table.
 
         Remote backends (S3, Slack, GDrive, ...) are **shared by
-        reference**: a write the child sends to them is real and visible
-        to the parent and the outside world. Forking isolates agent
+        reference**: a write the staged workspace sends to them is real
+        and visible to live and the outside world. Forking isolates agent
         state, not the external world — staged/reversible external writes
         are a separate layer.
 

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -445,9 +445,9 @@ class Workspace:
         bytes) are shared by reference and only the lightweight key index
         is copied, so a write or delete in the staged workspace never
         touches live and vice versa. Sessions (cwd/env), history, and
-        revision pins are copied by value. Disk mounts are copied eagerly
-        (correct, not yet cheap). The staged workspace gets its own
-        observer and job table.
+        revision pins are copied by value. Disk mounts are not yet
+        forkable (raise NotImplementedError — deferred to Lane C, #178).
+        The staged workspace gets its own observer and job table.
 
         Remote backends (S3, Slack, GDrive, ...) are **shared by
         reference**: a write the staged workspace sends to them is real

--- a/python/tests/cache/file/test_fork.py
+++ b/python/tests/cache/file/test_fork.py
@@ -1,0 +1,66 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.cache.file.ram import RAMFileCacheStore
+
+
+def test_cache_fork_fresh_drain_tasks_and_size():
+    parent = RAMFileCacheStore()
+    child = parent.fork()
+    assert child.cache_size == parent.cache_size
+    assert child._drain_tasks is not parent._drain_tasks
+    assert child._drain_tasks == {}
+    assert child._entries is not parent._entries
+
+
+@pytest.mark.asyncio
+async def test_cache_fork_payload_shared_then_isolated():
+    parent = RAMFileCacheStore()
+    await parent.set("/a", b"hello")
+    child = parent.fork()
+    assert await child.get("/a") == b"hello"
+    assert child._store.files["/a"] is parent._store.files["/a"]
+
+    await child.set("/a", b"world")
+    assert await parent.get("/a") == b"hello"
+    assert await child.get("/a") == b"world"
+
+    await child.remove("/a")
+    assert await parent.get("/a") == b"hello"
+
+    await child.set("/b", b"x")
+    assert await parent.get("/b") is None
+
+
+@pytest.mark.asyncio
+async def test_cache_fork_size_accounting_diverges():
+    parent = RAMFileCacheStore()
+    await parent.set("/a", b"hello")
+    base = parent.cache_size
+    child = parent.fork()
+    await child.set("/b", b"world")
+    assert child.cache_size > base
+    assert parent.cache_size == base
+
+
+def test_redis_cache_fork_raises():
+    pytest.importorskip("redis")
+    from mirage.cache.file.redis import RedisFileCacheStore
+
+    # fork() refuses before any I/O, so call the unbound method with a
+    # dummy self to exercise the contract without a live Redis server.
+    with pytest.raises(NotImplementedError):
+        RedisFileCacheStore.fork(object())

--- a/python/tests/cache/file/test_fork.py
+++ b/python/tests/cache/file/test_fork.py
@@ -18,42 +18,42 @@ from mirage.cache.file.ram import RAMFileCacheStore
 
 
 def test_cache_fork_fresh_drain_tasks_and_size():
-    parent = RAMFileCacheStore()
-    child = parent.fork()
-    assert child.cache_size == parent.cache_size
-    assert child._drain_tasks is not parent._drain_tasks
-    assert child._drain_tasks == {}
-    assert child._entries is not parent._entries
+    live = RAMFileCacheStore()
+    staged = live.fork()
+    assert staged.cache_size == live.cache_size
+    assert staged._drain_tasks is not live._drain_tasks
+    assert staged._drain_tasks == {}
+    assert staged._entries is not live._entries
 
 
 @pytest.mark.asyncio
 async def test_cache_fork_payload_shared_then_isolated():
-    parent = RAMFileCacheStore()
-    await parent.set("/a", b"hello")
-    child = parent.fork()
-    assert await child.get("/a") == b"hello"
-    assert child._store.files["/a"] is parent._store.files["/a"]
+    live = RAMFileCacheStore()
+    await live.set("/a", b"hello")
+    staged = live.fork()
+    assert await staged.get("/a") == b"hello"
+    assert staged._store.files["/a"] is live._store.files["/a"]
 
-    await child.set("/a", b"world")
-    assert await parent.get("/a") == b"hello"
-    assert await child.get("/a") == b"world"
+    await staged.set("/a", b"world")
+    assert await live.get("/a") == b"hello"
+    assert await staged.get("/a") == b"world"
 
-    await child.remove("/a")
-    assert await parent.get("/a") == b"hello"
+    await staged.remove("/a")
+    assert await live.get("/a") == b"hello"
 
-    await child.set("/b", b"x")
-    assert await parent.get("/b") is None
+    await staged.set("/b", b"x")
+    assert await live.get("/b") is None
 
 
 @pytest.mark.asyncio
 async def test_cache_fork_size_accounting_diverges():
-    parent = RAMFileCacheStore()
-    await parent.set("/a", b"hello")
-    base = parent.cache_size
-    child = parent.fork()
-    await child.set("/b", b"world")
-    assert child.cache_size > base
-    assert parent.cache_size == base
+    live = RAMFileCacheStore()
+    await live.set("/a", b"hello")
+    base = live.cache_size
+    staged = live.fork()
+    await staged.set("/b", b"world")
+    assert staged.cache_size > base
+    assert live.cache_size == base
 
 
 def test_redis_cache_fork_raises():

--- a/python/tests/resource/test_ram_fork.py
+++ b/python/tests/resource/test_ram_fork.py
@@ -1,0 +1,72 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.resource.base import BaseResource
+from mirage.resource.ram import RAMResource
+from mirage.resource.ram.store import RAMStore
+
+
+def test_store_fork_shares_payload_by_reference():
+    parent = RAMStore(files={"/a": b"hello"},
+                      dirs={"/", "/d"},
+                      modified={"/a": "t"})
+    child = parent.fork()
+    assert child.files["/a"] is parent.files["/a"]
+    assert child.dirs == parent.dirs
+    assert child.modified == parent.modified
+
+
+def test_store_fork_write_isolates():
+    parent = RAMStore(files={"/a": b"hello"})
+    child = parent.fork()
+    child.files["/a"] = b"world"
+    child.files["/b"] = b"new"
+    assert parent.files["/a"] == b"hello"
+    assert "/b" not in parent.files
+
+
+def test_store_fork_delete_isolates():
+    parent = RAMStore(files={"/a": b"hello"})
+    child = parent.fork()
+    del child.files["/a"]
+    assert "/a" in parent.files
+
+
+def test_store_fork_dirs_isolate():
+    parent = RAMStore(dirs={"/"})
+    child = parent.fork()
+    child.dirs.add("/sub")
+    assert "/sub" not in parent.dirs
+
+
+def test_resource_fork_independent_store_and_index():
+    parent = RAMResource()
+    child = parent.fork()
+    assert child._store is not parent._store
+    assert child.accessor.store is child._store
+    assert child.index is not parent.index
+
+
+def test_resource_fork_shares_bytes_then_isolates():
+    parent = RAMResource()
+    parent._store.files["/a"] = b"hello"
+    child = parent.fork()
+    assert child._store.files["/a"] is parent._store.files["/a"]
+    child._store.files["/a"] = b"bye"
+    assert parent._store.files["/a"] == b"hello"
+
+
+def test_base_resource_fork_shares_by_reference():
+    r = BaseResource()
+    assert r.fork() is r

--- a/python/tests/resource/test_ram_fork.py
+++ b/python/tests/resource/test_ram_fork.py
@@ -18,53 +18,53 @@ from mirage.resource.ram.store import RAMStore
 
 
 def test_store_fork_shares_payload_by_reference():
-    parent = RAMStore(files={"/a": b"hello"},
-                      dirs={"/", "/d"},
-                      modified={"/a": "t"})
-    child = parent.fork()
-    assert child.files["/a"] is parent.files["/a"]
-    assert child.dirs == parent.dirs
-    assert child.modified == parent.modified
+    live = RAMStore(files={"/a": b"hello"},
+                    dirs={"/", "/d"},
+                    modified={"/a": "t"})
+    staged = live.fork()
+    assert staged.files["/a"] is live.files["/a"]
+    assert staged.dirs == live.dirs
+    assert staged.modified == live.modified
 
 
 def test_store_fork_write_isolates():
-    parent = RAMStore(files={"/a": b"hello"})
-    child = parent.fork()
-    child.files["/a"] = b"world"
-    child.files["/b"] = b"new"
-    assert parent.files["/a"] == b"hello"
-    assert "/b" not in parent.files
+    live = RAMStore(files={"/a": b"hello"})
+    staged = live.fork()
+    staged.files["/a"] = b"world"
+    staged.files["/b"] = b"new"
+    assert live.files["/a"] == b"hello"
+    assert "/b" not in live.files
 
 
 def test_store_fork_delete_isolates():
-    parent = RAMStore(files={"/a": b"hello"})
-    child = parent.fork()
-    del child.files["/a"]
-    assert "/a" in parent.files
+    live = RAMStore(files={"/a": b"hello"})
+    staged = live.fork()
+    del staged.files["/a"]
+    assert "/a" in live.files
 
 
 def test_store_fork_dirs_isolate():
-    parent = RAMStore(dirs={"/"})
-    child = parent.fork()
-    child.dirs.add("/sub")
-    assert "/sub" not in parent.dirs
+    live = RAMStore(dirs={"/"})
+    staged = live.fork()
+    staged.dirs.add("/sub")
+    assert "/sub" not in live.dirs
 
 
 def test_resource_fork_independent_store_and_index():
-    parent = RAMResource()
-    child = parent.fork()
-    assert child._store is not parent._store
-    assert child.accessor.store is child._store
-    assert child.index is not parent.index
+    live = RAMResource()
+    staged = live.fork()
+    assert staged._store is not live._store
+    assert staged.accessor.store is staged._store
+    assert staged.index is not live.index
 
 
 def test_resource_fork_shares_bytes_then_isolates():
-    parent = RAMResource()
-    parent._store.files["/a"] = b"hello"
-    child = parent.fork()
-    assert child._store.files["/a"] is parent._store.files["/a"]
-    child._store.files["/a"] = b"bye"
-    assert parent._store.files["/a"] == b"hello"
+    live = RAMResource()
+    live._store.files["/a"] = b"hello"
+    staged = live.fork()
+    assert staged._store.files["/a"] is live._store.files["/a"]
+    staged._store.files["/a"] = b"bye"
+    assert live._store.files["/a"] == b"hello"
 
 
 def test_base_resource_fork_shares_by_reference():

--- a/python/tests/workspace/test_fork.py
+++ b/python/tests/workspace/test_fork.py
@@ -1,0 +1,289 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mirage.resource.disk import DiskResource
+from mirage.resource.ram import RAMResource
+from mirage.types import DEFAULT_SESSION_ID, MountMode
+from mirage.workspace import Workspace
+
+
+class _SharedRAM(RAMResource):
+    """RAM backend that forks by sharing — mimics a live remote backend
+    (S3, Slack, ...) whose `fork()` is the BaseResource share-by-ref
+    default."""
+
+    def fork(self) -> "_SharedRAM":
+        return self
+
+
+class _FakeRedisCache:
+    """Stand-in so the Redis-cache guard can be exercised without a live
+    Redis server (a real RedisFileCacheStore connects on construction)."""
+
+
+def _ws() -> Workspace:
+    ram = RAMResource()
+    ram._store.files["/seed.txt"] = b"seed\n"
+    ws = Workspace(
+        {"/ram/": (ram, MountMode.EXEC)},
+        history=None,
+    )
+    ws.get_session(DEFAULT_SESSION_ID).cwd = "/ram"
+    return ws
+
+
+def _files(ws, prefix="/ram"):
+    return ws.mount(prefix).resource._store.files
+
+
+def _dirs(ws, prefix="/ram"):
+    return ws.mount(prefix).resource._store.dirs
+
+
+@pytest.mark.asyncio
+async def test_fork_inherits_parent_ram_content():
+    ws = _ws()
+    child = await ws.fork()
+    result = await child.execute("cat /ram/seed.txt")
+    assert b"seed" in result.stdout
+
+
+@pytest.mark.asyncio
+async def test_fork_ram_write_does_not_leak_to_parent():
+    ws = _ws()
+    child = await ws.fork()
+    await child.execute("echo hi > /ram/a.txt")
+    assert "/a.txt" in child.mount("/ram").resource._store.files
+    assert "/a.txt" not in ws.mount("/ram").resource._store.files
+
+
+@pytest.mark.asyncio
+async def test_fork_parent_write_does_not_leak_to_child():
+    ws = _ws()
+    child = await ws.fork()
+    await ws.execute("echo bye > /ram/b.txt")
+    assert "/b.txt" in ws.mount("/ram").resource._store.files
+    assert "/b.txt" not in child.mount("/ram").resource._store.files
+
+
+@pytest.mark.asyncio
+async def test_fork_session_cwd_inherited_then_isolated():
+    ws = _ws()
+    child = await ws.fork()
+    assert child.get_session(DEFAULT_SESSION_ID).cwd == "/ram"
+    child.get_session(DEFAULT_SESSION_ID).cwd = "/"
+    assert ws.get_session(DEFAULT_SESSION_ID).cwd == "/ram"
+
+
+@pytest.mark.asyncio
+async def test_fork_shares_remote_style_resource():
+    shared = _SharedRAM()
+    ws = Workspace({"/s3/": (shared, MountMode.EXEC)}, history=None)
+    ws.get_session(DEFAULT_SESSION_ID).cwd = "/s3"
+    child = await ws.fork()
+    assert child.mount("/s3").resource is shared
+    await child.execute("echo hi > /s3/r.txt")
+    assert "/r.txt" in shared._store.files
+
+
+@pytest.mark.asyncio
+async def test_fork_copies_history_then_diverges():
+    ws = Workspace({"/ram/": (RAMResource(), MountMode.EXEC)}, history=100)
+    await ws.execute("echo hi > /ram/a.txt")
+    child = await ws.fork()
+    assert len(child.history.entries()) == len(ws.history.entries())
+    await child.execute("echo bye > /ram/b.txt")
+    assert len(child.history.entries()) == len(ws.history.entries()) + 1
+
+
+@pytest.mark.asyncio
+async def test_fork_on_closed_workspace_raises():
+    ws = _ws()
+    await ws.close()
+    with pytest.raises(RuntimeError):
+        await ws.fork()
+
+
+@pytest.mark.asyncio
+async def test_fork_rejects_redis_backed_cache(monkeypatch):
+    monkeypatch.setattr("mirage.workspace.fork.RedisFileCacheStore",
+                        _FakeRedisCache)
+    ws = _ws()
+    ws._cache = _FakeRedisCache()
+    with pytest.raises(NotImplementedError):
+        await ws.fork()
+
+
+@pytest.mark.asyncio
+async def test_fork_child_overwrite_of_inherited_is_isolated():
+    ws = _ws()
+    child = await ws.fork()
+    await child.execute("echo changed > /ram/seed.txt")
+    assert (await ws.execute("cat /ram/seed.txt")).stdout == b"seed\n"
+    assert b"changed" in (await child.execute("cat /ram/seed.txt")).stdout
+
+
+@pytest.mark.asyncio
+async def test_fork_child_delete_of_inherited_is_isolated():
+    ws = _ws()
+    child = await ws.fork()
+    await child.execute("rm /ram/seed.txt")
+    assert "/seed.txt" in _files(ws)
+    assert "/seed.txt" not in _files(child)
+
+
+@pytest.mark.asyncio
+async def test_fork_child_append_to_inherited_is_isolated():
+    ws = _ws()
+    child = await ws.fork()
+    await child.execute("echo more >> /ram/seed.txt")
+    assert (await ws.execute("cat /ram/seed.txt")).stdout == b"seed\n"
+    child_out = (await child.execute("cat /ram/seed.txt")).stdout
+    assert b"seed" in child_out and b"more" in child_out
+
+
+@pytest.mark.asyncio
+async def test_fork_shares_payload_by_reference_with_cow_granularity():
+    ws = _ws()
+    await ws.execute("echo bbb > /ram/b.txt")
+    child = await ws.fork()
+    assert _files(child)["/seed.txt"] is _files(ws)["/seed.txt"]
+    assert _files(child)["/b.txt"] is _files(ws)["/b.txt"]
+    await child.execute("echo b2 > /ram/b.txt")
+    assert _files(child)["/b.txt"] != _files(ws)["/b.txt"]
+    assert _files(child)["/seed.txt"] is _files(ws)["/seed.txt"]
+    assert _files(ws)["/b.txt"] == b"bbb\n"
+
+
+@pytest.mark.asyncio
+async def test_fork_grandchild_three_level_isolation():
+    ws = _ws()
+    await ws.execute("echo a > /ram/a.txt")
+    child = await ws.fork()
+    await child.execute("echo b > /ram/b.txt")
+    grand = await child.fork()
+    await grand.execute("echo c > /ram/c.txt")
+    assert "/a.txt" in _files(grand) and "/b.txt" in _files(grand)
+    assert "/c.txt" not in _files(child)
+    assert "/b.txt" not in _files(ws) and "/c.txt" not in _files(ws)
+
+
+@pytest.mark.asyncio
+async def test_fork_two_siblings_isolated():
+    ws = _ws()
+    a = await ws.fork()
+    b = await ws.fork()
+    await a.execute("echo a > /ram/a.txt")
+    await b.execute("echo b > /ram/b.txt")
+    assert "/b.txt" not in _files(a)
+    assert "/a.txt" not in _files(b)
+    assert "/a.txt" not in _files(ws) and "/b.txt" not in _files(ws)
+
+
+@pytest.mark.asyncio
+async def test_fork_dirs_isolation_via_mkdir():
+    ws = _ws()
+    await ws.execute("mkdir /ram/d")
+    child = await ws.fork()
+    await child.execute("mkdir /ram/e")
+    assert "/d" in _dirs(ws) and "/e" not in _dirs(ws)
+    assert "/d" in _dirs(child) and "/e" in _dirs(child)
+
+
+@pytest.mark.asyncio
+async def test_fork_cross_mount_cp_isolated():
+    ws = Workspace(
+        {
+            "/a/": (RAMResource(), MountMode.EXEC),
+            "/b/": (RAMResource(), MountMode.EXEC),
+        },
+        history=None,
+    )
+    await ws.execute("echo data > /a/x.txt")
+    child = await ws.fork()
+    await child.execute("cp /a/x.txt /b/y.txt")
+    assert "/y.txt" in _files(child, "/b")
+    assert "/y.txt" not in _files(ws, "/b")
+
+
+@pytest.mark.asyncio
+async def test_fork_disk_eager_copy_distinct_root_and_isolated():
+    root = tempfile.mkdtemp(prefix="mirage-test-disk-")
+    ws = Workspace({"/disk/": (DiskResource(root=root), MountMode.EXEC)},
+                   history=None)
+    ws.get_session(DEFAULT_SESSION_ID).cwd = "/disk"
+    await ws.execute("echo parent > /disk/p.txt")
+    child = await ws.fork()
+    proot = Path(ws.mount("/disk").resource.root)
+    croot = Path(child.mount("/disk").resource.root)
+    assert proot != croot
+    await child.execute("echo child > /disk/c.txt")
+    assert not (proot / "c.txt").exists()
+    assert (croot / "p.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_fork_session_env_inherited_then_isolated():
+    ws = _ws()
+    ws.get_session(DEFAULT_SESSION_ID).env["FOO"] = "bar"
+    child = await ws.fork()
+    assert child.get_session(DEFAULT_SESSION_ID).env.get("FOO") == "bar"
+    child.get_session(DEFAULT_SESSION_ID).env["FOO"] = "baz"
+    assert ws.get_session(DEFAULT_SESSION_ID).env["FOO"] == "bar"
+
+
+@pytest.mark.asyncio
+async def test_fork_nondefault_session_inherited_and_isolated():
+    ws = _ws()
+    sess = ws.create_session("work")
+    sess.env["K"] = "v"
+    child = await ws.fork()
+    assert child.get_session("work").env.get("K") == "v"
+    child.get_session("work").env["K"] = "changed"
+    assert ws.get_session("work").env["K"] == "v"
+
+
+@pytest.mark.asyncio
+async def test_fork_cache_distinct_and_isolated():
+    ws = _ws()
+    await ws._cache.set("/seedcache", b"v")
+    child = await ws.fork()
+    assert child._cache is not ws._cache
+    assert await child._cache.get("/seedcache") == b"v"
+    await child._cache.set("/probe", b"x")
+    assert await ws._cache.get("/probe") is None
+    await child._cache.remove("/seedcache")
+    assert await ws._cache.get("/seedcache") == b"v"
+
+
+@pytest.mark.asyncio
+async def test_fork_has_isolated_observer():
+    ws = _ws()
+    child = await ws.fork()
+    assert child.observer is not ws.observer
+    assert child.observer.resource is not ws.observer.resource
+
+
+@pytest.mark.asyncio
+async def test_fork_parent_usable_after_fork_snapshot_at_fork():
+    ws = _ws()
+    child = await ws.fork()
+    await ws.execute("echo a2 > /ram/post.txt")
+    assert "/post.txt" in _files(ws)
+    assert "/post.txt" not in _files(child)

--- a/python/tests/workspace/test_fork.py
+++ b/python/tests/workspace/test_fork.py
@@ -13,13 +13,12 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import tempfile
-from pathlib import Path
 
 import pytest
 
 from mirage.resource.disk import DiskResource
 from mirage.resource.ram import RAMResource
-from mirage.types import DEFAULT_SESSION_ID, MountMode
+from mirage.types import DEFAULT_SESSION_ID, CommandSafeguard, MountMode
 from mirage.workspace import Workspace
 
 
@@ -35,6 +34,11 @@ class _SharedRAM(RAMResource):
 class _FakeRedisCache:
     """Stand-in so the Redis-cache guard can be exercised without a live
     Redis server (a real RedisFileCacheStore connects on construction)."""
+
+
+class _FakeRedisIndex:
+    """Stand-in for RedisIndexCacheStore so the index-rejection guard can
+    be exercised without a live Redis server."""
 
 
 def _ws() -> Workspace:
@@ -57,37 +61,37 @@ def _dirs(ws, prefix="/ram"):
 
 
 @pytest.mark.asyncio
-async def test_fork_inherits_parent_ram_content():
+async def test_fork_inherits_live_ram_content():
     ws = _ws()
-    child = await ws.fork()
-    result = await child.execute("cat /ram/seed.txt")
+    staged = await ws.fork()
+    result = await staged.execute("cat /ram/seed.txt")
     assert b"seed" in result.stdout
 
 
 @pytest.mark.asyncio
-async def test_fork_ram_write_does_not_leak_to_parent():
+async def test_fork_ram_write_does_not_leak_to_live():
     ws = _ws()
-    child = await ws.fork()
-    await child.execute("echo hi > /ram/a.txt")
-    assert "/a.txt" in child.mount("/ram").resource._store.files
+    staged = await ws.fork()
+    await staged.execute("echo hi > /ram/a.txt")
+    assert "/a.txt" in staged.mount("/ram").resource._store.files
     assert "/a.txt" not in ws.mount("/ram").resource._store.files
 
 
 @pytest.mark.asyncio
-async def test_fork_parent_write_does_not_leak_to_child():
+async def test_fork_live_write_does_not_leak_to_staged():
     ws = _ws()
-    child = await ws.fork()
+    staged = await ws.fork()
     await ws.execute("echo bye > /ram/b.txt")
     assert "/b.txt" in ws.mount("/ram").resource._store.files
-    assert "/b.txt" not in child.mount("/ram").resource._store.files
+    assert "/b.txt" not in staged.mount("/ram").resource._store.files
 
 
 @pytest.mark.asyncio
 async def test_fork_session_cwd_inherited_then_isolated():
     ws = _ws()
-    child = await ws.fork()
-    assert child.get_session(DEFAULT_SESSION_ID).cwd == "/ram"
-    child.get_session(DEFAULT_SESSION_ID).cwd = "/"
+    staged = await ws.fork()
+    assert staged.get_session(DEFAULT_SESSION_ID).cwd == "/ram"
+    staged.get_session(DEFAULT_SESSION_ID).cwd = "/"
     assert ws.get_session(DEFAULT_SESSION_ID).cwd == "/ram"
 
 
@@ -96,9 +100,9 @@ async def test_fork_shares_remote_style_resource():
     shared = _SharedRAM()
     ws = Workspace({"/s3/": (shared, MountMode.EXEC)}, history=None)
     ws.get_session(DEFAULT_SESSION_ID).cwd = "/s3"
-    child = await ws.fork()
-    assert child.mount("/s3").resource is shared
-    await child.execute("echo hi > /s3/r.txt")
+    staged = await ws.fork()
+    assert staged.mount("/s3").resource is shared
+    await staged.execute("echo hi > /s3/r.txt")
     assert "/r.txt" in shared._store.files
 
 
@@ -106,10 +110,10 @@ async def test_fork_shares_remote_style_resource():
 async def test_fork_copies_history_then_diverges():
     ws = Workspace({"/ram/": (RAMResource(), MountMode.EXEC)}, history=100)
     await ws.execute("echo hi > /ram/a.txt")
-    child = await ws.fork()
-    assert len(child.history.entries()) == len(ws.history.entries())
-    await child.execute("echo bye > /ram/b.txt")
-    assert len(child.history.entries()) == len(ws.history.entries()) + 1
+    staged = await ws.fork()
+    assert len(staged.history.entries()) == len(ws.history.entries())
+    await staged.execute("echo bye > /ram/b.txt")
+    assert len(staged.history.entries()) == len(ws.history.entries()) + 1
 
 
 @pytest.mark.asyncio
@@ -131,56 +135,56 @@ async def test_fork_rejects_redis_backed_cache(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_fork_child_overwrite_of_inherited_is_isolated():
+async def test_fork_staged_overwrite_of_inherited_is_isolated():
     ws = _ws()
-    child = await ws.fork()
-    await child.execute("echo changed > /ram/seed.txt")
+    staged = await ws.fork()
+    await staged.execute("echo changed > /ram/seed.txt")
     assert (await ws.execute("cat /ram/seed.txt")).stdout == b"seed\n"
-    assert b"changed" in (await child.execute("cat /ram/seed.txt")).stdout
+    assert b"changed" in (await staged.execute("cat /ram/seed.txt")).stdout
 
 
 @pytest.mark.asyncio
-async def test_fork_child_delete_of_inherited_is_isolated():
+async def test_fork_staged_delete_of_inherited_is_isolated():
     ws = _ws()
-    child = await ws.fork()
-    await child.execute("rm /ram/seed.txt")
+    staged = await ws.fork()
+    await staged.execute("rm /ram/seed.txt")
     assert "/seed.txt" in _files(ws)
-    assert "/seed.txt" not in _files(child)
+    assert "/seed.txt" not in _files(staged)
 
 
 @pytest.mark.asyncio
-async def test_fork_child_append_to_inherited_is_isolated():
+async def test_fork_staged_append_to_inherited_is_isolated():
     ws = _ws()
-    child = await ws.fork()
-    await child.execute("echo more >> /ram/seed.txt")
+    staged = await ws.fork()
+    await staged.execute("echo more >> /ram/seed.txt")
     assert (await ws.execute("cat /ram/seed.txt")).stdout == b"seed\n"
-    child_out = (await child.execute("cat /ram/seed.txt")).stdout
-    assert b"seed" in child_out and b"more" in child_out
+    staged_out = (await staged.execute("cat /ram/seed.txt")).stdout
+    assert b"seed" in staged_out and b"more" in staged_out
 
 
 @pytest.mark.asyncio
 async def test_fork_shares_payload_by_reference_with_cow_granularity():
     ws = _ws()
     await ws.execute("echo bbb > /ram/b.txt")
-    child = await ws.fork()
-    assert _files(child)["/seed.txt"] is _files(ws)["/seed.txt"]
-    assert _files(child)["/b.txt"] is _files(ws)["/b.txt"]
-    await child.execute("echo b2 > /ram/b.txt")
-    assert _files(child)["/b.txt"] != _files(ws)["/b.txt"]
-    assert _files(child)["/seed.txt"] is _files(ws)["/seed.txt"]
+    staged = await ws.fork()
+    assert _files(staged)["/seed.txt"] is _files(ws)["/seed.txt"]
+    assert _files(staged)["/b.txt"] is _files(ws)["/b.txt"]
+    await staged.execute("echo b2 > /ram/b.txt")
+    assert _files(staged)["/b.txt"] != _files(ws)["/b.txt"]
+    assert _files(staged)["/seed.txt"] is _files(ws)["/seed.txt"]
     assert _files(ws)["/b.txt"] == b"bbb\n"
 
 
 @pytest.mark.asyncio
-async def test_fork_grandchild_three_level_isolation():
+async def test_fork_three_level_staged_isolation():
     ws = _ws()
     await ws.execute("echo a > /ram/a.txt")
-    child = await ws.fork()
-    await child.execute("echo b > /ram/b.txt")
-    grand = await child.fork()
+    staged = await ws.fork()
+    await staged.execute("echo b > /ram/b.txt")
+    grand = await staged.fork()
     await grand.execute("echo c > /ram/c.txt")
     assert "/a.txt" in _files(grand) and "/b.txt" in _files(grand)
-    assert "/c.txt" not in _files(child)
+    assert "/c.txt" not in _files(staged)
     assert "/b.txt" not in _files(ws) and "/c.txt" not in _files(ws)
 
 
@@ -200,10 +204,10 @@ async def test_fork_two_siblings_isolated():
 async def test_fork_dirs_isolation_via_mkdir():
     ws = _ws()
     await ws.execute("mkdir /ram/d")
-    child = await ws.fork()
-    await child.execute("mkdir /ram/e")
+    staged = await ws.fork()
+    await staged.execute("mkdir /ram/e")
     assert "/d" in _dirs(ws) and "/e" not in _dirs(ws)
-    assert "/d" in _dirs(child) and "/e" in _dirs(child)
+    assert "/d" in _dirs(staged) and "/e" in _dirs(staged)
 
 
 @pytest.mark.asyncio
@@ -216,35 +220,28 @@ async def test_fork_cross_mount_cp_isolated():
         history=None,
     )
     await ws.execute("echo data > /a/x.txt")
-    child = await ws.fork()
-    await child.execute("cp /a/x.txt /b/y.txt")
-    assert "/y.txt" in _files(child, "/b")
+    staged = await ws.fork()
+    await staged.execute("cp /a/x.txt /b/y.txt")
+    assert "/y.txt" in _files(staged, "/b")
     assert "/y.txt" not in _files(ws, "/b")
 
 
 @pytest.mark.asyncio
-async def test_fork_disk_eager_copy_distinct_root_and_isolated():
+async def test_fork_rejects_disk_mount():
     root = tempfile.mkdtemp(prefix="mirage-test-disk-")
     ws = Workspace({"/disk/": (DiskResource(root=root), MountMode.EXEC)},
                    history=None)
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/disk"
-    await ws.execute("echo parent > /disk/p.txt")
-    child = await ws.fork()
-    proot = Path(ws.mount("/disk").resource.root)
-    croot = Path(child.mount("/disk").resource.root)
-    assert proot != croot
-    await child.execute("echo child > /disk/c.txt")
-    assert not (proot / "c.txt").exists()
-    assert (croot / "p.txt").exists()
+    with pytest.raises(NotImplementedError):
+        await ws.fork()
 
 
 @pytest.mark.asyncio
 async def test_fork_session_env_inherited_then_isolated():
     ws = _ws()
     ws.get_session(DEFAULT_SESSION_ID).env["FOO"] = "bar"
-    child = await ws.fork()
-    assert child.get_session(DEFAULT_SESSION_ID).env.get("FOO") == "bar"
-    child.get_session(DEFAULT_SESSION_ID).env["FOO"] = "baz"
+    staged = await ws.fork()
+    assert staged.get_session(DEFAULT_SESSION_ID).env.get("FOO") == "bar"
+    staged.get_session(DEFAULT_SESSION_ID).env["FOO"] = "baz"
     assert ws.get_session(DEFAULT_SESSION_ID).env["FOO"] == "bar"
 
 
@@ -253,9 +250,9 @@ async def test_fork_nondefault_session_inherited_and_isolated():
     ws = _ws()
     sess = ws.create_session("work")
     sess.env["K"] = "v"
-    child = await ws.fork()
-    assert child.get_session("work").env.get("K") == "v"
-    child.get_session("work").env["K"] = "changed"
+    staged = await ws.fork()
+    assert staged.get_session("work").env.get("K") == "v"
+    staged.get_session("work").env["K"] = "changed"
     assert ws.get_session("work").env["K"] == "v"
 
 
@@ -263,27 +260,94 @@ async def test_fork_nondefault_session_inherited_and_isolated():
 async def test_fork_cache_distinct_and_isolated():
     ws = _ws()
     await ws._cache.set("/seedcache", b"v")
-    child = await ws.fork()
-    assert child._cache is not ws._cache
-    assert await child._cache.get("/seedcache") == b"v"
-    await child._cache.set("/probe", b"x")
+    staged = await ws.fork()
+    assert staged._cache is not ws._cache
+    assert await staged._cache.get("/seedcache") == b"v"
+    await staged._cache.set("/probe", b"x")
     assert await ws._cache.get("/probe") is None
-    await child._cache.remove("/seedcache")
+    await staged._cache.remove("/seedcache")
     assert await ws._cache.get("/seedcache") == b"v"
 
 
 @pytest.mark.asyncio
 async def test_fork_has_isolated_observer():
     ws = _ws()
-    child = await ws.fork()
-    assert child.observer is not ws.observer
-    assert child.observer.resource is not ws.observer.resource
+    staged = await ws.fork()
+    assert staged.observer is not ws.observer
+    assert staged.observer.resource is not ws.observer.resource
 
 
 @pytest.mark.asyncio
-async def test_fork_parent_usable_after_fork_snapshot_at_fork():
+async def test_fork_live_usable_after_fork_snapshot_at_fork():
     ws = _ws()
-    child = await ws.fork()
+    staged = await ws.fork()
     await ws.execute("echo a2 > /ram/post.txt")
     assert "/post.txt" in _files(ws)
-    assert "/post.txt" not in _files(child)
+    assert "/post.txt" not in _files(staged)
+
+
+@pytest.mark.asyncio
+async def test_fork_preserves_command_safeguards():
+    ws = _ws()
+    guard = CommandSafeguard(max_lines=3)
+    ws.mount("/ram").command_safeguards["grep"] = guard
+    staged = await ws.fork()
+    assert staged.mount("/ram").command_safeguards.get("grep") is guard
+    staged.mount("/ram").command_safeguards["cat"] = CommandSafeguard(
+        max_lines=1)
+    assert "cat" not in ws.mount("/ram").command_safeguards
+
+
+@pytest.mark.asyncio
+async def test_fork_rejects_redis_backed_index(monkeypatch):
+    monkeypatch.setattr("mirage.workspace.fork.RedisIndexCacheStore",
+                        _FakeRedisIndex)
+    ws = _ws()
+    ws.mount("/ram").resource._index = _FakeRedisIndex()
+    with pytest.raises(NotImplementedError):
+        await ws.fork()
+
+
+@pytest.mark.asyncio
+async def test_fork_mixed_mounts_ram_isolated_remote_shared():
+    ram = RAMResource()
+    shared = _SharedRAM()
+    ws = Workspace(
+        {
+            "/ram/": (ram, MountMode.EXEC),
+            "/s3/": (shared, MountMode.EXEC),
+        },
+        history=None,
+    )
+    staged = await ws.fork()
+    await staged.execute("echo hi > /ram/a.txt")
+    await staged.execute("echo hi > /s3/r.txt")
+    assert "/a.txt" in _files(staged, "/ram")
+    assert "/a.txt" not in _files(ws, "/ram")
+    assert staged.mount("/s3").resource is shared
+    assert "/r.txt" in shared._store.files
+
+
+@pytest.mark.asyncio
+async def test_fork_copies_revision_pins():
+    ws = _ws()
+    ws.mount("/ram").revisions = {"/seed.txt": "v1"}
+    staged = await ws.fork()
+    assert staged.mount("/ram").revisions == {"/seed.txt": "v1"}
+    staged.mount("/ram").revisions["/seed.txt"] = "v2"
+    assert ws.mount("/ram").revisions["/seed.txt"] == "v1"
+
+
+@pytest.mark.asyncio
+async def test_fork_history_maxlen_preserved():
+    ws = Workspace({"/ram/": (RAMResource(), MountMode.EXEC)}, history=7)
+    staged = await ws.fork()
+    assert staged.history._buffer.maxlen == 7
+
+
+@pytest.mark.asyncio
+async def test_fork_propagates_agent_id():
+    ws = _ws()
+    ws._current_agent_id = "agent-x"
+    staged = await ws.fork()
+    assert staged._current_agent_id == "agent-x"


### PR DESCRIPTION
## Overview

Lands the **F1 fork substrate** for #167 — Phase 0 of the transactional-workspace roadmap (#166). `await ws.fork()` returns an isolated **copy-on-write staged workspace**:

- **RAM mounts + the read/scratch cache** are isolated copy-on-write — they share immutable byte payloads by reference and copy only the lightweight key index, so a write/delete in the staged workspace never touches live (and vice versa).
- **Sessions (cwd/env), history, and revision pins** are copied by value, then diverge independently.
- **Remote backends** (S3, Slack, …) are shared by reference (documented; isolation is a later lane).
- Backends that can't be cheaply forked — **Redis cache/index** and **disk** — fail loud (`NotImplementedError`) rather than silently leak.

This PR is the **isolation primitive only**. There is no commit/abort yet — merging staged changes back (Lane D), disk copy-up (Lane C), remote write-delta (Lane B), and the `stage()` context manager (Lane A) are separate follow-ups. A staged workspace is currently a dead-end isolated copy by design.

> **Terminology:** **live workspace** = the original / source of truth (commit target); **staged workspace** = the copy-on-write fork. `parent`/`child` is reserved for the *agent* hierarchy, since that composes with this (a sub-agent can run in its own staged workspace).

## Detailed changes

**Fork substrate**
- `workspace/fork.py` — `fork_workspace()` orchestration: builds the staged workspace via `type(ws)(...)` (never imports `Workspace`, avoiding an import cycle); `_assert_forkable()` guard; copies sessions / history / revision pins by value.
- `workspace/workspace.py` — `Workspace.fork()` + the `_cache_store` constructor seam (lets fork inject a pre-forked cache instead of building a fresh one).
- Per-backend `.fork()`:
  - `resource/ram/store.py`, `resource/ram/ram.py` — RAM copy-on-write (copy the key index, share the byte values).
  - `cache/file/ram.py` — `RAMFileCacheStore` CoW (own LRU metadata + size counter; fresh drain tasks / per-key locks).
  - `resource/base.py` — `BaseResource.fork()` share-by-reference default (live remotes).
  - `cache/file/redis.py` — `RedisFileCacheStore.fork()` raises `NotImplementedError` (out-of-process state can't be cheaply forked).

**Fixes & scope decisions in this PR**
- **`command_safeguards` now propagate through fork.** `_fork_resources` carries `dict(m.command_safeguards)` as the mount tuple's 3rd element, so a staged workspace inherits each mount's per-command safeguards (timeouts/overrides) instead of silently dropping them. This reconciles fork with the merged PR #103, which post-dated the original fork WIP — the gap was that safeguards live on the `Mount`, not the resource, and fork only re-passed `(resource, mode)`.
- **Disk deferred to Lane C (#178).** `DiskResource.fork()` now raises `NotImplementedError` instead of the WIP's eager full-tree copy (which the ticket explicitly scopes out). Forking a disk-mounted workspace fails loud rather than silently leaking writes to the live directory. Removed the now-unused `tempfile` import.
- **live/staged terminology** swept across the fork code and tests.

## Tests

Fork test suite grows **33 → 39** across `tests/workspace/test_fork.py`, `tests/resource/test_ram_fork.py`, `tests/cache/file/test_fork.py`.

Retained coverage: both-direction RAM isolation, CoW byte-sharing granularity (`is` vs `!=`), overwrite / delete / append of inherited files, 3-level nesting, two-sibling independence, session cwd + env, history divergence, cache distinctness, isolated observer, closed-workspace guard, Redis-**cache** rejection, plus store/resource/cache unit tests.

New tests added:
- `test_fork_preserves_command_safeguards` — safeguards survive fork (covers the fix above)
- `test_fork_rejects_redis_backed_index` — the previously-**untested** `_assert_forkable` Redis-index branch
- `test_fork_mixed_mounts_ram_isolated_remote_shared` — RAM isolated *and* remote shared in one fork
- `test_fork_copies_revision_pins` — revision pins copied, then diverge
- `test_fork_history_maxlen_preserved`, `test_fork_propagates_agent_id`
- `test_fork_rejects_disk_mount` — replaces the out-of-scope eager-copy test

**Results**
- Fork suite: **39 passed**. `command_safeguards` suite: **59 passed** (DoD "stay green") → **98 passed** combined.
- `pre-commit run --all-files`: all **Python** hooks pass. (The TS hooks fail only with `pnpm: not found` in this environment; no TypeScript files are changed.)
- Full Python suite: green except **environmental-only** failures unrelated to this change — `tests/fuse/*` can't `dlopen` `libosxfuse` on arm64; `test_tac.py` compares against the GNU `tac` binary (absent on macOS — `which tac` → missing); one Redis test needs a running `redis-server`. Excluding exactly those, the suite runs to 100% with **0 failures / 0 errors**.

## Definition of Done (#167)
- [x] `uv run python -c "import mirage.workspace.fork"` succeeds
- [x] `await ws.fork()` returns a staged workspace; a RAM write in staged does **not** change live (and vice-versa) — tested
- [x] forking a workspace whose cache **or index** is Redis-backed raises a clear `NotImplementedError` — tested
- [x] the fork tests pass (39) **and** the existing `command_safeguards` tests stay green (59)
- [x] `pre-commit` clean (Python) and the relevant tests green

## Out of scope / follow-ups
- Disk copy-up overlay → **Lane C (#178)**; remote write-delta → **Lane B**; commit/abort → **Lane D**; `stage()` context manager → **Lane A**.
- Roadmap / issue `Branch` → `stage` naming reconciliation is deferred (those are unbuilt planning artifacts).

Closes #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
