### PR TITLE
feat(ts): databricks_volume resource

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -408,7 +408,8 @@
                 "icon": "folder-open",
                 "pages": [
                   "typescript/dropbox",
-                  "typescript/box"
+                  "typescript/box",
+                  "typescript/setup/databricks_volume"
                 ]
               },
               {

--- a/docs/home/resource-matrix.mdx
+++ b/docs/home/resource-matrix.mdx
@@ -61,7 +61,7 @@ No external setup, these run locally or against a connection string you already 
 
 | Resource | Mount Mode | Setup | Docs | Notes |
 | --- | --- | --- | --- | --- |
-| Databricks Volume | read | [Databricks Volume](/home/setup/databricks) | [<Icon icon="python" />](/python/resource/databricks_volume) | Unity Catalog volume subtree; read-only today |
+| Databricks Volume | read, write | [Databricks Volume](/home/setup/databricks) | [<Icon icon="python" />](/python/resource/databricks_volume) [<Icon icon="node-js" />](/typescript/setup/databricks_volume) | Unity Catalog volume subtree; mv/cp are non-atomic copies |
 | Dropbox | read | [Dropbox](/home/setup/dropbox) | [<Icon icon="node-js" />](/typescript/dropbox) [<Icon icon="globe" />](/typescript/dropbox) | OAuth2 + PKCE; Node and browser |
 | Box | read | [Box](/home/setup/box) | [<Icon icon="node-js" />](/typescript/box) [<Icon icon="globe" />](/typescript/box) | OAuth2 + PKCE or developer token; `.boxnote.json` / `.boxcanvas.json` / `.gdoc.json` decoded |
 | Nextcloud | read, write | [Nextcloud](/home/setup/nextcloud) | [<Icon icon="python" />](/python/resource/nextcloud) | Self-hosted Nextcloud / ownCloud / WebDAV; HTTP Basic auth with app password |

--- a/docs/python/resource/databricks_volume.mdx
+++ b/docs/python/resource/databricks_volume.mdx
@@ -1,13 +1,12 @@
 ---
 title: Databricks Volume
 icon: folder-open
-description: Mount a Databricks Unity Catalog volume as a read-only filesystem.
+description: Mount a Databricks Unity Catalog volume as a filesystem.
 ---
 
 `DatabricksVolumeResource` exposes files from a Unity Catalog volume through
-Mirage's standard filesystem interface. The current branch is read-only:
-agents can list, stat, read, stream, and glob files under the configured
-volume root.
+Mirage's standard filesystem interface. Agents can list, stat, read, stream,
+glob, and write files under the configured volume root.
 
 For auth and environment setup, see [Databricks Volume Setup](/python/setup/databricks).
 
@@ -42,7 +41,7 @@ ws = Workspace({"/dbx": resource}, mode=MountMode.READ)
 
 ## Mount mode
 
-`read` only.
+`read` or `write`.
 
 ## Filesystem layout
 
@@ -76,18 +75,15 @@ would escape above that configured subtree.
 
 ## Supported operations
 
-This branch wires the core read surface:
-
-- `readdir`
-- `stat`
-- `exists`
-- `read_bytes`
-- `read_stream`
-- `range_read`
-- glob resolution
+Reads: `readdir`, `stat`, `exists`, `read_bytes`, `read_stream`,
+`range_read`, and glob resolution. Writes: `write`, `create`, `mkdir`,
+`rmdir`, `unlink`, recursive `rm`, `cp`, and `mv`.
 
 Standard shell commands like `ls`, `cat`, `head`, `tail`, `grep`, `rg`,
-`find`, and `tree` work through those primitives.
+`find`, `tree`, `touch`, `mkdir`, `rm`, `cp`, and `mv` work through those
+primitives. `mv`/`cp` are non-atomic download + upload (the Files API has no
+server-side rename); moving a path onto itself is a no-op and never deletes
+the file.
 
 ## Snapshot behavior
 

--- a/docs/typescript/setup/databricks_volume.mdx
+++ b/docs/typescript/setup/databricks_volume.mdx
@@ -1,0 +1,99 @@
+---
+title: Databricks Volume
+icon: folder-open
+description: Set up a Databricks Unity Catalog volume as a MIRAGE resource from Node.
+---
+
+`DatabricksVolumeResource` exposes files from a Unity Catalog volume through
+MIRAGE's standard filesystem interface. Agents can list, stat, read, stream,
+glob, and write files under the configured volume root.
+
+MIRAGE ships it in `@struktoai/mirage-node` only. The TypeScript client calls
+the Databricks Files REST API directly with `fetch`; the Databricks API does
+not allow cross-origin browser requests, so there is no browser runtime.
+
+For auth and environment setup, see [Databricks Volume Setup](/home/setup/databricks).
+
+## Node
+
+```bash
+pnpm add @struktoai/mirage-node
+```
+
+```ts
+import {
+  DatabricksVolumeResource,
+  MountMode,
+  Workspace,
+  normalizeDatabricksVolumeConfig,
+} from '@struktoai/mirage-node'
+
+const resource = await DatabricksVolumeResource.create(
+  normalizeDatabricksVolumeConfig({
+    catalog: 'main',
+    schema: 'default',
+    volume: 'agent_files',
+    root_path: '/reports',
+  }),
+)
+const ws = new Workspace({ '/dbx/': resource }, { mode: MountMode.READ })
+const res = await ws.execute('ls /dbx/')
+console.log(res.stdoutText)
+```
+
+| Field | Default | Notes |
+| --- | --- | --- |
+| `catalog` | required | Unity Catalog catalog name. |
+| `schema` | required | Unity Catalog schema name. |
+| `volume` | required | Unity Catalog volume name. |
+| `root_path` | `/` | Subdirectory inside the volume to expose. |
+| `host` | none | Optional workspace host override. |
+| `token` | none | Optional PAT override. Redacted in snapshots. |
+| `profile` | none | Optional `~/.databrickscfg` profile name. |
+| `timeout` | `30` | Request timeout in seconds. |
+
+Credentials resolve in order: explicit `host`/`token` in the config, then the
+`DATABRICKS_HOST`/`DATABRICKS_TOKEN` environment variables, then the
+`profile` section of `~/.databrickscfg` (or `DATABRICKS_CONFIG_PROFILE`,
+falling back to `DEFAULT`).
+
+## Filesystem layout
+
+MIRAGE maps the configured mount prefix onto the configured volume subtree.
+With `root_path: '/reports/2026'` and mount prefix `/dbx/`, the volume path
+
+```text
+/Volumes/main/default/agent_files/reports/2026/q1/summary.md
+```
+
+appears in MIRAGE as
+
+```text
+/dbx/q1/summary.md
+```
+
+`root_path` is normalized before use, and MIRAGE rejects any virtual path that
+would escape above that configured subtree.
+
+## Supported operations
+
+Reads: `readdir`, `stat`, `exists`, `read_bytes`, `read_stream`, `range_read`,
+and glob resolution. Writes: `write`, `create`, `mkdir`, `rmdir`, `unlink`,
+recursive `rm`, `cp`, and `mv`.
+
+Standard shell commands like `ls`, `cat`, `head`, `tail`, `grep`, `rg`,
+`find`, `tree`, `touch`, `mkdir`, `rm`, `cp`, and `mv` work through those
+primitives. `mv`/`cp` are non-atomic download + upload (the Files API has no
+server-side rename); moving a path onto itself is a no-op and never deletes
+the file.
+
+## Snapshot behavior
+
+`token` is redacted in resource state. Loading a snapshot back requires an
+override config that provides fresh credentials if the runtime auth chain does
+not already supply them.
+
+## Example
+
+See `examples/typescript/databricks_volume/databricks_volume.ts`, which
+mirrors `examples/python/databricks_volume/databricks_volume.py`.

--- a/examples/typescript/databricks_volume/databricks_volume.ts
+++ b/examples/typescript/databricks_volume/databricks_volume.ts
@@ -1,0 +1,85 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import dotenv from 'dotenv'
+import {
+  DatabricksVolumeResource,
+  MountMode,
+  Workspace,
+  normalizeDatabricksVolumeConfig,
+} from '@struktoai/mirage-node'
+
+const __HERE = fileURLToPath(new URL('.', import.meta.url))
+dotenv.config({ path: resolve(__HERE, '../../../.env.development'), override: true })
+
+async function run(ws: Workspace, cmd: string): Promise<void> {
+  console.log(`\n>>> ${cmd}`)
+  const result = await ws.execute(cmd)
+  const stdout = result.stdoutText.trim()
+  const stderr = result.stderrText.trim()
+  if (stdout !== '') {
+    const lines = stdout.split('\n')
+    for (const line of lines.slice(0, 12)) {
+      console.log(`  ${line.slice(0, 140)}`)
+    }
+    if (lines.length > 12) {
+      console.log(`  ... (${String(lines.length)} lines total)`)
+    }
+  }
+  if (stderr !== '') {
+    console.log(`  [stderr] ${stderr.slice(0, 140)}`)
+  }
+  if (stdout === '' && stderr === '') {
+    console.log(`  (empty, exit=${String(result.exitCode)})`)
+  }
+}
+
+async function main(): Promise<void> {
+  const config = normalizeDatabricksVolumeConfig({
+    catalog: process.env.DATABRICKS_VOLUME_CATALOG!,
+    schema: process.env.DATABRICKS_VOLUME_SCHEMA!,
+    volume: process.env.DATABRICKS_VOLUME_NAME!,
+    root_path: process.env.DATABRICKS_VOLUME_ROOT_PATH ?? '/',
+    ...(process.env.DATABRICKS_HOST !== undefined ? { host: process.env.DATABRICKS_HOST } : {}),
+    ...(process.env.DATABRICKS_TOKEN !== undefined ? { token: process.env.DATABRICKS_TOKEN } : {}),
+    ...(process.env.DATABRICKS_CONFIG_PROFILE !== undefined
+      ? { profile: process.env.DATABRICKS_CONFIG_PROFILE }
+      : {}),
+  })
+  const resource = await DatabricksVolumeResource.create(config)
+  const ws = new Workspace({ '/dbx/': resource }, { mode: MountMode.READ })
+  try {
+    await run(ws, 'ls /dbx/')
+    await run(ws, 'tree -L 2 /dbx/')
+    await run(ws, 'find /dbx/ -name "*.md"')
+
+    const target = process.env.DATABRICKS_VOLUME_SAMPLE_FILE
+    if (target !== undefined && target !== '') {
+      await run(ws, `stat "${target}"`)
+      await run(ws, `head -n 20 "${target}"`)
+      await run(ws, `grep -n TODO "${target}"`)
+    } else {
+      console.log('\nSet DATABRICKS_VOLUME_SAMPLE_FILE to run file reads.')
+    }
+  } finally {
+    await ws.close()
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/typescript/packages/core/src/accessor/databricks_volume.ts
+++ b/typescript/packages/core/src/accessor/databricks_volume.ts
@@ -1,0 +1,36 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { Accessor } from './base.ts'
+import type { Resource } from '../resource/base.ts'
+import type { DatabricksVolumeConfig } from '../resource/databricks_volume/config.ts'
+
+export class DatabricksVolumeAccessor extends Accessor {
+  readonly config: DatabricksVolumeConfig
+  readonly host: string
+  readonly token: string
+
+  constructor(config: DatabricksVolumeConfig, host: string, token: string) {
+    super()
+    this.config = config
+    let h = host
+    while (h.endsWith('/')) h = h.slice(0, -1)
+    this.host = h
+    this.token = token
+  }
+}
+
+export interface DatabricksVolumeResourceLike extends Resource {
+  readonly accessor: DatabricksVolumeAccessor
+}

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/awk.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/awk.ts
@@ -1,0 +1,114 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { readBytes as dbxRead } from '../../../core/databricks_volume/read.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { IOResult } from '../../../io/types.ts'
+import { PathSpec, ResourceName } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { awkStream } from '../generic/awk_helper.ts'
+import { resolveSource } from '../utils/stream.ts'
+import { lstripSlash } from '../../../util/slash.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder('utf-8', { fatal: false })
+
+function stripMount(virtualPath: string, prefix: string): string {
+  if (prefix !== '' && virtualPath.startsWith(prefix + '/')) {
+    return '/' + lstripSlash(virtualPath.slice(prefix.length))
+  }
+  return virtualPath
+}
+
+async function awkCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : paths
+  const mountPrefix = resolved[0]?.prefix ?? ''
+  const fFlag = typeof opts.flags.f === 'string' ? opts.flags.f : null
+  let program: string
+  let dataPaths: string[]
+  if (fFlag !== null) {
+    const programSpec = new PathSpec({
+      original: fFlag,
+      directory: fFlag,
+      resolved: false,
+      prefix: mountPrefix,
+    })
+    try {
+      const bytes = await dbxRead(accessor, programSpec)
+      program = DEC.decode(bytes).trim()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
+    }
+    dataPaths = [
+      ...texts.map((t) => stripMount(t, mountPrefix)),
+      ...resolved.map((p) => p.stripPrefix),
+    ]
+  } else if (texts.length > 0 && texts[0] !== undefined) {
+    program = texts[0]
+    dataPaths = resolved.map((p) => p.stripPrefix)
+  } else {
+    return [
+      null,
+      new IOResult({
+        exitCode: 1,
+        stderr: ENC.encode(`awk: usage: awk [-F fs] [-v var=val] 'program' [file ...]\n`),
+      }),
+    ]
+  }
+  const fs = typeof opts.flags.F === 'string' ? opts.flags.F : ' '
+  const variables: Record<string, string> = {}
+  if (typeof opts.flags.v === 'string' && opts.flags.v.includes('=')) {
+    const [key, val] = opts.flags.v.split('=', 2)
+    if (key !== undefined && val !== undefined) variables[key] = val
+  }
+  const cache: string[] = []
+  let source: AsyncIterable<Uint8Array>
+  if (dataPaths.length > 0) {
+    const firstPath = dataPaths[0]
+    if (firstPath === undefined) return [null, new IOResult()]
+    const spec = new PathSpec({
+      original: firstPath,
+      directory: firstPath,
+      resolved: false,
+      prefix: mountPrefix,
+    })
+    source = dbxStream(accessor, spec)
+    cache.push(firstPath)
+  } else {
+    try {
+      source = resolveSource(opts.stdin, 'awk: missing input')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
+    }
+  }
+  return [awkStream(source, program, fs, variables), new IOResult({ cache })]
+}
+
+export const DATABRICKS_VOLUME_AWK = command({
+  name: 'awk',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('awk'),
+  fn: awkCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/cat.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/cat.ts
@@ -1,0 +1,48 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { stat as dbxStat } from '../../../core/databricks_volume/stat.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { catGeneric } from '../generic/cat.ts'
+import { fileReadProvision } from './provision.ts'
+
+async function catCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return catGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => dbxStat(accessor, p, opts.index ?? undefined),
+    (p) => dbxStream(accessor, p),
+  )
+}
+
+export const DATABRICKS_VOLUME_CAT = command({
+  name: 'cat',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('cat'),
+  fn: catCommand,
+  provision: fileReadProvision,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/commands.test.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/commands.test.ts
@@ -61,7 +61,8 @@ async function run(
   const [out, io] = result
   let stdout = ''
   if (out !== null) {
-    const buf = out instanceof Uint8Array ? out : await materialize(out as AsyncIterable<Uint8Array>)
+    const buf =
+      out instanceof Uint8Array ? out : await materialize(out as AsyncIterable<Uint8Array>)
     stdout = DEC.decode(buf)
   }
   return { stdout, exitCode: io.exitCode }
@@ -71,9 +72,30 @@ describe('databricks_volume commands registry', () => {
   it('registers the same 24 commands as Python', () => {
     const names = DATABRICKS_VOLUME_COMMANDS.map((c) => c.name).sort()
     expect(names).toEqual([
-      'awk', 'cat', 'cp', 'cut', 'diff', 'find', 'grep', 'head', 'jq', 'ls',
-      'mkdir', 'mv', 'nl', 'rg', 'rm', 'sed', 'sort', 'stat', 'tail', 'touch',
-      'tr', 'tree', 'uniq', 'wc',
+      'awk',
+      'cat',
+      'cp',
+      'cut',
+      'diff',
+      'find',
+      'grep',
+      'head',
+      'jq',
+      'ls',
+      'mkdir',
+      'mv',
+      'nl',
+      'rg',
+      'rm',
+      'sed',
+      'sort',
+      'stat',
+      'tail',
+      'touch',
+      'tr',
+      'tree',
+      'uniq',
+      'wc',
     ])
   })
 })
@@ -107,7 +129,12 @@ describe('ls', () => {
     })
     vi.stubGlobal('fetch', fetch)
     const { stdout } = await run('ls', [
-      new PathSpec({ original: '/volume/', directory: '/volume/', prefix: '/volume', resolved: false }),
+      new PathSpec({
+        original: '/volume/',
+        directory: '/volume/',
+        prefix: '/volume',
+        resolved: false,
+      }),
     ])
     expect(stdout.split('\n').filter(Boolean)).toEqual(['a', 'b.txt'])
   })

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/commands.test.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/commands.test.ts
@@ -1,0 +1,150 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { materialize } from '../../../io/types.ts'
+import { PathSpec } from '../../../types.ts'
+import type { Resource } from '../../../resource/base.ts'
+import type { RegisteredCommand } from '../../config.ts'
+import {
+  jsonResponse,
+  makeAccessor,
+  notFoundResponse,
+  routedFetch,
+  TEST_ROOT,
+  type FetchCall,
+} from '../../../core/databricks_volume/_test_util.ts'
+import { DATABRICKS_VOLUME_COMMANDS } from './index.ts'
+
+const DEC = new TextDecoder()
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function cmdOf(name: string): RegisteredCommand {
+  const cmd = DATABRICKS_VOLUME_COMMANDS.find((c) => c.name === name)
+  if (cmd === undefined) throw new Error(`${name} not registered`)
+  return cmd
+}
+
+function pathOf(original: string): PathSpec {
+  return PathSpec.fromStrPath(original, '/volume')
+}
+
+async function run(
+  name: string,
+  paths: PathSpec[],
+  texts: string[] = [],
+  flags: Record<string, string | boolean> = {},
+): Promise<{ stdout: string; exitCode: number }> {
+  const cmd = cmdOf(name)
+  const result = await cmd.fn(makeAccessor(), paths, texts, {
+    stdin: null,
+    flags,
+    filetypeFns: null,
+    cwd: '/',
+    resource: null as unknown as Resource,
+  })
+  if (result === null) return { stdout: '', exitCode: 0 }
+  const [out, io] = result
+  let stdout = ''
+  if (out !== null) {
+    const buf = out instanceof Uint8Array ? out : await materialize(out as AsyncIterable<Uint8Array>)
+    stdout = DEC.decode(buf)
+  }
+  return { stdout, exitCode: io.exitCode }
+}
+
+describe('databricks_volume commands registry', () => {
+  it('registers the same 24 commands as Python', () => {
+    const names = DATABRICKS_VOLUME_COMMANDS.map((c) => c.name).sort()
+    expect(names).toEqual([
+      'awk', 'cat', 'cp', 'cut', 'diff', 'find', 'grep', 'head', 'jq', 'ls',
+      'mkdir', 'mv', 'nl', 'rg', 'rm', 'sed', 'sort', 'stat', 'tail', 'touch',
+      'tr', 'tree', 'uniq', 'wc',
+    ])
+  })
+})
+
+describe('cat', () => {
+  it('streams file contents', async () => {
+    const { fetch } = routedFetch((call: FetchCall) => {
+      if (call.method === 'HEAD') {
+        return new Response(null, { status: 200, headers: { 'Content-Length': '5' } })
+      }
+      return new Response('hello', { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const { stdout } = await run('cat', [pathOf('/volume/a.txt')])
+    expect(stdout).toBe('hello')
+  })
+})
+
+describe('ls', () => {
+  it('lists directory entries', async () => {
+    const { fetch } = routedFetch((call: FetchCall) => {
+      if (call.method === 'GET' && call.url.includes('/fs/directories/')) {
+        return jsonResponse({
+          contents: [
+            { path: `${TEST_ROOT}/b.txt`, file_size: 2 },
+            { path: `${TEST_ROOT}/a`, is_directory: true },
+          ],
+        })
+      }
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const { stdout } = await run('ls', [
+      new PathSpec({ original: '/volume/', directory: '/volume/', prefix: '/volume', resolved: false }),
+    ])
+    expect(stdout.split('\n').filter(Boolean)).toEqual(['a', 'b.txt'])
+  })
+})
+
+describe('grep', () => {
+  it('matches lines in a file', async () => {
+    const { fetch } = routedFetch((call: FetchCall) => {
+      if (call.method === 'HEAD' && call.url.includes('/fs/files/')) {
+        return new Response(null, { status: 200, headers: { 'Content-Length': '20' } })
+      }
+      if (call.method === 'HEAD') return notFoundResponse()
+      return new Response('alpha\nTODO: beta\ngamma', { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const { stdout, exitCode } = await run('grep', [pathOf('/volume/notes.md')], ['TODO'])
+    expect(exitCode).toBe(0)
+    expect(stdout.trim()).toBe('TODO: beta')
+  })
+})
+
+describe('mv', () => {
+  it('same-path mv never deletes the file (PR 142)', async () => {
+    const deletes: string[] = []
+    const { fetch } = routedFetch((call: FetchCall) => {
+      if (call.method === 'DELETE') {
+        deletes.push(call.url)
+        return new Response(null, { status: 200 })
+      }
+      if (call.method === 'HEAD' && call.url.includes('/fs/files/')) {
+        return new Response(null, { status: 200, headers: { 'Content-Length': '5' } })
+      }
+      if (call.method === 'HEAD') return notFoundResponse()
+      return new Response('hello', { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    await run('mv', [pathOf('/volume/a.txt'), pathOf('/volume/a.txt')])
+    expect(deletes).toHaveLength(0)
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/cp.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/cp.ts
@@ -1,0 +1,59 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import type { IndexCacheStore } from '../../../cache/index/store.ts'
+import { copy as dbxCopy } from '../../../core/databricks_volume/copy.ts'
+import { find as dbxFind } from '../../../core/databricks_volume/find.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { stat as dbxStat } from '../../../core/databricks_volume/stat.ts'
+import { IOResult } from '../../../io/types.ts'
+import type { FindOptions } from '../../../resource/base.ts'
+import { type PathSpec, ResourceName } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { cpGeneric } from '../generic/cp.ts'
+
+const ENC = new TextEncoder()
+
+async function cpCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  if (paths.length < 2) {
+    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('cp: requires src and dst\n') })]
+  }
+  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
+  const recursive = opts.flags.r === true || opts.flags.R === true || opts.flags.a === true
+  return cpGeneric(
+    resolved,
+    (src: PathSpec, target: PathSpec) => dbxCopy(accessor, src, target),
+    (src: PathSpec, options: FindOptions) => dbxFind(accessor, src, options),
+    (p: PathSpec, idx?: IndexCacheStore) => dbxStat(accessor, p, idx),
+    recursive,
+    opts.flags.n === true,
+    opts.flags.v === true,
+    opts.index ?? undefined,
+  )
+}
+
+export const DATABRICKS_VOLUME_CP = command({
+  name: 'cp',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('cp'),
+  fn: cpCommand,
+  write: true,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/cut.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/cut.ts
@@ -1,0 +1,39 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { cutGeneric } from '../generic/cut.ts'
+
+async function cutCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return cutGeneric(resolved, opts, (p) => dbxStream(accessor, p))
+}
+
+export const DATABRICKS_VOLUME_CUT = command({
+  name: 'cut',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('cut'),
+  fn: cutCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/diff.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/diff.ts
@@ -1,0 +1,39 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { diffGeneric } from '../generic/diff.ts'
+
+async function diffCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return diffGeneric(resolved, opts, (p) => dbxStream(accessor, p))
+}
+
+export const DATABRICKS_VOLUME_DIFF = command({
+  name: 'diff',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('diff'),
+  fn: diffCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/find.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/find.ts
@@ -1,0 +1,30 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { find as dbxFind } from '../../../core/databricks_volume/find.ts'
+import { ResourceName } from '../../../types.ts'
+import { command } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { findGeneric } from '../generic/find.ts'
+import { metadataProvision } from './provision.ts'
+
+export const DATABRICKS_VOLUME_FIND = command({
+  name: 'find',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('find'),
+  fn: (accessor: DatabricksVolumeAccessor, paths, texts, opts) =>
+    findGeneric(paths, texts, opts, (root, options) => dbxFind(accessor, root, options)),
+  provision: metadataProvision,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/grep.ts
@@ -1,0 +1,48 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { readdir as dbxReaddir } from '../../../core/databricks_volume/readdir.ts'
+import { stat as dbxStat } from '../../../core/databricks_volume/stat.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { type FileStat, ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { prefixAggregate } from '../aggregators.ts'
+import { grepGeneric } from '../generic/grep.ts'
+import { fileReadProvision } from './provision.ts'
+
+async function grepCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  const stat = (p: PathSpec): Promise<FileStat> => dbxStat(accessor, p, opts.index ?? undefined)
+  const readdir = (p: PathSpec): Promise<string[]> =>
+    dbxReaddir(accessor, p, opts.index ?? undefined)
+  return grepGeneric('grep', resolved, texts, opts, stat, readdir, (p) => dbxStream(accessor, p))
+}
+
+export const DATABRICKS_VOLUME_GREP = command({
+  name: 'grep',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('grep'),
+  fn: grepCommand,
+  aggregate: prefixAggregate,
+  provision: fileReadProvision,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/head.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/head.ts
@@ -1,0 +1,43 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { stat as dbxStat } from '../../../core/databricks_volume/stat.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { type FileStat, ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { headGeneric } from '../generic/head.ts'
+import { headTailProvision } from './provision.ts'
+
+async function headCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  const stat = (p: PathSpec): Promise<FileStat> => dbxStat(accessor, p, opts.index ?? undefined)
+  return headGeneric(resolved, texts, opts, stat, (p) => dbxStream(accessor, p))
+}
+
+export const DATABRICKS_VOLUME_HEAD = command({
+  name: 'head',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('head'),
+  fn: headCommand,
+  provision: headTailProvision,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/index.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/index.ts
@@ -1,0 +1,66 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { RegisteredCommand } from '../../config.ts'
+import { DATABRICKS_VOLUME_AWK } from './awk.ts'
+import { DATABRICKS_VOLUME_CAT } from './cat.ts'
+import { DATABRICKS_VOLUME_CP } from './cp.ts'
+import { DATABRICKS_VOLUME_CUT } from './cut.ts'
+import { DATABRICKS_VOLUME_DIFF } from './diff.ts'
+import { DATABRICKS_VOLUME_FIND } from './find.ts'
+import { DATABRICKS_VOLUME_GREP } from './grep.ts'
+import { DATABRICKS_VOLUME_HEAD } from './head.ts'
+import { DATABRICKS_VOLUME_JQ } from './jq.ts'
+import { DATABRICKS_VOLUME_LS } from './ls.ts'
+import { DATABRICKS_VOLUME_MKDIR } from './mkdir.ts'
+import { DATABRICKS_VOLUME_MV } from './mv.ts'
+import { DATABRICKS_VOLUME_NL } from './nl.ts'
+import { DATABRICKS_VOLUME_RG } from './rg.ts'
+import { DATABRICKS_VOLUME_RM } from './rm.ts'
+import { DATABRICKS_VOLUME_SED } from './sed.ts'
+import { DATABRICKS_VOLUME_SORT } from './sort.ts'
+import { DATABRICKS_VOLUME_STAT } from './stat.ts'
+import { DATABRICKS_VOLUME_TAIL } from './tail.ts'
+import { DATABRICKS_VOLUME_TOUCH } from './touch.ts'
+import { DATABRICKS_VOLUME_TR } from './tr.ts'
+import { DATABRICKS_VOLUME_TREE } from './tree.ts'
+import { DATABRICKS_VOLUME_UNIQ } from './uniq.ts'
+import { DATABRICKS_VOLUME_WC } from './wc.ts'
+
+export const DATABRICKS_VOLUME_COMMANDS: readonly RegisteredCommand[] = [
+  ...DATABRICKS_VOLUME_AWK,
+  ...DATABRICKS_VOLUME_CAT,
+  ...DATABRICKS_VOLUME_CP,
+  ...DATABRICKS_VOLUME_CUT,
+  ...DATABRICKS_VOLUME_DIFF,
+  ...DATABRICKS_VOLUME_FIND,
+  ...DATABRICKS_VOLUME_GREP,
+  ...DATABRICKS_VOLUME_HEAD,
+  ...DATABRICKS_VOLUME_JQ,
+  ...DATABRICKS_VOLUME_LS,
+  ...DATABRICKS_VOLUME_MKDIR,
+  ...DATABRICKS_VOLUME_MV,
+  ...DATABRICKS_VOLUME_NL,
+  ...DATABRICKS_VOLUME_RG,
+  ...DATABRICKS_VOLUME_RM,
+  ...DATABRICKS_VOLUME_SED,
+  ...DATABRICKS_VOLUME_SORT,
+  ...DATABRICKS_VOLUME_STAT,
+  ...DATABRICKS_VOLUME_TAIL,
+  ...DATABRICKS_VOLUME_TOUCH,
+  ...DATABRICKS_VOLUME_TR,
+  ...DATABRICKS_VOLUME_TREE,
+  ...DATABRICKS_VOLUME_UNIQ,
+  ...DATABRICKS_VOLUME_WC,
+]

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/jq.ts
@@ -1,0 +1,76 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { stat as dbxStat } from '../../../core/databricks_volume/stat.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { isJsonlPath, isStreamableJsonlExpr } from '../../../core/jq/index.ts'
+import { Precision, ProvisionResult } from '../../../provision/types.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { jqGeneric } from '../generic/jq.ts'
+
+export async function jqProvision(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  _opts: CommandOpts,
+): Promise<ProvisionResult> {
+  const [first] = paths
+  const [expr] = texts
+  if (first === undefined || expr === undefined) return new ProvisionResult({ command: 'jq' })
+  try {
+    const s = await dbxStat(accessor, first)
+    const fileSize = s.size ?? 0
+    if (isJsonlPath(first.original) && isStreamableJsonlExpr(expr)) {
+      return new ProvisionResult({
+        command: `jq '${expr}' ${first.original}`,
+        networkReadLow: 0,
+        networkReadHigh: fileSize,
+        readOps: 1,
+        precision: Precision.RANGE,
+      })
+    }
+    return new ProvisionResult({
+      command: `jq '${expr}' ${first.original}`,
+      networkReadLow: fileSize,
+      networkReadHigh: fileSize,
+      readOps: 1,
+      precision: Precision.EXACT,
+    })
+  } catch {
+    return new ProvisionResult({ command: 'jq' })
+  }
+}
+
+async function jqCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return jqGeneric(resolved, texts, opts, (p) => dbxStream(accessor, p))
+}
+
+export const DATABRICKS_VOLUME_JQ = command({
+  name: 'jq',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('jq'),
+  fn: jqCommand,
+  provision: jqProvision,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/ls.ts
@@ -1,0 +1,47 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { readdir as dbxReaddir } from '../../../core/databricks_volume/readdir.ts'
+import { stat as dbxStat } from '../../../core/databricks_volume/stat.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { lsGeneric } from '../generic/ls.ts'
+import { metadataProvision } from './provision.ts'
+
+async function lsCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return lsGeneric(
+    resolved,
+    opts,
+    (p) => dbxReaddir(accessor, p, opts.index ?? undefined),
+    (p) => dbxStat(accessor, p, opts.index ?? undefined),
+  )
+}
+
+export const DATABRICKS_VOLUME_LS = command({
+  name: 'ls',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('ls'),
+  fn: lsCommand,
+  provision: metadataProvision,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/mkdir.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/mkdir.ts
@@ -1,0 +1,53 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { mkdir as dbxMkdir } from '../../../core/databricks_volume/mkdir.ts'
+import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { type PathSpec, ResourceName } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+
+const ENC = new TextEncoder()
+
+async function mkdirCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  if (paths.length === 0) {
+    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('mkdir: missing operand\n') })]
+  }
+  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
+  const verbose = opts.flags.v === true
+  const lines: string[] = []
+  const writes: Record<string, Uint8Array> = {}
+  for (const path of resolved) {
+    await dbxMkdir(accessor, path)
+    writes[path.original] = new Uint8Array()
+    if (verbose) lines.push(`mkdir: created directory '${path.original}'`)
+  }
+  const output: ByteSource | null = lines.length > 0 ? ENC.encode(lines.join('\n') + '\n') : null
+  return [output, new IOResult({ writes })]
+}
+
+export const DATABRICKS_VOLUME_MKDIR = command({
+  name: 'mkdir',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('mkdir'),
+  fn: mkdirCommand,
+  write: true,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/mv.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/mv.ts
@@ -1,0 +1,54 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import type { IndexCacheStore } from '../../../cache/index/store.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { rename as dbxRename } from '../../../core/databricks_volume/rename.ts'
+import { stat as dbxStat } from '../../../core/databricks_volume/stat.ts'
+import { IOResult } from '../../../io/types.ts'
+import { type PathSpec, ResourceName } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { mvGeneric } from '../generic/mv.ts'
+
+const ENC = new TextEncoder()
+
+async function mvCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  if (paths.length < 2) {
+    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('mv: requires src and dst\n') })]
+  }
+  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
+  return mvGeneric(
+    resolved,
+    (src: PathSpec, target: PathSpec) => dbxRename(accessor, src, target),
+    (p: PathSpec, idx?: IndexCacheStore) => dbxStat(accessor, p, idx),
+    opts.flags.n === true,
+    opts.flags.v === true,
+    opts.index ?? undefined,
+  )
+}
+
+export const DATABRICKS_VOLUME_MV = command({
+  name: 'mv',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('mv'),
+  fn: mvCommand,
+  write: true,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/nl.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/nl.ts
@@ -1,0 +1,39 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { nlGeneric } from '../generic/nl.ts'
+
+async function nlCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return nlGeneric(resolved, opts, (p) => dbxStream(accessor, p))
+}
+
+export const DATABRICKS_VOLUME_NL = command({
+  name: 'nl',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('nl'),
+  fn: nlCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/provision.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/provision.ts
@@ -74,7 +74,11 @@ export async function fileReadProvision(
     return new ProvisionResult({ precision: Precision.UNKNOWN })
   }
   const index = opts.index ?? undefined
-  const { resolved, missing } = await resolveSizes(accessor as DatabricksVolumeAccessor, paths, index)
+  const { resolved, missing } = await resolveSizes(
+    accessor as DatabricksVolumeAccessor,
+    paths,
+    index,
+  )
   if (missing > 0 || resolved.length === 0) {
     return new ProvisionResult({ precision: Precision.UNKNOWN })
   }
@@ -97,7 +101,11 @@ export async function headTailProvision(
     return new ProvisionResult({ precision: Precision.UNKNOWN })
   }
   const index = opts.index ?? undefined
-  const { resolved, missing } = await resolveSizes(accessor as DatabricksVolumeAccessor, paths, index)
+  const { resolved, missing } = await resolveSizes(
+    accessor as DatabricksVolumeAccessor,
+    paths,
+    index,
+  )
   if (missing > 0 || resolved.length === 0) {
     return new ProvisionResult({ precision: Precision.UNKNOWN })
   }

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/provision.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/provision.ts
@@ -1,0 +1,136 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { Accessor } from '../../../accessor/base.ts'
+import type { IndexCacheStore } from '../../../cache/index/store.ts'
+import type { PathSpec } from '../../../types.ts'
+import { Precision, ProvisionResult } from '../../../provision/types.ts'
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import type { CommandOpts } from '../../config.ts'
+import { stat as dbxStat } from '../../../core/databricks_volume/stat.ts'
+
+interface ResolvedSizes {
+  resolved: [string, number][]
+  missing: number
+}
+
+async function resolveSizes(
+  accessor: DatabricksVolumeAccessor,
+  paths: readonly PathSpec[],
+  index: IndexCacheStore | undefined,
+): Promise<ResolvedSizes> {
+  const resolved: [string, number][] = []
+  let missing = 0
+  for (const p of paths) {
+    const pathStr = p.original
+    let size: number | null = null
+    if (index !== undefined) {
+      const lookup = await index.get(pathStr)
+      if (lookup.entry !== undefined && lookup.entry !== null) {
+        size = lookup.entry.size
+      }
+    }
+    if (size === null) {
+      try {
+        const fileStat = await dbxStat(accessor, p)
+        size = fileStat.size
+      } catch {
+        // fall through — size stays null
+      }
+    }
+    if (size !== null) {
+      resolved.push([pathStr, size])
+    } else {
+      missing += 1
+    }
+  }
+  return { resolved, missing }
+}
+
+function parseNumFlag(value: string | boolean | undefined): number | null {
+  if (typeof value !== 'string') return null
+  const n = Number.parseInt(value, 10)
+  return Number.isFinite(n) ? n : null
+}
+
+export async function fileReadProvision(
+  accessor: Accessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<ProvisionResult> {
+  if (paths.length === 0) {
+    return new ProvisionResult({ precision: Precision.UNKNOWN })
+  }
+  const index = opts.index ?? undefined
+  const { resolved, missing } = await resolveSizes(accessor as DatabricksVolumeAccessor, paths, index)
+  if (missing > 0 || resolved.length === 0) {
+    return new ProvisionResult({ precision: Precision.UNKNOWN })
+  }
+  const total = resolved.reduce((sum, [, size]) => sum + size, 0)
+  return new ProvisionResult({
+    networkReadLow: total,
+    networkReadHigh: total,
+    readOps: resolved.length,
+    precision: Precision.EXACT,
+  })
+}
+
+export async function headTailProvision(
+  accessor: Accessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<ProvisionResult> {
+  if (paths.length === 0) {
+    return new ProvisionResult({ precision: Precision.UNKNOWN })
+  }
+  const index = opts.index ?? undefined
+  const { resolved, missing } = await resolveSizes(accessor as DatabricksVolumeAccessor, paths, index)
+  if (missing > 0 || resolved.length === 0) {
+    return new ProvisionResult({ precision: Precision.UNKNOWN })
+  }
+  const c = parseNumFlag(opts.flags.c)
+  if (c !== null) {
+    const total = resolved.reduce((sum, [, size]) => sum + Math.min(c, size), 0)
+    return new ProvisionResult({
+      networkReadLow: total,
+      networkReadHigh: total,
+      readOps: resolved.length,
+      precision: Precision.EXACT,
+    })
+  }
+  const full = resolved.reduce((sum, [, size]) => sum + size, 0)
+  return new ProvisionResult({
+    networkReadLow: 0,
+    networkReadHigh: full,
+    readOps: resolved.length,
+    precision: Precision.RANGE,
+  })
+}
+
+export function metadataProvision(
+  _accessor: Accessor,
+  paths: PathSpec[],
+  _texts: string[],
+  _opts: CommandOpts,
+): ProvisionResult {
+  const n = Math.max(1, paths.length > 0 ? paths.length : 1)
+  return new ProvisionResult({
+    networkReadLow: 0,
+    networkReadHigh: 0,
+    readOps: n,
+    precision: Precision.EXACT,
+  })
+}

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/rg.ts
@@ -1,0 +1,46 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { readdir as dbxReaddir } from '../../../core/databricks_volume/readdir.ts'
+import { stat as dbxStat } from '../../../core/databricks_volume/stat.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { type FileStat, ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { rgGeneric } from '../generic/rg.ts'
+import { fileReadProvision } from './provision.ts'
+
+async function rgCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  const stat = (p: PathSpec): Promise<FileStat> => dbxStat(accessor, p, opts.index ?? undefined)
+  const readdir = (p: PathSpec): Promise<string[]> =>
+    dbxReaddir(accessor, p, opts.index ?? undefined)
+  return rgGeneric(resolved, texts, opts, stat, readdir, (p) => dbxStream(accessor, p))
+}
+
+export const DATABRICKS_VOLUME_RG = command({
+  name: 'rg',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('rg'),
+  fn: rgCommand,
+  provision: fileReadProvision,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/rm.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/rm.ts
@@ -1,0 +1,102 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { readdir as dbxReaddir } from '../../../core/databricks_volume/readdir.ts'
+import { rmRecursive as dbxRmR } from '../../../core/databricks_volume/rm.ts'
+import { rmdir as dbxRmdir } from '../../../core/databricks_volume/rmdir.ts'
+import { stat as dbxStat } from '../../../core/databricks_volume/stat.ts'
+import { unlink as dbxUnlink } from '../../../core/databricks_volume/unlink.ts'
+import { IOResult, type ByteSource } from '../../../io/types.ts'
+import { FileType, type PathSpec, ResourceName } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+
+const ENC = new TextEncoder()
+
+interface RmOpts {
+  recursive: boolean
+  force: boolean
+  removeDir: boolean
+}
+
+async function rmOne(
+  accessor: DatabricksVolumeAccessor,
+  path: PathSpec,
+  opts: RmOpts,
+  index: CommandOpts['index'],
+): Promise<void> {
+  let isDir = false
+  try {
+    const st = await dbxStat(accessor, path, index ?? undefined)
+    isDir = st.type === FileType.DIRECTORY
+  } catch (err) {
+    if (opts.force) return
+    throw err
+  }
+  if (isDir) {
+    if (opts.recursive) {
+      await dbxRmR(accessor, path)
+    } else if (opts.removeDir) {
+      const children = await dbxReaddir(accessor, path, index ?? undefined)
+      if (children.length > 0) {
+        throw new Error(`directory not empty: ${path.original}`)
+      }
+      await dbxRmdir(accessor, path)
+    } else {
+      throw new Error(`${path.original}: is a directory (use recursive=True)`)
+    }
+  } else {
+    await dbxUnlink(accessor, path)
+  }
+}
+
+async function rmCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  if (paths.length === 0) {
+    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('rm: missing operand\n') })]
+  }
+  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
+  const recursive = opts.flags.r === true || opts.flags.R === true
+  const force = opts.flags.f === true
+  const removeDir = opts.flags.d === true
+  const verbose = opts.flags.v === true
+  const verboseParts: string[] = []
+  const writes: Record<string, Uint8Array> = {}
+  for (const p of resolved) {
+    try {
+      await rmOne(accessor, p, { recursive, force, removeDir }, opts.index)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
+    }
+    writes[p.stripPrefix] = new Uint8Array()
+    if (verbose) verboseParts.push(`removed '${p.original}'`)
+  }
+  const output: ByteSource | null = verbose ? ENC.encode(verboseParts.join('\n')) : null
+  return [output, new IOResult({ writes })]
+}
+
+export const DATABRICKS_VOLUME_RM = command({
+  name: 'rm',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('rm'),
+  fn: rmCommand,
+  write: true,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/sed.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/sed.ts
@@ -1,0 +1,46 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { writeBytes as dbxWrite } from '../../../core/databricks_volume/write.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { sedGeneric } from '../generic/sed.ts'
+
+async function sedCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return sedGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => dbxStream(accessor, p),
+    (p, data) => dbxWrite(accessor, p, data),
+  )
+}
+
+export const DATABRICKS_VOLUME_SED = command({
+  name: 'sed',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('sed'),
+  fn: sedCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/sort.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/sort.ts
@@ -1,0 +1,39 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { sortGeneric } from '../generic/sort.ts'
+
+async function sortCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return sortGeneric(resolved, opts, (p) => dbxStream(accessor, p))
+}
+
+export const DATABRICKS_VOLUME_SORT = command({
+  name: 'sort',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('sort'),
+  fn: sortCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/stat.ts
@@ -1,0 +1,41 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { stat as dbxStat } from '../../../core/databricks_volume/stat.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { statGeneric } from '../generic/stat.ts'
+import { metadataProvision } from './provision.ts'
+
+async function statCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return statGeneric(resolved, opts, (p) => dbxStat(accessor, p, opts.index ?? undefined))
+}
+
+export const DATABRICKS_VOLUME_STAT = command({
+  name: 'stat',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('stat'),
+  fn: statCommand,
+  provision: metadataProvision,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/tail.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/tail.ts
@@ -1,0 +1,41 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { tailGeneric } from '../generic/tail.ts'
+import { fileReadProvision } from './provision.ts'
+
+async function tailCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return tailGeneric(resolved, texts, opts, (p) => dbxStream(accessor, p))
+}
+
+export const DATABRICKS_VOLUME_TAIL = command({
+  name: 'tail',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('tail'),
+  fn: tailCommand,
+  provision: fileReadProvision,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/touch.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/touch.ts
@@ -1,0 +1,54 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { exists as dbxExists } from '../../../core/databricks_volume/exists.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { writeBytes as dbxWrite } from '../../../core/databricks_volume/write.ts'
+import { IOResult } from '../../../io/types.ts'
+import { type PathSpec, ResourceName } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+
+const ENC = new TextEncoder()
+
+async function touchCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  if (paths.length === 0) {
+    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('touch: missing operand\n') })]
+  }
+  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
+  const createOnly = opts.flags.c === true
+  const writes: Record<string, Uint8Array> = {}
+  for (const p of resolved) {
+    if (createOnly) continue
+    if (!(await dbxExists(accessor, p))) {
+      await dbxWrite(accessor, p, new Uint8Array(0))
+      writes[p.original] = new Uint8Array()
+    }
+  }
+  return [null, new IOResult({ writes })]
+}
+
+export const DATABRICKS_VOLUME_TOUCH = command({
+  name: 'touch',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('touch'),
+  fn: touchCommand,
+  write: true,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/tr.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/tr.ts
@@ -1,0 +1,39 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { trGeneric } from '../generic/tr.ts'
+
+async function trCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return trGeneric(resolved, texts, opts, (p) => dbxStream(accessor, p))
+}
+
+export const DATABRICKS_VOLUME_TR = command({
+  name: 'tr',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('tr'),
+  fn: trCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/tree.ts
@@ -1,0 +1,44 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { readdir as dbxReaddir } from '../../../core/databricks_volume/readdir.ts'
+import { stat as dbxStat } from '../../../core/databricks_volume/stat.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { treeGeneric } from '../generic/tree.ts'
+
+async function treeCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
+  return treeGeneric(
+    resolved,
+    opts,
+    (p) => dbxReaddir(accessor, p, opts.index ?? undefined),
+    (p) => dbxStat(accessor, p, opts.index ?? undefined),
+  )
+}
+
+export const DATABRICKS_VOLUME_TREE = command({
+  name: 'tree',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('tree'),
+  fn: treeCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/uniq.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/uniq.ts
@@ -1,0 +1,39 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { uniqGeneric } from '../generic/uniq.ts'
+
+async function uniqCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return uniqGeneric(resolved, opts, (p) => dbxStream(accessor, p))
+}
+
+export const DATABRICKS_VOLUME_UNIQ = command({
+  name: 'uniq',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('uniq'),
+  fn: uniqCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/wc.ts
@@ -1,0 +1,41 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
+import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { wcGeneric } from '../generic/wc.ts'
+import { fileReadProvision } from './provision.ts'
+
+async function wcCommand(
+  accessor: DatabricksVolumeAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return wcGeneric(resolved, texts, opts, (p) => dbxStream(accessor, p))
+}
+
+export const DATABRICKS_VOLUME_WC = command({
+  name: 'wc',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  spec: specOf('wc'),
+  fn: wcCommand,
+  provision: fileReadProvision,
+})

--- a/typescript/packages/core/src/core/databricks_volume/_client.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/_client.test.ts
@@ -1,0 +1,87 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import { normalizeDatabricksVolumeConfig } from '../../resource/databricks_volume/config.ts'
+import { dbxFetch, dbxUrl, encodeRemotePath } from './_client.ts'
+import { DatabricksVolumeApiError } from './errors.ts'
+
+function makeAccessor(): DatabricksVolumeAccessor {
+  const config = normalizeDatabricksVolumeConfig({
+    catalog: 'main',
+    schema: 'default',
+    volume: 'agent_files',
+  })
+  return new DatabricksVolumeAccessor(config, 'https://dbc.example.com/', 'tok-123')
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('encodeRemotePath', () => {
+  it('encodes segments but keeps slashes', () => {
+    expect(encodeRemotePath('/Volumes/main/a b/c#d.txt')).toBe('/Volumes/main/a%20b/c%23d.txt')
+  })
+})
+
+describe('dbxUrl', () => {
+  it('builds files URLs from a slash-trimmed host', () => {
+    const url = dbxUrl(makeAccessor(), 'files', '/Volumes/main/default/agent_files/a.txt')
+    expect(url).toBe(
+      'https://dbc.example.com/api/2.0/fs/files/Volumes/main/default/agent_files/a.txt',
+    )
+  })
+
+  it('appends query parameters', () => {
+    const url = dbxUrl(makeAccessor(), 'directories', '/Volumes/x', { page_token: 'abc' })
+    expect(url).toBe('https://dbc.example.com/api/2.0/fs/directories/Volumes/x?page_token=abc')
+  })
+})
+
+describe('dbxFetch', () => {
+  it('sends bearer auth and returns the response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const r = await dbxFetch(makeAccessor(), 'GET', 'files', '/Volumes/x/a.txt')
+    expect(await r.text()).toBe('ok')
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://dbc.example.com/api/2.0/fs/files/Volumes/x/a.txt')
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer tok-123')
+  })
+
+  it('throws DatabricksVolumeApiError with parsed error_code on failure', async () => {
+    const body = JSON.stringify({ error_code: 'RESOURCE_DOES_NOT_EXIST', message: 'gone' })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(body, { status: 404 })))
+    const err = await dbxFetch(makeAccessor(), 'GET', 'files', '/Volumes/x/a.txt').catch(
+      (e: unknown) => e,
+    )
+    expect(err).toBeInstanceOf(DatabricksVolumeApiError)
+    const apiErr = err as DatabricksVolumeApiError
+    expect(apiErr.statusCode).toBe(404)
+    expect(apiErr.errorCode).toBe('RESOURCE_DOES_NOT_EXIST')
+    expect(apiErr.message).toContain('gone')
+  })
+
+  it('keeps non-JSON error bodies as the message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('plain boom', { status: 500 })))
+    const err = (await dbxFetch(makeAccessor(), 'DELETE', 'directories', '/Volumes/x').catch(
+      (e: unknown) => e,
+    )) as DatabricksVolumeApiError
+    expect(err.statusCode).toBe(500)
+    expect(err.errorCode).toBeNull()
+    expect(err.message).toContain('plain boom')
+  })
+})

--- a/typescript/packages/core/src/core/databricks_volume/_client.ts
+++ b/typescript/packages/core/src/core/databricks_volume/_client.ts
@@ -1,0 +1,95 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import { DatabricksVolumeApiError } from './errors.ts'
+
+export type DbxEndpoint = 'files' | 'directories'
+
+export interface DbxFetchOptions {
+  query?: Record<string, string>
+  headers?: Record<string, string>
+  body?: Uint8Array | string
+}
+
+export function encodeRemotePath(remotePath: string): string {
+  return remotePath
+    .split('/')
+    .map((part) => encodeURIComponent(part))
+    .join('/')
+}
+
+export function dbxUrl(
+  accessor: DatabricksVolumeAccessor,
+  endpoint: DbxEndpoint,
+  remotePath: string,
+  query?: Record<string, string>,
+): string {
+  let url = `${accessor.host}/api/2.0/fs/${endpoint}${encodeRemotePath(remotePath)}`
+  if (query !== undefined && Object.keys(query).length > 0) {
+    url += `?${new URLSearchParams(query).toString()}`
+  }
+  return url
+}
+
+async function errorFromResponse(method: string, url: string, r: Response): Promise<Error> {
+  let errorCode: string | null = null
+  let message = ''
+  const text = await r.text().catch(() => '')
+  try {
+    const data = JSON.parse(text) as { error_code?: string; message?: string }
+    errorCode = data.error_code ?? null
+    message = data.message ?? text
+  } catch {
+    message = text
+  }
+  return new DatabricksVolumeApiError(
+    `databricks_volume: ${method} ${url} → ${String(r.status)} ${message}`,
+    r.status,
+    errorCode,
+  )
+}
+
+export async function dbxFetch(
+  accessor: DatabricksVolumeAccessor,
+  method: string,
+  endpoint: DbxEndpoint,
+  remotePath: string,
+  options: DbxFetchOptions = {},
+): Promise<Response> {
+  const url = dbxUrl(accessor, endpoint, remotePath, options.query)
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${accessor.token}`,
+    ...options.headers,
+  }
+  const controller = new AbortController()
+  const timer = setTimeout(() => {
+    controller.abort()
+  }, accessor.config.timeout * 1000)
+  let r: Response
+  try {
+    r = await fetch(url, {
+      method,
+      headers,
+      ...(options.body !== undefined ? { body: options.body as BodyInit } : {}),
+      signal: controller.signal,
+    })
+  } finally {
+    clearTimeout(timer)
+  }
+  if (!r.ok) {
+    throw await errorFromResponse(method, url, r)
+  }
+  return r
+}

--- a/typescript/packages/core/src/core/databricks_volume/_helpers.ts
+++ b/typescript/packages/core/src/core/databricks_volume/_helpers.ts
@@ -23,9 +23,7 @@ export function ensurePathSpec(path: PathSpec | string): PathSpec {
 export function parentPath(path: PathSpec | string): PathSpec {
   const p = ensurePathSpec(path)
   const stripped = rstripSlash(p.stripPrefix)
-  let parentRelative = stripped.includes('/')
-    ? stripped.slice(0, stripped.lastIndexOf('/'))
-    : '/'
+  let parentRelative = stripped.includes('/') ? stripped.slice(0, stripped.lastIndexOf('/')) : '/'
   if (!parentRelative.startsWith('/')) parentRelative = '/' + parentRelative
   let original: string
   if (p.prefix !== '') {

--- a/typescript/packages/core/src/core/databricks_volume/_helpers.ts
+++ b/typescript/packages/core/src/core/databricks_volume/_helpers.ts
@@ -1,0 +1,38 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { PathSpec } from '../../types.ts'
+import { rstripSlash } from '../../util/slash.ts'
+
+export function ensurePathSpec(path: PathSpec | string): PathSpec {
+  if (path instanceof PathSpec) return path
+  return PathSpec.fromStrPath(path)
+}
+
+export function parentPath(path: PathSpec | string): PathSpec {
+  const p = ensurePathSpec(path)
+  const stripped = rstripSlash(p.stripPrefix)
+  let parentRelative = stripped.includes('/')
+    ? stripped.slice(0, stripped.lastIndexOf('/'))
+    : '/'
+  if (!parentRelative.startsWith('/')) parentRelative = '/' + parentRelative
+  let original: string
+  if (p.prefix !== '') {
+    original = rstripSlash(p.prefix)
+    if (parentRelative !== '/') original += parentRelative
+  } else {
+    original = parentRelative
+  }
+  return PathSpec.fromStrPath(original !== '' ? original : '/', p.prefix)
+}

--- a/typescript/packages/core/src/core/databricks_volume/_test_util.ts
+++ b/typescript/packages/core/src/core/databricks_volume/_test_util.ts
@@ -50,9 +50,10 @@ export interface FetchCall {
   body: Uint8Array | string | undefined
 }
 
-export function routedFetch(
-  route: (call: FetchCall) => Response | Promise<Response>,
-): { fetch: typeof fetch; calls: FetchCall[] } {
+export function routedFetch(route: (call: FetchCall) => Response | Promise<Response>): {
+  fetch: typeof fetch
+  calls: FetchCall[]
+} {
   const calls: FetchCall[] = []
   const impl = async (input: unknown, init?: RequestInit): Promise<Response> => {
     const call: FetchCall = {

--- a/typescript/packages/core/src/core/databricks_volume/_test_util.ts
+++ b/typescript/packages/core/src/core/databricks_volume/_test_util.ts
@@ -1,0 +1,68 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import { normalizeDatabricksVolumeConfig } from '../../resource/databricks_volume/config.ts'
+import { PathSpec } from '../../types.ts'
+
+export const TEST_ROOT = '/Volumes/main/default/agent_files/root'
+
+export function makeAccessor(rootPath = '/root'): DatabricksVolumeAccessor {
+  const config = normalizeDatabricksVolumeConfig({
+    catalog: 'main',
+    schema: 'default',
+    volume: 'agent_files',
+    root_path: rootPath,
+  })
+  return new DatabricksVolumeAccessor(config, 'https://dbc.example.com', 'tok-123')
+}
+
+export function spec(original: string, prefix = '/volume'): PathSpec {
+  return PathSpec.fromStrPath(original, prefix)
+}
+
+export function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export function notFoundResponse(): Response {
+  return jsonResponse({ error_code: 'NOT_FOUND', message: 'does not exist' }, 404)
+}
+
+export interface FetchCall {
+  method: string
+  url: string
+  headers: Record<string, string>
+  body: Uint8Array | string | undefined
+}
+
+export function routedFetch(
+  route: (call: FetchCall) => Response | Promise<Response>,
+): { fetch: typeof fetch; calls: FetchCall[] } {
+  const calls: FetchCall[] = []
+  const impl = async (input: unknown, init?: RequestInit): Promise<Response> => {
+    const call: FetchCall = {
+      method: init?.method ?? 'GET',
+      url: String(input),
+      headers: (init?.headers ?? {}) as Record<string, string>,
+      body: init?.body as Uint8Array | string | undefined,
+    }
+    calls.push(call)
+    return route(call)
+  }
+  return { fetch: impl as typeof fetch, calls }
+}

--- a/typescript/packages/core/src/core/databricks_volume/copy.ts
+++ b/typescript/packages/core/src/core/databricks_volume/copy.ts
@@ -1,0 +1,92 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { FileType, type PathSpec } from '../../types.ts'
+import { rstripSlash } from '../../util/slash.ts'
+import { dbxFetch } from './_client.ts'
+import { ensurePathSpec } from './_helpers.ts'
+import { isADirectoryError } from './errors.ts'
+import { backendPath } from './path.ts'
+import { readBytes } from './read.ts'
+import { listDirectoryContents } from './readdir.ts'
+import { stat } from './stat.ts'
+import { writeBytes } from './write.ts'
+
+async function uploadBytes(
+  accessor: DatabricksVolumeAccessor,
+  remotePath: string,
+  data: Uint8Array,
+): Promise<void> {
+  await dbxFetch(accessor, 'PUT', 'files', remotePath, {
+    query: { overwrite: 'true' },
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: data,
+  })
+}
+
+async function downloadBytes(
+  accessor: DatabricksVolumeAccessor,
+  remotePath: string,
+): Promise<Uint8Array> {
+  const r = await dbxFetch(accessor, 'GET', 'files', remotePath, {
+    headers: { Accept: 'application/octet-stream' },
+  })
+  return new Uint8Array(await r.arrayBuffer())
+}
+
+async function copyTree(
+  accessor: DatabricksVolumeAccessor,
+  remoteSrc: string,
+  remoteDst: string,
+): Promise<void> {
+  await dbxFetch(accessor, 'PUT', 'directories', remoteDst)
+  for (const entry of await listDirectoryContents(accessor, remoteSrc)) {
+    const name = rstripSlash(entry.path).split('/').pop() ?? ''
+    const childDst = `${rstripSlash(remoteDst)}/${name}`
+    if (entry.is_directory === true) {
+      await copyTree(accessor, entry.path, childDst)
+    } else {
+      await uploadBytes(accessor, childDst, await downloadBytes(accessor, entry.path))
+    }
+  }
+}
+
+export async function copy(
+  accessor: DatabricksVolumeAccessor,
+  src: PathSpec,
+  dst: PathSpec,
+  index?: IndexCacheStore,
+  recursive = false,
+): Promise<void> {
+  const s = ensurePathSpec(src)
+  const d = ensurePathSpec(dst)
+  const srcStat = await stat(accessor, s, index)
+  // Same-path guard runs after stat (and the non-recursive directory check)
+  // so a missing source or `cp` of a directory still raises.
+  const samePath = backendPath(accessor.config, s) === backendPath(accessor.config, d)
+  if (srcStat.type === FileType.DIRECTORY) {
+    if (!recursive) throw isADirectoryError(s.stripPrefix)
+    if (samePath) return
+    await copyTree(accessor, backendPath(accessor.config, s), backendPath(accessor.config, d))
+    return
+  }
+  if (samePath) {
+    // Copying a file onto itself would re-upload it; skip.
+    return
+  }
+  const data = await readBytes(accessor, s, index)
+  await writeBytes(accessor, d, data, index)
+}

--- a/typescript/packages/core/src/core/databricks_volume/copy_rename.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/copy_rename.test.ts
@@ -60,9 +60,11 @@ describe('copy', () => {
   it('still raises for a missing source on same-path copy', async () => {
     const { fetch } = routedFetch(() => notFoundResponse())
     vi.stubGlobal('fetch', fetch)
-    const err = (await copy(makeAccessor(), spec('/volume/gone.txt'), spec('/volume/gone.txt')).catch(
-      (e: unknown) => e,
-    )) as Error & { code?: string }
+    const err = (await copy(
+      makeAccessor(),
+      spec('/volume/gone.txt'),
+      spec('/volume/gone.txt'),
+    ).catch((e: unknown) => e)) as Error & { code?: string }
     expect(err.code).toBe('ENOENT')
   })
 

--- a/typescript/packages/core/src/core/databricks_volume/copy_rename.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/copy_rename.test.ts
@@ -1,0 +1,165 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { copy } from './copy.ts'
+import { rename } from './rename.ts'
+import { resolveGlob } from './glob.ts'
+import { PathSpec } from '../../types.ts'
+import {
+  jsonResponse,
+  makeAccessor,
+  notFoundResponse,
+  routedFetch,
+  spec,
+  TEST_ROOT,
+  type FetchCall,
+} from './_test_util.ts'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function fileRoutes(call: FetchCall): Response {
+  if (call.method === 'HEAD' && call.url.includes('/fs/files/')) {
+    return new Response(null, { status: 200, headers: { 'Content-Length': '5' } })
+  }
+  if (call.method === 'HEAD') return new Response(null, { status: 200 })
+  if (call.method === 'GET') return new Response('hello', { status: 200 })
+  return new Response(null, { status: 200 })
+}
+
+describe('copy', () => {
+  it('downloads then uploads file contents', async () => {
+    const { fetch, calls } = routedFetch(fileRoutes)
+    vi.stubGlobal('fetch', fetch)
+    await copy(makeAccessor(), spec('/volume/a.txt'), spec('/volume/b.txt'))
+    const put = calls.find((c) => c.method === 'PUT')
+    expect(put?.url).toContain('b.txt')
+    expect(put?.url).toContain('overwrite=true')
+  })
+
+  it('is a no-op for the same backend path', async () => {
+    const { fetch, calls } = routedFetch(fileRoutes)
+    vi.stubGlobal('fetch', fetch)
+    await copy(makeAccessor(), spec('/volume/a.txt'), spec('/volume/a.txt'))
+    expect(calls.filter((c) => c.method === 'PUT' || c.method === 'DELETE')).toHaveLength(0)
+  })
+
+  it('still raises for a missing source on same-path copy', async () => {
+    const { fetch } = routedFetch(() => notFoundResponse())
+    vi.stubGlobal('fetch', fetch)
+    const err = (await copy(makeAccessor(), spec('/volume/gone.txt'), spec('/volume/gone.txt')).catch(
+      (e: unknown) => e,
+    )) as Error & { code?: string }
+    expect(err.code).toBe('ENOENT')
+  })
+
+  it('refuses directories without recursive', async () => {
+    const { fetch } = routedFetch((call) => {
+      if (call.method === 'HEAD' && call.url.includes('/fs/files/')) return notFoundResponse()
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const err = (await copy(makeAccessor(), spec('/volume/dir'), spec('/volume/dir2')).catch(
+      (e: unknown) => e,
+    )) as Error & { code?: string }
+    expect(err.code).toBe('EISDIR')
+  })
+
+  it('copies trees recursively', async () => {
+    const { fetch, calls } = routedFetch((call) => {
+      if (call.method === 'HEAD' && call.url.includes('/fs/files/')) return notFoundResponse()
+      if (call.method === 'HEAD') return new Response(null, { status: 200 })
+      if (call.method === 'GET' && call.url.includes('/fs/directories/')) {
+        return jsonResponse({ contents: [{ path: `${TEST_ROOT}/dir/a.txt` }] })
+      }
+      if (call.method === 'GET') return new Response('data', { status: 200 })
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    await copy(makeAccessor(), spec('/volume/dir'), spec('/volume/dir2'), undefined, true)
+    const puts = calls.filter((c) => c.method === 'PUT')
+    expect(puts.some((c) => c.url.includes('/fs/directories/') && c.url.includes('dir2'))).toBe(
+      true,
+    )
+    expect(puts.some((c) => c.url.includes('dir2/a.txt'))).toBe(true)
+  })
+})
+
+describe('rename', () => {
+  it('same-path rename is a no-op and never deletes (PR 142 guard)', async () => {
+    const { fetch, calls } = routedFetch(fileRoutes)
+    vi.stubGlobal('fetch', fetch)
+    await rename(makeAccessor(), spec('/volume/a.txt'), spec('/volume/a.txt'))
+    expect(calls.filter((c) => c.method === 'DELETE')).toHaveLength(0)
+    expect(calls.filter((c) => c.method === 'PUT')).toHaveLength(0)
+  })
+
+  it('copies then unlinks for distinct paths', async () => {
+    const { fetch, calls } = routedFetch(fileRoutes)
+    vi.stubGlobal('fetch', fetch)
+    await rename(makeAccessor(), spec('/volume/a.txt'), spec('/volume/b.txt'))
+    const methods = calls.map((c) => c.method)
+    expect(methods).toContain('PUT')
+    expect(methods).toContain('DELETE')
+    expect(calls.findIndex((c) => c.method === 'DELETE')).toBeGreaterThan(
+      calls.findIndex((c) => c.method === 'PUT'),
+    )
+  })
+
+  it('raises for a missing source', async () => {
+    const { fetch } = routedFetch(() => notFoundResponse())
+    vi.stubGlobal('fetch', fetch)
+    const err = (await rename(
+      makeAccessor(),
+      spec('/volume/gone.txt'),
+      spec('/volume/gone.txt'),
+    ).catch((e: unknown) => e)) as Error & { code?: string }
+    expect(err.code).toBe('ENOENT')
+  })
+})
+
+describe('resolveGlob', () => {
+  it('expands patterns against readdir output', async () => {
+    const { fetch } = routedFetch(() =>
+      jsonResponse({
+        contents: [
+          { path: `${TEST_ROOT}/a.md` },
+          { path: `${TEST_ROOT}/b.txt` },
+          { path: `${TEST_ROOT}/c.md` },
+        ],
+      }),
+    )
+    vi.stubGlobal('fetch', fetch)
+    const pattern = new PathSpec({
+      original: '/volume/*.md',
+      directory: '/volume/',
+      pattern: '*.md',
+      resolved: false,
+      prefix: '/volume',
+    })
+    const resolved = await resolveGlob(makeAccessor(), [pattern])
+    expect(resolved.map((p) => p.original)).toEqual(['/volume/a.md', '/volume/c.md'])
+  })
+
+  it('passes through resolved paths untouched', async () => {
+    const { fetch, calls } = routedFetch(() => jsonResponse({ contents: [] }))
+    vi.stubGlobal('fetch', fetch)
+    const plain = spec('/volume/a.txt')
+    const resolved = await resolveGlob(makeAccessor(), [plain])
+    expect(resolved).toEqual([plain])
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/typescript/packages/core/src/core/databricks_volume/create.ts
+++ b/typescript/packages/core/src/core/databricks_volume/create.ts
@@ -1,0 +1,26 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import type { PathSpec } from '../../types.ts'
+import { writeBytes } from './write.ts'
+
+export async function create(
+  accessor: DatabricksVolumeAccessor,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<void> {
+  await writeBytes(accessor, path, new Uint8Array(0), index)
+}

--- a/typescript/packages/core/src/core/databricks_volume/errors.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/errors.test.ts
@@ -26,9 +26,7 @@ describe('isNotFound', () => {
   })
 
   it('matches databricks not-found error codes', () => {
-    expect(isNotFound(new DatabricksVolumeApiError('x', 500, 'RESOURCE_DOES_NOT_EXIST'))).toBe(
-      true,
-    )
+    expect(isNotFound(new DatabricksVolumeApiError('x', 500, 'RESOURCE_DOES_NOT_EXIST'))).toBe(true)
     expect(isNotFound(new DatabricksVolumeApiError('x', 500, 'NOT_FOUND'))).toBe(true)
   })
 
@@ -38,9 +36,7 @@ describe('isNotFound', () => {
   })
 
   it('rejects other errors and non-errors', () => {
-    expect(isNotFound(new DatabricksVolumeApiError('denied', 403, 'PERMISSION_DENIED'))).toBe(
-      false,
-    )
+    expect(isNotFound(new DatabricksVolumeApiError('denied', 403, 'PERMISSION_DENIED'))).toBe(false)
     expect(isNotFound('not an error')).toBe(false)
   })
 })

--- a/typescript/packages/core/src/core/databricks_volume/errors.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/errors.test.ts
@@ -1,0 +1,59 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import {
+  DatabricksVolumeApiError,
+  isNotFound,
+  notADirectoryError,
+  notFoundError,
+} from './errors.ts'
+
+describe('isNotFound', () => {
+  it('matches 404 status codes', () => {
+    expect(isNotFound(new DatabricksVolumeApiError('boom', 404))).toBe(true)
+  })
+
+  it('matches databricks not-found error codes', () => {
+    expect(isNotFound(new DatabricksVolumeApiError('x', 500, 'RESOURCE_DOES_NOT_EXIST'))).toBe(
+      true,
+    )
+    expect(isNotFound(new DatabricksVolumeApiError('x', 500, 'NOT_FOUND'))).toBe(true)
+  })
+
+  it('matches not-found phrasing in messages', () => {
+    expect(isNotFound(new Error('path Not Found'))).toBe(true)
+    expect(isNotFound(new Error('object does not exist'))).toBe(true)
+  })
+
+  it('rejects other errors and non-errors', () => {
+    expect(isNotFound(new DatabricksVolumeApiError('denied', 403, 'PERMISSION_DENIED'))).toBe(
+      false,
+    )
+    expect(isNotFound('not an error')).toBe(false)
+  })
+})
+
+describe('error constructors', () => {
+  it('builds ENOENT errors', () => {
+    const e = notFoundError('/a.txt') as Error & { code: string }
+    expect(e.code).toBe('ENOENT')
+    expect(e.message).toContain('/a.txt')
+  })
+
+  it('builds ENOTDIR errors', () => {
+    const e = notADirectoryError('/a.txt') as Error & { code: string }
+    expect(e.code).toBe('ENOTDIR')
+  })
+})

--- a/typescript/packages/core/src/core/databricks_volume/errors.ts
+++ b/typescript/packages/core/src/core/databricks_volume/errors.ts
@@ -40,6 +40,24 @@ export function notADirectoryError(path: string): Error {
   return e
 }
 
+export function alreadyExistsError(path: string): Error {
+  const e = new Error(`databricks_volume: file exists: ${path}`) as Error & { code: string }
+  e.code = 'EEXIST'
+  return e
+}
+
+export function isADirectoryError(path: string): Error {
+  const e = new Error(`databricks_volume: is a directory: ${path}`) as Error & { code: string }
+  e.code = 'EISDIR'
+  return e
+}
+
+export function notEmptyError(path: string): Error {
+  const e = new Error(`directory not empty: ${path}`) as Error & { code: string }
+  e.code = 'ENOTEMPTY'
+  return e
+}
+
 export function isNotFound(exc: unknown): boolean {
   if (!(exc instanceof Error)) return false
   const statusCode = (exc as { statusCode?: unknown }).statusCode

--- a/typescript/packages/core/src/core/databricks_volume/errors.ts
+++ b/typescript/packages/core/src/core/databricks_volume/errors.ts
@@ -1,0 +1,51 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+export class DatabricksVolumeApiError extends Error {
+  readonly statusCode: number
+  readonly errorCode: string | null
+
+  constructor(message: string, statusCode: number, errorCode: string | null = null) {
+    super(message)
+    this.name = 'DatabricksVolumeApiError'
+    this.statusCode = statusCode
+    this.errorCode = errorCode
+  }
+}
+
+const NOT_FOUND_CODES = new Set(['RESOURCE_DOES_NOT_EXIST', 'NOT_FOUND'])
+
+export function notFoundError(path: string): Error {
+  const e = new Error(`databricks_volume: no such file or directory: ${path}`) as Error & {
+    code: string
+  }
+  e.code = 'ENOENT'
+  return e
+}
+
+export function notADirectoryError(path: string): Error {
+  const e = new Error(`databricks_volume: not a directory: ${path}`) as Error & { code: string }
+  e.code = 'ENOTDIR'
+  return e
+}
+
+export function isNotFound(exc: unknown): boolean {
+  if (!(exc instanceof Error)) return false
+  const statusCode = (exc as { statusCode?: unknown }).statusCode
+  if (statusCode === 404) return true
+  const errorCode = (exc as { errorCode?: unknown }).errorCode
+  if (typeof errorCode === 'string' && NOT_FOUND_CODES.has(errorCode)) return true
+  const message = exc.message.toLowerCase()
+  return message.includes('not found') || message.includes('does not exist')
+}

--- a/typescript/packages/core/src/core/databricks_volume/exists.ts
+++ b/typescript/packages/core/src/core/databricks_volume/exists.ts
@@ -1,0 +1,27 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import type { PathSpec } from '../../types.ts'
+import { stat } from './stat.ts'
+
+export async function exists(accessor: DatabricksVolumeAccessor, path: PathSpec): Promise<boolean> {
+  try {
+    await stat(accessor, path)
+    return true
+  } catch (exc) {
+    if ((exc as { code?: string }).code === 'ENOENT') return false
+    throw exc
+  }
+}

--- a/typescript/packages/core/src/core/databricks_volume/find.ts
+++ b/typescript/packages/core/src/core/databricks_volume/find.ts
@@ -1,0 +1,45 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import type { FindOptions } from '../../resource/base.ts'
+import type { PathSpec } from '../../types.ts'
+import { walkFind } from '../generic/find.ts'
+import { readdir } from './readdir.ts'
+import { stat } from './stat.ts'
+
+function isDirName(_child: string): boolean | null {
+  // Databricks readdir returns slash-less paths, so classification always
+  // falls back to stat (which the walker resolves via the index cache).
+  return null
+}
+
+export async function find(
+  accessor: DatabricksVolumeAccessor,
+  path: PathSpec,
+  options: FindOptions = {},
+  index?: IndexCacheStore,
+): Promise<string[]> {
+  return walkFind(
+    path,
+    {
+      readdir: (spec, idx) => readdir(accessor, spec, idx),
+      stat: (spec, idx) => stat(accessor, spec, idx),
+      isDirName,
+    },
+    options,
+    index,
+  )
+}

--- a/typescript/packages/core/src/core/databricks_volume/glob.ts
+++ b/typescript/packages/core/src/core/databricks_volume/glob.ts
@@ -1,0 +1,49 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { PathSpec } from '../../types.ts'
+import { fnmatch } from '../../util/fnmatch.ts'
+import { readdir } from './readdir.ts'
+
+const SCOPE_ERROR = 10_000
+
+export async function resolveGlob(
+  accessor: DatabricksVolumeAccessor,
+  paths: readonly PathSpec[],
+  index?: IndexCacheStore,
+): Promise<PathSpec[]> {
+  const result: PathSpec[] = []
+  for (const p of paths) {
+    if (p.resolved) {
+      result.push(p)
+      continue
+    }
+    if (p.pattern !== null && p.pattern !== '') {
+      const entries = await readdir(accessor, p.dir, index)
+      const matched: PathSpec[] = []
+      for (const entry of entries) {
+        const entryBase = entry.split('/').pop() ?? ''
+        if (!fnmatch(entryBase, p.pattern)) continue
+        matched.push(PathSpec.fromStrPath(entry, p.prefix))
+      }
+      const truncated = matched.length > SCOPE_ERROR ? matched.slice(0, SCOPE_ERROR) : matched
+      result.push(...truncated)
+    } else {
+      result.push(p)
+    }
+  }
+  return result
+}

--- a/typescript/packages/core/src/core/databricks_volume/mkdir.ts
+++ b/typescript/packages/core/src/core/databricks_volume/mkdir.ts
@@ -1,0 +1,58 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { FileType, type PathSpec } from '../../types.ts'
+import { dbxFetch } from './_client.ts'
+import { ensurePathSpec, parentPath } from './_helpers.ts'
+import { alreadyExistsError, isNotFound, notADirectoryError, notFoundError } from './errors.ts'
+import { exists } from './exists.ts'
+import { backendPath } from './path.ts'
+import { stat } from './stat.ts'
+
+async function createDirectory(
+  accessor: DatabricksVolumeAccessor,
+  remotePath: string,
+  virtualTarget: string,
+): Promise<void> {
+  try {
+    await dbxFetch(accessor, 'PUT', 'directories', remotePath)
+  } catch (exc) {
+    if (isNotFound(exc)) throw notFoundError(virtualTarget)
+    throw exc
+  }
+}
+
+export async function mkdir(
+  accessor: DatabricksVolumeAccessor,
+  path: PathSpec,
+  index?: IndexCacheStore,
+  parents = false,
+): Promise<void> {
+  const p = ensurePathSpec(path)
+  const remotePath = backendPath(accessor.config, p)
+  if (parents) {
+    await createDirectory(accessor, remotePath, p.stripPrefix)
+    return
+  }
+  if (await exists(accessor, p)) {
+    throw alreadyExistsError(p.stripPrefix)
+  }
+  const parentStat = await stat(accessor, parentPath(p), index)
+  if (parentStat.type !== FileType.DIRECTORY) {
+    throw notADirectoryError(p.stripPrefix)
+  }
+  await createDirectory(accessor, remotePath, p.stripPrefix)
+}

--- a/typescript/packages/core/src/core/databricks_volume/path.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/path.test.ts
@@ -18,13 +18,7 @@ import {
   normalizeDatabricksVolumeConfig,
   type DatabricksVolumeConfig,
 } from '../../resource/databricks_volume/config.ts'
-import {
-  backendPath,
-  configuredRoot,
-  normalizePosix,
-  virtualPath,
-  volumeRoot,
-} from './path.ts'
+import { backendPath, configuredRoot, normalizePosix, virtualPath, volumeRoot } from './path.ts'
 
 const CONFIG: DatabricksVolumeConfig = normalizeDatabricksVolumeConfig({
   catalog: 'main',
@@ -119,9 +113,7 @@ describe('virtualPath', () => {
   })
 
   it('returns the prefix for the root itself', () => {
-    expect(virtualPath(CONFIG, '/Volumes/main/default/agent_files/root', '/volume')).toBe(
-      '/volume',
-    )
+    expect(virtualPath(CONFIG, '/Volumes/main/default/agent_files/root', '/volume')).toBe('/volume')
   })
 
   it('rejects backend paths outside the root', () => {

--- a/typescript/packages/core/src/core/databricks_volume/path.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/path.test.ts
@@ -1,0 +1,132 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { PathSpec } from '../../types.ts'
+import {
+  normalizeDatabricksVolumeConfig,
+  type DatabricksVolumeConfig,
+} from '../../resource/databricks_volume/config.ts'
+import {
+  backendPath,
+  configuredRoot,
+  normalizePosix,
+  virtualPath,
+  volumeRoot,
+} from './path.ts'
+
+const CONFIG: DatabricksVolumeConfig = normalizeDatabricksVolumeConfig({
+  catalog: 'main',
+  schema: 'default',
+  volume: 'agent_files',
+  root_path: '/root',
+})
+
+describe('normalizePosix', () => {
+  it('collapses dot segments and duplicate slashes', () => {
+    expect(normalizePosix('/a//b/./c')).toBe('/a/b/c')
+    expect(normalizePosix('/a/b/../c')).toBe('/a/c')
+    expect(normalizePosix('/')).toBe('/')
+  })
+})
+
+describe('volumeRoot / configuredRoot', () => {
+  it('joins catalog, schema, and volume', () => {
+    expect(volumeRoot(CONFIG)).toBe('/Volumes/main/default/agent_files')
+  })
+
+  it('appends the normalized root_path', () => {
+    expect(configuredRoot(CONFIG)).toBe('/Volumes/main/default/agent_files/root')
+  })
+
+  it('defaults to the volume root without root_path', () => {
+    const config = normalizeDatabricksVolumeConfig({
+      catalog: 'main',
+      schema: 'default',
+      volume: 'agent_files',
+    })
+    expect(configuredRoot(config)).toBe('/Volumes/main/default/agent_files')
+  })
+})
+
+describe('backendPath', () => {
+  it('maps a mounted path under the configured root', () => {
+    const path = new PathSpec({
+      original: '/volume/reports/latest.md',
+      directory: '/volume/reports',
+      prefix: '/volume',
+    })
+    expect(backendPath(CONFIG, path)).toBe(
+      '/Volumes/main/default/agent_files/root/reports/latest.md',
+    )
+  })
+
+  it('allows normalized paths that stay inside the root', () => {
+    const path = new PathSpec({
+      original: '/volume/reports/../latest.md',
+      directory: '/volume/reports',
+      prefix: '/volume',
+    })
+    expect(backendPath(CONFIG, path)).toBe('/Volumes/main/default/agent_files/root/latest.md')
+  })
+
+  it('rejects escapes above the configured root', () => {
+    const path = new PathSpec({
+      original: '/volume/../../other_schema/other_volume/secret.txt',
+      directory: '/volume',
+      prefix: '/volume',
+    })
+    expect(() => backendPath(CONFIG, path)).toThrow('escapes Databricks volume root')
+  })
+
+  it('accepts raw string paths', () => {
+    expect(backendPath(CONFIG, '/reports/a.txt')).toBe(
+      '/Volumes/main/default/agent_files/root/reports/a.txt',
+    )
+    expect(backendPath(CONFIG, '/')).toBe('/Volumes/main/default/agent_files/root')
+  })
+})
+
+describe('config root_path validation', () => {
+  it('rejects parent segments in root_path', () => {
+    expect(() =>
+      normalizeDatabricksVolumeConfig({
+        catalog: 'main',
+        schema: 'default',
+        volume: 'agent_files',
+        root_path: '/root/../other',
+      }),
+    ).toThrow()
+  })
+})
+
+describe('virtualPath', () => {
+  it('maps backend paths back under the mount prefix', () => {
+    expect(
+      virtualPath(CONFIG, '/Volumes/main/default/agent_files/root/reports/latest.md', '/volume'),
+    ).toBe('/volume/reports/latest.md')
+  })
+
+  it('returns the prefix for the root itself', () => {
+    expect(virtualPath(CONFIG, '/Volumes/main/default/agent_files/root', '/volume')).toBe(
+      '/volume',
+    )
+  })
+
+  it('rejects backend paths outside the root', () => {
+    expect(() =>
+      virtualPath(CONFIG, '/Volumes/main/default/other_volume/secret.txt', '/volume'),
+    ).toThrow('outside Databricks volume root')
+  })
+})

--- a/typescript/packages/core/src/core/databricks_volume/path.ts
+++ b/typescript/packages/core/src/core/databricks_volume/path.ts
@@ -62,11 +62,7 @@ export function backendPath(config: DatabricksVolumeConfig, path: PathSpec | str
 export function virtualPath(config: DatabricksVolumeConfig, backend: string, prefix = ''): string {
   const root = configuredRoot(config)
   const remotePath = normalizePosix(backend)
-  assertInsideRoot(
-    root,
-    remotePath,
-    `backend path is outside Databricks volume root: ${backend}`,
-  )
+  assertInsideRoot(root, remotePath, `backend path is outside Databricks volume root: ${backend}`)
   const relative = stripSlash(remotePath === root ? '' : remotePath.slice(root.length))
   const path = relative !== '' ? '/' + relative : '/'
   if (prefix !== '' && path !== '/') return rstripSlash(prefix) + path

--- a/typescript/packages/core/src/core/databricks_volume/path.ts
+++ b/typescript/packages/core/src/core/databricks_volume/path.ts
@@ -1,0 +1,74 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeConfig } from '../../resource/databricks_volume/config.ts'
+import { PathSpec } from '../../types.ts'
+import { stripSlash, rstripSlash } from '../../util/slash.ts'
+
+export function normalizePosix(path: string): string {
+  const absolute = path.startsWith('/')
+  const out: string[] = []
+  for (const part of path.split('/')) {
+    if (part === '' || part === '.') continue
+    if (part === '..') {
+      if (out.length > 0 && out[out.length - 1] !== '..') out.pop()
+      else if (!absolute) out.push('..')
+      continue
+    }
+    out.push(part)
+  }
+  const joined = out.join('/')
+  if (absolute) return '/' + joined
+  return joined === '' ? '.' : joined
+}
+
+export function volumeRoot(config: DatabricksVolumeConfig): string {
+  return `/Volumes/${config.catalog}/${config.schema}/${config.volume}`
+}
+
+function assertInsideRoot(root: string, path: string, message: string): void {
+  if (path === root || path.startsWith(root + '/')) return
+  throw new Error(message)
+}
+
+export function configuredRoot(config: DatabricksVolumeConfig): string {
+  const rootRelative = stripSlash(config.rootPath)
+  if (rootRelative !== '') {
+    return normalizePosix(`${volumeRoot(config)}/${rootRelative}`)
+  }
+  return normalizePosix(volumeRoot(config))
+}
+
+export function backendPath(config: DatabricksVolumeConfig, path: PathSpec | string): string {
+  const raw = path instanceof PathSpec ? path.stripPrefix : path
+  const relative = stripSlash(raw)
+  const root = configuredRoot(config)
+  const remotePath = normalizePosix(relative !== '' ? `${root}/${relative}` : root)
+  assertInsideRoot(root, remotePath, `path escapes Databricks volume root: ${raw}`)
+  return remotePath
+}
+
+export function virtualPath(config: DatabricksVolumeConfig, backend: string, prefix = ''): string {
+  const root = configuredRoot(config)
+  const remotePath = normalizePosix(backend)
+  assertInsideRoot(
+    root,
+    remotePath,
+    `backend path is outside Databricks volume root: ${backend}`,
+  )
+  const relative = stripSlash(remotePath === root ? '' : remotePath.slice(root.length))
+  const path = relative !== '' ? '/' + relative : '/'
+  if (prefix !== '' && path !== '/') return rstripSlash(prefix) + path
+  return prefix !== '' ? prefix : path
+}

--- a/typescript/packages/core/src/core/databricks_volume/read.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/read.test.ts
@@ -42,7 +42,7 @@ describe('readBytes', () => {
     vi.stubGlobal('fetch', fetch)
     const data = await readBytes(makeAccessor(), spec('/volume/a.txt'))
     expect(new TextDecoder().decode(data)).toBe('hello')
-    expect(calls[0].headers.Range).toBeUndefined()
+    expect(calls[0]?.headers.Range).toBeUndefined()
   })
 
   it('sends Range for offset/size reads', async () => {
@@ -53,7 +53,7 @@ describe('readBytes', () => {
       size: 3,
     })
     expect(new TextDecoder().decode(data)).toBe('ell')
-    expect(calls[0].headers.Range).toBe('bytes=1-3')
+    expect(calls[0]?.headers.Range).toBe('bytes=1-3')
   })
 
   it('short-circuits size=0 reads without a request', async () => {

--- a/typescript/packages/core/src/core/databricks_volume/read.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/read.test.ts
@@ -1,0 +1,75 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { rangeHeader, readBytes } from './read.ts'
+import { makeAccessor, notFoundResponse, routedFetch, spec } from './_test_util.ts'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('rangeHeader', () => {
+  it('returns null for whole-file reads', () => {
+    expect(rangeHeader(0, null)).toBeNull()
+  })
+
+  it('builds open and closed ranges', () => {
+    expect(rangeHeader(5, null)).toBe('bytes=5-')
+    expect(rangeHeader(5, 10)).toBe('bytes=5-14')
+  })
+
+  it('rejects negative offset or size', () => {
+    expect(() => rangeHeader(-1, null)).toThrow('offset must be non-negative')
+    expect(() => rangeHeader(0, -2)).toThrow('size must be non-negative')
+  })
+})
+
+describe('readBytes', () => {
+  it('downloads whole files without a Range header', async () => {
+    const { fetch, calls } = routedFetch(() => new Response('hello', { status: 200 }))
+    vi.stubGlobal('fetch', fetch)
+    const data = await readBytes(makeAccessor(), spec('/volume/a.txt'))
+    expect(new TextDecoder().decode(data)).toBe('hello')
+    expect(calls[0].headers.Range).toBeUndefined()
+  })
+
+  it('sends Range for offset/size reads', async () => {
+    const { fetch, calls } = routedFetch(() => new Response('ell', { status: 206 }))
+    vi.stubGlobal('fetch', fetch)
+    const data = await readBytes(makeAccessor(), spec('/volume/a.txt'), undefined, {
+      offset: 1,
+      size: 3,
+    })
+    expect(new TextDecoder().decode(data)).toBe('ell')
+    expect(calls[0].headers.Range).toBe('bytes=1-3')
+  })
+
+  it('short-circuits size=0 reads without a request', async () => {
+    const { fetch, calls } = routedFetch(() => new Response('x', { status: 200 }))
+    vi.stubGlobal('fetch', fetch)
+    const data = await readBytes(makeAccessor(), spec('/volume/a.txt'), undefined, { size: 0 })
+    expect(data.byteLength).toBe(0)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('raises ENOENT for missing files', async () => {
+    const { fetch } = routedFetch(() => notFoundResponse())
+    vi.stubGlobal('fetch', fetch)
+    const err = (await readBytes(makeAccessor(), spec('/volume/gone.txt')).catch(
+      (e: unknown) => e,
+    )) as Error & { code?: string }
+    expect(err.code).toBe('ENOENT')
+  })
+})

--- a/typescript/packages/core/src/core/databricks_volume/read.ts
+++ b/typescript/packages/core/src/core/databricks_volume/read.ts
@@ -1,0 +1,64 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { record } from '../../observe/context.ts'
+import { ResourceName, type PathSpec } from '../../types.ts'
+import { dbxFetch } from './_client.ts'
+import { isNotFound, notFoundError } from './errors.ts'
+import { backendPath } from './path.ts'
+
+export function rangeHeader(offset: number, size: number | null): string | null {
+  if (offset < 0) throw new Error('offset must be non-negative')
+  if (size !== null && size < 0) throw new Error('size must be non-negative')
+  if (offset === 0 && size === null) return null
+  if (size === null) return `bytes=${String(offset)}-`
+  return `bytes=${String(offset)}-${String(offset + size - 1)}`
+}
+
+export interface DbxReadOptions {
+  offset?: number
+  size?: number
+}
+
+export async function readBytes(
+  accessor: DatabricksVolumeAccessor,
+  path: PathSpec,
+  _index?: IndexCacheStore,
+  options: DbxReadOptions = {},
+): Promise<Uint8Array> {
+  const virtual = path.original
+  const remotePath = backendPath(accessor.config, path)
+  const startMs = performance.now()
+  const offset = options.offset ?? 0
+  const size = options.size ?? null
+  if (size === 0) {
+    record('read', virtual, ResourceName.DATABRICKS_VOLUME, 0, startMs)
+    return new Uint8Array(0)
+  }
+  const range = rangeHeader(offset, size)
+  const headers: Record<string, string> = { Accept: 'application/octet-stream' }
+  if (range !== null) headers.Range = range
+  let r: Response
+  try {
+    r = await dbxFetch(accessor, 'GET', 'files', remotePath, { headers })
+  } catch (exc) {
+    if (isNotFound(exc)) throw notFoundError(path.stripPrefix)
+    throw exc
+  }
+  const data = new Uint8Array(await r.arrayBuffer())
+  record('read', virtual, ResourceName.DATABRICKS_VOLUME, data.byteLength, startMs)
+  return data
+}

--- a/typescript/packages/core/src/core/databricks_volume/readdir.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/readdir.test.ts
@@ -15,7 +15,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
 import { readdir } from './readdir.ts'
-import { jsonResponse, makeAccessor, notFoundResponse, routedFetch, spec, TEST_ROOT } from './_test_util.ts'
+import {
+  jsonResponse,
+  makeAccessor,
+  notFoundResponse,
+  routedFetch,
+  spec,
+  TEST_ROOT,
+} from './_test_util.ts'
 
 afterEach(() => {
   vi.unstubAllGlobals()

--- a/typescript/packages/core/src/core/databricks_volume/readdir.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/readdir.test.ts
@@ -1,0 +1,76 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
+import { readdir } from './readdir.ts'
+import { jsonResponse, makeAccessor, notFoundResponse, routedFetch, spec, TEST_ROOT } from './_test_util.ts'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('readdir', () => {
+  it('lists sorted virtual paths without trailing slashes', async () => {
+    const { fetch } = routedFetch(() =>
+      jsonResponse({
+        contents: [
+          { path: `${TEST_ROOT}/b.txt`, is_directory: false, file_size: 2 },
+          { path: `${TEST_ROOT}/a`, is_directory: true },
+        ],
+      }),
+    )
+    vi.stubGlobal('fetch', fetch)
+    const names = await readdir(makeAccessor(), spec('/volume/'))
+    expect(names).toEqual(['/volume/a', '/volume/b.txt'])
+  })
+
+  it('follows next_page_token pagination', async () => {
+    const { fetch, calls } = routedFetch((call) => {
+      if (call.url.includes('page_token=next')) {
+        return jsonResponse({ contents: [{ path: `${TEST_ROOT}/b.txt` }] })
+      }
+      return jsonResponse({
+        contents: [{ path: `${TEST_ROOT}/a.txt` }],
+        next_page_token: 'next',
+      })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const names = await readdir(makeAccessor(), spec('/volume/'))
+    expect(names).toEqual(['/volume/a.txt', '/volume/b.txt'])
+    expect(calls).toHaveLength(2)
+  })
+
+  it('raises ENOENT for missing directories', async () => {
+    const { fetch } = routedFetch(() => notFoundResponse())
+    vi.stubGlobal('fetch', fetch)
+    const err = (await readdir(makeAccessor(), spec('/volume/missing')).catch(
+      (e: unknown) => e,
+    )) as Error & { code?: string }
+    expect(err.code).toBe('ENOENT')
+  })
+
+  it('serves and fills the index cache', async () => {
+    const { fetch, calls } = routedFetch(() =>
+      jsonResponse({ contents: [{ path: `${TEST_ROOT}/a.txt`, file_size: 1 }] }),
+    )
+    vi.stubGlobal('fetch', fetch)
+    const index = new RAMIndexCacheStore()
+    const first = await readdir(makeAccessor(), spec('/volume/'), index)
+    const second = await readdir(makeAccessor(), spec('/volume/'), index)
+    expect(first).toEqual(['/volume/a.txt'])
+    expect(second).toEqual(first)
+    expect(calls).toHaveLength(1)
+  })
+})

--- a/typescript/packages/core/src/core/databricks_volume/readdir.ts
+++ b/typescript/packages/core/src/core/databricks_volume/readdir.ts
@@ -1,0 +1,101 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import { IndexEntry } from '../../cache/index/config.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import type { PathSpec } from '../../types.ts'
+import { rstripSlash } from '../../util/slash.ts'
+import { dbxFetch } from './_client.ts'
+import { isNotFound, notFoundError } from './errors.ts'
+import { backendPath, virtualPath } from './path.ts'
+
+export interface DbxDirectoryEntry {
+  path: string
+  is_directory?: boolean
+  file_size?: number
+  last_modified?: number
+  name?: string
+}
+
+interface DbxDirectoryPage {
+  contents?: DbxDirectoryEntry[]
+  next_page_token?: string
+}
+
+export async function listDirectoryContents(
+  accessor: DatabricksVolumeAccessor,
+  remotePath: string,
+): Promise<DbxDirectoryEntry[]> {
+  const entries: DbxDirectoryEntry[] = []
+  let pageToken: string | undefined
+  do {
+    const query: Record<string, string> = pageToken !== undefined ? { page_token: pageToken } : {}
+    const r = await dbxFetch(accessor, 'GET', 'directories', remotePath, { query })
+    const page = (await r.json()) as DbxDirectoryPage
+    entries.push(...(page.contents ?? []))
+    pageToken = page.next_page_token !== '' ? page.next_page_token : undefined
+  } while (pageToken !== undefined)
+  return entries
+}
+
+export async function readdir(
+  accessor: DatabricksVolumeAccessor,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<string[]> {
+  const listPath = path.pattern !== null ? path.dir : path
+  const virtualKey = rstripSlash(listPath.original) || '/'
+  if (index !== undefined) {
+    const listing = await index.listDir(virtualKey)
+    if (listing.entries !== undefined && listing.entries !== null) return listing.entries
+  }
+  const remotePath = backendPath(accessor.config, listPath)
+  let entries: DbxDirectoryEntry[]
+  try {
+    entries = await listDirectoryContents(accessor, remotePath)
+  } catch (exc) {
+    if (isNotFound(exc)) throw notFoundError(listPath.stripPrefix)
+    throw exc
+  }
+  const pairs = entries
+    .map(
+      (entry) =>
+        [virtualPath(accessor.config, entry.path, path.prefix), entry] as [
+          string,
+          DbxDirectoryEntry,
+        ],
+    )
+    .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+  const names: string[] = []
+  const indexEntries: [string, IndexEntry][] = []
+  for (const [fullPath, entry] of pairs) {
+    const isDir = entry.is_directory === true
+    names.push(fullPath)
+    const name = rstripSlash(fullPath).split('/').pop() ?? fullPath
+    indexEntries.push([
+      name,
+      new IndexEntry({
+        id: fullPath,
+        name,
+        resourceType: isDir ? 'folder' : 'file',
+        size: !isDir && typeof entry.file_size === 'number' ? entry.file_size : null,
+      }),
+    ])
+  }
+  if (index !== undefined) {
+    await index.setDir(virtualKey, indexEntries)
+  }
+  return names
+}

--- a/typescript/packages/core/src/core/databricks_volume/rename.ts
+++ b/typescript/packages/core/src/core/databricks_volume/rename.ts
@@ -1,0 +1,49 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { FileType, type PathSpec } from '../../types.ts'
+import { ensurePathSpec } from './_helpers.ts'
+import { copy } from './copy.ts'
+import { backendPath } from './path.ts'
+import { rmRecursive } from './rm.ts'
+import { stat } from './stat.ts'
+import { unlink } from './unlink.ts'
+
+export async function rename(
+  accessor: DatabricksVolumeAccessor,
+  src: PathSpec,
+  dst: PathSpec,
+  index?: IndexCacheStore,
+): Promise<void> {
+  // Non-atomic: the Databricks Files API has no native rename, so this is
+  // implemented as copy + delete and can leave partial state on failure.
+  const s = ensurePathSpec(src)
+  const d = ensurePathSpec(dst)
+  const srcStat = await stat(accessor, s, index)
+  if (backendPath(accessor.config, s) === backendPath(accessor.config, d)) {
+    // rename(2) onto the same path is a no-op; copy + unlink here would
+    // upload the file onto itself then delete it, destroying the data.
+    // Guard runs after stat so a missing source still raises.
+    return
+  }
+  if (srcStat.type === FileType.DIRECTORY) {
+    await copy(accessor, s, d, index, true)
+    await rmRecursive(accessor, s, index)
+  } else {
+    await copy(accessor, s, d, index)
+    await unlink(accessor, s, index)
+  }
+}

--- a/typescript/packages/core/src/core/databricks_volume/rm.ts
+++ b/typescript/packages/core/src/core/databricks_volume/rm.ts
@@ -1,0 +1,63 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { FileType, type PathSpec } from '../../types.ts'
+import { dbxFetch } from './_client.ts'
+import { ensurePathSpec } from './_helpers.ts'
+import { isNotFound, notFoundError } from './errors.ts'
+import { backendPath, virtualPath } from './path.ts'
+import { listDirectoryContents } from './readdir.ts'
+import { stat } from './stat.ts'
+import { unlink } from './unlink.ts'
+
+async function removeTreeRecurse(
+  accessor: DatabricksVolumeAccessor,
+  remoteDir: string,
+  removed: string[],
+): Promise<void> {
+  for (const entry of await listDirectoryContents(accessor, remoteDir)) {
+    if (entry.is_directory === true) {
+      await removeTreeRecurse(accessor, entry.path, removed)
+    } else {
+      await dbxFetch(accessor, 'DELETE', 'files', entry.path)
+      removed.push(entry.path)
+    }
+  }
+  await dbxFetch(accessor, 'DELETE', 'directories', remoteDir)
+  removed.push(remoteDir)
+}
+
+export async function rmRecursive(
+  accessor: DatabricksVolumeAccessor,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<string[]> {
+  const p = ensurePathSpec(path)
+  const fileStat = await stat(accessor, p, index)
+  if (fileStat.type !== FileType.DIRECTORY) {
+    await unlink(accessor, p, index)
+    return [p.stripPrefix]
+  }
+  const remoteRoot = backendPath(accessor.config, p)
+  const removed: string[] = []
+  try {
+    await removeTreeRecurse(accessor, remoteRoot, removed)
+  } catch (exc) {
+    if (isNotFound(exc)) throw notFoundError(p.stripPrefix)
+    throw exc
+  }
+  return removed.map((backend) => virtualPath(accessor.config, backend, ''))
+}

--- a/typescript/packages/core/src/core/databricks_volume/rmdir.ts
+++ b/typescript/packages/core/src/core/databricks_volume/rmdir.ts
@@ -1,0 +1,52 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { FileType, type PathSpec } from '../../types.ts'
+import { dbxFetch } from './_client.ts'
+import { ensurePathSpec } from './_helpers.ts'
+import { isNotFound, notADirectoryError, notEmptyError, notFoundError } from './errors.ts'
+import { backendPath } from './path.ts'
+import { listDirectoryContents } from './readdir.ts'
+import { stat } from './stat.ts'
+
+export async function rmdir(
+  accessor: DatabricksVolumeAccessor,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<void> {
+  const p = ensurePathSpec(path)
+  const fileStat = await stat(accessor, p, index)
+  if (fileStat.type !== FileType.DIRECTORY) {
+    throw notADirectoryError(p.stripPrefix)
+  }
+  const remotePath = backendPath(accessor.config, p)
+  let entries
+  try {
+    entries = await listDirectoryContents(accessor, remotePath)
+  } catch (exc) {
+    if (isNotFound(exc)) throw notFoundError(p.stripPrefix)
+    throw exc
+  }
+  if (entries.length > 0) {
+    throw notEmptyError(p.stripPrefix)
+  }
+  try {
+    await dbxFetch(accessor, 'DELETE', 'directories', remotePath)
+  } catch (exc) {
+    if (isNotFound(exc)) throw notFoundError(p.stripPrefix)
+    throw exc
+  }
+}

--- a/typescript/packages/core/src/core/databricks_volume/stat.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/stat.test.ts
@@ -40,8 +40,8 @@ describe('stat', () => {
     expect(st.size).toBe(42)
     expect(st.modified).toBe('2026-06-10T01:02:03.000Z')
     expect(st.type).not.toBe(FileType.DIRECTORY)
-    expect(calls[0].method).toBe('HEAD')
-    expect(calls[0].url).toContain('/fs/files/')
+    expect(calls[0]?.method).toBe('HEAD')
+    expect(calls[0]?.url).toContain('/fs/files/')
   })
 
   it('falls back to directory metadata on file 404', async () => {
@@ -54,7 +54,7 @@ describe('stat', () => {
     expect(st.name).toBe('reports')
     expect(st.type).toBe(FileType.DIRECTORY)
     expect(calls.map((c) => c.method)).toEqual(['HEAD', 'HEAD'])
-    expect(calls[1].url).toContain('/fs/directories/')
+    expect(calls[1]?.url).toContain('/fs/directories/')
   })
 
   it('raises ENOENT when neither file nor directory exists', async () => {

--- a/typescript/packages/core/src/core/databricks_volume/stat.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/stat.test.ts
@@ -1,0 +1,90 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { FileType } from '../../types.ts'
+import { exists } from './exists.ts'
+import { stat } from './stat.ts'
+import { makeAccessor, notFoundResponse, routedFetch, spec } from './_test_util.ts'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('stat', () => {
+  it('returns file metadata from HEAD headers', async () => {
+    const { fetch, calls } = routedFetch(
+      () =>
+        new Response(null, {
+          status: 200,
+          headers: {
+            'Content-Length': '42',
+            'Last-Modified': 'Wed, 10 Jun 2026 01:02:03 GMT',
+          },
+        }),
+    )
+    vi.stubGlobal('fetch', fetch)
+    const st = await stat(makeAccessor(), spec('/volume/reports/a.txt'))
+    expect(st.name).toBe('a.txt')
+    expect(st.size).toBe(42)
+    expect(st.modified).toBe('2026-06-10T01:02:03.000Z')
+    expect(st.type).not.toBe(FileType.DIRECTORY)
+    expect(calls[0].method).toBe('HEAD')
+    expect(calls[0].url).toContain('/fs/files/')
+  })
+
+  it('falls back to directory metadata on file 404', async () => {
+    const { fetch, calls } = routedFetch((call) => {
+      if (call.url.includes('/fs/files/')) return notFoundResponse()
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const st = await stat(makeAccessor(), spec('/volume/reports'))
+    expect(st.name).toBe('reports')
+    expect(st.type).toBe(FileType.DIRECTORY)
+    expect(calls.map((c) => c.method)).toEqual(['HEAD', 'HEAD'])
+    expect(calls[1].url).toContain('/fs/directories/')
+  })
+
+  it('raises ENOENT when neither file nor directory exists', async () => {
+    const { fetch } = routedFetch(() => notFoundResponse())
+    vi.stubGlobal('fetch', fetch)
+    const err = (await stat(makeAccessor(), spec('/volume/gone')).catch(
+      (e: unknown) => e,
+    )) as Error & { code?: string }
+    expect(err.code).toBe('ENOENT')
+  })
+
+  it('returns a directory stat for the mount root without any request', async () => {
+    const { fetch, calls } = routedFetch(() => notFoundResponse())
+    vi.stubGlobal('fetch', fetch)
+    const st = await stat(makeAccessor(), spec('/volume/'))
+    expect(st.name).toBe('/')
+    expect(st.type).toBe(FileType.DIRECTORY)
+    expect(calls).toHaveLength(0)
+  })
+})
+
+describe('exists', () => {
+  it('maps stat success and ENOENT to booleans', async () => {
+    const { fetch } = routedFetch((call) =>
+      call.url.includes('a.txt')
+        ? new Response(null, { status: 200, headers: { 'Content-Length': '1' } })
+        : notFoundResponse(),
+    )
+    vi.stubGlobal('fetch', fetch)
+    expect(await exists(makeAccessor(), spec('/volume/a.txt'))).toBe(true)
+    expect(await exists(makeAccessor(), spec('/volume/gone.txt'))).toBe(false)
+  })
+})

--- a/typescript/packages/core/src/core/databricks_volume/stat.ts
+++ b/typescript/packages/core/src/core/databricks_volume/stat.ts
@@ -1,0 +1,74 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { FileStat, FileType, type PathSpec } from '../../types.ts'
+import { guessType } from '../../utils/filetype.ts'
+import { stripSlash } from '../../util/slash.ts'
+import { dbxFetch } from './_client.ts'
+import { isNotFound, notFoundError } from './errors.ts'
+import { backendPath } from './path.ts'
+
+function nameFromBackendPath(remotePath: string): string {
+  const stripped = stripSlash(remotePath)
+  return stripped.split('/').pop() ?? stripped
+}
+
+export function modifiedFromHeader(value: string | null): string | null {
+  if (value === null || value === '') return null
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return parsed.toISOString()
+}
+
+async function directoryStatOrRaise(
+  accessor: DatabricksVolumeAccessor,
+  remotePath: string,
+  path: PathSpec,
+): Promise<FileStat> {
+  try {
+    await dbxFetch(accessor, 'HEAD', 'directories', remotePath)
+  } catch (exc) {
+    if (isNotFound(exc)) throw notFoundError(path.stripPrefix)
+    throw exc
+  }
+  return new FileStat({ name: nameFromBackendPath(remotePath), type: FileType.DIRECTORY })
+}
+
+export async function stat(
+  accessor: DatabricksVolumeAccessor,
+  path: PathSpec,
+  _index?: IndexCacheStore,
+): Promise<FileStat> {
+  const stripped = stripSlash(path.stripPrefix)
+  if (stripped === '') {
+    return new FileStat({ name: '/', type: FileType.DIRECTORY })
+  }
+  const remotePath = backendPath(accessor.config, path)
+  let r: Response
+  try {
+    r = await dbxFetch(accessor, 'HEAD', 'files', remotePath)
+  } catch (exc) {
+    if (isNotFound(exc)) {
+      return directoryStatOrRaise(accessor, remotePath, path)
+    }
+    throw exc
+  }
+  const name = nameFromBackendPath(remotePath)
+  const lengthHeader = r.headers.get('content-length')
+  const size = lengthHeader !== null && lengthHeader !== '' ? Number(lengthHeader) : null
+  const modified = modifiedFromHeader(r.headers.get('last-modified'))
+  return new FileStat({ name, size, modified, type: guessType(name) })
+}

--- a/typescript/packages/core/src/core/databricks_volume/stream.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/stream.test.ts
@@ -46,9 +46,7 @@ describe('readStream', () => {
   })
 
   it('coalesces small network chunks', async () => {
-    const { fetch } = routedFetch(() =>
-      bodyResponse([new Uint8Array([1, 2]), new Uint8Array([3])]),
-    )
+    const { fetch } = routedFetch(() => bodyResponse([new Uint8Array([1, 2]), new Uint8Array([3])]))
     vi.stubGlobal('fetch', fetch)
     const chunks = await collect(readStream(makeAccessor(), spec('/volume/small.bin')))
     expect(chunks).toHaveLength(1)

--- a/typescript/packages/core/src/core/databricks_volume/stream.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/stream.test.ts
@@ -52,7 +52,7 @@ describe('readStream', () => {
     vi.stubGlobal('fetch', fetch)
     const chunks = await collect(readStream(makeAccessor(), spec('/volume/small.bin')))
     expect(chunks).toHaveLength(1)
-    expect(Array.from(chunks[0])).toEqual([1, 2, 3])
+    expect(Array.from(chunks[0] ?? [])).toEqual([1, 2, 3])
   })
 
   it('raises ENOENT for missing files', async () => {

--- a/typescript/packages/core/src/core/databricks_volume/stream.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/stream.test.ts
@@ -1,0 +1,66 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readStream } from './stream.ts'
+import { makeAccessor, notFoundResponse, routedFetch, spec } from './_test_util.ts'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function bodyResponse(chunks: Uint8Array[]): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk)
+      controller.close()
+    },
+  })
+  return new Response(stream, { status: 200 })
+}
+
+async function collect(iter: AsyncIterable<Uint8Array>): Promise<Uint8Array[]> {
+  const out: Uint8Array[] = []
+  for await (const chunk of iter) out.push(chunk)
+  return out
+}
+
+describe('readStream', () => {
+  it('re-chunks the body at 8192 bytes', async () => {
+    const big = new Uint8Array(8192 + 100).fill(7)
+    const { fetch } = routedFetch(() => bodyResponse([big]))
+    vi.stubGlobal('fetch', fetch)
+    const chunks = await collect(readStream(makeAccessor(), spec('/volume/big.bin')))
+    expect(chunks.map((c) => c.byteLength)).toEqual([8192, 100])
+  })
+
+  it('coalesces small network chunks', async () => {
+    const { fetch } = routedFetch(() =>
+      bodyResponse([new Uint8Array([1, 2]), new Uint8Array([3])]),
+    )
+    vi.stubGlobal('fetch', fetch)
+    const chunks = await collect(readStream(makeAccessor(), spec('/volume/small.bin')))
+    expect(chunks).toHaveLength(1)
+    expect(Array.from(chunks[0])).toEqual([1, 2, 3])
+  })
+
+  it('raises ENOENT for missing files', async () => {
+    const { fetch } = routedFetch(() => notFoundResponse())
+    vi.stubGlobal('fetch', fetch)
+    const err = (await collect(readStream(makeAccessor(), spec('/volume/gone.bin'))).catch(
+      (e: unknown) => e,
+    )) as Error & { code?: string }
+    expect(err.code).toBe('ENOENT')
+  })
+})

--- a/typescript/packages/core/src/core/databricks_volume/stream.ts
+++ b/typescript/packages/core/src/core/databricks_volume/stream.ts
@@ -49,7 +49,7 @@ export async function* readStream(
   if (body === null) return
   const reader = body.getReader()
   let pending: Uint8Array = new Uint8Array(0)
-  while (true) {
+  for (;;) {
     const { done, value } = await reader.read()
     if (done) break
     pending = concatChunks(pending, value)

--- a/typescript/packages/core/src/core/databricks_volume/stream.ts
+++ b/typescript/packages/core/src/core/databricks_volume/stream.ts
@@ -18,6 +18,7 @@ import { ResourceName, type PathSpec } from '../../types.ts'
 import { dbxFetch } from './_client.ts'
 import { isNotFound, notFoundError } from './errors.ts'
 import { backendPath } from './path.ts'
+import { readBytes } from './read.ts'
 
 const DEFAULT_CHUNK_SIZE = 8192
 
@@ -63,4 +64,13 @@ export async function* readStream(
     if (rec !== null) rec.bytes += pending.byteLength
     yield pending
   }
+}
+
+export async function rangeRead(
+  accessor: DatabricksVolumeAccessor,
+  path: PathSpec,
+  start: number,
+  end: number,
+): Promise<Uint8Array> {
+  return readBytes(accessor, path, undefined, { offset: start, size: end - start })
 }

--- a/typescript/packages/core/src/core/databricks_volume/stream.ts
+++ b/typescript/packages/core/src/core/databricks_volume/stream.ts
@@ -1,0 +1,66 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import { recordStream } from '../../observe/context.ts'
+import { ResourceName, type PathSpec } from '../../types.ts'
+import { dbxFetch } from './_client.ts'
+import { isNotFound, notFoundError } from './errors.ts'
+import { backendPath } from './path.ts'
+
+const DEFAULT_CHUNK_SIZE = 8192
+
+function concatChunks(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.byteLength + b.byteLength)
+  out.set(a, 0)
+  out.set(b, a.byteLength)
+  return out
+}
+
+export async function* readStream(
+  accessor: DatabricksVolumeAccessor,
+  path: PathSpec,
+): AsyncIterable<Uint8Array> {
+  const virtual = path.original
+  const remotePath = backendPath(accessor.config, path)
+  const rec = recordStream('read', virtual, ResourceName.DATABRICKS_VOLUME)
+  let r: Response
+  try {
+    r = await dbxFetch(accessor, 'GET', 'files', remotePath, {
+      headers: { Accept: 'application/octet-stream' },
+    })
+  } catch (exc) {
+    if (isNotFound(exc)) throw notFoundError(path.stripPrefix)
+    throw exc
+  }
+  const body = r.body
+  if (body === null) return
+  const reader = body.getReader()
+  let pending: Uint8Array = new Uint8Array(0)
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    pending = concatChunks(pending, value)
+    while (pending.byteLength >= DEFAULT_CHUNK_SIZE) {
+      const piece = pending.slice(0, DEFAULT_CHUNK_SIZE)
+      if (rec !== null) rec.bytes += piece.byteLength
+      yield piece
+      pending = pending.slice(DEFAULT_CHUNK_SIZE)
+    }
+  }
+  if (pending.byteLength > 0) {
+    if (rec !== null) rec.bytes += pending.byteLength
+    yield pending
+  }
+}

--- a/typescript/packages/core/src/core/databricks_volume/unlink.ts
+++ b/typescript/packages/core/src/core/databricks_volume/unlink.ts
@@ -1,0 +1,44 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { record } from '../../observe/context.ts'
+import { FileType, ResourceName, type PathSpec } from '../../types.ts'
+import { dbxFetch } from './_client.ts'
+import { ensurePathSpec } from './_helpers.ts'
+import { isADirectoryError, isNotFound, notFoundError } from './errors.ts'
+import { backendPath } from './path.ts'
+import { stat } from './stat.ts'
+
+export async function unlink(
+  accessor: DatabricksVolumeAccessor,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): Promise<void> {
+  const p = ensurePathSpec(path)
+  const fileStat = await stat(accessor, p, index)
+  if (fileStat.type === FileType.DIRECTORY) {
+    throw isADirectoryError(p.stripPrefix)
+  }
+  const remotePath = backendPath(accessor.config, p)
+  const startMs = performance.now()
+  try {
+    await dbxFetch(accessor, 'DELETE', 'files', remotePath)
+  } catch (exc) {
+    if (isNotFound(exc)) throw notFoundError(p.stripPrefix)
+    throw exc
+  }
+  record('unlink', p.original, ResourceName.DATABRICKS_VOLUME, 0, startMs)
+}

--- a/typescript/packages/core/src/core/databricks_volume/write.ts
+++ b/typescript/packages/core/src/core/databricks_volume/write.ts
@@ -1,0 +1,66 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { record } from '../../observe/context.ts'
+import { ResourceName, type PathSpec } from '../../types.ts'
+import { dbxFetch } from './_client.ts'
+import { ensurePathSpec, parentPath } from './_helpers.ts'
+import { isNotFound, notADirectoryError, notFoundError } from './errors.ts'
+import { backendPath } from './path.ts'
+
+async function ensureParentDirectory(
+  accessor: DatabricksVolumeAccessor,
+  remoteParent: string,
+  virtualTarget: string,
+): Promise<void> {
+  try {
+    await dbxFetch(accessor, 'HEAD', 'directories', remoteParent)
+    return
+  } catch (exc) {
+    if (!isNotFound(exc)) throw exc
+  }
+  try {
+    await dbxFetch(accessor, 'HEAD', 'files', remoteParent)
+  } catch (exc) {
+    if (isNotFound(exc)) throw notFoundError(virtualTarget)
+    throw exc
+  }
+  throw notADirectoryError(virtualTarget)
+}
+
+export async function writeBytes(
+  accessor: DatabricksVolumeAccessor,
+  path: PathSpec,
+  data: Uint8Array,
+  _index?: IndexCacheStore,
+): Promise<void> {
+  const p = ensurePathSpec(path)
+  const remoteParent = backendPath(accessor.config, parentPath(p))
+  const remotePath = backendPath(accessor.config, p)
+  const startMs = performance.now()
+  await ensureParentDirectory(accessor, remoteParent, p.stripPrefix)
+  try {
+    await dbxFetch(accessor, 'PUT', 'files', remotePath, {
+      query: { overwrite: 'true' },
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: data,
+    })
+  } catch (exc) {
+    if (isNotFound(exc)) throw notFoundError(p.stripPrefix)
+    throw exc
+  }
+  record('write', p.original, ResourceName.DATABRICKS_VOLUME, data.byteLength, startMs)
+}

--- a/typescript/packages/core/src/core/databricks_volume/write_ops.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/write_ops.test.ts
@@ -108,8 +108,8 @@ describe('mkdir', () => {
     vi.stubGlobal('fetch', fetch)
     await mkdir(makeAccessor(), spec('/volume/a/b'), undefined, true)
     expect(calls).toHaveLength(1)
-    expect(calls[0].method).toBe('PUT')
-    expect(calls[0].url).toContain('/fs/directories/')
+    expect(calls[0]?.method).toBe('PUT')
+    expect(calls[0]?.url).toContain('/fs/directories/')
   })
 
   it('creates after parent check when target is missing', async () => {

--- a/typescript/packages/core/src/core/databricks_volume/write_ops.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/write_ops.test.ts
@@ -1,0 +1,221 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { create } from './create.ts'
+import { mkdir } from './mkdir.ts'
+import { rmRecursive } from './rm.ts'
+import { rmdir } from './rmdir.ts'
+import { unlink } from './unlink.ts'
+import { writeBytes } from './write.ts'
+import {
+  jsonResponse,
+  makeAccessor,
+  notFoundResponse,
+  routedFetch,
+  spec,
+  TEST_ROOT,
+  type FetchCall,
+} from './_test_util.ts'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const ENC = new TextEncoder()
+
+function isDirHead(call: FetchCall): boolean {
+  return call.method === 'HEAD' && call.url.includes('/fs/directories/')
+}
+
+describe('writeBytes', () => {
+  it('PUTs with overwrite=true after checking the parent directory', async () => {
+    const { fetch, calls } = routedFetch((call) => {
+      if (isDirHead(call)) return new Response(null, { status: 200 })
+      return new Response(null, { status: 204 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    await writeBytes(makeAccessor(), spec('/volume/reports/a.txt'), ENC.encode('hi'))
+    const put = calls.find((c) => c.method === 'PUT')
+    expect(put).toBeDefined()
+    expect(put?.url).toContain('/fs/files/')
+    expect(put?.url).toContain('overwrite=true')
+    expect(put?.body).toEqual(ENC.encode('hi'))
+  })
+
+  it('raises ENOENT when the parent directory is missing', async () => {
+    const { fetch } = routedFetch(() => notFoundResponse())
+    vi.stubGlobal('fetch', fetch)
+    const err = (await writeBytes(
+      makeAccessor(),
+      spec('/volume/missing/a.txt'),
+      ENC.encode('x'),
+    ).catch((e: unknown) => e)) as Error & { code?: string }
+    expect(err.code).toBe('ENOENT')
+  })
+
+  it('raises ENOTDIR when the parent is a file', async () => {
+    const { fetch } = routedFetch((call) => {
+      if (isDirHead(call)) return notFoundResponse()
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const err = (await writeBytes(
+      makeAccessor(),
+      spec('/volume/file.txt/a.txt'),
+      ENC.encode('x'),
+    ).catch((e: unknown) => e)) as Error & { code?: string }
+    expect(err.code).toBe('ENOTDIR')
+  })
+})
+
+describe('create', () => {
+  it('writes empty bytes', async () => {
+    const { fetch, calls } = routedFetch((call) => {
+      if (isDirHead(call)) return new Response(null, { status: 200 })
+      return new Response(null, { status: 204 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    await create(makeAccessor(), spec('/volume/new.txt'))
+    const put = calls.find((c) => c.method === 'PUT')
+    expect((put?.body as Uint8Array).byteLength).toBe(0)
+  })
+})
+
+describe('mkdir', () => {
+  it('rejects existing targets without parents', async () => {
+    const { fetch } = routedFetch(() => new Response(null, { status: 200 }))
+    vi.stubGlobal('fetch', fetch)
+    const err = (await mkdir(makeAccessor(), spec('/volume/exists')).catch(
+      (e: unknown) => e,
+    )) as Error & { code?: string }
+    expect(err.code).toBe('EEXIST')
+  })
+
+  it('creates directories via PUT when parents=true', async () => {
+    const { fetch, calls } = routedFetch(() => new Response(null, { status: 200 }))
+    vi.stubGlobal('fetch', fetch)
+    await mkdir(makeAccessor(), spec('/volume/a/b'), undefined, true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].method).toBe('PUT')
+    expect(calls[0].url).toContain('/fs/directories/')
+  })
+
+  it('creates after parent check when target is missing', async () => {
+    const { fetch, calls } = routedFetch((call) => {
+      if (call.method === 'PUT') return new Response(null, { status: 200 })
+      if (call.url.includes('/newdir')) return notFoundResponse()
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    await mkdir(makeAccessor(), spec('/volume/newdir'))
+    expect(calls.at(-1)?.method).toBe('PUT')
+  })
+})
+
+describe('unlink', () => {
+  it('deletes files', async () => {
+    const { fetch, calls } = routedFetch((call) => {
+      if (call.method === 'HEAD') {
+        return new Response(null, { status: 200, headers: { 'Content-Length': '1' } })
+      }
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    await unlink(makeAccessor(), spec('/volume/a.txt'))
+    expect(calls.at(-1)?.method).toBe('DELETE')
+    expect(calls.at(-1)?.url).toContain('/fs/files/')
+  })
+
+  it('refuses to delete directories', async () => {
+    const { fetch } = routedFetch((call) => {
+      if (call.method === 'HEAD' && call.url.includes('/fs/files/')) return notFoundResponse()
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const err = (await unlink(makeAccessor(), spec('/volume/dir')).catch(
+      (e: unknown) => e,
+    )) as Error & { code?: string }
+    expect(err.code).toBe('EISDIR')
+  })
+})
+
+describe('rmdir', () => {
+  it('rejects non-empty directories', async () => {
+    const { fetch } = routedFetch((call) => {
+      if (call.method === 'HEAD' && call.url.includes('/fs/files/')) return notFoundResponse()
+      if (call.method === 'HEAD') return new Response(null, { status: 200 })
+      return jsonResponse({ contents: [{ path: `${TEST_ROOT}/dir/x.txt` }] })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const err = (await rmdir(makeAccessor(), spec('/volume/dir')).catch(
+      (e: unknown) => e,
+    )) as Error & { code?: string }
+    expect(err.code).toBe('ENOTEMPTY')
+  })
+
+  it('deletes empty directories', async () => {
+    const { fetch, calls } = routedFetch((call) => {
+      if (call.method === 'HEAD' && call.url.includes('/fs/files/')) return notFoundResponse()
+      if (call.method === 'HEAD') return new Response(null, { status: 200 })
+      if (call.method === 'GET') return jsonResponse({ contents: [] })
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    await rmdir(makeAccessor(), spec('/volume/empty'))
+    expect(calls.at(-1)?.method).toBe('DELETE')
+    expect(calls.at(-1)?.url).toContain('/fs/directories/')
+  })
+})
+
+describe('rmRecursive', () => {
+  it('removes children before parents and returns virtual paths', async () => {
+    const deletes: string[] = []
+    const { fetch } = routedFetch((call) => {
+      if (call.method === 'HEAD' && call.url.includes('/fs/files/')) return notFoundResponse()
+      if (call.method === 'HEAD') return new Response(null, { status: 200 })
+      if (call.method === 'DELETE') {
+        deletes.push(call.url)
+        return new Response(null, { status: 200 })
+      }
+      if (call.url.includes('sub')) {
+        return jsonResponse({ contents: [{ path: `${TEST_ROOT}/dir/sub/b.txt` }] })
+      }
+      return jsonResponse({
+        contents: [
+          { path: `${TEST_ROOT}/dir/a.txt` },
+          { path: `${TEST_ROOT}/dir/sub`, is_directory: true },
+        ],
+      })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const removed = await rmRecursive(makeAccessor(), spec('/volume/dir'))
+    expect(removed).toEqual(['/dir/a.txt', '/dir/sub/b.txt', '/dir/sub', '/dir'])
+    expect(deletes).toHaveLength(4)
+    expect(deletes.at(-1)).toContain('/fs/directories/')
+  })
+
+  it('unlinks plain files', async () => {
+    const { fetch, calls } = routedFetch((call) => {
+      if (call.method === 'HEAD') {
+        return new Response(null, { status: 200, headers: { 'Content-Length': '5' } })
+      }
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const removed = await rmRecursive(makeAccessor(), spec('/volume/a.txt'))
+    expect(removed).toEqual(['/a.txt'])
+    expect(calls.at(-1)?.method).toBe('DELETE')
+  })
+})

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -1178,3 +1178,41 @@ export { setHttpProxyBase } from './commands/builtin/utils/http.ts'
 
 export { lstripSlash, rstripSlash, stripSlash } from './util/slash.ts'
 export { fnmatch } from './util/fnmatch.ts'
+
+export {
+  DatabricksVolumeAccessor,
+  type DatabricksVolumeResourceLike,
+} from './accessor/databricks_volume.ts'
+export {
+  DatabricksVolumeConfigSchema,
+  normalizeDatabricksVolumeConfig,
+  redactDatabricksVolumeConfig,
+  type DatabricksVolumeConfig,
+  type DatabricksVolumeConfigRedacted,
+} from './resource/databricks_volume/config.ts'
+export { DATABRICKS_VOLUME_PROMPT } from './resource/databricks_volume/prompt.ts'
+export { DATABRICKS_VOLUME_OPS } from './ops/databricks_volume/index.ts'
+export { DATABRICKS_VOLUME_COMMANDS } from './commands/builtin/databricks_volume/index.ts'
+export {
+  DatabricksVolumeApiError,
+  isNotFound as isDatabricksVolumeNotFound,
+} from './core/databricks_volume/errors.ts'
+export { readBytes as databricksVolumeRead } from './core/databricks_volume/read.ts'
+export { readStream as databricksVolumeReadStream } from './core/databricks_volume/stream.ts'
+export { readdir as databricksVolumeReaddir } from './core/databricks_volume/readdir.ts'
+export { stat as databricksVolumeStat } from './core/databricks_volume/stat.ts'
+export { exists as databricksVolumeExists } from './core/databricks_volume/exists.ts'
+export { find as databricksVolumeFind } from './core/databricks_volume/find.ts'
+export { resolveGlob as resolveDatabricksVolumeGlob } from './core/databricks_volume/glob.ts'
+export { writeBytes as databricksVolumeWrite } from './core/databricks_volume/write.ts'
+export { create as databricksVolumeCreate } from './core/databricks_volume/create.ts'
+export { mkdir as databricksVolumeMkdir } from './core/databricks_volume/mkdir.ts'
+export { rmdir as databricksVolumeRmdir } from './core/databricks_volume/rmdir.ts'
+export { unlink as databricksVolumeUnlink } from './core/databricks_volume/unlink.ts'
+export { rmRecursive as databricksVolumeRmRecursive } from './core/databricks_volume/rm.ts'
+export { copy as databricksVolumeCopy } from './core/databricks_volume/copy.ts'
+export { rename as databricksVolumeRename } from './core/databricks_volume/rename.ts'
+export {
+  backendPath as databricksVolumeBackendPath,
+  virtualPath as databricksVolumeVirtualPath,
+} from './core/databricks_volume/path.ts'

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -1198,7 +1198,7 @@ export {
   isNotFound as isDatabricksVolumeNotFound,
 } from './core/databricks_volume/errors.ts'
 export { readBytes as databricksVolumeRead } from './core/databricks_volume/read.ts'
-export { readStream as databricksVolumeReadStream } from './core/databricks_volume/stream.ts'
+export { readStream as databricksVolumeReadStream, rangeRead as databricksVolumeRangeRead } from './core/databricks_volume/stream.ts'
 export { readdir as databricksVolumeReaddir } from './core/databricks_volume/readdir.ts'
 export { stat as databricksVolumeStat } from './core/databricks_volume/stat.ts'
 export { exists as databricksVolumeExists } from './core/databricks_volume/exists.ts'

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -1198,7 +1198,10 @@ export {
   isNotFound as isDatabricksVolumeNotFound,
 } from './core/databricks_volume/errors.ts'
 export { readBytes as databricksVolumeRead } from './core/databricks_volume/read.ts'
-export { readStream as databricksVolumeReadStream, rangeRead as databricksVolumeRangeRead } from './core/databricks_volume/stream.ts'
+export {
+  readStream as databricksVolumeReadStream,
+  rangeRead as databricksVolumeRangeRead,
+} from './core/databricks_volume/stream.ts'
 export { readdir as databricksVolumeReaddir } from './core/databricks_volume/readdir.ts'
 export { stat as databricksVolumeStat } from './core/databricks_volume/stat.ts'
 export { exists as databricksVolumeExists } from './core/databricks_volume/exists.ts'

--- a/typescript/packages/core/src/ops/databricks_volume/create.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/create.ts
@@ -22,7 +22,12 @@ export const createOp: RegisteredOp = {
   resource: ResourceName.DATABRICKS_VOLUME,
   filetype: null,
   write: true,
-  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+  fn: (
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    _args: readonly unknown[],
+    kwargs: OpKwargs,
+  ) => {
     return coreCreate(accessor, path, kwargs.index)
   },
 }

--- a/typescript/packages/core/src/ops/databricks_volume/create.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/create.ts
@@ -1,0 +1,28 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { OpKwargs, RegisteredOp } from '../../ops/registry.ts'
+import { type PathSpec, ResourceName } from '../../types.ts'
+import { create as coreCreate } from '../../core/databricks_volume/create.ts'
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+
+export const createOp: RegisteredOp = {
+  name: 'create',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  filetype: null,
+  write: true,
+  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+    return coreCreate(accessor, path, kwargs.index)
+  },
+}

--- a/typescript/packages/core/src/ops/databricks_volume/index.test.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/index.test.ts
@@ -1,0 +1,50 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { ResourceName } from '../../types.ts'
+import { DATABRICKS_VOLUME_OPS } from './index.ts'
+
+describe('DATABRICKS_VOLUME_OPS', () => {
+  it('exposes the same nine ops as Python', () => {
+    const names = DATABRICKS_VOLUME_OPS.map((op) => op.name).sort()
+    expect(names).toEqual([
+      'create',
+      'mkdir',
+      'read',
+      'readdir',
+      'rename',
+      'rmdir',
+      'stat',
+      'unlink',
+      'write',
+    ])
+  })
+
+  it('marks mutating ops as writes', () => {
+    const writes = new Set(
+      DATABRICKS_VOLUME_OPS.filter((op) => (op as { write?: boolean }).write === true).map(
+        (op) => op.name,
+      ),
+    )
+    expect(writes).toEqual(new Set(['create', 'mkdir', 'rename', 'rmdir', 'unlink', 'write']))
+  })
+
+  it('targets the databricks_volume resource', () => {
+    for (const op of DATABRICKS_VOLUME_OPS) {
+      expect(op.resource).toBe(ResourceName.DATABRICKS_VOLUME)
+      expect(op.filetype).toBeNull()
+    }
+  })
+})

--- a/typescript/packages/core/src/ops/databricks_volume/index.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/index.ts
@@ -1,0 +1,36 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { RegisteredOp } from '../../ops/registry.ts'
+import { createOp } from './create.ts'
+import { mkdirOp } from './mkdir.ts'
+import { readOp } from './read.ts'
+import { readdirOp } from './readdir.ts'
+import { renameOp } from './rename.ts'
+import { rmdirOp } from './rmdir.ts'
+import { statOp } from './stat.ts'
+import { unlinkOp } from './unlink.ts'
+import { writeOp } from './write.ts'
+
+export const DATABRICKS_VOLUME_OPS: readonly RegisteredOp[] = [
+  createOp,
+  mkdirOp,
+  readOp,
+  readdirOp,
+  renameOp,
+  rmdirOp,
+  statOp,
+  unlinkOp,
+  writeOp,
+]

--- a/typescript/packages/core/src/ops/databricks_volume/mkdir.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/mkdir.ts
@@ -1,0 +1,28 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { OpKwargs, RegisteredOp } from '../../ops/registry.ts'
+import { type PathSpec, ResourceName } from '../../types.ts'
+import { mkdir as coreMkdir } from '../../core/databricks_volume/mkdir.ts'
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+
+export const mkdirOp: RegisteredOp = {
+  name: 'mkdir',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  filetype: null,
+  write: true,
+  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+    return coreMkdir(accessor, path, kwargs.index, true)
+  },
+}

--- a/typescript/packages/core/src/ops/databricks_volume/mkdir.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/mkdir.ts
@@ -22,7 +22,12 @@ export const mkdirOp: RegisteredOp = {
   resource: ResourceName.DATABRICKS_VOLUME,
   filetype: null,
   write: true,
-  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+  fn: (
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    _args: readonly unknown[],
+    kwargs: OpKwargs,
+  ) => {
     return coreMkdir(accessor, path, kwargs.index, true)
   },
 }

--- a/typescript/packages/core/src/ops/databricks_volume/read.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/read.ts
@@ -1,0 +1,28 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { OpKwargs, RegisteredOp } from '../../ops/registry.ts'
+import { type PathSpec, ResourceName } from '../../types.ts'
+import { readBytes } from '../../core/databricks_volume/read.ts'
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+
+export const readOp: RegisteredOp = {
+  name: 'read',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  filetype: null,
+  write: false,
+  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+    return readBytes(accessor, path, kwargs.index)
+  },
+}

--- a/typescript/packages/core/src/ops/databricks_volume/read.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/read.ts
@@ -22,7 +22,12 @@ export const readOp: RegisteredOp = {
   resource: ResourceName.DATABRICKS_VOLUME,
   filetype: null,
   write: false,
-  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+  fn: (
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    _args: readonly unknown[],
+    kwargs: OpKwargs,
+  ) => {
     return readBytes(accessor, path, kwargs.index)
   },
 }

--- a/typescript/packages/core/src/ops/databricks_volume/readdir.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/readdir.ts
@@ -1,0 +1,28 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { OpKwargs, RegisteredOp } from '../../ops/registry.ts'
+import { type PathSpec, ResourceName } from '../../types.ts'
+import { readdir as coreReaddir } from '../../core/databricks_volume/readdir.ts'
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+
+export const readdirOp: RegisteredOp = {
+  name: 'readdir',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  filetype: null,
+  write: false,
+  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+    return coreReaddir(accessor, path, kwargs.index)
+  },
+}

--- a/typescript/packages/core/src/ops/databricks_volume/readdir.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/readdir.ts
@@ -22,7 +22,12 @@ export const readdirOp: RegisteredOp = {
   resource: ResourceName.DATABRICKS_VOLUME,
   filetype: null,
   write: false,
-  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+  fn: (
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    _args: readonly unknown[],
+    kwargs: OpKwargs,
+  ) => {
     return coreReaddir(accessor, path, kwargs.index)
   },
 }

--- a/typescript/packages/core/src/ops/databricks_volume/rename.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/rename.ts
@@ -22,7 +22,12 @@ export const renameOp: RegisteredOp = {
   resource: ResourceName.DATABRICKS_VOLUME,
   filetype: null,
   write: true,
-  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, args: readonly unknown[], kwargs: OpKwargs) => {
+  fn: (
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    args: readonly unknown[],
+    kwargs: OpKwargs,
+  ) => {
     const dst = args[0]
     if (dst === null || typeof dst !== 'object' || !('original' in dst)) {
       throw new TypeError('rename op requires a dst PathSpec as the first arg')

--- a/typescript/packages/core/src/ops/databricks_volume/rename.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/rename.ts
@@ -1,0 +1,32 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { OpKwargs, RegisteredOp } from '../../ops/registry.ts'
+import { type PathSpec, ResourceName } from '../../types.ts'
+import { rename as coreRename } from '../../core/databricks_volume/rename.ts'
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+
+export const renameOp: RegisteredOp = {
+  name: 'rename',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  filetype: null,
+  write: true,
+  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, args: readonly unknown[], kwargs: OpKwargs) => {
+    const dst = args[0]
+    if (dst === null || typeof dst !== 'object' || !('original' in dst)) {
+      throw new TypeError('rename op requires a dst PathSpec as the first arg')
+    }
+    return coreRename(accessor, path, dst as PathSpec, kwargs.index)
+  },
+}

--- a/typescript/packages/core/src/ops/databricks_volume/rmdir.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/rmdir.ts
@@ -22,7 +22,12 @@ export const rmdirOp: RegisteredOp = {
   resource: ResourceName.DATABRICKS_VOLUME,
   filetype: null,
   write: true,
-  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+  fn: (
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    _args: readonly unknown[],
+    kwargs: OpKwargs,
+  ) => {
     return coreRmdir(accessor, path, kwargs.index)
   },
 }

--- a/typescript/packages/core/src/ops/databricks_volume/rmdir.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/rmdir.ts
@@ -1,0 +1,28 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { OpKwargs, RegisteredOp } from '../../ops/registry.ts'
+import { type PathSpec, ResourceName } from '../../types.ts'
+import { rmdir as coreRmdir } from '../../core/databricks_volume/rmdir.ts'
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+
+export const rmdirOp: RegisteredOp = {
+  name: 'rmdir',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  filetype: null,
+  write: true,
+  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+    return coreRmdir(accessor, path, kwargs.index)
+  },
+}

--- a/typescript/packages/core/src/ops/databricks_volume/stat.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/stat.ts
@@ -22,7 +22,12 @@ export const statOp: RegisteredOp = {
   resource: ResourceName.DATABRICKS_VOLUME,
   filetype: null,
   write: false,
-  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+  fn: (
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    _args: readonly unknown[],
+    kwargs: OpKwargs,
+  ) => {
     return coreStat(accessor, path, kwargs.index)
   },
 }

--- a/typescript/packages/core/src/ops/databricks_volume/stat.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/stat.ts
@@ -1,0 +1,28 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { OpKwargs, RegisteredOp } from '../../ops/registry.ts'
+import { type PathSpec, ResourceName } from '../../types.ts'
+import { stat as coreStat } from '../../core/databricks_volume/stat.ts'
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+
+export const statOp: RegisteredOp = {
+  name: 'stat',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  filetype: null,
+  write: false,
+  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+    return coreStat(accessor, path, kwargs.index)
+  },
+}

--- a/typescript/packages/core/src/ops/databricks_volume/unlink.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/unlink.ts
@@ -1,0 +1,28 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { OpKwargs, RegisteredOp } from '../../ops/registry.ts'
+import { type PathSpec, ResourceName } from '../../types.ts'
+import { unlink as coreUnlink } from '../../core/databricks_volume/unlink.ts'
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+
+export const unlinkOp: RegisteredOp = {
+  name: 'unlink',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  filetype: null,
+  write: true,
+  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+    return coreUnlink(accessor, path, kwargs.index)
+  },
+}

--- a/typescript/packages/core/src/ops/databricks_volume/unlink.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/unlink.ts
@@ -22,7 +22,12 @@ export const unlinkOp: RegisteredOp = {
   resource: ResourceName.DATABRICKS_VOLUME,
   filetype: null,
   write: true,
-  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, _args: readonly unknown[], kwargs: OpKwargs) => {
+  fn: (
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    _args: readonly unknown[],
+    kwargs: OpKwargs,
+  ) => {
     return coreUnlink(accessor, path, kwargs.index)
   },
 }

--- a/typescript/packages/core/src/ops/databricks_volume/write.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/write.ts
@@ -23,7 +23,12 @@ export const writeOp: RegisteredOp = {
   resource: ResourceName.DATABRICKS_VOLUME,
   filetype: null,
   write: true,
-  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, args: readonly unknown[], kwargs: OpKwargs) => {
+  fn: (
+    accessor: DatabricksVolumeAccessor,
+    path: PathSpec,
+    args: readonly unknown[],
+    kwargs: OpKwargs,
+  ) => {
     const data = extractWriteData(args)
     return writeBytes(accessor, path, data, kwargs.index)
   },

--- a/typescript/packages/core/src/ops/databricks_volume/write.ts
+++ b/typescript/packages/core/src/ops/databricks_volume/write.ts
@@ -1,0 +1,30 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { OpKwargs, RegisteredOp } from '../../ops/registry.ts'
+import { type PathSpec, ResourceName } from '../../types.ts'
+import { writeBytes } from '../../core/databricks_volume/write.ts'
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
+import { extractWriteData } from '../write_args.ts'
+
+export const writeOp: RegisteredOp = {
+  name: 'write',
+  resource: ResourceName.DATABRICKS_VOLUME,
+  filetype: null,
+  write: true,
+  fn: (accessor: DatabricksVolumeAccessor, path: PathSpec, args: readonly unknown[], kwargs: OpKwargs) => {
+    const data = extractWriteData(args)
+    return writeBytes(accessor, path, data, kwargs.index)
+  },
+}

--- a/typescript/packages/core/src/resource/databricks_volume/config.ts
+++ b/typescript/packages/core/src/resource/databricks_volume/config.ts
@@ -1,0 +1,81 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { z } from 'zod'
+import { redactConfigWithSchema, secretStr } from '../secrets.ts'
+import { normalizeFields } from '../../utils/normalize.ts'
+
+export interface DatabricksVolumeConfig {
+  catalog: string
+  schema: string
+  volume: string
+  rootPath: string
+  host?: string
+  token?: string
+  profile?: string
+  timeout: number
+}
+
+export interface DatabricksVolumeConfigRedacted {
+  catalog: string
+  schema: string
+  volume: string
+  rootPath: string
+  host?: string
+  token?: '<REDACTED>'
+  profile?: string
+  timeout: number
+}
+
+function validVolumePart(value: string): boolean {
+  return value !== '' && !value.includes('/')
+}
+
+export function normalizeRootPath(value: string): string {
+  const parts = value.split('/').filter((p) => p !== '' && p !== '.')
+  if (parts.some((p) => p === '..')) {
+    throw new Error("root_path must not contain '..' segments")
+  }
+  if (parts.length === 0) return '/'
+  return '/' + parts.join('/')
+}
+
+export const DatabricksVolumeConfigSchema = z.object({
+  catalog: z.string().refine(validVolumePart, 'must be a non-empty path segment'),
+  schema: z.string().refine(validVolumePart, 'must be a non-empty path segment'),
+  volume: z.string().refine(validVolumePart, 'must be a non-empty path segment'),
+  rootPath: z.string().transform(normalizeRootPath).default('/'),
+  host: z.string().optional(),
+  token: secretStr().optional(),
+  profile: z.string().optional(),
+  timeout: z.number().default(30),
+})
+
+export function redactDatabricksVolumeConfig(
+  config: DatabricksVolumeConfig,
+): DatabricksVolumeConfigRedacted {
+  return redactConfigWithSchema(
+    DatabricksVolumeConfigSchema,
+    config,
+  ) as unknown as DatabricksVolumeConfigRedacted
+}
+
+export function normalizeDatabricksVolumeConfig(
+  input: Record<string, unknown>,
+): DatabricksVolumeConfig {
+  const renamed = normalizeFields(input, {
+    rename: { root_path: 'rootPath' },
+  })
+  return DatabricksVolumeConfigSchema.parse(renamed) as DatabricksVolumeConfig
+}

--- a/typescript/packages/core/src/resource/databricks_volume/prompt.ts
+++ b/typescript/packages/core/src/resource/databricks_volume/prompt.ts
@@ -1,0 +1,25 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+export const DATABRICKS_VOLUME_PROMPT = `{prefix}
+  Remote Databricks Unity Catalog volume filesystem.
+  IMPORTANT: This is a remote mount - every file/dir access is an API round-trip.
+  Prefer targeted reads (ls, head, grep, rg, find with a path/glob) over full
+  scans; recursive ops (rm -r, cp -r, tree, grep -r) over a large tree are slow.
+  Create parent dirs before writing: \`mkdir -p /path && cmd > /path/out\`.
+  mv/cp are non-atomic full copies (no server-side rename) - avoid on large files.
+  sed -i is not supported; transform and redirect to a new file instead.
+  Read/analyze: ls, cat, head, tail, grep, rg, find, tree, stat, wc, sort, uniq,
+    cut, nl, tr, sed, awk, jq, diff.
+  Write: touch, rm, rm -r, mkdir, mkdir -p, cp, mv, and >/>> redirects.`

--- a/typescript/packages/core/src/types.test.ts
+++ b/typescript/packages/core/src/types.test.ts
@@ -76,8 +76,8 @@ describe('ResourceName', () => {
     expect(ResourceName.POSTGRES).toBe('postgres')
   })
 
-  it('contains exactly 33 entries', () => {
-    expect(Object.keys(ResourceName)).toHaveLength(33)
+  it('contains exactly 34 entries', () => {
+    expect(Object.keys(ResourceName)).toHaveLength(34)
   })
 
   it('is frozen at runtime', () => {

--- a/typescript/packages/core/src/types.ts
+++ b/typescript/packages/core/src/types.ts
@@ -141,6 +141,7 @@ export const ResourceName = Object.freeze({
   POSTHOG: 'posthog',
   LANCEDB: 'lancedb',
   CHROMA: 'chroma',
+  DATABRICKS_VOLUME: 'databricks_volume',
 } as const)
 
 export type ResourceName = (typeof ResourceName)[keyof typeof ResourceName]

--- a/typescript/packages/node/src/index.ts
+++ b/typescript/packages/node/src/index.ts
@@ -56,6 +56,15 @@ export {
 export { isMacosMetadata } from './fuse/platform/macos.ts'
 export { S3Resource, type S3ResourceState } from './resource/s3/s3.ts'
 export {
+  DatabricksVolumeResource,
+  type DatabricksVolumeResourceState,
+} from './resource/databricks_volume/databricks_volume.ts'
+export {
+  loadDatabricksProfile,
+  parseDatabricksCfg,
+  type DatabricksProfile,
+} from './resource/databricks_volume/profile.ts'
+export {
   redactConfig as redactS3Config,
   type S3Config,
   type S3ConfigRedacted,

--- a/typescript/packages/node/src/resource/databricks_volume/config.ts
+++ b/typescript/packages/node/src/resource/databricks_volume/config.ts
@@ -1,0 +1,21 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+export {
+  DatabricksVolumeConfigSchema,
+  normalizeDatabricksVolumeConfig,
+  redactDatabricksVolumeConfig,
+  type DatabricksVolumeConfig,
+  type DatabricksVolumeConfigRedacted,
+} from '@struktoai/mirage-core'

--- a/typescript/packages/node/src/resource/databricks_volume/databricks_volume.test.ts
+++ b/typescript/packages/node/src/resource/databricks_volume/databricks_volume.test.ts
@@ -35,9 +35,7 @@ describe('config normalization', () => {
   })
 
   it('rejects invalid volume parts', () => {
-    expect(() =>
-      normalizeDatabricksVolumeConfig({ ...BASE_CONFIG, catalog: 'a/b' }),
-    ).toThrow()
+    expect(() => normalizeDatabricksVolumeConfig({ ...BASE_CONFIG, catalog: 'a/b' })).toThrow()
   })
 
   it('redacts the token', () => {

--- a/typescript/packages/node/src/resource/databricks_volume/databricks_volume.test.ts
+++ b/typescript/packages/node/src/resource/databricks_volume/databricks_volume.test.ts
@@ -1,0 +1,91 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { ResourceName } from '@struktoai/mirage-core'
+import { normalizeDatabricksVolumeConfig, redactDatabricksVolumeConfig } from './config.ts'
+import { DatabricksVolumeResource } from './databricks_volume.ts'
+import { parseDatabricksCfg } from './profile.ts'
+import { buildResource } from '../registry.ts'
+
+const BASE_CONFIG = {
+  catalog: 'main',
+  schema: 'default',
+  volume: 'agent_files',
+  host: 'https://dbc.example.com',
+  token: 'tok-123',
+}
+
+describe('config normalization', () => {
+  it('accepts snake_case YAML keys and applies defaults', () => {
+    const config = normalizeDatabricksVolumeConfig({ ...BASE_CONFIG, root_path: '/root/' })
+    expect(config.rootPath).toBe('/root')
+    expect(config.timeout).toBe(30)
+  })
+
+  it('rejects invalid volume parts', () => {
+    expect(() =>
+      normalizeDatabricksVolumeConfig({ ...BASE_CONFIG, catalog: 'a/b' }),
+    ).toThrow()
+  })
+
+  it('redacts the token', () => {
+    const config = normalizeDatabricksVolumeConfig(BASE_CONFIG)
+    const redacted = redactDatabricksVolumeConfig(config)
+    expect(redacted.token).toBe('<REDACTED>')
+    expect(redacted.catalog).toBe('main')
+  })
+})
+
+describe('parseDatabricksCfg', () => {
+  it('extracts host and token from the named section', () => {
+    const content = [
+      '[DEFAULT]',
+      'host = https://default.example.com',
+      'token = tok-default',
+      '',
+      '[work]',
+      'host = https://work.example.com',
+      'token = tok-work',
+    ].join('\n')
+    expect(parseDatabricksCfg(content, 'work')).toEqual({
+      host: 'https://work.example.com',
+      token: 'tok-work',
+    })
+    expect(parseDatabricksCfg(content, 'DEFAULT')).toEqual({
+      host: 'https://default.example.com',
+      token: 'tok-default',
+    })
+    expect(parseDatabricksCfg(content, 'missing')).toEqual({})
+  })
+})
+
+describe('DatabricksVolumeResource', () => {
+  it('creates with explicit credentials and exposes commands/ops', async () => {
+    const resource = await DatabricksVolumeResource.create(
+      normalizeDatabricksVolumeConfig(BASE_CONFIG),
+    )
+    expect(resource.kind).toBe(ResourceName.DATABRICKS_VOLUME)
+    expect(resource.isRemote).toBe(true)
+    expect(resource.commands().length).toBeGreaterThan(20)
+    expect(resource.ops().map((op) => op.name)).toContain('write')
+    const state = await resource.getState()
+    expect(state.config.token).toBe('<REDACTED>')
+  })
+
+  it('builds via the registry under the python name', async () => {
+    const resource = await buildResource('databricks_volume', { ...BASE_CONFIG, root_path: '/r' })
+    expect(resource.kind).toBe(ResourceName.DATABRICKS_VOLUME)
+  })
+})

--- a/typescript/packages/node/src/resource/databricks_volume/databricks_volume.ts
+++ b/typescript/packages/node/src/resource/databricks_volume/databricks_volume.ts
@@ -1,0 +1,223 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import {
+  BaseResource,
+  DATABRICKS_VOLUME_COMMANDS,
+  DATABRICKS_VOLUME_OPS,
+  DATABRICKS_VOLUME_PROMPT,
+  DatabricksVolumeAccessor,
+  databricksVolumeCopy,
+  databricksVolumeCreate,
+  databricksVolumeExists,
+  databricksVolumeFind,
+  databricksVolumeMkdir,
+  databricksVolumeRangeRead,
+  databricksVolumeRead,
+  databricksVolumeReadStream,
+  databricksVolumeReaddir,
+  databricksVolumeRename,
+  databricksVolumeRmRecursive,
+  databricksVolumeRmdir,
+  databricksVolumeStat,
+  databricksVolumeUnlink,
+  databricksVolumeWrite,
+  type FileStat,
+  type FindOptions,
+  PathSpec,
+  type RegisteredCommand,
+  type RegisteredOp,
+  type Resource,
+  ResourceName,
+  resolveDatabricksVolumeGlob,
+} from '@struktoai/mirage-core'
+import {
+  redactDatabricksVolumeConfig,
+  type DatabricksVolumeConfig,
+  type DatabricksVolumeConfigRedacted,
+} from './config.ts'
+import { loadDatabricksProfile } from './profile.ts'
+
+export interface DatabricksVolumeResourceState {
+  type: string
+  config: DatabricksVolumeConfigRedacted
+}
+
+async function resolveAuth(config: DatabricksVolumeConfig): Promise<[string, string]> {
+  let host = config.host ?? process.env.DATABRICKS_HOST
+  let token = config.token ?? process.env.DATABRICKS_TOKEN
+  if (host === undefined || host === '' || token === undefined || token === '') {
+    const profileName = config.profile ?? process.env.DATABRICKS_CONFIG_PROFILE ?? 'DEFAULT'
+    const profile = await loadDatabricksProfile(profileName)
+    host = host !== undefined && host !== '' ? host : profile.host
+    token = token !== undefined && token !== '' ? token : profile.token
+  }
+  if (host === undefined || host === '' || token === undefined || token === '') {
+    throw new Error(
+      'databricks_volume: missing credentials; set host/token in the config, ' +
+        'DATABRICKS_HOST/DATABRICKS_TOKEN env vars, or a ~/.databrickscfg profile',
+    )
+  }
+  return [host, token]
+}
+
+export class DatabricksVolumeResource extends BaseResource implements Resource {
+  readonly kind: string = ResourceName.DATABRICKS_VOLUME
+  readonly isRemote: boolean = true
+  readonly indexTtl: number = 600
+  readonly prompt: string = DATABRICKS_VOLUME_PROMPT
+  readonly config: DatabricksVolumeConfig
+  readonly accessor: DatabricksVolumeAccessor
+  readonly opsMap: Record<string, unknown> = {
+    read_bytes: databricksVolumeRead,
+    write: databricksVolumeWrite,
+    readdir: databricksVolumeReaddir,
+    stat: databricksVolumeStat,
+    read_stream: databricksVolumeReadStream,
+    range_read: databricksVolumeRangeRead,
+    exists: databricksVolumeExists,
+    create: databricksVolumeCreate,
+    unlink: databricksVolumeUnlink,
+    mkdir: databricksVolumeMkdir,
+    rmdir: databricksVolumeRmdir,
+    copy: databricksVolumeCopy,
+    rename: databricksVolumeRename,
+    rm_recursive: databricksVolumeRmRecursive,
+  }
+
+  private constructor(config: DatabricksVolumeConfig, accessor: DatabricksVolumeAccessor) {
+    super()
+    this.config = config
+    this.accessor = accessor
+  }
+
+  static async create(config: DatabricksVolumeConfig): Promise<DatabricksVolumeResource> {
+    const [host, token] = await resolveAuth(config)
+    const accessor = new DatabricksVolumeAccessor(config, host, token)
+    return new DatabricksVolumeResource(config, accessor)
+  }
+
+  open(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  commands(): readonly RegisteredCommand[] {
+    return DATABRICKS_VOLUME_COMMANDS
+  }
+
+  ops(): readonly RegisteredOp[] {
+    return DATABRICKS_VOLUME_OPS
+  }
+
+  streamPath(p: PathSpec): AsyncIterable<Uint8Array> {
+    return databricksVolumeReadStream(this.accessor, p)
+  }
+
+  readFile(p: PathSpec): Promise<Uint8Array> {
+    return databricksVolumeRead(this.accessor, p)
+  }
+
+  writeFile(p: PathSpec, data: Uint8Array): Promise<void> {
+    return databricksVolumeWrite(this.accessor, p, data)
+  }
+
+  async appendFile(p: PathSpec, data: Uint8Array): Promise<void> {
+    let existing: Uint8Array
+    try {
+      existing = await databricksVolumeRead(this.accessor, p)
+    } catch (err) {
+      if ((err as { code?: string } | null)?.code === 'ENOENT') {
+        existing = new Uint8Array()
+      } else {
+        throw err
+      }
+    }
+    const merged = new Uint8Array(existing.byteLength + data.byteLength)
+    merged.set(existing, 0)
+    merged.set(data, existing.byteLength)
+    await databricksVolumeWrite(this.accessor, p, merged)
+  }
+
+  readdir(p: PathSpec): Promise<string[]> {
+    return databricksVolumeReaddir(this.accessor, p, this.index)
+  }
+
+  stat(p: PathSpec): Promise<FileStat> {
+    return databricksVolumeStat(this.accessor, p)
+  }
+
+  exists(p: PathSpec): Promise<boolean> {
+    return databricksVolumeExists(this.accessor, p)
+  }
+
+  mkdir(p: PathSpec): Promise<void> {
+    return databricksVolumeMkdir(this.accessor, p, undefined, true)
+  }
+
+  rmdir(p: PathSpec): Promise<void> {
+    return databricksVolumeRmdir(this.accessor, p)
+  }
+
+  unlink(p: PathSpec): Promise<void> {
+    return databricksVolumeUnlink(this.accessor, p)
+  }
+
+  rename(src: PathSpec, dst: PathSpec): Promise<void> {
+    return databricksVolumeRename(this.accessor, src, dst)
+  }
+
+  copy(src: PathSpec, dst: PathSpec): Promise<void> {
+    return databricksVolumeCopy(this.accessor, src, dst)
+  }
+
+  async rmR(p: PathSpec): Promise<void> {
+    await databricksVolumeRmRecursive(this.accessor, p)
+  }
+
+  find(p: PathSpec, options: FindOptions = {}): Promise<string[]> {
+    return databricksVolumeFind(this.accessor, p, options, this.index)
+  }
+
+  glob(paths: readonly PathSpec[], prefix = ''): Promise<PathSpec[]> {
+    const effective = prefix
+      ? paths.map((p) =>
+          p.prefix
+            ? p
+            : new PathSpec({
+                original: p.original,
+                directory: p.directory,
+                ...(p.pattern !== null ? { pattern: p.pattern } : {}),
+                resolved: p.resolved,
+                prefix,
+              }),
+        )
+      : paths
+    return resolveDatabricksVolumeGlob(this.accessor, effective, this.index)
+  }
+
+  getState(): Promise<DatabricksVolumeResourceState> {
+    return Promise.resolve({
+      type: this.kind,
+      config: redactDatabricksVolumeConfig(this.config),
+    })
+  }
+
+  loadState(_state: DatabricksVolumeResourceState): Promise<void> {
+    return Promise.resolve()
+  }
+}

--- a/typescript/packages/node/src/resource/databricks_volume/profile.ts
+++ b/typescript/packages/node/src/resource/databricks_volume/profile.ts
@@ -1,0 +1,55 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export interface DatabricksProfile {
+  host?: string
+  token?: string
+}
+
+export function parseDatabricksCfg(content: string, profile: string): DatabricksProfile {
+  const result: DatabricksProfile = {}
+  let inSection = false
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim()
+    if (line === '' || line.startsWith('#') || line.startsWith(';')) continue
+    if (line.startsWith('[') && line.endsWith(']')) {
+      inSection = line.slice(1, -1).trim() === profile
+      continue
+    }
+    if (!inSection) continue
+    const eq = line.indexOf('=')
+    if (eq === -1) continue
+    const key = line.slice(0, eq).trim()
+    const value = line.slice(eq + 1).trim()
+    if (key === 'host') result.host = value
+    if (key === 'token') result.token = value
+  }
+  return result
+}
+
+export async function loadDatabricksProfile(profile: string): Promise<DatabricksProfile> {
+  const cfgPath = process.env.DATABRICKS_CONFIG_FILE ?? join(homedir(), '.databrickscfg')
+  let content: string
+  try {
+    content = await readFile(cfgPath, 'utf-8')
+  } catch (err) {
+    if ((err as { code?: string } | null)?.code === 'ENOENT') return {}
+    throw err
+  }
+  return parseDatabricksCfg(content, profile)
+}

--- a/typescript/packages/node/src/resource/registry.ts
+++ b/typescript/packages/node/src/resource/registry.ts
@@ -69,6 +69,11 @@ const REGISTRY: Record<string, ResourceFactory> = {
     const { normalizeSupabaseConfig } = await import('./supabase/config.ts')
     return new SupabaseResource(normalizeSupabaseConfig(config))
   },
+  databricks_volume: async (config) => {
+    const { DatabricksVolumeResource } = await import('./databricks_volume/databricks_volume.ts')
+    const { normalizeDatabricksVolumeConfig } = await import('@struktoai/mirage-core')
+    return DatabricksVolumeResource.create(normalizeDatabricksVolumeConfig(config))
+  },
   postgres: async (config) => {
     const { PostgresResource } = await import('./postgres/postgres.ts')
     const { normalizePostgresConfig } = await import('@struktoai/mirage-core')


### PR DESCRIPTION
Port the Python databricks_volume resource to TypeScript (node runtime), covering PRs #93/#109/#116/#134/#135/#142.

- REST client on fetch against the Files API (no SDK dependency, async-native)
- core ops: read/stream/write/create/mkdir/rmdir/unlink/rm -r/cp/mv/stat/readdir/glob/find
- mv/cp same-path guard (#142): same-path mv is a no-op, never deletes
- 24 builtin commands delegating to the generic helpers
- 9 VFS ops, node resource + registry entry, ~/.databrickscfg profile support
- example mirroring examples/python/databricks_volume (not live-verified: no Databricks creds in .env.development)