### PR TITLE
fix(commands): unify cp/mv multi-source handling across backends

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -418,11 +418,20 @@ CASES: list[tuple[str, str]] = [
     ("sort_stdin", "cat /data/dup.txt | sort"),
     ("rev_stdin", "echo hello | rev"),
     ("base64_stdin_d", "echo aGVsbG8= | base64 -d"),
+
+    # ----- cp / mv multi-source into a directory (last; these mutate) -----
+    ("cp_multi_into_dir", "cp /data/a.txt /data/b.txt /data/sub"),
+    ("cp_multi_verify_a", "cat /data/sub/a.txt"),
+    ("cp_multi_verify_b", "cat /data/sub/b.txt"),
+    ("mv_multi_into_dir", "mv /data/sub/a.txt /data/sub/b.txt /data/sub/deep"),
+    ("mv_multi_verify_a", "cat /data/sub/deep/a.txt"),
+    ("mv_multi_verify_b", "cat /data/sub/deep/b.txt"),
 ]
 
 EXIT_CODE_CASES: list[tuple[str, str]] = [
     ("lazy_exit_grep_match", "grep hello /data/a.txt"),
     ("lazy_exit_grep_no_match", "grep zzz /data/a.txt"),
+    ("cp_reject_multi_nondir", "cp /data/a.txt /data/b.txt /data/c.txt"),
 ]
 
 

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -1122,8 +1122,34 @@ c
 olleh
 === base64_stdin_d ===
 hello
+=== cp_multi_into_dir ===
+
+=== cp_multi_verify_a ===
+hello
+world
+foo
+bar
+baz
+=== cp_multi_verify_b ===
+1
+2
+3
+=== mv_multi_into_dir ===
+
+=== mv_multi_verify_a ===
+hello
+world
+foo
+bar
+baz
+=== mv_multi_verify_b ===
+1
+2
+3
 === lazy_exit_grep_match ===
 exit=0
 hello
 === lazy_exit_grep_no_match ===
+exit=1
+=== cp_reject_multi_nondir ===
 exit=1

--- a/python/mirage/commands/builtin/databricks_volume/_helpers.py
+++ b/python/mirage/commands/builtin/databricks_volume/_helpers.py
@@ -21,9 +21,8 @@ from mirage.commands.builtin.utils.wrap import (call_read_bytes,
                                                 call_read_stream)
 from mirage.core.databricks_volume.path import backend_path
 from mirage.core.databricks_volume.read import read_bytes as _read_bytes
-from mirage.core.databricks_volume.stat import stat as _stat
 from mirage.core.databricks_volume.stream import read_stream as _read_stream
-from mirage.types import FileType, PathSpec
+from mirage.types import PathSpec
 
 
 def path_prefix(paths: list[PathSpec],
@@ -33,31 +32,6 @@ def path_prefix(paths: list[PathSpec],
     if fallback is not None:
         return fallback.prefix
     return ""
-
-
-async def is_directory(accessor: DatabricksVolumeAccessor,
-                       path: PathSpec,
-                       index: IndexCacheStore | None = None) -> bool:
-    try:
-        file_stat = await _stat(accessor, path, index)
-    except FileNotFoundError:
-        return False
-    return file_stat.type == FileType.DIRECTORY
-
-
-async def path_exists(accessor: DatabricksVolumeAccessor,
-                      path: PathSpec,
-                      index: IndexCacheStore | None = None) -> bool:
-    try:
-        await _stat(accessor, path, index)
-    except FileNotFoundError:
-        return False
-    return True
-
-
-def child_path(parent: PathSpec, name: str) -> PathSpec:
-    base = parent.original.rstrip("/")
-    return PathSpec.from_str_path(f"{base}/{name}", parent.prefix)
 
 
 def same_backend_file(accessor: DatabricksVolumeAccessor, a: PathSpec,

--- a/python/mirage/commands/builtin/databricks_volume/cp.py
+++ b/python/mirage/commands/builtin/databricks_volume/cp.py
@@ -12,14 +12,19 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.databricks_volume._helpers import (
-    child_path, is_directory, path_exists, same_backend_file)
+from mirage.commands.builtin.databricks_volume._helpers import \
+    same_backend_file
+from mirage.commands.builtin.utils.copy import (copy_targets, is_directory,
+                                                path_exists)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.copy import copy as copy_core
 from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.stat import stat as stat_core
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -43,24 +48,18 @@ async def cp(
         raise ValueError("cp: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
     recursive = r or R or a
+    stat = partial(stat_core, accessor)
     *sources, dst = paths
-    dst_is_dir = await is_directory(accessor, dst, index)
-    # POSIX multi-source form requires the final operand to be a directory.
-    if len(sources) > 1 and not dst_is_dir:
-        raise NotADirectoryError(f"target '{dst.original}' is not a directory")
+    dst_is_dir = await is_directory(stat, dst, index)
     writes: dict[str, bytes] = {}
     lines: list[str] = []
     errors: list[str] = []
-    for src in sources:
-        target = dst
-        if dst_is_dir:
-            name = src.strip_prefix.rstrip("/").rsplit("/", 1)[-1]
-            target = child_path(dst, name)
+    for src, target in copy_targets(sources, dst, dst_is_dir):
         if same_backend_file(accessor, src, target):
             errors.append(f"cp: '{src.original}' and '{target.original}' "
                           "are the same file")
             continue
-        if n and await path_exists(accessor, target, index):
+        if n and await path_exists(stat, target):
             continue
         await copy_core(accessor, src, target, index, recursive=recursive)
         writes[target.strip_prefix] = b""

--- a/python/mirage/commands/builtin/databricks_volume/mv.py
+++ b/python/mirage/commands/builtin/databricks_volume/mv.py
@@ -12,14 +12,19 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.databricks_volume._helpers import (
-    child_path, is_directory, path_exists, same_backend_file)
+from mirage.commands.builtin.databricks_volume._helpers import \
+    same_backend_file
+from mirage.commands.builtin.utils.copy import (copy_targets, is_directory,
+                                                path_exists)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
 from mirage.core.databricks_volume.rename import rename as rename_core
+from mirage.core.databricks_volume.stat import stat as stat_core
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -39,24 +44,18 @@ async def mv(
     if len(paths) < 2:
         raise ValueError("mv: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
+    stat = partial(stat_core, accessor)
     *sources, dst = paths
-    dst_is_dir = await is_directory(accessor, dst, index)
-    # POSIX multi-source form requires the final operand to be a directory.
-    if len(sources) > 1 and not dst_is_dir:
-        raise NotADirectoryError(f"target '{dst.original}' is not a directory")
+    dst_is_dir = await is_directory(stat, dst, index)
     writes: dict[str, bytes] = {}
     lines: list[str] = []
     errors: list[str] = []
-    for src in sources:
-        target = dst
-        if dst_is_dir:
-            name = src.strip_prefix.rstrip("/").rsplit("/", 1)[-1]
-            target = child_path(dst, name)
+    for src, target in copy_targets(sources, dst, dst_is_dir):
         if same_backend_file(accessor, src, target):
             errors.append(f"mv: '{src.original}' and '{target.original}' "
                           "are the same file")
             continue
-        if n and await path_exists(accessor, target, index):
+        if n and await path_exists(stat, target):
             continue
         await rename_core(accessor, src, target, index)
         writes[src.strip_prefix] = b""

--- a/python/mirage/commands/builtin/disk/cp.py
+++ b/python/mirage/commands/builtin/disk/cp.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.disk import DiskAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cp import cp as generic_cp
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.disk.copy import copy
@@ -22,14 +25,6 @@ from mirage.core.disk.glob import resolve_glob
 from mirage.core.disk.stat import stat as stat_impl
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _exists(accessor: DiskAccessor, path: PathSpec | str) -> bool:
-    try:
-        await stat_impl(accessor, path)
-        return True
-    except (FileNotFoundError, ValueError):
-        return False
 
 
 @command("cp", resource="disk", spec=SPECS["cp"], write=True)
@@ -50,25 +45,12 @@ async def cp(
     if accessor.root is None or len(paths) < 2:
         raise ValueError("cp: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
-    recursive = r or R or a
-    verbose_lines: list[str] = []
-    if recursive:
-        src_base = paths[0].strip_prefix.rstrip("/")
-        entries = await find_impl(accessor, paths[0], type="file")
-        for entry in entries:
-            rel = entry[len(src_base):]
-            dst = paths[1].strip_prefix.rstrip("/") + rel
-            if n and await _exists(accessor, dst):
-                continue
-            await copy(accessor, entry, dst)
-            if v:
-                verbose_lines.append(f"{entry} -> {dst}")
-        output = "\n".join(verbose_lines) + "\n" if verbose_lines else None
-        return output.encode() if output else None, IOResult()
-    if n and await _exists(accessor, paths[1]):
-        return None, IOResult()
-    await copy(accessor, paths[0], paths[1])
-    output = None
-    if v:
-        output = f"{paths[0].original} -> {paths[1].original}\n".encode()
-    return output, IOResult(writes={paths[1].original: b""})
+    return await generic_cp(paths,
+                            copy=partial(copy, accessor),
+                            find=partial(find_impl, accessor),
+                            find_type="file",
+                            stat=partial(stat_impl, accessor),
+                            recursive=r or R or a,
+                            n=n,
+                            v=v,
+                            index=index)

--- a/python/mirage/commands/builtin/disk/mv.py
+++ b/python/mirage/commands/builtin/disk/mv.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.disk import DiskAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.mv import mv as generic_mv
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.disk.glob import resolve_glob
@@ -21,14 +24,6 @@ from mirage.core.disk.rename import rename
 from mirage.core.disk.stat import stat as stat_impl
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _exists(accessor: DiskAccessor, path: PathSpec | str) -> bool:
-    try:
-        await stat_impl(accessor, path)
-        return True
-    except (FileNotFoundError, ValueError):
-        return False
 
 
 @command("mv", resource="disk", spec=SPECS["mv"], write=True)
@@ -46,10 +41,9 @@ async def mv(
     if accessor.root is None or len(paths) < 2:
         raise ValueError("mv: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
-    if n and await _exists(accessor, paths[1]):
-        return None, IOResult()
-    await rename(accessor, paths[0], paths[1])
-    output = None
-    if v:
-        output = f"'{paths[0].original}' -> '{paths[1].original}'\n".encode()
-    return output, IOResult()
+    return await generic_mv(paths,
+                            rename=partial(rename, accessor),
+                            stat=partial(stat_impl, accessor),
+                            n=n,
+                            v=v,
+                            index=index)

--- a/python/mirage/commands/builtin/generic/cp.py
+++ b/python/mirage/commands/builtin/generic/cp.py
@@ -1,0 +1,76 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from typing import Awaitable, Callable
+
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.copy import (copy_targets, is_directory,
+                                                path_exists)
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+async def cp(
+    paths: list[PathSpec],
+    *,
+    copy: Callable[..., Awaitable[None]],
+    find: Callable[..., Awaitable[list[str]]],
+    find_type: str,
+    stat: Callable[..., Awaitable[object]],
+    recursive: bool,
+    n: bool,
+    v: bool,
+    index: IndexCacheStore | None = None,
+) -> tuple[ByteSource | None, IOResult]:
+    """Copy sources to a destination, fanning out into a directory.
+
+    Args:
+        paths (list[PathSpec]): Source operands followed by the destination.
+        copy (Callable): Copies a single source to a target.
+        find (Callable): Lists files beneath a directory for ``recursive``.
+        find_type (str): File-type selector passed to ``find``.
+        stat (Callable): Stats a path; raises when missing.
+        recursive (bool): Whether to copy directories recursively.
+        n (bool): No-clobber; skip targets that already exist.
+        v (bool): Verbose; emit one ``src -> target`` line per write.
+        index (IndexCacheStore | None): Cache for the destination dir probe.
+
+    Returns:
+        tuple[ByteSource | None, IOResult]: Verbose output and recorded writes.
+    """
+    *sources, dst = paths
+    dst_is_dir = await is_directory(stat, dst, index)
+    writes: dict[str, bytes] = {}
+    lines: list[str] = []
+    for src, target in copy_targets(sources, dst, dst_is_dir):
+        if recursive:
+            src_base = src.strip_prefix.rstrip("/")
+            dst_base = target.strip_prefix.rstrip("/")
+            for entry in await find(src, type=find_type):
+                entry_dst = dst_base + entry[len(src_base):]
+                if n and await path_exists(stat, entry_dst):
+                    continue
+                await copy(entry, entry_dst)
+                writes[entry_dst] = b""
+                if v:
+                    lines.append(f"{entry} -> {entry_dst}")
+            continue
+        if n and await path_exists(stat, target):
+            continue
+        await copy(src, target)
+        writes[target.strip_prefix] = b""
+        if v:
+            lines.append(f"{src.original} -> {target.original}")
+    output = "\n".join(lines) + "\n" if lines else None
+    return output.encode() if output else None, IOResult(writes=writes)

--- a/python/mirage/commands/builtin/generic/mv.py
+++ b/python/mirage/commands/builtin/generic/mv.py
@@ -1,0 +1,59 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from typing import Awaitable, Callable
+
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.utils.copy import (copy_targets, is_directory,
+                                                path_exists)
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+async def mv(
+    paths: list[PathSpec],
+    *,
+    rename: Callable[..., Awaitable[None]],
+    stat: Callable[..., Awaitable[object]],
+    n: bool,
+    v: bool,
+    index: IndexCacheStore | None = None,
+) -> tuple[ByteSource | None, IOResult]:
+    """Move sources to a destination, fanning out into a directory.
+
+    Args:
+        paths (list[PathSpec]): Source operands followed by the destination.
+        rename (Callable): Renames a single source to a target.
+        stat (Callable): Stats a path; raises when missing.
+        n (bool): No-clobber; skip targets that already exist.
+        v (bool): Verbose; emit one ``src -> target`` line per move.
+        index (IndexCacheStore | None): Cache for the destination dir probe.
+
+    Returns:
+        tuple[ByteSource | None, IOResult]: Verbose output and recorded writes.
+    """
+    *sources, dst = paths
+    dst_is_dir = await is_directory(stat, dst, index)
+    writes: dict[str, bytes] = {}
+    lines: list[str] = []
+    for src, target in copy_targets(sources, dst, dst_is_dir):
+        if n and await path_exists(stat, target):
+            continue
+        await rename(src, target)
+        writes[src.strip_prefix] = b""
+        writes[target.strip_prefix] = b""
+        if v:
+            lines.append(f"'{src.original}' -> '{target.original}'")
+    output = "\n".join(lines) + "\n" if lines else None
+    return output.encode() if output else None, IOResult(writes=writes)

--- a/python/mirage/commands/builtin/nextcloud/cp.py
+++ b/python/mirage/commands/builtin/nextcloud/cp.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cp import cp as generic_cp
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.nextcloud.copy import copy
@@ -22,14 +25,6 @@ from mirage.core.nextcloud.glob import resolve_glob
 from mirage.core.nextcloud.stat import stat as stat_impl
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _exists(accessor: NextcloudAccessor, path: PathSpec | str) -> bool:
-    try:
-        await stat_impl(accessor, path)
-        return True
-    except (FileNotFoundError, ValueError, Exception):
-        return False
 
 
 @command("cp", resource="nextcloud", spec=SPECS["cp"], write=True)
@@ -50,27 +45,12 @@ async def cp(
     if len(paths) < 2:
         raise ValueError("cp: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
-    recursive = r or R or a
-    verbose_lines: list[str] = []
-    if recursive:
-        src_base = paths[0].strip_prefix.rstrip("/")
-        dst_base = paths[1].strip_prefix.rstrip("/")
-        entries = await find_impl(accessor, paths[0], type="f")
-        for entry in entries:
-            rel = entry[len(src_base):]
-            dst = dst_base + rel
-            if n and await _exists(accessor, dst):
-                continue
-            await copy(accessor, entry, dst)
-            if v:
-                verbose_lines.append(f"{entry} -> {dst}")
-        writes = {dst_base + entry[len(src_base):]: b"" for entry in entries}
-        output = "\n".join(verbose_lines) + "\n" if verbose_lines else None
-        return output.encode() if output else None, IOResult(writes=writes)
-    if n and await _exists(accessor, paths[1]):
-        return None, IOResult()
-    await copy(accessor, paths[0], paths[1])
-    output = None
-    if v:
-        output = f"{paths[0].original} -> {paths[1].original}\n".encode()
-    return output, IOResult(writes={paths[1].original: b""})
+    return await generic_cp(paths,
+                            copy=partial(copy, accessor),
+                            find=partial(find_impl, accessor),
+                            find_type="f",
+                            stat=partial(stat_impl, accessor),
+                            recursive=r or R or a,
+                            n=n,
+                            v=v,
+                            index=index)

--- a/python/mirage/commands/builtin/nextcloud/mv.py
+++ b/python/mirage/commands/builtin/nextcloud/mv.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.nextcloud import NextcloudAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.mv import mv as generic_mv
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.nextcloud.glob import resolve_glob
@@ -21,14 +24,6 @@ from mirage.core.nextcloud.rename import rename
 from mirage.core.nextcloud.stat import stat as stat_impl
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _exists(accessor: NextcloudAccessor, path: PathSpec | str) -> bool:
-    try:
-        await stat_impl(accessor, path)
-        return True
-    except (FileNotFoundError, ValueError, Exception):
-        return False
 
 
 @command("mv", resource="nextcloud", spec=SPECS["mv"], write=True)
@@ -46,14 +41,9 @@ async def mv(
     if len(paths) < 2:
         raise ValueError("mv: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
-    if n and await _exists(accessor, paths[1]):
-        return None, IOResult()
-    await rename(accessor, paths[0], paths[1])
-    writes = {
-        paths[0].original: b"",
-        paths[1].original: b"",
-    }
-    output = None
-    if v:
-        output = f"'{paths[0].original}' -> '{paths[1].original}'\n".encode()
-    return output, IOResult(writes=writes)
+    return await generic_mv(paths,
+                            rename=partial(rename, accessor),
+                            stat=partial(stat_impl, accessor),
+                            n=n,
+                            v=v,
+                            index=index)

--- a/python/mirage/commands/builtin/ram/cp.py
+++ b/python/mirage/commands/builtin/ram/cp.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cp import cp as generic_cp
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.ram.copy import copy
@@ -22,14 +25,6 @@ from mirage.core.ram.glob import resolve_glob
 from mirage.core.ram.stat import stat as stat_core
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _exists(accessor: RAMAccessor, path: str) -> bool:
-    try:
-        await stat_core(accessor, path)
-        return True
-    except (FileNotFoundError, ValueError):
-        return False
 
 
 @command("cp", resource="ram", spec=SPECS["cp"], write=True)
@@ -50,26 +45,12 @@ async def cp(
     if accessor.store is None or len(paths) < 2:
         raise ValueError("cp: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
-    recursive = r or R or a
-    verbose_lines: list[str] = []
-    if recursive:
-        src_base = paths[0].strip_prefix.rstrip("/")
-        dst_base = paths[1].strip_prefix.rstrip("/")
-        entries = await find_core(accessor, paths[0], type="f")
-        for entry in entries:
-            rel = entry[len(src_base):]
-            dst = dst_base + rel
-            if n and await _exists(accessor, dst):
-                continue
-            await copy(accessor, entry, dst)
-            if v:
-                verbose_lines.append(f"{entry} -> {dst}")
-        output = "\n".join(verbose_lines) + "\n" if verbose_lines else None
-        return output.encode() if output else None, IOResult()
-    if n and await _exists(accessor, paths[1]):
-        return None, IOResult()
-    await copy(accessor, paths[0], paths[1])
-    output = None
-    if v:
-        output = f"{paths[0].original} -> {paths[1].original}\n".encode()
-    return output, IOResult(writes={paths[1].original: b""})
+    return await generic_cp(paths,
+                            copy=partial(copy, accessor),
+                            find=partial(find_core, accessor),
+                            find_type="f",
+                            stat=partial(stat_core, accessor),
+                            recursive=r or R or a,
+                            n=n,
+                            v=v,
+                            index=index)

--- a/python/mirage/commands/builtin/ram/mv.py
+++ b/python/mirage/commands/builtin/ram/mv.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.mv import mv as generic_mv
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.ram.glob import resolve_glob
@@ -21,14 +24,6 @@ from mirage.core.ram.rename import rename
 from mirage.core.ram.stat import stat as stat_core
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _exists(accessor: RAMAccessor, path: str) -> bool:
-    try:
-        await stat_core(accessor, path)
-        return True
-    except (FileNotFoundError, ValueError):
-        return False
 
 
 @command("mv", resource="ram", spec=SPECS["mv"], write=True)
@@ -46,10 +41,9 @@ async def mv(
     if accessor.store is None or len(paths) < 2:
         raise ValueError("mv: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
-    if n and await _exists(accessor, paths[1]):
-        return None, IOResult()
-    await rename(accessor, paths[0], paths[1])
-    output = None
-    if v:
-        output = f"'{paths[0].original}' -> '{paths[1].original}'\n".encode()
-    return output, IOResult()
+    return await generic_mv(paths,
+                            rename=partial(rename, accessor),
+                            stat=partial(stat_core, accessor),
+                            n=n,
+                            v=v,
+                            index=index)

--- a/python/mirage/commands/builtin/redis/cp.py
+++ b/python/mirage/commands/builtin/redis/cp.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.redis import RedisAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cp import cp as generic_cp
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.redis.copy import copy
@@ -22,14 +25,6 @@ from mirage.core.redis.glob import resolve_glob
 from mirage.core.redis.stat import stat as stat_core
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _exists(accessor: RedisAccessor, path: str) -> bool:
-    try:
-        await stat_core(accessor, path)
-        return True
-    except (FileNotFoundError, ValueError):
-        return False
 
 
 @command("cp", resource="redis", spec=SPECS["cp"], write=True)
@@ -50,26 +45,12 @@ async def cp(
     if accessor.store is None or len(paths) < 2:
         raise ValueError("cp: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
-    recursive = r or R or a
-    verbose_lines: list[str] = []
-    if recursive:
-        src_base = paths[0].strip_prefix.rstrip("/")
-        dst_base = paths[1].strip_prefix.rstrip("/")
-        entries = await find_core(accessor, paths[0], type="f")
-        for entry in entries:
-            rel = entry[len(src_base):]
-            dst = dst_base + rel
-            if n and await _exists(accessor, dst):
-                continue
-            await copy(accessor, entry, dst)
-            if v:
-                verbose_lines.append(f"{entry} -> {dst}")
-        output = "\n".join(verbose_lines) + "\n" if verbose_lines else None
-        return output.encode() if output else None, IOResult()
-    if n and await _exists(accessor, paths[1]):
-        return None, IOResult()
-    await copy(accessor, paths[0], paths[1])
-    output = None
-    if v:
-        output = f"{paths[0].original} -> {paths[1].original}\n".encode()
-    return output, IOResult(writes={paths[1].original: b""})
+    return await generic_cp(paths,
+                            copy=partial(copy, accessor),
+                            find=partial(find_core, accessor),
+                            find_type="f",
+                            stat=partial(stat_core, accessor),
+                            recursive=r or R or a,
+                            n=n,
+                            v=v,
+                            index=index)

--- a/python/mirage/commands/builtin/redis/mv.py
+++ b/python/mirage/commands/builtin/redis/mv.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.redis import RedisAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.mv import mv as generic_mv
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.redis.glob import resolve_glob
@@ -21,14 +24,6 @@ from mirage.core.redis.rename import rename
 from mirage.core.redis.stat import stat as stat_core
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _exists(accessor: RedisAccessor, path: str) -> bool:
-    try:
-        await stat_core(accessor, path)
-        return True
-    except (FileNotFoundError, ValueError):
-        return False
 
 
 @command("mv", resource="redis", spec=SPECS["mv"], write=True)
@@ -46,10 +41,9 @@ async def mv(
     if accessor.store is None or len(paths) < 2:
         raise ValueError("mv: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
-    if n and await _exists(accessor, paths[1]):
-        return None, IOResult()
-    await rename(accessor, paths[0], paths[1])
-    output = None
-    if v:
-        output = f"'{paths[0].original}' -> '{paths[1].original}'\n".encode()
-    return output, IOResult()
+    return await generic_mv(paths,
+                            rename=partial(rename, accessor),
+                            stat=partial(stat_core, accessor),
+                            n=n,
+                            v=v,
+                            index=index)

--- a/python/mirage/commands/builtin/s3/cp.py
+++ b/python/mirage/commands/builtin/s3/cp.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cp import cp as generic_cp
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.s3.copy import copy
@@ -22,14 +25,6 @@ from mirage.core.s3.glob import resolve_glob
 from mirage.core.s3.stat import stat as stat_impl
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _exists(accessor: S3Accessor, path: PathSpec | str) -> bool:
-    try:
-        await stat_impl(accessor, path)
-        return True
-    except (FileNotFoundError, ValueError, Exception):
-        return False
 
 
 @command("cp", resource="s3", spec=SPECS["cp"], write=True)
@@ -50,27 +45,12 @@ async def cp(
     if len(paths) < 2:
         raise ValueError("cp: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
-    recursive = r or R or a
-    verbose_lines: list[str] = []
-    if recursive:
-        src_base = paths[0].strip_prefix.rstrip("/")
-        dst_base = paths[1].strip_prefix.rstrip("/")
-        entries = await find_impl(accessor, paths[0], type="f")
-        for entry in entries:
-            rel = entry[len(src_base):]
-            dst = dst_base + rel
-            if n and await _exists(accessor, dst):
-                continue
-            await copy(accessor, entry, dst)
-            if v:
-                verbose_lines.append(f"{entry} -> {dst}")
-        writes = {dst_base + entry[len(src_base):]: b"" for entry in entries}
-        output = "\n".join(verbose_lines) + "\n" if verbose_lines else None
-        return output.encode() if output else None, IOResult(writes=writes)
-    if n and await _exists(accessor, paths[1]):
-        return None, IOResult()
-    await copy(accessor, paths[0], paths[1])
-    output = None
-    if v:
-        output = f"{paths[0].original} -> {paths[1].original}\n".encode()
-    return output, IOResult(writes={paths[1].original: b""})
+    return await generic_cp(paths,
+                            copy=partial(copy, accessor),
+                            find=partial(find_impl, accessor),
+                            find_type="f",
+                            stat=partial(stat_impl, accessor),
+                            recursive=r or R or a,
+                            n=n,
+                            v=v,
+                            index=index)

--- a/python/mirage/commands/builtin/s3/mv.py
+++ b/python/mirage/commands/builtin/s3/mv.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.mv import mv as generic_mv
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.s3.glob import resolve_glob
@@ -21,14 +24,6 @@ from mirage.core.s3.rename import rename
 from mirage.core.s3.stat import stat as stat_impl
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _exists(accessor: S3Accessor, path: PathSpec | str) -> bool:
-    try:
-        await stat_impl(accessor, path)
-        return True
-    except (FileNotFoundError, ValueError, Exception):
-        return False
 
 
 @command("mv", resource="s3", spec=SPECS["mv"], write=True)
@@ -46,14 +41,9 @@ async def mv(
     if len(paths) < 2:
         raise ValueError("mv: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
-    if n and await _exists(accessor, paths[1]):
-        return None, IOResult()
-    await rename(accessor, paths[0], paths[1])
-    writes = {
-        paths[0].original: b"",
-        paths[1].original: b"",
-    }
-    output = None
-    if v:
-        output = f"'{paths[0].original}' -> '{paths[1].original}'\n".encode()
-    return output, IOResult(writes=writes)
+    return await generic_mv(paths,
+                            rename=partial(rename, accessor),
+                            stat=partial(stat_impl, accessor),
+                            n=n,
+                            v=v,
+                            index=index)

--- a/python/mirage/commands/builtin/ssh/cp.py
+++ b/python/mirage/commands/builtin/ssh/cp.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.ssh import SSHAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cp import cp as generic_cp
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.ssh.copy import copy
@@ -22,14 +25,6 @@ from mirage.core.ssh.glob import resolve_glob
 from mirage.core.ssh.stat import stat as stat_impl
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _exists(accessor: SSHAccessor, path: PathSpec | str) -> bool:
-    try:
-        await stat_impl(accessor, path)
-        return True
-    except (FileNotFoundError, ValueError, Exception):
-        return False
 
 
 @command("cp", resource="ssh", spec=SPECS["cp"], write=True)
@@ -50,26 +45,12 @@ async def cp(
     if len(paths) < 2:
         raise ValueError("cp: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
-    recursive = r or R or a
-    verbose_lines: list[str] = []
-    if recursive:
-        src_base = paths[0].strip_prefix.rstrip("/")
-        dst_base = paths[1].strip_prefix.rstrip("/")
-        entries = await find_impl(accessor, paths[0], type="f")
-        for entry in entries:
-            rel = entry[len(src_base):]
-            dst = dst_base + rel
-            if n and await _exists(accessor, dst):
-                continue
-            await copy(accessor, entry, dst)
-            if v:
-                verbose_lines.append(f"{entry} -> {dst}")
-        output = "\n".join(verbose_lines) + "\n" if verbose_lines else None
-        return output.encode() if output else None, IOResult()
-    if n and await _exists(accessor, paths[1]):
-        return None, IOResult()
-    await copy(accessor, paths[0], paths[1])
-    output = None
-    if v:
-        output = f"{paths[0].original} -> {paths[1].original}\n".encode()
-    return output, IOResult(writes={paths[1].strip_prefix: b""})
+    return await generic_cp(paths,
+                            copy=partial(copy, accessor),
+                            find=partial(find_impl, accessor),
+                            find_type="f",
+                            stat=partial(stat_impl, accessor),
+                            recursive=r or R or a,
+                            n=n,
+                            v=v,
+                            index=index)

--- a/python/mirage/commands/builtin/ssh/mv.py
+++ b/python/mirage/commands/builtin/ssh/mv.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.ssh import SSHAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.mv import mv as generic_mv
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.ssh.glob import resolve_glob
@@ -21,14 +24,6 @@ from mirage.core.ssh.rename import rename
 from mirage.core.ssh.stat import stat as stat_impl
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _exists(accessor: SSHAccessor, path: PathSpec | str) -> bool:
-    try:
-        await stat_impl(accessor, path)
-        return True
-    except (FileNotFoundError, ValueError, Exception):
-        return False
 
 
 @command("mv", resource="ssh", spec=SPECS["mv"], write=True)
@@ -46,14 +41,9 @@ async def mv(
     if len(paths) < 2:
         raise ValueError("mv: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
-    if n and await _exists(accessor, paths[1]):
-        return None, IOResult()
-    await rename(accessor, paths[0], paths[1])
-    output = None
-    if v:
-        output = f"'{paths[0].original}' -> '{paths[1].original}'\n".encode()
-    writes = {
-        paths[0].strip_prefix: b"",
-        paths[1].strip_prefix: b"",
-    }
-    return output, IOResult(writes=writes)
+    return await generic_mv(paths,
+                            rename=partial(rename, accessor),
+                            stat=partial(stat_impl, accessor),
+                            n=n,
+                            v=v,
+                            index=index)

--- a/python/mirage/commands/builtin/utils/copy.py
+++ b/python/mirage/commands/builtin/utils/copy.py
@@ -1,0 +1,75 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from typing import Awaitable, Callable
+
+from mirage.cache.index import IndexCacheStore
+from mirage.types import FileType, PathSpec
+
+_SWALLOW = (FileNotFoundError, ValueError)
+
+StatFn = Callable[..., Awaitable[object]]
+
+
+def child_path(parent: PathSpec, name: str) -> PathSpec:
+    base = parent.original.rstrip("/")
+    return PathSpec.from_str_path(f"{base}/{name}", parent.prefix)
+
+
+def copy_targets(sources: list[PathSpec], dst: PathSpec,
+                 dst_is_dir: bool) -> list[tuple[PathSpec, PathSpec]]:
+    """Map copy or move sources to their destination paths.
+
+    Follows POSIX operand semantics: when the destination is an existing
+    directory each source maps to ``destination/basename``; otherwise a
+    single source maps directly to the destination. Multiple sources require
+    the directory form.
+
+    Args:
+        sources (list[PathSpec]): Source operands.
+        dst (PathSpec): Final operand, the destination.
+        dst_is_dir (bool): Whether the destination is an existing directory.
+
+    Returns:
+        list[tuple[PathSpec, PathSpec]]: Source-to-target pairs.
+    """
+    if len(sources) > 1 and not dst_is_dir:
+        raise NotADirectoryError(f"target '{dst.original}' is not a directory")
+    if not dst_is_dir:
+        return [(sources[0], dst)]
+    pairs: list[tuple[PathSpec, PathSpec]] = []
+    for src in sources:
+        name = src.strip_prefix.rstrip("/").rsplit("/", 1)[-1]
+        pairs.append((src, child_path(dst, name)))
+    return pairs
+
+
+async def path_exists(stat: StatFn, path: PathSpec | str) -> bool:
+    # No index: a no-clobber probe must see targets written earlier in the
+    # same command (duplicate basenames), which the cache does not reflect.
+    try:
+        await stat(path)
+    except _SWALLOW:
+        return False
+    return True
+
+
+async def is_directory(stat: StatFn,
+                       path: PathSpec | str,
+                       index: IndexCacheStore | None = None) -> bool:
+    try:
+        info = await stat(path, index)
+    except _SWALLOW:
+        return False
+    return info.type == FileType.DIRECTORY

--- a/python/tests/commands/builtin/generic/test_cp.py
+++ b/python/tests/commands/builtin/generic/test_cp.py
@@ -1,0 +1,132 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.commands.builtin.generic.cp import cp
+from mirage.types import FileStat, FileType, PathSpec
+
+
+def _spec(path: str) -> PathSpec:
+    return PathSpec(original=path, directory=path)
+
+
+def _key(p) -> str:
+    return (p.original if isinstance(p, PathSpec) else p).rstrip("/")
+
+
+def _make_backend(files: dict[str, bytes], dirs: set[str]):
+
+    async def stat(p, index=None) -> FileStat:
+        k = _key(p)
+        if k in dirs:
+            return FileStat(name=k.rsplit("/", 1)[-1], type=FileType.DIRECTORY)
+        if k in files:
+            return FileStat(name=k.rsplit("/", 1)[-1], type=FileType.TEXT)
+        raise FileNotFoundError(k)
+
+    async def copy(src, dst) -> None:
+        files[_key(dst)] = files[_key(src)]
+
+    async def find(p, type=None) -> list[str]:
+        base = _key(p) + "/"
+        return sorted(k for k in files if k.startswith(base))
+
+    return stat, copy, find
+
+
+async def _run(files, dirs, paths, **kw):
+    stat, copy, find = _make_backend(files, dirs)
+    return await cp([_spec(p) for p in paths],
+                    copy=copy,
+                    find=find,
+                    find_type="f",
+                    stat=stat,
+                    recursive=kw.get("recursive", False),
+                    n=kw.get("n", False),
+                    v=kw.get("v", False))
+
+
+@pytest.mark.asyncio
+async def test_single_source_to_new_path():
+    files = {"/a.txt": b"AAA"}
+    await _run(files, set(), ["/a.txt", "/copy.txt"])
+    assert files["/copy.txt"] == b"AAA"
+
+
+@pytest.mark.asyncio
+async def test_single_source_into_directory():
+    files = {"/a.txt": b"AAA", "/d/keep": b"K"}
+    await _run(files, {"/d"}, ["/a.txt", "/d"])
+    assert files["/d/a.txt"] == b"AAA"
+    assert files["/a.txt"] == b"AAA"
+
+
+@pytest.mark.asyncio
+async def test_multiple_sources_into_directory():
+    files = {"/a.txt": b"AAA", "/b.txt": b"BBB", "/d/keep": b"K"}
+    await _run(files, {"/d"}, ["/a.txt", "/b.txt", "/d"])
+    assert files["/d/a.txt"] == b"AAA"
+    assert files["/d/b.txt"] == b"BBB"
+
+
+@pytest.mark.asyncio
+async def test_multiple_sources_nondir_raises():
+    files = {"/a.txt": b"AAA", "/b.txt": b"BBB", "/dst.txt": b"DST"}
+    with pytest.raises(NotADirectoryError):
+        await _run(files, set(), ["/a.txt", "/b.txt", "/dst.txt"])
+    assert files["/dst.txt"] == b"DST"
+
+
+@pytest.mark.asyncio
+async def test_no_clobber_skips_existing():
+    files = {"/a.txt": b"NEW", "/d/a.txt": b"OLD"}
+    await _run(files, {"/d"}, ["/a.txt", "/d"], n=True)
+    assert files["/d/a.txt"] == b"OLD"
+
+
+@pytest.mark.asyncio
+async def test_no_clobber_duplicate_basenames_first_wins():
+    files = {"/x/a.txt": b"FIRST", "/y/a.txt": b"SECOND", "/d/keep": b"K"}
+    await _run(files, {"/d"}, ["/x/a.txt", "/y/a.txt", "/d"], n=True)
+    assert files["/d/a.txt"] == b"FIRST"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_basenames_without_n_last_wins():
+    files = {"/x/a.txt": b"FIRST", "/y/a.txt": b"SECOND", "/d/keep": b"K"}
+    await _run(files, {"/d"}, ["/x/a.txt", "/y/a.txt", "/d"])
+    assert files["/d/a.txt"] == b"SECOND"
+
+
+@pytest.mark.asyncio
+async def test_recursive_into_directory():
+    files = {"/src/x.txt": b"X", "/src/sub/y.txt": b"Y"}
+    await _run(files, {"/src"}, ["/src", "/dst"], recursive=True)
+    assert files["/dst/x.txt"] == b"X"
+    assert files["/dst/sub/y.txt"] == b"Y"
+
+
+@pytest.mark.asyncio
+async def test_verbose_emits_arrow_lines():
+    files = {"/a.txt": b"AAA"}
+    out, _ = await _run(files, set(), ["/a.txt", "/copy.txt"], v=True)
+    assert out == b"/a.txt -> /copy.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_records_writes_by_strip_prefix():
+    files = {"/a.txt": b"AAA", "/b.txt": b"BBB", "/d/keep": b"K"}
+    _, io = await _run(files, {"/d"}, ["/a.txt", "/b.txt", "/d"])
+    assert set(io.writes) == {"/d/a.txt", "/d/b.txt"}

--- a/python/tests/commands/builtin/generic/test_mv.py
+++ b/python/tests/commands/builtin/generic/test_mv.py
@@ -1,0 +1,103 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.commands.builtin.generic.mv import mv
+from mirage.types import FileStat, FileType, PathSpec
+
+
+def _spec(path: str) -> PathSpec:
+    return PathSpec(original=path, directory=path)
+
+
+def _key(p) -> str:
+    return (p.original if isinstance(p, PathSpec) else p).rstrip("/")
+
+
+def _make_backend(files: dict[str, bytes], dirs: set[str]):
+
+    async def stat(p, index=None) -> FileStat:
+        k = _key(p)
+        if k in dirs:
+            return FileStat(name=k.rsplit("/", 1)[-1], type=FileType.DIRECTORY)
+        if k in files:
+            return FileStat(name=k.rsplit("/", 1)[-1], type=FileType.TEXT)
+        raise FileNotFoundError(k)
+
+    async def rename(src, dst) -> None:
+        files[_key(dst)] = files.pop(_key(src))
+
+    return stat, rename
+
+
+async def _run(files, dirs, paths, **kw):
+    stat, rename = _make_backend(files, dirs)
+    return await mv([_spec(p) for p in paths],
+                    rename=rename,
+                    stat=stat,
+                    n=kw.get("n", False),
+                    v=kw.get("v", False))
+
+
+@pytest.mark.asyncio
+async def test_single_source_renames():
+    files = {"/a.txt": b"AAA"}
+    await _run(files, set(), ["/a.txt", "/b.txt"])
+    assert files["/b.txt"] == b"AAA"
+    assert "/a.txt" not in files
+
+
+@pytest.mark.asyncio
+async def test_multiple_sources_into_directory():
+    files = {"/a.txt": b"AAA", "/b.txt": b"BBB", "/d/keep": b"K"}
+    await _run(files, {"/d"}, ["/a.txt", "/b.txt", "/d"])
+    assert files["/d/a.txt"] == b"AAA"
+    assert files["/d/b.txt"] == b"BBB"
+    assert "/a.txt" not in files
+    assert "/b.txt" not in files
+
+
+@pytest.mark.asyncio
+async def test_multiple_sources_nondir_raises():
+    files = {"/a.txt": b"AAA", "/b.txt": b"BBB", "/dst.txt": b"DST"}
+    with pytest.raises(NotADirectoryError):
+        await _run(files, set(), ["/a.txt", "/b.txt", "/dst.txt"])
+    assert files["/a.txt"] == b"AAA"
+    assert files["/b.txt"] == b"BBB"
+    assert files["/dst.txt"] == b"DST"
+
+
+@pytest.mark.asyncio
+async def test_no_clobber_preserves_source_and_target():
+    files = {"/a.txt": b"NEW", "/d/a.txt": b"OLD"}
+    await _run(files, {"/d"}, ["/a.txt", "/d"], n=True)
+    assert files["/d/a.txt"] == b"OLD"
+    assert files["/a.txt"] == b"NEW"
+
+
+@pytest.mark.asyncio
+async def test_no_clobber_duplicate_basenames_keeps_skipped_source():
+    files = {"/x/a.txt": b"FIRST", "/y/a.txt": b"SECOND", "/d/keep": b"K"}
+    await _run(files, {"/d"}, ["/x/a.txt", "/y/a.txt", "/d"], n=True)
+    assert files["/d/a.txt"] == b"FIRST"
+    assert "/x/a.txt" not in files
+    assert files["/y/a.txt"] == b"SECOND"
+
+
+@pytest.mark.asyncio
+async def test_records_writes_for_source_and_target():
+    files = {"/a.txt": b"AAA", "/d/keep": b"K"}
+    _, io = await _run(files, {"/d"}, ["/a.txt", "/d"])
+    assert set(io.writes) == {"/a.txt", "/d/a.txt"}


### PR DESCRIPTION
## Summary

Multi-source `cp`/`mv` silently lost data on disk/ram/redis/s3/ssh/nextcloud: only the first source and second operand were used, so `cp a b dir/` copied a onto b and ignored dir (exit 0). This unifies cp/mv into shared generic command bodies and fixes the bug for all backends.

## Changes

- Add `generic/cp.py` + `generic/mv.py`: one POSIX cp/mv implementation taking injected callables (no backend I/O), plus `utils/copy.py` helpers (`copy_targets`, `is_directory`, `path_exists`).
- disk/ram/redis/s3/ssh/nextcloud cp/mv become thin wrappers that bind the accessor with `partial` and delegate to the generic. `index` is threaded for the destination-directory cache probe.
- Multi-source into an existing directory fans out to `dir/basename`; multiple sources with a non-directory destination now raise `NotADirectoryError` instead of clobbering.
- databricks cp/mv adopt the shared `copy_targets` (keeping their same-file guard and core recursion); removed duplicated `is_directory`/`path_exists` from databricks `_helpers`.

## Tests

- New generic unit tests (`tests/commands/builtin/generic/test_cp.py`, `test_mv.py`) covering fan-out, the non-directory guard, no-clobber (incl. duplicate basenames), recursive, verbose, and writes.
- Cross-backend integ cases (ram/disk/redis) in `integ/cases.py` + regenerated `integ/truth.txt`.
- Kept databricks unit tests and added the require-directory cases.

Note: databricks cp/mv remain memory-buffered for large files (pre-existing; out of scope).