### PR TITLE
refactor(ts): align discord/gmail/slack/email with python generic reuse

### DIFF
--- a/examples/typescript/discord/discord.ts
+++ b/examples/typescript/discord/discord.ts
@@ -98,6 +98,30 @@ async function main(): Promise<void> {
       console.log('  (no attachments on this date)')
     }
 
+    // ── stat + cat first attachment (byte-exact CDN download) ──
+    if (filesOut !== '') {
+      const firstAtt = filesOut.split('\n')[0]!.trim()
+      const attPath = `${base}/${targetDate}/files/${firstAtt}`
+
+      console.log(`\n=== stat ${firstAtt} ===`)
+      r = await ws.execute(`stat "${attPath}"`)
+      const statOut = r.stdoutText.trim()
+      console.log(`  ${statOut.slice(0, 200)}`)
+      const sizeMatch = /size=(\d+)/.exec(statOut)
+      const expectedSize = sizeMatch !== null ? Number.parseInt(sizeMatch[1]!, 10) : null
+
+      console.log(`\n=== cat ${firstAtt} (byte-exact CDN download) ===`)
+      r = await ws.execute(`cat "${attPath}"`)
+      console.log(
+        `  bytes=${String(r.stdout.byteLength)} expected=${String(expectedSize)} exit=${String(r.exitCode)}`,
+      )
+      if (expectedSize !== null && r.stdout.byteLength !== expectedSize) {
+        throw new Error(
+          `regression: attachment cat got ${String(r.stdout.byteLength)} bytes, expected ${String(expectedSize)}`,
+        )
+      }
+    }
+
     // ── grep at FILE level ─────────────────────────
     console.log(`\n=== grep at FILE level: grep -c . ${targetDate}/chat.jsonl ===`)
     r = await ws.execute(`grep -c . "${filePath}"`)
@@ -143,6 +167,33 @@ async function main(): Promise<void> {
     r = await ws.execute(`wc -l "${filePath}"`)
     console.log(`  ${r.stdoutText.trim()}`)
 
+    // ── basename / dirname / realpath (path ops) ───────
+    console.log(`\n=== basename ${filePath} ===`)
+    r = await ws.execute(`basename "${filePath}"`)
+    const baseOut = r.stdoutText.trim()
+    console.log(`  ${baseOut}`)
+    if (baseOut !== 'chat.jsonl') throw new Error(`basename expected 'chat.jsonl', got ${baseOut}`)
+
+    const expectedDir = `${base}/${targetDate}`
+    console.log(`\n=== dirname ${filePath} ===`)
+    r = await ws.execute(`dirname "${filePath}"`)
+    const dirOut = r.stdoutText.trim()
+    console.log(`  ${dirOut}`)
+    if (dirOut !== expectedDir) throw new Error(`dirname expected ${expectedDir}, got ${dirOut}`)
+
+    console.log(`\n=== realpath ${filePath} ===`)
+    r = await ws.execute(`realpath "${filePath}"`)
+    const realOut = r.stdoutText.trim()
+    console.log(`  ${realOut}`)
+    if (realOut !== filePath) throw new Error(`realpath expected ${filePath}, got ${realOut}`)
+
+    console.log(`\n=== realpath -e ${filePath} (must exist) ===`)
+    r = await ws.execute(`realpath -e "${filePath}"`)
+    console.log(`  exit=${String(r.exitCode)} ${r.stdoutText.trim()}`)
+    if (r.exitCode !== 0) {
+      throw new Error(`regression: realpath -e failed for existing file; stderr=${r.stderrText}`)
+    }
+
     // ── tree ───────────────────────────────────────
     console.log(`\n=== tree -L 2 /discord/${guild}/ | head -n 20 ===`)
     r = await ws.execute(`tree -L 2 "/discord/${guild}/" | head -n 20`)
@@ -177,6 +228,20 @@ async function main(): Promise<void> {
     r = await ws.execute(`cat "${targetDate}/chat.jsonl" | head -n 1`)
     if (r.stdoutText.trim() !== '') {
       console.log(`  ${r.stdoutText.trim().slice(0, 120)}`)
+    }
+
+    // ── members ────────────────────────────────────────
+    console.log(`\n=== ls /discord/${guild}/members/ | head -n 5 ===`)
+    r = await ws.execute(`ls "/discord/${guild}/members/" | head -n 5`)
+    const memOut = r.stdoutText.trim()
+    if (memOut !== '') {
+      for (const line of memOut.split('\n')) console.log(`  ${line}`)
+      const firstMember = memOut.split('\n')[0]!.trim()
+      console.log(`\n=== cat /discord/${guild}/members/${firstMember} ===`)
+      r = await ws.execute(`cat "/discord/${guild}/members/${firstMember}"`)
+      console.log(`  ${r.stdoutText.trim().slice(0, 200)}`)
+    } else {
+      console.log('  (no members visible)')
     }
   } finally {
     await ws.close()

--- a/examples/typescript/slack/slack.ts
+++ b/examples/typescript/slack/slack.ts
@@ -133,6 +133,32 @@ async function main(): Promise<void> {
       console.log(`  ${tailOut.slice(0, 120)}`)
     }
 
+    // ── basename / dirname / realpath (path ops) ───────
+    console.log(`\n=== basename ${filePath} ===`)
+    r = await ws.execute(`basename "${filePath}"`)
+    const baseOut = r.stdoutText.trim()
+    console.log(`  ${baseOut}`)
+    if (baseOut !== target) throw new Error(`basename expected ${target}, got ${baseOut}`)
+
+    console.log(`\n=== dirname ${filePath} ===`)
+    r = await ws.execute(`dirname "${filePath}"`)
+    const dirOut = r.stdoutText.trim()
+    console.log(`  ${dirOut}`)
+    if (dirOut !== datePath) throw new Error(`dirname expected ${datePath}, got ${dirOut}`)
+
+    console.log(`\n=== realpath ${filePath} ===`)
+    r = await ws.execute(`realpath "${filePath}"`)
+    const realOut = r.stdoutText.trim()
+    console.log(`  ${realOut}`)
+    if (realOut !== filePath) throw new Error(`realpath expected ${filePath}, got ${realOut}`)
+
+    console.log(`\n=== realpath -e ${filePath} (must exist) ===`)
+    r = await ws.execute(`realpath -e "${filePath}"`)
+    console.log(`  exit=${r.exitCode} ${r.stdoutText.trim()}`)
+    if (r.exitCode !== 0) {
+      throw new Error(`regression: realpath -e failed for existing file; stderr=${r.stderrText}`)
+    }
+
     // ── grep at FILE level ─────────────────────────────
     console.log(`\n=== grep message ${target} ===`)
     r = await ws.execute(`grep message "${filePath}"`)

--- a/python/mirage/accessor/email.py
+++ b/python/mirage/accessor/email.py
@@ -38,6 +38,15 @@ class EmailAccessor(Accessor):
                     port=self.config.imap_port,
                 )
             await self._imap.wait_hello_from_server()
-            await self._imap.login(self.config.username,
-                                   reveal_secret(self.config.password))
+            response = await self._imap.login(
+                self.config.username, reveal_secret(self.config.password))
+            if response.result != "OK":
+                detail = " ".join(
+                    line.decode(errors="replace") if isinstance(
+                        line, (bytes, bytearray)) else str(line)
+                    for line in (response.lines or []))
+                self._imap = None
+                raise ConnectionError(
+                    f"IMAP login failed for {self.config.username} on "
+                    f"{self.config.imap_host}: {detail or response.result}")
         return self._imap

--- a/python/mirage/commands/builtin/s3/find.py
+++ b/python/mirage/commands/builtin/s3/find.py
@@ -12,16 +12,15 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.find_helper import (_extract_not_name,
-                                                 _extract_or_names,
-                                                 _parse_mtime, _parse_size)
+from mirage.commands.builtin.generic.find import find as generic_find
 from mirage.commands.builtin.s3._provision import metadata_provision
-from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
-from mirage.core.s3.find import find as find_impl
+from mirage.core.s3.find import find as find_core
 from mirage.core.s3.glob import resolve_glob
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -49,43 +48,14 @@ async def find(
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     paths = await resolve_glob(accessor, paths, index)
-    path_pattern = path
-    p0 = paths[0]
-    search_path = p0
-    ftype = None
-    if type == "d":
-        ftype = "directory"
-    elif type == "f":
-        ftype = "file"
-    elif type is not None:
-        ftype = type
-    md = int(maxdepth) if maxdepth is not None else None
-    min_size, max_size = (None, None)
-    if size is not None:
-        min_size, max_size = _parse_size(size)
-    mtime_min, mtime_max = (None, None)
-    if mtime is not None:
-        mtime_min, mtime_max = _parse_mtime(mtime)
-    name_exclude = _extract_not_name(texts)
-    or_names = _extract_or_names(name, texts)
-    md_min = int(mindepth) if mindepth is not None else None
-    results = await find_impl(
-        accessor,
-        search_path,
-        name=name,
-        type=ftype,
-        min_size=min_size,
-        max_size=max_size,
-        maxdepth=md,
-        name_exclude=name_exclude,
-        or_names=or_names if len(or_names) > 1 else None,
-        mtime_min=mtime_min,
-        mtime_max=mtime_max,
-        iname=iname,
-        path_pattern=path_pattern,
-        mindepth=md_min,
-    )
-    if p0.prefix:
-        results = [p0.prefix + "/" + r.lstrip("/") for r in results]
-    output = format_records(results)
-    return output, IOResult()
+    return await generic_find(paths,
+                              texts,
+                              find_core=partial(find_core, accessor),
+                              name=name,
+                              type=type,
+                              size=size,
+                              mtime=mtime,
+                              maxdepth=maxdepth,
+                              iname=iname,
+                              path=path,
+                              mindepth=mindepth)

--- a/python/mirage/core/s3/find.py
+++ b/python/mirage/core/s3/find.py
@@ -42,7 +42,7 @@ async def find(
         accessor (S3Accessor): S3 accessor.
         path (PathSpec | str): Prefix path.
         name (str | None): Glob pattern to match entry name.
-        type (str | None): "file" or "directory".
+        type (str | None): "f" (file) or "d" (directory).
         min_size (int | None): Minimum object size.
         max_size (int | None): Maximum object size.
         maxdepth (int | None): Maximum directory depth.
@@ -93,9 +93,9 @@ async def find(
                     continue
                 if name_exclude and fnmatch.fnmatch(entry_name, name_exclude):
                     continue
-                if type == "file" and is_dir:
+                if type == "f" and is_dir:
                     continue
-                if type == "directory" and not is_dir:
+                if type == "d" and not is_dir:
                     continue
                 if not is_dir:
                     size = obj.get("Size", 0)

--- a/typescript/packages/core/src/commands/builtin/discord/basename.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/basename.ts
@@ -1,0 +1,25 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { ResourceName } from '../../../types.ts'
+import { command } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { basenameFn } from '../path_helper.ts'
+
+export const DISCORD_BASENAME = command({
+  name: 'basename',
+  resource: ResourceName.DISCORD,
+  spec: specOf('basename'),
+  fn: basenameFn,
+})

--- a/typescript/packages/core/src/commands/builtin/discord/dirname.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/dirname.ts
@@ -1,0 +1,25 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { ResourceName } from '../../../types.ts'
+import { command } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { dirnameFn } from '../path_helper.ts'
+
+export const DISCORD_DIRNAME = command({
+  name: 'dirname',
+  resource: ResourceName.DISCORD,
+  spec: specOf('dirname'),
+  fn: dirnameFn,
+})

--- a/typescript/packages/core/src/commands/builtin/discord/index.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/index.ts
@@ -25,6 +25,7 @@ import { DISCORD_GREP } from './grep.ts'
 import { DISCORD_HEAD } from './head.ts'
 import { DISCORD_JQ } from './jq.ts'
 import { DISCORD_LS } from './ls.ts'
+import { DISCORD_REALPATH } from './realpath.ts'
 import { DISCORD_RG } from './rg.ts'
 import { DISCORD_STAT } from './stat.ts'
 import { DISCORD_TAIL } from './tail.ts'
@@ -45,6 +46,7 @@ export const DISCORD_COMMANDS: readonly RegisteredCommand[] = [
   ...DISCORD_JQ,
   ...DISCORD_BASENAME,
   ...DISCORD_DIRNAME,
+  ...DISCORD_REALPATH,
   ...DISCORD_SEND_MESSAGE,
   ...DISCORD_ADD_REACTION,
   ...DISCORD_GET_SERVER_INFO,

--- a/typescript/packages/core/src/commands/builtin/discord/index.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/index.ts
@@ -13,7 +13,9 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { RegisteredCommand } from '../../config.ts'
+import { DISCORD_BASENAME } from './basename.ts'
 import { DISCORD_CAT } from './cat.ts'
+import { DISCORD_DIRNAME } from './dirname.ts'
 import { DISCORD_ADD_REACTION } from './discord_add_reaction.ts'
 import { DISCORD_GET_SERVER_INFO } from './discord_get_server_info.ts'
 import { DISCORD_LIST_MEMBERS } from './discord_list_members.ts'
@@ -41,6 +43,8 @@ export const DISCORD_COMMANDS: readonly RegisteredCommand[] = [
   ...DISCORD_RG,
   ...DISCORD_STAT,
   ...DISCORD_JQ,
+  ...DISCORD_BASENAME,
+  ...DISCORD_DIRNAME,
   ...DISCORD_SEND_MESSAGE,
   ...DISCORD_ADD_REACTION,
   ...DISCORD_GET_SERVER_INFO,

--- a/typescript/packages/core/src/commands/builtin/discord/realpath.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/realpath.ts
@@ -1,0 +1,41 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DiscordAccessor } from '../../../accessor/discord.ts'
+import { resolveDiscordGlob } from '../../../core/discord/glob.ts'
+import { stat as discordStat } from '../../../core/discord/stat.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { realpathGeneric } from '../generic/realpath.ts'
+
+async function realpathCommand(
+  accessor: DiscordAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveDiscordGlob(accessor, paths, opts.index ?? undefined) : []
+  return realpathGeneric(resolved, texts, opts, (p) =>
+    discordStat(accessor, p, opts.index ?? undefined),
+  )
+}
+
+export const DISCORD_REALPATH = command({
+  name: 'realpath',
+  resource: ResourceName.DISCORD,
+  spec: specOf('realpath'),
+  fn: realpathCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/discord/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/rg.ts
@@ -18,81 +18,24 @@ import { DiscordApiError } from '../../../core/discord/_client.ts'
 import { resolveDiscordGlob } from '../../../core/discord/glob.ts'
 import { read as discordRead } from '../../../core/discord/read.ts'
 import { readdir as discordReaddir } from '../../../core/discord/readdir.ts'
+import { stat as discordStat } from '../../../core/discord/stat.ts'
 import { detectScope } from '../../../core/discord/scope.ts'
 import { listChannels } from '../../../core/discord/channels.ts'
 import { formatGrepResults, searchGuild } from '../../../core/discord/search.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
+import { IOResult } from '../../../io/types.ts'
+import { type FileStat, type PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { compilePattern, grepLines } from '../grep_helper.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { rgGeneric } from '../generic/rg.ts'
 
 const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
 
-interface RgFlags {
-  ignoreCase: boolean
-  invert: boolean
-  lineNumbers: boolean
-  countOnly: boolean
-  filesOnly: boolean
-  wholeWord: boolean
-  fixedString: boolean
-  onlyMatching: boolean
-  maxCount: number | null
-  hidden: boolean
-}
-
-function parseRgFlags(flags: Record<string, string | boolean>): RgFlags {
-  const toInt = (v: string | boolean | undefined): number | null =>
-    typeof v === 'string' ? Number.parseInt(v, 10) : null
-  return {
-    ignoreCase: flags.i === true,
-    invert: flags.v === true,
-    lineNumbers: flags.n === true,
-    countOnly: flags.c === true,
-    filesOnly: flags.args_l === true,
-    wholeWord: flags.w === true,
-    fixedString: flags.F === true,
-    onlyMatching: flags.o === true,
-    maxCount: toInt(flags.m),
-    hidden: flags.hidden === true,
-  }
-}
-
-async function collectFiles(
+async function* discordStream(
   accessor: DiscordAccessor,
-  path: PathSpec,
+  p: PathSpec,
   index: IndexCacheStore | undefined,
-): Promise<string[]> {
-  let children: string[]
-  try {
-    children = await discordReaddir(accessor, path, index)
-  } catch {
-    return []
-  }
-  const files: string[] = []
-  for (const child of children) {
-    if (child.endsWith('.json') || child.endsWith('.jsonl')) {
-      files.push(child)
-    } else {
-      const childSpec = new PathSpec({
-        original: child,
-        directory: child,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const sub = await collectFiles(accessor, childSpec, index)
-      files.push(...sub)
-    }
-  }
-  return files
-}
-
-function splitLinesNoTrailing(text: string): string[] {
-  const stripped = text.endsWith('\n') ? text.slice(0, -1) : text
-  return stripped === '' ? [] : stripped.split('\n')
+): AsyncIterable<Uint8Array> {
+  yield await discordRead(accessor, p, index)
 }
 
 async function rgCommand(
@@ -108,8 +51,7 @@ async function rgCommand(
       new IOResult({ exitCode: 2, stderr: ENC.encode('rg: usage: rg [flags] pattern [path]\n') }),
     ]
   }
-  const f = parseRgFlags(opts.flags)
-  const pat = compilePattern(exprText, f.ignoreCase, f.fixedString, f.wholeWord)
+  const maxCount = typeof opts.flags.m === 'string' ? Number.parseInt(opts.flags.m, 10) : null
 
   const pushdownWarnings: string[] = []
   if (paths.length > 0) {
@@ -118,7 +60,7 @@ async function rgCommand(
       const scope = detectScope(firstPath)
       if (scope.useNative && scope.guildId !== undefined) {
         try {
-          const count = f.maxCount ?? 100
+          const count = maxCount ?? 100
           const raw = await searchGuild(accessor, scope.guildId, exprText, scope.channelId, count)
           const channelMap = new Map<string, string>()
           if (scope.channelId === undefined) {
@@ -132,7 +74,7 @@ async function rgCommand(
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err)
           pushdownWarnings.push(
-            `discord: native search push-down failed (${msg}); ` + `falling back to per-file scan`,
+            `discord: native search push-down failed (${msg}); falling back to per-file scan`,
           )
           const status = err instanceof DiscordApiError ? err.status : null
           const lower = msg.toLowerCase()
@@ -151,72 +93,20 @@ async function rgCommand(
         }
       }
     }
-    const resolved = await resolveDiscordGlob(accessor, paths, opts.index ?? undefined)
-    const filePaths: string[] = []
-    const filePrefix = resolved[0]?.prefix ?? ''
-    for (const p of resolved) {
-      const sub = await collectFiles(accessor, p, opts.index ?? undefined)
-      filePaths.push(...sub)
-    }
-    const sortedFiles = Array.from(new Set(filePaths)).sort()
-    const allResults: string[] = []
-    let anyMatch = false
-    for (const bp of sortedFiles) {
-      if (!f.hidden && bp.split('/').some((part) => part.startsWith('.'))) continue
-      let data: Uint8Array
-      try {
-        const bpSpec = new PathSpec({
-          original: bp,
-          directory: bp,
-          resolved: true,
-          prefix: filePrefix,
-        })
-        data = await discordRead(accessor, bpSpec, opts.index ?? undefined)
-      } catch {
-        continue
-      }
-      const text = DEC.decode(data)
-      if (text === '') continue
-      const lines = splitLinesNoTrailing(text)
-      const matched = grepLines(bp, lines, pat, f)
-      if (matched.length === 0) continue
-      anyMatch = true
-      if (f.filesOnly) {
-        allResults.push(bp)
-        continue
-      }
-      if (f.countOnly) {
-        allResults.push(`${bp}:${String(matched.length)}`)
-        continue
-      }
-      for (const line of matched) {
-        allResults.push(`${bp}:${line}`)
-      }
-    }
-    const stderr =
-      pushdownWarnings.length > 0 ? ENC.encode(pushdownWarnings.join('\n') + '\n') : undefined
-    if (!anyMatch) {
-      return [
-        new Uint8Array(0),
-        new IOResult({ exitCode: 1, ...(stderr !== undefined ? { stderr } : {}) }),
-      ]
-    }
-    const out: ByteSource = ENC.encode(allResults.join('\n'))
-    return [out, new IOResult({ ...(stderr !== undefined ? { stderr } : {}) })]
   }
 
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [
-      null,
-      new IOResult({ exitCode: 2, stderr: ENC.encode('rg: usage: rg [flags] pattern path\n') }),
-    ]
+  const resolved =
+    paths.length > 0 ? await resolveDiscordGlob(accessor, paths, opts.index ?? undefined) : []
+  const stat = (p: PathSpec): Promise<FileStat> => discordStat(accessor, p, opts.index ?? undefined)
+  const readdir = (p: PathSpec): Promise<string[]> =>
+    discordReaddir(accessor, p, opts.index ?? undefined)
+  const result = await rgGeneric(resolved, texts, opts, stat, readdir, (p) =>
+    discordStream(accessor, p, opts.index ?? undefined),
+  )
+  if (result !== null && pushdownWarnings.length > 0) {
+    result[1].stderr = ENC.encode(pushdownWarnings.join('\n') + '\n')
   }
-  const lines = splitLinesNoTrailing(DEC.decode(raw))
-  const matched = grepLines('<stdin>', lines, pat, f)
-  if (matched.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-  if (f.countOnly) return [ENC.encode(String(matched.length)), new IOResult()]
-  return [ENC.encode(matched.join('\n')), new IOResult()]
+  return result
 }
 
 export const DISCORD_RG = command({

--- a/typescript/packages/core/src/commands/builtin/gmail/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/rg.ts
@@ -13,50 +13,27 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { GmailAccessor } from '../../../accessor/gmail.ts'
+import type { IndexCacheStore } from '../../../cache/index/index.ts'
 import { resolveGlob } from '../../../core/gmail/glob.ts'
 import { read as gmailRead } from '../../../core/gmail/read.ts'
 import { readdir as gmailReaddir } from '../../../core/gmail/readdir.ts'
+import { stat as gmailStat } from '../../../core/gmail/stat.ts'
 import { detectScope } from '../../../core/gmail/scope.ts'
 import { formatGrepResults, searchMessages } from '../../../core/gmail/search.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
+import { type FileStat, type PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { compilePattern, grepLines, type GrepLinesOptions } from '../grep_helper.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { rgGeneric } from '../generic/rg.ts'
 
 const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
 
-async function collectFiles(
+async function* gmailStream(
   accessor: GmailAccessor,
-  path: PathSpec,
-  index: CommandOpts['index'],
-): Promise<string[]> {
-  if (path.original.endsWith('.json') || path.original.endsWith('.jsonl')) {
-    return [path.original]
-  }
-  let children: string[]
-  try {
-    children = await gmailReaddir(accessor, path, index ?? undefined)
-  } catch {
-    return []
-  }
-  const files: string[] = []
-  for (const child of children) {
-    if (child.endsWith('.gmail.json')) {
-      files.push(child)
-    } else {
-      const childSpec = new PathSpec({
-        original: child,
-        directory: child,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      files.push(...(await collectFiles(accessor, childSpec, index)))
-    }
-  }
-  return files
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await gmailRead(accessor, p, index)
 }
 
 async function rgCommand(
@@ -72,26 +49,7 @@ async function rgCommand(
     ]
   }
   const pattern = texts[0]
-  const ignoreCase = opts.flags.i === true
-  const invert = opts.flags.v === true
-  const lineNumbers = opts.flags.n === true
-  const countOnly = opts.flags.c === true
-  const filesOnly = opts.flags.args_l === true || opts.flags.l === true
-  const wholeWord = opts.flags.w === true
-  const fixedString = opts.flags.F === true
-  const onlyMatching = opts.flags.o === true
   const maxCount = typeof opts.flags.m === 'string' ? Number.parseInt(opts.flags.m, 10) : null
-  const hidden = opts.flags.hidden === true
-  const pat = compilePattern(pattern, ignoreCase, fixedString, wholeWord)
-
-  const lineOpts: GrepLinesOptions = {
-    invert,
-    lineNumbers,
-    countOnly,
-    filesOnly,
-    onlyMatching,
-    maxCount,
-  }
 
   if (paths.length > 0) {
     const first = paths[0]
@@ -112,64 +70,16 @@ async function rgCommand(
         return [out, new IOResult()]
       }
     }
-
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const filePrefix = resolved[0]?.prefix ?? ''
-    const blobPaths: string[] = []
-    for (const p of resolved) blobPaths.push(...(await collectFiles(accessor, p, opts.index)))
-    const sortedUnique = [...new Set(blobPaths)].sort()
-    const allResults: string[] = []
-    let anyMatch = false
-    for (const bp of sortedUnique) {
-      if (!hidden && bp.split('/').some((part) => part.startsWith('.'))) continue
-      let data: Uint8Array
-      try {
-        const spec = new PathSpec({
-          original: bp,
-          directory: bp,
-          resolved: true,
-          prefix: filePrefix,
-        })
-        data = await gmailRead(accessor, spec, opts.index ?? undefined)
-      } catch {
-        continue
-      }
-      const text = DEC.decode(data)
-      if (text === '') continue
-      const lines = text.split('\n')
-      if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
-      const matched = grepLines(bp, lines, pat, lineOpts)
-      if (matched.length === 0) continue
-      anyMatch = true
-      if (filesOnly) {
-        allResults.push(bp)
-        continue
-      }
-      if (countOnly) {
-        allResults.push(`${bp}:${String(matched.length)}`)
-        continue
-      }
-      for (const line of matched) allResults.push(`${bp}:${line}`)
-    }
-    if (!anyMatch) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-    const out: ByteSource = ENC.encode(allResults.join('\n'))
-    return [out, new IOResult()]
   }
 
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [
-      null,
-      new IOResult({ exitCode: 2, stderr: ENC.encode('rg: usage: rg [flags] pattern path\n') }),
-    ]
-  }
-  const lines = DEC.decode(raw).split('\n')
-  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
-  const matched = grepLines('<stdin>', lines, pat, lineOpts)
-  if (matched.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-  if (countOnly) return [ENC.encode(String(matched.length)), new IOResult()]
-  const out: ByteSource = ENC.encode(matched.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  const stat = (p: PathSpec): Promise<FileStat> => gmailStat(accessor, p, opts.index ?? undefined)
+  const readdir = (p: PathSpec): Promise<string[]> =>
+    gmailReaddir(accessor, p, opts.index ?? undefined)
+  return rgGeneric(resolved, texts, opts, stat, readdir, (p) =>
+    gmailStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const GMAIL_RG = command({

--- a/typescript/packages/core/src/commands/builtin/slack/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/rg.ts
@@ -17,6 +17,7 @@ import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { resolveSlackGlob } from '../../../core/slack/glob.ts'
 import { read as slackRead } from '../../../core/slack/read.ts'
 import { readdir as slackReaddir } from '../../../core/slack/readdir.ts'
+import { stat as slackStat } from '../../../core/slack/stat.ts'
 import {
   buildQuery,
   formatFileGrepResults,
@@ -24,78 +25,20 @@ import {
 } from '../../../core/slack/formatters.ts'
 import { detectScope } from '../../../core/slack/scope.ts'
 import { searchFiles, searchMessages } from '../../../core/slack/search.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
+import { IOResult } from '../../../io/types.ts'
+import { type FileStat, type PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { compilePattern, grepLines } from '../grep_helper.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { rgGeneric } from '../generic/rg.ts'
 
 const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
 
-interface RgFlags {
-  ignoreCase: boolean
-  invert: boolean
-  lineNumbers: boolean
-  countOnly: boolean
-  filesOnly: boolean
-  wholeWord: boolean
-  fixedString: boolean
-  onlyMatching: boolean
-  maxCount: number | null
-  hidden: boolean
-}
-
-function parseRgFlags(flags: Record<string, string | boolean>): RgFlags {
-  const toInt = (v: string | boolean | undefined): number | null =>
-    typeof v === 'string' ? Number.parseInt(v, 10) : null
-  return {
-    ignoreCase: flags.i === true,
-    invert: flags.v === true,
-    lineNumbers: flags.n === true,
-    countOnly: flags.c === true,
-    filesOnly: flags.args_l === true,
-    wholeWord: flags.w === true,
-    fixedString: flags.F === true,
-    onlyMatching: flags.o === true,
-    maxCount: toInt(flags.m),
-    hidden: flags.hidden === true,
-  }
-}
-
-async function collectFiles(
+async function* slackStream(
   accessor: SlackAccessor,
-  path: PathSpec,
+  p: PathSpec,
   index: IndexCacheStore | undefined,
-): Promise<string[]> {
-  let children: string[]
-  try {
-    children = await slackReaddir(accessor, path, index)
-  } catch {
-    return []
-  }
-  const files: string[] = []
-  for (const child of children) {
-    if (child.endsWith('.json') || child.endsWith('.jsonl')) {
-      files.push(child)
-    } else {
-      const childSpec = new PathSpec({
-        original: child,
-        directory: child,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const sub = await collectFiles(accessor, childSpec, index)
-      files.push(...sub)
-    }
-  }
-  return files
-}
-
-function splitLinesNoTrailing(text: string): string[] {
-  const stripped = text.endsWith('\n') ? text.slice(0, -1) : text
-  return stripped === '' ? [] : stripped.split('\n')
+): AsyncIterable<Uint8Array> {
+  yield await slackRead(accessor, p, index)
 }
 
 async function rgCommand(
@@ -111,8 +54,7 @@ async function rgCommand(
       new IOResult({ exitCode: 2, stderr: ENC.encode('rg: usage: rg [flags] pattern [path]\n') }),
     ]
   }
-  const f = parseRgFlags(opts.flags)
-  const pat = compilePattern(exprText, f.ignoreCase, f.fixedString, f.wholeWord)
+  const maxCount = typeof opts.flags.m === 'string' ? Number.parseInt(opts.flags.m, 10) : null
 
   const pushdownWarnings: string[] = []
   if (paths.length > 0) {
@@ -122,7 +64,7 @@ async function rgCommand(
       if (scope.useNative) {
         const filePrefix = firstPath.prefix
         const query = buildQuery(exprText, scope)
-        const count = f.maxCount ?? 100
+        const count = maxCount ?? 100
         const target = scope.target
         const doMessages = target === undefined || target === 'date' || target === 'messages'
         const doFiles = target === undefined || target === 'date' || target === 'files'
@@ -151,72 +93,20 @@ async function rgCommand(
         }
       }
     }
-    const resolved = await resolveSlackGlob(accessor, paths, opts.index ?? undefined)
-    const filePaths: string[] = []
-    const filePrefix = resolved[0]?.prefix ?? ''
-    for (const p of resolved) {
-      const sub = await collectFiles(accessor, p, opts.index ?? undefined)
-      filePaths.push(...sub)
-    }
-    const sortedFiles = Array.from(new Set(filePaths)).sort()
-    const allResults: string[] = []
-    let anyMatch = false
-    for (const bp of sortedFiles) {
-      if (!f.hidden && bp.split('/').some((part) => part.startsWith('.'))) continue
-      let data: Uint8Array
-      try {
-        const bpSpec = new PathSpec({
-          original: bp,
-          directory: bp,
-          resolved: true,
-          prefix: filePrefix,
-        })
-        data = await slackRead(accessor, bpSpec, opts.index ?? undefined)
-      } catch {
-        continue
-      }
-      const text = DEC.decode(data)
-      if (text === '') continue
-      const lines = splitLinesNoTrailing(text)
-      const matched = grepLines(bp, lines, pat, f)
-      if (matched.length === 0) continue
-      anyMatch = true
-      if (f.filesOnly) {
-        allResults.push(bp)
-        continue
-      }
-      if (f.countOnly) {
-        allResults.push(`${bp}:${String(matched.length)}`)
-        continue
-      }
-      for (const line of matched) {
-        allResults.push(`${bp}:${line}`)
-      }
-    }
-    const stderr =
-      pushdownWarnings.length > 0 ? ENC.encode(pushdownWarnings.join('\n') + '\n') : undefined
-    if (!anyMatch) {
-      return [
-        new Uint8Array(0),
-        new IOResult({ exitCode: 1, ...(stderr !== undefined ? { stderr } : {}) }),
-      ]
-    }
-    const out: ByteSource = ENC.encode(allResults.join('\n'))
-    return [out, new IOResult({ ...(stderr !== undefined ? { stderr } : {}) })]
   }
 
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [
-      null,
-      new IOResult({ exitCode: 2, stderr: ENC.encode('rg: usage: rg [flags] pattern path\n') }),
-    ]
+  const resolved =
+    paths.length > 0 ? await resolveSlackGlob(accessor, paths, opts.index ?? undefined) : []
+  const stat = (p: PathSpec): Promise<FileStat> => slackStat(accessor, p, opts.index ?? undefined)
+  const readdir = (p: PathSpec): Promise<string[]> =>
+    slackReaddir(accessor, p, opts.index ?? undefined)
+  const result = await rgGeneric(resolved, texts, opts, stat, readdir, (p) =>
+    slackStream(accessor, p, opts.index ?? undefined),
+  )
+  if (result !== null && pushdownWarnings.length > 0) {
+    result[1].stderr = ENC.encode(pushdownWarnings.join('\n') + '\n')
   }
-  const lines = splitLinesNoTrailing(DEC.decode(raw))
-  const matched = grepLines('<stdin>', lines, pat, f)
-  if (matched.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-  if (f.countOnly) return [ENC.encode(String(matched.length)), new IOResult()]
-  return [ENC.encode(matched.join('\n')), new IOResult()]
+  return result
 }
 
 export const SLACK_RG = command({

--- a/typescript/packages/node/src/accessor/email.ts
+++ b/typescript/packages/node/src/accessor/email.ts
@@ -44,7 +44,12 @@ export class EmailAccessor extends Accessor {
       await client.connect()
       return client
     })()
-    return this.clientPromise
+    try {
+      return await this.clientPromise
+    } catch (err) {
+      this.clientPromise = null
+      throw err
+    }
   }
 
   async close(): Promise<void> {

--- a/typescript/packages/node/src/commands/builtin/email/cat.ts
+++ b/typescript/packages/node/src/commands/builtin/email/cat.ts
@@ -13,48 +13,44 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
-  numberLines,
-  IOResult,
   ResourceName,
+  catGeneric,
   command,
-  resolveSource,
   specOf,
-  wrapBytes,
   type CommandFnResult,
   type CommandOpts,
+  type IndexCacheStore,
   type PathSpec,
 } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../../accessor/email.ts'
 import { resolveGlob } from '../../../core/email/glob.ts'
 import { read as emailRead } from '../../../core/email/read.ts'
+import { stat as emailStat } from '../../../core/email/stat.ts'
 import { fileReadProvision } from './provision.ts'
 
-const ENC = new TextEncoder()
+async function* emailStream(
+  accessor: EmailAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await emailRead(accessor, p, index)
+}
 
 async function catCommand(
   accessor: EmailAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const nFlag = opts.flags.n === true
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const data = await emailRead(accessor, first, opts.index ?? undefined)
-    const io = new IOResult({ reads: { [first.stripPrefix]: data }, cache: [first.stripPrefix] })
-    if (nFlag) return [numberLines(wrapBytes(data)), io]
-    return [data, io]
-  }
-  try {
-    const source = resolveSource(opts.stdin, 'cat: missing operand')
-    if (nFlag) return [numberLines(source), new IOResult()]
-    return [source, new IOResult()]
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
-  }
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return catGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => emailStat(accessor, p, opts.index ?? undefined),
+    (p) => emailStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const EMAIL_CAT = command({

--- a/typescript/packages/node/src/commands/builtin/email/head.ts
+++ b/typescript/packages/node/src/commands/builtin/email/head.ts
@@ -13,59 +13,44 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
-  IOResult,
   ResourceName,
   command,
-  readStdinAsync,
+  headGeneric,
   specOf,
-  type ByteSource,
   type CommandFnResult,
   type CommandOpts,
+  type IndexCacheStore,
   type PathSpec,
 } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../../accessor/email.ts'
 import { resolveGlob } from '../../../core/email/glob.ts'
 import { read as emailRead } from '../../../core/email/read.ts'
+import { stat as emailStat } from '../../../core/email/stat.ts'
 import { fileReadProvision } from './provision.ts'
 
-const ENC = new TextEncoder()
-
-function headBytes(data: Uint8Array, lines: number, bytesMode: number | null): Uint8Array {
-  if (bytesMode !== null) return data.slice(0, bytesMode)
-  let count = 0
-  let end = 0
-  for (let i = 0; i < data.byteLength && count < lines; i++) {
-    if (data[i] === 0x0a) {
-      count += 1
-      end = i + 1
-    }
-  }
-  if (count < lines) return data
-  return data.slice(0, end - 1)
+async function* emailStream(
+  accessor: EmailAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await emailRead(accessor, p, index)
 }
 
 async function headCommand(
   accessor: EmailAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const lines = typeof opts.flags.n === 'string' ? Number.parseInt(opts.flags.n, 10) : 10
-  const bytesMode = typeof opts.flags.c === 'string' ? Number.parseInt(opts.flags.c, 10) : null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const data = await emailRead(accessor, first, opts.index ?? undefined)
-    const out: ByteSource = headBytes(data, lines, bytesMode)
-    return [out, new IOResult()]
-  }
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('head: missing operand\n') })]
-  }
-  const out: ByteSource = headBytes(raw, lines, bytesMode)
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return headGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => emailStat(accessor, p, opts.index ?? undefined),
+    (p) => emailStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const EMAIL_HEAD = command({

--- a/typescript/packages/node/src/commands/builtin/email/ls.ts
+++ b/typescript/packages/node/src/commands/builtin/email/ls.ts
@@ -13,17 +13,13 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
-  FileType,
-  IOResult,
   PathSpec,
   ResourceName,
   command,
-  humanSize,
+  lsGeneric,
   specOf,
-  type ByteSource,
   type CommandFnResult,
   type CommandOpts,
-  type FileStat,
 } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../../accessor/email.ts'
 import { resolveGlob } from '../../../core/email/glob.ts'
@@ -31,150 +27,30 @@ import { readdir as emailReaddir } from '../../../core/email/readdir.ts'
 import { stat as emailStat } from '../../../core/email/stat.ts'
 import { metadataProvision } from './provision.ts'
 
-const ENC = new TextEncoder()
-
-async function lsEntries(
-  accessor: EmailAccessor,
-  path: PathSpec,
-  allFiles: boolean,
-  sortBy: 'name' | 'size',
-  reverse: boolean,
-  recursive: boolean,
-  listDir: boolean,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<FileStat[]> {
-  if (listDir) {
-    const s = await emailStat(accessor, path, indexCache ?? undefined)
-    return [s]
-  }
-  let entries: string[]
-  try {
-    entries = await emailReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`ls: cannot access '${path.original}': ${msg}`)
-    return []
-  }
-  const stats: FileStat[] = []
-  for (const entry of entries) {
-    try {
-      const eSpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await emailStat(accessor, eSpec, indexCache ?? undefined)
-      if (!allFiles && s.name.startsWith('.')) continue
-      stats.push(s)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${entry}': ${msg}`)
-    }
-  }
-  if (sortBy === 'size') {
-    stats.sort((a, b) => (a.size ?? 0) - (b.size ?? 0))
-    if (!reverse) stats.reverse()
-  } else {
-    stats.sort((a, b) => a.name.localeCompare(b.name))
-    if (reverse) stats.reverse()
-  }
-  if (recursive) {
-    const subEntries: FileStat[] = []
-    for (const s of stats) {
-      subEntries.push(s)
-      if (s.type === FileType.DIRECTORY) {
-        const childPath = path.child(s.name)
-        const childSpec = new PathSpec({
-          original: childPath,
-          directory: childPath,
-          resolved: false,
-          prefix: path.prefix,
-        })
-        const sub = await lsEntries(
-          accessor,
-          childSpec,
-          allFiles,
-          sortBy,
-          reverse,
-          recursive,
-          false,
-          warnings,
-          indexCache,
-        )
-        subEntries.push(...sub)
-      }
-    }
-    return subEntries
-  }
-  return stats
-}
-
 async function lsCommand(
   accessor: EmailAccessor,
   paths: PathSpec[],
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const targets: PathSpec[] =
-    resolved.length > 0
-      ? resolved
-      : [
-          new PathSpec({
-            original: opts.cwd,
-            directory: opts.cwd,
-            resolved: false,
-            prefix: opts.mountPrefix ?? '',
-          }),
-        ]
-  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
-  const allFiles = opts.flags.a === true || opts.flags.A === true
-  const human = opts.flags.h === true
-  const reverse = opts.flags.r === true
-  const recursive = opts.flags.R === true
-  const listDir = opts.flags.d === true
-  const classify = opts.flags.F === true
-  const sortBy: 'name' | 'size' = opts.flags.S === true ? 'size' : 'name'
-  const warnings: string[] = []
-  const results: string[] = []
-  for (const p of targets) {
-    let entries: FileStat[]
-    try {
-      entries = await lsEntries(
-        accessor,
-        p,
-        allFiles,
-        sortBy,
-        reverse,
-        recursive,
-        listDir,
-        warnings,
-        opts.index,
-      )
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`ls: cannot access '${p.original}': ${msg}`)
-      continue
-    }
-    if (long) {
-      for (const e of entries) {
-        const sizeStr = human ? humanSize(e.size ?? 0) : String(e.size ?? 0)
-        results.push(`${e.type ?? '-'}\t${sizeStr}\t${e.modified ?? ''}\t${e.name}`)
-      }
-    } else {
-      for (const e of entries) {
-        const isDir = classify && e.type === FileType.DIRECTORY
-        const name = isDir ? e.name + '/' : e.name
-        results.push(name)
-      }
-    }
+  let workingPaths: PathSpec[] = paths
+  if (workingPaths.length === 0) {
+    workingPaths = [
+      new PathSpec({
+        original: opts.cwd,
+        directory: opts.cwd,
+        resolved: false,
+        prefix: opts.mountPrefix ?? '',
+      }),
+    ]
   }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  return [out, new IOResult({ stderr, exitCode })]
+  const resolved = await resolveGlob(accessor, workingPaths, opts.index ?? undefined)
+  return lsGeneric(
+    resolved,
+    opts,
+    (p) => emailReaddir(accessor, p, opts.index ?? undefined),
+    (p) => emailStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const EMAIL_LS = command({

--- a/typescript/packages/node/src/commands/builtin/email/nl.ts
+++ b/typescript/packages/node/src/commands/builtin/email/nl.ts
@@ -13,33 +13,26 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
-  IOResult,
   ResourceName,
   command,
-  readStdinAsync,
+  nlGeneric,
   specOf,
-  type ByteSource,
   type CommandFnResult,
   type CommandOpts,
+  type IndexCacheStore,
   type PathSpec,
 } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../../accessor/email.ts'
 import { resolveGlob } from '../../../core/email/glob.ts'
 import { read as emailRead } from '../../../core/email/read.ts'
+import { fileReadProvision } from './provision.ts'
 
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function shouldNumber(line: string, mode: string, pattern: RegExp | null): boolean {
-  if (mode === 'n') return false
-  if (mode === 'a') return true
-  if (mode === 'p' && pattern !== null) return pattern.test(line)
-  return line.trim() !== ''
-}
-
-function pad(n: number, width: number): string {
-  const s = String(n)
-  return s.length >= width ? s : ' '.repeat(width - s.length) + s
+async function* emailStream(
+  accessor: EmailAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await emailRead(accessor, p, index)
 }
 
 async function nlCommand(
@@ -48,43 +41,9 @@ async function nlCommand(
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const bRaw = typeof opts.flags.b === 'string' ? opts.flags.b : 't'
-  let mode = bRaw
-  let pattern: RegExp | null = null
-  if (bRaw.startsWith('p')) {
-    mode = 'p'
-    pattern = new RegExp(bRaw.slice(1))
-  }
-  const start = typeof opts.flags.v === 'string' ? Number.parseInt(opts.flags.v, 10) : 1
-  const increment = typeof opts.flags.i === 'string' ? Number.parseInt(opts.flags.i, 10) : 1
-  const width = typeof opts.flags.w === 'string' ? Number.parseInt(opts.flags.w, 10) : 6
-  const separator = typeof opts.flags.s === 'string' ? opts.flags.s : '\t'
-
-  let raw: Uint8Array | null = null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    raw = await emailRead(accessor, first, opts.index ?? undefined)
-  } else {
-    raw = await readStdinAsync(opts.stdin)
-    if (raw === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('nl: missing operand\n') })]
-    }
-  }
-
-  let num = start
-  const outLines: string[] = []
-  for (const line of DEC.decode(raw).split('\n')) {
-    if (shouldNumber(line, mode, pattern)) {
-      outLines.push(`${pad(num, width)}${separator}${line}`)
-      num += increment
-    } else {
-      outLines.push(`${' '.repeat(width)}${separator}${line}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(outLines.join('\n') + '\n')
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return nlGeneric(resolved, opts, (p) => emailStream(accessor, p, opts.index ?? undefined))
 }
 
 export const EMAIL_NL = command({
@@ -92,4 +51,5 @@ export const EMAIL_NL = command({
   resource: ResourceName.EMAIL,
   spec: specOf('nl'),
   fn: nlCommand,
+  provision: fileReadProvision,
 })

--- a/typescript/packages/node/src/commands/builtin/email/rg.ts
+++ b/typescript/packages/node/src/commands/builtin/email/rg.ts
@@ -14,57 +14,36 @@
 
 import {
   IOResult,
-  PathSpec,
   ResourceName,
   command,
   compilePattern,
   grepLines,
-  readStdinAsync,
+  rgGeneric,
   specOf,
   type ByteSource,
   type CommandFnResult,
   type CommandOpts,
+  type FileStat,
   type GrepLinesOptions,
+  type IndexCacheStore,
+  type PathSpec,
 } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../../accessor/email.ts'
 import { resolveGlob } from '../../../core/email/glob.ts'
 import { read as emailRead } from '../../../core/email/read.ts'
 import { readdir as emailReaddir } from '../../../core/email/readdir.ts'
+import { stat as emailStat } from '../../../core/email/stat.ts'
 import { detectScope } from '../../../core/email/scope.ts'
 import { searchAndFormat } from '../../../core/email/search.ts'
 
 const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
 
-async function collectFiles(
+async function* emailStream(
   accessor: EmailAccessor,
-  path: PathSpec,
-  index: CommandOpts['index'],
-): Promise<string[]> {
-  if (path.original.endsWith('.json') || path.original.endsWith('.jsonl')) {
-    return [path.original]
-  }
-  let children: string[]
-  try {
-    children = await emailReaddir(accessor, path, index ?? undefined)
-  } catch {
-    return []
-  }
-  const files: string[] = []
-  for (const child of children) {
-    if (child.endsWith('.email.json')) {
-      files.push(child)
-    } else {
-      const childSpec = new PathSpec({
-        original: child,
-        directory: child,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      files.push(...(await collectFiles(accessor, childSpec, index)))
-    }
-  }
-  return files
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await emailRead(accessor, p, index)
 }
 
 async function rgCommand(
@@ -89,7 +68,6 @@ async function rgCommand(
   const fixedString = opts.flags.F === true
   const onlyMatching = opts.flags.o === true
   const maxCount = typeof opts.flags.m === 'string' ? Number.parseInt(opts.flags.m, 10) : null
-  const hidden = opts.flags.hidden === true
   const pat = compilePattern(pattern, ignoreCase, fixedString, wholeWord)
 
   const lineOpts: GrepLinesOptions = {
@@ -118,64 +96,16 @@ async function rgCommand(
         return [out, new IOResult()]
       }
     }
-
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const filePrefix = resolved[0]?.prefix ?? ''
-    const blobPaths: string[] = []
-    for (const p of resolved) blobPaths.push(...(await collectFiles(accessor, p, opts.index)))
-    const sortedUnique = [...new Set(blobPaths)].sort()
-    const allResults: string[] = []
-    let anyMatch = false
-    for (const bp of sortedUnique) {
-      if (!hidden && bp.split('/').some((part) => part.startsWith('.'))) continue
-      let data: Uint8Array
-      try {
-        const spec = new PathSpec({
-          original: bp,
-          directory: bp,
-          resolved: true,
-          prefix: filePrefix,
-        })
-        data = await emailRead(accessor, spec, opts.index ?? undefined)
-      } catch {
-        continue
-      }
-      const text = DEC.decode(data)
-      if (text === '') continue
-      const lines = text.split('\n')
-      if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
-      const matched = grepLines(bp, lines, pat, lineOpts)
-      if (matched.length === 0) continue
-      anyMatch = true
-      if (filesOnly) {
-        allResults.push(bp)
-        continue
-      }
-      if (countOnly) {
-        allResults.push(`${bp}:${String(matched.length)}`)
-        continue
-      }
-      for (const line of matched) allResults.push(`${bp}:${line}`)
-    }
-    if (!anyMatch) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-    const out: ByteSource = ENC.encode(allResults.join('\n'))
-    return [out, new IOResult()]
   }
 
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [
-      null,
-      new IOResult({ exitCode: 2, stderr: ENC.encode('rg: usage: rg [flags] pattern path\n') }),
-    ]
-  }
-  const lines = DEC.decode(raw).split('\n')
-  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
-  const matched = grepLines('<stdin>', lines, pat, lineOpts)
-  if (matched.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-  if (countOnly) return [ENC.encode(String(matched.length)), new IOResult()]
-  const out: ByteSource = ENC.encode(matched.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  const stat = (p: PathSpec): Promise<FileStat> => emailStat(accessor, p, opts.index ?? undefined)
+  const readdir = (p: PathSpec): Promise<string[]> =>
+    emailReaddir(accessor, p, opts.index ?? undefined)
+  return rgGeneric(resolved, texts, opts, stat, readdir, (p) =>
+    emailStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const EMAIL_RG = command({

--- a/typescript/packages/node/src/commands/builtin/email/stat.ts
+++ b/typescript/packages/node/src/commands/builtin/email/stat.ts
@@ -13,15 +13,12 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
-  FileType,
-  IOResult,
   ResourceName,
   command,
   specOf,
-  type ByteSource,
+  statGeneric,
   type CommandFnResult,
   type CommandOpts,
-  type FileStat,
   type PathSpec,
 } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../../accessor/email.ts'
@@ -29,57 +26,15 @@ import { resolveGlob } from '../../../core/email/glob.ts'
 import { stat as emailStat } from '../../../core/email/stat.ts'
 import { metadataProvision } from './provision.ts'
 
-const ENC = new TextEncoder()
-
-const TYPE_LABELS: Record<string, string> = {
-  [FileType.DIRECTORY]: 'directory',
-  [FileType.TEXT]: 'regular file',
-  [FileType.BINARY]: 'regular file',
-  [FileType.JSON]: 'regular file',
-  [FileType.CSV]: 'regular file',
-}
-
-function formatStat(fmt: string, s: FileStat): string {
-  return fmt.replace(/%(.)/g, (_, spec: string) => {
-    if (spec === 'n') return s.name
-    if (spec === 's') return String(s.size ?? 0)
-    if (spec === 'F')
-      return s.type !== null ? (TYPE_LABELS[s.type] ?? 'regular file') : 'regular file'
-    if (spec === 'y') return s.modified ?? ''
-    return '?'
-  })
-}
-
 async function statCommand(
   accessor: EmailAccessor,
   paths: PathSpec[],
   _texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (paths.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('stat: missing operand\n') })]
-  }
-  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const fmt =
-    typeof opts.flags.c === 'string'
-      ? opts.flags.c
-      : typeof opts.flags.f === 'string'
-        ? opts.flags.f
-        : null
-  const lines: string[] = []
-  for (const p of resolved) {
-    const s = await emailStat(accessor, p, opts.index ?? undefined)
-    if (fmt !== null) {
-      lines.push(formatStat(fmt, s))
-    } else {
-      const sizeStr = s.size === null ? 'None' : String(s.size)
-      const modStr = s.modified ?? 'None'
-      const typeStr = s.type ?? 'None'
-      lines.push(`name=${s.name} size=${sizeStr} modified=${modStr} type=${typeStr}`)
-    }
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return statGeneric(resolved, opts, (p) => emailStat(accessor, p, opts.index ?? undefined))
 }
 
 export const EMAIL_STAT = command({

--- a/typescript/packages/node/src/commands/builtin/email/tail.ts
+++ b/typescript/packages/node/src/commands/builtin/email/tail.ts
@@ -13,16 +13,13 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
-  IOResult,
   ResourceName,
   command,
-  parseN,
-  readStdinAsync,
   specOf,
-  tailBytes,
-  type ByteSource,
+  tailGeneric,
   type CommandFnResult,
   type CommandOpts,
+  type IndexCacheStore,
   type PathSpec,
 } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../../accessor/email.ts'
@@ -30,30 +27,25 @@ import { resolveGlob } from '../../../core/email/glob.ts'
 import { read as emailRead } from '../../../core/email/read.ts'
 import { fileReadProvision } from './provision.ts'
 
-const ENC = new TextEncoder()
+async function* emailStream(
+  accessor: EmailAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await emailRead(accessor, p, index)
+}
 
 async function tailCommand(
   accessor: EmailAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const [lines, plusMode] = parseN(typeof opts.flags.n === 'string' ? opts.flags.n : null)
-  const bytesMode = typeof opts.flags.c === 'string' ? Number.parseInt(opts.flags.c, 10) : null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    const raw = await emailRead(accessor, first, opts.index ?? undefined)
-    const out: ByteSource = tailBytes(raw, lines, bytesMode, plusMode)
-    return [out, new IOResult()]
-  }
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('tail: missing operand\n') })]
-  }
-  const out: ByteSource = tailBytes(raw, lines, bytesMode, plusMode)
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return tailGeneric(resolved, texts, opts, (p) =>
+    emailStream(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const EMAIL_TAIL = command({

--- a/typescript/packages/node/src/commands/builtin/email/tree.ts
+++ b/typescript/packages/node/src/commands/builtin/email/tree.ts
@@ -13,104 +13,18 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
-  FileType,
-  IOResult,
-  PathSpec,
   ResourceName,
   command,
   specOf,
-  type ByteSource,
+  treeGeneric,
   type CommandFnResult,
   type CommandOpts,
-  type FileStat,
+  type PathSpec,
 } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../../accessor/email.ts'
 import { resolveGlob } from '../../../core/email/glob.ts'
 import { readdir as emailReaddir } from '../../../core/email/readdir.ts'
 import { stat as emailStat } from '../../../core/email/stat.ts'
-
-const ENC = new TextEncoder()
-
-function fnmatch(name: string, pattern: string): boolean {
-  const re = pattern
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\?/g, '.')
-    .replace(/\*/g, '.*')
-  return new RegExp(`^${re}$`).test(name)
-}
-
-interface TreeOpts {
-  maxDepth: number | null
-  showHidden: boolean
-  ignorePattern: string | null
-  dirsOnly: boolean
-  matchPattern: string | null
-}
-
-async function treeRecurse(
-  accessor: EmailAccessor,
-  path: PathSpec,
-  prefix: string,
-  depth: number,
-  treeOpts: TreeOpts,
-  warnings: string[],
-  indexCache: CommandOpts['index'],
-): Promise<string[]> {
-  const lines: string[] = []
-  let entries: string[]
-  try {
-    entries = await emailReaddir(accessor, path, indexCache ?? undefined)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`tree: '${path.original}': ${msg}`)
-    return lines
-  }
-  const filtered: [PathSpec, FileStat][] = []
-  for (const entry of entries) {
-    try {
-      const entrySpec = new PathSpec({
-        original: entry,
-        directory: entry,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const s = await emailStat(accessor, entrySpec, indexCache ?? undefined)
-      if (!treeOpts.showHidden && s.name.startsWith('.')) continue
-      if (treeOpts.ignorePattern !== null && fnmatch(s.name, treeOpts.ignorePattern)) continue
-      if (treeOpts.dirsOnly && s.type !== FileType.DIRECTORY) continue
-      const notDir = s.type !== FileType.DIRECTORY
-      if (treeOpts.matchPattern !== null && notDir && !fnmatch(s.name, treeOpts.matchPattern))
-        continue
-      filtered.push([entrySpec, s])
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      warnings.push(`tree: '${entry}': ${msg}`)
-    }
-  }
-  for (let i = 0; i < filtered.length; i++) {
-    const pair = filtered[i]
-    if (pair === undefined) continue
-    const [entrySpec, s] = pair
-    const isLast = i === filtered.length - 1
-    const connector = isLast ? '\u2514\u2500\u2500 ' : '\u251c\u2500\u2500 '
-    lines.push(prefix + connector + s.name)
-    if (s.type === FileType.DIRECTORY) {
-      if (treeOpts.maxDepth !== null && depth >= treeOpts.maxDepth) continue
-      const extension = isLast ? '    ' : '\u2502   '
-      const sub = await treeRecurse(
-        accessor,
-        entrySpec,
-        prefix + extension,
-        depth + 1,
-        treeOpts,
-        warnings,
-        indexCache,
-      )
-      lines.push(...sub)
-    }
-  }
-  return lines
-}
 
 async function treeCommand(
   accessor: EmailAccessor,
@@ -119,27 +33,12 @@ async function treeCommand(
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-  const p0 =
-    resolved[0] ??
-    new PathSpec({
-      original: opts.cwd,
-      directory: opts.cwd,
-      resolved: false,
-      prefix: opts.mountPrefix ?? '',
-    })
-  const maxDepth = typeof opts.flags.L === 'string' ? Number.parseInt(opts.flags.L, 10) : null
-  const treeOpts: TreeOpts = {
-    maxDepth,
-    showHidden: opts.flags.a === true,
-    ignorePattern: typeof opts.flags.args_I === 'string' ? opts.flags.args_I : null,
-    dirsOnly: opts.flags.d === true,
-    matchPattern: typeof opts.flags.P === 'string' ? opts.flags.P : null,
-  }
-  const warnings: string[] = []
-  const results = await treeRecurse(accessor, p0, '', 0, treeOpts, warnings, opts.index)
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
-  return [out, new IOResult({ stderr })]
+  return treeGeneric(
+    resolved,
+    opts,
+    (p) => emailReaddir(accessor, p, opts.index ?? undefined),
+    (p) => emailStat(accessor, p, opts.index ?? undefined),
+  )
 }
 
 export const EMAIL_TREE = command({

--- a/typescript/packages/node/src/commands/builtin/email/wc.ts
+++ b/typescript/packages/node/src/commands/builtin/email/wc.ts
@@ -13,14 +13,13 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
-  IOResult,
   ResourceName,
   command,
-  readStdinAsync,
   specOf,
-  type ByteSource,
+  wcGeneric,
   type CommandFnResult,
   type CommandOpts,
+  type IndexCacheStore,
   type PathSpec,
 } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../../accessor/email.ts'
@@ -28,61 +27,23 @@ import { resolveGlob } from '../../../core/email/glob.ts'
 import { read as emailRead } from '../../../core/email/read.ts'
 import { fileReadProvision } from './provision.ts'
 
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-function countLines(text: string): number {
-  let n = 0
-  for (let i = 0; i < text.length; i++) if (text.charCodeAt(i) === 10) n += 1
-  return n
-}
-
-function countWords(text: string): number {
-  const trimmed = text.trim()
-  if (trimmed === '') return 0
-  return trimmed.split(/\s+/).length
-}
-
-function maxLineLen(text: string): number {
-  let max = 0
-  for (const line of text.split('\n')) if (line.length > max) max = line.length
-  return max
+async function* emailStream(
+  accessor: EmailAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await emailRead(accessor, p, index)
 }
 
 async function wcCommand(
   accessor: EmailAccessor,
   paths: PathSpec[],
-  _texts: string[],
+  texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  let data: Uint8Array | null = null
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const first = resolved[0]
-    if (first === undefined) return [null, new IOResult()]
-    data = await emailRead(accessor, first, opts.index ?? undefined)
-  } else {
-    data = await readStdinAsync(opts.stdin)
-    if (data === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('wc: missing operand\n') })]
-    }
-  }
-  const text = DEC.decode(data)
-  const lineCount = countLines(text)
-  const wordCount = countWords(text)
-  const byteCount = data.byteLength
-  if (opts.flags.L === true) {
-    const out: ByteSource = ENC.encode(String(maxLineLen(text)))
-    return [out, new IOResult()]
-  }
-  if (opts.flags.args_l === true) return [ENC.encode(String(lineCount)), new IOResult()]
-  if (opts.flags.w === true) return [ENC.encode(String(wordCount)), new IOResult()]
-  if (opts.flags.m === true) return [ENC.encode(String(text.length)), new IOResult()]
-  if (opts.flags.c === true) return [ENC.encode(String(byteCount)), new IOResult()]
-  const out: ByteSource = ENC.encode(
-    `${String(lineCount)}\t${String(wordCount)}\t${String(byteCount)}`,
-  )
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return wcGeneric(resolved, texts, opts, (p) => emailStream(accessor, p, opts.index ?? undefined))
 }
 
 export const EMAIL_WC = command({

--- a/typescript/packages/node/src/core/email/_client.ts
+++ b/typescript/packages/node/src/core/email/_client.ts
@@ -23,7 +23,7 @@ export interface FetchedMessage extends ParsedRfc822 {
 export async function listFolders(accessor: EmailAccessor): Promise<string[]> {
   const imap = await accessor.getImap()
   const tree = await imap.list()
-  return tree.map((m) => m.path)
+  return tree.map((m) => m.pathAsListed)
 }
 
 export async function listMessageUids(


### PR DESCRIPTION
Brings these API backends in line with python, which reuses the shared generics for read commands and delegates rg's per-file fallback to the generic.

## email read commands -> generic
email reimplemented cat/head/tail/wc/nl/ls/stat/tree with bespoke logic (and cat/head only read paths[0], dropping multi-file support). Now thin wrappers that inject the email stream/stat/readdir into the shared generics, like gmail/discord/slack already do. Fixes multi-file handling; behavior locked transitively by discord's command tests (same generics).

## rg push-down + generic fallback (discord/gmail/slack/email)
Each rg kept its native search push-down but reimplemented the per-file fallback scan (collectFiles + grepLines). Now: push-down stays, fallback delegates to rgGeneric (the same generic s3/ram/disk use), and push-down warnings are merged into stderr like python's rg.py.

## Not changed
- grep stays bespoke in both languages (full custom push-down + formatting) for all four backends.
- basename/dirname already delegate to the shared path_helper.

## Verification
- core 2733, node 1357 tests pass; discord/gmail/slack rg push-down tests pass.
- Note: the rg per-file fallback path has no direct backend test (pre-existing gap); it now routes through the integ-verified rgGeneric.