### PR TITLE
fix(google): find warm-cache dir detection, missing flags, GNU depth

### DIFF
--- a/python/mirage/commands/builtin/gdocs/find.py
+++ b/python/mirage/commands/builtin/gdocs/find.py
@@ -12,48 +12,25 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import fnmatch
+from functools import partial
 
 from mirage.accessor.gdocs import GDocsAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.gdocs._provision import metadata_provision
+from mirage.commands.builtin.generic.find import parse_find_args, walk_find
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdocs.glob import resolve_glob
 from mirage.core.gdocs.readdir import readdir as _readdir
+from mirage.core.gdocs.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
 
 
-async def _walk(
-    accessor: GDocsAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-    maxdepth: int | None,
-    depth: int = 0,
-) -> list[str]:
-    if maxdepth is not None and depth > maxdepth:
-        return []
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    results: list[str] = []
-    for child in children:
-        results.append(child)
-        if not child.endswith(".json") and not child.endswith(".jsonl"):
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            results.extend(await _walk(accessor,
-                                       child_spec,
-                                       index,
-                                       maxdepth,
-                                       depth=depth + 1))
-    return results
+def _is_dir_name(child: str) -> bool | None:
+    return not child.endswith(".json") and not child.endswith(".jsonl")
 
 
 async def find_provision(
@@ -94,26 +71,24 @@ async def find(
     p0 = paths[0] if paths else None
     search_path = p0.original if p0 else "/"
     search_prefix = p0.prefix if p0 else ""
-    md = int(maxdepth) if maxdepth is not None else None
-    md_min = int(mindepth) if mindepth is not None else None
-
+    args = parse_find_args(texts,
+                           name=name,
+                           type=type,
+                           size=size,
+                           mtime=mtime,
+                           maxdepth=maxdepth,
+                           iname=iname,
+                           path=path,
+                           mindepth=mindepth)
     search_spec = PathSpec(original=search_path,
                            directory=search_path,
                            resolved=False,
                            prefix=search_prefix)
-    all_paths = await _walk(accessor, search_spec, index, md)
-    results: list[str] = []
-    base_depth = search_path.strip("/").count("/") if search_path.strip(
-        "/") else -1
-    for p in sorted(all_paths):
-        entry_name = p.rsplit("/", 1)[-1]
-        depth = p.strip("/").count("/") - (base_depth + 1)
-        if md_min is not None and depth < md_min:
-            continue
-        if name and not fnmatch.fnmatch(entry_name, name):
-            continue
-        if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
-            continue
-        results.append(p)
+    results = await walk_find(search_spec,
+                              readdir=partial(_readdir, accessor),
+                              stat=partial(_stat, accessor),
+                              is_dir_name=_is_dir_name,
+                              index=index,
+                              args=args)
     output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/gdrive/find.py
+++ b/python/mirage/commands/builtin/gdrive/find.py
@@ -12,48 +12,27 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import fnmatch
+from functools import partial
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.gdrive._provision import metadata_provision
+from mirage.commands.builtin.generic.find import parse_find_args, walk_find
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdrive.glob import resolve_glob
 from mirage.core.gdrive.readdir import readdir as _readdir
+from mirage.core.gdrive.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
 
 
-async def _walk(
-    accessor: GDriveAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-    maxdepth: int | None,
-    depth: int = 0,
-) -> list[str]:
-    if maxdepth is not None and depth > maxdepth:
-        return []
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    results: list[str] = []
-    for child in children:
-        results.append(child)
-        if child.endswith("/"):
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            results.extend(await _walk(accessor,
-                                       child_spec,
-                                       index,
-                                       maxdepth,
-                                       depth=depth + 1))
-    return results
+def _is_dir_name(child: str) -> bool | None:
+    # Cold reads mark folders with a trailing slash; warm index-cache hits
+    # return slash-less keys, so fall back to stat for classification.
+    return True if child.endswith("/") else None
 
 
 async def find_provision(
@@ -94,26 +73,24 @@ async def find(
     p0 = paths[0] if paths else None
     search_path = p0.original if p0 else "/"
     search_prefix = p0.prefix if p0 else ""
-    md = int(maxdepth) if maxdepth is not None else None
-    md_min = int(mindepth) if mindepth is not None else None
-
+    args = parse_find_args(texts,
+                           name=name,
+                           type=type,
+                           size=size,
+                           mtime=mtime,
+                           maxdepth=maxdepth,
+                           iname=iname,
+                           path=path,
+                           mindepth=mindepth)
     search_spec = PathSpec(original=search_path,
                            directory=search_path,
                            resolved=False,
                            prefix=search_prefix)
-    all_paths = await _walk(accessor, search_spec, index, md)
-    results: list[str] = []
-    base_depth = search_path.strip("/").count("/") if search_path.strip(
-        "/") else -1
-    for p in sorted(all_paths):
-        entry_name = p.rsplit("/", 1)[-1]
-        depth = p.strip("/").count("/") - (base_depth + 1)
-        if md_min is not None and depth < md_min:
-            continue
-        if name and not fnmatch.fnmatch(entry_name, name):
-            continue
-        if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
-            continue
-        results.append(p)
+    results = await walk_find(search_spec,
+                              readdir=partial(_readdir, accessor),
+                              stat=partial(_stat, accessor),
+                              is_dir_name=_is_dir_name,
+                              index=index,
+                              args=args)
     output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/generic/find.py
+++ b/python/mirage/commands/builtin/generic/find.py
@@ -1,13 +1,15 @@
+import fnmatch
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.find_helper import (_extract_not_name,
                                                  _extract_or_names,
                                                  _parse_mtime, _parse_size)
 from mirage.commands.builtin.utils.output import format_records
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileStat, FindType, PathSpec
+from mirage.types import FileStat, FileType, FindType, PathSpec
 
 
 @dataclass
@@ -158,3 +160,134 @@ async def find(
                                            mount_prefix=search_path.prefix)
     results = apply_mount_prefix(results, search_path.prefix)
     return format_records(results), IOResult()
+
+
+def _modified_ts(modified: str | None) -> float | None:
+    # Missing or unparseable timestamps exclude the entry from -mtime
+    # matching, mirroring the TS implementation's NaN handling.
+    if not modified:
+        return None
+    try:
+        dt = datetime.fromisoformat(modified)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+async def _stat_entry(
+    stat: Callable[[PathSpec, IndexCacheStore | None], Awaitable[FileStat]],
+    path: str,
+    prefix: str,
+    index: IndexCacheStore | None,
+) -> FileStat | None:
+    spec = PathSpec(original=path,
+                    directory=path,
+                    resolved=False,
+                    prefix=prefix)
+    try:
+        return await stat(spec, index)
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+async def _walk_collect(
+    readdir: Callable[[PathSpec, IndexCacheStore | None],
+                      Awaitable[list[str]]],
+    stat: Callable[[PathSpec, IndexCacheStore | None], Awaitable[FileStat]],
+    is_dir_name: Callable[[str], bool | None],
+    spec: PathSpec,
+    index: IndexCacheStore | None,
+    maxdepth: int | None,
+    depth: int,
+    acc: list[tuple[str, bool]],
+) -> None:
+    if maxdepth is not None and depth > maxdepth:
+        return
+    try:
+        children = await readdir(spec, index)
+    except (FileNotFoundError, ValueError):
+        return
+    for child in children:
+        hint = is_dir_name(child)
+        trimmed = child.rstrip("/") if child.endswith("/") else child
+        if hint is None:
+            st = await _stat_entry(stat, trimmed, spec.prefix, index)
+            is_dir = st is not None and st.type == FileType.DIRECTORY
+        else:
+            is_dir = hint
+        acc.append((trimmed, is_dir))
+        if is_dir:
+            child_spec = PathSpec(original=trimmed,
+                                  directory=trimmed,
+                                  resolved=False,
+                                  prefix=spec.prefix)
+            await _walk_collect(readdir, stat, is_dir_name, child_spec, index,
+                                maxdepth, depth + 1, acc)
+
+
+async def walk_find(
+    search_path: PathSpec,
+    *,
+    readdir: Callable[[PathSpec, IndexCacheStore | None],
+                      Awaitable[list[str]]],
+    stat: Callable[[PathSpec, IndexCacheStore | None], Awaitable[FileStat]],
+    is_dir_name: Callable[[str], bool | None],
+    index: IndexCacheStore | None,
+    args: FindArgs,
+) -> list[str]:
+    collected: list[tuple[str, bool]] = []
+    await _walk_collect(readdir, stat, is_dir_name, search_path, index,
+                        args.maxdepth, 0, collected)
+    prefix = search_path.prefix
+    search_key = search_path.strip_prefix.strip("/")
+    base_depth = search_key.count("/") if search_key else -1
+    results: list[str] = []
+    for p, is_dir in sorted(collected):
+        entry_name = p.rsplit("/", 1)[-1]
+        key = p[len(prefix):] if prefix and p.startswith(prefix) else p
+        depth = key.strip("/").count("/") - (base_depth + 1)
+        if args.mindepth is not None and depth < args.mindepth:
+            continue
+        if args.type == FindType.FILE and is_dir:
+            continue
+        if args.type == FindType.DIRECTORY and not is_dir:
+            continue
+        if args.or_names:
+            if not any(
+                    fnmatch.fnmatch(entry_name, pat) for pat in args.or_names):
+                continue
+        elif args.name and not fnmatch.fnmatch(entry_name, args.name):
+            continue
+        if args.iname and not fnmatch.fnmatch(entry_name.lower(),
+                                              args.iname.lower()):
+            continue
+        if args.path_pattern and not fnmatch.fnmatch(key, args.path_pattern):
+            continue
+        if args.name_exclude and fnmatch.fnmatch(entry_name,
+                                                 args.name_exclude):
+            continue
+        need_size = not is_dir and (args.min_size is not None
+                                    or args.max_size is not None)
+        need_mtime = args.mtime_min is not None or args.mtime_max is not None
+        if need_size or need_mtime:
+            st = await _stat_entry(stat, p, prefix, index)
+            if st is None:
+                continue
+            if need_size:
+                size = st.size or 0
+                if args.min_size is not None and size < args.min_size:
+                    continue
+                if args.max_size is not None and size > args.max_size:
+                    continue
+            if need_mtime:
+                ts = _modified_ts(st.modified)
+                if ts is None:
+                    continue
+                if args.mtime_min is not None and ts < args.mtime_min:
+                    continue
+                if args.mtime_max is not None and ts > args.mtime_max:
+                    continue
+        results.append(p)
+    return results

--- a/python/mirage/commands/builtin/generic/find.py
+++ b/python/mirage/commands/builtin/generic/find.py
@@ -188,7 +188,9 @@ async def _stat_entry(
                     prefix=prefix)
     try:
         return await stat(spec, index)
-    except (FileNotFoundError, ValueError):
+    except FileNotFoundError:
+        # Only missing entries resolve to None; API errors (rate limit, auth)
+        # propagate.
         return None
 
 
@@ -207,7 +209,9 @@ async def _walk_collect(
         return
     try:
         children = await readdir(spec, index)
-    except (FileNotFoundError, ValueError):
+    except FileNotFoundError:
+        # Only vanished dirs are skipped; API errors (rate limit, auth)
+        # propagate.
         return
     for child in children:
         hint = is_dir_name(child)

--- a/python/mirage/commands/builtin/generic/find.py
+++ b/python/mirage/commands/builtin/generic/find.py
@@ -238,8 +238,10 @@ async def walk_find(
     args: FindArgs,
 ) -> list[str]:
     collected: list[tuple[str, bool]] = []
+    # GNU depth convention: the search root is depth 0, its children are
+    # depth 1, so the walk starts at 1 and -maxdepth 0 lists nothing.
     await _walk_collect(readdir, stat, is_dir_name, search_path, index,
-                        args.maxdepth, 0, collected)
+                        args.maxdepth, 1, collected)
     prefix = search_path.prefix
     search_key = search_path.strip_prefix.strip("/")
     base_depth = search_key.count("/") if search_key else -1
@@ -247,7 +249,7 @@ async def walk_find(
     for p, is_dir in sorted(collected):
         entry_name = p.rsplit("/", 1)[-1]
         key = p[len(prefix):] if prefix and p.startswith(prefix) else p
-        depth = key.strip("/").count("/") - (base_depth + 1)
+        depth = key.strip("/").count("/") - base_depth
         if args.mindepth is not None and depth < args.mindepth:
             continue
         if args.type == FindType.FILE and is_dir:

--- a/python/mirage/commands/builtin/gmail/find.py
+++ b/python/mirage/commands/builtin/gmail/find.py
@@ -12,48 +12,25 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import fnmatch
+from functools import partial
 
 from mirage.accessor.gmail import GmailAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.find import parse_find_args, walk_find
 from mirage.commands.builtin.gmail._provision import metadata_provision
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gmail.glob import resolve_glob
 from mirage.core.gmail.readdir import readdir as _readdir
+from mirage.core.gmail.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
 
 
-async def _walk(
-    accessor: GmailAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-    maxdepth: int | None,
-    depth: int = 0,
-) -> list[str]:
-    if maxdepth is not None and depth > maxdepth:
-        return []
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    results: list[str] = []
-    for child in children:
-        results.append(child)
-        if not child.endswith(".gmail.json"):
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            results.extend(await _walk(accessor,
-                                       child_spec,
-                                       index,
-                                       maxdepth,
-                                       depth=depth + 1))
-    return results
+def _is_dir_name(child: str) -> bool | None:
+    return not child.endswith(".gmail.json")
 
 
 async def find_provision(
@@ -90,31 +67,28 @@ async def find(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    index = index
     paths = await resolve_glob(accessor, paths, index)
     p0 = paths[0] if paths else None
     search_path = p0.original if p0 else "/"
     search_prefix = p0.prefix if p0 else ""
-    md = int(maxdepth) if maxdepth is not None else None
-    md_min = int(mindepth) if mindepth is not None else None
-
+    args = parse_find_args(texts,
+                           name=name,
+                           type=type,
+                           size=size,
+                           mtime=mtime,
+                           maxdepth=maxdepth,
+                           iname=iname,
+                           path=path,
+                           mindepth=mindepth)
     search_spec = PathSpec(original=search_path,
                            directory=search_path,
                            resolved=False,
                            prefix=search_prefix)
-    all_paths = await _walk(accessor, search_spec, index, md)
-    results: list[str] = []
-    base_depth = search_path.strip("/").count("/") if search_path.strip(
-        "/") else -1
-    for p in sorted(all_paths):
-        entry_name = p.rsplit("/", 1)[-1]
-        depth = p.strip("/").count("/") - (base_depth + 1)
-        if md_min is not None and depth < md_min:
-            continue
-        if name and not fnmatch.fnmatch(entry_name, name):
-            continue
-        if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
-            continue
-        results.append(p)
+    results = await walk_find(search_spec,
+                              readdir=partial(_readdir, accessor),
+                              stat=partial(_stat, accessor),
+                              is_dir_name=_is_dir_name,
+                              index=index,
+                              args=args)
     output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/gsheets/find.py
+++ b/python/mirage/commands/builtin/gsheets/find.py
@@ -12,48 +12,25 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import fnmatch
+from functools import partial
 
 from mirage.accessor.gsheets import GSheetsAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.find import parse_find_args, walk_find
 from mirage.commands.builtin.gsheets._provision import metadata_provision
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gsheets.glob import resolve_glob
 from mirage.core.gsheets.readdir import readdir as _readdir
+from mirage.core.gsheets.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
 
 
-async def _walk(
-    accessor: GSheetsAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-    maxdepth: int | None,
-    depth: int = 0,
-) -> list[str]:
-    if maxdepth is not None and depth > maxdepth:
-        return []
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    results: list[str] = []
-    for child in children:
-        results.append(child)
-        if not child.endswith(".gsheet.json"):
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            results.extend(await _walk(accessor,
-                                       child_spec,
-                                       index,
-                                       maxdepth,
-                                       depth=depth + 1))
-    return results
+def _is_dir_name(child: str) -> bool | None:
+    return not child.endswith(".gsheet.json")
 
 
 async def find_provision(
@@ -90,31 +67,28 @@ async def find(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    index = index
     paths = await resolve_glob(accessor, paths, index)
     p0 = paths[0] if paths else None
     search_path = p0.original if p0 else "/"
     search_prefix = p0.prefix if p0 else ""
-    md = int(maxdepth) if maxdepth is not None else None
-    md_min = int(mindepth) if mindepth is not None else None
-
+    args = parse_find_args(texts,
+                           name=name,
+                           type=type,
+                           size=size,
+                           mtime=mtime,
+                           maxdepth=maxdepth,
+                           iname=iname,
+                           path=path,
+                           mindepth=mindepth)
     search_spec = PathSpec(original=search_path,
                            directory=search_path,
                            resolved=False,
                            prefix=search_prefix)
-    all_paths = await _walk(accessor, search_spec, index, md)
-    results: list[str] = []
-    base_depth = search_path.strip("/").count("/") if search_path.strip(
-        "/") else -1
-    for p in sorted(all_paths):
-        entry_name = p.rsplit("/", 1)[-1]
-        depth = p.strip("/").count("/") - (base_depth + 1)
-        if md_min is not None and depth < md_min:
-            continue
-        if name and not fnmatch.fnmatch(entry_name, name):
-            continue
-        if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
-            continue
-        results.append(p)
+    results = await walk_find(search_spec,
+                              readdir=partial(_readdir, accessor),
+                              stat=partial(_stat, accessor),
+                              is_dir_name=_is_dir_name,
+                              index=index,
+                              args=args)
     output = format_records(results)
     return output, IOResult()

--- a/python/mirage/commands/builtin/gslides/find.py
+++ b/python/mirage/commands/builtin/gslides/find.py
@@ -12,48 +12,25 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import fnmatch
+from functools import partial
 
 from mirage.accessor.gslides import GSlidesAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.find import parse_find_args, walk_find
 from mirage.commands.builtin.gslides._provision import metadata_provision
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gslides.glob import resolve_glob
 from mirage.core.gslides.readdir import readdir as _readdir
+from mirage.core.gslides.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision.types import ProvisionResult
 from mirage.types import PathSpec
 
 
-async def _walk(
-    accessor: GSlidesAccessor,
-    path: PathSpec,
-    index: IndexCacheStore | None,
-    maxdepth: int | None,
-    depth: int = 0,
-) -> list[str]:
-    if maxdepth is not None and depth > maxdepth:
-        return []
-    try:
-        children = await _readdir(accessor, path, index)
-    except FileNotFoundError:
-        return []
-    results: list[str] = []
-    for child in children:
-        results.append(child)
-        if not child.endswith(".json"):
-            child_spec = PathSpec(original=child,
-                                  directory=child,
-                                  resolved=False,
-                                  prefix=path.prefix)
-            results.extend(await _walk(accessor,
-                                       child_spec,
-                                       index,
-                                       maxdepth,
-                                       depth=depth + 1))
-    return results
+def _is_dir_name(child: str) -> bool | None:
+    return not child.endswith(".json")
 
 
 async def find_provision(
@@ -90,31 +67,28 @@ async def find(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    index = index
     paths = await resolve_glob(accessor, paths, index)
     p0 = paths[0] if paths else None
     search_path = p0.original if p0 else "/"
     search_prefix = p0.prefix if p0 else ""
-    md = int(maxdepth) if maxdepth is not None else None
-    md_min = int(mindepth) if mindepth is not None else None
-
+    args = parse_find_args(texts,
+                           name=name,
+                           type=type,
+                           size=size,
+                           mtime=mtime,
+                           maxdepth=maxdepth,
+                           iname=iname,
+                           path=path,
+                           mindepth=mindepth)
     search_spec = PathSpec(original=search_path,
                            directory=search_path,
                            resolved=False,
                            prefix=search_prefix)
-    all_paths = await _walk(accessor, search_spec, index, md)
-    results: list[str] = []
-    base_depth = search_path.strip("/").count("/") if search_path.strip(
-        "/") else -1
-    for p in sorted(all_paths):
-        entry_name = p.rsplit("/", 1)[-1]
-        depth = p.strip("/").count("/") - (base_depth + 1)
-        if md_min is not None and depth < md_min:
-            continue
-        if name and not fnmatch.fnmatch(entry_name, name):
-            continue
-        if iname and not fnmatch.fnmatch(entry_name.lower(), iname.lower()):
-            continue
-        results.append(p)
+    results = await walk_find(search_spec,
+                              readdir=partial(_readdir, accessor),
+                              stat=partial(_stat, accessor),
+                              is_dir_name=_is_dir_name,
+                              index=index,
+                              args=args)
     output = format_records(results)
     return output, IOResult()

--- a/python/mirage/core/gdrive/readdir.py
+++ b/python/mirage/core/gdrive/readdir.py
@@ -37,6 +37,9 @@ async def readdir(
 
     if index is not None:
         cached = await index.list_dir(virtual_key)
+        # Cached entries are slash-less, while the cold path below marks
+        # folders with a trailing slash. Callers must not infer dir-ness
+        # from the slash alone (see find's stat fallback).
         if cached.entries is not None:
             return cached.entries
 

--- a/python/tests/commands/builtin/gdocs/test_find.py
+++ b/python/tests/commands/builtin/gdocs/test_find.py
@@ -1,0 +1,109 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from mirage.accessor.gdocs import GDocsAccessor
+from mirage.cache.index import IndexEntry
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.commands.builtin.gdocs.find import find
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def accessor():
+    return GDocsAccessor(config=None, token_manager=None)
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+def _dir_spec(path: str, prefix: str = "") -> PathSpec:
+    return PathSpec(original=path,
+                    directory=path,
+                    resolved=False,
+                    prefix=prefix)
+
+
+def _lines(output: bytes) -> list[str]:
+    return output.decode().splitlines()
+
+
+async def _populate(index: RAMIndexCacheStore) -> None:
+    recent = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    old = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+    await index.set_dir("/owned", [
+        ("Doc_A__d1.gdoc.json",
+         IndexEntry(id="d1",
+                    name="Doc A",
+                    resource_type="gdocs/file",
+                    remote_time=recent,
+                    vfs_name="Doc_A__d1.gdoc.json",
+                    size=None)),
+        ("Big__d2.gdoc.json",
+         IndexEntry(id="d2",
+                    name="Big",
+                    resource_type="gdocs/file",
+                    remote_time=old,
+                    vfs_name="Big__d2.gdoc.json",
+                    size=2048)),
+    ])
+    await index.set_dir("/shared", [])
+
+
+@pytest.mark.asyncio
+async def test_find_type_f(accessor, index):
+    await _populate(index)
+    result, _ = await find(accessor, [_dir_spec("/")], type="f", index=index)
+    assert _lines(result) == [
+        "/owned/Big__d2.gdoc.json", "/owned/Doc_A__d1.gdoc.json"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_find_type_d(accessor, index):
+    await _populate(index)
+    result, _ = await find(accessor, [_dir_spec("/")], type="d", index=index)
+    assert _lines(result) == ["/owned", "/shared"]
+
+
+@pytest.mark.asyncio
+async def test_find_size_treats_none_as_zero(accessor, index):
+    await _populate(index)
+    result, _ = await find(accessor, [_dir_spec("/")], size="+1k", index=index)
+    lines = _lines(result)
+    assert "/owned/Big__d2.gdoc.json" in lines
+    assert "/owned/Doc_A__d1.gdoc.json" not in lines
+
+
+@pytest.mark.asyncio
+async def test_find_mtime_recent(accessor, index):
+    await _populate(index)
+    result, _ = await find(accessor, [_dir_spec("/")], mtime="-1", index=index)
+    assert _lines(result) == ["/owned/Doc_A__d1.gdoc.json"]
+
+
+@pytest.mark.asyncio
+async def test_find_path_pattern(accessor, index):
+    await _populate(index)
+    result, _ = await find(accessor, [_dir_spec("/")],
+                           path="/owned/*",
+                           index=index)
+    assert _lines(result) == [
+        "/owned/Big__d2.gdoc.json", "/owned/Doc_A__d1.gdoc.json"
+    ]

--- a/python/tests/commands/builtin/gdrive/test_find.py
+++ b/python/tests/commands/builtin/gdrive/test_find.py
@@ -270,15 +270,35 @@ async def test_find_name_matches_native_gdoc(accessor, index):
 async def test_find_maxdepth_limits_recursion(accessor, index):
     await _populate_warm(index)
     result, _ = await find(accessor, [_dir_spec("/")],
-                           maxdepth="0",
+                           maxdepth="1",
                            index=index)
     assert _lines(result) == ["/doc.gdoc.json", "/docs", "/file.txt"]
+
+
+@pytest.mark.asyncio
+async def test_find_maxdepth_zero_lists_nothing(accessor, index):
+    await _populate_warm(index)
+    result, _ = await find(accessor, [_dir_spec("/")],
+                           maxdepth="0",
+                           index=index)
+    assert _lines(result) == []
+
+
+@pytest.mark.asyncio
+async def test_find_mindepth_one_keeps_top_level(accessor, index):
+    await _populate_warm(index)
+    result, _ = await find(accessor, [_dir_spec("/")],
+                           mindepth="1",
+                           index=index)
+    assert _lines(result) == [
+        "/doc.gdoc.json", "/docs", "/docs/inner.txt", "/file.txt"
+    ]
 
 
 @pytest.mark.asyncio
 async def test_find_mindepth_skips_top_level(accessor, index):
     await _populate_warm(index)
     result, _ = await find(accessor, [_dir_spec("/")],
-                           mindepth="1",
+                           mindepth="2",
                            index=index)
     assert _lines(result) == ["/docs/inner.txt"]

--- a/python/tests/commands/builtin/gdrive/test_find.py
+++ b/python/tests/commands/builtin/gdrive/test_find.py
@@ -1,0 +1,284 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mirage.accessor.gdrive import GDriveAccessor
+from mirage.cache.index.config import IndexEntry
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.commands.builtin.gdrive.find import find
+from mirage.core.google._client import TokenManager
+from mirage.core.google.config import GoogleConfig
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def config():
+    return GoogleConfig(
+        client_id="test-id",
+        client_secret="test-secret",
+        refresh_token="test-refresh",
+    )
+
+
+@pytest.fixture
+def token_manager(config):
+    mgr = TokenManager(config)
+    mgr._access_token = "fake-token"
+    mgr._expires_at = 9999999999
+    return mgr
+
+
+@pytest.fixture
+def accessor(config, token_manager):
+    return GDriveAccessor(config=config, token_manager=token_manager)
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+def _dir_spec(path: str, prefix: str = "") -> PathSpec:
+    return PathSpec(original=path,
+                    directory=path,
+                    resolved=False,
+                    prefix=prefix)
+
+
+def _entry(eid: str,
+           name: str,
+           resource_type: str,
+           size: int | None = None,
+           modified: str = "") -> IndexEntry:
+    return IndexEntry(
+        id=eid,
+        name=name,
+        resource_type=resource_type,
+        remote_time=modified,
+        vfs_name=name,
+        size=size,
+    )
+
+
+def _recent() -> str:
+    return (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+
+
+def _old() -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+
+
+async def _populate_warm(index: RAMIndexCacheStore, prefix: str = "") -> None:
+    root = prefix or "/"
+    await index.set_dir(root, [
+        ("docs", _entry(
+            "fid-docs", "docs", "gdrive/folder", modified=_recent())),
+        ("file.txt",
+         _entry("fid-file",
+                "file.txt",
+                "gdrive/file",
+                size=2048,
+                modified=_recent())),
+        ("doc.gdoc.json",
+         _entry("fid-gdoc", "doc.gdoc.json", "gdrive/gdoc", size=None)),
+    ])
+    await index.set_dir(f"{prefix}/docs", [
+        ("inner.txt",
+         _entry(
+             "fid-inner", "inner.txt", "gdrive/file", size=10,
+             modified=_old())),
+    ])
+
+
+def _lines(output: bytes) -> list[str]:
+    return output.decode().splitlines()
+
+
+@pytest.mark.asyncio
+async def test_find_warm_cache_recurses_into_directories(accessor, index):
+    await _populate_warm(index)
+    result, io = await find(accessor, [_dir_spec("/")], index=index)
+    lines = _lines(result)
+    assert "/docs/inner.txt" in lines
+    assert "/docs" in lines
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_find_warm_cache_no_trailing_slash(accessor, index):
+    await _populate_warm(index)
+    result, _ = await find(accessor, [_dir_spec("/")], index=index)
+    assert all(not line.endswith("/") for line in _lines(result))
+
+
+@pytest.mark.asyncio
+async def test_find_cold_name_matches_directory(accessor, index):
+    files_by_folder = {
+        "root": [
+            {
+                "id": "fid-docs",
+                "name": "docs",
+                "mimeType": "application/vnd.google-apps.folder",
+                "modifiedTime": "2026-01-01T00:00:00Z",
+            },
+            {
+                "id": "fid-file",
+                "name": "file.txt",
+                "mimeType": "text/plain",
+                "modifiedTime": "2026-01-02T00:00:00Z",
+                "size": "2048",
+            },
+            {
+                "id": "fid-gdoc",
+                "name": "doc",
+                "mimeType": "application/vnd.google-apps.document",
+                "modifiedTime": "2026-01-03T00:00:00Z",
+            },
+        ],
+        "fid-docs": [
+            {
+                "id": "fid-inner",
+                "name": "inner.txt",
+                "mimeType": "text/plain",
+                "modifiedTime": "2026-01-04T00:00:00Z",
+                "size": "10",
+            },
+        ],
+    }
+
+    async def fake_list_files(token_manager, folder_id="root"):
+        return files_by_folder.get(folder_id, [])
+
+    with patch(
+            "mirage.core.gdrive.readdir.list_files",
+            new=AsyncMock(side_effect=fake_list_files),
+    ):
+        result, _ = await find(accessor, [_dir_spec("/")],
+                               name="docs",
+                               index=index)
+        assert _lines(result) == ["/docs"]
+
+
+@pytest.mark.asyncio
+async def test_find_cold_output_has_no_trailing_slash(accessor, index):
+
+    async def fake_list_files(token_manager, folder_id="root"):
+        if folder_id == "root":
+            return [{
+                "id": "fid-docs",
+                "name": "docs",
+                "mimeType": "application/vnd.google-apps.folder",
+                "modifiedTime": "2026-01-01T00:00:00Z",
+            }]
+        return []
+
+    with patch(
+            "mirage.core.gdrive.readdir.list_files",
+            new=AsyncMock(side_effect=fake_list_files),
+    ):
+        result, _ = await find(accessor, [_dir_spec("/")], index=index)
+        assert _lines(result) == ["/docs"]
+
+
+@pytest.mark.asyncio
+async def test_find_type_f(accessor, index):
+    await _populate_warm(index)
+    result, _ = await find(accessor, [_dir_spec("/")], type="f", index=index)
+    assert _lines(result) == ["/doc.gdoc.json", "/docs/inner.txt", "/file.txt"]
+
+
+@pytest.mark.asyncio
+async def test_find_type_d(accessor, index):
+    await _populate_warm(index)
+    result, _ = await find(accessor, [_dir_spec("/")], type="d", index=index)
+    assert _lines(result) == ["/docs"]
+
+
+@pytest.mark.asyncio
+async def test_find_size_min(accessor, index):
+    await _populate_warm(index)
+    result, _ = await find(accessor, [_dir_spec("/")], size="+1k", index=index)
+    assert "/file.txt" in _lines(result)
+    assert "/docs/inner.txt" not in _lines(result)
+    assert "/doc.gdoc.json" not in _lines(result)
+
+
+@pytest.mark.asyncio
+async def test_find_size_max_treats_none_as_zero(accessor, index):
+    await _populate_warm(index)
+    result, _ = await find(accessor, [_dir_spec("/")],
+                           size="-100c",
+                           index=index)
+    lines = _lines(result)
+    assert "/docs/inner.txt" in lines
+    assert "/doc.gdoc.json" in lines
+    assert "/file.txt" not in lines
+
+
+@pytest.mark.asyncio
+async def test_find_mtime_recent(accessor, index):
+    await _populate_warm(index)
+    result, _ = await find(accessor, [_dir_spec("/")], mtime="-1", index=index)
+    lines = _lines(result)
+    assert "/file.txt" in lines
+    assert "/docs" in lines
+    assert "/docs/inner.txt" not in lines
+    assert "/doc.gdoc.json" not in lines
+
+
+@pytest.mark.asyncio
+async def test_find_mtime_old(accessor, index):
+    await _populate_warm(index)
+    result, _ = await find(accessor, [_dir_spec("/")], mtime="+5", index=index)
+    assert _lines(result) == ["/docs/inner.txt"]
+
+
+@pytest.mark.asyncio
+async def test_find_path_pattern_strips_mount_prefix(accessor, index):
+    await _populate_warm(index, prefix="/gd")
+    result, _ = await find(accessor, [_dir_spec("/gd", prefix="/gd")],
+                           path="/docs/*",
+                           index=index)
+    assert _lines(result) == ["/gd/docs/inner.txt"]
+
+
+@pytest.mark.asyncio
+async def test_find_name_matches_native_gdoc(accessor, index):
+    await _populate_warm(index)
+    result, _ = await find(accessor, [_dir_spec("/")],
+                           name="*.gdoc.json",
+                           index=index)
+    assert _lines(result) == ["/doc.gdoc.json"]
+
+
+@pytest.mark.asyncio
+async def test_find_maxdepth_limits_recursion(accessor, index):
+    await _populate_warm(index)
+    result, _ = await find(accessor, [_dir_spec("/")],
+                           maxdepth="0",
+                           index=index)
+    assert _lines(result) == ["/doc.gdoc.json", "/docs", "/file.txt"]
+
+
+@pytest.mark.asyncio
+async def test_find_mindepth_skips_top_level(accessor, index):
+    await _populate_warm(index)
+    result, _ = await find(accessor, [_dir_spec("/")],
+                           mindepth="1",
+                           index=index)
+    assert _lines(result) == ["/docs/inner.txt"]

--- a/python/tests/commands/builtin/generic/test_find.py
+++ b/python/tests/commands/builtin/generic/test_find.py
@@ -1,11 +1,12 @@
 from dataclasses import asdict
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock
 
 import pytest
 
 from mirage.commands.builtin.generic.find import (FindArgs, apply_mount_prefix,
                                                   apply_mtime_filter,
-                                                  parse_find_args)
+                                                  parse_find_args, walk_find)
 from mirage.types import FileStat, FileType, FindType, PathSpec
 
 
@@ -190,3 +191,85 @@ def test_apply_mount_prefix_strips_leading_slash_from_entries():
 
 async def _unreached_stat(_spec: PathSpec) -> FileStat:
     raise AssertionError("stat should not be called when no mtime window set")
+
+
+def _root_spec() -> PathSpec:
+    return PathSpec(original="/", directory="/", resolved=False, prefix="")
+
+
+@pytest.mark.asyncio
+async def test_walk_find_tolerates_not_found_readdir():
+    readdir = AsyncMock(side_effect=FileNotFoundError("/"))
+    stat = AsyncMock()
+    results = await walk_find(_root_spec(),
+                              readdir=readdir,
+                              stat=stat,
+                              is_dir_name=lambda c: None,
+                              index=None,
+                              args=FindArgs())
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_walk_find_propagates_non_not_found_readdir_errors():
+    readdir = AsyncMock(side_effect=ValueError("bad page token"))
+    stat = AsyncMock()
+    with pytest.raises(ValueError, match="bad page token"):
+        await walk_find(_root_spec(),
+                        readdir=readdir,
+                        stat=stat,
+                        is_dir_name=lambda c: None,
+                        index=None,
+                        args=FindArgs())
+
+
+@pytest.mark.asyncio
+async def test_walk_find_stat_fallback_treats_not_found_as_file():
+    readdir = AsyncMock(return_value=["/mystery"])
+    stat = AsyncMock(side_effect=FileNotFoundError("/mystery"))
+    results = await walk_find(_root_spec(),
+                              readdir=readdir,
+                              stat=stat,
+                              is_dir_name=lambda c: None,
+                              index=None,
+                              args=FindArgs(type=FindType.FILE))
+    assert results == ["/mystery"]
+
+
+@pytest.mark.asyncio
+async def test_walk_find_stat_fallback_propagates_other_errors():
+    readdir = AsyncMock(return_value=["/mystery"])
+    stat = AsyncMock(side_effect=ValueError("rate limited"))
+    with pytest.raises(ValueError, match="rate limited"):
+        await walk_find(_root_spec(),
+                        readdir=readdir,
+                        stat=stat,
+                        is_dir_name=lambda c: None,
+                        index=None,
+                        args=FindArgs())
+
+
+@pytest.mark.asyncio
+async def test_walk_find_size_filter_drops_not_found_entries():
+    readdir = AsyncMock(return_value=["/a.json"])
+    stat = AsyncMock(side_effect=FileNotFoundError("/a.json"))
+    results = await walk_find(_root_spec(),
+                              readdir=readdir,
+                              stat=stat,
+                              is_dir_name=lambda c: False,
+                              index=None,
+                              args=FindArgs(min_size=1))
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_walk_find_size_filter_propagates_other_stat_errors():
+    readdir = AsyncMock(return_value=["/a.json"])
+    stat = AsyncMock(side_effect=ValueError("rate limited"))
+    with pytest.raises(ValueError, match="rate limited"):
+        await walk_find(_root_spec(),
+                        readdir=readdir,
+                        stat=stat,
+                        is_dir_name=lambda c: False,
+                        index=None,
+                        args=FindArgs(min_size=1))

--- a/python/tests/commands/builtin/gmail/test_find.py
+++ b/python/tests/commands/builtin/gmail/test_find.py
@@ -1,0 +1,90 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.accessor.gmail import GmailAccessor
+from mirage.cache.index import IndexEntry
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.commands.builtin.gmail.find import find
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def accessor():
+    return GmailAccessor(config=None, token_manager=None)
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+def _dir_spec(path: str, prefix: str = "") -> PathSpec:
+    return PathSpec(original=path,
+                    directory=path,
+                    resolved=False,
+                    prefix=prefix)
+
+
+def _lines(output: bytes) -> list[str]:
+    return output.decode().splitlines()
+
+
+async def _populate(index: RAMIndexCacheStore) -> None:
+    await index.set_dir("/", [
+        ("INBOX",
+         IndexEntry(id="INBOX",
+                    name="INBOX",
+                    resource_type="gmail/label",
+                    vfs_name="INBOX")),
+    ])
+    await index.set_dir("/INBOX", [
+        ("2026-06-01",
+         IndexEntry(id="2026-06-01",
+                    name="2026-06-01",
+                    resource_type="gmail/date",
+                    vfs_name="2026-06-01")),
+    ])
+    await index.set_dir("/INBOX/2026-06-01", [
+        ("Hello__m1.gmail.json",
+         IndexEntry(id="m1",
+                    name="Hello",
+                    resource_type="gmail/message",
+                    vfs_name="Hello__m1.gmail.json",
+                    size=123)),
+    ])
+
+
+@pytest.mark.asyncio
+async def test_find_type_f(accessor, index):
+    await _populate(index)
+    result, _ = await find(accessor, [_dir_spec("/")], type="f", index=index)
+    assert _lines(result) == ["/INBOX/2026-06-01/Hello__m1.gmail.json"]
+
+
+@pytest.mark.asyncio
+async def test_find_type_d(accessor, index):
+    await _populate(index)
+    result, _ = await find(accessor, [_dir_spec("/")], type="d", index=index)
+    assert _lines(result) == ["/INBOX", "/INBOX/2026-06-01"]
+
+
+@pytest.mark.asyncio
+async def test_find_name_matches_message(accessor, index):
+    await _populate(index)
+    result, _ = await find(accessor, [_dir_spec("/")],
+                           name="*.gmail.json",
+                           index=index)
+    assert _lines(result) == ["/INBOX/2026-06-01/Hello__m1.gmail.json"]

--- a/python/tests/commands/builtin/gsheets/test_find.py
+++ b/python/tests/commands/builtin/gsheets/test_find.py
@@ -1,0 +1,68 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.accessor.gsheets import GSheetsAccessor
+from mirage.cache.index import IndexEntry
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.commands.builtin.gsheets.find import find
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def accessor():
+    return GSheetsAccessor(config=None, token_manager=None)
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+def _dir_spec(path: str, prefix: str = "") -> PathSpec:
+    return PathSpec(original=path,
+                    directory=path,
+                    resolved=False,
+                    prefix=prefix)
+
+
+def _lines(output: bytes) -> list[str]:
+    return output.decode().splitlines()
+
+
+async def _populate(index: RAMIndexCacheStore) -> None:
+    await index.set_dir("/owned", [
+        ("Sheet_A__s1.gsheet.json",
+         IndexEntry(id="s1",
+                    name="Sheet A",
+                    resource_type="gsheets/file",
+                    vfs_name="Sheet_A__s1.gsheet.json",
+                    size=None)),
+    ])
+    await index.set_dir("/shared", [])
+
+
+@pytest.mark.asyncio
+async def test_find_type_f(accessor, index):
+    await _populate(index)
+    result, _ = await find(accessor, [_dir_spec("/")], type="f", index=index)
+    assert _lines(result) == ["/owned/Sheet_A__s1.gsheet.json"]
+
+
+@pytest.mark.asyncio
+async def test_find_type_d(accessor, index):
+    await _populate(index)
+    result, _ = await find(accessor, [_dir_spec("/")], type="d", index=index)
+    assert _lines(result) == ["/owned", "/shared"]

--- a/python/tests/commands/builtin/gslides/test_find.py
+++ b/python/tests/commands/builtin/gslides/test_find.py
@@ -1,0 +1,68 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.accessor.gslides import GSlidesAccessor
+from mirage.cache.index import IndexEntry
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.commands.builtin.gslides.find import find
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def accessor():
+    return GSlidesAccessor(config=None, token_manager=None)
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+def _dir_spec(path: str, prefix: str = "") -> PathSpec:
+    return PathSpec(original=path,
+                    directory=path,
+                    resolved=False,
+                    prefix=prefix)
+
+
+def _lines(output: bytes) -> list[str]:
+    return output.decode().splitlines()
+
+
+async def _populate(index: RAMIndexCacheStore) -> None:
+    await index.set_dir("/owned", [
+        ("Deck_A__p1.gslide.json",
+         IndexEntry(id="p1",
+                    name="Deck A",
+                    resource_type="gslides/file",
+                    vfs_name="Deck_A__p1.gslide.json",
+                    size=None)),
+    ])
+    await index.set_dir("/shared", [])
+
+
+@pytest.mark.asyncio
+async def test_find_type_f(accessor, index):
+    await _populate(index)
+    result, _ = await find(accessor, [_dir_spec("/")], type="f", index=index)
+    assert _lines(result) == ["/owned/Deck_A__p1.gslide.json"]
+
+
+@pytest.mark.asyncio
+async def test_find_type_d(accessor, index):
+    await _populate(index)
+    result, _ = await find(accessor, [_dir_spec("/")], type="d", index=index)
+    assert _lines(result) == ["/owned", "/shared"]


### PR DESCRIPTION
Fixes three defects in the python find command for gdrive/gdocs/gsheets/gslides/gmail, mirroring the TS fix merged in #228/#230.

- Warm index-cache hits return slash-less keys, so the walk treated directories as files and stopped recursing. Slash-less entries now fall back to stat for classification (gdrive); the other backends keep their extension-based classification.
- -type, -size, -mtime, and -path were accepted but ignored. All are now implemented in a shared walk (generic walk_find) with injected readdir/stat, matching the TS semantics: size applies to files with missing size as 0, entries lacking modified time are excluded from -mtime, -path matches the prefix-stripped path.
- Directory results kept their trailing slash, breaking -name matching and polluting output. Slashes are stripped before name derivation and output.

Also switches -maxdepth/-mindepth to the GNU depth convention (top-level children are depth 1), consistent with the TS implementation and python's nextcloud find.

Tests: new test_find.py for all five backends (warm-cache and cold fixtures, gdoc native files with size None); full python suite passes (7203 passed, 270 skipped).