### PR TITLE
test(ls): strip trailing newline before splitting ls output

### DIFF
--- a/typescript/packages/core/src/commands/builtin/generic/ls.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.test.ts
@@ -64,7 +64,8 @@ async function run(flags: Record<string, string | boolean>): Promise<string[]> {
   const result = await lsGeneric([spec('/')], opts(flags), readdir, stat)
   if (result === null) return []
   const [out] = result
-  return DEC.decode(out as Uint8Array).split('\n')
+  const text = DEC.decode(out as Uint8Array)
+  return (text.endsWith('\n') ? text.slice(0, -1) : text).split('\n')
 }
 
 describe('lsGeneric', () => {


### PR DESCRIPTION
Main is red: #248 gave ls a POSIX trailing newline, #246 added ls sort tests that split on newline without stripping it. Both were green against the main they branched from; #248's main run was cancelled by concurrency, so the collision only surfaced after #246 merged. Fixes the test helper; the trailing newline itself is correct.