### PR TITLE
One declarative command-behavior spec run by both Python and TS (#151)

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -57,3 +57,34 @@ empty output, and binary output are all part of the contract.
 - `spec/` (command definitions exported from the registries) is a different
   artifact: it describes the command *surface*; this folder describes command
   *behavior*.
+
+## Adding a backend
+
+Add a backend when its command behavior should be compared against the same
+expectations as the existing implementations:
+
+1. Add its name to `SUPPORTED_MATRIX` in the Python and/or TypeScript runner.
+
+2. Add runner setup that constructs a fresh workspace and resets backend state
+   between cases.
+
+3. For API-backed resources, use mocked clients with payloads shaped like real
+   provider responses. Do not call live APIs from this suite.
+
+4. Add the backend to the applicable case matrices:
+
+   ```json
+   "matrix": {
+     "python": ["ram", "disk", "redis", "github"],
+     "typescript": ["ram", "github"]
+   }
+   ```
+
+5. Run the focused Python and TypeScript conformance tests.
+
+Both runners are discovered by the existing Python and TypeScript CI test jobs;
+no workflow change is required.
+
+Only add a backend to a case when both should produce the same exact stdout,
+stderr, and exit code. Keep provider-specific API calls, cache behavior, error
+injection, and concurrency in backend tests.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -30,7 +30,7 @@ empty output, and binary output are all part of the contract.
       "matrix": { "python": ["ram", "disk", "redis"], "typescript": ["ram"] },
       "expect": {
         "exit": 0,
-        "stdout_text": "5\t5\t24\t/data/a.txt\n",
+        "stdout_text": " 5  5 24 /data/a.txt\n",
         "stderr_text": ""
       }
     }

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -65,13 +65,13 @@ expectations as the existing implementations:
 
 1. Add its name to `SUPPORTED_MATRIX` in the Python and/or TypeScript runner.
 
-2. Add runner setup that constructs a fresh workspace and resets backend state
+1. Add runner setup that constructs a fresh workspace and resets backend state
    between cases.
 
-3. For API-backed resources, use mocked clients with payloads shaped like real
+1. For API-backed resources, use mocked clients with payloads shaped like real
    provider responses. Do not call live APIs from this suite.
 
-4. Add the backend to the applicable case matrices:
+1. Add the backend to the applicable case matrices:
 
    ```json
    "matrix": {
@@ -80,7 +80,7 @@ expectations as the existing implementations:
    }
    ```
 
-5. Run the focused Python and TypeScript conformance tests.
+1. Run the focused Python and TypeScript conformance tests.
 
 Both runners are discovered by the existing Python and TypeScript CI test jobs;
 no workflow change is required.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,0 +1,59 @@
+# Command Conformance Spec
+
+One declarative spec for command behavior, run by both the Python and
+TypeScript implementations (issue #151). Each case pins the exact bytes of
+stdout, the exact bytes of stderr, and the exit code — so trailing newlines,
+empty output, and binary output are all part of the contract.
+
+## Runners
+
+- Python: `python/tests/conformance/test_conformance.py` runs every case
+  against `ram` and `disk`, plus `redis` when `REDIS_URL` is set. Runs as part
+  of `uv run pytest`.
+- TypeScript: `typescript/packages/node/src/conformance.test.ts` runs every
+  case against `ram`. Runs as part of `pnpm test`.
+
+## Files
+
+- `seeds.json` — files written into the workspace before every case, via the
+  ops/fs write API (not shell commands). Values are `{"text": ...}` for UTF-8
+  content or `{"base64": ...}` for binary content.
+- `cases/<command>.json` — cases for one command:
+
+```json
+{
+  "command": "wc",
+  "cases": [
+    {
+      "id": "wc_default",
+      "cmd": "wc /data/a.txt",
+      "matrix": { "python": ["ram", "disk", "redis"], "typescript": ["ram"] },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "5\t5\t24\t/data/a.txt\n",
+        "stderr_text": ""
+      }
+    }
+  ]
+}
+```
+
+- `stdout` / `stderr` use exactly one of `*_text` (UTF-8) or `*_base64`
+  (arbitrary bytes). Trailing newlines are significant.
+- `stdin_text` / `stdin_base64` optionally feed stdin to the command.
+- `matrix` is explicit: a case runs only on the listed backends. Listing a
+  backend is a claim of support — a missing command there is a failure, not a
+  skip. A case whose matrix is empty is a load-time error in both runners.
+
+## Policy
+
+- One expected value per case. If a backend or language legitimately diverges,
+  that divergence is triaged first: either it is a bug (fix the
+  implementation) or it is intended semantics (document it and add an explicit
+  per-backend override mechanism — not yet needed).
+- This spec is an acceptance/parity net, not a replacement for backend tests.
+  API call counts, pushdown/fallback, cache invalidation, error injection, and
+  concurrency stay in hand-written per-backend tests.
+- `spec/` (command definitions exported from the registries) is a different
+  artifact: it describes the command *surface*; this folder describes command
+  *behavior*.

--- a/conformance/cases/cat.json
+++ b/conformance/cases/cat.json
@@ -1,0 +1,62 @@
+{
+  "command": "cat",
+  "cases": [
+    {
+      "id": "cat_no_trailing_newline",
+      "cmd": "cat /data/no_nl.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "no trailing newline",
+        "stderr_text": ""
+      }
+    },
+    {
+      "id": "cat_empty",
+      "cmd": "cat /data/empty.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "",
+        "stderr_text": ""
+      }
+    },
+    {
+      "id": "cat_binary",
+      "cmd": "cat /data/binary.bin",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_base64": "AAECaGVsbG///g==",
+        "stderr_text": ""
+      }
+    }
+  ]
+}

--- a/conformance/cases/cmp.json
+++ b/conformance/cases/cmp.json
@@ -1,0 +1,43 @@
+{
+  "command": "cmp",
+  "cases": [
+    {
+      "id": "cmp_identical",
+      "cmd": "cmp /data/same_a.txt /data/same_b.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "",
+        "stderr_text": ""
+      }
+    },
+    {
+      "id": "cmp_differ",
+      "cmd": "cmp /data/a.txt /data/b.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 1,
+        "stdout_text": "/data/a.txt /data/b.txt differ: char 1, line 1\n",
+        "stderr_text": ""
+      }
+    }
+  ]
+}

--- a/conformance/cases/du.json
+++ b/conformance/cases/du.json
@@ -1,0 +1,43 @@
+{
+  "command": "du",
+  "cases": [
+    {
+      "id": "du_file",
+      "cmd": "du /data/a.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "24\t/data/a.txt\n",
+        "stderr_text": ""
+      }
+    },
+    {
+      "id": "du_dir_summary",
+      "cmd": "du -s /data/sub",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "20\t/data/sub\n",
+        "stderr_text": ""
+      }
+    }
+  ]
+}

--- a/conformance/cases/file.json
+++ b/conformance/cases/file.json
@@ -1,0 +1,43 @@
+{
+  "command": "file",
+  "cases": [
+    {
+      "id": "file_text",
+      "cmd": "file /data/a.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "/data/a.txt: text\n",
+        "stderr_text": ""
+      }
+    },
+    {
+      "id": "file_binary",
+      "cmd": "file /data/binary.bin",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "/data/binary.bin: binary\n",
+        "stderr_text": ""
+      }
+    }
+  ]
+}

--- a/conformance/cases/find.json
+++ b/conformance/cases/find.json
@@ -1,0 +1,43 @@
+{
+  "command": "find",
+  "cases": [
+    {
+      "id": "find_subdir",
+      "cmd": "find /data/sub",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "/data/sub/deep\n/data/sub/deep/deeper.txt\n/data/sub/nested.txt\n",
+        "stderr_text": ""
+      }
+    },
+    {
+      "id": "find_name_glob",
+      "cmd": "find /data/sub -name \"*.txt\"",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "/data/sub/deep/deeper.txt\n/data/sub/nested.txt\n",
+        "stderr_text": ""
+      }
+    }
+  ]
+}

--- a/conformance/cases/grep.json
+++ b/conformance/cases/grep.json
@@ -1,0 +1,43 @@
+{
+  "command": "grep",
+  "cases": [
+    {
+      "id": "grep_match",
+      "cmd": "grep world /data/a.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "world\n",
+        "stderr_text": ""
+      }
+    },
+    {
+      "id": "grep_no_match",
+      "cmd": "grep zzz /data/a.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 1,
+        "stdout_text": "",
+        "stderr_text": ""
+      }
+    }
+  ]
+}

--- a/conformance/cases/head.json
+++ b/conformance/cases/head.json
@@ -1,0 +1,24 @@
+{
+  "command": "head",
+  "cases": [
+    {
+      "id": "head_bytes",
+      "cmd": "head -c 5 /data/a.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "hello",
+        "stderr_text": ""
+      }
+    }
+  ]
+}

--- a/conformance/cases/ls.json
+++ b/conformance/cases/ls.json
@@ -1,0 +1,43 @@
+{
+  "command": "ls",
+  "cases": [
+    {
+      "id": "ls_dir",
+      "cmd": "ls /data",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "a.txt\nb.txt\nbinary.bin\nempty.txt\nno_nl.txt\nsame_a.txt\nsame_b.txt\nsub\n",
+        "stderr_text": ""
+      }
+    },
+    {
+      "id": "ls_subdir",
+      "cmd": "ls /data/sub",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "deep\nnested.txt\n",
+        "stderr_text": ""
+      }
+    }
+  ]
+}

--- a/conformance/cases/md5.json
+++ b/conformance/cases/md5.json
@@ -1,0 +1,24 @@
+{
+  "command": "md5",
+  "cases": [
+    {
+      "id": "md5_file",
+      "cmd": "md5 /data/a.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "191c53e00627438f88824862472a3f59  /data/a.txt\n",
+        "stderr_text": ""
+      }
+    }
+  ]
+}

--- a/conformance/cases/stat.json
+++ b/conformance/cases/stat.json
@@ -1,0 +1,24 @@
+{
+  "command": "stat",
+  "cases": [
+    {
+      "id": "stat_name_size",
+      "cmd": "stat -c \"%n %s\" /data/a.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "a.txt 24\n",
+        "stderr_text": ""
+      }
+    }
+  ]
+}

--- a/conformance/cases/tree.json
+++ b/conformance/cases/tree.json
@@ -1,0 +1,24 @@
+{
+  "command": "tree",
+  "cases": [
+    {
+      "id": "tree_subdir",
+      "cmd": "tree /data/sub",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "\u251c\u2500\u2500 deep\n\u2502   \u2514\u2500\u2500 deeper.txt\n\u2514\u2500\u2500 nested.txt\n",
+        "stderr_text": ""
+      }
+    }
+  ]
+}

--- a/conformance/cases/wc.json
+++ b/conformance/cases/wc.json
@@ -16,7 +16,7 @@
       },
       "expect": {
         "exit": 0,
-        "stdout_text": "5\t5\t24\t/data/a.txt\n",
+        "stdout_text": " 5  5 24 /data/a.txt\n",
         "stderr_text": ""
       }
     },
@@ -35,7 +35,7 @@
       },
       "expect": {
         "exit": 0,
-        "stdout_text": "5\t/data/a.txt\n",
+        "stdout_text": "5 /data/a.txt\n",
         "stderr_text": ""
       }
     },
@@ -54,7 +54,7 @@
       },
       "expect": {
         "exit": 0,
-        "stdout_text": "5\t/data/a.txt\n",
+        "stdout_text": "5 /data/a.txt\n",
         "stderr_text": ""
       }
     },
@@ -73,7 +73,7 @@
       },
       "expect": {
         "exit": 0,
-        "stdout_text": "24\t/data/a.txt\n",
+        "stdout_text": "24 /data/a.txt\n",
         "stderr_text": ""
       }
     },
@@ -92,7 +92,7 @@
       },
       "expect": {
         "exit": 0,
-        "stdout_text": "0\t3\t19\t/data/no_nl.txt\n",
+        "stdout_text": " 0  3 19 /data/no_nl.txt\n",
         "stderr_text": ""
       }
     },
@@ -112,7 +112,7 @@
       },
       "expect": {
         "exit": 0,
-        "stdout_text": "2\t2\t4\n",
+        "stdout_text": "      2       2       4\n",
         "stderr_text": ""
       }
     },

--- a/conformance/cases/wc.json
+++ b/conformance/cases/wc.json
@@ -1,0 +1,140 @@
+{
+  "command": "wc",
+  "cases": [
+    {
+      "id": "wc_default",
+      "cmd": "wc /data/a.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "5\t5\t24\t/data/a.txt\n",
+        "stderr_text": ""
+      }
+    },
+    {
+      "id": "wc_lines",
+      "cmd": "wc -l /data/a.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "5\t/data/a.txt\n",
+        "stderr_text": ""
+      }
+    },
+    {
+      "id": "wc_words",
+      "cmd": "wc -w /data/a.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "5\t/data/a.txt\n",
+        "stderr_text": ""
+      }
+    },
+    {
+      "id": "wc_bytes",
+      "cmd": "wc -c /data/a.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "24\t/data/a.txt\n",
+        "stderr_text": ""
+      }
+    },
+    {
+      "id": "wc_no_trailing_newline",
+      "cmd": "wc /data/no_nl.txt",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "0\t3\t19\t/data/no_nl.txt\n",
+        "stderr_text": ""
+      }
+    },
+    {
+      "id": "wc_stdin",
+      "cmd": "wc",
+      "stdin_text": "a\nb\n",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "2\t2\t4\n",
+        "stderr_text": ""
+      }
+    },
+    {
+      "id": "wc_lines_stdin",
+      "cmd": "wc -l",
+      "stdin_text": "a\nb\n",
+      "matrix": {
+        "python": [
+          "ram",
+          "disk",
+          "redis"
+        ],
+        "typescript": [
+          "ram"
+        ]
+      },
+      "expect": {
+        "exit": 0,
+        "stdout_text": "2\n",
+        "stderr_text": ""
+      }
+    }
+  ]
+}

--- a/conformance/seeds.json
+++ b/conformance/seeds.json
@@ -1,0 +1,29 @@
+{
+  "/data/a.txt": {
+    "text": "hello\nworld\nfoo\nbar\nbaz\n"
+  },
+  "/data/b.txt": {
+    "text": "1\n2\n3\n"
+  },
+  "/data/no_nl.txt": {
+    "text": "no trailing newline"
+  },
+  "/data/empty.txt": {
+    "text": ""
+  },
+  "/data/binary.bin": {
+    "base64": "AAECaGVsbG///g=="
+  },
+  "/data/same_a.txt": {
+    "text": "identical\n"
+  },
+  "/data/same_b.txt": {
+    "text": "identical\n"
+  },
+  "/data/sub/nested.txt": {
+    "text": "nested\ncontent\n"
+  },
+  "/data/sub/deep/deeper.txt": {
+    "text": "deep\n"
+  }
+}

--- a/python/tests/conformance/test_conformance.py
+++ b/python/tests/conformance/test_conformance.py
@@ -72,8 +72,7 @@ def _params() -> list:
         for backend in case["matrix"].get("python", []):
             marks = []
             if backend == "redis" and not REDIS_URL:
-                marks.append(
-                    pytest.mark.skip(reason="REDIS_URL not set"))
+                marks.append(pytest.mark.skip(reason="REDIS_URL not set"))
             params.append(
                 pytest.param(backend,
                              case,

--- a/python/tests/conformance/test_conformance.py
+++ b/python/tests/conformance/test_conformance.py
@@ -27,6 +27,10 @@ from mirage.resource.redis import RedisResource
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CONFORMANCE_DIR = REPO_ROOT / "conformance"
 REDIS_URL = os.environ.get("REDIS_URL", "")
+SUPPORTED_MATRIX = {
+    "python": {"ram", "disk", "redis"},
+    "typescript": {"ram"},
+}
 
 
 def _decode_bytes(record: dict, text_key: str, base64_key: str) -> bytes:
@@ -49,15 +53,34 @@ def _load_seeds() -> dict[str, bytes]:
     }
 
 
+def _validate_matrix(case: dict, spec_name: str) -> None:
+    matrix = case["matrix"]
+    unknown_languages = set(matrix) - set(SUPPORTED_MATRIX)
+    if unknown_languages:
+        names = ", ".join(sorted(unknown_languages))
+        raise ValueError(
+            f"case {case['id']} in {spec_name} has unknown matrix "
+            f"language(s): {names}")
+
+    for language, backends in matrix.items():
+        unsupported = set(backends) - SUPPORTED_MATRIX[language]
+        if unsupported:
+            names = ", ".join(sorted(unsupported))
+            raise ValueError(
+                f"case {case['id']} in {spec_name} has unsupported "
+                f"{language} backend(s): {names}")
+
+    if not any(matrix.values()):
+        raise ValueError(
+            f"case {case['id']} in {spec_name} applies to no backend")
+
+
 def _load_cases() -> list[dict]:
     cases = []
     for spec_path in sorted((CONFORMANCE_DIR / "cases").glob("*.json")):
         doc = json.loads(spec_path.read_text())
         for case in doc["cases"]:
-            if not any(case["matrix"].values()):
-                raise ValueError(
-                    f"case {case['id']} in {spec_path.name} applies to "
-                    "no backend")
+            _validate_matrix(case, spec_path.name)
             cases.append(case)
     return cases
 
@@ -129,3 +152,36 @@ async def test_conformance(backend: str, case: dict, tmp_path: Path) -> None:
         if resource is not None:
             await resource._store.clear()
             await resource._store.close()
+
+
+@pytest.mark.parametrize(
+    ("matrix", "message"),
+    [
+        ({
+            "pyhton": ["ram"]
+        }, "unknown matrix language"),
+        ({
+            "typescript": ["disk"]
+        }, "unsupported typescript backend"),
+        ({
+            "python": [],
+            "typescript": []
+        }, "applies to no backend"),
+    ],
+)
+def test_validate_matrix_rejects_invalid_targets(matrix: dict,
+                                                 message: str) -> None:
+    case = {"id": "invalid_matrix", "matrix": matrix}
+    with pytest.raises(ValueError, match=message):
+        _validate_matrix(case, "invalid.json")
+
+
+def test_validate_matrix_accepts_supported_targets() -> None:
+    case = {
+        "id": "valid_matrix",
+        "matrix": {
+            "python": ["ram", "disk", "redis"],
+            "typescript": ["ram"],
+        },
+    }
+    _validate_matrix(case, "valid.json")

--- a/python/tests/conformance/test_conformance.py
+++ b/python/tests/conformance/test_conformance.py
@@ -1,0 +1,132 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import base64
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from mirage import MountMode, Workspace
+from mirage.resource.disk import DiskResource
+from mirage.resource.ram import RAMResource
+from mirage.resource.redis import RedisResource
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONFORMANCE_DIR = REPO_ROOT / "conformance"
+REDIS_URL = os.environ.get("REDIS_URL", "")
+
+
+def _decode_bytes(record: dict, text_key: str, base64_key: str) -> bytes:
+    has_text = text_key in record
+    has_base64 = base64_key in record
+    if has_text == has_base64:
+        raise ValueError(
+            f"record must set exactly one of {text_key}/{base64_key}: "
+            f"{record}")
+    if has_text:
+        return record[text_key].encode()
+    return base64.b64decode(record[base64_key])
+
+
+def _load_seeds() -> dict[str, bytes]:
+    raw = json.loads((CONFORMANCE_DIR / "seeds.json").read_text())
+    return {
+        path: _decode_bytes(spec, "text", "base64")
+        for path, spec in raw.items()
+    }
+
+
+def _load_cases() -> list[dict]:
+    cases = []
+    for spec_path in sorted((CONFORMANCE_DIR / "cases").glob("*.json")):
+        doc = json.loads(spec_path.read_text())
+        for case in doc["cases"]:
+            if not any(case["matrix"].values()):
+                raise ValueError(
+                    f"case {case['id']} in {spec_path.name} applies to "
+                    "no backend")
+            cases.append(case)
+    return cases
+
+
+SEEDS = _load_seeds()
+CASES = _load_cases()
+
+
+def _params() -> list:
+    params = []
+    for case in CASES:
+        for backend in case["matrix"].get("python", []):
+            marks = []
+            if backend == "redis" and not REDIS_URL:
+                marks.append(
+                    pytest.mark.skip(reason="REDIS_URL not set"))
+            params.append(
+                pytest.param(backend,
+                             case,
+                             id=f"{backend}-{case['id']}",
+                             marks=marks))
+    return params
+
+
+async def _build_workspace(
+        backend: str, tmp_path: Path,
+        case_id: str) -> tuple[Workspace, RedisResource | None]:
+    if backend == "ram":
+        return Workspace({"/": RAMResource()}, mode=MountMode.WRITE), None
+    if backend == "disk":
+        return Workspace({"/": DiskResource(root=str(tmp_path))},
+                         mode=MountMode.WRITE), None
+    if backend == "redis":
+        resource = RedisResource(url=REDIS_URL,
+                                 key_prefix=f"test:conformance:{case_id}:")
+        await resource._store.clear()
+        return Workspace({"/": resource}, mode=MountMode.WRITE), resource
+    raise ValueError(f"unknown python backend in matrix: {backend}")
+
+
+async def _seed(ws: Workspace) -> None:
+    made: set[str] = set()
+    for path, content in SEEDS.items():
+        parts = [p for p in path.rsplit("/", 1)[0].split("/") if p]
+        for depth in range(1, len(parts) + 1):
+            directory = "/" + "/".join(parts[:depth])
+            if directory not in made:
+                made.add(directory)
+                await ws.ops.mkdir(directory)
+        await ws.ops.write(path, content)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("backend", "case"), _params())
+async def test_conformance(backend: str, case: dict, tmp_path: Path) -> None:
+    ws, resource = await _build_workspace(backend, tmp_path, case["id"])
+    try:
+        await _seed(ws)
+        stdin = None
+        if "stdin_text" in case or "stdin_base64" in case:
+            stdin = _decode_bytes(case, "stdin_text", "stdin_base64")
+        result = await ws.execute(case["cmd"], stdin=stdin)
+        stdout = await result.materialize_stdout()
+        stderr = await result.materialize_stderr()
+        expect = case["expect"]
+        assert result.exit_code == expect["exit"]
+        assert stdout == _decode_bytes(expect, "stdout_text", "stdout_base64")
+        assert stderr == _decode_bytes(expect, "stderr_text", "stderr_base64")
+    finally:
+        if resource is not None:
+            await resource._store.clear()
+            await resource._store.close()

--- a/typescript/packages/core/src/commands/builtin/generic/cmp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cmp.ts
@@ -74,9 +74,9 @@ export async function cmpGeneric(
       if (opts.flags.b === true) {
         msg += ` is ${octal(data1[idx] ?? 0)} ${String.fromCharCode(data1[idx] ?? 0)} ${octal(data2[idx] ?? 0)} ${String.fromCharCode(data2[idx] ?? 0)}`
       }
-      return [ENC.encode(msg), new IOResult({ exitCode: 1 })]
+      return [formatRecords([msg]), new IOResult({ exitCode: 1 })]
     }
   }
   const shorter = data1.byteLength < data2.byteLength ? p0 : p1
-  return [ENC.encode(`cmp: EOF on ${shorter.original}`), new IOResult({ exitCode: 1 })]
+  return [formatRecords([`cmp: EOF on ${shorter.original}`]), new IOResult({ exitCode: 1 })]
 }

--- a/typescript/packages/node/src/conformance.test.ts
+++ b/typescript/packages/node/src/conformance.test.ts
@@ -1,0 +1,144 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { MountMode, RAMResource, Workspace } from './index.ts'
+
+const CONFORMANCE_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  '..',
+  'conformance',
+)
+
+const ENC = new TextEncoder()
+
+interface ConformanceExpect {
+  exit: number
+  stdout_text?: string
+  stdout_base64?: string
+  stderr_text?: string
+  stderr_base64?: string
+}
+
+interface ConformanceCase {
+  id: string
+  cmd: string
+  stdin_text?: string
+  stdin_base64?: string
+  matrix: Record<string, string[]>
+  expect: ConformanceExpect
+}
+
+function decodeBytes(record: object, textKey: string, base64Key: string): Uint8Array {
+  const rec = record as Record<string, unknown>
+  const hasText = textKey in rec
+  const hasBase64 = base64Key in rec
+  if (hasText === hasBase64) {
+    throw new Error(`record must set exactly one of ${textKey}/${base64Key}`)
+  }
+  if (hasText) return ENC.encode(rec[textKey] as string)
+  return Uint8Array.from(Buffer.from(rec[base64Key] as string, 'base64'))
+}
+
+function comparable(bytes: Uint8Array): string {
+  const buf = Buffer.from(bytes)
+  const text = buf.toString('utf8')
+  if (Buffer.from(text, 'utf8').equals(buf)) return `txt:${text}`
+  return `b64:${buf.toString('base64')}`
+}
+
+function loadSeeds(): Map<string, Uint8Array> {
+  const raw = JSON.parse(readFileSync(join(CONFORMANCE_DIR, 'seeds.json'), 'utf8')) as Record<
+    string,
+    Record<string, unknown>
+  >
+  const seeds = new Map<string, Uint8Array>()
+  for (const [path, spec] of Object.entries(raw)) {
+    seeds.set(path, decodeBytes(spec, 'text', 'base64'))
+  }
+  return seeds
+}
+
+function loadCases(): ConformanceCase[] {
+  const cases: ConformanceCase[] = []
+  const casesDir = join(CONFORMANCE_DIR, 'cases')
+  for (const name of readdirSync(casesDir).sort()) {
+    if (!name.endsWith('.json')) continue
+    const doc = JSON.parse(readFileSync(join(casesDir, name), 'utf8')) as {
+      cases: ConformanceCase[]
+    }
+    for (const c of doc.cases) {
+      if (!Object.values(c.matrix).some((backends) => backends.length > 0)) {
+        throw new Error(`case ${c.id} in ${name} applies to no backend`)
+      }
+      cases.push(c)
+    }
+  }
+  return cases
+}
+
+const SEEDS = loadSeeds()
+const CASES = loadCases()
+
+async function seedWorkspace(ws: Workspace): Promise<void> {
+  const made = new Set<string>()
+  for (const [path, content] of SEEDS) {
+    const parts = path.split('/').slice(0, -1).filter(Boolean)
+    for (let depth = 1; depth <= parts.length; depth++) {
+      const dir = '/' + parts.slice(0, depth).join('/')
+      if (!made.has(dir)) {
+        made.add(dir)
+        await ws.fs.mkdir(dir)
+      }
+    }
+    await ws.fs.writeFile(path, content)
+  }
+}
+
+async function runCase(c: ConformanceCase): Promise<void> {
+  const ws = new Workspace({ '/': new RAMResource() }, { mode: MountMode.WRITE })
+  try {
+    await seedWorkspace(ws)
+    const hasStdin = 'stdin_text' in c || 'stdin_base64' in c
+    const stdin = hasStdin ? decodeBytes(c, 'stdin_text', 'stdin_base64') : undefined
+    const result = await ws.execute(c.cmd, stdin === undefined ? undefined : { stdin })
+    expect(result.exitCode).toBe(c.expect.exit)
+    expect(comparable(result.stdout)).toBe(
+      comparable(decodeBytes(c.expect, 'stdout_text', 'stdout_base64')),
+    )
+    expect(comparable(result.stderr)).toBe(
+      comparable(decodeBytes(c.expect, 'stderr_text', 'stderr_base64')),
+    )
+  } finally {
+    await ws.close()
+  }
+}
+
+describe('command conformance spec (ram)', () => {
+  for (const c of CASES) {
+    const backends = c.matrix.typescript ?? []
+    if (!backends.includes('ram')) continue
+    it(c.id, async () => {
+      await runCase(c)
+    })
+  }
+})

--- a/typescript/packages/node/src/conformance.test.ts
+++ b/typescript/packages/node/src/conformance.test.ts
@@ -30,6 +30,10 @@ const CONFORMANCE_DIR = join(
 )
 
 const ENC = new TextEncoder()
+const SUPPORTED_MATRIX: Record<string, ReadonlySet<string>> = {
+  python: new Set(['ram', 'disk', 'redis']),
+  typescript: new Set(['ram']),
+}
 
 interface ConformanceExpect {
   exit: number
@@ -78,6 +82,32 @@ function loadSeeds(): Map<string, Uint8Array> {
   return seeds
 }
 
+function validateMatrix(c: ConformanceCase, specName: string): void {
+  const unknownLanguages = Object.keys(c.matrix).filter(
+    (language) => !(language in SUPPORTED_MATRIX),
+  )
+  if (unknownLanguages.length > 0) {
+    throw new Error(
+      `case ${c.id} in ${specName} has unknown matrix language(s): ${unknownLanguages.sort().join(', ')}`,
+    )
+  }
+
+  for (const [language, backends] of Object.entries(c.matrix)) {
+    const supported = SUPPORTED_MATRIX[language]
+    if (supported === undefined) continue
+    const unsupported = backends.filter((backend) => !supported.has(backend))
+    if (unsupported.length > 0) {
+      throw new Error(
+        `case ${c.id} in ${specName} has unsupported ${language} backend(s): ${unsupported.sort().join(', ')}`,
+      )
+    }
+  }
+
+  if (!Object.values(c.matrix).some((backends) => backends.length > 0)) {
+    throw new Error(`case ${c.id} in ${specName} applies to no backend`)
+  }
+}
+
 function loadCases(): ConformanceCase[] {
   const cases: ConformanceCase[] = []
   const casesDir = join(CONFORMANCE_DIR, 'cases')
@@ -87,9 +117,7 @@ function loadCases(): ConformanceCase[] {
       cases: ConformanceCase[]
     }
     for (const c of doc.cases) {
-      if (!Object.values(c.matrix).some((backends) => backends.length > 0)) {
-        throw new Error(`case ${c.id} in ${name} applies to no backend`)
-      }
+      validateMatrix(c, name)
       cases.push(c)
     }
   }
@@ -141,4 +169,37 @@ describe('command conformance spec (ram)', () => {
       await runCase(c)
     })
   }
+})
+
+describe('command conformance matrix validation', () => {
+  it.each([
+    [{ pyhton: ['ram'] }, 'unknown matrix language'],
+    [{ typescript: ['disk'] }, 'unsupported typescript backend'],
+    [{ python: [], typescript: [] }, 'applies to no backend'],
+  ])('rejects invalid targets', (matrix, message) => {
+    const c = {
+      id: 'invalid_matrix',
+      cmd: 'true',
+      matrix,
+      expect: { exit: 0, stdout_text: '', stderr_text: '' },
+    }
+    expect(() => {
+      validateMatrix(c, 'invalid.json')
+    }).toThrow(message)
+  })
+
+  it('accepts supported targets', () => {
+    const c = {
+      id: 'valid_matrix',
+      cmd: 'true',
+      matrix: {
+        python: ['ram', 'disk', 'redis'],
+        typescript: ['ram'],
+      },
+      expect: { exit: 0, stdout_text: '', stderr_text: '' },
+    }
+    expect(() => {
+      validateMatrix(c, 'valid.json')
+    }).not.toThrow()
+  })
 })


### PR DESCRIPTION
Closes #151.

## Summary

Adds one shared command behavior spec used by Python and TypeScript.

The spec asserts exact:

- stdout bytes
- stderr bytes
- exit code

## Changes

- Add `conformance/seeds.json` for workspace fixtures.
- Add 26 cases for `cat`, `cmp`, `du`, `file`, `find`, `grep`, `head`, `ls`, `md5`, `stat`, `tree`, and `wc`.
- Run Python cases against RAM, disk, and Redis.
- Run TypeScript cases against RAM.
- Validate language and backend matrix targets at load time.
- Seed through workspace APIs instead of shell commands.
- Document how to add another backend using realistic mocked API payloads.
- Use the existing Python and TypeScript CI test jobs; no new workflow is required.

The behavioral spec stays separate from `spec/`:

- `spec/`: command definitions and options
- `conformance/`: command output and exit behavior

## TypeScript parity fix

The shared cases originally exposed missing trailing newlines across several TypeScript commands. Most of those fixes have since landed on `main`.

This PR retains the remaining `cmp` fix: default difference and EOF diagnostics now end with a newline, matching Python and Unix behavior.

## Scope

This does not replace backend-specific tests for API calls, cache invalidation, error injection, or concurrency.

## Verification

- Python conformance tests
- TypeScript conformance tests
- Python and TypeScript command tests
- TypeScript integration truth output
- Pre-commit
