### PR TITLE
refactor(ts): delegate s3 text commands to generic (follow python)

### DIFF
--- a/typescript/packages/browser/src/commands/builtin/opfs/fmt.ts
+++ b/typescript/packages/browser/src/commands/builtin/opfs/fmt.ts
@@ -13,13 +13,10 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
-  IOResult,
   ResourceName,
   command,
-  materialize,
-  readStdinAsync,
+  fmtGeneric,
   specOf,
-  type ByteSource,
   type CommandFnResult,
   type CommandOpts,
   type PathSpec,
@@ -27,61 +24,13 @@ import {
 import { stream as opfsStream } from '../../../core/opfs/stream.ts'
 import type { OPFSAccessor } from '../../../accessor/opfs.ts'
 
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function wrapText(text: string, width: number): string {
-  const words = text.split(/\s+/).filter((w) => w !== '')
-  if (words.length === 0) return ''
-  const lines: string[] = []
-  let current = ''
-  for (const w of words) {
-    if (current === '') {
-      current = w
-    } else if (current.length + 1 + w.length <= width) {
-      current = current + ' ' + w
-    } else {
-      lines.push(current)
-      current = w
-    }
-  }
-  if (current !== '') lines.push(current)
-  return lines.join('\n')
-}
-
-function fmtText(text: string, width: number): string {
-  const paragraphs = text.split('\n\n')
-  const formatted: string[] = []
-  for (const para of paragraphs) {
-    const trimmed = para.trim()
-    if (trimmed !== '') formatted.push(wrapText(trimmed, width))
-    else formatted.push('')
-  }
-  return formatted.join('\n\n') + '\n'
-}
-
 async function fmtCommand(
   accessor: OPFSAccessor,
   paths: PathSpec[],
-  texts: string[],
+  _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const width = typeof opts.flags.w === 'string' ? Number.parseInt(opts.flags.w, 10) : 75
-  if (paths.length > 0) {
-    const parts: string[] = []
-    for (const p of paths) {
-      parts.push(DEC.decode(await materialize(opfsStream(accessor, p))))
-    }
-    const result: ByteSource = ENC.encode(fmtText(parts.join(''), width))
-    return [result, new IOResult()]
-  }
-  const stdinData = await readStdinAsync(opts.stdin)
-  if (stdinData === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('fmt: missing operand\n') })]
-  }
-  const text = DEC.decode(stdinData)
-  const result: ByteSource = ENC.encode(fmtText(text, width))
-  return [result, new IOResult()]
+  return fmtGeneric(paths, opts, (p) => opfsStream(accessor, p))
 }
 
 export const OPFS_FMT = command({

--- a/typescript/packages/core/src/commands/builtin/generic/fmt.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/fmt.ts
@@ -1,0 +1,74 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
+import type { PathSpec } from '../../../types.ts'
+import type { CommandFnResult, CommandOpts } from '../../config.ts'
+import { readStdinAsync } from '../utils/stream.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder('utf-8', { fatal: false })
+
+function wrapText(text: string, width: number): string {
+  const words = text.split(/\s+/).filter((w) => w !== '')
+  if (words.length === 0) return ''
+  const lines: string[] = []
+  let current = ''
+  for (const w of words) {
+    if (current === '') {
+      current = w
+    } else if (current.length + 1 + w.length <= width) {
+      current = current + ' ' + w
+    } else {
+      lines.push(current)
+      current = w
+    }
+  }
+  if (current !== '') lines.push(current)
+  return lines.join('\n')
+}
+
+function fmtText(text: string, width: number): string {
+  const paragraphs = text.split('\n\n')
+  const formatted: string[] = []
+  for (const para of paragraphs) {
+    const trimmed = para.trim()
+    if (trimmed !== '') formatted.push(wrapText(trimmed, width))
+    else formatted.push('')
+  }
+  return formatted.join('\n\n') + '\n'
+}
+
+export async function fmtGeneric(
+  paths: PathSpec[],
+  opts: CommandOpts,
+  stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
+): Promise<CommandFnResult> {
+  const width = typeof opts.flags.w === 'string' ? Number.parseInt(opts.flags.w, 10) : 75
+  if (paths.length > 0) {
+    const parts: string[] = []
+    for (const p of paths) {
+      parts.push(DEC.decode(await materialize(stream(p))))
+    }
+    const result: ByteSource = ENC.encode(fmtText(parts.join(''), width))
+    return [result, new IOResult()]
+  }
+  const stdinData = await readStdinAsync(opts.stdin)
+  if (stdinData === null) {
+    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('fmt: missing operand\n') })]
+  }
+  const text = DEC.decode(stdinData)
+  const result: ByteSource = ENC.encode(fmtText(text, width))
+  return [result, new IOResult()]
+}

--- a/typescript/packages/core/src/commands/builtin/ram/fmt.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/fmt.ts
@@ -12,69 +12,20 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { stream as ramStream } from '../../../core/ram/stream.ts'
 import type { RAMAccessor } from '../../../accessor/ram.ts'
-import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
+import { stream as ramStream } from '../../../core/ram/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function wrapText(text: string, width: number): string {
-  const words = text.split(/\s+/).filter((w) => w !== '')
-  if (words.length === 0) return ''
-  const lines: string[] = []
-  let current = ''
-  for (const w of words) {
-    if (current === '') {
-      current = w
-    } else if (current.length + 1 + w.length <= width) {
-      current = current + ' ' + w
-    } else {
-      lines.push(current)
-      current = w
-    }
-  }
-  if (current !== '') lines.push(current)
-  return lines.join('\n')
-}
-
-function fmtText(text: string, width: number): string {
-  const paragraphs = text.split('\n\n')
-  const formatted: string[] = []
-  for (const para of paragraphs) {
-    const trimmed = para.trim()
-    if (trimmed !== '') formatted.push(wrapText(trimmed, width))
-    else formatted.push('')
-  }
-  return formatted.join('\n\n') + '\n'
-}
+import { fmtGeneric } from '../generic/fmt.ts'
 
 async function fmtCommand(
   accessor: RAMAccessor,
   paths: PathSpec[],
-  texts: string[],
+  _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const width = typeof opts.flags.w === 'string' ? Number.parseInt(opts.flags.w, 10) : 75
-  if (paths.length > 0) {
-    const parts: string[] = []
-    for (const p of paths) {
-      parts.push(DEC.decode(await materialize(ramStream(accessor, p))))
-    }
-    const result: ByteSource = ENC.encode(fmtText(parts.join(''), width))
-    return [result, new IOResult()]
-  }
-  const stdinData = await readStdinAsync(opts.stdin)
-  if (stdinData === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('fmt: missing operand\n') })]
-  }
-  const text = DEC.decode(stdinData)
-  const result: ByteSource = ENC.encode(fmtText(text, width))
-  return [result, new IOResult()]
+  return fmtGeneric(paths, opts, (p) => ramStream(accessor, p))
 }
 
 export const RAM_FMT = command({

--- a/typescript/packages/core/src/commands/builtin/s3/cut.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/cut.ts
@@ -15,14 +15,10 @@
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
 import { stream as s3Stream } from '../../../core/s3/stream.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { cutStream, parseCutRanges } from '../cut_helper.ts'
-import { resolveSource } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
+import { cutGeneric } from '../generic/cut.ts'
 
 async function cutCommand(
   accessor: S3Accessor,
@@ -30,31 +26,9 @@ async function cutCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const f = typeof opts.flags.f === 'string' ? opts.flags.f : null
-  const d = typeof opts.flags.d === 'string' ? opts.flags.d : null
-  const c = typeof opts.flags.c === 'string' ? opts.flags.c : null
-  const complement = opts.flags.complement === true
-  const z = opts.flags.z === true
-  const fields = f !== null ? parseCutRanges(f) : null
-  const chars = c !== null ? parseCutRanges(c) : null
-  const delim = d ?? '\t'
-
-  let source: AsyncIterable<Uint8Array>
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    source = s3Stream(accessor, first)
-  } else {
-    try {
-      source = resolveSource(opts.stdin, 'cut: missing operand')
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-    }
-  }
-  const out: ByteSource = cutStream(source, delim, fields, chars, complement, z)
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return cutGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_CUT = command({

--- a/typescript/packages/core/src/commands/builtin/s3/diff.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/diff.ts
@@ -13,72 +13,12 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { edScript, normalDiff, unifiedDiff } from '../diff_helper.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-interface DiffFlags {
-  i: boolean
-  w: boolean
-  b: boolean
-  e: boolean
-  q: boolean
-  u: boolean
-}
-
-function splitLinesKeepEnds(text: string): string[] {
-  const lines: string[] = []
-  let start = 0
-  for (let i = 0; i < text.length; i++) {
-    if (text[i] === '\n') {
-      lines.push(text.slice(start, i + 1))
-      start = i + 1
-    }
-  }
-  if (start < text.length) lines.push(text.slice(start))
-  return lines
-}
-
-async function diffPair(
-  accessor: S3Accessor,
-  path1: PathSpec,
-  path2: PathSpec,
-  flags: DiffFlags,
-): Promise<Uint8Array> {
-  const dataA = await s3Read(accessor, path1)
-  const dataB = await s3Read(accessor, path2)
-  let textA = DEC.decode(dataA)
-  let textB = DEC.decode(dataB)
-  if (flags.i) {
-    textA = textA.toLowerCase()
-    textB = textB.toLowerCase()
-  }
-  if (flags.w) {
-    textA = textA.replace(/\s+/g, '')
-    textB = textB.replace(/\s+/g, '')
-  } else if (flags.b) {
-    textA = textA.replace(/[ \t]+/g, ' ')
-    textB = textB.replace(/[ \t]+/g, ' ')
-  }
-  if (flags.q) {
-    if (textA !== textB) return ENC.encode(`Files ${path1.original} and ${path2.original} differ\n`)
-    return new Uint8Array(0)
-  }
-  const aLines = splitLinesKeepEnds(textA)
-  const bLines = splitLinesKeepEnds(textB)
-  let result: string[]
-  if (flags.e) result = edScript(aLines, bLines)
-  else if (flags.u) result = unifiedDiff(aLines, bLines, path1.original, path2.original)
-  else result = normalDiff(aLines, bLines)
-  return ENC.encode(result.join(''))
-}
+import { diffGeneric } from '../generic/diff.ts'
 
 async function diffCommand(
   accessor: S3Accessor,
@@ -86,31 +26,9 @@ async function diffCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length < 2) {
-    return [null, new IOResult({ exitCode: 2, stderr: ENC.encode('diff: requires two paths\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  if (opts.flags.r === true) {
-    return [
-      new Uint8Array(0),
-      new IOResult({ exitCode: 1, stderr: ENC.encode('diff: -r not supported for this resource') }),
-    ]
-  }
-  const flags: DiffFlags = {
-    i: opts.flags.i === true,
-    w: opts.flags.w === true,
-    b: opts.flags.b === true,
-    e: opts.flags.e === true,
-    q: opts.flags.q === true,
-    u: opts.flags.u === true,
-  }
-  const p0 = resolved[0]
-  const p1 = resolved[1]
-  if (p0 === undefined || p1 === undefined) return [null, new IOResult()]
-  const output = await diffPair(accessor, p0, p1, flags)
-  const exitCode = output.byteLength > 0 ? 1 : 0
-  const out: ByteSource = output
-  return [out, new IOResult({ exitCode, cache: [p0.original, p1.original] })]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return diffGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_DIFF = command({

--- a/typescript/packages/core/src/commands/builtin/s3/fmt.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/fmt.ts
@@ -13,46 +13,12 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function wrapText(text: string, width: number): string {
-  const words = text.split(/\s+/).filter((w) => w !== '')
-  if (words.length === 0) return ''
-  const lines: string[] = []
-  let current = ''
-  for (const w of words) {
-    if (current === '') {
-      current = w
-    } else if (current.length + 1 + w.length <= width) {
-      current = current + ' ' + w
-    } else {
-      lines.push(current)
-      current = w
-    }
-  }
-  if (current !== '') lines.push(current)
-  return lines.join('\n')
-}
-
-function fmtText(text: string, width: number): string {
-  const paragraphs = text.split('\n\n')
-  const formatted: string[] = []
-  for (const para of paragraphs) {
-    const trimmed = para.trim()
-    if (trimmed !== '') formatted.push(wrapText(trimmed, width))
-    else formatted.push('')
-  }
-  return formatted.join('\n\n') + '\n'
-}
+import { fmtGeneric } from '../generic/fmt.ts'
 
 async function fmtCommand(
   accessor: S3Accessor,
@@ -60,23 +26,9 @@ async function fmtCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const width = typeof opts.flags.w === 'string' ? Number.parseInt(opts.flags.w, 10) : 75
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const parts: string[] = []
-    for (const p of resolved) {
-      parts.push(DEC.decode(await s3Read(accessor, p)))
-    }
-    const result: ByteSource = ENC.encode(fmtText(parts.join(''), width))
-    return [result, new IOResult()]
-  }
-  const stdinData = await readStdinAsync(opts.stdin)
-  if (stdinData === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('fmt: missing operand\n') })]
-  }
-  const text = DEC.decode(stdinData)
-  const result: ByteSource = ENC.encode(fmtText(text, width))
-  return [result, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return fmtGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_FMT = command({

--- a/typescript/packages/core/src/commands/builtin/s3/head.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/head.ts
@@ -13,42 +13,25 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
-import { headStream } from '../head_helper.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
+import { stat as s3Stat } from '../../../core/s3/stat.ts'
 import { stream as s3Stream } from '../../../core/s3/stream.ts'
-import { IOResult } from '../../../io/types.ts'
-import { ResourceName, type PathSpec } from '../../../types.ts'
+import { type FileStat, ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { resolveSource } from '../utils/stream.ts'
+import { headGeneric } from '../generic/head.ts'
 import { headTailProvision } from './provision.ts'
-
-const ENC = new TextEncoder()
 
 async function headCommand(
   accessor: S3Accessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const nRaw = typeof opts.flags.n === 'string' ? opts.flags.n : null
-  const cRaw = typeof opts.flags.c === 'string' ? opts.flags.c : null
-  const lines = nRaw !== null ? Number.parseInt(nRaw, 10) : 10
-  const bytesMode = cRaw !== null ? Number.parseInt(cRaw, 10) : null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const source = s3Stream(accessor, first)
-    return [headStream(source, lines, bytesMode), new IOResult()]
-  }
-  try {
-    const source = resolveSource(opts.stdin, 'head: missing operand')
-    return [headStream(source, lines, bytesMode), new IOResult()]
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-  }
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  const stat = (p: PathSpec): Promise<FileStat> => s3Stat(accessor, p, opts.index ?? undefined)
+  return headGeneric(resolved, texts, opts, stat, (p) => s3Stream(accessor, p))
 }
 
 export const S3_HEAD = command({

--- a/typescript/packages/core/src/commands/builtin/s3/sed.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/sed.ts
@@ -13,19 +13,13 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
 import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { write as s3Write } from '../../../core/s3/write.ts'
-import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { executeProgram, parseOneCommand, parseProgram, type SedCommand } from '../sed_helper.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
+import { sedGeneric } from '../generic/sed.ts'
 
 async function sedCommand(
   accessor: S3Accessor,
@@ -33,86 +27,15 @@ async function sedCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const script = texts[0]
-  if (script === undefined) {
-    return [
-      null,
-      new IOResult({ exitCode: 1, stderr: ENC.encode('sed: usage: sed EXPRESSION [path]\n') }),
-    ]
-  }
-  const suppress = opts.flags.n === true
-  const inPlace = opts.flags.i === true
-  let commands: SedCommand[]
-  try {
-    if (script.includes(';') || script.includes('{')) {
-      commands = parseProgram(script)
-    } else {
-      commands = [parseOneCommand(script)[0]]
-    }
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-  }
-  const first = commands[0]
-  const isSimpleSub =
-    commands.length === 1 &&
-    first?.cmd === 's' &&
-    (first.addrStart === null || first.addrStart === undefined) &&
-    !suppress
-
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    if (isSimpleSub) {
-      const pat = first.pattern ?? ''
-      const repl = first.replacement ?? ''
-      const ef = first.exprFlags ?? ''
-      const ignoreCase = ef.includes('i')
-      const global = ef.includes('g')
-      const flags = (ignoreCase ? 'i' : '') + (global ? 'g' : '')
-      if (inPlace) {
-        const p = resolved[0]
-        if (p === undefined) return [null, new IOResult()]
-        const data = await s3Read(accessor, p)
-        const text = DEC.decode(data)
-        const newText = text.replace(new RegExp(pat, flags), repl)
-        const newData = ENC.encode(newText)
-        await s3Write(accessor, p, newData)
-        return [null, new IOResult({ writes: { [p.original]: new Uint8Array(0) } })]
-      }
-      const outputs: string[] = []
-      for (const p of resolved) {
-        const data = await s3Read(accessor, p)
-        const text = DEC.decode(data)
-        outputs.push(text.replace(new RegExp(pat, flags), repl))
-      }
-      const out: ByteSource = ENC.encode(outputs.join(''))
-      return [out, new IOResult({ cache: resolved.map((p) => p.original) })]
-    }
-
-    const p = resolved[0]
-    if (p === undefined) return [null, new IOResult()]
-    const data = await materialize(s3Stream(accessor, p))
-    const text = DEC.decode(data)
-    const result = executeProgram(text, commands, suppress)
-    const modifying = inPlace && commands.some((c) => c.cmd === 's' || c.cmd === 'd')
-    if (modifying) {
-      const newData = ENC.encode(result)
-      await s3Write(accessor, p, newData)
-      return [null, new IOResult({ writes: { [p.original]: newData }, cache: [p.stripPrefix] })]
-    }
-    return [ENC.encode(result), new IOResult()]
-  }
-
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [
-      null,
-      new IOResult({ exitCode: 1, stderr: ENC.encode('sed: usage: sed EXPRESSION path\n') }),
-    ]
-  }
-  const text = DEC.decode(raw)
-  const result = executeProgram(text, commands, suppress)
-  return [ENC.encode(result), new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return sedGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => s3Stream(accessor, p),
+    (p, data) => s3Write(accessor, p, data),
+  )
 }
 
 export const S3_SED = command({

--- a/typescript/packages/core/src/commands/builtin/s3/sort.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/sort.ts
@@ -14,16 +14,11 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { parseKeyOptions, sortAndDedupe, splitSortLines } from '../sort_helper.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
+import { sortGeneric } from '../generic/sort.ts'
 
 async function sortCommand(
   accessor: S3Accessor,
@@ -31,27 +26,9 @@ async function sortCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const keyOpts = parseKeyOptions(opts.flags)
-  const reverse = opts.flags.r === true
-  const unique = opts.flags.u === true
-  let allLines: string[] = []
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    for (const p of resolved) {
-      const data = DEC.decode(await s3Read(accessor, p, opts.index ?? undefined))
-      allLines = allLines.concat(splitSortLines(data))
-    }
-  } else {
-    const raw = await readStdinAsync(opts.stdin)
-    if (raw === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('sort: missing operand\n') })]
-    }
-    allLines = splitSortLines(DEC.decode(raw))
-  }
-  const sorted = sortAndDedupe(allLines, keyOpts, reverse, unique)
-  const output = sorted.join('\n')
-  const out: ByteSource = output === '' ? new Uint8Array(0) : ENC.encode(output + '\n')
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return sortGeneric(resolved, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_SORT = command({

--- a/typescript/packages/core/src/commands/builtin/s3/zgrep.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/zgrep.ts
@@ -14,77 +14,11 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
-import { read as s3Read } from '../../../core/s3/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { type PathSpec, ResourceName } from '../../../types.ts'
-import { gunzip } from '../../../utils/compress.ts'
+import { stream as s3Stream } from '../../../core/s3/stream.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { compilePattern } from '../grep_helper.ts'
-import { readStdinAsync } from '../utils/stream.ts'
-
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function splitLinesNoTrailing(text: string): string[] {
-  const stripped = text.endsWith('\n') ? text.slice(0, -1) : text
-  return stripped === '' ? [] : stripped.split('\n')
-}
-
-interface ZgrepOpts {
-  ignoreCase: boolean
-  invert: boolean
-  count: boolean
-  lineNumbers: boolean
-  onlyMatching: boolean
-  maxCount: number | null
-}
-
-function zgrepSearch(
-  data: Uint8Array,
-  pattern: RegExp,
-  opts: ZgrepOpts,
-  filename: string | null,
-): [string[], boolean] {
-  const text = DEC.decode(data)
-  const lines = splitLinesNoTrailing(text)
-  const reGlobal = opts.onlyMatching
-    ? new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : pattern.flags + 'g')
-    : null
-  const matched: [number, string][] = []
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i] ?? ''
-    if (opts.onlyMatching && !opts.invert && reGlobal !== null) {
-      reGlobal.lastIndex = 0
-      let m: RegExpExecArray | null
-      const hits: RegExpExecArray[] = []
-      while ((m = reGlobal.exec(line)) !== null) {
-        hits.push(m)
-        if (m[0] === '') reGlobal.lastIndex += 1
-      }
-      if (hits.length > 0) {
-        for (const h of hits) {
-          matched.push([i + 1, h[0]])
-          if (opts.maxCount !== null && matched.length >= opts.maxCount) break
-        }
-      }
-    } else {
-      let hit = pattern.test(line)
-      if (opts.invert) hit = !hit
-      if (hit) matched.push([i + 1, line])
-    }
-    if (opts.maxCount !== null && matched.length >= opts.maxCount) break
-  }
-  if (opts.count) return [[String(matched.length)], matched.length > 0]
-  const result: string[] = []
-  for (const [idx, line] of matched) {
-    let prefix = ''
-    if (filename !== null) prefix = filename + ':'
-    if (opts.lineNumbers) prefix += String(idx) + ':'
-    result.push(prefix + line)
-  }
-  return [result, matched.length > 0]
-}
+import { zgrepGeneric } from '../generic/zgrep.ts'
 
 async function zgrepCommand(
   accessor: S3Accessor,
@@ -92,104 +26,9 @@ async function zgrepCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const rawPattern =
-    typeof opts.flags.e === 'string'
-      ? opts.flags.e
-      : texts.length > 0 && texts[0] !== undefined
-        ? texts[0]
-        : ''
-  const extendedRegex = opts.flags.E === true
-  const fixedString = opts.flags.F === true
-  const wholeWord = opts.flags.w === true
-  const ignoreCase = opts.flags.i === true
-  const invert = opts.flags.v === true
-  const countOnly = opts.flags.c === true
-  const lineNumbers = opts.flags.n === true
-  const onlyMatching = opts.flags.o === true
-  const quiet = opts.flags.q === true
-  const filesOnly = opts.flags.args_l === true
-  const forceH = opts.flags.H === true
-  const hideH = opts.flags.h === true
-  const maxCount = typeof opts.flags.m === 'string' ? Number.parseInt(opts.flags.m, 10) : null
-  void extendedRegex
-  const pattern = compilePattern(rawPattern, ignoreCase, fixedString, wholeWord)
-
   const resolved =
     paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
-  const multi = resolved.length > 1
-  const showFilename = forceH || (multi && !hideH)
-  let anyMatch = false
-  const allResults: string[] = []
-
-  if (resolved.length > 0) {
-    for (const p of resolved) {
-      const compressed = await s3Read(accessor, p, opts.index ?? undefined)
-      const data = await gunzip(compressed)
-      const fname = showFilename ? p.original : null
-      if (filesOnly) {
-        const text = DEC.decode(data)
-        const lines = splitLinesNoTrailing(text)
-        for (const line of lines) {
-          let hit = pattern.test(line)
-          if (invert) hit = !hit
-          if (hit) {
-            allResults.push(p.original)
-            anyMatch = true
-            break
-          }
-        }
-      } else {
-        const [result, hadMatch] = zgrepSearch(
-          data,
-          pattern,
-          {
-            ignoreCase,
-            invert,
-            count: countOnly,
-            lineNumbers,
-            onlyMatching,
-            maxCount,
-          },
-          fname,
-        )
-        if (hadMatch) anyMatch = true
-        for (const r of result) allResults.push(r)
-      }
-    }
-  } else {
-    const stdinData = await readStdinAsync(opts.stdin)
-    if (stdinData === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('zgrep: missing input\n') })]
-    }
-    const data = await gunzip(stdinData)
-    if (filesOnly) {
-      const text = DEC.decode(data)
-      const lines = splitLinesNoTrailing(text)
-      for (const line of lines) {
-        let hit = pattern.test(line)
-        if (invert) hit = !hit
-        if (hit) {
-          allResults.push('(standard input)')
-          anyMatch = true
-          break
-        }
-      }
-    } else {
-      const [result, hadMatch] = zgrepSearch(
-        data,
-        pattern,
-        { ignoreCase, invert, count: countOnly, lineNumbers, onlyMatching, maxCount },
-        null,
-      )
-      if (hadMatch) anyMatch = true
-      for (const r of result) allResults.push(r)
-    }
-  }
-
-  if (quiet) return [null, new IOResult({ exitCode: anyMatch ? 0 : 1 })]
-  if (!anyMatch) return [null, new IOResult({ exitCode: 1 })]
-  const result: ByteSource = ENC.encode(allResults.join('\n') + '\n')
-  return [result, new IOResult()]
+  return zgrepGeneric(resolved, texts, opts, (p) => s3Stream(accessor, p))
 }
 
 export const S3_ZGREP = command({

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -285,6 +285,7 @@ export { headGeneric, headProvisionGeneric } from './commands/builtin/generic/he
 export { tailGeneric } from './commands/builtin/generic/tail.ts'
 export { wcGeneric } from './commands/builtin/generic/wc.ts'
 export { readlinkGeneric } from './commands/builtin/generic/readlink.ts'
+export { fmtGeneric } from './commands/builtin/generic/fmt.ts'
 export { headStream } from './commands/builtin/head_helper.ts'
 export { basenameFn, dirnameFn, gnuBasename, gnuDirname } from './commands/builtin/path_helper.ts'
 export { detectFileType, FILE_MIME_MAP, formatFileResult } from './commands/builtin/file_helper.ts'

--- a/typescript/packages/node/src/commands/builtin/disk/fmt.ts
+++ b/typescript/packages/node/src/commands/builtin/disk/fmt.ts
@@ -13,13 +13,10 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
-  IOResult,
   ResourceName,
   command,
-  materialize,
-  readStdinAsync,
+  fmtGeneric,
   specOf,
-  type ByteSource,
   type CommandFnResult,
   type CommandOpts,
   type PathSpec,
@@ -27,61 +24,13 @@ import {
 import { stream as diskStream } from '../../../core/disk/stream.ts'
 import type { DiskAccessor } from '../../../accessor/disk.ts'
 
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function wrapText(text: string, width: number): string {
-  const words = text.split(/\s+/).filter((w) => w !== '')
-  if (words.length === 0) return ''
-  const lines: string[] = []
-  let current = ''
-  for (const w of words) {
-    if (current === '') {
-      current = w
-    } else if (current.length + 1 + w.length <= width) {
-      current = current + ' ' + w
-    } else {
-      lines.push(current)
-      current = w
-    }
-  }
-  if (current !== '') lines.push(current)
-  return lines.join('\n')
-}
-
-function fmtText(text: string, width: number): string {
-  const paragraphs = text.split('\n\n')
-  const formatted: string[] = []
-  for (const para of paragraphs) {
-    const trimmed = para.trim()
-    if (trimmed !== '') formatted.push(wrapText(trimmed, width))
-    else formatted.push('')
-  }
-  return formatted.join('\n\n') + '\n'
-}
-
 async function fmtCommand(
   accessor: DiskAccessor,
   paths: PathSpec[],
-  texts: string[],
+  _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const width = typeof opts.flags.w === 'string' ? Number.parseInt(opts.flags.w, 10) : 75
-  if (paths.length > 0) {
-    const parts: string[] = []
-    for (const p of paths) {
-      parts.push(DEC.decode(await materialize(diskStream(accessor, p))))
-    }
-    const result: ByteSource = ENC.encode(fmtText(parts.join(''), width))
-    return [result, new IOResult()]
-  }
-  const stdinData = await readStdinAsync(opts.stdin)
-  if (stdinData === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('fmt: missing operand\n') })]
-  }
-  const text = DEC.decode(stdinData)
-  const result: ByteSource = ENC.encode(fmtText(text, width))
-  return [result, new IOResult()]
+  return fmtGeneric(paths, opts, (p) => diskStream(accessor, p))
 }
 
 export const DISK_FMT = command({

--- a/typescript/packages/node/src/commands/builtin/redis/fmt.ts
+++ b/typescript/packages/node/src/commands/builtin/redis/fmt.ts
@@ -13,13 +13,10 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
-  IOResult,
   ResourceName,
   command,
-  materialize,
-  readStdinAsync,
+  fmtGeneric,
   specOf,
-  type ByteSource,
   type CommandFnResult,
   type CommandOpts,
   type PathSpec,
@@ -27,61 +24,13 @@ import {
 import { stream as redisStream } from '../../../core/redis/stream.ts'
 import type { RedisAccessor } from '../../../accessor/redis.ts'
 
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function wrapText(text: string, width: number): string {
-  const words = text.split(/\s+/).filter((w) => w !== '')
-  if (words.length === 0) return ''
-  const lines: string[] = []
-  let current = ''
-  for (const w of words) {
-    if (current === '') {
-      current = w
-    } else if (current.length + 1 + w.length <= width) {
-      current = current + ' ' + w
-    } else {
-      lines.push(current)
-      current = w
-    }
-  }
-  if (current !== '') lines.push(current)
-  return lines.join('\n')
-}
-
-function fmtText(text: string, width: number): string {
-  const paragraphs = text.split('\n\n')
-  const formatted: string[] = []
-  for (const para of paragraphs) {
-    const trimmed = para.trim()
-    if (trimmed !== '') formatted.push(wrapText(trimmed, width))
-    else formatted.push('')
-  }
-  return formatted.join('\n\n') + '\n'
-}
-
 async function fmtCommand(
   accessor: RedisAccessor,
   paths: PathSpec[],
-  texts: string[],
+  _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const width = typeof opts.flags.w === 'string' ? Number.parseInt(opts.flags.w, 10) : 75
-  if (paths.length > 0) {
-    const parts: string[] = []
-    for (const p of paths) {
-      parts.push(DEC.decode(await materialize(redisStream(accessor, p))))
-    }
-    const result: ByteSource = ENC.encode(fmtText(parts.join(''), width))
-    return [result, new IOResult()]
-  }
-  const stdinData = await readStdinAsync(opts.stdin)
-  if (stdinData === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('fmt: missing operand\n') })]
-  }
-  const text = DEC.decode(stdinData)
-  const result: ByteSource = ENC.encode(fmtText(text, width))
-  return [result, new IOResult()]
+  return fmtGeneric(paths, opts, (p) => redisStream(accessor, p))
 }
 
 export const REDIS_FMT = command({


### PR DESCRIPTION
Follows python's structure where every backend reuses one generic per command. Converts the s3 text-processing commands that were still bespoke in TS, and consolidates the one command (fmt) that was duplicated across backends.

## s3 commands now delegate to the existing generic
- head (also restores multi-file `==> name <==` headers; the bespoke version only read paths[0])
- sed, sort, cut, diff, zgrep

Each is now a thin wrapper that injects the s3 stream (and write, for sed) into the shared generic helper, matching python's s3 wrappers and TS's local backends.

## fmt consolidated (was duplicated 5x)
`fmt` had identical `wrapText`/`fmtText` logic copied across s3, ram, disk, redis, opfs and no generic. Added `generic/fmt.ts` (exported from core) and reduced all five backends to thin wrappers, mirroring python's single `generic.fmt` that every backend delegates to.

## Not touched
- basename/dirname already delegate to the shared `path_helper` (`basenameFn`/`dirnameFn`); no change needed.
- Write/archive commands (rm, mkdir, tar, gzip, tee, touch, ...) stay backend-native in both languages.

## Verification
- core 2733, node 1357, browser 162 tests pass.
- Shared integ suite still byte-identical to `truth.txt` on ram and s3 (covers head/sed/sort/cut/diff/zgrep/fmt cases cross-language).