### PR TITLE
fix(ts): formatted command output ends with trailing newline like Python

### DIFF
--- a/typescript/packages/core/src/commands/builtin/discord/find.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/find.ts
@@ -23,8 +23,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { metadataProvision } from './_provision.ts'
 import { stripSlash } from '../../../util/slash.ts'
 import { fnmatch } from '../../../util/fnmatch.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 async function walk(
   accessor: DiscordAccessor,
@@ -94,7 +93,7 @@ async function findCommand(
     if (inameFlag !== null && !fnmatch(entryName.toLowerCase(), inameFlag.toLowerCase())) continue
     results.push(p)
   }
-  const out: ByteSource = ENC.encode(results.join('\n'))
+  const out: ByteSource = formatRecords(results)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/core/src/commands/builtin/discord/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/grep.ts
@@ -29,6 +29,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { compilePattern, grepFilesOnly, grepLines, grepStream } from '../grep_helper.ts'
 import { resolveSource } from '../utils/stream.ts'
 import { fileReadProvision } from './_provision.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
@@ -209,7 +210,7 @@ async function grepCommand(
           new IOResult({ exitCode: 1, ...(stderr !== undefined ? { stderr } : {}) }),
         ]
       }
-      const out: ByteSource = ENC.encode(allResults.join('\n'))
+      const out: ByteSource = formatRecords(allResults)
       return [out, new IOResult({ ...(stderr !== undefined ? { stderr } : {}) })]
     }
 

--- a/typescript/packages/core/src/commands/builtin/discord/ls.test.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/ls.test.ts
@@ -76,7 +76,7 @@ describe('discord ls', () => {
       {},
       { index: idx },
     )
-    expect(out.stdout.split('\n').sort()).toEqual(['channels', 'members'])
+    expect(out.stdout.trimEnd().split('\n').sort()).toEqual(['channels', 'members'])
   })
 
   it('lists channels under a guild from cached index', async () => {
@@ -98,7 +98,7 @@ describe('discord ls', () => {
       {},
       { index: idx, transport },
     )
-    expect(out.stdout).toBe('general__C1')
+    expect(out.stdout).toBe('general__C1\n')
     expect(transport.calls).toHaveLength(0)
   })
 
@@ -123,7 +123,7 @@ describe('discord ls', () => {
       {},
       { index: idx, transport },
     )
-    const lines = out.stdout.split('\n').sort()
+    const lines = out.stdout.trimEnd().split('\n').sort()
     expect(lines).toEqual(['2024-01-01', '2024-01-02'])
   })
 })

--- a/typescript/packages/core/src/commands/builtin/discord/stat.test.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/stat.test.ts
@@ -86,7 +86,7 @@ describe('discord stat', () => {
       { c: '%n' },
       { index: idx },
     )
-    expect(out.stdout).toBe('general__C1')
+    expect(out.stdout).toBe('general__C1\n')
   })
 
   it('returns exit 1 with no operand', async () => {

--- a/typescript/packages/core/src/commands/builtin/discord/tree.test.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/tree.test.ts
@@ -61,7 +61,7 @@ describe('discord tree', () => {
       { L: '1' },
       { index: idx },
     )
-    const lines = out.split('\n')
+    const lines = out.trimEnd().split('\n')
     expect(lines).toHaveLength(2)
     expect(lines[0]).toContain('channels')
     expect(lines[1]).toContain('members')

--- a/typescript/packages/core/src/commands/builtin/discord/wc.test.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/wc.test.ts
@@ -74,7 +74,7 @@ describe('discord wc', () => {
       {},
       { index: idx, transport },
     )
-    const parts = out.split('\t')
+    const parts = out.trimEnd().split('\t')
     expect(parts).toHaveLength(4)
     expect(parts[0]).toBe('3')
     expect(parts[3]).toBe('/mnt/discord/My Server__G1/channels/general__C1/2016-04-30/chat.jsonl')
@@ -107,6 +107,6 @@ describe('discord wc', () => {
       { args_l: true },
       { index: idx, transport },
     )
-    expect(out).toBe('2\t/mnt/discord/My Server__G1/channels/general__C1/2016-04-30/chat.jsonl')
+    expect(out).toBe('2\t/mnt/discord/My Server__G1/channels/general__C1/2016-04-30/chat.jsonl\n')
   })
 })

--- a/typescript/packages/core/src/commands/builtin/gdocs/rm.ts
+++ b/typescript/packages/core/src/commands/builtin/gdocs/rm.ts
@@ -19,6 +19,7 @@ import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -48,7 +49,7 @@ async function rmCommand(
     writes[p.stripPrefix] = new Uint8Array()
     if (verbose) verboseParts.push(`removed '${p.original}'`)
   }
-  const output: ByteSource | null = verbose ? ENC.encode(verboseParts.join('\n')) : null
+  const output: ByteSource | null = verbose ? formatRecords(verboseParts) : null
   return [output, new IOResult({ writes })]
 }
 

--- a/typescript/packages/core/src/commands/builtin/generic/cmp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cmp.ts
@@ -15,6 +15,7 @@
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -61,7 +62,7 @@ export async function cmpGeneric(
         outLines.push(`${String(idx + 1)} ${octal(data1[idx] ?? 0)} ${octal(data2[idx] ?? 0)}`)
       }
     }
-    const out: ByteSource = ENC.encode(outLines.join('\n'))
+    const out: ByteSource = formatRecords(outLines)
     return [out, new IOResult({ exitCode: 1 })]
   }
   const limit = Math.min(data1.byteLength, data2.byteLength)

--- a/typescript/packages/core/src/commands/builtin/generic/du.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/du.ts
@@ -16,8 +16,7 @@ import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { rstripSlash, stripSlash } from '../../../util/slash.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 function humanSize(n: number): string {
   const units = ['B', 'K', 'M', 'G', 'T']
@@ -83,6 +82,6 @@ export async function duGeneric(
   if (cumulative) {
     lines.push(`${fmt(grand)}\ttotal`)
   }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
+  const out: ByteSource = formatRecords(lines)
   return [out, new IOResult()]
 }

--- a/typescript/packages/core/src/commands/builtin/generic/file.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/file.ts
@@ -16,6 +16,7 @@ import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { FileType, type FileStat, type PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { detectFileType, formatFileResult } from '../file_helper.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -47,6 +48,6 @@ export async function fileGeneric(
     const result = detectFileType(header, s)
     lines.push(formatFileResult(p.original, result, brief, mime))
   }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
+  const out: ByteSource = formatRecords(lines)
   return [out, new IOResult()]
 }

--- a/typescript/packages/core/src/commands/builtin/generic/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.ts
@@ -17,8 +17,7 @@ import { FileType, PathSpec, type FileStat } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { formatLsLong } from '../utils/formatting.ts'
 import { rstripSlash } from '../../../util/slash.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 type Readdir = (p: PathSpec) => Promise<string[]>
 type Stat = (p: PathSpec) => Promise<FileStat>
@@ -149,10 +148,10 @@ export async function lsGeneric(
       }
     }
     appendListing(collected, long, human, classify, lines)
-    const out: ByteSource = ENC.encode(lines.join('\n'))
+    const out: ByteSource = formatRecords(lines)
     const exitCode = warnings.length > 0 && lines.length === 0 ? 1 : 0
     if (warnings.length > 0) {
-      const stderr = ENC.encode(warnings.join('\n'))
+      const stderr = formatRecords(warnings)
       return [out, new IOResult({ stderr, exitCode })]
     }
     return [out, new IOResult({ exitCode })]
@@ -172,10 +171,10 @@ export async function lsGeneric(
       lines.push(`${dirSpec.original}:`)
       appendListing(entries, long, human, classify, lines)
     }
-    const out: ByteSource = ENC.encode(lines.join('\n'))
+    const out: ByteSource = formatRecords(lines)
     const exitCode = warnings.length > 0 && lines.length === 0 ? 1 : 0
     if (warnings.length > 0) {
-      const stderr = ENC.encode(warnings.join('\n'))
+      const stderr = formatRecords(warnings)
       return [out, new IOResult({ stderr, exitCode })]
     }
     return [out, new IOResult({ exitCode })]
@@ -196,10 +195,10 @@ export async function lsGeneric(
     }
     appendListing(sortStats(stats, sortBy, reverse), long, human, classify, lines)
   }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
+  const out: ByteSource = formatRecords(lines)
   const exitCode = warnings.length > 0 && lines.length === 0 ? 1 : 0
   if (warnings.length > 0) {
-    const stderr = ENC.encode(warnings.join('\n'))
+    const stderr = formatRecords(warnings)
     return [out, new IOResult({ stderr, exitCode })]
   }
   return [out, new IOResult({ exitCode })]

--- a/typescript/packages/core/src/commands/builtin/generic/md5.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/md5.ts
@@ -16,6 +16,7 @@ import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import { md5Hex } from '../../../utils/hash.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
+import { formatRecords } from '../utils/output.ts'
 
 export async function md5Generic(
   paths: PathSpec[],
@@ -32,6 +33,6 @@ export async function md5Generic(
     const data = await materialize(opts.stdin)
     lines.push(`${md5Hex(data)}  -`)
   }
-  const out: ByteSource = new TextEncoder().encode(lines.join('\n'))
+  const out: ByteSource = formatRecords(lines)
   return [out, new IOResult()]
 }

--- a/typescript/packages/core/src/commands/builtin/generic/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/stat.ts
@@ -17,6 +17,7 @@ import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { ProvisionResult } from '../../../provision/types.ts'
 import { FileType, type FileStat, type PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -76,6 +77,6 @@ export async function statGeneric(
       lines.push(`name=${s.name} size=${sizeStr} modified=${modStr} type=${typeStr}`)
     }
   }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
+  const out: ByteSource = formatRecords(lines)
   return [out, new IOResult()]
 }

--- a/typescript/packages/core/src/commands/builtin/generic/tree.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tree.test.ts
@@ -75,16 +75,16 @@ async function run(
 
 describe('treeGeneric with trailing-slash folder entries', () => {
   it('shows folder names and hides hidden folders by default', async () => {
-    expect(await run(boxReaddir, {})).toBe('├── docs\n│   └── a.txt\n└── readme.txt')
+    expect(await run(boxReaddir, {})).toBe('├── docs\n│   └── a.txt\n└── readme.txt\n')
   })
 
   it('shows hidden folders by name with -a', async () => {
     expect(await run(boxReaddir, { a: true })).toBe(
-      '├── .secret\n├── docs\n│   └── a.txt\n└── readme.txt',
+      '├── .secret\n├── docs\n│   └── a.txt\n└── readme.txt\n',
     )
   })
 
   it('produces identical output for slash-free entries', async () => {
-    expect(await run(s3Readdir, {})).toBe('├── docs\n│   └── a.txt\n└── readme.txt')
+    expect(await run(s3Readdir, {})).toBe('├── docs\n│   └── a.txt\n└── readme.txt\n')
   })
 })

--- a/typescript/packages/core/src/commands/builtin/generic/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tree.ts
@@ -17,8 +17,7 @@ import { FileType, PathSpec, type FileStat } from '../../../types.ts'
 import { rstripSlash } from '../../../util/slash.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { fnmatch } from '../../../util/fnmatch.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 interface TreeOpts {
   showHidden: boolean
@@ -112,6 +111,6 @@ export async function treeGeneric(
   for (const p of targets) {
     await walkTree(readdir, stat, p, '', lines, treeOpts, 0)
   }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
+  const out: ByteSource = formatRecords(lines)
   return [out, new IOResult()]
 }

--- a/typescript/packages/core/src/commands/builtin/generic/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/wc.ts
@@ -16,6 +16,7 @@ import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { resolveSource } from '../utils/stream.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
@@ -92,7 +93,7 @@ export async function wcGeneric(
       else
         outputs.push(`${String(totalLines)}\t${String(totalWords)}\t${String(totalBytes)}\ttotal`)
     }
-    const out: ByteSource = ENC.encode(outputs.join('\n'))
+    const out: ByteSource = formatRecords(outputs)
     return [out, new IOResult()]
   }
   let source: AsyncIterable<Uint8Array>

--- a/typescript/packages/core/src/commands/builtin/github_ci/find.ts
+++ b/typescript/packages/core/src/commands/builtin/github_ci/find.ts
@@ -22,8 +22,8 @@ import { specOf } from '../../spec/builtins.ts'
 import { metadataProvision } from './provision.ts'
 import { stripSlash } from '../../../util/slash.ts'
 import { fnmatch } from '../../../util/fnmatch.ts'
+import { formatRecords } from '../utils/output.ts'
 
-const ENC = new TextEncoder()
 const TERMINAL_EXTS = ['.json', '.jsonl', '.log', '.zip']
 
 async function walk(
@@ -94,7 +94,7 @@ async function findCommand(
     if (inameFlag !== null && !fnmatch(entryName.toLowerCase(), inameFlag.toLowerCase())) continue
     results.push(p)
   }
-  const out: ByteSource = ENC.encode(results.join('\n'))
+  const out: ByteSource = formatRecords(results)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/core/src/commands/builtin/gmail/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/grep.ts
@@ -36,6 +36,7 @@ import {
 } from '../grep_helper.ts'
 import { resolveSource } from '../utils/stream.ts'
 import { fileReadProvision } from './provision.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
@@ -178,9 +179,9 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+      const stderr = warnings.length > 0 ? formatRecords(warnings) : null
       if (results.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1, stderr })]
-      const out: ByteSource = ENC.encode(results.join('\n'))
+      const out: ByteSource = formatRecords(results)
       return [out, new IOResult({ stderr })]
     }
 
@@ -200,7 +201,7 @@ async function grepCommand(
         }
       }
       if (allResults.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      const out: ByteSource = ENC.encode(allResults.join('\n'))
+      const out: ByteSource = formatRecords(allResults)
       return [out, new IOResult()]
     }
 

--- a/typescript/packages/core/src/commands/builtin/gsheets/rm.ts
+++ b/typescript/packages/core/src/commands/builtin/gsheets/rm.ts
@@ -19,6 +19,7 @@ import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -48,7 +49,7 @@ async function rmCommand(
     writes[p.stripPrefix] = new Uint8Array()
     if (verbose) verboseParts.push(`removed '${p.original}'`)
   }
-  const output: ByteSource | null = verbose ? ENC.encode(verboseParts.join('\n')) : null
+  const output: ByteSource | null = verbose ? formatRecords(verboseParts) : null
   return [output, new IOResult({ writes })]
 }
 

--- a/typescript/packages/core/src/commands/builtin/gslides/rm.ts
+++ b/typescript/packages/core/src/commands/builtin/gslides/rm.ts
@@ -19,6 +19,7 @@ import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -48,7 +49,7 @@ async function rmCommand(
     writes[p.stripPrefix] = new Uint8Array()
     if (verbose) verboseParts.push(`removed '${p.original}'`)
   }
-  const output: ByteSource | null = verbose ? ENC.encode(verboseParts.join('\n')) : null
+  const output: ByteSource | null = verbose ? formatRecords(verboseParts) : null
   return [output, new IOResult({ writes })]
 }
 

--- a/typescript/packages/core/src/commands/builtin/langfuse/find.ts
+++ b/typescript/packages/core/src/commands/builtin/langfuse/find.ts
@@ -23,8 +23,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { metadataProvision } from './_provision.ts'
 import { stripSlash } from '../../../util/slash.ts'
 import { fnmatch } from '../../../util/fnmatch.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 async function walk(
   accessor: LangfuseAccessor,
@@ -94,7 +93,7 @@ async function findCommand(
     if (inameFlag !== null && !fnmatch(entryName.toLowerCase(), inameFlag.toLowerCase())) continue
     results.push(p)
   }
-  const out: ByteSource = ENC.encode(results.join('\n'))
+  const out: ByteSource = formatRecords(results)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/core/src/commands/builtin/langfuse/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/langfuse/grep.ts
@@ -32,6 +32,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { compilePattern, grepFilesOnly, grepRecursive, grepStream } from '../grep_helper.ts'
 import { resolveSource } from '../utils/stream.ts'
 import { fileReadProvision } from './_provision.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -95,7 +96,7 @@ function filterTraces(
     lines.push(`traces/${traceId}.json:${lineJson}`)
   }
   if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-  return [ENC.encode(lines.join('\n')), new IOResult()]
+  return [formatRecords(lines), new IOResult()]
 }
 
 function filterSessions(
@@ -110,7 +111,7 @@ function filterSessions(
     lines.push(`sessions/${sessionId}:${lineJson}`)
   }
   if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-  return [ENC.encode(lines.join('\n')), new IOResult()]
+  return [formatRecords(lines), new IOResult()]
 }
 
 function filterPrompts(
@@ -128,7 +129,7 @@ function filterPrompts(
     lines.push(`prompts/${promptName}:${lineJson}`)
   }
   if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-  return [ENC.encode(lines.join('\n')), new IOResult()]
+  return [formatRecords(lines), new IOResult()]
 }
 
 function filterDatasets(
@@ -143,7 +144,7 @@ function filterDatasets(
     lines.push(`datasets/${datasetName}:${lineJson}`)
   }
   if (lines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-  return [ENC.encode(lines.join('\n')), new IOResult()]
+  return [formatRecords(lines), new IOResult()]
 }
 
 async function grepCommand(
@@ -220,7 +221,7 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : undefined
+      const stderr = warnings.length > 0 ? formatRecords(warnings) : undefined
       if (results.length === 0) {
         return [
           new Uint8Array(0),
@@ -270,11 +271,11 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+      const stderr = warnings.length > 0 ? formatRecords(warnings) : null
       if (results.length === 0) {
         return [new Uint8Array(0), new IOResult({ exitCode: 1, stderr })]
       }
-      return [ENC.encode(results.join('\n')), new IOResult({ stderr })]
+      return [formatRecords(results), new IOResult({ stderr })]
     }
 
     const data = await langfuseRead(accessor, target, opts.index ?? undefined)

--- a/typescript/packages/core/src/commands/builtin/linear/find.ts
+++ b/typescript/packages/core/src/commands/builtin/linear/find.ts
@@ -23,8 +23,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { metadataProvision } from './_provision.ts'
 import { stripSlash } from '../../../util/slash.ts'
 import { fnmatch } from '../../../util/fnmatch.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 async function walk(
   accessor: LinearAccessor,
@@ -94,7 +93,7 @@ async function findCommand(
     if (inameFlag !== null && !fnmatch(entryName.toLowerCase(), inameFlag.toLowerCase())) continue
     results.push(p)
   }
-  const out: ByteSource = ENC.encode(results.join('\n'))
+  const out: ByteSource = formatRecords(results)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/core/src/commands/builtin/mongodb/find.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/find.ts
@@ -23,8 +23,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { metadataProvision } from './_provision.ts'
 import { stripSlash } from '../../../util/slash.ts'
 import { fnmatch } from '../../../util/fnmatch.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 async function walk(
   accessor: MongoDBAccessor,
@@ -94,7 +93,7 @@ async function findCommand(
     if (inameFlag !== null && !fnmatch(entryName.toLowerCase(), inameFlag.toLowerCase())) continue
     results.push(p)
   }
-  const out: ByteSource = ENC.encode(results.join('\n'))
+  const out: ByteSource = formatRecords(results)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/core/src/commands/builtin/mongodb/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/grep.ts
@@ -33,6 +33,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { compilePattern, grepFilesOnly, grepRecursive, grepStream } from '../grep_helper.ts'
 import { resolveSource } from '../utils/stream.ts'
 import { fileReadProvision } from './_provision.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -108,14 +109,14 @@ async function grepCommand(
       }
       const allLines = formatGrepResults(results)
       if (allLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
+      return [formatRecords(allLines), new IOResult()]
     }
 
     if (scope.level === ScopeLevel.DATABASE && scope.database !== null) {
       const results = await searchDatabase(accessor, scope.database, pattern, limit)
       const allLines = formatGrepResults(results)
       if (allLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
+      return [formatRecords(allLines), new IOResult()]
     }
 
     if (scope.level === ScopeLevel.ENTITY && scope.database !== null && scope.name !== null) {
@@ -123,7 +124,7 @@ async function grepCommand(
       if (docs.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
       const results = [{ database: scope.database, collection: scope.name, docs }]
       const allLines = formatGrepResults(results)
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
+      return [formatRecords(allLines), new IOResult()]
     }
 
     const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
@@ -161,7 +162,7 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : undefined
+      const stderr = warnings.length > 0 ? formatRecords(warnings) : undefined
       if (results.length === 0) {
         return [
           new Uint8Array(0),
@@ -212,11 +213,11 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+      const stderr = warnings.length > 0 ? formatRecords(warnings) : null
       if (results.length === 0) {
         return [new Uint8Array(0), new IOResult({ exitCode: 1, stderr })]
       }
-      return [ENC.encode(results.join('\n')), new IOResult({ stderr })]
+      return [formatRecords(results), new IOResult({ stderr })]
     }
 
     const data = await mongoRead(accessor, target, opts.index ?? undefined)

--- a/typescript/packages/core/src/commands/builtin/mongodb/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/ls.ts
@@ -22,8 +22,7 @@ import { command, type CommandFnResult, type CommandOpts } from '../../config.ts
 import { specOf } from '../../spec/builtins.ts'
 import { humanSize } from '../utils/formatting.ts'
 import { metadataProvision } from './_provision.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 async function lsEntries(
   accessor: MongoDBAccessor,
@@ -164,9 +163,9 @@ async function lsCommand(
       }
     }
   }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+  const stderr = warnings.length > 0 ? formatRecords(warnings) : null
   const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
+  const out: ByteSource = formatRecords(results)
   return [out, new IOResult({ stderr, exitCode })]
 }
 

--- a/typescript/packages/core/src/commands/builtin/mongodb/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/rg.ts
@@ -31,6 +31,7 @@ import { command, type CommandFnResult, type CommandOpts } from '../../config.ts
 import { specOf } from '../../spec/builtins.ts'
 import { compilePattern, grepLines } from '../grep_helper.ts'
 import { readStdinAsync } from '../utils/stream.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
@@ -129,20 +130,20 @@ async function rgCommand(
       }
       const allLines = formatGrepResults(results)
       if (allLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
+      return [formatRecords(allLines), new IOResult()]
     }
     if (scope.level === ScopeLevel.DATABASE && scope.database !== null) {
       const results = await searchDatabase(accessor, scope.database, exprText, limit)
       const allLines = formatGrepResults(results)
       if (allLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
+      return [formatRecords(allLines), new IOResult()]
     }
     if (scope.level === ScopeLevel.ENTITY && scope.database !== null && scope.name !== null) {
       const docs = await searchCollection(accessor, scope.database, scope.name, exprText, limit)
       if (docs.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
       const results = [{ database: scope.database, collection: scope.name, docs }]
       const allLines = formatGrepResults(results)
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
+      return [formatRecords(allLines), new IOResult()]
     }
 
     const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
@@ -188,7 +189,7 @@ async function rgCommand(
       }
     }
     if (!anyMatch) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-    const out: ByteSource = ENC.encode(allResults.join('\n'))
+    const out: ByteSource = formatRecords(allResults)
     return [out, new IOResult()]
   }
 
@@ -203,7 +204,7 @@ async function rgCommand(
   const matched = grepLines('<stdin>', lines, pat, f)
   if (matched.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
   if (f.countOnly) return [ENC.encode(String(matched.length)), new IOResult()]
-  return [ENC.encode(matched.join('\n')), new IOResult()]
+  return [formatRecords(matched), new IOResult()]
 }
 
 export const MONGODB_RG = command({

--- a/typescript/packages/core/src/commands/builtin/mongodb/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/stat.ts
@@ -20,6 +20,7 @@ import { type FileStat, FileType, type PathSpec, ResourceName } from '../../../t
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { metadataProvision } from './_provision.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -69,7 +70,7 @@ async function statCommand(
       )
     }
   }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
+  const out: ByteSource = formatRecords(lines)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/core/src/commands/builtin/mongodb/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/tree.ts
@@ -21,8 +21,7 @@ import { type FileStat, FileType, PathSpec, ResourceName } from '../../../types.
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { fnmatch } from '../../../util/fnmatch.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 interface TreeOpts {
   maxDepth: number | null
@@ -123,8 +122,8 @@ async function treeCommand(
   }
   const warnings: string[] = []
   const results = await treeRecurse(accessor, p0, '', 0, treeOpts, warnings, opts.index)
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+  const out: ByteSource = formatRecords(results)
+  const stderr = warnings.length > 0 ? formatRecords(warnings) : null
   return [out, new IOResult({ stderr })]
 }
 

--- a/typescript/packages/core/src/commands/builtin/notion/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/notion/grep.ts
@@ -25,6 +25,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { compilePattern, grepFilesOnly, grepRecursive, grepStream } from '../grep_helper.ts'
 import { resolveSource } from '../utils/stream.ts'
 import { fileReadProvision } from './_provision.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -122,7 +123,7 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : undefined
+      const stderr = warnings.length > 0 ? formatRecords(warnings) : undefined
       if (results.length === 0) {
         return [
           new Uint8Array(0),
@@ -172,11 +173,11 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+      const stderr = warnings.length > 0 ? formatRecords(warnings) : null
       if (results.length === 0) {
         return [new Uint8Array(0), new IOResult({ exitCode: 1, stderr })]
       }
-      return [ENC.encode(results.join('\n')), new IOResult({ stderr })]
+      return [formatRecords(results), new IOResult({ stderr })]
     }
 
     const data = await notionRead(accessor, target, opts.index ?? undefined)

--- a/typescript/packages/core/src/commands/builtin/postgres/find.ts
+++ b/typescript/packages/core/src/commands/builtin/postgres/find.ts
@@ -23,8 +23,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { metadataProvision } from './_provision.ts'
 import { stripSlash } from '../../../util/slash.ts'
 import { fnmatch } from '../../../util/fnmatch.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 async function walk(
   accessor: PostgresAccessor,
@@ -94,7 +93,7 @@ async function findCommand(
     if (inameFlag !== null && !fnmatch(entryName.toLowerCase(), inameFlag.toLowerCase())) continue
     results.push(p)
   }
-  const out: ByteSource = ENC.encode(results.join('\n'))
+  const out: ByteSource = formatRecords(results)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/core/src/commands/builtin/postgres/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/postgres/grep.ts
@@ -33,6 +33,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { compilePattern, grepFilesOnly, grepRecursive, grepStream } from '../grep_helper.ts'
 import { resolveSource } from '../utils/stream.ts'
 import { fileReadProvision } from './_provision.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -104,21 +105,21 @@ async function grepCommand(
       const results = await searchDatabase(accessor, pattern, limit)
       const allLines = formatGrepResults(results)
       if (allLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
+      return [formatRecords(allLines), new IOResult()]
     }
 
     if (scope.level === 'schema') {
       const results = await searchSchema(accessor, scope.schema, pattern, limit)
       const allLines = formatGrepResults(results)
       if (allLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
+      return [formatRecords(allLines), new IOResult()]
     }
 
     if (scope.level === 'kind') {
       const results = await searchKind(accessor, scope.schema, scope.kind, pattern, limit)
       const allLines = formatGrepResults(results)
       if (allLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
+      return [formatRecords(allLines), new IOResult()]
     }
 
     if (scope.level === 'entity' || scope.level === 'entity_rows') {
@@ -133,7 +134,7 @@ async function grepCommand(
       if (rows.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
       const results = [{ schema: scope.schema, kind: scope.kind, entity: scope.entity, rows }]
       const allLines = formatGrepResults(results)
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
+      return [formatRecords(allLines), new IOResult()]
     }
 
     const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
@@ -171,7 +172,7 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : undefined
+      const stderr = warnings.length > 0 ? formatRecords(warnings) : undefined
       if (results.length === 0) {
         return [
           new Uint8Array(0),
@@ -221,11 +222,11 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+      const stderr = warnings.length > 0 ? formatRecords(warnings) : null
       if (results.length === 0) {
         return [new Uint8Array(0), new IOResult({ exitCode: 1, stderr })]
       }
-      return [ENC.encode(results.join('\n')), new IOResult({ stderr })]
+      return [formatRecords(results), new IOResult({ stderr })]
     }
 
     const data = await postgresRead(accessor, target, opts.index ?? undefined)

--- a/typescript/packages/core/src/commands/builtin/postgres/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/postgres/ls.ts
@@ -22,8 +22,7 @@ import { command, type CommandFnResult, type CommandOpts } from '../../config.ts
 import { specOf } from '../../spec/builtins.ts'
 import { humanSize } from '../utils/formatting.ts'
 import { metadataProvision } from './_provision.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 async function lsEntries(
   accessor: PostgresAccessor,
@@ -164,9 +163,9 @@ async function lsCommand(
       }
     }
   }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+  const stderr = warnings.length > 0 ? formatRecords(warnings) : null
   const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
+  const out: ByteSource = formatRecords(results)
   return [out, new IOResult({ stderr, exitCode })]
 }
 

--- a/typescript/packages/core/src/commands/builtin/postgres/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/postgres/rg.ts
@@ -31,6 +31,7 @@ import { command, type CommandFnResult, type CommandOpts } from '../../config.ts
 import { specOf } from '../../spec/builtins.ts'
 import { compilePattern, grepLines } from '../grep_helper.ts'
 import { readStdinAsync } from '../utils/stream.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
@@ -125,19 +126,19 @@ async function rgCommand(
       const results = await searchDatabase(accessor, exprText, limit)
       const allLines = formatGrepResults(results)
       if (allLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
+      return [formatRecords(allLines), new IOResult()]
     }
     if (scope.level === 'schema') {
       const results = await searchSchema(accessor, scope.schema, exprText, limit)
       const allLines = formatGrepResults(results)
       if (allLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
+      return [formatRecords(allLines), new IOResult()]
     }
     if (scope.level === 'kind') {
       const results = await searchKind(accessor, scope.schema, scope.kind, exprText, limit)
       const allLines = formatGrepResults(results)
       if (allLines.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
+      return [formatRecords(allLines), new IOResult()]
     }
     if (scope.level === 'entity' || scope.level === 'entity_rows') {
       const rows = await searchEntity(
@@ -151,7 +152,7 @@ async function rgCommand(
       if (rows.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
       const results = [{ schema: scope.schema, kind: scope.kind, entity: scope.entity, rows }]
       const allLines = formatGrepResults(results)
-      return [ENC.encode(allLines.join('\n')), new IOResult()]
+      return [formatRecords(allLines), new IOResult()]
     }
 
     const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
@@ -197,7 +198,7 @@ async function rgCommand(
       }
     }
     if (!anyMatch) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-    const out: ByteSource = ENC.encode(allResults.join('\n'))
+    const out: ByteSource = formatRecords(allResults)
     return [out, new IOResult()]
   }
 
@@ -212,7 +213,7 @@ async function rgCommand(
   const matched = grepLines('<stdin>', lines, pat, f)
   if (matched.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
   if (f.countOnly) return [ENC.encode(String(matched.length)), new IOResult()]
-  return [ENC.encode(matched.join('\n')), new IOResult()]
+  return [formatRecords(matched), new IOResult()]
 }
 
 export const POSTGRES_RG = command({

--- a/typescript/packages/core/src/commands/builtin/postgres/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/postgres/stat.ts
@@ -20,6 +20,7 @@ import { type FileStat, FileType, type PathSpec, ResourceName } from '../../../t
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { metadataProvision } from './_provision.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -69,7 +70,7 @@ async function statCommand(
       )
     }
   }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
+  const out: ByteSource = formatRecords(lines)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/core/src/commands/builtin/postgres/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/postgres/tree.ts
@@ -21,8 +21,7 @@ import { type FileStat, FileType, PathSpec, ResourceName } from '../../../types.
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { fnmatch } from '../../../util/fnmatch.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 interface TreeOpts {
   maxDepth: number | null
@@ -123,8 +122,8 @@ async function treeCommand(
   }
   const warnings: string[] = []
   const results = await treeRecurse(accessor, p0, '', 0, treeOpts, warnings, opts.index)
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+  const out: ByteSource = formatRecords(results)
+  const stderr = warnings.length > 0 ? formatRecords(warnings) : null
   return [out, new IOResult({ stderr })]
 }
 

--- a/typescript/packages/core/src/commands/builtin/posthog/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/posthog/grep.ts
@@ -24,6 +24,7 @@ import { command, type CommandFnResult, type CommandOpts } from '../../config.ts
 import { specOf } from '../../spec/builtins.ts'
 import { compilePattern, grepFilesOnly, grepRecursive, grepStream } from '../grep_helper.ts'
 import { resolveSource } from '../utils/stream.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -121,7 +122,7 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : undefined
+      const stderr = warnings.length > 0 ? formatRecords(warnings) : undefined
       if (results.length === 0) {
         return [
           new Uint8Array(0),
@@ -171,11 +172,11 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+      const stderr = warnings.length > 0 ? formatRecords(warnings) : null
       if (results.length === 0) {
         return [new Uint8Array(0), new IOResult({ exitCode: 1, stderr })]
       }
-      return [ENC.encode(results.join('\n')), new IOResult({ stderr })]
+      return [formatRecords(results), new IOResult({ stderr })]
     }
 
     const data = await rb(target.original)

--- a/typescript/packages/core/src/commands/builtin/posthog/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/posthog/ls.ts
@@ -22,8 +22,7 @@ import { command, type CommandFnResult, type CommandOpts } from '../../config.ts
 import { specOf } from '../../spec/builtins.ts'
 import { humanSize } from '../utils/formatting.ts'
 import { metadataProvision } from './_provision.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 async function lsEntries(
   accessor: PostHogAccessor,
@@ -161,9 +160,9 @@ async function lsCommand(
       }
     }
   }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+  const stderr = warnings.length > 0 ? formatRecords(warnings) : null
   const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
+  const out: ByteSource = formatRecords(results)
   return [out, new IOResult({ stderr, exitCode })]
 }
 

--- a/typescript/packages/core/src/commands/builtin/posthog/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/posthog/rg.ts
@@ -23,6 +23,7 @@ import { command, type CommandFnResult, type CommandOpts } from '../../config.ts
 import { specOf } from '../../spec/builtins.ts'
 import { compilePattern, grepLines, grepRecursive } from '../grep_helper.ts'
 import { readStdinAsync } from '../utils/stream.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
@@ -146,9 +147,9 @@ async function rgCommand(
         for (const line of matched) allResults.push(`${p.original}:${line}`)
       }
     }
-    const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+    const stderr = warnings.length > 0 ? formatRecords(warnings) : null
     if (!anyMatch) return [new Uint8Array(0), new IOResult({ exitCode: 1, stderr })]
-    return [ENC.encode(allResults.join('\n')), new IOResult({ stderr })]
+    return [formatRecords(allResults), new IOResult({ stderr })]
   }
 
   const raw = await readStdinAsync(opts.stdin)
@@ -162,7 +163,7 @@ async function rgCommand(
   const matched = grepLines('<stdin>', lines, pat, f)
   if (matched.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
   if (f.countOnly) return [ENC.encode(String(matched.length)), new IOResult()]
-  return [ENC.encode(matched.join('\n')), new IOResult()]
+  return [formatRecords(matched), new IOResult()]
 }
 
 export const POSTHOG_RG = command({

--- a/typescript/packages/core/src/commands/builtin/ram/du.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/du.test.ts
@@ -44,7 +44,7 @@ async function runDu(
         ? out
         : await materialize(out as AsyncIterable<Uint8Array>)
   const text = DEC.decode(buf)
-  const lines = text === '' ? [] : text.split('\n')
+  const lines = text === '' ? [] : text.trimEnd().split('\n')
   return { lines, exitCode: ioResult.exitCode }
 }
 

--- a/typescript/packages/core/src/commands/builtin/ram/ls/ls.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/ls/ls.test.ts
@@ -54,7 +54,7 @@ describe('ls', () => {
     const resource = new RAMResource()
     seed(resource, ['/tmp'], { '/tmp/a.txt': 'hello' })
     const out = await runLs(resource, [PathSpec.fromStrPath('/tmp')])
-    expect(out.split('\n')).toEqual(['a.txt'])
+    expect(out.trimEnd().split('\n')).toEqual(['a.txt'])
   })
 
   it('empty directory', async () => {
@@ -72,7 +72,7 @@ describe('ls', () => {
       '/tmp/banana.txt': 'b',
     })
     const out = await runLs(resource, [PathSpec.fromStrPath('/tmp')])
-    expect(out.split('\n')).toEqual(['apple.txt', 'banana.txt', 'cherry.txt'])
+    expect(out.trimEnd().split('\n')).toEqual(['apple.txt', 'banana.txt', 'cherry.txt'])
   })
 
   it('-l long format includes size and standard mode string', async () => {
@@ -93,7 +93,7 @@ describe('ls', () => {
       '/tmp/visible.txt': 'hi',
     })
     const out = await runLs(resource, [PathSpec.fromStrPath('/tmp')])
-    expect(out.split('\n')).toEqual(['visible.txt'])
+    expect(out.trimEnd().split('\n')).toEqual(['visible.txt'])
   })
 
   it('-a shows dotfiles', async () => {
@@ -103,7 +103,7 @@ describe('ls', () => {
       '/tmp/visible.txt': 'hi',
     })
     const out = await runLs(resource, [PathSpec.fromStrPath('/tmp')], { a: true })
-    expect(out.split('\n').sort()).toEqual(['.hidden', 'visible.txt'])
+    expect(out.trimEnd().split('\n').sort()).toEqual(['.hidden', 'visible.txt'])
   })
 
   it('-r reverses name sort', async () => {
@@ -114,7 +114,7 @@ describe('ls', () => {
       '/tmp/c.txt': 'c',
     })
     const out = await runLs(resource, [PathSpec.fromStrPath('/tmp')], { r: true })
-    expect(out.split('\n')).toEqual(['c.txt', 'b.txt', 'a.txt'])
+    expect(out.trimEnd().split('\n')).toEqual(['c.txt', 'b.txt', 'a.txt'])
   })
 
   it('-S sorts by size descending', async () => {
@@ -125,7 +125,7 @@ describe('ls', () => {
       '/tmp/medium.txt': 'x'.repeat(50),
     })
     const out = await runLs(resource, [PathSpec.fromStrPath('/tmp')], { S: true })
-    expect(out.split('\n')).toEqual(['big.txt', 'medium.txt', 'small.txt'])
+    expect(out.trimEnd().split('\n')).toEqual(['big.txt', 'medium.txt', 'small.txt'])
   })
 
   it('-S -r sorts by size ascending', async () => {
@@ -136,7 +136,7 @@ describe('ls', () => {
       '/tmp/medium.txt': 'x'.repeat(50),
     })
     const out = await runLs(resource, [PathSpec.fromStrPath('/tmp')], { S: true, r: true })
-    expect(out.split('\n')).toEqual(['small.txt', 'medium.txt', 'big.txt'])
+    expect(out.trimEnd().split('\n')).toEqual(['small.txt', 'medium.txt', 'big.txt'])
   })
 
   it('-a with -r reverses all entries', async () => {
@@ -147,7 +147,7 @@ describe('ls', () => {
       '/tmp/m.txt': 'm',
     })
     const out = await runLs(resource, [PathSpec.fromStrPath('/tmp')], { a: true, r: true })
-    expect(out.split('\n')).toEqual(['m.txt', 'a.txt', '.z_hidden'])
+    expect(out.trimEnd().split('\n')).toEqual(['m.txt', 'a.txt', '.z_hidden'])
   })
 
   it('recursive listing (-R) walks subdirectories with headers', async () => {
@@ -167,7 +167,7 @@ describe('ls', () => {
     const resource = new RAMResource()
     seed(resource, ['/tmp'], { '/tmp/a.txt': 'a' })
     const out = await runLs(resource, [PathSpec.fromStrPath('/tmp')], { d: true })
-    expect(out).toBe('tmp')
+    expect(out).toBe('tmp\n')
   })
 
   it('-1 overrides -l: forces short (one-per-line) format', async () => {

--- a/typescript/packages/core/src/commands/builtin/ram/md5.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/md5.test.ts
@@ -56,7 +56,7 @@ describe('md5', () => {
     const expected = md5Hex(data)
     const r = await runMd5(resource, [PathSpec.fromStrPath('/tmp/f.txt')])
     expect(r.exitCode).toBe(0)
-    expect(r.out).toBe(`${expected}  /tmp/f.txt`)
+    expect(r.out).toBe(`${expected}  /tmp/f.txt\n`)
   })
 
   it('handles empty file', async () => {
@@ -67,13 +67,13 @@ describe('md5', () => {
     const expected = md5Hex(data)
     const r = await runMd5(resource, [PathSpec.fromStrPath('/tmp/empty.txt')])
     expect(r.exitCode).toBe(0)
-    expect(r.out).toBe(`${expected}  /tmp/empty.txt`)
+    expect(r.out).toBe(`${expected}  /tmp/empty.txt\n`)
   })
 
   it('hashes stdin when no paths', async () => {
     const resource = new RAMResource()
     const data = ENC.encode('disk content')
-    const expected = `${md5Hex(data)}  -`
+    const expected = `${md5Hex(data)}  -\n`
     const r = await runMd5(resource, [], data)
     expect(r.exitCode).toBe(0)
     expect(r.out).toBe(expected)
@@ -90,6 +90,6 @@ describe('md5', () => {
       PathSpec.fromStrPath('/b.txt'),
     ])
     expect(r.exitCode).toBe(0)
-    expect(r.out).toBe(`${md5Hex(d1)}  /a.txt\n${md5Hex(d2)}  /b.txt`)
+    expect(r.out).toBe(`${md5Hex(d1)}  /a.txt\n${md5Hex(d2)}  /b.txt\n`)
   })
 })

--- a/typescript/packages/core/src/commands/builtin/ram/rm.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/rm.ts
@@ -21,6 +21,7 @@ import { IOResult } from '../../../io/types.ts'
 import { FileType, ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { formatRecords } from '../utils/output.ts'
 
 async function rmCommand(
   accessor: RAMAccessor,
@@ -61,7 +62,7 @@ async function rmCommand(
     }
     if (verbose) lines.push(`removed '${p.original}'`)
   }
-  const out = lines.length > 0 ? new TextEncoder().encode(lines.join('\n')) : null
+  const out = lines.length > 0 ? formatRecords(lines) : null
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/core/src/commands/builtin/ram/tree.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/tree.test.ts
@@ -44,7 +44,7 @@ async function runTree(
         ? out
         : await materialize(out as AsyncIterable<Uint8Array>)
   const text = DEC.decode(buf)
-  const lines = text === '' ? [] : text.split('\n')
+  const lines = text === '' ? [] : text.trimEnd().split('\n')
   return { lines, exitCode: ioResult.exitCode }
 }
 

--- a/typescript/packages/core/src/commands/builtin/ram/wc/wc.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/wc/wc.test.ts
@@ -46,20 +46,24 @@ describe('wc', () => {
   it('default shows lines, words, bytes, path', async () => {
     const resource = new RAMResource()
     resource.store.files.set('/tmp/f.txt', ENC.encode('hello world\nfoo bar\n'))
-    expect(await runWc(resource, [PathSpec.fromStrPath('/tmp/f.txt')])).toBe('2\t4\t20\t/tmp/f.txt')
+    expect(await runWc(resource, [PathSpec.fromStrPath('/tmp/f.txt')])).toBe(
+      '2\t4\t20\t/tmp/f.txt\n',
+    )
   })
 
   it('empty file', async () => {
     const resource = new RAMResource()
     resource.store.files.set('/tmp/f.txt', new Uint8Array())
-    expect(await runWc(resource, [PathSpec.fromStrPath('/tmp/f.txt')])).toBe('0\t0\t0\t/tmp/f.txt')
+    expect(await runWc(resource, [PathSpec.fromStrPath('/tmp/f.txt')])).toBe(
+      '0\t0\t0\t/tmp/f.txt\n',
+    )
   })
 
   it('-l counts lines with trailing newline', async () => {
     const resource = new RAMResource()
     resource.store.files.set('/tmp/f.txt', ENC.encode('a\nb\nc\n'))
     expect(await runWc(resource, [PathSpec.fromStrPath('/tmp/f.txt')], { args_l: true })).toBe(
-      '3\t/tmp/f.txt',
+      '3\t/tmp/f.txt\n',
     )
   })
 
@@ -67,7 +71,7 @@ describe('wc', () => {
     const resource = new RAMResource()
     resource.store.files.set('/tmp/f.txt', ENC.encode('a\nb\nc'))
     expect(await runWc(resource, [PathSpec.fromStrPath('/tmp/f.txt')], { args_l: true })).toBe(
-      '2\t/tmp/f.txt',
+      '2\t/tmp/f.txt\n',
     )
   })
 
@@ -75,7 +79,7 @@ describe('wc', () => {
     const resource = new RAMResource()
     resource.store.files.set('/tmp/f.txt', ENC.encode('one two three'))
     expect(await runWc(resource, [PathSpec.fromStrPath('/tmp/f.txt')], { w: true })).toBe(
-      '3\t/tmp/f.txt',
+      '3\t/tmp/f.txt\n',
     )
   })
 
@@ -83,7 +87,7 @@ describe('wc', () => {
     const resource = new RAMResource()
     resource.store.files.set('/tmp/f.txt', ENC.encode('one two\nthree four five\nsix\n'))
     expect(await runWc(resource, [PathSpec.fromStrPath('/tmp/f.txt')], { w: true })).toBe(
-      '6\t/tmp/f.txt',
+      '6\t/tmp/f.txt\n',
     )
   })
 
@@ -91,7 +95,7 @@ describe('wc', () => {
     const resource = new RAMResource()
     resource.store.files.set('/tmp/f.txt', ENC.encode('hello'))
     expect(await runWc(resource, [PathSpec.fromStrPath('/tmp/f.txt')], { c: true })).toBe(
-      '5\t/tmp/f.txt',
+      '5\t/tmp/f.txt\n',
     )
   })
 
@@ -99,7 +103,7 @@ describe('wc', () => {
     const resource = new RAMResource()
     resource.store.files.set('/tmp/f.txt', ENC.encode('caf\u00e9'))
     expect(await runWc(resource, [PathSpec.fromStrPath('/tmp/f.txt')], { c: true })).toBe(
-      '5\t/tmp/f.txt',
+      '5\t/tmp/f.txt\n',
     )
   })
 
@@ -107,7 +111,7 @@ describe('wc', () => {
     const resource = new RAMResource()
     resource.store.files.set('/tmp/f.txt', ENC.encode('hello'))
     expect(await runWc(resource, [PathSpec.fromStrPath('/tmp/f.txt')], { m: true })).toBe(
-      '5\t/tmp/f.txt',
+      '5\t/tmp/f.txt\n',
     )
   })
 
@@ -115,7 +119,7 @@ describe('wc', () => {
     const resource = new RAMResource()
     resource.store.files.set('/tmp/f.txt', ENC.encode('caf\u00e9'))
     expect(await runWc(resource, [PathSpec.fromStrPath('/tmp/f.txt')], { m: true })).toBe(
-      '4\t/tmp/f.txt',
+      '4\t/tmp/f.txt\n',
     )
   })
 })

--- a/typescript/packages/core/src/commands/builtin/s3/rm.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/rm.ts
@@ -23,6 +23,7 @@ import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { FileType, type PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -89,7 +90,7 @@ async function rmCommand(
     writes[p.stripPrefix] = new Uint8Array()
     if (verbose) verboseParts.push(`removed '${p.original}'`)
   }
-  const output: ByteSource | null = verbose ? ENC.encode(verboseParts.join('\n')) : null
+  const output: ByteSource | null = verbose ? formatRecords(verboseParts) : null
   return [output, new IOResult({ writes })]
 }
 

--- a/typescript/packages/core/src/commands/builtin/slack/find.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/find.ts
@@ -23,8 +23,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { metadataProvision } from './_provision.ts'
 import { stripSlash } from '../../../util/slash.ts'
 import { fnmatch } from '../../../util/fnmatch.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 async function walk(
   accessor: SlackAccessor,
@@ -94,7 +93,7 @@ async function findCommand(
     if (inameFlag !== null && !fnmatch(entryName.toLowerCase(), inameFlag.toLowerCase())) continue
     results.push(p)
   }
-  const out: ByteSource = ENC.encode(results.join('\n'))
+  const out: ByteSource = formatRecords(results)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/core/src/commands/builtin/slack/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/grep.ts
@@ -32,6 +32,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { compilePattern, grepFilesOnly, grepLines, grepStream } from '../grep_helper.ts'
 import { resolveSource } from '../utils/stream.ts'
 import { fileReadProvision } from './_provision.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
@@ -207,7 +208,7 @@ async function grepCommand(
         }
       }
       if (allResults.length === 0) return [new Uint8Array(0), ioWith({ exitCode: 1 })]
-      const out: ByteSource = ENC.encode(allResults.join('\n'))
+      const out: ByteSource = formatRecords(allResults)
       return [out, ioWith()]
     }
 

--- a/typescript/packages/core/src/commands/builtin/slack/ls.test.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/ls.test.ts
@@ -75,7 +75,7 @@ describe('slack ls', () => {
       {},
       { index: idx },
     )
-    expect(out.stdout.split('\n').sort()).toEqual(['channels', 'dms', 'users'])
+    expect(out.stdout.trimEnd().split('\n').sort()).toEqual(['channels', 'dms', 'users'])
   })
 
   it('lists channel directory entries from cached index', async () => {
@@ -96,7 +96,7 @@ describe('slack ls', () => {
       {},
       { index: idx, transport },
     )
-    expect(out.stdout).toBe('general__C1')
+    expect(out.stdout).toBe('general__C1\n')
     expect(transport.calls).toHaveLength(0)
   })
 
@@ -118,6 +118,6 @@ describe('slack ls', () => {
       {},
       { index: idx, transport },
     )
-    expect(out.stdout).toBe('alice__U1.json')
+    expect(out.stdout).toBe('alice__U1.json\n')
   })
 })

--- a/typescript/packages/core/src/commands/builtin/slack/stat.test.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/stat.test.ts
@@ -84,7 +84,7 @@ describe('slack stat', () => {
       { c: '%n' },
       { index: idx },
     )
-    expect(out.stdout).toBe('general__C1')
+    expect(out.stdout).toBe('general__C1\n')
   })
 
   it('returns exit 1 with no operand', async () => {

--- a/typescript/packages/core/src/commands/builtin/slack/tree.test.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/tree.test.ts
@@ -60,7 +60,7 @@ describe('slack tree', () => {
       { L: '1' },
       { index: idx },
     )
-    const lines = out.split('\n')
+    const lines = out.trimEnd().split('\n')
     expect(lines).toHaveLength(3)
     expect(lines[0]).toContain('channels')
     expect(lines[1]).toContain('dms')

--- a/typescript/packages/core/src/commands/builtin/slack/wc.test.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/wc.test.ts
@@ -74,7 +74,7 @@ describe('slack wc', () => {
       {},
       { index: idx, transport },
     )
-    const parts = out.split('\t')
+    const parts = out.trimEnd().split('\t')
     expect(parts).toHaveLength(4)
     expect(parts[0]).toBe('3')
     expect(parts[3]).toBe('/mnt/slack/channels/general__C1/2024-01-01/chat.jsonl')
@@ -107,6 +107,6 @@ describe('slack wc', () => {
       { args_l: true },
       { index: idx, transport },
     )
-    expect(out).toBe('2\t/mnt/slack/channels/general__C1/2024-01-01/chat.jsonl')
+    expect(out).toBe('2\t/mnt/slack/channels/general__C1/2024-01-01/chat.jsonl\n')
   })
 })

--- a/typescript/packages/core/src/commands/builtin/trello/find.ts
+++ b/typescript/packages/core/src/commands/builtin/trello/find.ts
@@ -23,8 +23,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { metadataProvision } from './_provision.ts'
 import { stripSlash } from '../../../util/slash.ts'
 import { fnmatch } from '../../../util/fnmatch.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 async function walk(
   accessor: TrelloAccessor,
@@ -94,7 +93,7 @@ async function findCommand(
     if (inameFlag !== null && !fnmatch(entryName.toLowerCase(), inameFlag.toLowerCase())) continue
     results.push(p)
   }
-  const out: ByteSource = ENC.encode(results.join('\n'))
+  const out: ByteSource = formatRecords(results)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/core/src/commands/builtin/utils/output.test.ts
+++ b/typescript/packages/core/src/commands/builtin/utils/output.test.ts
@@ -1,0 +1,44 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { formatOptionalRecords, formatRecordText, formatRecords } from './output.ts'
+
+const DEC = new TextDecoder()
+
+describe('formatRecords', () => {
+  it('empty returns empty bytes', () => {
+    expect(formatRecords([]).length).toBe(0)
+  })
+
+  it('single record terminates line', () => {
+    expect(DEC.decode(formatRecords(['a']))).toBe('a\n')
+  })
+
+  it('multiple records terminates last line', () => {
+    expect(DEC.decode(formatRecords(['a', 'b']))).toBe('a\nb\n')
+  })
+})
+
+describe('formatOptionalRecords', () => {
+  it('empty returns null', () => {
+    expect(formatOptionalRecords([])).toBeNull()
+  })
+})
+
+describe('formatRecordText', () => {
+  it('multiple records terminates last line', () => {
+    expect(formatRecordText(['a', 'b'])).toBe('a\nb\n')
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/utils/output.ts
+++ b/typescript/packages/core/src/commands/builtin/utils/output.ts
@@ -1,0 +1,34 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+const ENC = new TextEncoder()
+
+export function formatRecords(records: readonly string[]): Uint8Array {
+  if (records.length === 0) {
+    return new Uint8Array(0)
+  }
+  return ENC.encode(records.join('\n') + '\n')
+}
+
+export function formatOptionalRecords(records: readonly string[]): Uint8Array | null {
+  const output = formatRecords(records)
+  return output.length > 0 ? output : null
+}
+
+export function formatRecordText(records: readonly string[]): string {
+  if (records.length === 0) {
+    return ''
+  }
+  return records.join('\n') + '\n'
+}

--- a/typescript/packages/core/src/commands/builtin/vercel/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/vercel/grep.ts
@@ -25,6 +25,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { compilePattern, grepFilesOnly, grepRecursive, grepStream } from '../grep_helper.ts'
 import { resolveSource } from '../utils/stream.ts'
 import { fileReadProvision } from './_provision.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 
@@ -122,7 +123,7 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : undefined
+      const stderr = warnings.length > 0 ? formatRecords(warnings) : undefined
       if (results.length === 0) {
         return [
           new Uint8Array(0),
@@ -172,11 +173,11 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+      const stderr = warnings.length > 0 ? formatRecords(warnings) : null
       if (results.length === 0) {
         return [new Uint8Array(0), new IOResult({ exitCode: 1, stderr })]
       }
-      return [ENC.encode(results.join('\n')), new IOResult({ stderr })]
+      return [formatRecords(results), new IOResult({ stderr })]
     }
 
     const data = await vercelRead(accessor, target, opts.index ?? undefined)

--- a/typescript/packages/core/src/commands/builtin/vercel/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/vercel/ls.ts
@@ -22,8 +22,7 @@ import { command, type CommandFnResult, type CommandOpts } from '../../config.ts
 import { specOf } from '../../spec/builtins.ts'
 import { humanSize } from '../utils/formatting.ts'
 import { metadataProvision } from './_provision.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 async function lsEntries(
   accessor: VercelAccessor,
@@ -161,9 +160,9 @@ async function lsCommand(
       }
     }
   }
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+  const stderr = warnings.length > 0 ? formatRecords(warnings) : null
   const exitCode = warnings.length > 0 && results.length === 0 ? 1 : 0
-  const out: ByteSource = ENC.encode(results.join('\n'))
+  const out: ByteSource = formatRecords(results)
   return [out, new IOResult({ stderr, exitCode })]
 }
 

--- a/typescript/packages/core/src/commands/builtin/vercel/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/vercel/rg.ts
@@ -23,6 +23,7 @@ import { command, type CommandFnResult, type CommandOpts } from '../../config.ts
 import { specOf } from '../../spec/builtins.ts'
 import { compilePattern, grepLines, grepRecursive } from '../grep_helper.ts'
 import { readStdinAsync } from '../utils/stream.ts'
+import { formatRecords } from '../utils/output.ts'
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
@@ -146,9 +147,9 @@ async function rgCommand(
         for (const line of matched) allResults.push(`${p.original}:${line}`)
       }
     }
-    const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+    const stderr = warnings.length > 0 ? formatRecords(warnings) : null
     if (!anyMatch) return [new Uint8Array(0), new IOResult({ exitCode: 1, stderr })]
-    return [ENC.encode(allResults.join('\n')), new IOResult({ stderr })]
+    return [formatRecords(allResults), new IOResult({ stderr })]
   }
 
   const raw = await readStdinAsync(opts.stdin)
@@ -162,7 +163,7 @@ async function rgCommand(
   const matched = grepLines('<stdin>', lines, pat, f)
   if (matched.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
   if (f.countOnly) return [ENC.encode(String(matched.length)), new IOResult()]
-  return [ENC.encode(matched.join('\n')), new IOResult()]
+  return [formatRecords(matched), new IOResult()]
 }
 
 export const VERCEL_RG = command({

--- a/typescript/packages/core/src/commands/builtin/vercel/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/vercel/tree.ts
@@ -22,8 +22,7 @@ import { FileType, PathSpec, ResourceName } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { fnmatch } from '../../../util/fnmatch.ts'
-
-const ENC = new TextEncoder()
+import { formatRecords } from '../utils/output.ts'
 
 interface TreeOpts {
   maxDepth: number | null
@@ -123,8 +122,8 @@ async function treeCommand(
   }
   const warnings: string[] = []
   const results = await treeRecurse(accessor, p0, '', 0, treeOpts, warnings, opts.index)
-  const out: ByteSource = ENC.encode(results.join('\n'))
-  const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+  const out: ByteSource = formatRecords(results)
+  const stderr = warnings.length > 0 ? formatRecords(warnings) : null
   return [out, new IOResult({ stderr })]
 }
 

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -328,6 +328,11 @@ export { countNewlines, parseN, tailBytes } from './commands/builtin/tail_helper
 export { AsyncLineIterator } from './io/async_line_iterator.ts'
 export { readStdinAsync, resolveSource, wrapBytes } from './commands/builtin/utils/stream.ts'
 export { formatLsLong, humanSize } from './commands/builtin/utils/formatting.ts'
+export {
+  formatOptionalRecords,
+  formatRecordText,
+  formatRecords,
+} from './commands/builtin/utils/output.ts'
 export { grepFilesOnly, grepRecursive } from './commands/builtin/grep_helper.ts'
 export { interpretEscapes } from './commands/builtin/utils/escapes.ts'
 export { deflateRaw, gunzip, gzip, inflateRaw } from './utils/compress.ts'

--- a/typescript/packages/core/src/workspace/execute.test.ts
+++ b/typescript/packages/core/src/workspace/execute.test.ts
@@ -156,7 +156,7 @@ describe('Workspace.execute', () => {
     ram.store.files.set('/b.txt', new Uint8Array([2]))
     const res = await ws.execute('ls /ram/')
     expect(res.exitCode).toBe(0)
-    expect(new TextDecoder().decode(res.stdout)).toBe('a.txt\nb.txt')
+    expect(new TextDecoder().decode(res.stdout)).toBe('a.txt\nb.txt\n')
     await ws.close()
   })
 

--- a/typescript/packages/node/src/commands/builtin/disk/rm.ts
+++ b/typescript/packages/node/src/commands/builtin/disk/rm.ts
@@ -21,6 +21,7 @@ import {
   type CommandFnResult,
   type CommandOpts,
   type PathSpec,
+  formatRecords,
 } from '@struktoai/mirage-core'
 import { rmdir as diskRmdir } from '../../../core/disk/rmdir.ts'
 import { stat as diskStat } from '../../../core/disk/stat.ts'
@@ -67,7 +68,7 @@ async function rmCommand(
     }
     if (verbose) lines.push(`removed '${p.original}'`)
   }
-  const out = lines.length > 0 ? new TextEncoder().encode(lines.join('\n')) : null
+  const out = lines.length > 0 ? formatRecords(lines) : null
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/node/src/commands/builtin/email/find.ts
+++ b/typescript/packages/node/src/commands/builtin/email/find.ts
@@ -23,14 +23,13 @@ import {
   type CommandOpts,
   rstripSlash,
   stripSlash,
+  formatRecords,
 } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../../accessor/email.ts'
 import { resolveGlob } from '../../../core/email/glob.ts'
 import { readdir as emailReaddir } from '../../../core/email/readdir.ts'
 import { metadataProvision } from './provision.ts'
 import { fnmatch } from '@struktoai/mirage-core'
-
-const ENC = new TextEncoder()
 
 async function walk(
   accessor: EmailAccessor,
@@ -101,7 +100,7 @@ async function findCommand(
     if (inameFlag !== null && !fnmatch(entryName.toLowerCase(), inameFlag.toLowerCase())) continue
     results.push(p)
   }
-  const out: ByteSource = ENC.encode(results.join('\n'))
+  const out: ByteSource = formatRecords(results)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/node/src/commands/builtin/email/grep.ts
+++ b/typescript/packages/node/src/commands/builtin/email/grep.ts
@@ -33,6 +33,7 @@ import {
   type ByteSource,
   type CommandFnResult,
   type CommandOpts,
+  formatRecords,
 } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../../accessor/email.ts'
 import { resolveGlob } from '../../../core/email/glob.ts'
@@ -187,9 +188,9 @@ async function grepCommand(
         },
         warnings,
       )
-      const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n')) : null
+      const stderr = warnings.length > 0 ? formatRecords(warnings) : null
       if (results.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1, stderr })]
-      const out: ByteSource = ENC.encode(results.join('\n'))
+      const out: ByteSource = formatRecords(results)
       return [out, new IOResult({ stderr })]
     }
 
@@ -209,7 +210,7 @@ async function grepCommand(
         }
       }
       if (allResults.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
-      const out: ByteSource = ENC.encode(allResults.join('\n'))
+      const out: ByteSource = formatRecords(allResults)
       return [out, new IOResult()]
     }
 

--- a/typescript/packages/node/src/commands/builtin/ssh/du.ts
+++ b/typescript/packages/node/src/commands/builtin/ssh/du.ts
@@ -23,6 +23,7 @@ import {
   type CommandOpts,
   rstripSlash,
   stripSlash,
+  formatRecords,
 } from '@struktoai/mirage-core'
 import { du as sshDu, duAll as sshDuAll } from '../../../core/ssh/du.ts'
 import type { SSHAccessor } from '../../../accessor/ssh.ts'
@@ -96,7 +97,7 @@ async function duCommand(
     const grand = entries.reduce((acc, [, sz]) => acc + sz, 0)
     lines.push(`${fmt(grand)}\ttotal`)
   }
-  return [new TextEncoder().encode(lines.join('\n')) as ByteSource, new IOResult()]
+  return [formatRecords(lines) as ByteSource, new IOResult()]
 }
 
 export const SSH_DU = command({

--- a/typescript/packages/node/src/commands/builtin/ssh/file/file.ts
+++ b/typescript/packages/node/src/commands/builtin/ssh/file/file.ts
@@ -24,6 +24,7 @@ import {
   type CommandFnResult,
   type CommandOpts,
   type PathSpec,
+  formatRecords,
 } from '@struktoai/mirage-core'
 import { stat as sshStat } from '../../../../core/ssh/stat.ts'
 import { read as sshRead } from '../../../../core/ssh/read.ts'
@@ -59,7 +60,7 @@ async function fileCommand(
     const result = detectFileType(header, s)
     lines.push(formatFileResult(p.original, result, brief, mime))
   }
-  const out: ByteSource = ENC.encode(lines.join('\n'))
+  const out: ByteSource = formatRecords(lines)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/node/src/commands/builtin/ssh/find.ts
+++ b/typescript/packages/node/src/commands/builtin/ssh/find.ts
@@ -22,6 +22,7 @@ import {
   type CommandFnResult,
   type CommandOpts,
   rstripSlash,
+  formatRecords,
 } from '@struktoai/mirage-core'
 import { find as sshFind } from '../../../core/ssh/find.ts'
 import type { SSHAccessor } from '../../../accessor/ssh.ts'
@@ -128,7 +129,7 @@ async function findCommand(
     }
   }
   matches.sort()
-  const out: ByteSource = new TextEncoder().encode(matches.join('\n'))
+  const out: ByteSource = formatRecords(matches)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/node/src/commands/builtin/ssh/ls/ls.ts
+++ b/typescript/packages/node/src/commands/builtin/ssh/ls/ls.ts
@@ -24,6 +24,7 @@ import {
   type CommandOpts,
   type FileStat,
   rstripSlash,
+  formatRecords,
 } from '@struktoai/mirage-core'
 import { stat as sshStat } from '../../../../core/ssh/stat.ts'
 import { readdir as sshReaddir } from '../../../../core/ssh/readdir.ts'
@@ -155,10 +156,10 @@ async function lsCommand(
         warnings.push(`ls: cannot access '${p.original}': ${msg}`)
       }
     }
-    const out: ByteSource = new TextEncoder().encode(lines.join('\n'))
+    const out: ByteSource = formatRecords(lines)
     const exitCode = warnings.length > 0 && lines.length === 0 ? 1 : 0
     if (warnings.length > 0) {
-      const stderr = new TextEncoder().encode(warnings.join('\n'))
+      const stderr = formatRecords(warnings)
       return [out, new IOResult({ stderr, exitCode })]
     }
     return [out, new IOResult({ exitCode })]
@@ -172,10 +173,10 @@ async function lsCommand(
       if (i > 0) lines.push('')
       await walkRecursive(accessor, p, walkOpts, true, lines, warnings)
     }
-    const out: ByteSource = new TextEncoder().encode(lines.join('\n'))
+    const out: ByteSource = formatRecords(lines)
     const exitCode = warnings.length > 0 && lines.length === 0 ? 1 : 0
     if (warnings.length > 0) {
-      const stderr = new TextEncoder().encode(warnings.join('\n'))
+      const stderr = formatRecords(warnings)
       return [out, new IOResult({ stderr, exitCode })]
     }
     return [out, new IOResult({ exitCode })]
@@ -197,10 +198,10 @@ async function lsCommand(
     for (const s of sortStats(stats, sortBy, reverse))
       lines.push(formatEntry(s, long, human, classify))
   }
-  const out: ByteSource = new TextEncoder().encode(lines.join('\n'))
+  const out: ByteSource = formatRecords(lines)
   const exitCode = warnings.length > 0 && lines.length === 0 ? 1 : 0
   if (warnings.length > 0) {
-    const stderr = new TextEncoder().encode(warnings.join('\n'))
+    const stderr = formatRecords(warnings)
     return [out, new IOResult({ stderr, exitCode })]
   }
   return [out, new IOResult({ exitCode })]

--- a/typescript/packages/node/src/commands/builtin/ssh/rm.ts
+++ b/typescript/packages/node/src/commands/builtin/ssh/rm.ts
@@ -21,6 +21,7 @@ import {
   type CommandFnResult,
   type CommandOpts,
   type PathSpec,
+  formatRecords,
 } from '@struktoai/mirage-core'
 import { rmdir as sshRmdir } from '../../../core/ssh/rmdir.ts'
 import { stat as sshStat } from '../../../core/ssh/stat.ts'
@@ -67,7 +68,7 @@ async function rmCommand(
     }
     if (verbose) lines.push(`removed '${p.original}'`)
   }
-  const out = lines.length > 0 ? new TextEncoder().encode(lines.join('\n')) : null
+  const out = lines.length > 0 ? formatRecords(lines) : null
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/node/src/commands/builtin/ssh/stat/stat.ts
+++ b/typescript/packages/node/src/commands/builtin/ssh/stat/stat.ts
@@ -24,6 +24,7 @@ import {
   type CommandOpts,
   type FileStat,
   type PathSpec,
+  formatRecords,
 } from '@struktoai/mirage-core'
 import { stat as sshStat } from '../../../../core/ssh/stat.ts'
 import type { SSHAccessor } from '../../../../accessor/ssh.ts'
@@ -91,7 +92,7 @@ async function statCommand(
       lines.push(`name=${s.name} size=${sizeStr} modified=${modStr} type=${typeStr}`)
     }
   }
-  const out: ByteSource = new TextEncoder().encode(lines.join('\n'))
+  const out: ByteSource = formatRecords(lines)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/node/src/commands/builtin/ssh/tree.ts
+++ b/typescript/packages/node/src/commands/builtin/ssh/tree.ts
@@ -22,6 +22,7 @@ import {
   type ByteSource,
   type CommandFnResult,
   type CommandOpts,
+  formatRecords,
 } from '@struktoai/mirage-core'
 import { readdir as sshReaddir } from '../../../core/ssh/readdir.ts'
 import { stat as sshStat } from '../../../core/ssh/stat.ts'
@@ -118,7 +119,7 @@ async function treeCommand(
   for (const p of targets) {
     await walkTree(accessor, p, '', lines, treeOpts, 0)
   }
-  const out: ByteSource = new TextEncoder().encode(lines.join('\n'))
+  const out: ByteSource = formatRecords(lines)
   return [out, new IOResult()]
 }
 

--- a/typescript/packages/node/src/resource/s3/s3_complex.test.ts
+++ b/typescript/packages/node/src/resource/s3/s3_complex.test.ts
@@ -141,8 +141,10 @@ describe('S3 complex scenarios (mocked)', () => {
     expect(lines).toEqual([
       '=== /s3/data/example.json ===',
       '/s3/data/example.json: json',
+      '',
       '=== /s3/data/example.jsonl ===',
       '/s3/data/example.jsonl: json',
+      '',
       '=== /s3/reports/summary.txt ===',
       '/s3/reports/summary.txt: text',
     ])
@@ -164,6 +166,7 @@ describe('S3 complex scenarios (mocked)', () => {
     if (jsonBytes === undefined || jsonlBytes === undefined) throw new Error('missing fixture')
     expect(lines).toEqual([
       `/s3/data/example.json ${jsonBytes.byteLength.toString()}\t/s3/data/example.json`,
+      '',
       `/s3/data/example.jsonl ${jsonlBytes.byteLength.toString()}\t/s3/data/example.jsonl`,
     ])
   })


### PR DESCRIPTION
TS generic commands (ls/stat/tree/du/wc/file/md5/cmp) and per-backend wrappers emitted formatted output without a trailing newline, diverging from Python and coreutils by one byte.

- Add formatRecords/formatOptionalRecords/formatRecordText in core (mirrors python utils/output.py) and use it at all formatted-output sites in core and node, stdout and stderr warnings.
- Left unchanged to match Python: generic sed, chroma grep core, parquet/feather/hdf5 renderers (no trailing newline in Python either).
- Update test expectations accordingly.

All TS package suites pass (core 2962, node 1359, browser/server/cli/agents green).