### PR TITLE
Port notion-search, notion-block-append, notion-comment-add to TS

### DIFF
--- a/docs/python/resource/notion.mdx
+++ b/docs/python/resource/notion.mdx
@@ -108,17 +108,22 @@ async def main():
     r = await ws.execute("tree -L 2 /notion/")
     print(await r.stdout_str())
 
+    # Search pages with the Notion search API
+    r = await ws.execute('notion-search --query "Roadmap" --limit 5')
+    print(await r.stdout_str())
+
     # Create a new page
     r = await ws.execute(
-        'notion-page-create --parent_id a1b2c3d4'
-        ' --title "New Page" --content "Hello from Mirage"'
+        'notion-page-create --json \'{"parent":{"page_id":"a1b2c3d4"},'
+        '"properties":{"title":[{"text":{"content":"New Page"}}]}}\''
     )
     print(await r.stdout_str())
 
     # Append content to an existing page
     r = await ws.execute(
-        'notion-block-append --page_id a1b2c3d4'
-        ' --content "Appended paragraph"'
+        'notion-block-append --params \'{"block_id":"a1b2c3d4"}\''
+        ' --json \'{"children":[{"type":"paragraph","paragraph":'
+        '{"rich_text":[{"text":{"content":"Appended paragraph"}}]}}]}\''
     )
     print(await r.stdout_str())
 
@@ -147,36 +152,37 @@ Resource-specific commands:
 
 ### `notion-page-create`
 
-Create a new page under a parent page.
+Create a new page under a parent page. Prints the new page normalized as JSON.
 
-| Option        | Required | Description                |
-| ------------- | -------- | -------------------------- |
-| `--parent_id` | yes      | Parent page ID             |
-| `--title`     | yes      | Page title                 |
-| `--content`   | no       | Initial paragraph content  |
+| Option   | Required | Description                                                            |
+| -------- | -------- | ---------------------------------------------------------------------- |
+| `--json` | yes      | Page body with `parent` (required) and `properties`, per the Notion API |
+
+In the TypeScript SDK this command takes `--parent <parent-path>` and
+`--title "title"` instead of a raw `--json` body.
 
 ### `notion-block-append`
 
-Append content blocks to an existing page.
+Append content blocks to an existing page. Prints the refreshed page as JSON.
 
-| Option      | Required | Description              |
-| ----------- | -------- | ------------------------ |
-| `--page_id` | yes      | Target page ID           |
-| `--content` | yes      | Text content to append   |
+| Option     | Required | Description                                       |
+| ---------- | -------- | ------------------------------------------------- |
+| `--params` | yes      | JSON object with the target `block_id` (page ID)  |
+| `--json`   | yes      | JSON object with the `children` blocks to append  |
 
 ### `notion-comment-add`
 
-Add a comment to a page.
+Add a comment to a page. Prints the created comment as JSON.
 
-| Option      | Required | Description            |
-| ----------- | -------- | ---------------------- |
-| `--page_id` | yes      | Target page ID         |
-| `--text`    | yes      | Comment text           |
+| Option   | Required | Description                                          |
+| -------- | -------- | ---------------------------------------------------- |
+| `--json` | yes      | Comment body with `parent` (required) and `rich_text` |
 
 ### `notion-search`
 
-Search for pages by title.
+Search pages with the Notion search API.
 
-| Option    | Required | Description  |
-| --------- | -------- | ------------ |
-| `--query` | yes      | Search query |
+| Option    | Required | Description                  |
+| --------- | -------- | ---------------------------- |
+| `--query` | yes      | Search query                 |
+| `--limit` | no       | Max results (default 20)     |

--- a/docs/typescript/setup/notion.mdx
+++ b/docs/typescript/setup/notion.mdx
@@ -52,4 +52,15 @@ await ws.execute('ls /notion/')
 
 `read`, `write` (page edits via the MCP server in the browser SDK).
 
+## Resource commands
+
+`notion-search` works on read mounts; the rest require a write mount:
+
+```text
+notion-search --query "Roadmap" [--limit 20]
+notion-page-create --parent <parent-path> --title "title"
+notion-block-append --params '{"block_id":"..."}' --json '{"children":[...]}'
+notion-comment-add --json '{"parent":{"page_id":"..."},"rich_text":[{"text":{"content":"Comment"}}]}'
+```
+
 For the page/database layout and supported edits see the [Python Notion docs](/python/resource/notion).

--- a/examples/typescript/notion/notion.ts
+++ b/examples/typescript/notion/notion.ts
@@ -88,6 +88,9 @@ async function main(): Promise<void> {
     console.log(`\n=== dirname ${pagePath}/page.json ===`)
     await run(ws, `dirname "${pagePath}/page.json"`)
 
+    console.log('\n=== notion-search --query EVO ===')
+    await run(ws, 'notion-search --query EVO')
+
     console.log(`\n=== grep Graph ${pagePath}/*.json (page glob) ===`)
     await run(ws, `grep -c Graph "${pagePath}/"*.json`)
 

--- a/typescript/packages/core/src/commands/builtin/notion/index.ts
+++ b/typescript/packages/core/src/commands/builtin/notion/index.ts
@@ -21,7 +21,10 @@ import { NOTION_GREP } from './grep.ts'
 import { NOTION_HEAD } from './head.ts'
 import { NOTION_JQ } from './jq.ts'
 import { NOTION_LS } from './ls.ts'
+import { NOTION_BLOCK_APPEND } from './notion_block_append.ts'
+import { NOTION_COMMENT_ADD } from './notion_comment_add.ts'
 import { NOTION_PAGE_CREATE } from './notion_page_create.ts'
+import { NOTION_SEARCH } from './notion_search.ts'
 import { NOTION_REALPATH } from './realpath.ts'
 import { NOTION_RG } from './rg.ts'
 import { NOTION_STAT } from './stat.ts'
@@ -44,5 +47,8 @@ export const NOTION_COMMANDS: readonly RegisteredCommand[] = [
   ...NOTION_BASENAME,
   ...NOTION_DIRNAME,
   ...NOTION_REALPATH,
+  ...NOTION_SEARCH,
   ...NOTION_PAGE_CREATE,
+  ...NOTION_BLOCK_APPEND,
+  ...NOTION_COMMENT_ADD,
 ]

--- a/typescript/packages/core/src/commands/builtin/notion/notion_block_append.test.ts
+++ b/typescript/packages/core/src/commands/builtin/notion/notion_block_append.test.ts
@@ -1,0 +1,137 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { NotionAccessor, type NotionResourceLike } from '../../../accessor/notion.ts'
+import type { NotionTransport } from '../../../core/notion/_client.ts'
+import { materialize } from '../../../io/types.ts'
+import type { Resource } from '../../../resource/base.ts'
+import { NOTION_BLOCK_APPEND } from './notion_block_append.ts'
+
+const DEC = new TextDecoder()
+const PAGE_ID = 'abc123def4567890123456789012345a'
+
+class FakeTransport implements NotionTransport {
+  invocations: { name: string; args: Record<string, unknown> }[] = []
+  responses: Record<string, unknown>[] = []
+  callTool(name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+    this.invocations.push({ name, args })
+    if (this.responses.length === 0) return Promise.reject(new Error('no canned response'))
+    const response = this.responses.shift()
+    if (response === undefined) return Promise.reject(new Error('no canned response'))
+    return Promise.resolve(response)
+  }
+}
+
+function makeFakeResource(transport: NotionTransport): NotionResourceLike {
+  const accessor = new NotionAccessor(transport)
+  const resource: Resource & { accessor: NotionAccessor } = {
+    kind: 'notion',
+    accessor,
+    open: () => Promise.resolve(),
+    close: () => Promise.resolve(),
+  }
+  return resource as NotionResourceLike
+}
+
+interface RunOpts {
+  flags: Record<string, string | boolean>
+  responses?: Record<string, unknown>[]
+}
+
+async function runAppend(opts: RunOpts): Promise<{ out: string; transport: FakeTransport }> {
+  const cmd = NOTION_BLOCK_APPEND[0]
+  if (cmd === undefined) throw new Error('notion-block-append not registered')
+  const transport = new FakeTransport()
+  transport.responses.push(
+    ...(opts.responses ?? [
+      { results: [] },
+      {
+        id: PAGE_ID,
+        object: 'page',
+        parent: { type: 'workspace', workspace: true },
+        properties: { title: { type: 'title', title: [{ plain_text: 'Doc' }] } },
+      },
+      {
+        results: [
+          {
+            id: 'b1',
+            type: 'paragraph',
+            paragraph: { rich_text: [{ plain_text: 'hello' }] },
+          },
+        ],
+        has_more: false,
+      },
+    ]),
+  )
+  const resource = makeFakeResource(transport)
+  const result = await cmd.fn(resource.accessor, [], [], {
+    stdin: null,
+    flags: opts.flags,
+    filetypeFns: null,
+    cwd: '/',
+    resource,
+  })
+  if (result === null) return { out: '', transport }
+  const [bs] = result
+  if (bs === null) return { out: '', transport }
+  const buf = bs instanceof Uint8Array ? bs : await materialize(bs as AsyncIterable<Uint8Array>)
+  return { out: DEC.decode(buf), transport }
+}
+
+describe('notion-block-append command', () => {
+  it('appends blocks then returns the refreshed normalized page', async () => {
+    const children = [{ type: 'paragraph', paragraph: { rich_text: [] } }]
+    const { out, transport } = await runAppend({
+      flags: {
+        params: JSON.stringify({ block_id: PAGE_ID }),
+        json: JSON.stringify({ children }),
+      },
+    })
+    expect(transport.invocations.map((c) => c.name)).toEqual([
+      'API-patch-block-children',
+      'API-retrieve-a-page',
+      'API-retrieve-block-children',
+    ])
+    expect(transport.invocations[0]?.args).toEqual({ block_id: PAGE_ID, children })
+    expect(transport.invocations[1]?.args).toEqual({ page_id: PAGE_ID })
+    expect(JSON.parse(out)).toMatchObject({
+      page_id: PAGE_ID,
+      title: 'Doc',
+      parent_type: 'workspace',
+      blocks: [{ id: 'b1', type: 'paragraph' }],
+    })
+  })
+
+  it('throws when --params is missing', async () => {
+    await expect(runAppend({ flags: { json: '{}' } })).rejects.toThrow(/--params is required/)
+  })
+
+  it('throws when --json is missing', async () => {
+    await expect(
+      runAppend({ flags: { params: JSON.stringify({ block_id: PAGE_ID }) } }),
+    ).rejects.toThrow(/--json is required/)
+  })
+
+  it('throws when --params lacks block_id', async () => {
+    await expect(runAppend({ flags: { params: '{}', json: '{}' } })).rejects.toThrow(
+      /--params must contain block_id/,
+    )
+  })
+
+  it('is registered as a write command', () => {
+    const cmd = NOTION_BLOCK_APPEND[0]
+    expect(cmd?.write).toBe(true)
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/notion/notion_block_append.ts
+++ b/typescript/packages/core/src/commands/builtin/notion/notion_block_append.ts
@@ -1,0 +1,62 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { NotionAccessor } from '../../../accessor/notion.ts'
+import { normalizePage, toJsonBytes } from '../../../core/notion/normalize.ts'
+import { appendBlocks, getChildBlocks, getPage } from '../../../core/notion/pages.ts'
+import { IOResult } from '../../../io/types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { CommandSpec, OperandKind, Option } from '../../spec/types.ts'
+
+const SPEC = new CommandSpec({
+  options: [
+    new Option({ long: '--params', valueKind: OperandKind.TEXT }),
+    new Option({ long: '--json', valueKind: OperandKind.TEXT }),
+  ],
+})
+
+async function notionBlockAppendCommand(
+  accessor: NotionAccessor,
+  _paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const paramsStr = opts.flags.params
+  if (typeof paramsStr !== 'string' || paramsStr === '') {
+    throw new Error('--params is required (must contain block_id)')
+  }
+  const jsonStr = opts.flags.json
+  if (typeof jsonStr !== 'string' || jsonStr === '') {
+    throw new Error('--json is required (must contain children)')
+  }
+  const params = JSON.parse(paramsStr) as Record<string, unknown>
+  const blockId = typeof params.block_id === 'string' ? params.block_id : ''
+  if (blockId === '') {
+    throw new Error('--params must contain block_id')
+  }
+  const body = JSON.parse(jsonStr) as Record<string, unknown>
+  await appendBlocks(accessor.transport, blockId, body)
+  const page = await getPage(accessor.transport, blockId)
+  const pageBlocks = await getChildBlocks(accessor.transport, blockId)
+  return [toJsonBytes(normalizePage(page, pageBlocks)), new IOResult()]
+}
+
+export const NOTION_BLOCK_APPEND = command({
+  name: 'notion-block-append',
+  resource: ResourceName.NOTION,
+  spec: SPEC,
+  fn: notionBlockAppendCommand,
+  write: true,
+})

--- a/typescript/packages/core/src/commands/builtin/notion/notion_comment_add.test.ts
+++ b/typescript/packages/core/src/commands/builtin/notion/notion_comment_add.test.ts
@@ -1,0 +1,112 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { NotionAccessor, type NotionResourceLike } from '../../../accessor/notion.ts'
+import type { NotionTransport } from '../../../core/notion/_client.ts'
+import { materialize } from '../../../io/types.ts'
+import type { Resource } from '../../../resource/base.ts'
+import { NOTION_COMMENT_ADD } from './notion_comment_add.ts'
+
+const DEC = new TextDecoder()
+const PAGE_ID = 'abc123def4567890123456789012345a'
+
+class FakeTransport implements NotionTransport {
+  invocations: { name: string; args: Record<string, unknown> }[] = []
+  responses: Record<string, unknown>[] = []
+  callTool(name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+    this.invocations.push({ name, args })
+    if (this.responses.length === 0) return Promise.reject(new Error('no canned response'))
+    const response = this.responses.shift()
+    if (response === undefined) return Promise.reject(new Error('no canned response'))
+    return Promise.resolve(response)
+  }
+}
+
+function makeFakeResource(transport: NotionTransport): NotionResourceLike {
+  const accessor = new NotionAccessor(transport)
+  const resource: Resource & { accessor: NotionAccessor } = {
+    kind: 'notion',
+    accessor,
+    open: () => Promise.resolve(),
+    close: () => Promise.resolve(),
+  }
+  return resource as NotionResourceLike
+}
+
+interface RunOpts {
+  flags: Record<string, string | boolean>
+  response?: Record<string, unknown>
+}
+
+async function runCommentAdd(opts: RunOpts): Promise<{ out: string; transport: FakeTransport }> {
+  const cmd = NOTION_COMMENT_ADD[0]
+  if (cmd === undefined) throw new Error('notion-comment-add not registered')
+  const transport = new FakeTransport()
+  transport.responses.push(
+    opts.response ?? {
+      id: 'comment-1',
+      object: 'comment',
+      parent: { type: 'page_id', page_id: PAGE_ID },
+    },
+  )
+  const resource = makeFakeResource(transport)
+  const result = await cmd.fn(resource.accessor, [], [], {
+    stdin: null,
+    flags: opts.flags,
+    filetypeFns: null,
+    cwd: '/',
+    resource,
+  })
+  if (result === null) return { out: '', transport }
+  const [bs] = result
+  if (bs === null) return { out: '', transport }
+  const buf = bs instanceof Uint8Array ? bs : await materialize(bs as AsyncIterable<Uint8Array>)
+  return { out: DEC.decode(buf), transport }
+}
+
+describe('notion-comment-add command', () => {
+  it('creates a comment and prints the API response', async () => {
+    const body = {
+      parent: { page_id: PAGE_ID },
+      rich_text: [{ text: { content: 'Nice page' } }],
+    }
+    const { out, transport } = await runCommentAdd({
+      flags: { json: JSON.stringify(body) },
+    })
+    expect(transport.invocations).toHaveLength(1)
+    expect(transport.invocations[0]?.name).toBe('API-create-a-comment')
+    expect(transport.invocations[0]?.args).toEqual(body)
+    expect(JSON.parse(out)).toEqual({
+      id: 'comment-1',
+      object: 'comment',
+      parent: { type: 'page_id', page_id: PAGE_ID },
+    })
+  })
+
+  it('throws a usage error when --json is missing', async () => {
+    await expect(runCommentAdd({ flags: {} })).rejects.toThrow(/Usage: notion-comment-add/)
+  })
+
+  it("throws when the JSON body lacks 'parent'", async () => {
+    await expect(
+      runCommentAdd({ flags: { json: JSON.stringify({ rich_text: [] }) } }),
+    ).rejects.toThrow(/JSON must contain 'parent'/)
+  })
+
+  it('is registered as a write command', () => {
+    const cmd = NOTION_COMMENT_ADD[0]
+    expect(cmd?.write).toBe(true)
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/notion/notion_comment_add.ts
+++ b/typescript/packages/core/src/commands/builtin/notion/notion_comment_add.ts
@@ -1,0 +1,54 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { NotionAccessor } from '../../../accessor/notion.ts'
+import { toJsonBytes } from '../../../core/notion/normalize.ts'
+import { createComment } from '../../../core/notion/pages.ts'
+import { IOResult } from '../../../io/types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { CommandSpec, OperandKind, Option } from '../../spec/types.ts'
+
+const SPEC = new CommandSpec({
+  options: [new Option({ long: '--json', valueKind: OperandKind.TEXT })],
+})
+
+async function notionCommentAddCommand(
+  accessor: NotionAccessor,
+  _paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const jsonStr = opts.flags.json
+  if (typeof jsonStr !== 'string' || jsonStr === '') {
+    throw new Error(
+      'Usage: notion-comment-add --json \'{"parent":{"page_id":"..."},' +
+        '"rich_text":[{"text":{"content":"Comment text"}}]}\'',
+    )
+  }
+  const body = JSON.parse(jsonStr) as Record<string, unknown>
+  if (!('parent' in body)) {
+    throw new Error("JSON must contain 'parent'")
+  }
+  const comment = await createComment(accessor.transport, body)
+  return [toJsonBytes(comment), new IOResult()]
+}
+
+export const NOTION_COMMENT_ADD = command({
+  name: 'notion-comment-add',
+  resource: ResourceName.NOTION,
+  spec: SPEC,
+  fn: notionCommentAddCommand,
+  write: true,
+})

--- a/typescript/packages/core/src/commands/builtin/notion/notion_search.test.ts
+++ b/typescript/packages/core/src/commands/builtin/notion/notion_search.test.ts
@@ -1,0 +1,159 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { NotionAccessor, type NotionResourceLike } from '../../../accessor/notion.ts'
+import type { NotionTransport } from '../../../core/notion/_client.ts'
+import { materialize } from '../../../io/types.ts'
+import type { Resource } from '../../../resource/base.ts'
+import { NOTION_SEARCH } from './notion_search.ts'
+
+const DEC = new TextDecoder()
+
+class FakeTransport implements NotionTransport {
+  invocations: { name: string; args: Record<string, unknown> }[] = []
+  responses: Record<string, unknown>[] = []
+  callTool(name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+    this.invocations.push({ name, args })
+    if (this.responses.length === 0) return Promise.reject(new Error('no canned response'))
+    const response = this.responses.shift()
+    if (response === undefined) return Promise.reject(new Error('no canned response'))
+    return Promise.resolve(response)
+  }
+}
+
+function makeFakeResource(transport: NotionTransport): NotionResourceLike {
+  const accessor = new NotionAccessor(transport)
+  const resource: Resource & { accessor: NotionAccessor } = {
+    kind: 'notion',
+    accessor,
+    open: () => Promise.resolve(),
+    close: () => Promise.resolve(),
+  }
+  return resource as NotionResourceLike
+}
+
+function makePage(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: 'abc123def4567890123456789012345a',
+    url: 'https://www.notion.so/abc123def4567890123456789012345a',
+    last_edited_time: '2026-01-01T00:00:00.000Z',
+    parent: { type: 'workspace', workspace: true },
+    properties: { title: { type: 'title', title: [{ plain_text: 'Roadmap' }] } },
+    ...overrides,
+  }
+}
+
+interface RunOpts {
+  flags: Record<string, string | boolean>
+  responses: Record<string, unknown>[]
+}
+
+async function runSearch(opts: RunOpts): Promise<{ out: string; transport: FakeTransport }> {
+  const cmd = NOTION_SEARCH[0]
+  if (cmd === undefined) throw new Error('notion-search not registered')
+  const transport = new FakeTransport()
+  transport.responses.push(...opts.responses)
+  const resource = makeFakeResource(transport)
+  const result = await cmd.fn(resource.accessor, [], [], {
+    stdin: null,
+    flags: opts.flags,
+    filetypeFns: null,
+    cwd: '/',
+    resource,
+  })
+  if (result === null) return { out: '', transport }
+  const [bs] = result
+  if (bs === null) return { out: '', transport }
+  const buf = bs instanceof Uint8Array ? bs : await materialize(bs as AsyncIterable<Uint8Array>)
+  return { out: DEC.decode(buf), transport }
+}
+
+describe('notion-search command', () => {
+  it('searches pages and prints normalized result rows', async () => {
+    const { out, transport } = await runSearch({
+      flags: { query: 'Roadmap' },
+      responses: [{ results: [makePage({})], has_more: false }],
+    })
+    expect(transport.invocations).toHaveLength(1)
+    const call = transport.invocations[0]
+    expect(call?.name).toBe('API-post-search')
+    expect(call?.args.query).toBe('Roadmap')
+    expect(call?.args.filter).toEqual({ value: 'page', property: 'object' })
+    expect(call?.args.page_size).toBe(20)
+    expect(JSON.parse(out)).toEqual([
+      {
+        title: 'Roadmap',
+        page_id: 'abc123def4567890123456789012345a',
+        url: 'https://www.notion.so/abc123def4567890123456789012345a',
+        last_edited: '2026-01-01T00:00:00.000Z',
+        parent_type: 'workspace',
+      },
+    ])
+  })
+
+  it('falls back to Untitled when the page has no title property', async () => {
+    const { out } = await runSearch({
+      flags: { query: 'x' },
+      responses: [{ results: [makePage({ properties: {} })], has_more: false }],
+    })
+    const parsed = JSON.parse(out) as { title: string }[]
+    expect(parsed[0]?.title).toBe('Untitled')
+  })
+
+  it('caps the result list at --limit', async () => {
+    const { out, transport } = await runSearch({
+      flags: { query: 'x', limit: '1' },
+      responses: [
+        {
+          results: [makePage({}), makePage({ id: 'abc123def4567890123456789012345b' })],
+          has_more: false,
+        },
+      ],
+    })
+    expect(transport.invocations[0]?.args.page_size).toBe(1)
+    expect(JSON.parse(out)).toHaveLength(1)
+  })
+
+  it('paginates until has_more is false', async () => {
+    const { out, transport } = await runSearch({
+      flags: { query: 'x' },
+      responses: [
+        { results: [makePage({})], has_more: true, next_cursor: 'cur1' },
+        {
+          results: [makePage({ id: 'abc123def4567890123456789012345b' })],
+          has_more: false,
+        },
+      ],
+    })
+    expect(transport.invocations).toHaveLength(2)
+    expect(transport.invocations[1]?.args.start_cursor).toBe('cur1')
+    expect(JSON.parse(out)).toHaveLength(2)
+  })
+
+  it('throws when --query is missing', async () => {
+    await expect(runSearch({ flags: {}, responses: [] })).rejects.toThrow(/query is required/)
+  })
+
+  it('throws when --limit is not a number', async () => {
+    await expect(runSearch({ flags: { query: 'x', limit: 'abc' }, responses: [] })).rejects.toThrow(
+      /invalid --limit/,
+    )
+  })
+
+  it('is registered as a read command', () => {
+    const cmd = NOTION_SEARCH[0]
+    expect(cmd?.write).toBe(false)
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/notion/notion_search.ts
+++ b/typescript/packages/core/src/commands/builtin/notion/notion_search.ts
@@ -1,0 +1,80 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { NotionAccessor } from '../../../accessor/notion.ts'
+import { pageContentTitle } from '../../../core/notion/normalize.ts'
+import { searchPages } from '../../../core/notion/pages.ts'
+import { IOResult } from '../../../io/types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { CommandSpec, OperandKind, Option } from '../../spec/types.ts'
+
+const ENC = new TextEncoder()
+
+const SPEC = new CommandSpec({
+  options: [
+    new Option({ long: '--query', valueKind: OperandKind.TEXT }),
+    new Option({ long: '--limit', valueKind: OperandKind.TEXT }),
+  ],
+})
+
+function strOf(record: Record<string, unknown>, key: string): string {
+  const value = record[key]
+  return typeof value === 'string' ? value : ''
+}
+
+async function notionSearchCommand(
+  accessor: NotionAccessor,
+  _paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const query = opts.flags.query
+  if (typeof query !== 'string' || query === '') {
+    throw new Error('--query is required')
+  }
+  const limitRaw = opts.flags.limit
+  let limit = 20
+  if (typeof limitRaw === 'string') {
+    limit = Number.parseInt(limitRaw, 10)
+    if (Number.isNaN(limit)) {
+      throw new Error(`invalid --limit: ${limitRaw}`)
+    }
+  }
+  const pages = await searchPages(accessor.transport, query, limit)
+  const results: Record<string, string>[] = []
+  for (const page of pages.slice(0, limit)) {
+    const title = pageContentTitle(page)
+    const parent = page.parent
+    const parentObj =
+      parent !== null && typeof parent === 'object' && !Array.isArray(parent)
+        ? (parent as Record<string, unknown>)
+        : {}
+    results.push({
+      title: title !== '' ? title : 'Untitled',
+      page_id: strOf(page, 'id'),
+      url: strOf(page, 'url'),
+      last_edited: strOf(page, 'last_edited_time'),
+      parent_type: strOf(parentObj, 'type'),
+    })
+  }
+  return [ENC.encode(JSON.stringify(results, null, 2)), new IOResult()]
+}
+
+export const NOTION_SEARCH = command({
+  name: 'notion-search',
+  resource: ResourceName.NOTION,
+  spec: SPEC,
+  fn: notionSearchCommand,
+})

--- a/typescript/packages/core/src/core/notion/_client.test.ts
+++ b/typescript/packages/core/src/core/notion/_client.test.ts
@@ -210,6 +210,25 @@ describe('HttpNotionTransport', () => {
     expect(requests[0]?.url).toBe('http://mock/v1/blocks/b1/children?page_size=100&start_cursor=c2')
   })
 
+  it('maps API-patch-block-children to PATCH /blocks/{id}/children with the body', async () => {
+    const { transport, requests } = makeHttpTransport([{ status: 200, payload: { results: [] } }])
+    await transport.callTool('API-patch-block-children', {
+      block_id: 'b1',
+      children: [{ type: 'paragraph' }],
+    })
+    expect(requests[0]?.url).toBe('http://mock/v1/blocks/b1/children')
+    expect(requests[0]?.method).toBe('PATCH')
+    expect(requests[0]?.body).toBe('{"children":[{"type":"paragraph"}]}')
+  })
+
+  it('maps API-create-a-comment to POST /comments with the args as JSON body', async () => {
+    const { transport, requests } = makeHttpTransport([{ status: 200, payload: { id: 'c1' } }])
+    await transport.callTool('API-create-a-comment', { parent: { page_id: 'p1' } })
+    expect(requests[0]?.url).toBe('http://mock/v1/comments')
+    expect(requests[0]?.method).toBe('POST')
+    expect(requests[0]?.body).toBe('{"parent":{"page_id":"p1"}}')
+  })
+
   it('throws NotionAPIError with status and code on HTTP errors', async () => {
     const { transport } = makeHttpTransport([
       { status: 404, payload: { message: 'not found', code: 'object_not_found' } },

--- a/typescript/packages/core/src/core/notion/_client.ts
+++ b/typescript/packages/core/src/core/notion/_client.ts
@@ -147,7 +147,7 @@ export interface HttpNotionTransportOptions {
 }
 
 interface RestCall {
-  method: 'GET' | 'POST'
+  method: 'GET' | 'POST' | 'PATCH'
   path: string
   query?: Record<string, unknown>
   body?: Record<string, unknown>
@@ -167,6 +167,13 @@ function restCallFor(name: string, args: Record<string, unknown>): RestCall {
   if (name === 'API-retrieve-block-children') {
     const { block_id, ...rest } = args
     return { method: 'GET', path: `/blocks/${String(block_id)}/children`, query: rest }
+  }
+  if (name === 'API-patch-block-children') {
+    const { block_id, ...rest } = args
+    return { method: 'PATCH', path: `/blocks/${String(block_id)}/children`, body: rest }
+  }
+  if (name === 'API-create-a-comment') {
+    return { method: 'POST', path: '/comments', body: args }
   }
   if (name === 'API-get-self') {
     return { method: 'GET', path: '/users/me' }
@@ -200,7 +207,7 @@ export class HttpNotionTransport implements NotionTransport {
         'Content-Type': 'application/json',
       },
     }
-    if (call.method === 'POST') init.body = JSON.stringify(call.body ?? {})
+    if (call.method !== 'GET') init.body = JSON.stringify(call.body ?? {})
     const res = await this.fetch(url, init)
     const data = (await res.json()) as Record<string, unknown>
     if (res.status >= 400) {

--- a/typescript/packages/core/src/core/notion/normalize.ts
+++ b/typescript/packages/core/src/core/notion/normalize.ts
@@ -85,7 +85,7 @@ export function pageSegmentName(page: Json): string {
   return formatSegment({ id: strOf(page, 'id'), title: pageContentTitle(page) })
 }
 
-function pageContentTitle(page: Json): string {
+export function pageContentTitle(page: Json): string {
   const properties = asObject(page.properties)
   for (const value of Object.values(properties)) {
     const prop = asObject(value)

--- a/typescript/packages/core/src/core/notion/pages.test.ts
+++ b/typescript/packages/core/src/core/notion/pages.test.ts
@@ -14,7 +14,16 @@
 
 import { describe, expect, it } from 'vitest'
 import type { NotionTransport } from './_client.ts'
-import { createPage, getChildBlocks, getChildPages, getPage, searchTopLevelPages } from './pages.ts'
+import {
+  appendBlocks,
+  createComment,
+  createPage,
+  getChildBlocks,
+  getChildPages,
+  getPage,
+  searchPages,
+  searchTopLevelPages,
+} from './pages.ts'
 
 class FakeTransport implements NotionTransport {
   invocations: { name: string; args: Record<string, unknown> }[] = []
@@ -186,5 +195,64 @@ describe('createPage', () => {
       },
     ])
     expect(result).toEqual(created)
+  })
+})
+
+describe('searchPages', () => {
+  it('invokes API-post-search with query, filter, and page_size, paginating to the end', async () => {
+    const transport = new FakeTransport()
+    transport.responses.push({
+      results: [{ id: 'p1' }],
+      has_more: true,
+      next_cursor: 'cursor-a',
+    })
+    transport.responses.push({ results: [{ id: 'p2' }], has_more: false, next_cursor: null })
+    const pages = await searchPages(transport, 'Roadmap', 20)
+    expect(transport.invocations[0]).toEqual({
+      name: 'API-post-search',
+      args: {
+        filter: { value: 'page', property: 'object' },
+        page_size: 20,
+        query: 'Roadmap',
+      },
+    })
+    expect(transport.invocations[1]?.args.start_cursor).toBe('cursor-a')
+    expect(pages.map((p) => p.id)).toEqual(['p1', 'p2'])
+  })
+
+  it('omits the query arg when the query is empty', async () => {
+    const transport = new FakeTransport()
+    transport.responses.push({ results: [], has_more: false })
+    await searchPages(transport, '', 100)
+    expect(transport.invocations[0]?.args).toEqual({
+      filter: { value: 'page', property: 'object' },
+      page_size: 100,
+    })
+  })
+})
+
+describe('appendBlocks', () => {
+  it('invokes API-patch-block-children with the block id merged into the body', async () => {
+    const transport = new FakeTransport()
+    const response = { results: [{ id: 'b1' }] }
+    transport.responses.push(response)
+    const children = [{ type: 'paragraph', paragraph: { rich_text: [] } }]
+    const result = await appendBlocks(transport, 'block-1', { children })
+    expect(transport.invocations).toEqual([
+      { name: 'API-patch-block-children', args: { block_id: 'block-1', children } },
+    ])
+    expect(result).toEqual(response)
+  })
+})
+
+describe('createComment', () => {
+  it('invokes API-create-a-comment with the body and returns the comment', async () => {
+    const transport = new FakeTransport()
+    const comment = { id: 'c1', object: 'comment' }
+    transport.responses.push(comment)
+    const body = { parent: { page_id: 'p1' }, rich_text: [{ text: { content: 'hi' } }] }
+    const result = await createComment(transport, body)
+    expect(transport.invocations).toEqual([{ name: 'API-create-a-comment', args: body }])
+    expect(result).toEqual(comment)
   })
 })

--- a/typescript/packages/core/src/core/notion/pages.ts
+++ b/typescript/packages/core/src/core/notion/pages.ts
@@ -114,6 +114,31 @@ export async function getChildPages(
   return refs
 }
 
+export async function searchPages(
+  transport: NotionTransport,
+  query: string,
+  pageSize: number,
+): Promise<Json[]> {
+  const baseArgs: Json = {
+    filter: { value: 'page', property: 'object' },
+    page_size: pageSize,
+  }
+  if (query !== '') baseArgs.query = query
+  return paginateTool(transport, 'API-post-search', baseArgs)
+}
+
+export async function appendBlocks(
+  transport: NotionTransport,
+  blockId: string,
+  body: Json,
+): Promise<Json> {
+  return transport.callTool('API-patch-block-children', { ...body, block_id: blockId })
+}
+
+export async function createComment(transport: NotionTransport, body: Json): Promise<Json> {
+  return transport.callTool('API-create-a-comment', body)
+}
+
 export interface CreatePageInput {
   parent: { type: 'workspace' } | { type: 'page_id'; page_id: string }
   title: string

--- a/typescript/packages/core/src/resource/notion/prompt.ts
+++ b/typescript/packages/core/src/resource/notion/prompt.ts
@@ -24,4 +24,6 @@ export const NOTION_PROMPT = `{prefix}
   <page-title> is sanitized; don't construct it, ls the parent dir.`
 
 export const NOTION_WRITE_PROMPT = `  Write commands:
-    notion-page-create --parent <parent-path> --title "title"`
+    notion-page-create --parent <parent-path> --title "title"
+    notion-block-append --params '{"block_id":"..."}' --json '{"children":[...]}'
+    notion-comment-add --json '{"parent":{"page_id":"..."},"rich_text":[{"text":{"content":"Comment"}}]}'`


### PR DESCRIPTION
Port the three Python notion resource commands to TypeScript, mirroring Python output JSON byte-for-byte.

- New commands with colocated faked-transport tests: notion-search, notion-block-append, notion-comment-add
- Core: searchPages / appendBlocks / createComment in core/notion/pages.ts; PATCH support + new REST mappings in HttpNotionTransport
- NOTION_WRITE_PROMPT lists the new write commands
- examples/typescript/notion/notion.ts runs notion-search like the Python example
- Docs: fix stale flag tables in docs/python/resource/notion.mdx and list resource commands in docs/typescript/setup/notion.mdx

Verified: pnpm typecheck, full core vitest suite, pre-commit; notion-search output live-checked byte-identical to Python.