### PR TITLE
refactor(chroma): grep delegates to generic with pushdown candidate filter

### DIFF
--- a/python/mirage/commands/builtin/chroma/grep.py
+++ b/python/mirage/commands/builtin/chroma/grep.py
@@ -1,7 +1,13 @@
+from functools import partial
+
+from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.chroma.glob import resolve_glob
-from mirage.core.chroma.grep import grep_bytes
+from mirage.core.chroma.grep import coarse_filter_slugs, target_slugs
+from mirage.core.chroma.read import read_bytes, read_stream
+from mirage.core.chroma.readdir import readdir
+from mirage.core.chroma.stat import stat_light
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -41,11 +47,36 @@ async def grep(
         pattern = texts[0]
     else:
         raise ValueError("grep: usage: grep [flags] pattern [path]")
-    output, reads = await grep_bytes(
-        accessor,
-        paths,
-        pattern,
-        index,
+    files = paths
+    show_filename = False
+    if paths:
+        # Pushdown: expand the scope to files and let ChromaDB pre-filter
+        # which documents can contain the pattern, so only candidate
+        # documents are fetched. The generic grep owns flag handling and
+        # output formatting on the surviving files.
+        targets = await target_slugs(accessor, paths, index)
+        matched = set(await coarse_filter_slugs(accessor,
+                                                pattern,
+                                                targets,
+                                                ignore_case=i or args_i,
+                                                invert=v,
+                                                fixed_string=F))
+        prefix = paths[0].prefix
+        files = [
+            PathSpec.from_str_path(p, prefix) for p, slug in targets.items()
+            if slug in matched
+        ]
+        if not files:
+            return b"", IOResult(exit_code=1)
+        show_filename = r or R or len(paths) > 1 or len(targets) > 1
+    return await generic_grep(
+        files,
+        pattern=pattern,
+        readdir=readdir,
+        stat=stat_light,
+        read_bytes=read_bytes,
+        read_stream=partial(read_stream, index=index),
+        accessor=accessor,
         ignore_case=i or args_i,
         invert=v,
         line_numbers=n,
@@ -54,9 +85,13 @@ async def grep(
         whole_word=w,
         fixed_string=F,
         only_matching=o,
+        quiet=q,
+        recursive=False,
         max_count=int(m) if m is not None else None,
-        show_filename=r or R or len(paths) > 1)
-    io = IOResult(reads=reads, cache=list(reads), exit_code=0 if output else 1)
-    if q:
-        return b"", io
-    return output, io
+        after_context=int(A) if A is not None else
+        (int(C) if C is not None else 0),
+        before_context=int(B) if B is not None else
+        (int(C) if C is not None else 0),
+        show_filename=show_filename,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/generic/grep.py
+++ b/python/mirage/commands/builtin/generic/grep.py
@@ -41,6 +41,7 @@ async def grep(
     after_context: int = 0,
     before_context: int = 0,
     scope_check: Callable[..., Awaitable[str | None]] | None = None,
+    show_filename: bool = False,
     index: IndexCacheStore | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
     """Run grep-style fallback search over backend paths or stdin.
@@ -73,6 +74,8 @@ async def grep(
         before_context (int): `-B`, leading context lines.
         scope_check (Callable[..., Awaitable[str | None]] | None): Optional
             backend warning hook.
+        show_filename (bool): Force filename prefixes on a single path,
+            for callers that pre-expanded a multi-file scope.
         index (IndexCacheStore | None): Optional cache index for wrapped
             backend calls.
 
@@ -182,7 +185,7 @@ async def grep(
 
         pat = compile_pattern(pattern, ignore_case, fixed_string, whole_word)
 
-        if len(paths) > 1:
+        if len(paths) > 1 or show_filename:
             all_results = []
             for p in paths:
                 data = split_lines((await

--- a/python/mirage/core/chroma/grep.py
+++ b/python/mirage/core/chroma/grep.py
@@ -21,13 +21,33 @@ async def grep_bytes(
     fixed_string: bool = False,
     only_matching: bool = False,
     max_count: int | None = None,
-    show_filename: bool = True,
 ) -> tuple[bytes, dict[str, bytes]]:
+    """Filename-prefixed grep used by the FUSE ops layer.
+
+    The grep command does not use this; it delegates to the generic
+    grep with the same pushdown (see commands/builtin/chroma/grep.py).
+
+    Args:
+        accessor: Chroma accessor.
+        paths (list[PathSpec]): Files or directories to search.
+        pattern (str): Pattern text.
+        index (IndexCacheStore): Cache index for path resolution.
+        ignore_case (bool): `-i`, case-insensitive matching.
+        invert (bool): `-v`, select non-matching lines.
+        line_numbers (bool): `-n`, prefix line numbers.
+        count_only (bool): `-c`, output match counts.
+        files_only (bool): `-l`, output only matching file paths.
+        whole_word (bool): `-w`, match whole words.
+        fixed_string (bool): `-F`, treat pattern as a literal string.
+        only_matching (bool): `-o`, output only matched text.
+        max_count (int | None): `-m`, stop after this many matches.
+
+    Returns:
+        tuple[bytes, dict[str, bytes]]: Output and per-file reads keyed
+            by mount-relative path.
+    """
     regex = compile_pattern(pattern, ignore_case, fixed_string, whole_word)
     targets = await target_slugs(accessor, paths, index)
-    # Match generic grep: a single explicit file prints bare lines;
-    # multiple targets always carry the filename prefix.
-    prefixed = show_filename or len(targets) > 1
     mount_prefix = paths[0].prefix if paths else ""
     lines: list[str] = []
     reads: dict[str, bytes] = {}
@@ -48,14 +68,11 @@ async def grep_bytes(
                           max_count)
         if count_only:
             if hits:
-                lines.append(f"{path}:{hits[0]}" if prefixed else hits[0])
+                lines.append(f"{path}:{hits[0]}")
         elif files_only:
             lines.extend(hits)
         else:
-            if prefixed:
-                lines.extend(f"{path}:{hit}" for hit in hits)
-            else:
-                lines.extend(hits)
+            lines.extend(f"{path}:{hit}" for hit in hits)
     return "\n".join(lines).encode(), reads
 
 

--- a/python/tests/commands/builtin/chroma/test_grep.py
+++ b/python/tests/commands/builtin/chroma/test_grep.py
@@ -1,37 +1,108 @@
 import pytest
 
 from mirage.commands.builtin.chroma.grep import grep
+from mirage.io.types import materialize
 from mirage.types import PathSpec
 
+DOCS = {
+    "/knowledge/a.md": b"alpha match\nbeta\n",
+    "/knowledge/b.md": b"gamma match\n",
+}
 
-@pytest.mark.asyncio
-async def test_chroma_grep_command_uses_optimized_core(monkeypatch):
-    calls = []
+
+def _spec(path: str) -> PathSpec:
+    return PathSpec.from_str_path(path, "/knowledge/")
+
+
+def _patch_pushdown(monkeypatch, targets: dict[str, str],
+                    matched: list[str]) -> list[tuple]:
+    calls: list[tuple] = []
+    g = grep.__wrapped__.__globals__
 
     async def fake_resolve_glob(accessor, paths, index):
         return paths
 
-    async def fake_grep_bytes(accessor, paths, pattern, index, **kwargs):
-        calls.append((paths, pattern, index, kwargs))
-        return b"/knowledge/a:match", {"/knowledge/a": b"match"}
+    async def fake_target_slugs(accessor, paths, index):
+        return targets
 
-    monkeypatch.setitem(grep.__wrapped__.__globals__, "resolve_glob",
-                        fake_resolve_glob)
-    monkeypatch.setitem(grep.__wrapped__.__globals__, "grep_bytes",
-                        fake_grep_bytes)
+    async def fake_coarse(accessor, pattern, t, *, ignore_case, invert,
+                          fixed_string):
+        calls.append((pattern, ignore_case, invert, fixed_string))
+        return matched
 
-    path = PathSpec.from_str_path("/knowledge/a", "/knowledge/")
-    index = object()
-    output, io = await grep(object(), [path],
+    def fake_read_stream(accessor, p, index=None):
+        return _stream_doc(p.original)
+
+    async def fake_read_bytes(accessor, p, index=None):
+        return DOCS[p.original]
+
+    monkeypatch.setitem(g, "resolve_glob", fake_resolve_glob)
+    monkeypatch.setitem(g, "target_slugs", fake_target_slugs)
+    monkeypatch.setitem(g, "coarse_filter_slugs", fake_coarse)
+    monkeypatch.setitem(g, "read_stream", fake_read_stream)
+    monkeypatch.setitem(g, "read_bytes", fake_read_bytes)
+    return calls
+
+
+async def _stream_doc(path: str):
+    yield DOCS[path]
+
+
+@pytest.mark.asyncio
+async def test_single_file_prints_bare_lines(monkeypatch):
+    calls = _patch_pushdown(monkeypatch, {"/knowledge/a.md": "a"}, ["a"])
+
+    output, io = await grep(object(), [_spec("/knowledge/a.md")],
                             "match",
-                            i=True,
-                            n=True,
-                            index=index)
+                            index=None)
 
-    assert output == b"/knowledge/a:match"
-    assert io.reads == {"/knowledge/a": b"match"}
-    assert io.cache == ["/knowledge/a"]
-    assert calls[0][1] == "match"
-    assert calls[0][2] is index
-    assert calls[0][3]["ignore_case"] is True
-    assert calls[0][3]["line_numbers"] is True
+    assert await materialize(output) == b"alpha match\n"
+    assert io.exit_code == 0
+    assert calls == [("match", False, False, False)]
+
+
+@pytest.mark.asyncio
+async def test_filtered_out_skips_reads_and_exits_one(monkeypatch):
+    _patch_pushdown(monkeypatch, {"/knowledge/a.md": "a"}, [])
+
+    output, io = await grep(object(), [_spec("/knowledge/a.md")],
+                            "absent",
+                            index=None)
+
+    assert output == b""
+    assert io.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_multi_target_prefixes_filenames(monkeypatch):
+    _patch_pushdown(monkeypatch, {
+        "/knowledge/a.md": "a",
+        "/knowledge/b.md": "b"
+    }, ["a", "b"])
+
+    output, io = await grep(
+        object(), [_spec("/knowledge/a.md"),
+                   _spec("/knowledge/b.md")],
+        "match",
+        index=None)
+
+    assert await materialize(output) == (b"/knowledge/a.md:alpha match\n"
+                                         b"/knowledge/b.md:gamma match\n")
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_pushdown_prunes_but_keeps_prefix(monkeypatch):
+    _patch_pushdown(monkeypatch, {
+        "/knowledge/a.md": "a",
+        "/knowledge/b.md": "b"
+    }, ["b"])
+
+    output, io = await grep(
+        object(), [_spec("/knowledge/a.md"),
+                   _spec("/knowledge/b.md")],
+        "gamma",
+        index=None)
+
+    assert await materialize(output) == b"/knowledge/b.md:gamma match\n"
+    assert io.exit_code == 0

--- a/typescript/packages/core/src/commands/builtin/chroma/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/chroma/grep.ts
@@ -14,13 +14,15 @@
 
 import type { ChromaAccessor } from '../../../accessor/chroma.ts'
 import { resolveGlob } from '../../../core/chroma/glob.ts'
-import { grepBytes } from '../../../core/chroma/grep.ts'
+import { coarseFilterSlugs, targetSlugs } from '../../../core/chroma/grep.ts'
+import { readStream } from '../../../core/chroma/read.ts'
+import { readdir as chromaReaddir } from '../../../core/chroma/readdir.ts'
+import { statLight } from '../../../core/chroma/stat.ts'
 import { IOResult } from '../../../io/types.ts'
-import { ResourceName, type PathSpec } from '../../../types.ts'
+import { type FileStat, PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-
-const ENC = new TextEncoder()
+import { grepGeneric } from '../generic/grep.ts'
 
 async function grepCommand(
   accessor: ChromaAccessor,
@@ -30,41 +32,49 @@ async function grepCommand(
 ): Promise<CommandFnResult> {
   const index = opts.index ?? undefined
   const resolved = paths.length > 0 ? await resolveGlob(accessor, paths, index) : []
-  let pattern: string
-  if (typeof opts.flags.e === 'string') {
-    pattern = opts.flags.e
-  } else if (texts.length > 0 && texts[0] !== undefined) {
-    pattern = texts[0]
-  } else {
-    return [
-      null,
-      new IOResult({
-        exitCode: 2,
-        stderr: ENC.encode('grep: usage: grep [flags] pattern [path]\n'),
+  const pattern =
+    typeof opts.flags.e === 'string' ? opts.flags.e : texts.length > 0 ? texts[0] : undefined
+  let files = resolved
+  let showFilename = false
+  let grepOpts = opts
+  if (resolved.length > 0 && pattern !== undefined) {
+    // Pushdown: expand the scope to files and let ChromaDB pre-filter
+    // which documents can contain the pattern, so only candidate
+    // documents are fetched. The generic grep owns flag handling and
+    // output formatting on the surviving files.
+    const targets = await targetSlugs(accessor, resolved, index)
+    const matched = new Set(
+      await coarseFilterSlugs(accessor, pattern, targets, {
+        ignoreCase: opts.flags.i === true,
+        invert: opts.flags.v === true,
+        fixedString: opts.flags.F === true,
       }),
-    ]
+    )
+    const prefix = resolved[0]?.prefix ?? ''
+    files = [...targets.entries()]
+      .filter(([, slug]) => matched.has(slug))
+      .map(([p]) => PathSpec.fromStrPath(p, prefix))
+    if (files.length === 0) {
+      return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
+    }
+    showFilename =
+      opts.flags.r === true || opts.flags.R === true || resolved.length > 1 || targets.size > 1
+    // Paths are pre-expanded to files, so the generic must not recurse.
+    grepOpts = { ...opts, flags: { ...opts.flags, r: false, R: false } }
   }
-  const [output, reads] = await grepBytes(accessor, resolved, pattern, index, {
-    ignoreCase: opts.flags.i === true,
-    invert: opts.flags.v === true,
-    lineNumbers: opts.flags.n === true,
-    countOnly: opts.flags.c === true,
-    filesOnly: opts.flags.args_l === true || opts.flags.l === true,
-    wholeWord: opts.flags.w === true,
-    fixedString: opts.flags.F === true,
-    onlyMatching: opts.flags.o === true,
-    maxCount: typeof opts.flags.m === 'string' ? Number.parseInt(opts.flags.m, 10) : null,
-    showFilename: opts.flags.r === true || opts.flags.R === true || resolved.length > 1,
-  })
-  const io = new IOResult({
-    reads,
-    cache: Object.keys(reads),
-    exitCode: output.byteLength > 0 ? 0 : 1,
-  })
-  if (opts.flags.q === true) {
-    return [new Uint8Array(0), io]
-  }
-  return [output, io]
+  const stat = (p: PathSpec): Promise<FileStat> => statLight(accessor, p, index)
+  const readdir = (p: PathSpec): Promise<string[]> => chromaReaddir(accessor, p, index)
+  return grepGeneric(
+    'grep',
+    files,
+    texts,
+    grepOpts,
+    stat,
+    readdir,
+    (p) => readStream(accessor, p, index),
+    undefined,
+    showFilename,
+  )
 }
 
 export const CHROMA_GREP = command({

--- a/typescript/packages/core/src/commands/builtin/generic/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/grep.ts
@@ -114,6 +114,7 @@ export async function grepGeneric(
   readdir: Readdir,
   stream: Stream,
   scopeCheck?: ScopeCheck,
+  showFilename = false,
 ): Promise<CommandFnResult> {
   let pattern: string
   try {
@@ -216,7 +217,7 @@ export async function grepGeneric(
       ]
     }
 
-    if (paths.length > 1) {
+    if (paths.length > 1 || showFilename) {
       const allResults: string[] = []
       for (const p of paths) {
         const data = splitLinesNoTrailing(DEC.decode(await materialize(stream(p))))

--- a/typescript/packages/core/src/core/chroma/grep.ts
+++ b/typescript/packages/core/src/core/chroma/grep.ts
@@ -14,91 +14,10 @@
 
 import type { ChromaAccessor } from '../../accessor/chroma.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
-import { compilePattern, grepLines } from '../../commands/builtin/grep_helper.ts'
 import { PathSpec } from '../../types.ts'
-import { fetchPageChunks, queryContains } from './_client.ts'
+import { queryContains } from './_client.ts'
 import { resolvePath } from './path.ts'
 import { walk } from './walk.ts'
-
-const ENC = new TextEncoder()
-
-export interface GrepBytesOptions {
-  ignoreCase?: boolean
-  invert?: boolean
-  lineNumbers?: boolean
-  countOnly?: boolean
-  filesOnly?: boolean
-  wholeWord?: boolean
-  fixedString?: boolean
-  onlyMatching?: boolean
-  maxCount?: number | null
-  showFilename?: boolean
-}
-
-function splitLines(text: string): string[] {
-  const lines = text.split('\n')
-  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
-  return lines
-}
-
-export async function grepBytes(
-  accessor: ChromaAccessor,
-  paths: readonly PathSpec[],
-  pattern: string,
-  index?: IndexCacheStore,
-  options: GrepBytesOptions = {},
-): Promise<[Uint8Array, Record<string, Uint8Array>]> {
-  const ignoreCase = options.ignoreCase ?? false
-  const invert = options.invert ?? false
-  const lineNumbers = options.lineNumbers ?? false
-  const countOnly = options.countOnly ?? false
-  const filesOnly = options.filesOnly ?? false
-  const wholeWord = options.wholeWord ?? false
-  const fixedString = options.fixedString ?? false
-  const onlyMatching = options.onlyMatching ?? false
-  const maxCount = options.maxCount ?? null
-
-  const showFilename = options.showFilename ?? true
-
-  const regex = compilePattern(pattern, ignoreCase, fixedString, wholeWord)
-  const targets = await targetSlugs(accessor, paths, index)
-  // Match generic grep: a single explicit file prints bare lines;
-  // multiple targets always carry the filename prefix.
-  const prefixed = showFilename || targets.size > 1
-  const mountPrefix = paths.length > 0 ? (paths[0]?.prefix ?? '') : ''
-  const matchedSlugs = await coarseFilterSlugs(accessor, pattern, targets, {
-    ignoreCase,
-    invert,
-    fixedString,
-  })
-  const lines: string[] = []
-  const reads: Record<string, Uint8Array> = {}
-  const slugToPath = new Map<string, string>()
-  for (const [path, slug] of targets) {
-    slugToPath.set(slug, path)
-  }
-  for (const slug of matchedSlugs) {
-    const content = await fetchPageChunks(accessor, slug)
-    const path = slugToPath.get(slug) ?? '/' + slug
-    reads[PathSpec.fromStrPath(path, mountPrefix).stripPrefix] = ENC.encode(content)
-    const hits = grepLines(path, splitLines(content), regex, {
-      invert,
-      lineNumbers,
-      countOnly,
-      filesOnly,
-      onlyMatching,
-      maxCount,
-    })
-    if (countOnly) {
-      if (hits.length > 0) lines.push(prefixed ? `${path}:${hits[0] ?? ''}` : (hits[0] ?? ''))
-    } else if (filesOnly) {
-      lines.push(...hits)
-    } else {
-      lines.push(...(prefixed ? hits.map((hit) => `${path}:${hit}`) : hits))
-    }
-  }
-  return [ENC.encode(lines.join('\n')), reads]
-}
 
 export async function coarseFilterSlugs(
   accessor: ChromaAccessor,

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -1063,7 +1063,6 @@ export { readBytes as chromaRead, readStream as chromaReadStream } from './core/
 export { readdir as chromaReaddir } from './core/chroma/readdir.ts'
 export { stat as chromaStat } from './core/chroma/stat.ts'
 export { resolveGlob as resolveChromaGlob } from './core/chroma/glob.ts'
-export { grepBytes as chromaGrep } from './core/chroma/grep.ts'
 export { searchSegments as chromaSearch } from './core/chroma/search.ts'
 export { scoreFromDistance } from './util/score.ts'
 export {


### PR DESCRIPTION
Stacked on #241. Removes the bespoke chroma grep so the command path cannot drift from the generic again.

- chroma grep (py + ts) now: expand scope to files, ask ChromaDB which documents can contain the pattern (`coarse_filter_slugs` pushdown), then hand the surviving files to the generic grep, which owns all flag handling and output formatting.
- generic grep gains a `show_filename` override for callers that pre-expanded a multi-file scope down to one file.
- `core/chroma/grep.py::grep_bytes` is kept only for the Python FUSE op (documented); the TS copy had no remaining consumer and is deleted.
- Side effect: single-file chroma grep now streams and supports `-A/-B/-C` context, matching the warm-cache generic path.

Verified: py + ts chroma integ byte-identical to existing `truth_chroma.txt` against live ChromaDB (no truth change needed); 3092 py command tests, 2964 ts core tests, pre-commit clean.

Follow-up candidate: chroma `rg` can reuse the same pushdown recipe (it currently delegates without the filter).