### PR TITLE
refactor(ts): delegate jq/realpath stragglers and langfuse rg to generic

### DIFF
--- a/examples/typescript/langfuse/langfuse.ts
+++ b/examples/typescript/langfuse/langfuse.ts
@@ -1,0 +1,96 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import dotenv from 'dotenv'
+import { LangfuseResource, MountMode, Workspace, type LangfuseConfig } from '@struktoai/mirage-node'
+
+const __HERE = fileURLToPath(new URL('.', import.meta.url))
+dotenv.config({ path: resolve(__HERE, '../../../.env.development') })
+
+function buildConfig(): LangfuseConfig {
+  const publicKey = process.env.LANGFUSE_PUBLIC_KEY ?? ''
+  const secretKey = process.env.LANGFUSE_SECRET_KEY ?? ''
+  if (publicKey === '' || secretKey === '') {
+    throw new Error('LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY env vars are required')
+  }
+  const host = process.env.LANGFUSE_HOST ?? ''
+  return { publicKey, secretKey, ...(host !== '' ? { host } : {}) }
+}
+
+async function run(ws: Workspace, cmd: string): Promise<string> {
+  console.log(`$ ${cmd}`)
+  const r = await ws.execute(cmd)
+  if (r.exitCode !== 0 && r.stderrText !== '') {
+    console.log(`  STDERR: ${r.stderrText.slice(0, 200)}`)
+  }
+  const out = r.stdoutText.replace(/\s+$/, '')
+  if (out !== '') {
+    for (const line of out.split('\n').slice(0, 10)) console.log(`  ${line.slice(0, 200)}`)
+  }
+  return out
+}
+
+async function main(): Promise<void> {
+  const ws = new Workspace(
+    { '/langfuse': new LangfuseResource(buildConfig()) },
+    { mode: MountMode.READ },
+  )
+  try {
+    console.log('=== ls /langfuse/ ===')
+    await run(ws, 'ls /langfuse/')
+    for (const scope of ['traces', 'sessions', 'prompts', 'datasets']) {
+      console.log(`\n=== ls /langfuse/${scope}/ ===`)
+      await run(ws, `ls /langfuse/${scope}/ | head -n 5`)
+    }
+
+    console.log('\n=== first trace ===')
+    const t0 = (await run(ws, 'ls /langfuse/traces/ | head -n 1')).trim()
+    if (t0 !== '') {
+      const tracePath = `/langfuse/traces/${t0}`
+      await run(ws, `cat "${tracePath}" | head -n 5`)
+      await run(ws, `jq ".name" "${tracePath}"`)
+      await run(ws, `jq -r ".id" "${tracePath}"`)
+      await run(ws, `wc "${tracePath}"`)
+      await run(ws, `stat "${tracePath}"`)
+    }
+
+    console.log('\n=== grep scope pushdown ===')
+    await run(ws, 'grep "a" /langfuse/traces/ | head -n 3')
+    await run(ws, 'grep "a" /langfuse/sessions/ | head -n 3')
+    await run(ws, 'grep "a" /langfuse/prompts/ | head -n 3')
+
+    console.log('\n=== rg across prompts ===')
+    await run(ws, 'rg -l "name" /langfuse/prompts/ | head -n 3')
+
+    console.log('\n=== datasets ===')
+    const d0 = (await run(ws, 'ls /langfuse/datasets/ | head -n 1')).trim().replace(/\/+$/, '')
+    if (d0 !== '') {
+      const itemsPath = `/langfuse/datasets/${d0}/items.jsonl`
+      await run(ws, `head -n 2 "${itemsPath}"`)
+      await run(ws, `jq ".[].id" "${itemsPath}" | head -n 3`)
+    }
+
+    console.log('\n=== tree -L 2 /langfuse/ ===')
+    await run(ws, 'tree -L 2 /langfuse/ | head -n 20')
+  } finally {
+    await ws.close()
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/examples/typescript/linear/linear.ts
+++ b/examples/typescript/linear/linear.ts
@@ -89,6 +89,16 @@ async function main(): Promise<void> {
 
     console.log(`\n=== grep -r -l bug ${teamBase}/issues/ | head -n 3 ===`)
     await run(ws, `grep -r -l bug "${teamBase}/issues/" | head -n 3`)
+
+    console.log(`\n=== stat ${i0}/issue.json ===`)
+    await run(ws, `stat "${issuePath}/issue.json"`)
+
+    console.log(`\n=== wc / tail issue.json ===`)
+    await run(ws, `wc "${issuePath}/issue.json"`)
+    await run(ws, `tail -n 3 "${issuePath}/issue.json"`)
+
+    console.log(`\n=== rg -l title ${teamBase}/issues/ | head -n 3 ===`)
+    await run(ws, `rg -l "title" "${teamBase}/issues/" | head -n 3`)
   } finally {
     await ws.close()
   }

--- a/examples/typescript/slack/slack.ts
+++ b/examples/typescript/slack/slack.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import dotenv from 'dotenv'
 import {
   MountMode,
@@ -20,7 +22,8 @@ import {
   type SlackConfig,
 } from '@struktoai/mirage-node'
 
-dotenv.config({ path: '.env.development' })
+const __HERE = fileURLToPath(new URL('.', import.meta.url))
+dotenv.config({ path: resolve(__HERE, '../../../.env.development') })
 
 function buildConfig(): SlackConfig {
   const token = process.env.SLACK_BOT_TOKEN

--- a/examples/typescript/slack/slack_fuse.ts
+++ b/examples/typescript/slack/slack_fuse.ts
@@ -14,6 +14,8 @@
 
 import { readdir, readFile } from 'node:fs/promises'
 import { createInterface } from 'node:readline/promises'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import dotenv from 'dotenv'
 import {
   FuseManager,
@@ -23,7 +25,8 @@ import {
   type SlackConfig,
 } from '@struktoai/mirage-node'
 
-dotenv.config({ path: '.env.development' })
+const __HERE = fileURLToPath(new URL('.', import.meta.url))
+dotenv.config({ path: resolve(__HERE, '../../../.env.development') })
 
 function buildConfig(): SlackConfig {
   const token = process.env.SLACK_BOT_TOKEN

--- a/examples/typescript/slack/slack_vfs.ts
+++ b/examples/typescript/slack/slack_vfs.ts
@@ -13,6 +13,8 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import dotenv from 'dotenv'
 import {
   MountMode,
@@ -25,7 +27,8 @@ import {
 const require = createRequire(import.meta.url)
 const fs = require('fs') as typeof import('fs')
 
-dotenv.config({ path: '.env.development' })
+const __HERE = fileURLToPath(new URL('.', import.meta.url))
+dotenv.config({ path: resolve(__HERE, '../../../.env.development') })
 
 function buildConfig(): SlackConfig {
   const token = process.env.SLACK_BOT_TOKEN

--- a/examples/typescript/trello/trello.ts
+++ b/examples/typescript/trello/trello.ts
@@ -46,7 +46,10 @@ async function run(ws: Workspace, cmd: string): Promise<string> {
 }
 
 async function main(): Promise<void> {
-  const ws = new Workspace({ '/trello': new TrelloResource(buildConfig()) }, { mode: MountMode.READ })
+  const ws = new Workspace(
+    { '/trello': new TrelloResource(buildConfig()) },
+    { mode: MountMode.WRITE },
+  )
   try {
     console.log('=== ls /trello/ ===')
     await run(ws, 'ls /trello/')
@@ -92,8 +95,48 @@ async function main(): Promise<void> {
     console.log(`\n=== grep -l hello ${boardBase} ===`)
     await run(ws, `grep -r -l hello "${boardBase}"`)
 
-    console.log(`\n=== wc -l ${boardBase}/lists/${l0}/cards/*/card.json ===`)
-    await run(ws, `find "${boardBase}/lists/${l0}/cards" -name "card.json" | head -n 1 | xargs wc -l`)
+    console.log(`\n=== wc -l first card.json ===`)
+    const card = (await run(ws, `find "${boardBase}" -name "card.json" | head -n 1`)).trim()
+    if (card !== '') {
+      await run(ws, `wc -l "${card}"`)
+    }
+
+    console.log('\n=== card write commands (sandbox card) ===')
+    const listId = l0.replace(/\/+$/, '').split('__').pop() ?? ''
+    if (listId !== '') {
+      const created = await run(
+        ws,
+        `trello-card-create --list_id ${listId} --name "mirage example card" --desc "created by examples/typescript/trello/trello.ts"`,
+      )
+      let cardId = ''
+      try {
+        cardId = (JSON.parse(created) as { card_id?: string; id?: string }).card_id ?? ''
+        if (cardId === '') cardId = (JSON.parse(created) as { id?: string }).id ?? ''
+      } catch {
+        console.log('  could not parse created card payload, skipping write demos')
+      }
+      if (cardId !== '') {
+        await run(ws, `trello-card-update --card_id ${cardId} --name "mirage example card (updated)"`)
+        await run(ws, `trello-card-move --card_id ${cardId} --list_id ${listId}`)
+        const comment = await run(
+          ws,
+          `trello-card-comment-add --card_id ${cardId} --text "hello from mirage"`,
+        )
+        let commentId = ''
+        try {
+          commentId = (JSON.parse(comment) as { comment_id?: string; id?: string }).comment_id ?? ''
+          if (commentId === '') commentId = (JSON.parse(comment) as { id?: string }).id ?? ''
+        } catch {
+          commentId = ''
+        }
+        if (commentId !== '') {
+          await run(
+            ws,
+            `trello-card-comment-update --comment_id ${commentId} --card_id ${cardId} --text "updated comment"`,
+          )
+        }
+      }
+    }
   } finally {
     await ws.close()
   }

--- a/integ/cases.py
+++ b/integ/cases.py
@@ -23,6 +23,8 @@ SEED_FILES = {
                          '{"name": "bob", "age": 25}]}\n'),
     "/data/data.jsonl":
     '{"id":1}\n{"id":2}\n{"id":3}\n',
+    "/data/chat.jsonl":
+    '{"msg":"hello"}\n{"msg":"world"}\n',
     "/data/dup.txt":
     "a\na\nb\nb\nc\n",
     "/data/csv.csv":
@@ -104,6 +106,8 @@ CASES: list[tuple[str, str]] = [
     ("jq_raw", 'jq -r ".name" /data/user.json'),
     ("jq_array_iter", 'jq ".users[].name" /data/users.json'),
     ("jq_jsonl_id", 'jq ".id" /data/data.jsonl'),
+    ("jq_jsonl_chain", 'jq ".[].id" /data/data.jsonl'),
+    ("jq_jsonl_chain_raw", 'jq -r ".[].msg" /data/chat.jsonl'),
 
     # ----- sort / uniq / shuffle -----
     ("sort", "sort /data/a.txt"),

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -21,6 +21,7 @@ export const SEED_FILES: Record<string, string> = {
   "/data/users.json":
     '{"users": [{"name": "alice", "age": 30}, {"name": "bob", "age": 25}]}\n',
   "/data/data.jsonl": '{"id":1}\n{"id":2}\n{"id":3}\n',
+  "/data/chat.jsonl": '{"msg":"hello"}\n{"msg":"world"}\n',
   "/data/dup.txt": "a\na\nb\nb\nc\n",
   "/data/csv.csv": "name,age\nalice,30\nbob,25\n",
   "/data/tabbed.txt": "a\t1\nb\t2\nc\t3\n",
@@ -76,6 +77,8 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
   ["jq_raw", 'jq -r ".name" /data/user.json'],
   ["jq_array_iter", 'jq ".users[].name" /data/users.json'],
   ["jq_jsonl_id", 'jq ".id" /data/data.jsonl'],
+  ["jq_jsonl_chain", 'jq ".[].id" /data/data.jsonl'],
+  ["jq_jsonl_chain_raw", 'jq -r ".[].msg" /data/chat.jsonl'],
 
   ["sort", "sort /data/a.txt"],
   ["sort_r", "sort -r /data/a.txt"],

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -93,6 +93,13 @@ alice
 1
 2
 3
+=== jq_jsonl_chain ===
+1
+2
+3
+=== jq_jsonl_chain_raw ===
+hello
+world
 === sort ===
 bar
 baz
@@ -246,6 +253,7 @@ a.txt
 /data/b.txt
 /data/binary.bin
 /data/c.txt
+/data/chat.jsonl
 /data/csv.csv
 /data/data.jsonl
 /data/dup.txt
@@ -273,6 +281,7 @@ abc.csv
 b.txt
 binary.bin
 c.txt
+chat.jsonl
 csv.csv
 data.jsonl
 dup.txt
@@ -299,6 +308,7 @@ abc.csv
 b.txt
 binary.bin
 c.txt
+chat.jsonl
 csv.csv
 data.jsonl
 dup.txt
@@ -405,6 +415,7 @@ baz
 /data/b.txt
 /data/binary.bin
 /data/c.txt
+/data/chat.jsonl
 /data/csv.csv
 /data/data.jsonl
 /data/dup.txt
@@ -432,6 +443,7 @@ baz
 /data/b.txt
 /data/binary.bin
 /data/c.txt
+/data/chat.jsonl
 /data/csv.csv
 /data/data.jsonl
 /data/dup.txt
@@ -602,6 +614,7 @@ world
 /data/abc.csv
 /data/binary.bin
 /data/c.txt
+/data/chat.jsonl
 /data/csv.csv
 /data/data.jsonl
 /data/dup.txt
@@ -876,6 +889,7 @@ baz,
 /data/b.txt
 /data/binary.bin
 /data/c.txt
+/data/chat.jsonl
 /data/csv.csv
 /data/data.jsonl
 /data/dup.txt
@@ -932,6 +946,7 @@ baz,
 /data/b.txt
 /data/binary.bin
 /data/c.txt
+/data/chat.jsonl
 /data/csv.csv
 /data/data.jsonl
 /data/dup.txt
@@ -959,6 +974,7 @@ baz,
 /data/b.txt
 /data/binary.bin
 /data/c.txt
+/data/chat.jsonl
 /data/csv.csv
 /data/data.jsonl
 /data/dup.txt
@@ -1019,7 +1035,7 @@ baz,
 === du_file ===
 24	/data/a.txt
 === du_dir ===
-570	/data
+602	/data
 === du_h ===
 24B	/data/a.txt
 === tree ===

--- a/python/mirage/commands/builtin/generic/jq.py
+++ b/python/mirage/commands/builtin/generic/jq.py
@@ -36,7 +36,7 @@ async def jq(
         if is_jsonl_path(
                 paths[0].original) and is_streamable_jsonl_expr(expression):
             source = read_stream(accessor, paths[0])
-            return eval_jsonl_stream(source, expression), IOResult()
+            return eval_jsonl_stream(source, expression, raw=r), IOResult()
         outputs: list[bytes] = []
         for p in paths:
             data = parse_json_path(await read_bytes(accessor, p), p.original)

--- a/python/mirage/core/jq/stream.py
+++ b/python/mirage/core/jq/stream.py
@@ -58,6 +58,7 @@ def is_streamable_jsonl_expr(expression: str) -> bool:
 async def eval_jsonl_stream(
     source: AsyncIterator[bytes],
     expression: str,
+    raw: bool = False,
 ) -> AsyncIterator[bytes]:
     from mirage.core.jq.eval import jq_eval
 
@@ -66,6 +67,8 @@ async def eval_jsonl_stream(
         per_item = "."
     elif expr.startswith(".[] | "):
         per_item = expr[6:]
+    elif expr.startswith(".[]."):
+        per_item = expr[3:]
     else:
         per_item = expr
 
@@ -77,4 +80,7 @@ async def eval_jsonl_stream(
         result = jq_eval(obj, per_item)
         if result is JQ_EMPTY:
             continue
-        yield orjson.dumps(result) + b"\n"
+        if raw and isinstance(result, str):
+            yield result.encode("utf-8") + b"\n"
+        else:
+            yield orjson.dumps(result) + b"\n"

--- a/python/tests/core/jq/test_stream.py
+++ b/python/tests/core/jq/test_stream.py
@@ -15,7 +15,7 @@
 import orjson
 import pytest
 
-from mirage.core.jq.stream import parse_json_auto
+from mirage.core.jq.stream import eval_jsonl_stream, parse_json_auto
 
 
 def test_parse_json_auto_empty_raises_clear_error():
@@ -40,3 +40,29 @@ def test_parse_json_auto_ndjson():
 def test_parse_json_auto_single_line_garbage_propagates_error():
     with pytest.raises(orjson.JSONDecodeError):
         parse_json_auto(b"this is not json")
+
+
+async def _lines(*items: bytes):
+    for item in items:
+        yield item
+
+
+async def _collect(stream) -> list[str]:
+    out = []
+    async for chunk in stream:
+        out.append(chunk.decode().rstrip("\n"))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_eval_jsonl_stream_dot_chain_maps_per_line():
+    source = _lines(b'{"msg":"hello"}\n', b'{"msg":"world"}\n')
+    out = await _collect(eval_jsonl_stream(source, ".[].msg"))
+    assert out == ['"hello"', '"world"']
+
+
+@pytest.mark.asyncio
+async def test_eval_jsonl_stream_raw_unquotes_strings():
+    source = _lines(b'{"msg":"hello"}\n', b'{"msg":"world"}\n')
+    out = await _collect(eval_jsonl_stream(source, ".[].msg", raw=True))
+    assert out == ["hello", "world"]

--- a/typescript/packages/core/src/commands/builtin/discord/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/jq.ts
@@ -13,22 +13,21 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { DiscordAccessor } from '../../../accessor/discord.ts'
-import { resolveDiscordGlob } from '../../../core/discord/glob.ts'
+import type { IndexCacheStore } from '../../../cache/index/index.ts'
 import { read as discordRead } from '../../../core/discord/read.ts'
-import {
-  concatBytes,
-  formatJqOutput,
-  jqEval,
-  parseJsonAuto,
-  parseJsonPath,
-} from '../../../core/jq/index.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { resolveDiscordGlob } from '../../../core/discord/glob.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { jqGeneric } from '../generic/jq.ts'
 
-const ENC = new TextEncoder()
+async function* discordStream(
+  accessor: DiscordAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await discordRead(accessor, p, index)
+}
 
 async function jqCommand(
   accessor: DiscordAccessor,
@@ -36,40 +35,11 @@ async function jqCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const expression = texts[0]
-  if (expression === undefined) {
-    return [
-      null,
-      new IOResult({ exitCode: 1, stderr: ENC.encode('jq: usage: jq EXPRESSION [path]\n') }),
-    ]
-  }
-  const raw = opts.flags.r === true
-  const compact = opts.flags.c === true
-  const slurp = opts.flags.s === true
-  const spread = expression.includes('[]')
-
-  if (paths.length > 0) {
-    const resolved = await resolveDiscordGlob(accessor, paths, opts.index ?? undefined)
-    const outputs: Uint8Array[] = []
-    for (const p of resolved) {
-      const bytes = await discordRead(accessor, p, opts.index ?? undefined)
-      let data = parseJsonPath(bytes, p.original)
-      if (slurp) data = Array.isArray(data) ? data : [data]
-      const result = await jqEval(data, expression.trim())
-      outputs.push(formatJqOutput(result, raw, compact, spread))
-    }
-    const out: ByteSource = concatBytes(outputs)
-    return [out, new IOResult()]
-  }
-
-  const bytes = await readStdinAsync(opts.stdin)
-  if (bytes === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('jq: missing input\n') })]
-  }
-  let data = parseJsonAuto(bytes)
-  if (slurp && !Array.isArray(data)) data = [data]
-  const result = await jqEval(data, expression.trim())
-  return [formatJqOutput(result, raw, compact, spread), new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveDiscordGlob(accessor, paths, opts.index ?? undefined) : []
+  const stream = (p: PathSpec): AsyncIterable<Uint8Array> =>
+    discordStream(accessor, p, opts.index ?? undefined)
+  return jqGeneric(resolved, texts, opts, stream)
 }
 
 export const DISCORD_JQ = command({

--- a/typescript/packages/core/src/commands/builtin/generic/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/jq.ts
@@ -85,7 +85,7 @@ export async function jqGeneric(
     const first = paths[0]
     if (first === undefined) return [null, new IOResult()]
     if (isJsonlPath(first.original) && isStreamableJsonlExpr(expression)) {
-      return [evalJsonlStream(stream(first), expression), new IOResult()]
+      return [evalJsonlStream(stream(first), expression, raw), new IOResult()]
     }
     const outputs: Uint8Array[] = []
     const spread = expression.includes('[]')

--- a/typescript/packages/core/src/commands/builtin/langfuse/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/langfuse/jq.ts
@@ -13,22 +13,21 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { LangfuseAccessor } from '../../../accessor/langfuse.ts'
-import {
-  concatBytes,
-  formatJqOutput,
-  jqEval,
-  parseJsonAuto,
-  parseJsonPath,
-} from '../../../core/jq/index.ts'
-import { resolveLangfuseGlob } from '../../../core/langfuse/glob.ts'
+import type { IndexCacheStore } from '../../../cache/index/index.ts'
 import { read as langfuseRead } from '../../../core/langfuse/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { resolveLangfuseGlob } from '../../../core/langfuse/glob.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { jqGeneric } from '../generic/jq.ts'
 
-const ENC = new TextEncoder()
+async function* langfuseStream(
+  accessor: LangfuseAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await langfuseRead(accessor, p, index)
+}
 
 async function jqCommand(
   accessor: LangfuseAccessor,
@@ -36,40 +35,11 @@ async function jqCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const expression = texts[0]
-  if (expression === undefined) {
-    return [
-      null,
-      new IOResult({ exitCode: 1, stderr: ENC.encode('jq: usage: jq EXPRESSION [path]\n') }),
-    ]
-  }
-  const raw = opts.flags.r === true
-  const compact = opts.flags.c === true
-  const slurp = opts.flags.s === true
-  const spread = expression.includes('[]')
-
-  if (paths.length > 0) {
-    const resolved = await resolveLangfuseGlob(accessor, paths, opts.index ?? undefined)
-    const outputs: Uint8Array[] = []
-    for (const p of resolved) {
-      const bytes = await langfuseRead(accessor, p, opts.index ?? undefined)
-      let data = parseJsonPath(bytes, p.original)
-      if (slurp) data = Array.isArray(data) ? data : [data]
-      const result = await jqEval(data, expression.trim())
-      outputs.push(formatJqOutput(result, raw, compact, spread))
-    }
-    const out: ByteSource = concatBytes(outputs)
-    return [out, new IOResult()]
-  }
-
-  const bytes = await readStdinAsync(opts.stdin)
-  if (bytes === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('jq: missing input\n') })]
-  }
-  let data = parseJsonAuto(bytes)
-  if (slurp && !Array.isArray(data)) data = [data]
-  const result = await jqEval(data, expression.trim())
-  return [formatJqOutput(result, raw, compact, spread), new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveLangfuseGlob(accessor, paths, opts.index ?? undefined) : []
+  const stream = (p: PathSpec): AsyncIterable<Uint8Array> =>
+    langfuseStream(accessor, p, opts.index ?? undefined)
+  return jqGeneric(resolved, texts, opts, stream)
 }
 
 export const LANGFUSE_JQ = command({

--- a/typescript/packages/core/src/commands/builtin/langfuse/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/langfuse/rg.ts
@@ -12,7 +12,6 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-
 import type { LangfuseAccessor } from '../../../accessor/langfuse.ts'
 import type { IndexCacheStore } from '../../../cache/index/index.ts'
 import { resolveLangfuseGlob } from '../../../core/langfuse/glob.ts'
@@ -40,7 +39,8 @@ async function rgCommand(
 ): Promise<CommandFnResult> {
   const resolved =
     paths.length > 0 ? await resolveLangfuseGlob(accessor, paths, opts.index ?? undefined) : []
-  const stat = (p: PathSpec): Promise<FileStat> => langfuseStat(accessor, p, opts.index ?? undefined)
+  const stat = (p: PathSpec): Promise<FileStat> =>
+    langfuseStat(accessor, p, opts.index ?? undefined)
   const readdir = (p: PathSpec): Promise<string[]> =>
     langfuseReaddir(accessor, p, opts.index ?? undefined)
   const stream = (p: PathSpec): AsyncIterable<Uint8Array> =>

--- a/typescript/packages/core/src/commands/builtin/langfuse/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/langfuse/rg.ts
@@ -12,83 +12,24 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+
 import type { LangfuseAccessor } from '../../../accessor/langfuse.ts'
-import type { IndexCacheStore } from '../../../cache/index/store.ts'
+import type { IndexCacheStore } from '../../../cache/index/index.ts'
 import { resolveLangfuseGlob } from '../../../core/langfuse/glob.ts'
 import { read as langfuseRead } from '../../../core/langfuse/read.ts'
 import { readdir as langfuseReaddir } from '../../../core/langfuse/readdir.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
+import { stat as langfuseStat } from '../../../core/langfuse/stat.ts'
+import { type FileStat, ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { compilePattern, grepLines } from '../grep_helper.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { rgGeneric } from '../generic/rg.ts'
 
-const ENC = new TextEncoder()
-const DEC = new TextDecoder('utf-8', { fatal: false })
-
-interface RgFlags {
-  ignoreCase: boolean
-  invert: boolean
-  lineNumbers: boolean
-  countOnly: boolean
-  filesOnly: boolean
-  wholeWord: boolean
-  fixedString: boolean
-  onlyMatching: boolean
-  maxCount: number | null
-  hidden: boolean
-}
-
-function parseRgFlags(flags: Record<string, string | boolean>): RgFlags {
-  const toInt = (v: string | boolean | undefined): number | null =>
-    typeof v === 'string' ? Number.parseInt(v, 10) : null
-  return {
-    ignoreCase: flags.i === true,
-    invert: flags.v === true,
-    lineNumbers: flags.n === true,
-    countOnly: flags.c === true,
-    filesOnly: flags.args_l === true,
-    wholeWord: flags.w === true,
-    fixedString: flags.F === true,
-    onlyMatching: flags.o === true,
-    maxCount: toInt(flags.m),
-    hidden: flags.hidden === true,
-  }
-}
-
-async function collectFiles(
+async function* langfuseStream(
   accessor: LangfuseAccessor,
-  path: PathSpec,
+  p: PathSpec,
   index: IndexCacheStore | undefined,
-): Promise<string[]> {
-  let children: string[]
-  try {
-    children = await langfuseReaddir(accessor, path, index)
-  } catch {
-    return []
-  }
-  const files: string[] = []
-  for (const child of children) {
-    if (child.endsWith('.json') || child.endsWith('.jsonl')) {
-      files.push(child)
-    } else {
-      const childSpec = new PathSpec({
-        original: child,
-        directory: child,
-        resolved: false,
-        prefix: path.prefix,
-      })
-      const sub = await collectFiles(accessor, childSpec, index)
-      files.push(...sub)
-    }
-  }
-  return files
-}
-
-function splitLinesNoTrailing(text: string): string[] {
-  const stripped = text.endsWith('\n') ? text.slice(0, -1) : text
-  return stripped === '' ? [] : stripped.split('\n')
+): AsyncIterable<Uint8Array> {
+  yield await langfuseRead(accessor, p, index)
 }
 
 async function rgCommand(
@@ -97,76 +38,14 @@ async function rgCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const [exprText] = texts
-  if (exprText === undefined) {
-    return [
-      null,
-      new IOResult({ exitCode: 2, stderr: ENC.encode('rg: usage: rg [flags] pattern [path]\n') }),
-    ]
-  }
-  const f = parseRgFlags(opts.flags)
-  const pat = compilePattern(exprText, f.ignoreCase, f.fixedString, f.wholeWord)
-
-  if (paths.length > 0) {
-    const resolved = await resolveLangfuseGlob(accessor, paths, opts.index ?? undefined)
-    const filePaths: string[] = []
-    const filePrefix = resolved[0]?.prefix ?? ''
-    for (const p of resolved) {
-      const sub = await collectFiles(accessor, p, opts.index ?? undefined)
-      filePaths.push(...sub)
-    }
-    const sortedFiles = Array.from(new Set(filePaths)).sort()
-    const allResults: string[] = []
-    let anyMatch = false
-    for (const bp of sortedFiles) {
-      if (!f.hidden && bp.split('/').some((part) => part.startsWith('.'))) continue
-      let data: Uint8Array
-      try {
-        const bpSpec = new PathSpec({
-          original: bp,
-          directory: bp,
-          resolved: true,
-          prefix: filePrefix,
-        })
-        data = await langfuseRead(accessor, bpSpec, opts.index ?? undefined)
-      } catch {
-        continue
-      }
-      const text = DEC.decode(data)
-      if (text === '') continue
-      const lines = splitLinesNoTrailing(text)
-      const matched = grepLines(bp, lines, pat, f)
-      if (matched.length === 0) continue
-      anyMatch = true
-      if (f.filesOnly) {
-        allResults.push(bp)
-        continue
-      }
-      if (f.countOnly) {
-        allResults.push(`${bp}:${String(matched.length)}`)
-        continue
-      }
-      for (const line of matched) {
-        allResults.push(`${bp}:${line}`)
-      }
-    }
-    if (!anyMatch) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-    const out: ByteSource = ENC.encode(allResults.join('\n'))
-    return [out, new IOResult()]
-  }
-
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [
-      null,
-      new IOResult({ exitCode: 2, stderr: ENC.encode('rg: usage: rg [flags] pattern path\n') }),
-    ]
-  }
-  const lines = splitLinesNoTrailing(DEC.decode(raw))
-  const matched = grepLines('<stdin>', lines, pat, f)
-  if (matched.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-  if (f.countOnly) return [ENC.encode(String(matched.length)), new IOResult()]
-  return [ENC.encode(matched.join('\n')), new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveLangfuseGlob(accessor, paths, opts.index ?? undefined) : []
+  const stat = (p: PathSpec): Promise<FileStat> => langfuseStat(accessor, p, opts.index ?? undefined)
+  const readdir = (p: PathSpec): Promise<string[]> =>
+    langfuseReaddir(accessor, p, opts.index ?? undefined)
+  const stream = (p: PathSpec): AsyncIterable<Uint8Array> =>
+    langfuseStream(accessor, p, opts.index ?? undefined)
+  return rgGeneric(resolved, texts, opts, stat, readdir, stream)
 }
 
 export const LANGFUSE_RG = command({

--- a/typescript/packages/core/src/commands/builtin/linear/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/linear/jq.ts
@@ -13,22 +13,21 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { LinearAccessor } from '../../../accessor/linear.ts'
-import {
-  concatBytes,
-  formatJqOutput,
-  jqEval,
-  parseJsonAuto,
-  parseJsonPath,
-} from '../../../core/jq/index.ts'
-import { resolveLinearGlob } from '../../../core/linear/glob.ts'
+import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { read as linearRead } from '../../../core/linear/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { resolveLinearGlob } from '../../../core/linear/glob.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { jqGeneric } from '../generic/jq.ts'
 
-const ENC = new TextEncoder()
+async function* linearStream(
+  accessor: LinearAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await linearRead(accessor, p, index)
+}
 
 async function jqCommand(
   accessor: LinearAccessor,
@@ -36,40 +35,11 @@ async function jqCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const expression = texts[0]
-  if (expression === undefined) {
-    return [
-      null,
-      new IOResult({ exitCode: 1, stderr: ENC.encode('jq: usage: jq EXPRESSION [path]\n') }),
-    ]
-  }
-  const raw = opts.flags.r === true
-  const compact = opts.flags.c === true
-  const slurp = opts.flags.s === true
-  const spread = expression.includes('[]')
-
-  if (paths.length > 0) {
-    const resolved = await resolveLinearGlob(accessor, paths, opts.index ?? undefined)
-    const outputs: Uint8Array[] = []
-    for (const p of resolved) {
-      const bytes = await linearRead(accessor, p, opts.index ?? undefined)
-      let data = parseJsonPath(bytes, p.original)
-      if (slurp) data = Array.isArray(data) ? data : [data]
-      const result = await jqEval(data, expression.trim())
-      outputs.push(formatJqOutput(result, raw, compact, spread))
-    }
-    const out: ByteSource = concatBytes(outputs)
-    return [out, new IOResult()]
-  }
-
-  const bytes = await readStdinAsync(opts.stdin)
-  if (bytes === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('jq: missing input\n') })]
-  }
-  let data = parseJsonAuto(bytes)
-  if (slurp && !Array.isArray(data)) data = [data]
-  const result = await jqEval(data, expression.trim())
-  return [formatJqOutput(result, raw, compact, spread), new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveLinearGlob(accessor, paths, opts.index ?? undefined) : []
+  const stream = (p: PathSpec): AsyncIterable<Uint8Array> =>
+    linearStream(accessor, p, opts.index ?? undefined)
+  return jqGeneric(resolved, texts, opts, stream)
 }
 
 export const LINEAR_JQ = command({

--- a/typescript/packages/core/src/commands/builtin/linear/realpath.ts
+++ b/typescript/packages/core/src/commands/builtin/linear/realpath.ts
@@ -13,79 +13,16 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { LinearAccessor } from '../../../accessor/linear.ts'
-import { resolveLinearGlob } from '../../../core/linear/glob.ts'
 import { stat as linearStat } from '../../../core/linear/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
-import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { ResourceName } from '../../../types.ts'
+import { command } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function posixNormpath(p: string): string {
-  const isAbs = p.startsWith('/')
-  const parts = p.split('/')
-  const out: string[] = []
-  for (const seg of parts) {
-    if (seg === '' || seg === '.') continue
-    if (seg === '..') {
-      if (out.length > 0 && out[out.length - 1] !== '..') {
-        out.pop()
-      } else if (!isAbs) {
-        out.push('..')
-      }
-      continue
-    }
-    out.push(seg)
-  }
-  const joined = out.join('/')
-  if (isAbs) return '/' + joined
-  return joined === '' ? '.' : joined
-}
-
-async function existsPath(accessor: LinearAccessor, path: PathSpec): Promise<boolean> {
-  try {
-    await linearStat(accessor, path)
-    return true
-  } catch {
-    return false
-  }
-}
-
-async function realpathCommand(
-  accessor: LinearAccessor,
-  paths: PathSpec[],
-  _texts: string[],
-  opts: CommandOpts,
-): Promise<CommandFnResult> {
-  const resolved =
-    paths.length > 0 ? await resolveLinearGlob(accessor, paths, opts.index ?? undefined) : []
-  const eFlag = opts.flags.e === true
-  const mountPrefix = resolved[0]?.prefix ?? ''
-  const lines: string[] = []
-  for (const p of resolved) {
-    const normalized = posixNormpath(p.original)
-    if (eFlag) {
-      const probe = new PathSpec({
-        original: normalized,
-        directory: normalized,
-        resolved: false,
-        prefix: mountPrefix,
-      })
-      if (!(await existsPath(accessor, probe))) {
-        const msg = `realpath: '${p.original}': No such file or directory\n`
-        return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(msg) })]
-      }
-    }
-    lines.push(normalized)
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
-  return [out, new IOResult()]
-}
+import { realpathGeneric } from '../generic/realpath.ts'
 
 export const LINEAR_REALPATH = command({
   name: 'realpath',
   resource: ResourceName.LINEAR,
   spec: specOf('realpath'),
-  fn: realpathCommand,
+  fn: (accessor: LinearAccessor, paths, texts, opts) =>
+    realpathGeneric(paths, texts, opts, (p) => linearStat(accessor, p, opts.index ?? undefined)),
 })

--- a/typescript/packages/core/src/commands/builtin/notion/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/notion/jq.ts
@@ -13,22 +13,21 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { NotionAccessor } from '../../../accessor/notion.ts'
-import {
-  concatBytes,
-  formatJqOutput,
-  jqEval,
-  parseJsonAuto,
-  parseJsonPath,
-} from '../../../core/jq/index.ts'
-import { resolveNotionGlob } from '../../../core/notion/glob.ts'
+import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { read as notionRead } from '../../../core/notion/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { resolveNotionGlob } from '../../../core/notion/glob.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { jqGeneric } from '../generic/jq.ts'
 
-const ENC = new TextEncoder()
+async function* notionStream(
+  accessor: NotionAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await notionRead(accessor, p, index)
+}
 
 async function jqCommand(
   accessor: NotionAccessor,
@@ -36,40 +35,11 @@ async function jqCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const expression = texts[0]
-  if (expression === undefined) {
-    return [
-      null,
-      new IOResult({ exitCode: 1, stderr: ENC.encode('jq: usage: jq EXPRESSION [path]\n') }),
-    ]
-  }
-  const raw = opts.flags.r === true
-  const compact = opts.flags.c === true
-  const slurp = opts.flags.s === true
-  const spread = expression.includes('[]')
-
-  if (paths.length > 0) {
-    const resolved = await resolveNotionGlob(accessor, paths, opts.index ?? undefined)
-    const outputs: Uint8Array[] = []
-    for (const p of resolved) {
-      const bytes = await notionRead(accessor, p, opts.index ?? undefined)
-      let data = parseJsonPath(bytes, p.original)
-      if (slurp) data = Array.isArray(data) ? data : [data]
-      const result = await jqEval(data, expression.trim())
-      outputs.push(formatJqOutput(result, raw, compact, spread))
-    }
-    const out: ByteSource = concatBytes(outputs)
-    return [out, new IOResult()]
-  }
-
-  const bytes = await readStdinAsync(opts.stdin)
-  if (bytes === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('jq: missing input\n') })]
-  }
-  let data = parseJsonAuto(bytes)
-  if (slurp && !Array.isArray(data)) data = [data]
-  const result = await jqEval(data, expression.trim())
-  return [formatJqOutput(result, raw, compact, spread), new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveNotionGlob(accessor, paths, opts.index ?? undefined) : []
+  const stream = (p: PathSpec): AsyncIterable<Uint8Array> =>
+    notionStream(accessor, p, opts.index ?? undefined)
+  return jqGeneric(resolved, texts, opts, stream)
 }
 
 export const NOTION_JQ = command({

--- a/typescript/packages/core/src/commands/builtin/notion/realpath.ts
+++ b/typescript/packages/core/src/commands/builtin/notion/realpath.ts
@@ -13,79 +13,16 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { NotionAccessor } from '../../../accessor/notion.ts'
-import { resolveNotionGlob } from '../../../core/notion/glob.ts'
 import { stat as notionStat } from '../../../core/notion/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
-import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { ResourceName } from '../../../types.ts'
+import { command } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function posixNormpath(p: string): string {
-  const isAbs = p.startsWith('/')
-  const parts = p.split('/')
-  const out: string[] = []
-  for (const seg of parts) {
-    if (seg === '' || seg === '.') continue
-    if (seg === '..') {
-      if (out.length > 0 && out[out.length - 1] !== '..') {
-        out.pop()
-      } else if (!isAbs) {
-        out.push('..')
-      }
-      continue
-    }
-    out.push(seg)
-  }
-  const joined = out.join('/')
-  if (isAbs) return '/' + joined
-  return joined === '' ? '.' : joined
-}
-
-async function existsPath(accessor: NotionAccessor, path: PathSpec): Promise<boolean> {
-  try {
-    await notionStat(accessor, path)
-    return true
-  } catch {
-    return false
-  }
-}
-
-async function realpathCommand(
-  accessor: NotionAccessor,
-  paths: PathSpec[],
-  _texts: string[],
-  opts: CommandOpts,
-): Promise<CommandFnResult> {
-  const resolved =
-    paths.length > 0 ? await resolveNotionGlob(accessor, paths, opts.index ?? undefined) : []
-  const eFlag = opts.flags.e === true
-  const mountPrefix = resolved[0]?.prefix ?? ''
-  const lines: string[] = []
-  for (const p of resolved) {
-    const normalized = posixNormpath(p.original)
-    if (eFlag) {
-      const probe = new PathSpec({
-        original: normalized,
-        directory: normalized,
-        resolved: false,
-        prefix: mountPrefix,
-      })
-      if (!(await existsPath(accessor, probe))) {
-        const msg = `realpath: '${p.original}': No such file or directory\n`
-        return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(msg) })]
-      }
-    }
-    lines.push(normalized)
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
-  return [out, new IOResult()]
-}
+import { realpathGeneric } from '../generic/realpath.ts'
 
 export const NOTION_REALPATH = command({
   name: 'realpath',
   resource: ResourceName.NOTION,
   spec: specOf('realpath'),
-  fn: realpathCommand,
+  fn: (accessor: NotionAccessor, paths, texts, opts) =>
+    realpathGeneric(paths, texts, opts, (p) => notionStat(accessor, p, opts.index ?? undefined)),
 })

--- a/typescript/packages/core/src/commands/builtin/slack/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/jq.ts
@@ -13,22 +13,21 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { SlackAccessor } from '../../../accessor/slack.ts'
-import {
-  concatBytes,
-  formatJqOutput,
-  jqEval,
-  parseJsonAuto,
-  parseJsonPath,
-} from '../../../core/jq/index.ts'
-import { resolveSlackGlob } from '../../../core/slack/glob.ts'
+import type { IndexCacheStore } from '../../../cache/index/index.ts'
 import { read as slackRead } from '../../../core/slack/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { resolveSlackGlob } from '../../../core/slack/glob.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { jqGeneric } from '../generic/jq.ts'
 
-const ENC = new TextEncoder()
+async function* slackStream(
+  accessor: SlackAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await slackRead(accessor, p, index)
+}
 
 async function jqCommand(
   accessor: SlackAccessor,
@@ -36,40 +35,11 @@ async function jqCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const expression = texts[0]
-  if (expression === undefined) {
-    return [
-      null,
-      new IOResult({ exitCode: 1, stderr: ENC.encode('jq: usage: jq EXPRESSION [path]\n') }),
-    ]
-  }
-  const raw = opts.flags.r === true
-  const compact = opts.flags.c === true
-  const slurp = opts.flags.s === true
-  const spread = expression.includes('[]')
-
-  if (paths.length > 0) {
-    const resolved = await resolveSlackGlob(accessor, paths, opts.index ?? undefined)
-    const outputs: Uint8Array[] = []
-    for (const p of resolved) {
-      const bytes = await slackRead(accessor, p, opts.index ?? undefined)
-      let data = parseJsonPath(bytes, p.original)
-      if (slurp) data = Array.isArray(data) ? data : [data]
-      const result = await jqEval(data, expression.trim())
-      outputs.push(formatJqOutput(result, raw, compact, spread))
-    }
-    const out: ByteSource = concatBytes(outputs)
-    return [out, new IOResult()]
-  }
-
-  const bytes = await readStdinAsync(opts.stdin)
-  if (bytes === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('jq: missing input\n') })]
-  }
-  let data = parseJsonAuto(bytes)
-  if (slurp && !Array.isArray(data)) data = [data]
-  const result = await jqEval(data, expression.trim())
-  return [formatJqOutput(result, raw, compact, spread), new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveSlackGlob(accessor, paths, opts.index ?? undefined) : []
+  const stream = (p: PathSpec): AsyncIterable<Uint8Array> =>
+    slackStream(accessor, p, opts.index ?? undefined)
+  return jqGeneric(resolved, texts, opts, stream)
 }
 
 export const SLACK_JQ = command({

--- a/typescript/packages/core/src/commands/builtin/trello/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/trello/jq.ts
@@ -13,22 +13,21 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { TrelloAccessor } from '../../../accessor/trello.ts'
-import {
-  concatBytes,
-  formatJqOutput,
-  jqEval,
-  parseJsonAuto,
-  parseJsonPath,
-} from '../../../core/jq/index.ts'
-import { resolveTrelloGlob } from '../../../core/trello/glob.ts'
+import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { read as trelloRead } from '../../../core/trello/read.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { resolveTrelloGlob } from '../../../core/trello/glob.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { readStdinAsync } from '../utils/stream.ts'
+import { jqGeneric } from '../generic/jq.ts'
 
-const ENC = new TextEncoder()
+async function* trelloStream(
+  accessor: TrelloAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await trelloRead(accessor, p, index)
+}
 
 async function jqCommand(
   accessor: TrelloAccessor,
@@ -36,40 +35,11 @@ async function jqCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const expression = texts[0]
-  if (expression === undefined) {
-    return [
-      null,
-      new IOResult({ exitCode: 1, stderr: ENC.encode('jq: usage: jq EXPRESSION [path]\n') }),
-    ]
-  }
-  const raw = opts.flags.r === true
-  const compact = opts.flags.c === true
-  const slurp = opts.flags.s === true
-  const spread = expression.includes('[]')
-
-  if (paths.length > 0) {
-    const resolved = await resolveTrelloGlob(accessor, paths, opts.index ?? undefined)
-    const outputs: Uint8Array[] = []
-    for (const p of resolved) {
-      const bytes = await trelloRead(accessor, p, opts.index ?? undefined)
-      let data = parseJsonPath(bytes, p.original)
-      if (slurp) data = Array.isArray(data) ? data : [data]
-      const result = await jqEval(data, expression.trim())
-      outputs.push(formatJqOutput(result, raw, compact, spread))
-    }
-    const out: ByteSource = concatBytes(outputs)
-    return [out, new IOResult()]
-  }
-
-  const bytes = await readStdinAsync(opts.stdin)
-  if (bytes === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('jq: missing input\n') })]
-  }
-  let data = parseJsonAuto(bytes)
-  if (slurp && !Array.isArray(data)) data = [data]
-  const result = await jqEval(data, expression.trim())
-  return [formatJqOutput(result, raw, compact, spread), new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveTrelloGlob(accessor, paths, opts.index ?? undefined) : []
+  const stream = (p: PathSpec): AsyncIterable<Uint8Array> =>
+    trelloStream(accessor, p, opts.index ?? undefined)
+  return jqGeneric(resolved, texts, opts, stream)
 }
 
 export const TRELLO_JQ = command({

--- a/typescript/packages/core/src/commands/builtin/trello/realpath.ts
+++ b/typescript/packages/core/src/commands/builtin/trello/realpath.ts
@@ -13,79 +13,16 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { TrelloAccessor } from '../../../accessor/trello.ts'
-import { resolveTrelloGlob } from '../../../core/trello/glob.ts'
 import { stat as trelloStat } from '../../../core/trello/stat.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec, ResourceName } from '../../../types.ts'
-import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { ResourceName } from '../../../types.ts'
+import { command } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
-
-function posixNormpath(p: string): string {
-  const isAbs = p.startsWith('/')
-  const parts = p.split('/')
-  const out: string[] = []
-  for (const seg of parts) {
-    if (seg === '' || seg === '.') continue
-    if (seg === '..') {
-      if (out.length > 0 && out[out.length - 1] !== '..') {
-        out.pop()
-      } else if (!isAbs) {
-        out.push('..')
-      }
-      continue
-    }
-    out.push(seg)
-  }
-  const joined = out.join('/')
-  if (isAbs) return '/' + joined
-  return joined === '' ? '.' : joined
-}
-
-async function existsPath(accessor: TrelloAccessor, path: PathSpec): Promise<boolean> {
-  try {
-    await trelloStat(accessor, path)
-    return true
-  } catch {
-    return false
-  }
-}
-
-async function realpathCommand(
-  accessor: TrelloAccessor,
-  paths: PathSpec[],
-  _texts: string[],
-  opts: CommandOpts,
-): Promise<CommandFnResult> {
-  const resolved =
-    paths.length > 0 ? await resolveTrelloGlob(accessor, paths, opts.index ?? undefined) : []
-  const eFlag = opts.flags.e === true
-  const mountPrefix = resolved[0]?.prefix ?? ''
-  const lines: string[] = []
-  for (const p of resolved) {
-    const normalized = posixNormpath(p.original)
-    if (eFlag) {
-      const probe = new PathSpec({
-        original: normalized,
-        directory: normalized,
-        resolved: false,
-        prefix: mountPrefix,
-      })
-      if (!(await existsPath(accessor, probe))) {
-        const msg = `realpath: '${p.original}': No such file or directory\n`
-        return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(msg) })]
-      }
-    }
-    lines.push(normalized)
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
-  return [out, new IOResult()]
-}
+import { realpathGeneric } from '../generic/realpath.ts'
 
 export const TRELLO_REALPATH = command({
   name: 'realpath',
   resource: ResourceName.TRELLO,
   spec: specOf('realpath'),
-  fn: realpathCommand,
+  fn: (accessor: TrelloAccessor, paths, texts, opts) =>
+    realpathGeneric(paths, texts, opts, (p) => trelloStat(accessor, p, opts.index ?? undefined)),
 })

--- a/typescript/packages/core/src/core/jq/stream.ts
+++ b/typescript/packages/core/src/core/jq/stream.ts
@@ -58,12 +58,14 @@ export function isStreamableJsonlExpr(expression: string): boolean {
 export async function* evalJsonlStream(
   source: AsyncIterable<Uint8Array>,
   expression: string,
+  raw = false,
 ): AsyncIterable<Uint8Array> {
   const { jqEval } = await import('./eval.ts')
   const expr = expression.trim()
   let perItem: string
   if (expr === '.[]') perItem = '.'
   else if (expr.startsWith('.[] | ')) perItem = expr.slice(6)
+  else if (expr.startsWith('.[].')) perItem = expr.slice(3)
   else perItem = expr
 
   const iter = new AsyncLineIterator(source)
@@ -73,6 +75,7 @@ export async function* evalJsonlStream(
     const obj: unknown = JSON.parse(text)
     const result = await jqEval(obj, perItem)
     if (result === JQ_EMPTY) continue
-    yield ENC.encode(JSON.stringify(result) + '\n')
+    const line = raw && typeof result === 'string' ? result : JSON.stringify(result)
+    yield ENC.encode(line + '\n')
   }
 }

--- a/typescript/packages/node/src/commands/builtin/email/jq.ts
+++ b/typescript/packages/node/src/commands/builtin/email/jq.ts
@@ -13,51 +13,25 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import {
-  IOResult,
   ResourceName,
   command,
-  jqEval,
-  parseJsonAuto,
-  parseJsonPath,
-  readStdinAsync,
+  jqGeneric,
   specOf,
-  type ByteSource,
   type CommandFnResult,
   type CommandOpts,
+  type IndexCacheStore,
   type PathSpec,
 } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../../accessor/email.ts'
 import { resolveGlob } from '../../../core/email/glob.ts'
 import { read as emailRead } from '../../../core/email/read.ts'
 
-const ENC = new TextEncoder()
-
-function formatResult(result: unknown, raw: boolean, compact: boolean): Uint8Array {
-  if (raw && typeof result === 'string') return ENC.encode(result + '\n')
-  const json = compact ? JSON.stringify(result) : JSON.stringify(result, null, 2)
-  return ENC.encode(json + '\n')
-}
-
-function formatResults(
-  results: unknown,
-  raw: boolean,
-  compact: boolean,
-  spread: boolean,
-): Uint8Array {
-  if (spread && Array.isArray(results)) {
-    const parts: Uint8Array[] = []
-    for (const item of results) parts.push(formatResult(item, raw, compact))
-    let total = 0
-    for (const p of parts) total += p.byteLength
-    const out = new Uint8Array(total)
-    let offset = 0
-    for (const p of parts) {
-      out.set(p, offset)
-      offset += p.byteLength
-    }
-    return out
-  }
-  return formatResult(results, raw, compact)
+async function* emailStream(
+  accessor: EmailAccessor,
+  p: PathSpec,
+  index: IndexCacheStore | undefined,
+): AsyncIterable<Uint8Array> {
+  yield await emailRead(accessor, p, index)
 }
 
 async function jqCommand(
@@ -66,47 +40,11 @@ async function jqCommand(
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  if (texts.length === 0 || texts[0] === undefined) {
-    return [
-      null,
-      new IOResult({ exitCode: 2, stderr: ENC.encode('jq: usage: jq EXPRESSION [path]\n') }),
-    ]
-  }
-  const expression = texts[0]
-  const r = opts.flags.r === true
-  const c = opts.flags.c === true
-  const s = opts.flags.s === true
-  const spread = expression.includes('[]')
-  if (paths.length > 0) {
-    const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
-    const parts: Uint8Array[] = []
-    for (const p of resolved) {
-      const raw = await emailRead(accessor, p, opts.index ?? undefined)
-      let data = parseJsonPath(raw, p.original)
-      if (s) data = Array.isArray(data) ? data : [data]
-      const result = await jqEval(data, expression.trim())
-      parts.push(formatResults(result, r, c, spread))
-    }
-    let total = 0
-    for (const part of parts) total += part.byteLength
-    const out = new Uint8Array(total)
-    let offset = 0
-    for (const part of parts) {
-      out.set(part, offset)
-      offset += part.byteLength
-    }
-    const result: ByteSource = out
-    return [result, new IOResult()]
-  }
-  const raw = await readStdinAsync(opts.stdin)
-  if (raw === null) {
-    return [null, new IOResult({ exitCode: 2, stderr: ENC.encode('jq: missing input\n') })]
-  }
-  let data = parseJsonAuto(raw)
-  if (s && !Array.isArray(data)) data = [data]
-  const result = await jqEval(data, expression.trim())
-  const out: ByteSource = formatResults(result, r, c, spread)
-  return [out, new IOResult()]
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  const stream = (p: PathSpec): AsyncIterable<Uint8Array> =>
+    emailStream(accessor, p, opts.index ?? undefined)
+  return jqGeneric(resolved, texts, opts, stream)
 }
 
 export const EMAIL_JQ = command({

--- a/typescript/packages/node/src/commands/builtin/email/realpath.ts
+++ b/typescript/packages/node/src/commands/builtin/email/realpath.ts
@@ -12,77 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import {
-  IOResult,
-  PathSpec,
-  ResourceName,
-  command,
-  specOf,
-  type ByteSource,
-  type CommandFnResult,
-  type CommandOpts,
-} from '@struktoai/mirage-core'
+import { ResourceName, command, realpathGeneric, specOf } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../../accessor/email.ts'
 import { stat as emailStat } from '../../../core/email/stat.ts'
-
-const ENC = new TextEncoder()
-
-function normalize(p: string): string {
-  const isAbs = p.startsWith('/')
-  const segments = p.split('/').filter((s) => s !== '' && s !== '.')
-  const out: string[] = []
-  for (const s of segments) {
-    if (s === '..') {
-      if (out.length > 0) out.pop()
-      else if (!isAbs) out.push('..')
-    } else {
-      out.push(s)
-    }
-  }
-  const joined = out.join('/')
-  return isAbs ? '/' + joined : joined === '' ? '.' : joined
-}
-
-async function exists(
-  accessor: EmailAccessor,
-  path: string,
-  index: CommandOpts['index'],
-  prefix: string,
-): Promise<boolean> {
-  try {
-    const spec = new PathSpec({ original: path, directory: path, prefix })
-    await emailStat(accessor, spec, index ?? undefined)
-    return true
-  } catch {
-    return false
-  }
-}
-
-async function realpathCommand(
-  accessor: EmailAccessor,
-  paths: PathSpec[],
-  _texts: string[],
-  opts: CommandOpts,
-): Promise<CommandFnResult> {
-  const prefix = opts.mountPrefix ?? ''
-  const e = opts.flags.e === true
-  const lines: string[] = []
-  for (const p of paths) {
-    const full = prefix !== '' ? prefix + p.original : p.original
-    const resolved = normalize(full)
-    if (e && !(await exists(accessor, resolved, opts.index, prefix))) {
-      const msg = `realpath: '${p.original}': No such file or directory\n`
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(msg) })]
-    }
-    lines.push(resolved)
-  }
-  const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
-  return [out, new IOResult()]
-}
 
 export const EMAIL_REALPATH = command({
   name: 'realpath',
   resource: ResourceName.EMAIL,
   spec: specOf('realpath'),
-  fn: realpathCommand,
+  fn: (accessor: EmailAccessor, paths, texts, opts) =>
+    realpathGeneric(paths, texts, opts, (p) => emailStat(accessor, p, opts.index ?? undefined)),
 })


### PR DESCRIPTION
Sweep batch A of the remaining TS generic-usage gaps:

- jq delegated to jqGeneric in discord, slack, trello, linear, langfuse, notion (core) and email (node).
- realpath delegated to realpathGeneric in trello, linear, notion, email.
- langfuse rg delegated to rgGeneric (was a plain read loop ignoring --type/--glob/context flags). langfuse grep stays bespoke: it pushes scope-level queries down to the Langfuse API.
- Two shared jq fixes surfaced by the existing discord/slack jq tests: evalJsonlStream now maps dot-chained expressions ('.[].content') per line, and the -r raw flag is honored in the JSONL streaming path. Both previously broke generic jq on .jsonl files for every backend.

Tests: 2882 core + 1291 node passed; typecheck/lint/pre-commit clean.

Remaining after this: the find sweep (needs core find modules per backend), mongodb/postgres/vercel/posthog/sscholar, node ssh.