### PR TITLE
fix: rg searches all paths and skips columnar files

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -426,6 +426,16 @@ CASES: list[tuple[str, str]] = [
     ("mv_multi_into_dir", "mv /data/sub/a.txt /data/sub/b.txt /data/sub/deep"),
     ("mv_multi_verify_a", "cat /data/sub/deep/a.txt"),
     ("mv_multi_verify_b", "cat /data/sub/deep/b.txt"),
+
+    # ----- rg multi-path + columnar skip -----
+    ("rg_multi_setup_d1", "mkdir -p /data/rgm/d1"),
+    ("rg_multi_setup_d2", "mkdir -p /data/rgm/d2"),
+    ("rg_multi_seed1", "cp /data/a.txt /data/rgm/d1/f1.txt"),
+    ("rg_multi_seed2", "cp /data/mixed.txt /data/rgm/d2/f2.txt"),
+    ("rg_multi_dir", "rg -i hello /data/rgm/d1 /data/rgm/d2"),
+    ("rg_l_multi_file", "rg -l hello /data/rgm/d1/f1.txt /data/rgm/d2/f2.txt"),
+    ("rg_col_seed_parquet", "cp /data/a.txt /data/rgm/d1/skip.parquet"),
+    ("rg_columnar_skip", "rg world /data/rgm/d1"),
 ]
 
 EXIT_CODE_CASES: list[tuple[str, str]] = [

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -352,6 +352,16 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
   ["mv_multi_into_dir", "mv /data/sub/a.txt /data/sub/b.txt /data/sub/deep"],
   ["mv_multi_verify_a", "cat /data/sub/deep/a.txt"],
   ["mv_multi_verify_b", "cat /data/sub/deep/b.txt"],
+
+  // ----- rg multi-path + columnar skip -----
+  ["rg_multi_setup_d1", "mkdir -p /data/rgm/d1"],
+  ["rg_multi_setup_d2", "mkdir -p /data/rgm/d2"],
+  ["rg_multi_seed1", "cp /data/a.txt /data/rgm/d1/f1.txt"],
+  ["rg_multi_seed2", "cp /data/mixed.txt /data/rgm/d2/f2.txt"],
+  ["rg_multi_dir", "rg -i hello /data/rgm/d1 /data/rgm/d2"],
+  ["rg_l_multi_file", "rg -l hello /data/rgm/d1/f1.txt /data/rgm/d2/f2.txt"],
+  ["rg_col_seed_parquet", "cp /data/a.txt /data/rgm/d1/skip.parquet"],
+  ["rg_columnar_skip", "rg world /data/rgm/d1"],
 ];
 
 export const EXIT_CODE_CASES: ReadonlyArray<readonly [string, string]> = [

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -1146,6 +1146,26 @@ baz
 1
 2
 3
+=== rg_multi_setup_d1 ===
+
+=== rg_multi_setup_d2 ===
+
+=== rg_multi_seed1 ===
+
+=== rg_multi_seed2 ===
+
+=== rg_multi_dir ===
+/data/rgm/d1/f1.txt:hello
+/data/rgm/d2/f2.txt:Hello World
+/data/rgm/d2/f2.txt:HELLO world
+/data/rgm/d2/f2.txt:hello WORLD
+=== rg_l_multi_file ===
+/data/rgm/d1/f1.txt
+/data/rgm/d2/f2.txt
+=== rg_col_seed_parquet ===
+
+=== rg_columnar_skip ===
+/data/rgm/d1/f1.txt:world
 === lazy_exit_grep_match ===
 exit=0
 hello

--- a/python/mirage/commands/builtin/generic/rg.py
+++ b/python/mirage/commands/builtin/generic/rg.py
@@ -120,28 +120,31 @@ async def rg(
             warnings_f: list[str] = []
             if scope_warning_str:
                 warnings_f.append(scope_warning_str)
-            results = await rg_full(
-                rd,
-                st,
-                rb,
-                paths[0].original,
-                pattern,
-                ignore_case=ignore_case,
-                invert=invert,
-                line_numbers=line_numbers,
-                count_only=count_only,
-                files_only=files_only,
-                fixed_string=fixed_string,
-                only_matching=only_matching,
-                max_count=max_count,
-                whole_word=whole_word,
-                context_before=context_before,
-                context_after=context_after,
-                file_type=file_type,
-                glob_pattern=glob_pattern,
-                hidden=hidden,
-                warnings=warnings_f,
-            )
+            results: list[str] = []
+            for p in paths:
+                results.extend(await rg_full(
+                    rd,
+                    st,
+                    rb,
+                    p.original,
+                    pattern,
+                    ignore_case=ignore_case,
+                    invert=invert,
+                    line_numbers=line_numbers,
+                    count_only=count_only,
+                    files_only=files_only,
+                    fixed_string=fixed_string,
+                    only_matching=only_matching,
+                    max_count=max_count,
+                    whole_word=whole_word,
+                    context_before=context_before,
+                    context_after=context_after,
+                    file_type=file_type,
+                    glob_pattern=glob_pattern,
+                    hidden=hidden,
+                    warnings=warnings_f,
+                    file_prefix=p.original if len(paths) > 1 else None,
+                ))
             stderr = format_optional_records(warnings_f)
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)

--- a/python/mirage/commands/builtin/rg_helper.py
+++ b/python/mirage/commands/builtin/rg_helper.py
@@ -270,6 +270,7 @@ async def rg_full(
     glob_pattern: str | None,
     hidden: bool,
     warnings: list[str] | None,
+    file_prefix: str | None = None,
 ) -> list[str]:
     compiled = compile_pattern(pattern, ignore_case, fixed_string, whole_word)
 
@@ -309,11 +310,16 @@ async def rg_full(
             else:
                 text = line
             pfx = f"{i_ln}:{text}" if line_numbers else text
+            if file_prefix is not None:
+                pfx = f"{file_prefix}:{pfx}"
             results.append(pfx)
             if max_count is not None and count >= max_count:
                 break
         if count_only:
-            return [str(count)] if count > 0 else []
+            if count == 0:
+                return []
+            return [f"{file_prefix}:{count}"
+                    ] if file_prefix is not None else [str(count)]
         return results
 
     results = []

--- a/python/tests/commands/builtin/generic/test_rg.py
+++ b/python/tests/commands/builtin/generic/test_rg.py
@@ -422,3 +422,42 @@ async def test_rg_single_file_threads_index():
     )
     decoded = (await _drain_async(output)).decode()
     assert "apple" in decoded
+
+
+@pytest.mark.asyncio
+async def test_rg_multiple_dirs_searches_all():
+    readdir, stat, rb, rs = _make_backend({
+        "/d1/a.txt": b"apple a\n",
+        "/d2/b.txt": b"apple b\n",
+    })
+    output, _ = await rg(
+        [_spec("/d1"), _spec("/d2")],
+        pattern="apple",
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+    )
+    decoded = (await _drain_async(output)).decode()
+    assert "/d1/a.txt:apple a" in decoded
+    assert "/d2/b.txt:apple b" in decoded
+
+
+@pytest.mark.asyncio
+async def test_rg_files_only_multiple_files():
+    readdir, stat, rb, rs = _make_backend({
+        "/t1.txt": b"apple\n",
+        "/t2.txt": b"apple\n",
+    })
+    output, _ = await rg(
+        [_spec("/t1.txt"), _spec("/t2.txt")],
+        pattern="apple",
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+        files_only=True,
+    )
+    decoded = (await _drain_async(output)).decode()
+    assert "/t1.txt" in decoded
+    assert "/t2.txt" in decoded

--- a/typescript/packages/core/src/commands/builtin/generic/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/rg.ts
@@ -142,29 +142,34 @@ export async function rgGeneric(
 
   if (isDir && opts.filetypeFns !== null && Object.keys(opts.filetypeFns).length > 0) {
     const warnings: string[] = scopeWarn !== null ? [scopeWarn] : []
-    const results = await rgFolderFiletype(
-      readdirFn,
-      statFn,
-      readBytesFn,
-      first.original,
-      exprText,
-      {},
-      {
-        ignoreCase: flags.ignoreCase,
-        invert: flags.invert,
-        lineNumbers: flags.lineNumbers,
-        countOnly: flags.countOnly,
-        filesOnly: flags.filesOnly,
-        onlyMatching: flags.onlyMatching,
-        maxCount: flags.maxCount,
-        fixedString: flags.fixedString,
-        wholeWord: flags.wholeWord,
-        fileType: flags.fileType,
-        globPattern: flags.globPattern,
-        hidden: flags.hidden,
-      },
-      warnings,
-    )
+    const folderOpts = {
+      ignoreCase: flags.ignoreCase,
+      invert: flags.invert,
+      lineNumbers: flags.lineNumbers,
+      countOnly: flags.countOnly,
+      filesOnly: flags.filesOnly,
+      onlyMatching: flags.onlyMatching,
+      maxCount: flags.maxCount,
+      fixedString: flags.fixedString,
+      wholeWord: flags.wholeWord,
+      fileType: flags.fileType,
+      globPattern: flags.globPattern,
+      hidden: flags.hidden,
+    }
+    const results: string[] = []
+    for (const p of paths) {
+      results.push(
+        ...(await rgFolderFiletype(
+          readdirFn,
+          statFn,
+          readBytesFn,
+          p.original,
+          exprText,
+          folderOpts,
+          warnings,
+        )),
+      )
+    }
     const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n') + '\n') : undefined
     if (results.length === 0) {
       const io = new IOResult({ exitCode: 1, ...(stderr !== undefined ? { stderr } : {}) })
@@ -184,30 +189,37 @@ export async function rgGeneric(
     flags.globPattern !== null
   if (needsFull) {
     const warnings: string[] = scopeWarn !== null ? [scopeWarn] : []
-    const results = await rgFull(
-      readdirFn,
-      statFn,
-      readBytesFn,
-      first.original,
-      exprText,
-      {
-        ignoreCase: flags.ignoreCase,
-        invert: flags.invert,
-        lineNumbers: flags.lineNumbers,
-        countOnly: flags.countOnly,
-        filesOnly: flags.filesOnly,
-        fixedString: flags.fixedString,
-        onlyMatching: flags.onlyMatching,
-        maxCount: flags.maxCount,
-        wholeWord: flags.wholeWord,
-        contextBefore: flags.beforeContext,
-        contextAfter: flags.afterContext,
-        fileType: flags.fileType,
-        globPattern: flags.globPattern,
-        hidden: flags.hidden,
-      },
-      warnings,
-    )
+    const fullOpts = {
+      ignoreCase: flags.ignoreCase,
+      invert: flags.invert,
+      lineNumbers: flags.lineNumbers,
+      countOnly: flags.countOnly,
+      filesOnly: flags.filesOnly,
+      fixedString: flags.fixedString,
+      onlyMatching: flags.onlyMatching,
+      maxCount: flags.maxCount,
+      wholeWord: flags.wholeWord,
+      contextBefore: flags.beforeContext,
+      contextAfter: flags.afterContext,
+      fileType: flags.fileType,
+      globPattern: flags.globPattern,
+      hidden: flags.hidden,
+    }
+    const results: string[] = []
+    for (const p of paths) {
+      results.push(
+        ...(await rgFull(
+          readdirFn,
+          statFn,
+          readBytesFn,
+          p.original,
+          exprText,
+          fullOpts,
+          warnings,
+          paths.length > 1 ? p.original : null,
+        )),
+      )
+    }
     const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n') + '\n') : undefined
     if (results.length === 0) {
       const io = new IOResult({ exitCode: 1, ...(stderr !== undefined ? { stderr } : {}) })

--- a/typescript/packages/core/src/commands/builtin/generic/rg_multipath.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/rg_multipath.test.ts
@@ -74,6 +74,7 @@ const readdir = (p: PathSpec): Promise<string[]> => {
 }
 
 async function* stream(p: PathSpec): AsyncIterable<Uint8Array> {
+  await Promise.resolve()
   const content = FILES[key(p)]
   if (content === undefined) throw new Error(`ENOENT: ${p.original}`)
   yield ENC.encode(content)

--- a/typescript/packages/core/src/commands/builtin/generic/rg_multipath.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/rg_multipath.test.ts
@@ -1,0 +1,126 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { FileStat, FileType, PathSpec } from '../../../types.ts'
+import { rstripSlash } from '../../../util/slash.ts'
+import type { CommandFn, CommandOpts } from '../../config.ts'
+import { rgGeneric } from './rg.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+const FOLDERS = new Set(['/', '/d1', '/d2'])
+
+const FILES: Record<string, string> = {
+  '/d1/a.txt': 'hello a\n',
+  '/d1/data.parquet': 'hello parquet\n',
+  '/d2/b.txt': 'hello b\n',
+  '/top1.txt': 'hello one\n',
+  '/top2.txt': 'hello two\n',
+}
+
+function key(p: PathSpec): string {
+  return rstripSlash(p.original) || '/'
+}
+
+function spec(path: string): PathSpec {
+  return new PathSpec({ original: path, directory: path, resolved: false, prefix: '' })
+}
+
+function opts(
+  flags: Record<string, string | boolean>,
+  filetypeFns: Record<string, CommandFn> | null = null,
+): CommandOpts {
+  return {
+    stdin: null,
+    flags,
+    filetypeFns,
+    cwd: '/',
+    resource: null,
+  } as unknown as CommandOpts
+}
+
+const stat = (p: PathSpec): Promise<FileStat> => {
+  const k = key(p)
+  if (!FOLDERS.has(k) && FILES[k] === undefined) {
+    return Promise.reject(new Error(`ENOENT: ${k}`))
+  }
+  return Promise.resolve(
+    new FileStat({
+      name: k.split('/').pop() ?? '',
+      type: FOLDERS.has(k) ? FileType.DIRECTORY : FileType.TEXT,
+    }),
+  )
+}
+
+const readdir = (p: PathSpec): Promise<string[]> => {
+  const k = key(p)
+  if (k === '/') return Promise.resolve(['/d1', '/d2', '/top1.txt', '/top2.txt'])
+  if (k === '/d1') return Promise.resolve(['/d1/a.txt', '/d1/data.parquet'])
+  if (k === '/d2') return Promise.resolve(['/d2/b.txt'])
+  return Promise.reject(new Error(`ENOTDIR: ${k}`))
+}
+
+async function* stream(p: PathSpec): AsyncIterable<Uint8Array> {
+  const content = FILES[key(p)]
+  if (content === undefined) throw new Error(`ENOENT: ${p.original}`)
+  yield ENC.encode(content)
+}
+
+async function run(
+  paths: string[],
+  flags: Record<string, string | boolean>,
+  filetypeFns: Record<string, CommandFn> | null = null,
+): Promise<string> {
+  const [out] = (await rgGeneric(
+    paths.map(spec),
+    ['hello'],
+    opts(flags, filetypeFns),
+    stat,
+    readdir,
+    stream,
+  )) as [Uint8Array, unknown]
+  return DEC.decode(out)
+}
+
+const fakeFiletypeFn = (() => {
+  throw new Error('not called')
+}) as unknown as CommandFn
+
+describe('rgGeneric multi-path dispatch', () => {
+  it('searches every directory argument', async () => {
+    expect(await run(['/d1', '/d2'], {})).toBe('/d1/a.txt:hello a\n/d2/b.txt:hello b\n')
+  })
+
+  it('lists every file argument with -l', async () => {
+    expect(await run(['/top1.txt', '/top2.txt'], { args_l: true })).toBe('/top1.txt\n/top2.txt\n')
+  })
+
+  it('searches every directory argument in the filetype walk', async () => {
+    expect(await run(['/d1', '/d2'], {}, { parquet: fakeFiletypeFn })).toBe(
+      '/d1/a.txt:hello a\n/d2/b.txt:hello b\n',
+    )
+  })
+})
+
+describe('rgGeneric columnar skip', () => {
+  it('skips columnar files in the recursive walk', async () => {
+    expect(await run(['/d1'], {})).toBe('/d1/a.txt:hello a\n')
+  })
+
+  it('skips columnar files in the filetype folder walk', async () => {
+    expect(await run(['/d1'], {}, { parquet: fakeFiletypeFn })).toBe('/d1/a.txt:hello a\n')
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/github/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/github/rg.ts
@@ -148,7 +148,6 @@ async function rgCommand(
       readBytesFn,
       first.original,
       exprText,
-      {},
       {
         ignoreCase: flags.ignoreCase,
         invert: flags.invert,

--- a/typescript/packages/core/src/commands/builtin/grep_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/grep_helper.ts
@@ -17,7 +17,7 @@ import { type FileStat, FileType } from '../../types.ts'
 import { getExtension } from '../resolve.ts'
 import { grepContextLines } from './grep_context.ts'
 
-const BINARY_EXTENSIONS: ReadonlySet<string> = new Set([
+export const BINARY_EXTENSIONS: ReadonlySet<string> = new Set([
   '.parquet',
   '.orc',
   '.feather',

--- a/typescript/packages/core/src/commands/builtin/rg_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/rg_helper.ts
@@ -12,10 +12,10 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { FileStat, PathSpec } from '../../types.ts'
+import type { FileStat } from '../../types.ts'
 import { FileType } from '../../types.ts'
 import { getExtension } from '../resolve.ts'
-import { compilePattern, grepLines } from './grep_helper.ts'
+import { BINARY_EXTENSIONS, compilePattern, grepLines } from './grep_helper.ts'
 
 export const TYPE_EXTENSIONS: Record<string, string[]> = {
   py: ['.py'],
@@ -147,6 +147,7 @@ export async function rgFull(
   pattern: string,
   opts: RgFullOptions,
   warnings: string[] | null,
+  filePrefix: string | null = null,
 ): Promise<string[]> {
   const compiled = compilePattern(pattern, opts.ignoreCase, opts.fixedString, opts.wholeWord)
 
@@ -176,7 +177,7 @@ export async function rgFull(
       if (warnings !== null) warnings.push(`rg: ${path}: ${String(err)}`)
       return []
     }
-    return searchFile(data, compiled, opts, null)
+    return searchFile(data, compiled, opts, filePrefix)
   }
 
   const results: string[] = []
@@ -205,6 +206,7 @@ export async function rgFull(
       continue
     }
 
+    if (BINARY_EXTENSIONS.has(getExtension(entry) ?? '')) continue
     if (!rgMatchesFilter(entry, opts.fileType, opts.globPattern, opts.hidden)) continue
 
     let data: string[]
@@ -222,12 +224,6 @@ export async function rgFull(
 
   return results
 }
-
-export type FiletypeFn = (
-  paths: PathSpec[],
-  pattern: string,
-  opts: { stdin: null; ignoreCase: boolean },
-) => Promise<[AsyncIterable<Uint8Array> | Uint8Array | null, unknown]>
 
 export interface RgFolderFiletypeOptions {
   ignoreCase: boolean
@@ -250,7 +246,6 @@ export async function rgFolderFiletype(
   readBytesFn: AsyncReadBytesFn,
   path: string,
   pattern: string,
-  filetypeFns: Record<string, FiletypeFn>,
   opts: RgFolderFiletypeOptions,
   warnings: string[] | null,
 ): Promise<string[]> {
@@ -282,7 +277,6 @@ export async function rgFolderFiletype(
         readBytesFn,
         entry,
         pattern,
-        filetypeFns,
         opts,
         warnings,
       )
@@ -290,16 +284,9 @@ export async function rgFolderFiletype(
       continue
     }
 
+    if (BINARY_EXTENSIONS.has(getExtension(entry) ?? '')) continue
     if (!rgMatchesFilter(entry, opts.fileType, opts.globPattern, opts.hidden)) continue
 
-    const ext = getExtension(entry)
-    const filetypeFn = ext !== null ? filetypeFns[ext] : undefined
-    if (filetypeFn !== undefined) {
-      // Filetype-specific extraction path (feather/parquet/hdf5 etc.)
-      // Skipped here; fall through to text scan below.
-    }
-
-    // Plain text scan
     let raw: Uint8Array
     try {
       raw = await readBytesFn(entry)

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -309,7 +309,6 @@ export {
   type AsyncReaddirFn,
   type AsyncReadBytesFn,
   type AsyncStatFn,
-  type FiletypeFn,
   rgFolderFiletype,
   type RgFolderFiletypeOptions,
   rgFull,


### PR DESCRIPTION
## What

- **Multi-path drop (TS + Python):** `rg pat dir1 dir2` or `rg -l pat f1 f2` only searched the first path whenever the full-scan branch was taken (directory target, or `-l`/`-A`/`-B`/`--type`/`--glob`). The dispatch now loops over all resolved paths and merges results; with multiple explicit files, matches are prefixed with the filename.
- **Columnar skip (TS):** `rgFull` and `rgFolderFiletype` text-scanned `.parquet`/`.orc`/`.feather`/`.hdf5` files during recursive walks. They now skip `BINARY_EXTENSIONS` (shared with grep), matching the Python behavior. Also removed the dead `filetypeFns` lookup/param from `rgFolderFiletype`.

## Tests

- New unit tests in `rg_multipath.test.ts` (TS) and `test_rg.py` (Python), written failing-first.
- New integ cases (`rg_multi_dir`, `rg_l_multi_file`, `rg_columnar_skip`) in `cases.py`/`cases.ts`; truth.txt regenerated and verified byte-identical across py ram/disk/redis and ts ram/disk/opfs/redis.