### PR TITLE
refactor: split ConsistencyPolicy into per-mount ReadPolicy and WritePolicy

### DIFF
--- a/examples/python/cross/workspace.yaml
+++ b/examples/python/cross/workspace.yaml
@@ -1,5 +1,5 @@
 mode: WRITE
-consistency: LAZY
+read_policy: CACHED
 
 mounts:
   /s3:

--- a/examples/python/cross/workspace_safeguards.yaml
+++ b/examples/python/cross/workspace_safeguards.yaml
@@ -1,5 +1,5 @@
 mode: WRITE
-consistency: LAZY
+read_policy: CACHED
 
 # Same /s3 mount as workspace.yaml, plus per-mount command_safeguards so the
 # guards can be observed firing from the CLI. Python-only: the TS config

--- a/examples/python/cross/workspace_versioning.yaml
+++ b/examples/python/cross/workspace_versioning.yaml
@@ -1,5 +1,5 @@
 mode: WRITE
-consistency: LAZY
+read_policy: CACHED
 
 # A standalone scratch workspace for the versioning walkthrough. Versioning is
 # backend-agnostic (it tracks the workspace tree, not the mount type), so this

--- a/examples/python/other/consistency.py
+++ b/examples/python/other/consistency.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from mirage import MountMode, Workspace
 from mirage.resource.disk import DiskResource
 from mirage.resource.ram import RAMResource
-from mirage.types import ConsistencyPolicy
+from mirage.types import ReadPolicy
 
 try:
     from mirage.resource.redis import RedisResource
@@ -38,8 +38,8 @@ def _banner(title: str) -> None:
 
 
 async def disk_demo() -> None:
-    """Disk has mtime fingerprints. ALWAYS detects external mutation."""
-    _banner("disk + LAZY — external mutation NOT detected (cached stale)")
+    """Disk has mtime fingerprints. FRESH detects external mutation."""
+    _banner("disk + CACHED — external mutation NOT detected (cached stale)")
     lazy_root = Path(tempfile.mkdtemp(prefix="mirage-disk-lazy-"))
     try:
         (lazy_root / "file.txt").write_bytes(b"v1")
@@ -47,7 +47,7 @@ async def disk_demo() -> None:
         ws = Workspace(
             {"/data": (resource, MountMode.WRITE)},
             mode=MountMode.WRITE,
-            consistency=ConsistencyPolicy.LAZY,
+            read_policy=ReadPolicy.CACHED,
         )
         io1 = await ws.execute("cat /data/file.txt")
         print(f"  first  read (v1 expected)        : "
@@ -56,11 +56,11 @@ async def disk_demo() -> None:
         (lazy_root / "file.txt").write_bytes(b"v2-external")
         io2 = await ws.execute("cat /data/file.txt")
         print(f"  second read after external write : "
-              f"{(await io2.materialize_stdout())!r}  <-- LAZY, stale")
+              f"{(await io2.materialize_stdout())!r}  <-- CACHED, stale")
     finally:
         shutil.rmtree(lazy_root, ignore_errors=True)
 
-    _banner("disk + ALWAYS — external mutation detected (fresh)")
+    _banner("disk + FRESH — external mutation detected (fresh)")
     always_root = Path(tempfile.mkdtemp(prefix="mirage-disk-always-"))
     try:
         (always_root / "file.txt").write_bytes(b"v1")
@@ -68,7 +68,7 @@ async def disk_demo() -> None:
         ws = Workspace(
             {"/data": (resource, MountMode.WRITE)},
             mode=MountMode.WRITE,
-            consistency=ConsistencyPolicy.ALWAYS,
+            read_policy=ReadPolicy.FRESH,
         )
         io1 = await ws.execute("cat /data/file.txt")
         print(f"  first  read (v1 expected)        : "
@@ -77,23 +77,23 @@ async def disk_demo() -> None:
         (always_root / "file.txt").write_bytes(b"v2-external")
         io2 = await ws.execute("cat /data/file.txt")
         print(f"  second read after external write : "
-              f"{(await io2.materialize_stdout())!r}  <-- ALWAYS, fresh")
+              f"{(await io2.materialize_stdout())!r}  <-- FRESH, fresh")
     finally:
         shutil.rmtree(always_root, ignore_errors=True)
 
 
 async def ram_demo() -> None:
-    """RAM has no fingerprint. ALWAYS falls back to LAZY.
+    """RAM has no fingerprint. FRESH falls back to CACHED.
 
     Workspace-originated writes still invalidate the cache.
     """
-    _banner("RAM + ALWAYS — no fingerprint, LAZY fallback serves stale")
+    _banner("RAM + FRESH — no fingerprint, CACHED fallback serves stale")
     resource = RAMResource()
     resource._store.files["/file.txt"] = b"v1"
     ws = Workspace(
         {"/data": (resource, MountMode.WRITE)},
         mode=MountMode.WRITE,
-        consistency=ConsistencyPolicy.ALWAYS,
+        read_policy=ReadPolicy.FRESH,
     )
     io1 = await ws.execute("cat /data/file.txt")
     print(f"  first  read (v1 expected)              : "
@@ -101,7 +101,7 @@ async def ram_demo() -> None:
     resource._store.files["/file.txt"] = b"v2-external"
     io2 = await ws.execute("cat /data/file.txt")
     print(f"  second read after external mutation    : "
-          f"{(await io2.materialize_stdout())!r}  <-- ALWAYS→LAZY, stale")
+          f"{(await io2.materialize_stdout())!r}  <-- FRESH→CACHED, stale")
 
     _banner("RAM — workspace-originated write invalidates cache (fresh)")
     resource2 = RAMResource()
@@ -109,7 +109,7 @@ async def ram_demo() -> None:
     ws2 = Workspace(
         {"/data": (resource2, MountMode.WRITE)},
         mode=MountMode.WRITE,
-        consistency=ConsistencyPolicy.ALWAYS,
+        read_policy=ReadPolicy.FRESH,
     )
     io3 = await ws2.execute("cat /data/file.txt")
     print(f"  first read (v1 expected)               : "
@@ -127,7 +127,7 @@ async def redis_demo() -> None:
     redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
     prefix = f"mirage_consistency_demo_{uuid.uuid4().hex[:8]}"
 
-    _banner("redis + ALWAYS — no fingerprint, LAZY fallback serves stale")
+    _banner("redis + FRESH — no fingerprint, CACHED fallback serves stale")
     try:
         resource = RedisResource(url=redis_url, key_prefix=prefix)
     except Exception as exc:
@@ -138,14 +138,14 @@ async def redis_demo() -> None:
     ws_primer = Workspace(
         {"/data": (resource, MountMode.WRITE)},
         mode=MountMode.WRITE,
-        consistency=ConsistencyPolicy.LAZY,
+        read_policy=ReadPolicy.CACHED,
     )
     await ws_primer.execute('echo -n "v1" > /data/file.txt')
     try:
         ws = Workspace(
             {"/data": (resource, MountMode.WRITE)},
             mode=MountMode.WRITE,
-            consistency=ConsistencyPolicy.ALWAYS,
+            read_policy=ReadPolicy.FRESH,
         )
         io1 = await ws.execute("cat /data/file.txt")
         print(f"  first  read (v1 expected)              : "
@@ -153,7 +153,7 @@ async def redis_demo() -> None:
 
         # Simulate external mutation: write directly through another workspace
         # instance. The target cache (ws._cache) never sees the other write,
-        # so it still serves v1 under ALWAYS (no fingerprint to compare).
+        # so it still serves v1 under FRESH (no fingerprint to compare).
         ws_other = Workspace(
             {
                 "/data": (RedisResource(url=redis_url,
@@ -165,7 +165,7 @@ async def redis_demo() -> None:
 
         io2 = await ws.execute("cat /data/file.txt")
         print(f"  second read after external mutation    : "
-              f"{(await io2.materialize_stdout())!r}  <-- ALWAYS→LAZY, stale")
+              f"{(await io2.materialize_stdout())!r}  <-- FRESH→CACHED, stale")
 
         # Workspace-owned write invalidates the local cache
         _banner("redis — workspace-originated write invalidates cache (fresh)")

--- a/python/mirage/__init__.py
+++ b/python/mirage/__init__.py
@@ -19,14 +19,15 @@ from mirage.commands.registry import command
 from mirage.types import FileStat, MountMode
 from mirage.workspace import (ExecutionHistory, ExecutionNode, ExecutionRecord,
                               Workspace, WorkspaceRunner)
-from mirage.types import ConsistencyPolicy
+from mirage.types import ReadPolicy, WritePolicy
 
 __all__ = [
     "Workspace",
     "WorkspaceRunner",
     "RAMResource",
     "DiskResource",
-    "ConsistencyPolicy",
+    "ReadPolicy",
+    "WritePolicy",
     "ExecutionHistory",
     "ExecutionNode",
     "ExecutionRecord",

--- a/python/mirage/config.py
+++ b/python/mirage/config.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from mirage.cache.file.config import CacheConfig, RedisCacheConfig
 from mirage.cache.index.config import IndexConfig, RedisIndexConfig
 from mirage.resource.registry import build_resource
-from mirage.types import CommandSafeguard, ConsistencyPolicy, MountMode
+from mirage.types import CommandSafeguard, MountMode, ReadPolicy, WritePolicy
 
 
 def _coerce_mount_mode(value):
@@ -34,11 +34,19 @@ def _coerce_mount_mode(value):
     return value
 
 
-def _coerce_consistency(value):
-    if isinstance(value, ConsistencyPolicy):
+def _coerce_read_policy(value):
+    if isinstance(value, ReadPolicy):
         return value
     if isinstance(value, str):
-        return ConsistencyPolicy(value.lower())
+        return ReadPolicy(value.lower())
+    return value
+
+
+def _coerce_write_policy(value):
+    if isinstance(value, WritePolicy):
+        return value
+    if isinstance(value, str):
+        return WritePolicy(value.lower())
     return value
 
 
@@ -169,7 +177,8 @@ class WorkspaceConfig(BaseModel):
 
     mounts: dict[str, MountBlock]
     mode: MountMode = MountMode.WRITE
-    consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY
+    read_policy: ReadPolicy = ReadPolicy.CACHED
+    write_policy: WritePolicy = WritePolicy.THROUGH
     default_session_id: str = "default"
     default_agent_id: str = "default"
     fuse: bool = False
@@ -184,10 +193,15 @@ class WorkspaceConfig(BaseModel):
     def _v_mode(cls, v):
         return _coerce_mount_mode(v)
 
-    @field_validator("consistency", mode="before")
+    @field_validator("read_policy", mode="before")
     @classmethod
-    def _v_cons(cls, v):
-        return _coerce_consistency(v)
+    def _v_read(cls, v):
+        return _coerce_read_policy(v)
+
+    @field_validator("write_policy", mode="before")
+    @classmethod
+    def _v_write(cls, v):
+        return _coerce_write_policy(v)
 
     def to_workspace_kwargs(self) -> dict[str, Any]:
         """Produce kwargs ready to splat into ``Workspace(**kwargs)``.
@@ -208,7 +222,8 @@ class WorkspaceConfig(BaseModel):
         kwargs: dict[str, Any] = {
             "resources": resources,
             "mode": self.mode,
-            "consistency": self.consistency,
+            "read_policy": self.read_policy,
+            "write_policy": self.write_policy,
             "session_id": self.default_session_id,
             "agent_id": self.default_agent_id,
             "fuse": self.fuse,

--- a/python/mirage/server/version/state_tree.py
+++ b/python/mirage/server/version/state_tree.py
@@ -73,8 +73,10 @@ def tree_inputs_from_state(state: dict) -> tuple[dict[str, bytes], dict]:
             prefix,
             MountKey.MODE:
             mount[MountKey.MODE],
-            MountKey.CONSISTENCY:
-            mount[MountKey.CONSISTENCY],
+            MountKey.READ_POLICY:
+            mount[MountKey.READ_POLICY],
+            MountKey.WRITE_POLICY:
+            mount[MountKey.WRITE_POLICY],
             MountKey.RESOURCE_CLASS:
             mount[MountKey.RESOURCE_CLASS],
             MountKey.RESOURCE_STATE:
@@ -128,7 +130,8 @@ def to_state(entries: dict[str, bytes], meta: dict) -> dict:
             MountKey.INDEX: mount[MountKey.INDEX],
             MountKey.PREFIX: prefix,
             MountKey.MODE: mount[MountKey.MODE],
-            MountKey.CONSISTENCY: mount[MountKey.CONSISTENCY],
+            MountKey.READ_POLICY: mount[MountKey.READ_POLICY],
+            MountKey.WRITE_POLICY: mount[MountKey.WRITE_POLICY],
             MountKey.RESOURCE_CLASS: mount[MountKey.RESOURCE_CLASS],
             MountKey.RESOURCE_STATE: resource_state,
         })

--- a/python/mirage/types.py
+++ b/python/mirage/types.py
@@ -90,9 +90,24 @@ class MountMode(str, Enum):
     EXEC = "exec"
 
 
-class ConsistencyPolicy(str, Enum):
-    LAZY = "lazy"
-    ALWAYS = "always"
+class ReadPolicy(str, Enum):
+    """When a cached copy may serve a read on a remote mount.
+
+    CACHED trusts the cache outright; FRESH fingerprint-checks the
+    backend before serving and evicts on mismatch or deletion.
+    """
+    CACHED = "cached"
+    FRESH = "fresh"
+
+
+class WritePolicy(str, Enum):
+    """When writes and deletes reach the backend.
+
+    THROUGH applies them immediately. A staged (write-back) value will
+    join once the staging overlay exists; it is deliberately absent
+    until the behavior is implemented.
+    """
+    THROUGH = "through"
 
 
 class OnExceed(str, Enum):
@@ -287,7 +302,8 @@ class MountKey(StrEnum):
     INDEX = "index"
     PREFIX = "prefix"
     MODE = "mode"
-    CONSISTENCY = "consistency"
+    READ_POLICY = "read_policy"
+    WRITE_POLICY = "write_policy"
     RESOURCE_CLASS = "resource_class"
     RESOURCE_STATE = "resource_state"
 

--- a/python/mirage/workspace/dispatcher.py
+++ b/python/mirage/workspace/dispatcher.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from mirage.cache.file import io as cache_io
 from mirage.io import IOResult
-from mirage.types import ConsistencyPolicy, FileStat, PathSpec
+from mirage.types import FileStat, PathSpec, ReadPolicy
 from mirage.workspace.mount import Mount, MountRegistry
 from mirage.workspace.session import assert_mount_allowed
 
@@ -31,17 +31,15 @@ class Dispatcher:
 
     Owns the cache/IO coordination that used to live on Workspace: cache
     lookups for remote reads, post-write file-cache eviction, and parent
-    index invalidation. Constructed with the registry, cache store, and
-    consistency policy; holds no other workspace state. Drift checking
+    index invalidation. Constructed with the registry and cache store;
+    read freshness comes from each mount's policy. Drift checking
     stays on Workspace (it reads/writes snapshot-owned state), which guards
     its own dispatch wrapper before delegating here.
     """
 
-    def __init__(self, registry: MountRegistry, cache,
-                 consistency: ConsistencyPolicy) -> None:
+    def __init__(self, registry: MountRegistry, cache) -> None:
         self._registry = registry
         self._cache = cache
-        self._consistency = consistency
 
     async def dispatch(self, op: str, path: PathSpec,
                        **kwargs: Any) -> tuple[Any, IOResult]:
@@ -52,7 +50,7 @@ class Dispatcher:
         if cacheable and op in _DISPATCH_READ_OPS:
             cached = await self._cache.get(path.original)
             if cached is not None:
-                if self._consistency == ConsistencyPolicy.ALWAYS:
+                if mount.read_policy == ReadPolicy.FRESH:
                     try:
                         remote_stat = await mount.execute_op(
                             "stat", path.original)

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -28,7 +28,7 @@ from mirage.observe.context import (push_mount_prefix, push_revisions,
                                     with_revisions)
 from mirage.ops.registry import RegisteredOp
 from mirage.resource.base import BaseResource
-from mirage.types import ConsistencyPolicy, MountMode, PathSpec
+from mirage.types import MountMode, PathSpec, ReadPolicy, WritePolicy
 
 
 def _wrap_cmd_streams(
@@ -92,8 +92,9 @@ class Mount:
         self,
         prefix: str,
         resource: BaseResource,
-        mode: MountMode = MountMode.READ,
-        consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY,
+        mode: MountMode,
+        read_policy: ReadPolicy,
+        write_policy: WritePolicy,
     ) -> None:
         if not prefix.startswith("/"):
             raise ValueError(f"prefix must start with /: {prefix!r}")
@@ -104,7 +105,8 @@ class Mount:
         self.prefix = prefix
         self.resource = resource
         self.mode = mode
-        self.consistency = consistency
+        self.read_policy = read_policy
+        self.write_policy = write_policy
         # Per-path revision pins installed at Workspace.load time. Read
         # functions consult these via the ``revision_for`` contextvar
         # lookup; on a hit, the backend GET pins to the recorded

--- a/python/mirage/workspace/mount/registry.py
+++ b/python/mirage/workspace/mount/registry.py
@@ -17,7 +17,7 @@ from mirage.commands.builtin.general import COMMANDS as GENERAL_COMMANDS
 from mirage.ops.config import OpsMount
 from mirage.resource.base import BaseResource
 from mirage.resource.dev import DevResource
-from mirage.types import ConsistencyPolicy, MountMode, PathSpec
+from mirage.types import MountMode, PathSpec, ReadPolicy, WritePolicy
 from mirage.workspace.mount.mount import Mount
 
 DEV_PREFIX = "/dev/"
@@ -34,11 +34,8 @@ class MountRegistry:
     def __init__(self) -> None:
         self._mounts: list[Mount] = []
         self._default_mount: Mount | None = None
-        self._consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY
-        self.mount(DEV_PREFIX, DevResource(), MountMode.WRITE)
-
-    def set_consistency(self, consistency: ConsistencyPolicy) -> None:
-        self._consistency = consistency
+        self.mount(DEV_PREFIX, DevResource(), MountMode.WRITE,
+                   ReadPolicy.CACHED, WritePolicy.THROUGH)
 
     def set_default_mount(self, resource: BaseResource) -> None:
         """Set a default fallback mount (cache resource).
@@ -46,7 +43,8 @@ class MountRegistry:
         Used when a command has no path args and cwd
         doesn't match any mount.
         """
-        m = Mount("/_default/", resource, MountMode.WRITE)
+        m = Mount("/_default/", resource, MountMode.WRITE, ReadPolicy.CACHED,
+                  WritePolicy.THROUGH)
         for cmd in resource.commands():
             m.register(cmd)
         for cmd in GENERAL_COMMANDS:
@@ -59,8 +57,9 @@ class MountRegistry:
         self,
         prefix: str,
         resource: BaseResource,
-        mode: MountMode = MountMode.READ,
-        consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY,
+        mode: MountMode,
+        read_policy: ReadPolicy,
+        write_policy: WritePolicy,
     ) -> Mount:
         """Mount a resource and return the Mount object."""
         stripped = prefix.strip("/")
@@ -69,7 +68,7 @@ class MountRegistry:
             if existing.prefix == norm_prefix:
                 raise ValueError(f"duplicate mount prefix: "
                                  f"{norm_prefix!r}")
-        m = Mount(norm_prefix, resource, mode, consistency)
+        m = Mount(norm_prefix, resource, mode, read_policy, write_policy)
         for cmd in resource.commands():
             m.register(cmd)
         for cmd in GENERAL_COMMANDS:
@@ -259,7 +258,7 @@ class MountRegistry:
                 and isinstance(default.resource, FileCacheMixin)
                 and mount.resource.is_remote is True):
             keys = [p.original for p in path_scopes]
-            if self._consistency == ConsistencyPolicy.ALWAYS:
+            if mount.read_policy == ReadPolicy.FRESH:
                 await self._evict_stale(mount, default.resource, path_scopes)
             if await default.resource.all_cached(keys):
                 mount = default
@@ -274,9 +273,9 @@ class MountRegistry:
     ) -> None:
         """Evict cached entries whose remote fingerprint has changed.
 
-        Only used when ConsistencyPolicy.ALWAYS is active. Backends that
-        return stat.fingerprint=None silently fall back to LAZY behavior
-        (no eviction, cache serves whatever it has).
+        Only used when the mount's ReadPolicy is FRESH. Backends that
+        return stat.fingerprint=None silently fall back to CACHED
+        behavior (no eviction, cache serves whatever it has).
         """
         for scope in path_scopes:
             key = scope.original

--- a/python/mirage/workspace/snapshot/config.py
+++ b/python/mirage/workspace/snapshot/config.py
@@ -14,7 +14,7 @@
 
 from dataclasses import dataclass
 
-from mirage.types import ConsistencyPolicy
+from mirage.types import ReadPolicy, WritePolicy
 
 
 @dataclass
@@ -25,6 +25,7 @@ class MountArgs:
     code never constructs Workspace itself.
     """
     mount_args: dict
-    consistency: ConsistencyPolicy
+    read_policy: ReadPolicy
+    write_policy: WritePolicy
     default_session_id: str
     default_agent_id: str

--- a/python/mirage/workspace/snapshot/state.py
+++ b/python/mirage/workspace/snapshot/state.py
@@ -18,9 +18,9 @@ import tempfile
 
 from mirage.resource.secrets import has_redacted_secret
 from mirage.shell.job_table import Job, JobStatus
-from mirage.types import (CacheKey, ConsistencyPolicy, JobKey, MountKey,
-                          MountMode, NodeKey, RecordKey, ResourceName,
-                          ResourceStateKey, SessionKey, StateKey)
+from mirage.types import (CacheKey, JobKey, MountKey, MountMode, NodeKey,
+                          ReadPolicy, RecordKey, ResourceName,
+                          ResourceStateKey, SessionKey, StateKey, WritePolicy)
 from mirage.workspace.snapshot.config import MountArgs
 from mirage.workspace.snapshot.drift import (capture_fingerprints,
                                              live_only_mount_prefixes)
@@ -47,7 +47,8 @@ def to_state_dict(ws) -> dict:
             MountKey.INDEX: idx,
             MountKey.PREFIX: m.prefix,
             MountKey.MODE: m.mode.value,
-            MountKey.CONSISTENCY: m.consistency.value,
+            MountKey.READ_POLICY: m.read_policy.value,
+            MountKey.WRITE_POLICY: m.write_policy.value,
             MountKey.RESOURCE_CLASS:
             f"{type(m.resource).__module__}.{type(m.resource).__name__}",
             MountKey.RESOURCE_STATE: m.resource.get_state(),
@@ -133,7 +134,8 @@ def build_mount_args(state: dict, resources: dict | None = None) -> MountArgs:
 
     return MountArgs(
         mount_args=mount_args,
-        consistency=ConsistencyPolicy.LAZY,
+        read_policy=ReadPolicy.CACHED,
+        write_policy=WritePolicy.THROUGH,
         default_session_id=state.get(StateKey.DEFAULT_SESSION_ID, "default"),
         default_agent_id=state.get(StateKey.DEFAULT_AGENT_ID, "default"),
     )

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -45,9 +45,9 @@ from mirage.resource.base import BaseResource
 from mirage.resource.ram import RAMResource
 from mirage.shell.job_table import JobTable
 from mirage.shell.parse import find_syntax_error, parse
-from mirage.types import (DEFAULT_AGENT_ID, DEFAULT_SESSION_ID,
-                          ConsistencyPolicy, DriftPolicy, FileStat, MountMode,
-                          PathSpec, StateKey)
+from mirage.types import (DEFAULT_AGENT_ID, DEFAULT_SESSION_ID, DriftPolicy,
+                          FileStat, MountMode, PathSpec, ReadPolicy, StateKey,
+                          WritePolicy)
 from mirage.workspace.abort import MirageAbortError
 from mirage.workspace.dispatcher import Dispatcher
 from mirage.workspace.file_prompt import build_file_prompt
@@ -84,7 +84,8 @@ class Workspace:
         cache: CacheConfig | None = None,
         index: IndexConfig | None = None,
         mode: MountMode = MountMode.READ,
-        consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY,
+        read_policy: ReadPolicy = ReadPolicy.CACHED,
+        write_policy: WritePolicy = WritePolicy.THROUGH,
         history: int | None = 100,
         history_path: str | None = None,
         session_id: str = DEFAULT_SESSION_ID,
@@ -124,9 +125,7 @@ class Workspace:
         self._default_session_id = session_id
         self._default_agent_id = agent_id
         self._session_mgr = SessionManager(session_id)
-        self._consistency = consistency
-        self._registry.set_consistency(consistency)
-        self._dispatcher = Dispatcher(self._registry, self._cache, consistency)
+        self._dispatcher = Dispatcher(self._registry, self._cache)
 
         for prefix, value in resources.items():
             mount_safeguards: dict = {}
@@ -140,7 +139,8 @@ class Workspace:
                 mount_mode = mode
             if index is not None:
                 prov.set_index(index)
-            mount_obj = self._registry.mount(prefix, prov, mount_mode)
+            mount_obj = self._registry.mount(prefix, prov, mount_mode,
+                                             read_policy, write_policy)
             if mount_safeguards:
                 mount_obj.command_safeguards.update(mount_safeguards)
 
@@ -154,7 +154,8 @@ class Workspace:
         observe_resource = (observe if observe is not None else RAMResource())
         self.observer = Observer(resource=observe_resource,
                                  prefix=observe_prefix)
-        self._registry.mount(observe_prefix, observe_resource, MountMode.READ)
+        self._registry.mount(observe_prefix, observe_resource, MountMode.READ,
+                             ReadPolicy.CACHED, WritePolicy.THROUGH)
 
         self._ops = Ops(self._registry.ops_mounts(),
                         on_write=self._invalidate_after_write_by_path,
@@ -438,7 +439,8 @@ class Workspace:
                     resources: dict | None = None) -> "Workspace":
         args = build_mount_args(state, resources)
         ws = cls(args.mount_args,
-                 consistency=args.consistency,
+                 read_policy=args.read_policy,
+                 write_policy=args.write_policy,
                  session_id=args.default_session_id,
                  agent_id=args.default_agent_id)
         apply_state_dict(ws, state)

--- a/python/tests/config/fixtures/full.yaml
+++ b/python/tests/config/fixtures/full.yaml
@@ -1,5 +1,6 @@
 mode: WRITE
-consistency: LAZY
+read_policy: CACHED
+write_policy: THROUGH
 default_session_id: default
 default_agent_id: default
 fuse: false

--- a/python/tests/config/test_loader.py
+++ b/python/tests/config/test_loader.py
@@ -22,7 +22,7 @@ from mirage.config import (RamCacheBlock, RedisCacheBlock, WorkspaceConfig,
                            load_config, merge_override)
 from mirage.resource.ram import RAMResource
 from mirage.resource.s3 import S3Resource
-from mirage.types import ConsistencyPolicy
+from mirage.types import ReadPolicy, WritePolicy
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -44,7 +44,8 @@ def test_load_full_yaml_with_env_interpolation():
     }
     cfg = load_config(FIXTURES / "full.yaml", env=env)
     assert cfg.mode == MountMode.WRITE
-    assert cfg.consistency == ConsistencyPolicy.LAZY
+    assert cfg.read_policy == ReadPolicy.CACHED
+    assert cfg.write_policy == WritePolicy.THROUGH
     assert cfg.history == 50
     assert isinstance(cfg.cache, RamCacheBlock)
     assert cfg.cache.limit == "256MB"

--- a/python/tests/integration/test_fingerprint_matrix.py
+++ b/python/tests/integration/test_fingerprint_matrix.py
@@ -16,12 +16,12 @@ import asyncio
 from contextlib import ExitStack
 
 from mirage.resource.s3 import S3Config, S3Resource
-from mirage.types import ConsistencyPolicy, MountMode
+from mirage.types import MountMode, ReadPolicy
 from mirage.workspace import Workspace
 from tests.integration.s3_mock import patch_s3_multi
 
 
-def _make_ws(consistency: ConsistencyPolicy) -> Workspace:
+def _make_ws(read_policy: ReadPolicy) -> Workspace:
     config = S3Config(
         bucket="test-bucket",
         region="us-east-1",
@@ -32,7 +32,7 @@ def _make_ws(consistency: ConsistencyPolicy) -> Workspace:
     return Workspace(
         {"/data": (resource, MountMode.WRITE)},
         mode=MountMode.WRITE,
-        consistency=consistency,
+        read_policy=read_policy,
     )
 
 
@@ -41,7 +41,7 @@ def test_s3_always_refetches_after_external_mutation():
     stack = ExitStack()
     stack.enter_context(patch_s3_multi({"test-bucket": store}))
     try:
-        ws = _make_ws(ConsistencyPolicy.ALWAYS)
+        ws = _make_ws(ReadPolicy.FRESH)
 
         async def run() -> tuple[bytes, bytes]:
             io1 = await ws.execute("cat /data/file.txt")
@@ -64,7 +64,7 @@ def test_s3_lazy_serves_cache():
     stack = ExitStack()
     stack.enter_context(patch_s3_multi({"test-bucket": store}))
     try:
-        ws = _make_ws(ConsistencyPolicy.LAZY)
+        ws = _make_ws(ReadPolicy.CACHED)
 
         async def run() -> tuple[bytes, bytes]:
             io1 = await ws.execute("cat /data/file.txt")

--- a/python/tests/integration/test_fingerprint_multi_writer.py
+++ b/python/tests/integration/test_fingerprint_multi_writer.py
@@ -16,12 +16,12 @@ import asyncio
 from contextlib import ExitStack
 
 from mirage.resource.s3 import S3Config, S3Resource
-from mirage.types import ConsistencyPolicy, MountMode
+from mirage.types import MountMode, ReadPolicy
 from mirage.workspace import Workspace
 from tests.integration.s3_mock import patch_s3_multi
 
 
-def _make_ws(consistency: ConsistencyPolicy) -> Workspace:
+def _make_ws(read_policy: ReadPolicy) -> Workspace:
     config = S3Config(
         bucket="shared-bucket",
         region="us-east-1",
@@ -32,7 +32,7 @@ def _make_ws(consistency: ConsistencyPolicy) -> Workspace:
     return Workspace(
         {"/data": (resource, MountMode.WRITE)},
         mode=MountMode.WRITE,
-        consistency=consistency,
+        read_policy=read_policy,
     )
 
 
@@ -41,8 +41,8 @@ def test_two_workspaces_always_sees_other_writers_update():
     stack = ExitStack()
     stack.enter_context(patch_s3_multi({"shared-bucket": store}))
     try:
-        ws_a = _make_ws(ConsistencyPolicy.ALWAYS)
-        ws_b = _make_ws(ConsistencyPolicy.ALWAYS)
+        ws_a = _make_ws(ReadPolicy.FRESH)
+        ws_b = _make_ws(ReadPolicy.FRESH)
 
         async def run() -> tuple[bytes, bytes]:
             io_b1 = await ws_b.execute("cat /data/file.txt")
@@ -68,8 +68,8 @@ def test_two_workspaces_lazy_may_serve_stale_after_other_writer():
     stack = ExitStack()
     stack.enter_context(patch_s3_multi({"shared-bucket": store}))
     try:
-        ws_a = _make_ws(ConsistencyPolicy.LAZY)
-        ws_b = _make_ws(ConsistencyPolicy.LAZY)
+        ws_a = _make_ws(ReadPolicy.CACHED)
+        ws_b = _make_ws(ReadPolicy.CACHED)
 
         async def run() -> bytes:
             io_b1 = await ws_b.execute("cat /data/file.txt")

--- a/python/tests/integration/test_gdrive_fingerprint.py
+++ b/python/tests/integration/test_gdrive_fingerprint.py
@@ -15,7 +15,7 @@
 import pytest
 
 from mirage.resource.gdrive import GoogleDriveConfig, GoogleDriveResource
-from mirage.types import ConsistencyPolicy, MountMode
+from mirage.types import MountMode, ReadPolicy
 from mirage.workspace import Workspace
 from tests.integration.gdrive_mock import FakeGDrive, patch_gdrive
 
@@ -33,7 +33,7 @@ async def test_gdrive_always_refetches_after_external_mutation():
     ws = Workspace(
         {"/gd": (resource, MountMode.WRITE)},
         mode=MountMode.WRITE,
-        consistency=ConsistencyPolicy.ALWAYS,
+        read_policy=ReadPolicy.FRESH,
     )
     with patch_gdrive(fake):
         await ws.execute("ls /gd")
@@ -61,7 +61,7 @@ async def test_gdrive_lazy_may_serve_stale():
     ws = Workspace(
         {"/gd": (resource, MountMode.WRITE)},
         mode=MountMode.WRITE,
-        consistency=ConsistencyPolicy.LAZY,
+        read_policy=ReadPolicy.CACHED,
     )
     with patch_gdrive(fake):
         await ws.execute("ls /gd")

--- a/python/tests/workspace/expand/test_classify.py
+++ b/python/tests/workspace/expand/test_classify.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.resource.ram import RAMResource
-from mirage.types import MountMode, PathSpec
+from mirage.types import MountMode, PathSpec, ReadPolicy, WritePolicy
 from mirage.workspace.expand.classify import _unescape_path, classify_word
 from mirage.workspace.mount import MountRegistry
 
@@ -34,7 +34,8 @@ def test_classify_backslash_escaped_absolute():
     registry = MountRegistry()
     resource = RAMResource()
     resource._store.dirs.add("/")
-    registry.mount("/ram/", resource, MountMode.WRITE)
+    registry.mount("/ram/", resource, MountMode.WRITE, ReadPolicy.CACHED,
+                   WritePolicy.THROUGH)
     result = classify_word(r"/ram/Zecheng\'s\ Server/", registry, "/")
     assert isinstance(result, PathSpec)
     assert result.original == "/ram/Zecheng's Server"
@@ -44,7 +45,8 @@ def test_classify_quoted_path():
     registry = MountRegistry()
     resource = RAMResource()
     resource._store.dirs.add("/")
-    registry.mount("/ram/", resource, MountMode.WRITE)
+    registry.mount("/ram/", resource, MountMode.WRITE, ReadPolicy.CACHED,
+                   WritePolicy.THROUGH)
     result = classify_word("/ram/Zecheng's Server/", registry, "/")
     assert isinstance(result, PathSpec)
     assert result.original == "/ram/Zecheng's Server"

--- a/python/tests/workspace/mount/conftest.py
+++ b/python/tests/workspace/mount/conftest.py
@@ -19,7 +19,7 @@ from moto import mock_aws
 from mirage.resource.disk import DiskResource
 from mirage.resource.ram import RAMResource
 from mirage.resource.s3.s3 import S3Config, S3Resource
-from mirage.types import MountMode
+from mirage.types import MountMode, ReadPolicy, WritePolicy
 from mirage.workspace.mount import MountRegistry
 
 
@@ -85,7 +85,8 @@ def s3_resource():
 def registry(ram_resource):
     """MountRegistry with /data/ mounted to RAMResource."""
     reg = MountRegistry()
-    reg.mount("/data/", ram_resource, MountMode.WRITE)
+    reg.mount("/data/", ram_resource, MountMode.WRITE, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
     return reg
 
 
@@ -93,9 +94,12 @@ def registry(ram_resource):
 def multi_registry(s3_resource, disk_resource, ram_resource):
     """MountRegistry with S3, disk, and RAM mounts."""
     reg = MountRegistry()
-    reg.mount("/s3/", s3_resource, MountMode.READ)
-    reg.mount("/disk/", disk_resource, MountMode.WRITE)
-    reg.mount("/ram/", ram_resource, MountMode.WRITE)
+    reg.mount("/s3/", s3_resource, MountMode.READ, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
+    reg.mount("/disk/", disk_resource, MountMode.WRITE, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
+    reg.mount("/ram/", ram_resource, MountMode.WRITE, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
     return reg
 
 
@@ -108,6 +112,8 @@ def nested_registry():
     p2._store.files["/deep.txt"] = b"inner\n"
 
     reg = MountRegistry()
-    reg.mount("/data/", p1, MountMode.WRITE)
-    reg.mount("/data/sub/", p2, MountMode.WRITE)
+    reg.mount("/data/", p1, MountMode.WRITE, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
+    reg.mount("/data/sub/", p2, MountMode.WRITE, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
     return reg

--- a/python/tests/workspace/mount/test_mount.py
+++ b/python/tests/workspace/mount/test_mount.py
@@ -17,7 +17,7 @@ import asyncio
 import pytest
 
 from mirage.resource.ram import RAMResource
-from mirage.types import MountMode, PathSpec
+from mirage.types import MountMode, PathSpec, ReadPolicy, WritePolicy
 from mirage.workspace.mount import MountRegistry
 from mirage.workspace.mount.mount import Mount
 
@@ -30,27 +30,32 @@ def _run(coro):
 
 
 def test_mount_accepts_root_prefix():
-    m = Mount("/", RAMResource())
+    m = Mount("/", RAMResource(), MountMode.READ, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
     assert m.prefix == "/"
 
 
 def test_mount_rejects_no_leading_slash():
     with pytest.raises(ValueError, match="must start with /"):
-        Mount("data/", RAMResource())
+        Mount("data/", RAMResource(), MountMode.READ, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
 
 
 def test_mount_rejects_no_trailing_slash():
     with pytest.raises(ValueError, match="must end with /"):
-        Mount("/data", RAMResource())
+        Mount("/data", RAMResource(), MountMode.READ, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
 
 
 def test_mount_rejects_double_slash():
     with pytest.raises(ValueError, match="must not contain //"):
-        Mount("/data//sub/", RAMResource())
+        Mount("/data//sub/", RAMResource(), MountMode.READ, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
 
 
 def test_mount_valid_prefix():
-    m = Mount("/data/", RAMResource())
+    m = Mount("/data/", RAMResource(), MountMode.READ, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
     assert m.prefix == "/data/"
 
 
@@ -59,7 +64,8 @@ def test_mount_valid_prefix():
 
 def test_read_only_blocks_write_ops():
     reg = MountRegistry()
-    reg.mount("/ro/", RAMResource(), MountMode.READ)
+    reg.mount("/ro/", RAMResource(), MountMode.READ, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
     mount = reg.mount_for("/ro/file.txt")
     with pytest.raises(PermissionError, match="read-only"):
         _run(mount.execute_op("write", "/file.txt", data=b"x"))
@@ -67,14 +73,16 @@ def test_read_only_blocks_write_ops():
 
 def test_write_mode_allows_write_ops():
     reg = MountRegistry()
-    reg.mount("/rw/", RAMResource(), MountMode.WRITE)
+    reg.mount("/rw/", RAMResource(), MountMode.WRITE, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
     mount = reg.mount_for("/rw/file.txt")
     _run(mount.execute_op("write", "/new.txt", data=b"hello"))
 
 
 def test_read_only_blocks_write_cmd():
     reg = MountRegistry()
-    reg.mount("/ro/", RAMResource(), MountMode.READ)
+    reg.mount("/ro/", RAMResource(), MountMode.READ, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
     mount = reg.mount_for("/ro/file.txt")
     scope = PathSpec(original="/ro/newdir", directory="/ro/", resolved=True)
     stdout, io = _run(mount.execute_cmd("mkdir", [scope], [], {}))
@@ -84,7 +92,8 @@ def test_read_only_blocks_write_cmd():
 
 def test_write_mode_allows_write_cmd():
     reg = MountRegistry()
-    reg.mount("/rw/", RAMResource(), MountMode.WRITE)
+    reg.mount("/rw/", RAMResource(), MountMode.WRITE, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
     mount = reg.mount_for("/rw/file.txt")
     scope = PathSpec(original="/rw/newdir", directory="/rw/", resolved=True)
     stdout, io = _run(mount.execute_cmd("mkdir", [scope], [], {}))
@@ -93,7 +102,8 @@ def test_write_mode_allows_write_cmd():
 
 def test_read_only_allows_read_cmd():
     reg = MountRegistry()
-    reg.mount("/ro/", RAMResource(), MountMode.READ)
+    reg.mount("/ro/", RAMResource(), MountMode.READ, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
     mount = reg.mount_for("/ro/")
     scope = PathSpec(original="/ro/", directory="/ro/", resolved=False)
     stdout, io = _run(mount.execute_cmd("ls", [scope], [], {}))

--- a/python/tests/workspace/mount/test_registry.py
+++ b/python/tests/workspace/mount/test_registry.py
@@ -17,7 +17,7 @@ import pytest
 from mirage.cache.file.ram import RAMFileCacheStore
 from mirage.resource.ram import RAMResource
 from mirage.resource.ssh import SSHConfig, SSHResource
-from mirage.types import MountMode, PathSpec
+from mirage.types import MountMode, PathSpec, ReadPolicy, WritePolicy
 from mirage.workspace.mount import MountRegistry
 
 # ── mount_for ──────────────────────────────────
@@ -186,20 +186,23 @@ def test_multi_mount_resource_paths(multi_registry):
 def test_mount_returns_mount_object():
     reg = MountRegistry()
     p = RAMResource()
-    m = reg.mount("/test/", p, MountMode.READ)
+    m = reg.mount("/test/", p, MountMode.READ, ReadPolicy.CACHED,
+                  WritePolicy.THROUGH)
     assert m.prefix == "/test/"
     assert m.resource is p
 
 
 def test_mount_normalizes_prefix():
     reg = MountRegistry()
-    m = reg.mount("/test/", RAMResource(), MountMode.READ)
+    m = reg.mount("/test/", RAMResource(), MountMode.READ, ReadPolicy.CACHED,
+                  WritePolicy.THROUGH)
     assert m.prefix == "/test/"
 
 
 def test_mount_duplicate_raises(registry):
     with pytest.raises(ValueError, match="duplicate"):
-        registry.mount("/data/", RAMResource())
+        registry.mount("/data/", RAMResource(), MountMode.READ,
+                       ReadPolicy.CACHED, WritePolicy.THROUGH)
 
 
 # ── mounts listing ─────────────────────────────
@@ -309,7 +312,7 @@ def test_mount_for_command_grep(multi_registry):
 def _remote_registry_with_cache():
     reg = MountRegistry()
     reg.mount("/ssh/", SSHResource(SSHConfig(host="example", root="/srv")),
-              MountMode.WRITE)
+              MountMode.WRITE, ReadPolicy.CACHED, WritePolicy.THROUGH)
     cache = RAMFileCacheStore()
     reg.set_default_mount(cache)
     return reg, cache

--- a/python/tests/workspace/mount/test_ssh_mount.py
+++ b/python/tests/workspace/mount/test_ssh_mount.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.resource.ssh import SSHConfig, SSHResource
-from mirage.types import MountMode
+from mirage.types import MountMode, ReadPolicy, WritePolicy
 from mirage.workspace.mount.registry import MountRegistry
 
 
@@ -21,7 +21,8 @@ def test_ssh_mount_registration():
     registry = MountRegistry()
     cfg = SSHConfig(host="dev", root="/home/ubuntu")
     resource = SSHResource(cfg)
-    registry.mount("/ssh/", resource, mode=MountMode.WRITE)
+    registry.mount("/ssh/", resource, MountMode.WRITE, ReadPolicy.CACHED,
+                   WritePolicy.THROUGH)
     mount = registry.mount_for("/ssh/some/file.txt")
     assert mount is not None
     assert mount.resource.name == "ssh"
@@ -31,7 +32,8 @@ def test_ssh_mount_command_resolution():
     registry = MountRegistry()
     cfg = SSHConfig(host="dev")
     resource = SSHResource(cfg)
-    registry.mount("/remote/", resource, mode=MountMode.WRITE)
+    registry.mount("/remote/", resource, MountMode.WRITE, ReadPolicy.CACHED,
+                   WritePolicy.THROUGH)
     mount = registry.mount_for("/remote/test.py")
     assert mount is not None
     cmd = mount.resolve_command("cat", None)

--- a/python/tests/workspace/node/test_run_tree.py
+++ b/python/tests/workspace/node/test_run_tree.py
@@ -19,7 +19,7 @@ from mirage.io.types import materialize
 from mirage.resource.ram import RAMResource
 from mirage.shell.job_table import JobTable
 from mirage.shell.parse import parse
-from mirage.types import MountMode
+from mirage.types import MountMode, ReadPolicy, WritePolicy
 from mirage.workspace.mount import MountRegistry
 from mirage.workspace.node import run_command_tree
 from mirage.workspace.session import Session
@@ -31,7 +31,8 @@ def registry():
     reg = MountRegistry()
     res = RAMResource()
     reg.set_default_mount(res)
-    reg.mount("/", res, MountMode.WRITE)
+    reg.mount("/", res, MountMode.WRITE, ReadPolicy.CACHED,
+              WritePolicy.THROUGH)
     return reg
 
 

--- a/python/tests/workspace/test_fingerprint_spike.py
+++ b/python/tests/workspace/test_fingerprint_spike.py
@@ -17,7 +17,7 @@ import time
 
 from mirage.resource.disk import DiskResource
 from mirage.resource.ram import RAMResource
-from mirage.types import ConsistencyPolicy, MountMode
+from mirage.types import MountMode, ReadPolicy
 from mirage.workspace import Workspace
 
 
@@ -30,7 +30,7 @@ def test_disk_always_refetches_after_external_mutation(tmp_path):
     ws = Workspace(
         {"/data": (resource, MountMode.WRITE)},
         mode=MountMode.WRITE,
-        consistency=ConsistencyPolicy.ALWAYS,
+        read_policy=ReadPolicy.FRESH,
     )
 
     async def run() -> tuple[bytes, bytes]:
@@ -57,7 +57,7 @@ def test_disk_lazy_keeps_stale_cache_after_external_mutation(tmp_path):
     ws = Workspace(
         {"/data": (resource, MountMode.WRITE)},
         mode=MountMode.WRITE,
-        consistency=ConsistencyPolicy.LAZY,
+        read_policy=ReadPolicy.CACHED,
     )
 
     async def run() -> tuple[bytes, bytes]:
@@ -81,7 +81,7 @@ def test_ram_falls_back_to_lazy_when_fingerprint_absent():
     ws = Workspace(
         {"/data": (resource, MountMode.WRITE)},
         mode=MountMode.WRITE,
-        consistency=ConsistencyPolicy.ALWAYS,
+        read_policy=ReadPolicy.FRESH,
     )
 
     async def run() -> bytes:

--- a/python/tests/workspace/test_snapshot.py
+++ b/python/tests/workspace/test_snapshot.py
@@ -255,7 +255,8 @@ def test_load_rejects_path_traversal_in_blob_ref(tmp_path):
             "index": 0,
             "prefix": "/m",
             "mode": "WRITE",
-            "consistency": "LAZY",
+            "read_policy": "cached",
+            "write_policy": "through",
             "resource_class": "mirage.resource.ram.RAMResource",
             "resource_state": {
                 "type": "ram",

--- a/typescript/packages/core/src/config.test.ts
+++ b/typescript/packages/core/src/config.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, it } from 'vitest'
 import { loadConfigFromObject, mergeOverride } from './config.ts'
-import { ConsistencyPolicy, MountMode } from './types.ts'
+import { MountMode, ReadPolicy, WritePolicy } from './types.ts'
 
 describe('loadConfigFromObject', () => {
   it('accepts a dict source', () => {
@@ -23,10 +23,11 @@ describe('loadConfigFromObject', () => {
     expect(cfg.mounts['/']?.resource).toBe('ram')
   })
 
-  it('fills workspace-level defaults (mode/consistency/history)', () => {
+  it('fills workspace-level defaults (mode/policies/history)', () => {
     const cfg = loadConfigFromObject({ mounts: { '/': { resource: 'ram' } } })
     expect(cfg.mode).toBe(MountMode.WRITE)
-    expect(cfg.consistency).toBe(ConsistencyPolicy.LAZY)
+    expect(cfg.readPolicy).toBe(ReadPolicy.CACHED)
+    expect(cfg.writePolicy).toBe(WritePolicy.THROUGH)
     expect(cfg.history).toBe(100)
     expect(cfg.cache).toBe(null)
   })

--- a/typescript/packages/core/src/config.ts
+++ b/typescript/packages/core/src/config.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { ConsistencyPolicy, MountMode } from './types.ts'
+import { MountMode, ReadPolicy, WritePolicy } from './types.ts'
 
 const VAR_RE = /\$\{([A-Z_][A-Z0-9_]*)\}/g
 
@@ -41,7 +41,8 @@ export interface MountBlock {
 export interface WorkspaceConfig {
   mounts: Record<string, MountBlock>
   mode?: MountMode
-  consistency?: ConsistencyPolicy
+  readPolicy?: ReadPolicy
+  writePolicy?: WritePolicy
   defaultSessionId?: string
   defaultAgentId?: string
   fuse?: boolean
@@ -141,7 +142,8 @@ function validateConfig(raw: Record<string, unknown>): WorkspaceConfig {
   const out: WorkspaceConfig = {
     mounts: mounts as Record<string, MountBlock>,
     mode: (raw.mode as MountMode | undefined) ?? MountMode.WRITE,
-    consistency: (raw.consistency as ConsistencyPolicy | undefined) ?? ConsistencyPolicy.LAZY,
+    readPolicy: (raw.readPolicy as ReadPolicy | undefined) ?? ReadPolicy.CACHED,
+    writePolicy: (raw.writePolicy as WritePolicy | undefined) ?? WritePolicy.THROUGH,
     defaultSessionId: (raw.defaultSessionId as string | undefined) ?? 'default',
     defaultAgentId: (raw.defaultAgentId as string | undefined) ?? 'default',
     fuse: (raw.fuse as boolean | undefined) ?? false,

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -16,7 +16,8 @@ export const VERSION = '0.0.0'
 export {
   CommandSafeguard,
   type CommandSafeguardInit,
-  ConsistencyPolicy,
+  ReadPolicy,
+  WritePolicy,
   DEFAULT_AGENT_ID,
   DEFAULT_SESSION_ID,
   DriftPolicy,

--- a/typescript/packages/core/src/types.test.ts
+++ b/typescript/packages/core/src/types.test.ts
@@ -14,14 +14,15 @@
 
 import { describe, expect, it } from 'vitest'
 import {
-  ConsistencyPolicy,
   DEFAULT_AGENT_ID,
   DEFAULT_SESSION_ID,
   FileStat,
   FileType,
   MountMode,
   PathSpec,
+  ReadPolicy,
   ResourceName,
+  WritePolicy,
 } from './types.ts'
 
 describe('MountMode', () => {
@@ -36,14 +37,24 @@ describe('MountMode', () => {
   })
 })
 
-describe('ConsistencyPolicy', () => {
-  it('exposes LAZY/ALWAYS with matching string values', () => {
-    expect(ConsistencyPolicy.LAZY).toBe('lazy')
-    expect(ConsistencyPolicy.ALWAYS).toBe('always')
+describe('ReadPolicy', () => {
+  it('exposes CACHED/FRESH with matching string values', () => {
+    expect(ReadPolicy.CACHED).toBe('cached')
+    expect(ReadPolicy.FRESH).toBe('fresh')
   })
 
   it('is frozen at runtime', () => {
-    expect(Object.isFrozen(ConsistencyPolicy)).toBe(true)
+    expect(Object.isFrozen(ReadPolicy)).toBe(true)
+  })
+})
+
+describe('WritePolicy', () => {
+  it('exposes THROUGH with matching string value', () => {
+    expect(WritePolicy.THROUGH).toBe('through')
+  })
+
+  it('is frozen at runtime', () => {
+    expect(Object.isFrozen(WritePolicy)).toBe(true)
   })
 })
 

--- a/typescript/packages/core/src/types.ts
+++ b/typescript/packages/core/src/types.ts
@@ -22,12 +22,29 @@ export const MountMode = Object.freeze({
 
 export type MountMode = (typeof MountMode)[keyof typeof MountMode]
 
-export const ConsistencyPolicy = Object.freeze({
-  LAZY: 'lazy',
-  ALWAYS: 'always',
+/**
+ * When a cached copy may serve a read on a remote mount. CACHED trusts
+ * the cache outright; FRESH fingerprint-checks the backend before
+ * serving and evicts on mismatch or deletion.
+ */
+export const ReadPolicy = Object.freeze({
+  CACHED: 'cached',
+  FRESH: 'fresh',
 } as const)
 
-export type ConsistencyPolicy = (typeof ConsistencyPolicy)[keyof typeof ConsistencyPolicy]
+export type ReadPolicy = (typeof ReadPolicy)[keyof typeof ReadPolicy]
+
+/**
+ * When writes and deletes reach the backend. THROUGH applies them
+ * immediately. A staged (write-back) value will join once the staging
+ * overlay exists; it is deliberately absent until the behavior is
+ * implemented.
+ */
+export const WritePolicy = Object.freeze({
+  THROUGH: 'through',
+} as const)
+
+export type WritePolicy = (typeof WritePolicy)[keyof typeof WritePolicy]
 
 /**
  * Behaviour when a remote resource's live fingerprint differs from the

--- a/typescript/packages/core/src/workspace/executor/builtins.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins.test.ts
@@ -18,7 +18,7 @@ import { IOResult, materialize } from '../../io/types.ts'
 import type { ByteSource } from '../../io/types.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
 import { CallStack } from '../../shell/call_stack.ts'
-import { FileStat, FileType, MountMode } from '../../types.ts'
+import { FileStat, FileType, MountMode, ReadPolicy, WritePolicy } from '../../types.ts'
 import { MountRegistry } from '../mount/registry.ts'
 import type { Mount } from '../mount/mount.ts'
 import { Session } from '../session/session.ts'
@@ -444,7 +444,13 @@ describe('handleSource', () => {
 
 describe('handleMan', () => {
   it('renders header, description, and RESOURCES list for a known command', async () => {
-    const reg = new MountRegistry({ '/ram/': new RAMResource() }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/ram/': new RAMResource() },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     wireRegistry(reg)
     const s = new Session({ sessionId: 'test', cwd: '/' })
     const [out, io] = handleMan(['date'], s, reg)
@@ -456,7 +462,13 @@ describe('handleMan', () => {
   })
 
   it('renders OPTIONS table when the spec has options', async () => {
-    const reg = new MountRegistry({ '/ram/': new RAMResource() }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/ram/': new RAMResource() },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     wireRegistry(reg)
     const s = new Session({ sessionId: 'test', cwd: '/' })
     const [out, io] = handleMan(['date'], s, reg)
@@ -469,6 +481,9 @@ describe('handleMan', () => {
     const reg = new MountRegistry(
       { '/ram-a/': new RAMResource(), '/ram-b/': new RAMResource() },
       MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
     )
     wireRegistry(reg)
     const s = new Session({ sessionId: 'test', cwd: '/' })
@@ -480,7 +495,13 @@ describe('handleMan', () => {
   })
 
   it('exits 1 with a clear error for unknown commands', () => {
-    const reg = new MountRegistry({ '/ram/': new RAMResource() }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/ram/': new RAMResource() },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     wireRegistry(reg)
     const s = new Session({ sessionId: 'test', cwd: '/' })
     const [, io] = handleMan(['definitely-not-a-real-command-xyz'], s, reg)
@@ -490,7 +511,13 @@ describe('handleMan', () => {
   })
 
   it('groups commands by resource kind, cwd resource first, general last', async () => {
-    const reg = new MountRegistry({ '/ram/': new RAMResource() }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/ram/': new RAMResource() },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     wireRegistry(reg)
     const s = new Session({ sessionId: 'test', cwd: '/ram/' })
     const [body, io] = handleMan([], s, reg)
@@ -506,6 +533,9 @@ describe('handleMan', () => {
     const reg = new MountRegistry(
       { '/ram-a/': new RAMResource(), '/ram-b/': new RAMResource() },
       MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
     )
     wireRegistry(reg)
     const s = new Session({ sessionId: 'test', cwd: '/' })

--- a/typescript/packages/core/src/workspace/executor/command.test.ts
+++ b/typescript/packages/core/src/workspace/executor/command.test.ts
@@ -18,7 +18,7 @@ import { CommandSpec, Operand, OperandKind, Option } from '../../commands/spec/t
 import { IOResult } from '../../io/types.ts'
 import { JobTable } from '../../shell/job_table.ts'
 import type { Resource } from '../../resource/base.ts'
-import { MountMode, PathSpec } from '../../types.ts'
+import { MountMode, PathSpec, ReadPolicy, WritePolicy } from '../../types.ts'
 import { MountRegistry } from '../mount/registry.ts'
 import { Session } from '../session/session.ts'
 import type { ExecuteNodeFn } from './jobs.ts'
@@ -50,7 +50,13 @@ function decode(b: Uint8Array | null): string {
 
 describe('handleCommand — command not found', () => {
   it('returns exit 127 when no mount has the command', async () => {
-    const reg = new MountRegistry({ '/ram': new StubResource('ram') }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/ram': new StubResource('ram') },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const [, io, exec] = await handleCommand(
       NEVER_EXECUTE,
       NEVER_DISPATCH,
@@ -69,7 +75,13 @@ describe('handleCommand — dispatches to mount that has the command', () => {
 
   it('routes to a mount whose resource registered the command', async () => {
     const ram = new StubResource('ram')
-    const reg = new MountRegistry({ '/ram': ram }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/ram': ram },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const mount = reg.mountFor('/ram/x')
     if (mount === null) throw new Error('mount missing')
     const [cmd] = command({
@@ -95,7 +107,13 @@ describe('handleCommand — dispatches to mount that has the command', () => {
 
   it('parses flags through the spec and forwards them', async () => {
     const ram = new StubResource('ram')
-    const reg = new MountRegistry({ '/ram': ram }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/ram': ram },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const mount = reg.mountFor('/ram')
     if (mount === null) throw new Error('mount missing')
     const spec = new CommandSpec({
@@ -131,6 +149,9 @@ describe('handleCommand — cross-mount', () => {
     const reg = new MountRegistry(
       { '/ram': new StubResource('ram'), '/disk': new StubResource('disk') },
       MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
     )
     const [, io, exec] = await handleCommand(
       NEVER_EXECUTE,
@@ -147,7 +168,13 @@ describe('handleCommand — cross-mount', () => {
 
 describe('handleCommand — job builtins', () => {
   it('routes "jobs" to handleJobs when jobTable provided', async () => {
-    const reg = new MountRegistry({ '/ram': new StubResource('ram') }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/ram': new StubResource('ram') },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const jt = new JobTable()
     const [, io] = await handleCommand(
       NEVER_EXECUTE,
@@ -163,7 +190,13 @@ describe('handleCommand — job builtins', () => {
   })
 
   it('routes "kill N" to handleKill', async () => {
-    const reg = new MountRegistry({ '/ram': new StubResource('ram') }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/ram': new StubResource('ram') },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const jt = new JobTable()
     const [, io] = await handleCommand(
       NEVER_EXECUTE,

--- a/typescript/packages/core/src/workspace/executor/cross_mount.test.ts
+++ b/typescript/packages/core/src/workspace/executor/cross_mount.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { IOResult } from '../../io/types.ts'
 import type { Resource } from '../../resource/base.ts'
-import { MountMode, PathSpec } from '../../types.ts'
+import { MountMode, PathSpec, ReadPolicy, WritePolicy } from '../../types.ts'
 import { MountRegistry } from '../mount/registry.ts'
 import { handleCrossMount, isCrossMount } from './cross_mount.ts'
 
@@ -35,7 +35,13 @@ function decode(b: Uint8Array | null): string {
 }
 
 describe('isCrossMount', () => {
-  const reg = new MountRegistry({ '/ram': new Stub(), '/disk': new Stub() }, MountMode.WRITE)
+  const reg = new MountRegistry(
+    { '/ram': new Stub(), '/disk': new Stub() },
+    MountMode.WRITE,
+    {},
+    ReadPolicy.CACHED,
+    WritePolicy.THROUGH,
+  )
 
   it('returns true when 2 paths live in different mounts and command is allowed', () => {
     const paths = [PathSpec.fromStrPath('/ram/a'), PathSpec.fromStrPath('/disk/b')]

--- a/typescript/packages/core/src/workspace/executor/fanout.test.ts
+++ b/typescript/packages/core/src/workspace/executor/fanout.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, it } from 'vitest'
 import { materialize } from '../../io/types.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
-import { MountMode } from '../../types.ts'
+import { MountMode, ReadPolicy, WritePolicy } from '../../types.ts'
 import { MountRegistry } from '../mount/registry.ts'
 import type { Mount } from '../mount/mount.ts'
 import { Session } from '../session/session.ts'
@@ -51,6 +51,9 @@ describe('fanOutTraversal glob matching', () => {
     const reg = new MountRegistry(
       { '/data/': new RAMResource(), '/data/sub/': new RAMResource() },
       MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
     )
     wireRegistry(reg)
     const s = new Session({ sessionId: 'test', cwd: '/' })
@@ -68,6 +71,9 @@ describe('fanOutTraversal glob matching', () => {
     const reg = new MountRegistry(
       { '/data/': new RAMResource(), '/data/sub1/': new RAMResource() },
       MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
     )
     wireRegistry(reg)
     const s = new Session({ sessionId: 'test', cwd: '/' })

--- a/typescript/packages/core/src/workspace/expand/classify.test.ts
+++ b/typescript/packages/core/src/workspace/expand/classify.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, it } from 'vitest'
 import type { Resource } from '../../resource/base.ts'
-import { MountMode, PathSpec } from '../../types.ts'
+import { MountMode, PathSpec, ReadPolicy, WritePolicy } from '../../types.ts'
 import { MountRegistry } from '../mount/registry.ts'
 import {
   classifyBarePath,
@@ -36,7 +36,13 @@ class StubResource implements Resource {
 }
 
 function setup(): MountRegistry {
-  return new MountRegistry({ '/ram': new StubResource() }, MountMode.WRITE)
+  return new MountRegistry(
+    { '/ram': new StubResource() },
+    MountMode.WRITE,
+    {},
+    ReadPolicy.CACHED,
+    WritePolicy.THROUGH,
+  )
 }
 
 describe('posixNormpath', () => {

--- a/typescript/packages/core/src/workspace/mount/mount.test.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.test.ts
@@ -20,7 +20,7 @@ import type { Accessor } from '../../accessor/base.ts'
 import { revisionFor } from '../../observe/context.ts'
 import type { RegisteredOp } from '../../ops/registry.ts'
 import type { Resource } from '../../resource/base.ts'
-import { MountMode, PathSpec } from '../../types.ts'
+import { MountMode, PathSpec, ReadPolicy, WritePolicy } from '../../types.ts'
 import { Mount } from './mount.ts'
 
 class StubResource implements Resource {
@@ -39,25 +39,43 @@ const OK_CMD: CommandFn = () => [null, new IOResult({ exitCode: 0 })]
 const OK_CMD_STDOUT: CommandFn = () => [new TextEncoder().encode('ok'), new IOResult()]
 
 function makeMount(mode: MountMode = MountMode.WRITE): Mount {
-  return new Mount({ prefix: '/ram/', resource: new StubResource(), mode })
+  return new Mount({
+    prefix: '/ram/',
+    resource: new StubResource(),
+    mode,
+    readPolicy: ReadPolicy.CACHED,
+    writePolicy: WritePolicy.THROUGH,
+  })
+}
+
+function init(prefix: string) {
+  return {
+    prefix,
+    resource: new StubResource(),
+    mode: MountMode.READ,
+    readPolicy: ReadPolicy.CACHED,
+    writePolicy: WritePolicy.THROUGH,
+  }
 }
 
 describe('Mount constructor validation', () => {
   it('requires prefix to start with /', () => {
-    expect(() => new Mount({ prefix: 'ram/', resource: new StubResource() })).toThrow(/start with/)
+    expect(() => new Mount(init('ram/'))).toThrow(/start with/)
   })
 
   it('requires prefix to end with /', () => {
-    expect(() => new Mount({ prefix: '/ram', resource: new StubResource() })).toThrow(/end with/)
+    expect(() => new Mount(init('/ram'))).toThrow(/end with/)
   })
 
   it('rejects double-slash prefixes', () => {
-    expect(() => new Mount({ prefix: '//ram/', resource: new StubResource() })).toThrow(/\/\//)
+    expect(() => new Mount(init('//ram/'))).toThrow(/\/\//)
   })
 
-  it('defaults mode to READ', () => {
-    const m = new Mount({ prefix: '/ram/', resource: new StubResource() })
+  it('records the explicit mode and policies', () => {
+    const m = new Mount(init('/ram/'))
     expect(m.mode).toBe(MountMode.READ)
+    expect(m.readPolicy).toBe(ReadPolicy.CACHED)
+    expect(m.writePolicy).toBe(WritePolicy.THROUGH)
   })
 })
 

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -32,7 +32,8 @@ import { IOResult } from '../../io/types.ts'
 import { runWithRevisions, setVirtualPrefix } from '../../observe/context.ts'
 import type { RegisteredOp } from '../../ops/registry.ts'
 import type { Resource } from '../../resource/base.ts'
-import { type CommandSafeguard, ConsistencyPolicy, MountMode, PathSpec } from '../../types.ts'
+import type { ReadPolicy, WritePolicy } from '../../types.ts'
+import { type CommandSafeguard, MountMode, PathSpec } from '../../types.ts'
 import type { PyodideRuntime } from '../executor/python/runtime.ts'
 import { rstripSlash } from '../../util/slash.ts'
 
@@ -58,15 +59,17 @@ function crossKey(name: string, targetResource: string): string {
 export interface MountInit {
   prefix: string
   resource: Resource
-  mode?: MountMode
-  consistency?: ConsistencyPolicy
+  mode: MountMode
+  readPolicy: ReadPolicy
+  writePolicy: WritePolicy
 }
 
 export class Mount {
   readonly prefix: string
   readonly resource: Resource
   readonly mode: MountMode
-  readonly consistency: ConsistencyPolicy
+  readonly readPolicy: ReadPolicy
+  readonly writePolicy: WritePolicy
 
   /**
    * Per-path revision pins installed at Workspace.load time. Read
@@ -98,8 +101,9 @@ export class Mount {
     }
     this.prefix = prefix
     this.resource = init.resource
-    this.mode = init.mode ?? MountMode.READ
-    this.consistency = init.consistency ?? ConsistencyPolicy.LAZY
+    this.mode = init.mode
+    this.readPolicy = init.readPolicy
+    this.writePolicy = init.writePolicy
   }
 
   // ── command registration ──────────────────────────

--- a/typescript/packages/core/src/workspace/mount/registry.test.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.test.ts
@@ -17,7 +17,7 @@ import { command, type CommandFn } from '../../commands/config.ts'
 import { CommandSpec } from '../../commands/spec/types.ts'
 import { IOResult } from '../../io/types.ts'
 import type { Resource } from '../../resource/base.ts'
-import { MountMode, PathSpec } from '../../types.ts'
+import { MountMode, PathSpec, ReadPolicy, WritePolicy } from '../../types.ts'
 import { MountRegistry } from './registry.ts'
 
 class StubResource implements Resource {
@@ -46,7 +46,13 @@ const EMPTY_SPEC = new CommandSpec()
 describe('MountRegistry.resolve', () => {
   it('resolves a nested path to the matching mount; PathSpec keeps original + sets prefix', () => {
     const ram = new StubResource()
-    const reg = new MountRegistry({ '/data': ram }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/data': ram },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const [r, p, mode] = reg.resolve('/data/foo.txt')
     expect(r).toBe(ram)
     expect(p.original).toBe('/data/foo.txt')
@@ -57,7 +63,13 @@ describe('MountRegistry.resolve', () => {
 
   it('resolves the mount root exactly', () => {
     const ram = new StubResource()
-    const reg = new MountRegistry({ '/data': ram }, MountMode.READ)
+    const reg = new MountRegistry(
+      { '/data': ram },
+      MountMode.READ,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const [, p] = reg.resolve('/data')
     expect(p.original).toBe('/data')
     expect(p.stripPrefix).toBe('/')
@@ -66,7 +78,13 @@ describe('MountRegistry.resolve', () => {
   it('picks the longest matching prefix', () => {
     const root = new StubResource()
     const logs = new StubResource()
-    const reg = new MountRegistry({ '/data': root, '/data/logs': logs }, MountMode.READ)
+    const reg = new MountRegistry(
+      { '/data': root, '/data/logs': logs },
+      MountMode.READ,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const [picked, p] = reg.resolve('/data/logs/2026.log')
     expect(picked).toBe(logs)
     expect(p.original).toBe('/data/logs/2026.log')
@@ -76,14 +94,26 @@ describe('MountRegistry.resolve', () => {
   it('falls back to the shorter mount when longer does not match', () => {
     const root = new StubResource()
     const logs = new StubResource()
-    const reg = new MountRegistry({ '/data': root, '/data/logs': logs }, MountMode.READ)
+    const reg = new MountRegistry(
+      { '/data': root, '/data/logs': logs },
+      MountMode.READ,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const [picked] = reg.resolve('/data/other')
     expect(picked).toBe(root)
   })
 
   it('uses a root mount when nothing more specific matches', () => {
     const rootRes = new StubResource()
-    const reg = new MountRegistry({ '/': rootRes }, MountMode.READ)
+    const reg = new MountRegistry(
+      { '/': rootRes },
+      MountMode.READ,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const [r, p] = reg.resolve('/anywhere/deep/file')
     expect(r).toBe(rootRes)
     expect(p.original).toBe('/anywhere/deep/file')
@@ -91,23 +121,42 @@ describe('MountRegistry.resolve', () => {
 
   it('preserves a trailing slash on the resolved path', () => {
     const ram = new StubResource()
-    const reg = new MountRegistry({ '/data': ram }, MountMode.READ)
+    const reg = new MountRegistry(
+      { '/data': ram },
+      MountMode.READ,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const [, p] = reg.resolve('/data/logs/')
     expect(p.original).toBe('/data/logs/')
     expect(p.stripPrefix).toBe('/logs/')
   })
 
   it('throws when no mount matches the path', () => {
-    const reg = new MountRegistry({ '/data': new StubResource() }, MountMode.READ)
+    const reg = new MountRegistry(
+      { '/data': new StubResource() },
+      MountMode.READ,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     expect(() => reg.resolve('/elsewhere')).toThrow(/no mount matches/)
   })
 
   it('normalizes mount prefixes so "/data", "data", and "/data/" collide', () => {
     const a = new StubResource()
     const b = new StubResource()
-    expect(() => new MountRegistry({ '/data': a, 'data/': b }, MountMode.READ)).toThrow(
-      /duplicate mount prefix/,
-    )
+    expect(
+      () =>
+        new MountRegistry(
+          { '/data': a, 'data/': b },
+          MountMode.READ,
+          {},
+          ReadPolicy.CACHED,
+          WritePolicy.THROUGH,
+        ),
+    ).toThrow(/duplicate mount prefix/)
   })
 })
 
@@ -116,6 +165,9 @@ describe('MountRegistry.descendantMounts', () => {
     return new MountRegistry(
       { '/': new StubResource(), '/r2': new StubResource(), '/ram': new StubResource() },
       MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
     )
   }
 
@@ -127,6 +179,9 @@ describe('MountRegistry.descendantMounts', () => {
         '/data/inner': new StubResource(),
       },
       MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
     )
   }
 
@@ -146,13 +201,25 @@ describe('MountRegistry.descendantMounts', () => {
   })
 
   it('returns empty when the path is exactly a mount root with no nested mount', () => {
-    const reg = new MountRegistry({ '/data': new StubResource() }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/data': new StubResource() },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     expect(reg.descendantMounts('/data')).toEqual([])
     expect(reg.descendantMounts('/data/')).toEqual([])
   })
 
   it('returns empty for a path inside a mount with no nested mount', () => {
-    const reg = new MountRegistry({ '/data': new StubResource() }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/data': new StubResource() },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     expect(reg.descendantMounts('/data/sub')).toEqual([])
   })
 
@@ -181,6 +248,9 @@ describe('MountRegistry.resolveMount: cross-mount fallback', () => {
     const reg = new MountRegistry(
       { '/a': new RAMStubResource(), '/b': new RAMStubResource() },
       MountMode.READ,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
     )
     const b = reg.mountForPrefix('/b')
     if (b === null) throw new Error('missing /b mount')
@@ -195,6 +265,9 @@ describe('MountRegistry.resolveMount: cross-mount fallback', () => {
     const reg = new MountRegistry(
       { '/a': new RAMStubResource(), '/b': new RAMStubResource() },
       MountMode.READ,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
     )
     const b = reg.mountForPrefix('/b')
     if (b === null) throw new Error('missing /b mount')
@@ -209,6 +282,9 @@ describe('MountRegistry.resolveMount: cross-mount fallback', () => {
     const reg = new MountRegistry(
       { '/home': new RAMStubResource(), '/home/zecheng/linear': new RAMStubResource() },
       MountMode.READ,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
     )
     const linear = reg.mountForPrefix('/home/zecheng/linear')
     if (linear === null) throw new Error('missing /home/zecheng/linear mount')
@@ -228,13 +304,22 @@ describe('MountRegistry.resolveMount: cross-mount fallback', () => {
     const reg = new MountRegistry(
       { '/a': new RAMStubResource(), '/b': new RAMStubResource() },
       MountMode.READ,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
     )
     const mount = await reg.resolveMount('nonexistent-cmd', [], '/a/x')
     expect(mount).toBeNull()
   })
 
   it('returns null when cwd matches no mount and no mount has the command', async () => {
-    const reg = new MountRegistry({ '/a': new RAMStubResource() }, MountMode.READ)
+    const reg = new MountRegistry(
+      { '/a': new RAMStubResource() },
+      MountMode.READ,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const mount = await reg.resolveMount('linear-search', [], '/somewhere/else')
     expect(mount).toBeNull()
   })
@@ -243,6 +328,9 @@ describe('MountRegistry.resolveMount: cross-mount fallback', () => {
     const reg = new MountRegistry(
       { '/a': new RAMStubResource(), '/b': new RAMStubResource() },
       MountMode.READ,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
     )
     const a = reg.mountForPrefix('/a')
     const b = reg.mountForPrefix('/b')
@@ -260,6 +348,9 @@ describe('MountRegistry.resolveMount: cross-mount fallback', () => {
     const reg = new MountRegistry(
       { '/a': new RAMStubResource(), '/b': new RAMStubResource() },
       MountMode.READ,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
     )
     const b = reg.mountForPrefix('/b')
     if (b === null) throw new Error('missing /b mount')
@@ -275,6 +366,9 @@ describe('MountRegistry.resolveMount: cross-mount fallback', () => {
     const reg = new MountRegistry(
       { '/a': new RAMStubResource(), '/b': new RAMStubResource() },
       MountMode.READ,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
     )
     const b = reg.mountForPrefix('/b')
     if (b === null) throw new Error('missing /b mount')

--- a/typescript/packages/core/src/workspace/mount/registry.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.ts
@@ -16,7 +16,7 @@ import type { FileCache } from '../../cache/file/mixin.ts'
 import { GENERAL_COMMANDS } from '../../commands/builtin/general/index.ts'
 import type { Resource } from '../../resource/base.ts'
 import { DevResource } from '../../resource/dev/dev.ts'
-import { ConsistencyPolicy, MountMode, PathSpec } from '../../types.ts'
+import { MountMode, PathSpec, ReadPolicy, WritePolicy } from '../../types.ts'
 import { Mount } from './mount.ts'
 import { rstripSlash, stripSlash } from '../../util/slash.ts'
 
@@ -38,13 +38,14 @@ export interface OpsMountInfo {
 export class MountRegistry {
   private readonly mountList: Mount[]
   private defaultMountRef: Mount | null = null
-  private consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY
   private readonly defaultMode: MountMode
 
   constructor(
     resources: Record<string, Resource>,
     defaultMode: MountMode,
-    modeOverrides: Record<string, MountMode> = {},
+    modeOverrides: Record<string, MountMode>,
+    readPolicy: ReadPolicy,
+    writePolicy: WritePolicy,
   ) {
     this.defaultMode = defaultMode
     const mounts: Mount[] = []
@@ -54,7 +55,13 @@ export class MountRegistry {
       overrides[normalizePrefix(k)] = v
     }
     mounts.push(
-      new Mount({ prefix: DEV_PREFIX, resource: new DevResource(), mode: MountMode.WRITE }),
+      new Mount({
+        prefix: DEV_PREFIX,
+        resource: new DevResource(),
+        mode: MountMode.WRITE,
+        readPolicy: ReadPolicy.CACHED,
+        writePolicy: WritePolicy.THROUGH,
+      }),
     )
     seen.add(DEV_PREFIX)
     for (const [rawPrefix, resource] of Object.entries(resources)) {
@@ -64,18 +71,10 @@ export class MountRegistry {
       }
       seen.add(prefix)
       const mode = overrides[prefix] ?? defaultMode
-      mounts.push(new Mount({ prefix, resource, mode }))
+      mounts.push(new Mount({ prefix, resource, mode, readPolicy, writePolicy }))
     }
     mounts.sort((a, b) => b.prefix.length - a.prefix.length)
     this.mountList = mounts
-  }
-
-  setConsistency(consistency: ConsistencyPolicy): void {
-    this.consistency = consistency
-  }
-
-  getConsistency(): ConsistencyPolicy {
-    return this.consistency
   }
 
   /**
@@ -86,8 +85,9 @@ export class MountRegistry {
   mount(
     prefix: string,
     resource: Resource,
-    mode: MountMode = MountMode.READ,
-    consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY,
+    mode: MountMode,
+    readPolicy: ReadPolicy,
+    writePolicy: WritePolicy,
   ): Mount {
     const norm = normalizePrefix(prefix)
     for (const existing of this.mountList) {
@@ -95,7 +95,7 @@ export class MountRegistry {
         throw new Error(`duplicate mount prefix: ${norm}`)
       }
     }
-    const m = new Mount({ prefix: norm, resource, mode, consistency })
+    const m = new Mount({ prefix: norm, resource, mode, readPolicy, writePolicy })
     const cmds = resource.commands?.()
     if (cmds !== undefined) {
       for (const cmd of cmds) {
@@ -225,7 +225,13 @@ export class MountRegistry {
   }
 
   setDefaultMount(resource: Resource): Mount {
-    const mount = new Mount({ prefix: '/_default/', resource, mode: MountMode.WRITE })
+    const mount = new Mount({
+      prefix: '/_default/',
+      resource,
+      mode: MountMode.WRITE,
+      readPolicy: ReadPolicy.CACHED,
+      writePolicy: WritePolicy.THROUGH,
+    })
     const ops = resource.ops?.()
     if (ops !== undefined) {
       for (const op of ops) {
@@ -314,7 +320,7 @@ export class MountRegistry {
     ) {
       const baseCmd = mount.resolveCommand(cmdName)
       if (!baseCmd?.write) {
-        if (this.consistency === ConsistencyPolicy.ALWAYS) {
+        if (mount.readPolicy === ReadPolicy.FRESH) {
           await this.evictStale(mount, defaultMount.resource, pathScopes)
         }
         const keys = pathScopes.map((p) => p.original)

--- a/typescript/packages/core/src/workspace/node/execute_node.test.ts
+++ b/typescript/packages/core/src/workspace/node/execute_node.test.ts
@@ -18,7 +18,7 @@ import { OpsRegistry } from '../../ops/registry.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
 import type { JobTable } from '../../shell/job_table.ts'
 import { NodeType as NT } from '../../shell/types.ts'
-import { MountMode } from '../../types.ts'
+import { MountMode, ReadPolicy, WritePolicy } from '../../types.ts'
 import type { TSNodeLike } from '../expand/variable.ts'
 import type { DispatchFn } from '../executor/cross_mount.ts'
 import { MountRegistry } from '../mount/registry.ts'
@@ -50,7 +50,13 @@ function plainRegistry(): MountRegistry {
   const ram = new RAMResource()
   const ops = new OpsRegistry()
   ops.registerResource(ram)
-  return new MountRegistry({ '/ram': ram }, MountMode.WRITE)
+  return new MountRegistry(
+    { '/ram': ram },
+    MountMode.WRITE,
+    {},
+    ReadPolicy.CACHED,
+    WritePolicy.THROUGH,
+  )
 }
 
 describe('executeNode dispatcher', () => {

--- a/typescript/packages/core/src/workspace/node/resolve_globs.test.ts
+++ b/typescript/packages/core/src/workspace/node/resolve_globs.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, it } from 'vitest'
 import type { Resource } from '../../resource/base.ts'
-import { MountMode, PathSpec } from '../../types.ts'
+import { MountMode, PathSpec, ReadPolicy, WritePolicy } from '../../types.ts'
 import { MountRegistry } from '../mount/registry.ts'
 import { resolveGlobs, type ResourceWithGlob } from './resolve_globs.ts'
 
@@ -44,20 +44,38 @@ class GlobResource implements ResourceWithGlob {
 
 describe('resolveGlobs', () => {
   it('passes through plain strings', async () => {
-    const reg = new MountRegistry({ '/ram': new PlainResource() }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/ram': new PlainResource() },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const out = await resolveGlobs(['-l', 'text'], reg)
     expect(out).toEqual(['-l', 'text'])
   })
 
   it('passes through non-glob PathSpecs', async () => {
-    const reg = new MountRegistry({ '/ram': new PlainResource() }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/ram': new PlainResource() },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const p = PathSpec.fromStrPath('/ram/x.txt')
     const out = await resolveGlobs([p], reg)
     expect(out).toEqual([p])
   })
 
   it('passes through glob PathSpecs when the resource lacks glob', async () => {
-    const reg = new MountRegistry({ '/ram': new PlainResource() }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/ram': new PlainResource() },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const p = new PathSpec({
       original: '/ram/*.txt',
       directory: '/ram/',
@@ -74,7 +92,13 @@ describe('resolveGlobs', () => {
       PathSpec.fromStrPath('/ram/a.txt'),
       PathSpec.fromStrPath('/ram/b.txt'),
     ])
-    const reg = new MountRegistry({ '/ram': res }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/ram': res },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const p = new PathSpec({
       original: '/ram/*.txt',
       directory: '/ram/',
@@ -89,7 +113,13 @@ describe('resolveGlobs', () => {
   })
 
   it('skips glob expansion for args in textArgs', async () => {
-    const reg = new MountRegistry({ '/ram': new PlainResource() }, MountMode.WRITE)
+    const reg = new MountRegistry(
+      { '/ram': new PlainResource() },
+      MountMode.WRITE,
+      {},
+      ReadPolicy.CACHED,
+      WritePolicy.THROUGH,
+    )
     const p = new PathSpec({
       original: '*.txt',
       directory: '',

--- a/typescript/packages/core/src/workspace/node/run_tree.test.ts
+++ b/typescript/packages/core/src/workspace/node/run_tree.test.ts
@@ -20,7 +20,7 @@ import { OpsRegistry } from '../../ops/registry.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
 import type { JobTable } from '../../shell/job_table.ts'
 import { createShellParser, type ShellParser } from '../../shell/parse.ts'
-import { MountMode } from '../../types.ts'
+import { MountMode, ReadPolicy, WritePolicy } from '../../types.ts'
 import type { TSNodeLike } from '../expand/variable.ts'
 import type { DispatchFn } from '../executor/cross_mount.ts'
 import { MountRegistry } from '../mount/registry.ts'
@@ -57,7 +57,13 @@ function registry(): MountRegistry {
   const ram = new RAMResource()
   const ops = new OpsRegistry()
   ops.registerResource(ram)
-  return new MountRegistry({ '/': ram }, MountMode.WRITE)
+  return new MountRegistry(
+    { '/': ram },
+    MountMode.WRITE,
+    {},
+    ReadPolicy.CACHED,
+    WritePolicy.THROUGH,
+  )
 }
 
 function parse(command: string): TSNodeLike {

--- a/typescript/packages/core/src/workspace/snapshot/config.ts
+++ b/typescript/packages/core/src/workspace/snapshot/config.ts
@@ -12,12 +12,13 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { ConsistencyPolicy, MountMode } from '../../types.ts'
+import type { MountMode, ReadPolicy, WritePolicy } from '../../types.ts'
 import type { Resource } from '../../resource/base.ts'
 
 export interface MountArgs {
   mountArgs: Record<string, [Resource, MountMode]>
-  consistency: ConsistencyPolicy
+  readPolicy: ReadPolicy
+  writePolicy: WritePolicy
   defaultSessionId: string
   defaultAgentId: string
 }

--- a/typescript/packages/core/src/workspace/snapshot/keys.ts
+++ b/typescript/packages/core/src/workspace/snapshot/keys.ts
@@ -29,7 +29,8 @@ export const MountKey = Object.freeze({
   INDEX: 'index',
   PREFIX: 'prefix',
   MODE: 'mode',
-  CONSISTENCY: 'consistency',
+  READ_POLICY: 'read_policy',
+  WRITE_POLICY: 'write_policy',
   RESOURCE_CLASS: 'resource_class',
   RESOURCE_STATE: 'resource_state',
 } as const)

--- a/typescript/packages/core/src/workspace/snapshot/state.ts
+++ b/typescript/packages/core/src/workspace/snapshot/state.ts
@@ -17,7 +17,7 @@ import type { RAMFileCacheStore } from '../../cache/file/ram.ts'
 import type { Resource } from '../../resource/base.ts'
 import type { RAMResourceState } from '../../resource/ram/ram.ts'
 import { resourceStateRequiresOverride } from '../../resource/secrets.ts'
-import { ConsistencyPolicy, ResourceName, type MountMode } from '../../types.ts'
+import { ReadPolicy, ResourceName, WritePolicy, type MountMode } from '../../types.ts'
 import type { MountArgs } from './config.ts'
 import { CacheKey, MountKey, ResourceStateKey, StateKey } from './keys.ts'
 import { FORMAT_VERSION, normMountPrefix } from './utils.ts'
@@ -30,7 +30,13 @@ interface WorkspaceLike {
   readonly observer: { readonly prefix: string } | null
   readonly cache: RAMFileCacheStore
   readonly records: unknown
-  listMounts(): { prefix: string; mode: MountMode; resource: Resource }[]
+  listMounts(): {
+    prefix: string
+    mode: MountMode
+    readPolicy: ReadPolicy
+    writePolicy: WritePolicy
+    resource: Resource
+  }[]
   snapshotSessions(): AnyDict[]
   snapshotDefaultSessionId(): string
   snapshotDefaultAgentId(): string
@@ -54,7 +60,8 @@ export function toStateDict(ws: WorkspaceLike): AnyDict {
       [MountKey.INDEX]: idx,
       [MountKey.PREFIX]: m.prefix,
       [MountKey.MODE]: m.mode,
-      [MountKey.CONSISTENCY]: ConsistencyPolicy.LAZY,
+      [MountKey.READ_POLICY]: m.readPolicy,
+      [MountKey.WRITE_POLICY]: m.writePolicy,
       [MountKey.RESOURCE_CLASS]: resource.kind,
       [MountKey.RESOURCE_STATE]: resState,
     })
@@ -130,7 +137,8 @@ export function buildMountArgs(
 
   return {
     mountArgs,
-    consistency: ConsistencyPolicy.LAZY,
+    readPolicy: ReadPolicy.CACHED,
+    writePolicy: WritePolicy.THROUGH,
     defaultSessionId: (state[StateKey.DEFAULT_SESSION_ID] as string | undefined) ?? 'default',
     defaultAgentId: (state[StateKey.DEFAULT_AGENT_ID] as string | undefined) ?? 'default',
   }

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -59,6 +59,8 @@ import {
   FileType,
   MountMode,
   type PathSpec,
+  ReadPolicy,
+  WritePolicy,
 } from '../types.ts'
 import type { TSNodeLike } from './expand/variable.ts'
 import type { ExecuteFn } from './expand/node.ts'
@@ -134,6 +136,8 @@ const VALID_MODES: readonly string[] = [MountMode.READ, MountMode.WRITE, MountMo
 
 export interface WorkspaceOptions {
   mode?: MountMode
+  readPolicy?: ReadPolicy
+  writePolicy?: WritePolicy
   modeOverrides?: Record<string, MountMode>
   commandSafeguards?: Record<string, Record<string, CommandSafeguard>>
   /**
@@ -233,6 +237,8 @@ export class Workspace {
   private readonly openOrder: Resource[] = []
   readonly jobTable = new JobTable()
   private readonly agentId: string
+  private readonly readPolicy: ReadPolicy
+  private readonly writePolicy: WritePolicy
   readonly cache: FileCache & Resource
   private readonly dispatcher: Dispatcher
   readonly history: ExecutionHistory = new ExecutionHistory()
@@ -270,10 +276,18 @@ export class Workspace {
     const observerPrefix = options.observerPrefix ?? '/.sessions'
     this.observer = new Observer(observerResource, observerPrefix)
     const withObserver = { ...resources, [observerPrefix]: observerResource }
-    this.registry = new MountRegistry(withObserver, options.mode ?? MountMode.READ, {
-      ...(options.modeOverrides ?? {}),
-      [observerPrefix]: MountMode.READ,
-    })
+    this.readPolicy = options.readPolicy ?? ReadPolicy.CACHED
+    this.writePolicy = options.writePolicy ?? WritePolicy.THROUGH
+    this.registry = new MountRegistry(
+      withObserver,
+      options.mode ?? MountMode.READ,
+      {
+        ...(options.modeOverrides ?? {}),
+        [observerPrefix]: MountMode.READ,
+      },
+      this.readPolicy,
+      this.writePolicy,
+    )
     if (options.index !== undefined) {
       for (const resource of Object.values(resources)) {
         resource.setIndex?.(options.index)
@@ -455,7 +469,7 @@ export class Workspace {
    */
   addMount(prefix: string, resource: Resource, mode: MountMode = MountMode.READ): Mount {
     if (this.closed) throw new Error('Workspace is closed')
-    const m = this.registry.mount(prefix, resource, mode)
+    const m = this.registry.mount(prefix, resource, mode, this.readPolicy, this.writePolicy)
     this.opsRegistry.registerResource(resource)
     const resourceOps = resource.ops?.()
     if (resourceOps !== undefined) {

--- a/typescript/packages/node/src/workspace/fingerprint_spike.test.ts
+++ b/typescript/packages/node/src/workspace/fingerprint_spike.test.ts
@@ -16,7 +16,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { ConsistencyPolicy, MountMode, RAMResource } from '@struktoai/mirage-core'
+import { MountMode, RAMResource, ReadPolicy } from '@struktoai/mirage-core'
 import { DiskResource } from '../resource/disk/disk.ts'
 import { Workspace } from '../workspace.ts'
 
@@ -26,7 +26,7 @@ async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-describe('fingerprint spike (ConsistencyPolicy port of test_fingerprint_spike.py)', () => {
+describe('fingerprint spike (ReadPolicy port of test_fingerprint_spike.py)', () => {
   let root: string
 
   beforeEach(() => {
@@ -36,11 +36,13 @@ describe('fingerprint spike (ConsistencyPolicy port of test_fingerprint_spike.py
     rmSync(root, { recursive: true, force: true })
   })
 
-  it('Disk + ALWAYS refetches after external mtime change', async () => {
+  it('Disk + FRESH refetches after external mtime change', async () => {
     writeFileSync(join(root, 'file.txt'), 'v1')
     const resource = new DiskResource({ root })
-    const ws = new Workspace({ '/data': resource }, { mode: MountMode.WRITE })
-    ws.registry.setConsistency(ConsistencyPolicy.ALWAYS)
+    const ws = new Workspace(
+      { '/data': resource },
+      { mode: MountMode.WRITE, readPolicy: ReadPolicy.FRESH },
+    )
 
     const io1 = await ws.execute('cat /data/file.txt')
     const first = DEC.decode(io1.stdout)
@@ -54,11 +56,13 @@ describe('fingerprint spike (ConsistencyPolicy port of test_fingerprint_spike.py
     await ws.close()
   })
 
-  it('Disk + LAZY may serve stale cache (no crash guaranteed)', async () => {
+  it('Disk + CACHED may serve stale cache (no crash guaranteed)', async () => {
     writeFileSync(join(root, 'file.txt'), 'v1')
     const resource = new DiskResource({ root })
-    const ws = new Workspace({ '/data': resource }, { mode: MountMode.WRITE })
-    ws.registry.setConsistency(ConsistencyPolicy.LAZY)
+    const ws = new Workspace(
+      { '/data': resource },
+      { mode: MountMode.WRITE, readPolicy: ReadPolicy.CACHED },
+    )
 
     const io1 = await ws.execute('cat /data/file.txt')
     const first = DEC.decode(io1.stdout)
@@ -72,11 +76,13 @@ describe('fingerprint spike (ConsistencyPolicy port of test_fingerprint_spike.py
     await ws.close()
   })
 
-  it('RAM + ALWAYS falls back gracefully when fingerprint absent', async () => {
+  it('RAM + FRESH falls back gracefully when fingerprint absent', async () => {
     const resource = new RAMResource()
     resource.store.files.set('/file.txt', new TextEncoder().encode('v1'))
-    const ws = new Workspace({ '/data': resource }, { mode: MountMode.WRITE })
-    ws.registry.setConsistency(ConsistencyPolicy.ALWAYS)
+    const ws = new Workspace(
+      { '/data': resource },
+      { mode: MountMode.WRITE, readPolicy: ReadPolicy.FRESH },
+    )
 
     const io1 = await ws.execute('cat /data/file.txt')
     expect(DEC.decode(io1.stdout)).toBe('v1')

--- a/typescript/packages/server/src/config.ts
+++ b/typescript/packages/server/src/config.ts
@@ -139,7 +139,8 @@ export interface RedisIndexBlock {
 export interface WorkspaceConfigRaw {
   mounts: Record<string, MountBlock>
   mode?: string
-  consistency?: string
+  readPolicy?: string
+  writePolicy?: string
   defaultSessionId?: string
   defaultAgentId?: string
   history?: number | null


### PR DESCRIPTION
Replaces the single `ConsistencyPolicy` (LAZY/ALWAYS) with two per-mount policies in both Python and TypeScript:

- `ReadPolicy`: `CACHED` (trust the cache) or `FRESH` (fingerprint-check the backend before serving, evict on mismatch or deletion).
- `WritePolicy`: `THROUGH` (writes and deletes reach the backend immediately). A staged (write-back) value will join once the staging overlay is implemented.

No behavior change: today's LAZY is (CACHED, THROUGH) and ALWAYS is (FRESH, THROUGH).

Internal layers (Mount, MountRegistry) now require both policies explicitly; defaults exist only at the public Workspace constructor and YAML config (`read_policy` / `readPolicy`).