### PR TITLE
feat(workspace): F2 dispatch-seam freeze — inert branch hooks + ContextVar + op-vocab (#168)

### DIFF
--- a/python/mirage/observe/context.py
+++ b/python/mirage/observe/context.py
@@ -288,3 +288,57 @@ async def with_revisions(revisions: dict[str, str] | None,
             return
         reset_revisions(token)
         yield chunk
+
+
+_active_branch: ContextVar[object | None] = ContextVar("_active_branch",
+                                                       default=None)
+
+
+def push_branch(branch: object):
+    """Bind the active branch for the current async context.
+
+    A branch is a copy-on-write staged workspace (a forked Workspace).
+    The VFS dispatcher consults :func:`branch_for` on every op so that,
+    when a branch is bound, reads can be served from the branch's
+    staging layer first and writes to share-by-ref mounts can be
+    diverted into it instead of the live backend. Entry points that
+    activate a branch push it here before dispatching, so any op fired
+    inside sees the binding without explicit threading.
+
+    Returns the token from ``ContextVar.set`` so callers can restore the
+    previous state via :func:`reset_branch`. Task-isolated: the
+    ContextVar copy is per-task, so concurrent contexts don't see each
+    other's branch.
+
+    Args:
+        branch (object): The active branch (Lane A's ``Branch``). Typed
+            as ``object`` to keep this module leaf-ward — the real class
+            lives in the workspace layer and importing it would cycle.
+
+    Returns:
+        Token: passable to ``reset_branch``.
+    """
+    return _active_branch.set(branch)
+
+
+def reset_branch(token) -> None:
+    """Restore the previous branch after a :func:`push_branch`.
+
+    Args:
+        token: The token returned by ``push_branch``.
+    """
+    _active_branch.reset(token)
+
+
+def branch_for() -> object | None:
+    """Return the branch bound to the current async context, if any.
+
+    The dispatcher calls this to decide whether to route an op through a
+    branch's staging layer. Returns ``None`` when no branch is bound
+    (the default), in which case dispatch behaves exactly as it does
+    without any branch machinery.
+
+    Returns:
+        object | None: The active branch, or None if none is bound.
+    """
+    return _active_branch.get()

--- a/python/mirage/workspace/branch_vocab.py
+++ b/python/mirage/workspace/branch_vocab.py
@@ -1,0 +1,17 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+READ_OPS = frozenset({"read", "read_bytes"})
+WRITE_OPS = frozenset(
+    {"write", "write_bytes", "append", "unlink", "create", "truncate"})

--- a/python/mirage/workspace/dispatcher.py
+++ b/python/mirage/workspace/dispatcher.py
@@ -16,13 +16,53 @@ from typing import Any
 
 from mirage.cache.file import io as cache_io
 from mirage.io import IOResult
+from mirage.observe.context import branch_for
+from mirage.resource.base import BaseResource
 from mirage.types import ConsistencyPolicy, FileStat, PathSpec
+from mirage.workspace.branch_vocab import READ_OPS, WRITE_OPS
 from mirage.workspace.mount import Mount, MountRegistry
 from mirage.workspace.session import assert_mount_allowed
 
-_DISPATCH_READ_OPS = frozenset({"read", "read_bytes"})
-_DISPATCH_WRITE_OPS = frozenset(
-    {"write", "write_bytes", "append", "unlink", "create", "truncate"})
+_DISPATCH_READ_OPS = READ_OPS
+_DISPATCH_WRITE_OPS = WRITE_OPS
+
+
+def _needs_staging(mount: Mount) -> bool:
+    """Whether writes to ``mount`` must be diverted into a branch's
+    staging layer instead of hitting the live backend.
+
+    True iff the resource shares its backend by reference across a fork
+    — i.e. it did not override ``BaseResource.fork`` — so the live and
+    staged workspaces hold the same live object and a staged write would
+    otherwise leak to the live side. S3 / Slack / GDrive and an
+    in-memory-but-externally-owned Redis mount all share by reference;
+    RAM / cache / Disk override ``fork`` to isolate on the fork and need
+    no diversion.
+
+    Deliberately NOT keyed on ``is_remote``: a Redis mount is
+    ``is_remote=False`` yet still shares by reference and must be staged.
+    F4 (#170) formalizes this into a resource strategy flag / WriteLayer
+    protocol and may swap this predicate's internals — but not its call
+    site in :meth:`Dispatcher.dispatch`.
+
+    Args:
+        mount (Mount): the mount the op resolved to.
+    """
+    return type(mount.resource).fork is BaseResource.fork
+
+
+def policy_for(mount: Mount) -> object | None:
+    """Staging/commit policy for ``mount`` — placeholder stub.
+
+    Returns ``None`` today: no policy is defined until the commit
+    contract lands. F3/F4 (#169/#170) and the commit lane (D) fill in
+    the real policy type and per-mount selection; this stub freezes the
+    call shape so they need not reopen the dispatcher.
+
+    Args:
+        mount (Mount): the mount to resolve a policy for.
+    """
+    return None
 
 
 class Dispatcher:
@@ -35,6 +75,14 @@ class Dispatcher:
     consistency policy; holds no other workspace state. Drift checking
     stays on Workspace (it reads/writes snapshot-owned state), which guards
     its own dispatch wrapper before delegating here.
+
+    Frozen seam (Phase 0 / F2, #168): ``dispatch`` carries inert branch
+    hooks — a ``branch_for()`` lookup, the ``_needs_staging`` gate, and
+    ``staged_read`` / ``divert_write`` calls on the bound branch — that
+    are dead until Lane A binds a branch. After this freeze the feature
+    lanes (A–J) plug in only by implementing those branch methods; they
+    never reopen ``dispatch``. dispatcher.py is read-only for all
+    downstream lanes.
     """
 
     def __init__(self, registry: MountRegistry, cache,
@@ -47,6 +95,20 @@ class Dispatcher:
                        **kwargs: Any) -> tuple[Any, IOResult]:
         mount = self._registry.mount_for(path.original)
         assert_mount_allowed(mount.prefix)
+        branch = branch_for()
+        # Dead seam until Lane A binds a branch: ``branch`` is None on
+        # every path today, so this block never runs and dispatch stays
+        # byte-for-byte. When a branch is bound, a share-by-ref mount
+        # serves reads through its staging layer and diverts writes into
+        # it. ``staged_read`` / ``divert_write`` are the frozen contract
+        # Lane A implements; both return ``(result, IOResult)`` like
+        # dispatch. F4 may refine ``_needs_staging`` internals, never
+        # this call site — dispatcher.py is read-only for other lanes.
+        if branch is not None and _needs_staging(mount):
+            if op in READ_OPS:
+                return await branch.staged_read(mount, path, **kwargs)
+            if op in WRITE_OPS:
+                return await branch.divert_write(mount, op, path, **kwargs)
         cacheable = mount.resource.is_remote is True
 
         if cacheable and op in _DISPATCH_READ_OPS:

--- a/python/mirage/workspace/dispatcher.py
+++ b/python/mirage/workspace/dispatcher.py
@@ -28,22 +28,23 @@ _DISPATCH_WRITE_OPS = WRITE_OPS
 
 
 def _needs_staging(mount: Mount) -> bool:
-    """Whether writes to ``mount`` must be diverted into a branch's
-    staging layer instead of hitting the live backend.
+    """Whether a bound branch must divert this mount's content writes
+    into its staging layer instead of the live backend.
 
-    True iff the resource shares its backend by reference across a fork
-    — i.e. it did not override ``BaseResource.fork`` — so the live and
-    staged workspaces hold the same live object and a staged write would
-    otherwise leak to the live side. S3 / Slack / GDrive and an
-    in-memory-but-externally-owned Redis mount all share by reference;
-    RAM / cache / Disk override ``fork`` to isolate on the fork and need
-    no diversion.
-
-    Deliberately NOT keyed on ``is_remote``: a Redis mount is
-    ``is_remote=False`` yet still shares by reference and must be staged.
-    F4 (#170) formalizes this into a resource strategy flag / WriteLayer
-    protocol and may swap this predicate's internals — but not its call
-    site in :meth:`Dispatcher.dispatch`.
+    Tests override-identity — ``type(mount.resource).fork is
+    BaseResource.fork`` — i.e. "did the resource leave ``fork`` at the
+    share-by-reference default?" For today's backends that coincides with
+    actual share-by-ref: RAM / cache / Disk override ``fork`` to isolate
+    on the fork (→ no staging); S3 / Slack / GDrive and an
+    ``is_remote=False`` Redis mount inherit the default and share one live
+    object (→ stage). It is an approximation, not a behavioral test — a
+    resource that overrode ``fork`` yet still returned a shared live
+    client would be misclassified as isolating and leak staged writes to
+    live; none do today. Deliberately NOT keyed on ``is_remote`` (Redis is
+    local yet shared). F4 (#170) replaces this with a resource strategy
+    flag, ideally fail-closed (an explicit ``isolates_on_fork`` opt-out so
+    unknown resources default to staging) — swapping the internals here,
+    never the call site.
 
     Args:
         mount (Mount): the mount the op resolved to.
@@ -52,12 +53,16 @@ def _needs_staging(mount: Mount) -> bool:
 
 
 def policy_for(mount: Mount) -> object | None:
-    """Staging/commit policy for ``mount`` — placeholder stub.
+    """Staging/commit policy for ``mount`` — deferred stub, ``None`` today.
 
-    Returns ``None`` today: no policy is defined until the commit
-    contract lands. F3/F4 (#169/#170) and the commit lane (D) fill in
-    the real policy type and per-mount selection; this stub freezes the
-    call shape so they need not reopen the dispatcher.
+    Public (unlike the private ``_needs_staging``) because it is a seam
+    other lanes import, parallel to ``READ_OPS`` / ``WRITE_OPS``. Unlike
+    ``staged_read`` / ``divert_write`` it has no inert call site in
+    ``dispatch``: policy is expected to be resolved at commit time,
+    outside the per-op path, so this only reserves the name rather than
+    anchoring a dispatch call site. F3/F4 (#169/#170) and the commit lane
+    (D) define the real policy type and selection, and may revise this
+    signature if they need op / path / branch context.
 
     Args:
         mount (Mount): the mount to resolve a policy for.
@@ -78,11 +83,19 @@ class Dispatcher:
 
     Frozen seam (Phase 0 / F2, #168): ``dispatch`` carries inert branch
     hooks — a ``branch_for()`` lookup, the ``_needs_staging`` gate, and
-    ``staged_read`` / ``divert_write`` calls on the bound branch — that
-    are dead until Lane A binds a branch. After this freeze the feature
-    lanes (A–J) plug in only by implementing those branch methods; they
-    never reopen ``dispatch``. dispatcher.py is read-only for all
-    downstream lanes.
+    ``staged_read`` / ``divert_write`` calls on the bound branch — dead
+    until Lane A binds a branch. Scope is deliberately narrow: the seam
+    covers content read/write routing only (``READ_OPS`` / ``WRITE_OPS``).
+    ``stat`` / ``readdir`` / ``find`` are intentionally not diverted —
+    with a branch bound they fall through to the live backend (content-
+    only staging; metadata stays live). Directory mutations (``mkdir`` /
+    ``rmdir`` / ``rename``) run via ``mount.execute_cmd`` and never
+    traverse ``dispatch`` at all, so they are outside this seam by
+    construction. Within that scope the feature lanes (A–J) extend
+    dispatch only by implementing the branch methods, never by reopening
+    this content read/write routing. Staging metadata or directory CoW,
+    if a later arc needs it, is owned by the ``execute_cmd`` / ``IOResult``
+    write-set path or a separate metadata seam — not by editing this block.
     """
 
     def __init__(self, registry: MountRegistry, cache,
@@ -96,18 +109,15 @@ class Dispatcher:
         mount = self._registry.mount_for(path.original)
         assert_mount_allowed(mount.prefix)
         branch = branch_for()
-        # Dead seam until Lane A binds a branch: ``branch`` is None on
-        # every path today, so this block never runs and dispatch stays
-        # byte-for-byte. When a branch is bound, a share-by-ref mount
-        # serves reads through its staging layer and diverts writes into
-        # it. ``staged_read`` / ``divert_write`` are the frozen contract
-        # Lane A implements; both return ``(result, IOResult)`` like
-        # dispatch. F4 may refine ``_needs_staging`` internals, never
-        # this call site — dispatcher.py is read-only for other lanes.
+        # Dead seam today: ``branch`` is None on every path (Lane A binds
+        # it later), so this block never runs and dispatch stays byte-for-
+        # byte. Routing contract, scope, and the read-only invariant: see
+        # the class docstring. staged_read / divert_write return
+        # ``(result, IOResult)`` like dispatch.
         if branch is not None and _needs_staging(mount):
-            if op in READ_OPS:
+            if op in _DISPATCH_READ_OPS:
                 return await branch.staged_read(mount, path, **kwargs)
-            if op in WRITE_OPS:
+            if op in _DISPATCH_WRITE_OPS:
                 return await branch.divert_write(mount, op, path, **kwargs)
         cacheable = mount.resource.is_remote is True
 

--- a/python/tests/observe/test_context.py
+++ b/python/tests/observe/test_context.py
@@ -12,8 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.observe.context import (push_mount_prefix, push_revisions, record,
-                                    record_stream, reset_revisions,
+from mirage.observe.context import (branch_for, push_branch, push_mount_prefix,
+                                    push_revisions, record, record_stream,
+                                    reset_branch, reset_revisions,
                                     revision_for, start_recording,
                                     stop_recording)
 
@@ -169,3 +170,34 @@ def test_revision_for_with_none_context():
         assert revision_for("/s3/a") is None
     finally:
         reset_revisions(token)
+
+
+def test_branch_for_default_is_none():
+    assert branch_for() is None
+
+
+def test_push_branch_then_reset_restores_none():
+    sentinel = object()
+    token = push_branch(sentinel)
+    try:
+        assert branch_for() is sentinel
+    finally:
+        reset_branch(token)
+    assert branch_for() is None
+
+
+def test_push_branch_nested_restores_previous():
+    outer = object()
+    inner = object()
+    outer_token = push_branch(outer)
+    try:
+        assert branch_for() is outer
+        inner_token = push_branch(inner)
+        try:
+            assert branch_for() is inner
+        finally:
+            reset_branch(inner_token)
+        assert branch_for() is outer
+    finally:
+        reset_branch(outer_token)
+    assert branch_for() is None

--- a/python/tests/workspace/test_branch_vocab.py
+++ b/python/tests/workspace/test_branch_vocab.py
@@ -1,0 +1,34 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.workspace import dispatcher
+from mirage.workspace.branch_vocab import READ_OPS, WRITE_OPS
+
+
+def test_read_ops_contents():
+    assert READ_OPS == frozenset({"read", "read_bytes"})
+
+
+def test_write_ops_contents():
+    assert WRITE_OPS == frozenset(
+        {"write", "write_bytes", "append", "unlink", "create", "truncate"})
+
+
+def test_read_and_write_ops_disjoint():
+    assert READ_OPS.isdisjoint(WRITE_OPS)
+
+
+def test_dispatcher_reexports_the_same_sets():
+    assert dispatcher._DISPATCH_READ_OPS is READ_OPS
+    assert dispatcher._DISPATCH_WRITE_OPS is WRITE_OPS

--- a/python/tests/workspace/test_dispatcher.py
+++ b/python/tests/workspace/test_dispatcher.py
@@ -12,10 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from mirage.io import IOResult
+from mirage.observe.context import push_branch, reset_branch
 from mirage.resource.ram.ram import RAMResource
 from mirage.resource.redis.redis import RedisResource
 from mirage.resource.s3.s3 import S3Resource
-from mirage.workspace.dispatcher import _needs_staging, policy_for
+from mirage.types import ConsistencyPolicy, PathSpec
+from mirage.workspace.dispatcher import Dispatcher, _needs_staging, policy_for
 from mirage.workspace.mount import Mount
 
 
@@ -48,3 +56,94 @@ def test_needs_staging_s3_remote_shares_by_ref():
 
 def test_policy_for_default_is_none():
     assert policy_for(_mount(RAMResource())) is None
+
+
+class _FakeBranch:
+
+    def __init__(self) -> None:
+        self.reads: list[tuple] = []
+        self.writes: list[tuple] = []
+
+    async def staged_read(self, mount, path, **kwargs):
+        self.reads.append((mount, path.original))
+        return "staged", IOResult()
+
+    async def divert_write(self, mount, op, path, **kwargs):
+        self.writes.append((op, path.original))
+        return "diverted", IOResult()
+
+
+def _dispatcher_for(resource):
+    mount = SimpleNamespace(prefix="/m/",
+                            resource=resource,
+                            execute_op=AsyncMock(return_value="live"))
+    registry = SimpleNamespace(mount_for=Mock(return_value=mount))
+    cache = SimpleNamespace(get=AsyncMock(return_value=None))
+    disp = Dispatcher(registry, cache, ConsistencyPolicy.LAZY)
+    return disp, mount
+
+
+def _path(p: str) -> PathSpec:
+    return PathSpec(original=p,
+                    directory=p.rsplit("/", 1)[0] or "/",
+                    resolved=True)
+
+
+@pytest.mark.asyncio
+async def test_bound_branch_routes_read_to_staged_read():
+    branch = _FakeBranch()
+    disp, mount = _dispatcher_for(object.__new__(RedisResource))
+    token = push_branch(branch)
+    try:
+        result, _ = await disp.dispatch("read_bytes", _path("/m/a.txt"))
+    finally:
+        reset_branch(token)
+    assert branch.reads == [(mount, "/m/a.txt")]
+    assert branch.writes == []
+    assert result == "staged"
+    mount.execute_op.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_bound_branch_diverts_write():
+    branch = _FakeBranch()
+    disp, mount = _dispatcher_for(object.__new__(RedisResource))
+    token = push_branch(branch)
+    try:
+        result, _ = await disp.dispatch("write", _path("/m/a.txt"), data=b"x")
+    finally:
+        reset_branch(token)
+    assert branch.writes == [("write", "/m/a.txt")]
+    assert branch.reads == []
+    assert result == "diverted"
+    mount.execute_op.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_vocab_op_falls_through_to_live():
+    branch = _FakeBranch()
+    disp, mount = _dispatcher_for(object.__new__(RedisResource))
+    token = push_branch(branch)
+    try:
+        result, _ = await disp.dispatch("stat", _path("/m/a.txt"))
+    finally:
+        reset_branch(token)
+    assert branch.reads == []
+    assert branch.writes == []
+    mount.execute_op.assert_awaited_once_with("stat", "/m/a.txt")
+    assert result == "live"
+
+
+@pytest.mark.asyncio
+async def test_isolating_mount_bypasses_branch_even_for_read():
+    branch = _FakeBranch()
+    disp, mount = _dispatcher_for(RAMResource())
+    token = push_branch(branch)
+    try:
+        result, _ = await disp.dispatch("read_bytes", _path("/m/a.txt"))
+    finally:
+        reset_branch(token)
+    assert branch.reads == []
+    assert branch.writes == []
+    mount.execute_op.assert_awaited_once_with("read_bytes", "/m/a.txt")
+    assert result == "live"

--- a/python/tests/workspace/test_dispatcher.py
+++ b/python/tests/workspace/test_dispatcher.py
@@ -1,0 +1,50 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.resource.ram.ram import RAMResource
+from mirage.resource.redis.redis import RedisResource
+from mirage.resource.s3.s3 import S3Resource
+from mirage.workspace.dispatcher import _needs_staging, policy_for
+from mirage.workspace.mount import Mount
+
+
+def _mount(resource) -> Mount:
+    return Mount("/m/", resource)
+
+
+def test_needs_staging_ram_isolates_on_fork():
+    mount = _mount(RAMResource())
+    assert _needs_staging(mount) is False
+
+
+def test_needs_staging_redis_shares_by_ref_despite_local():
+    # is_remote=False yet share-by-ref, so it must still be staged. The
+    # real RedisResource.__init__ connects to a live server; the gate
+    # only inspects type(resource).fork, so a bare instance of the real
+    # class proves the classification and keeps the test hermetic.
+    resource = object.__new__(RedisResource)
+    mount = _mount(resource)
+    assert mount.resource.is_remote is False
+    assert _needs_staging(mount) is True
+
+
+def test_needs_staging_s3_remote_shares_by_ref():
+    resource = object.__new__(S3Resource)
+    mount = _mount(resource)
+    assert mount.resource.is_remote is True
+    assert _needs_staging(mount) is True
+
+
+def test_policy_for_default_is_none():
+    assert policy_for(_mount(RAMResource())) is None


### PR DESCRIPTION
## Overview

Phase 0 / **F2 — the dispatch-seam freeze** (#168, epic #166, roadmap #165).

This is a **foundation freeze, not a feature**. It adds **dead-until-Lane-A** hook seams to the one VFS chokepoint (`workspace/dispatcher.py`) so the write-layer lanes (B/C) and the commit lane (D) plug in by *providing objects the hooks call* — never by reopening `dispatch()`. **With no branch bound, behavior is byte-for-byte unchanged**: every hook is gated on `branch is not None`, and nothing binds a branch yet (that's Lane A / #171), so all new branches are unreachable today.

> **Stacked on F1 (#206).** F2 consumes F1's `BaseResource.fork` substrate, which is **not yet on `main`** (`main` is not an ancestor of `feat/phase0-f1-fork`). So this PR is based on **`feat/phase0-f1-fork`** and should be **retargeted to `main` once F1 (#206) merges**. The diff shown here is F2-only.

## Detailed changes

### `observe/context.py` — the `_active_branch` ContextVar trio
Mirrors the existing `_revisions` trio exactly:
- `_active_branch: ContextVar[object | None]` (default `None`) — typed `object | None`; the real `Branch` class is Lane A's and is deliberately **not** imported (would be a cycle).
- `push_branch(branch) -> Token`, `reset_branch(token)`, `branch_for() -> object | None`.

Task-isolated, same as `_revisions`.

### `workspace/branch_vocab.py` (new) — the frozen op-vocabulary
The single source of truth all lanes import: `READ_OPS` and `WRITE_OPS`. Leaf module (no workspace imports → no cycle). `dispatcher.py`'s `_DISPATCH_READ_OPS` / `_DISPATCH_WRITE_OPS` now **re-point** here (the frozensets are byte-identical to the originals, so existing call sites are unchanged).

### `workspace/dispatcher.py` — inert hooks in `dispatch()`
- `branch = branch_for()` near the top (`None` today).
- `_needs_staging(mount)` — the **share-by-ref** classifier: `type(mount.resource).fork is BaseResource.fork`. A resource that did **not** override `BaseResource.fork` shares its live backend by reference across a fork and must be staged. **Deliberately NOT keyed on `is_remote`** — a Redis mount is `is_remote=False` yet still shares by ref. (RAM/cache/Disk override `fork` → isolate → no staging; Redis/S3/Slack/GDrive inherit the default → need staging.) A comment notes F4 (#170) may swap this predicate's internals but not its call site.
- a **write-layer-first read hook** (`branch.staged_read(mount, path, **kw)`) and a **write-divert hook** (`branch.divert_write(mount, op, path, **kw)`), both inside `if branch is not None and _needs_staging(mount):` and gated by op-vocab. Both return `(result, IOResult)` like `dispatch`. **These method names are the contract Lane A implements.**
- a `policy_for(mount)` stub returning `None` (documented for F3/F4/Lane D to fill).

Everything below the guard is the **existing dispatch logic, unchanged**.

### `commands/builtin/cross_mount.py`
#168 mentioned fixing this dead module's "op-name mismatch." It was deleted on `main` by Lane F (#186) — but **F1 predates that deletion**, so the file is still present on this stack's base. F2 **does not touch it**: its dispatch calls already use canonical op names (`read_bytes` / `write_bytes` / `unlink`), so there is no mismatch on this base, and the deletion is Lane F's to carry. It drops out when this stack rebases onto post-#186 `main`.

## Tests
- `tests/observe/test_context.py` — branch trio: `branch_for()` is `None` by default; push → returns it → reset restores previous; nested push/reset.
- `tests/workspace/test_branch_vocab.py` — vocab contents, disjointness, and that the dispatcher re-exports the *same* set objects.
- `tests/workspace/test_dispatcher.py` — `_needs_staging` across **RAM (False), Redis (True, `is_remote=False`), S3-style remote (True)**, plus `policy_for` default. (Redis's real `__init__` connects to a live server, so the test builds the real `RedisResource` *type* via `object.__new__` — the gate only inspects `type(resource).fork`, keeping the test hermetic.)
- **Byte-for-byte proof:** the full existing suite (excl. `tests/fuse`, which needs native libfuse) passes with no new failures; the only failures are pre-existing/environmental (`test_tac.py` — no system `tac` on macOS; one redis test — no `redis-server`).

## Definition of Done (#168)
- [x] With **no branch bound**, the full existing test suite passes byte-for-byte.
- [x] `push_branch` / `reset_branch` / `branch_for` added to `observe/context.py`, mirroring `_revisions`, with a unit test.
- [x] A Redis mount (`is_remote=False`, share-by-ref) is classified as **needing staging** — explicit `_needs_staging` test across RAM/Redis/S3.
- [x] Documented invariant: after this merge, `dispatcher.py` needs no further edits from any other lane (stated in the `Dispatcher` docstring + here).
- [x] `pre-commit run --all-files` clean and relevant tests green.

## The invariant
**`dispatcher.py` is now read-only for all downstream lanes.** Lanes A–J extend dispatch behavior solely by providing the bound `branch` object's `staged_read` / `divert_write` methods (Lane A) — they never reopen `dispatch()`. The seam call sites are frozen; F4 (#170), a sibling Phase-0 sub-issue, may refine the `_needs_staging` predicate internals and flesh out `policy_for`, but not the call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
