### PR TITLE
fix(ts): replace remaining localeCompare sorts with byte-order comparison

### DIFF
--- a/typescript/packages/core/src/commands/builtin/generic/ls.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.test.ts
@@ -1,0 +1,86 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { FileStat, FileType, PathSpec } from '../../../types.ts'
+import { rstripSlash } from '../../../util/slash.ts'
+import type { CommandOpts } from '../../config.ts'
+import { lsGeneric } from './ls.ts'
+
+const DEC = new TextDecoder()
+
+const MODIFIED: Record<string, string> = {
+  'apple.txt': '2026-01-03T00:00:00Z',
+  'Banana.txt': '2026-01-01T00:00:00Z',
+  'CHERRY.txt': '2026-01-02T00:00:00Z',
+}
+
+function key(p: PathSpec): string {
+  return rstripSlash(p.original) || '/'
+}
+
+function spec(path: string): PathSpec {
+  return new PathSpec({ original: path, directory: path, resolved: false, prefix: '' })
+}
+
+function opts(flags: Record<string, string | boolean>): CommandOpts {
+  return {
+    stdin: null,
+    flags,
+    filetypeFns: null,
+    cwd: '/',
+    resource: null,
+  } as unknown as CommandOpts
+}
+
+const stat = (p: PathSpec): Promise<FileStat> => {
+  const name = key(p).split('/').pop() ?? ''
+  return Promise.resolve(
+    new FileStat({
+      name,
+      type: key(p) === '/' ? FileType.DIRECTORY : FileType.TEXT,
+      modified: MODIFIED[name] ?? null,
+    }),
+  )
+}
+
+const readdir = (p: PathSpec): Promise<string[]> => {
+  if (key(p) === '/') return Promise.resolve(['/apple.txt', '/Banana.txt', '/CHERRY.txt'])
+  return Promise.resolve([])
+}
+
+async function run(flags: Record<string, string | boolean>): Promise<string[]> {
+  const result = await lsGeneric([spec('/')], opts(flags), readdir, stat)
+  if (result === null) return []
+  const [out] = result
+  return DEC.decode(out as Uint8Array).split('\n')
+}
+
+describe('lsGeneric', () => {
+  it('sorts names by ASCII byte order, uppercase before lowercase', async () => {
+    expect(await run({})).toEqual(['Banana.txt', 'CHERRY.txt', 'apple.txt'])
+  })
+
+  it('-r reverses the ASCII order', async () => {
+    expect(await run({ r: true })).toEqual(['apple.txt', 'CHERRY.txt', 'Banana.txt'])
+  })
+
+  it('-t sorts newest first by codepoint comparison of modified', async () => {
+    expect(await run({ t: true })).toEqual(['apple.txt', 'CHERRY.txt', 'Banana.txt'])
+  })
+
+  it('-tr sorts oldest first', async () => {
+    expect(await run({ t: true, r: true })).toEqual(['Banana.txt', 'CHERRY.txt', 'apple.txt'])
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/generic/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.ts
@@ -63,7 +63,11 @@ function sortStats(
   reverse: boolean,
 ): FileStat[] {
   const sorted = [...stats].sort((a, b) => {
-    if (sortBy === 'time') return (b.modified ?? '').localeCompare(a.modified ?? '')
+    if (sortBy === 'time') {
+      const am = a.modified ?? ''
+      const bm = b.modified ?? ''
+      return am < bm ? 1 : am > bm ? -1 : 0
+    }
     if (sortBy === 'size') return (b.size ?? 0) - (a.size ?? 0)
     return a.name < b.name ? -1 : a.name > b.name ? 1 : 0
   })

--- a/typescript/packages/core/src/core/github/du.test.ts
+++ b/typescript/packages/core/src/core/github/du.test.ts
@@ -57,4 +57,22 @@ describe('github core du', () => {
     const [, total] = await duAll(makeAccessor(), PathSpec.fromStrPath('/'))
     expect(total).toBe(157)
   })
+
+  it('duAll sorts paths by ASCII byte order, uppercase before lowercase', async () => {
+    const tree: Record<string, TreeEntry> = {
+      'apple.md': { path: 'apple.md', type: 'blob', sha: 't1', size: 1 },
+      'Banana.md': { path: 'Banana.md', type: 'blob', sha: 't2', size: 2 },
+      'CHERRY.md': { path: 'CHERRY.md', type: 'blob', sha: 't3', size: 3 },
+    }
+    const accessor = new GitHubAccessor({
+      transport: {} as GitHubTransport,
+      owner: 'o',
+      repo: 'r',
+      ref: 'main',
+      defaultBranch: 'main',
+      tree,
+    })
+    const [entries] = await duAll(accessor, PathSpec.fromStrPath('/'))
+    expect(entries.map((e) => e[0])).toEqual(['/Banana.md', '/CHERRY.md', '/apple.md'])
+  })
 })

--- a/typescript/packages/core/src/core/github/du.ts
+++ b/typescript/packages/core/src/core/github/du.ts
@@ -49,6 +49,6 @@ export function duAll(
       total += entry.size ?? 0
     }
   }
-  out.sort((a, b) => a[0].localeCompare(b[0]))
+  out.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
   return Promise.resolve([out, total])
 }

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -469,7 +469,9 @@ function sortFiletypeMap(m: Map<string, (string | null)[]>): Record<string, (str
       const aKey = a === null ? 0 : 1
       const bKey = b === null ? 0 : 1
       if (aKey !== bKey) return aKey - bKey
-      return (a ?? '').localeCompare(b ?? '')
+      const as = a ?? ''
+      const bs = b ?? ''
+      return as < bs ? -1 : as > bs ? 1 : 0
     })
     out[k] = list
   }

--- a/typescript/packages/node/src/resource/s3/mock.ts
+++ b/typescript/packages/node/src/resource/s3/mock.ts
@@ -91,7 +91,7 @@ interface PaginateResult {
 function paginateDirectory(objects: Map<string, Uint8Array>, prefix: string): PaginateResult {
   const commonPrefixes = new Set<string>()
   const contents: { Key: string; Size: number }[] = []
-  const sorted = [...objects.entries()].sort(([a], [b]) => a.localeCompare(b))
+  const sorted = [...objects.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
   for (const [key, data] of sorted) {
     if (!key.startsWith(prefix)) continue
     const relative = key.slice(prefix.length)
@@ -114,7 +114,7 @@ function paginateDirectory(objects: Map<string, Uint8Array>, prefix: string): Pa
 
 function paginateFlat(objects: Map<string, Uint8Array>, prefix: string): PaginateResult {
   const contents: { Key: string; Size: number }[] = []
-  const sorted = [...objects.entries()].sort(([a], [b]) => a.localeCompare(b))
+  const sorted = [...objects.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
   for (const [key, data] of sorted) {
     if (key.startsWith(prefix)) contents.push({ Key: key, Size: data.byteLength })
   }


### PR DESCRIPTION
localeCompare is runtime-locale dependent and diverges from Python's codepoint ordering. Replace the remaining uses with plain byte-order comparison: generic ls time sort, github du path sort, workspace filetype map sort, and the S3 mock listing (real S3 lists keys in UTF-8 binary order). The four ls commands in vercel/mongodb/postgres/posthog are left to #245, which removes or delegates them. Adds a lsGeneric unit test and a mixed-case github du case.