### PR TITLE
refactor: delegate redis fold to generic

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -392,6 +392,10 @@ CASES: list[tuple[str, str]] = [
     # ----- fmt / fold / expand -----
     ("fmt_w10", "fmt -w 10 /data/c.txt"),
     ("fold_s", "fold -s -w 6 /data/a.txt"),
+    ("fold_file", "fold -w 3 /data/a.txt"),
+    ("fold_multi", "fold -w 4 /data/a.txt /data/b.txt"),
+    ("fold_default", "fold /data/c.txt"),
+    ("fold_s_spaces", "fold -s -w 8 /data/mixed.txt"),
     ("expand_t4", "expand -t 4 /data/tabbed.txt"),
     ("unexpand_all", "echo '    hi' | unexpand -a"),
 

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -320,6 +320,10 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
 
   ["fmt_w10", "fmt -w 10 /data/c.txt"],
   ["fold_s", "fold -s -w 6 /data/a.txt"],
+  ["fold_file", "fold -w 3 /data/a.txt"],
+  ["fold_multi", "fold -w 4 /data/a.txt /data/b.txt"],
+  ["fold_default", "fold /data/c.txt"],
+  ["fold_s_spaces", "fold -s -w 8 /data/mixed.txt"],
   ["expand_t4", "expand -t 4 /data/tabbed.txt"],
   ["unexpand_all", "echo '    hi' | unexpand -a"],
 

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -1085,6 +1085,37 @@ world
 foo
 bar
 baz
+=== fold_file ===
+hel
+lo
+wor
+ld
+foo
+bar
+baz
+=== fold_multi ===
+hell
+o
+worl
+d
+foo
+bar
+baz
+1
+2
+3
+=== fold_default ===
+alpha
+beta
+gamma
+delta
+=== fold_s_spaces ===
+Hello 
+World
+HELLO 
+world
+hello 
+WORLD
 === expand_t4 ===
 a   1
 b   2

--- a/python/mirage/commands/builtin/redis/fold.py
+++ b/python/mirage/commands/builtin/redis/fold.py
@@ -16,34 +16,13 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.redis import RedisAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.generic.fold import fold as generic_fold
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.redis.glob import resolve_glob
-from mirage.core.redis.read import read_bytes as _read_bytes
+from mirage.core.redis.read import read_bytes
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-def _fold_line(line: str, width: int, break_spaces: bool) -> str:
-    if len(line) <= width:
-        return line
-    parts: list[str] = []
-    while len(line) > width:
-        if break_spaces:
-            idx = line.rfind(" ", 0, width)
-            if idx > 0:
-                parts.append(line[:idx + 1])
-                line = line[idx + 1:]
-            else:
-                parts.append(line[:width])
-                line = line[width:]
-        else:
-            parts.append(line[:width])
-            line = line[width:]
-    if line:
-        parts.append(line)
-    return "\n".join(parts)
 
 
 @command("fold", resource="redis", spec=SPECS["fold"])
@@ -57,18 +36,13 @@ async def fold(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    width = int(w) if w is not None else 80
     if paths and accessor.store is not None:
         paths = await resolve_glob(accessor, paths, index)
-        all_lines: list[str] = []
-        for p in paths:
-            data = (await _read_bytes(accessor, p)).decode(errors="replace")
-            for line in data.splitlines():
-                all_lines.append(_fold_line(line, width, s))
-        return ("\n".join(all_lines) + "\n").encode(), IOResult()
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("fold: missing operand")
-    lines = raw.decode(errors="replace").splitlines()
-    result = [_fold_line(ln, width, s) for ln in lines]
-    return ("\n".join(result) + "\n").encode(), IOResult()
+    else:
+        paths = []
+    return await generic_fold(paths,
+                              read_bytes=read_bytes,
+                              accessor=accessor,
+                              stdin=stdin,
+                              width=int(w) if w is not None else 80,
+                              break_spaces=s)


### PR DESCRIPTION
Python redis `fold` was the last bespoke copy; TS already delegates it. Now wraps `generic.fold` like fmt and the other backends.