### PR TITLE
refactor: delegate py lancedb grep to generic grep

### DIFF
--- a/.github/workflows/test_integ.yml
+++ b/.github/workflows/test_integ.yml
@@ -155,6 +155,11 @@ jobs:
           ./python/.venv/bin/python integ/s3_cases.py > /tmp/s3_cases.out
           diff integ/truth.txt /tmp/s3_cases.out
 
+      - name: Run lancedb integ (embedded) and diff against truth
+        run: |
+          ./python/.venv/bin/python integ/lancedb.py > /tmp/lancedb.out
+          diff integ/truth_lancedb.txt /tmp/lancedb.out
+
   integ-ts:
     needs: changes
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.ts == 'true') }}
@@ -276,6 +281,12 @@ jobs:
         run: |
           pnpm exec tsx notion.ts > /tmp/notion_ts.out
           diff truth_notion.txt /tmp/notion_ts.out
+
+      - name: Run lancedb integ (TS, embedded) and diff against truth
+        working-directory: integ
+        run: |
+          pnpm exec tsx lancedb.ts > /tmp/ts-lancedb.out
+          diff truth_lancedb.txt /tmp/ts-lancedb.out
 
   integ-database:
     needs: changes

--- a/integ/lancedb.py
+++ b/integ/lancedb.py
@@ -1,0 +1,136 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import sys
+from pathlib import Path
+
+_INTEG_DIR = str(Path(__file__).parent)
+sys.path[:] = [p for p in sys.path if p not in (_INTEG_DIR, "")]
+
+import asyncio  # noqa: E402
+import shutil  # noqa: E402
+import tempfile  # noqa: E402
+
+import lancedb  # noqa: E402
+
+from mirage import MountMode, Workspace  # noqa: E402
+from mirage.resource.lancedb import LanceDBConfig  # noqa: E402
+from mirage.resource.lancedb import LanceDBResource  # noqa: E402
+
+MOUNT = "/db/"
+
+ROWS = [
+    {
+        "id": 1,
+        "label": "cat",
+        "kind": "big",
+        "name": "a big orange cat"
+    },
+    {
+        "id": 2,
+        "label": "cat",
+        "kind": "small",
+        "name": "a small grey cat"
+    },
+    {
+        "id": 3,
+        "label": "dog",
+        "kind": "big",
+        "name": "a big brown dog"
+    },
+    {
+        "id": 4,
+        "label": "dog",
+        "kind": "small",
+        "name": "a small white dog"
+    },
+]
+
+CASES: list[tuple[str, str]] = [
+    ("ls_root", "ls {root}"),
+    ("ls_table", "ls {root}animals"),
+    ("ls_group", "ls {root}animals/cat"),
+    ("tree_table", "tree {root}animals"),
+    ("find_md", "find {root}animals -name '*.md'"),
+    ("cat_card", "cat {root}animals/cat/big/1.md"),
+    ("wc_c_card", "wc -c {root}animals/cat/big/1.md"),
+    # cold (bespoke) then warm (cache-mount generic) must be identical
+    ("grep_cold_single", "grep orange {root}animals/cat/big/1.md"),
+    ("grep_warm_single", "grep orange {root}animals/cat/big/1.md"),
+    ("grep_i", "grep -i ORANGE {root}animals/cat/big/1.md"),
+    ("grep_n", "grep -n label {root}animals/cat/big/1.md"),
+    ("grep_v", "grep -v cat {root}animals/cat/big/1.md"),
+    ("grep_c", "grep -c cat {root}animals/cat/big/1.md"),
+    ("grep_o", "grep -o cat {root}animals/cat/big/1.md"),
+    ("grep_w", "grep -w cat {root}animals/cat/big/1.md"),
+    ("grep_F_literal", 'grep -F "id: 1" {root}animals/cat/big/1.md'),
+    ("grep_m1", "grep -m 1 cat {root}animals/cat/big/1.md"),
+    ("grep_A1", "grep -A 1 id {root}animals/cat/big/1.md"),
+    ("grep_B1", "grep -B 1 label {root}animals/cat/big/1.md"),
+    ("grep_C1", "grep -C 1 label {root}animals/cat/big/1.md"),
+    ("grep_multi",
+     "grep small {root}animals/cat/small/2.md {root}animals/dog/small/4.md"),
+    ("grep_r_table", "grep -r orange {root}animals"),
+    ("grep_r_multipath", "grep -r small {root}animals/cat {root}animals/dog"),
+    ("grep_rl", "grep -rl cat {root}animals"),
+    ("grep_E_alt", 'grep -E "orange|brown" {root}animals/cat/big/1.md'),
+    ("pipe_grep_stdin", "cat {root}animals/cat/big/1.md | grep orange"),
+    ("rg_basic", "rg orange {root}animals/cat/big/1.md"),
+]
+
+EXIT_CODE_CASES: list[tuple[str, str]] = [
+    ("grep_q_match", "grep -q cat {root}animals/cat/big/1.md"),
+    ("grep_q_no_match", "grep -q zebra {root}animals/cat/big/1.md"),
+    ("grep_no_match", "grep zebra {root}animals/cat/big/1.md"),
+]
+
+
+async def run_cases(ws: Workspace) -> None:
+    for name, tmpl in CASES:
+        result = await ws.execute(tmpl.format(root=MOUNT))
+        out = await result.stdout_str()
+        print(f"=== {name} ===")
+        print(out, end="" if out.endswith("\n") else "\n")
+    for name, tmpl in EXIT_CODE_CASES:
+        result = await ws.execute(tmpl.format(root=MOUNT))
+        out = await result.stdout_str()
+        print(f"=== {name} ===")
+        print(f"exit={result.exit_code}")
+        if out:
+            print(out, end="" if out.endswith("\n") else "\n")
+
+
+async def main() -> None:
+    uri = tempfile.mkdtemp(prefix="mirage-integ-lancedb-")
+    try:
+        db = lancedb.connect(uri)
+        db.create_table("animals", data=ROWS)
+        config = LanceDBConfig(
+            uri=uri,
+            group_by=["label", "kind"],
+            id_column="id",
+            title_column="name",
+            text_column="name",
+        )
+        ws = Workspace({MOUNT: LanceDBResource(config)}, mode=MountMode.READ)
+        # Vector search (the `search` command) is not exercised here: the
+        # seed table ships no vector column. It is covered by unit tests
+        # (tests/core/lancedb/test_search.py).
+        await run_cases(ws)
+    finally:
+        shutil.rmtree(uri, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integ/lancedb.ts
+++ b/integ/lancedb.ts
@@ -1,0 +1,121 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as lancedb from "@lancedb/lancedb";
+import { LanceDBResource, MountMode, Workspace } from "@struktoai/mirage-node";
+
+const MOUNT = "/db/";
+
+const DEC = new TextDecoder();
+
+const ROWS = [
+  { id: 1, label: "cat", kind: "big", name: "a big orange cat" },
+  { id: 2, label: "cat", kind: "small", name: "a small grey cat" },
+  { id: 3, label: "dog", kind: "big", name: "a big brown dog" },
+  { id: 4, label: "dog", kind: "small", name: "a small white dog" },
+];
+
+const CASES: [string, string][] = [
+  ["ls_root", "ls {root}"],
+  ["ls_table", "ls {root}animals"],
+  ["ls_group", "ls {root}animals/cat"],
+  ["tree_table", "tree {root}animals"],
+  ["find_md", "find {root}animals -name '*.md'"],
+  ["cat_card", "cat {root}animals/cat/big/1.md"],
+  ["wc_c_card", "wc -c {root}animals/cat/big/1.md"],
+  // cold (bespoke) then warm (cache-mount generic) must be identical
+  ["grep_cold_single", "grep orange {root}animals/cat/big/1.md"],
+  ["grep_warm_single", "grep orange {root}animals/cat/big/1.md"],
+  ["grep_i", "grep -i ORANGE {root}animals/cat/big/1.md"],
+  ["grep_n", "grep -n label {root}animals/cat/big/1.md"],
+  ["grep_v", "grep -v cat {root}animals/cat/big/1.md"],
+  ["grep_c", "grep -c cat {root}animals/cat/big/1.md"],
+  ["grep_o", "grep -o cat {root}animals/cat/big/1.md"],
+  ["grep_w", "grep -w cat {root}animals/cat/big/1.md"],
+  ["grep_F_literal", 'grep -F "id: 1" {root}animals/cat/big/1.md'],
+  ["grep_m1", "grep -m 1 cat {root}animals/cat/big/1.md"],
+  ["grep_A1", "grep -A 1 id {root}animals/cat/big/1.md"],
+  ["grep_B1", "grep -B 1 label {root}animals/cat/big/1.md"],
+  ["grep_C1", "grep -C 1 label {root}animals/cat/big/1.md"],
+  [
+    "grep_multi",
+    "grep small {root}animals/cat/small/2.md {root}animals/dog/small/4.md",
+  ],
+  ["grep_r_table", "grep -r orange {root}animals"],
+  ["grep_r_multipath", "grep -r small {root}animals/cat {root}animals/dog"],
+  ["grep_rl", "grep -rl cat {root}animals"],
+  ["grep_E_alt", 'grep -E "orange|brown" {root}animals/cat/big/1.md'],
+  ["pipe_grep_stdin", "cat {root}animals/cat/big/1.md | grep orange"],
+  ["rg_basic", "rg orange {root}animals/cat/big/1.md"],
+];
+
+const EXIT_CODE_CASES: [string, string][] = [
+  ["grep_q_match", "grep -q cat {root}animals/cat/big/1.md"],
+  ["grep_q_no_match", "grep -q zebra {root}animals/cat/big/1.md"],
+  ["grep_no_match", "grep zebra {root}animals/cat/big/1.md"],
+];
+
+async function runCases(ws: Workspace): Promise<void> {
+  for (const [name, tmpl] of CASES) {
+    const result = await ws.execute(tmpl.replaceAll("{root}", MOUNT));
+    const out = DEC.decode(result.stdout);
+    process.stdout.write(`=== ${name} ===\n`);
+    process.stdout.write(out.endsWith("\n") ? out : out + "\n");
+  }
+  for (const [name, tmpl] of EXIT_CODE_CASES) {
+    const result = await ws.execute(tmpl.replaceAll("{root}", MOUNT));
+    const out = DEC.decode(result.stdout);
+    process.stdout.write(`=== ${name} ===\n`);
+    process.stdout.write(`exit=${result.exitCode}\n`);
+    if (out) process.stdout.write(out.endsWith("\n") ? out : out + "\n");
+  }
+}
+
+async function main(): Promise<void> {
+  const uri = mkdtempSync(join(tmpdir(), "mirage-integ-lancedb-"));
+  try {
+    const db = await lancedb.connect(uri);
+    await db.createTable("animals", ROWS);
+    const ws = new Workspace(
+      {
+        [MOUNT]: new LanceDBResource({
+          uri,
+          groupBy: ["label", "kind"],
+          idColumn: "id",
+          titleColumn: "name",
+          textColumn: "name",
+        }),
+      },
+      { mode: MountMode.READ },
+    );
+    // Vector search (the `search` command) is not exercised here: the seed
+    // table ships no vector column. It is covered by unit tests
+    // (src/core/lancedb tests).
+    try {
+      await runCases(ws);
+    } finally {
+      await ws.close();
+    }
+  } finally {
+    rmSync(uri, { recursive: true, force: true });
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(String(err) + "\n");
+  process.exit(1);
+});

--- a/integ/package.json
+++ b/integ/package.json
@@ -15,10 +15,12 @@
     "postgres": "tsx postgres.ts",
     "safeguard": "tsx safeguard.ts",
     "chroma": "tsx chroma.ts",
+    "lancedb": "tsx lancedb.ts",
     "ssh": "tsx ssh.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.0.0",
+    "@lancedb/lancedb": "^0.30.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "chromadb": "^3.4.3",
     "@struktoai/mirage-browser": "workspace:*",

--- a/integ/truth_lancedb.txt
+++ b/integ/truth_lancedb.txt
@@ -1,0 +1,107 @@
+=== ls_root ===
+animals
+=== ls_table ===
+cat
+dog
+=== ls_group ===
+big
+small
+=== tree_table ===
+├── cat
+│   ├── big
+│   │   └── 1.md
+│   └── small
+│       └── 2.md
+└── dog
+    ├── big
+    │   └── 3.md
+    └── small
+        └── 4.md
+=== find_md ===
+/db/animals/cat/big/1.md
+/db/animals/cat/small/2.md
+/db/animals/dog/big/3.md
+/db/animals/dog/small/4.md
+=== cat_card ===
+# a big orange cat
+
+id: 1
+label: cat
+kind: big
+name: a big orange cat
+=== wc_c_card ===
+70 /db/animals/cat/big/1.md
+=== grep_cold_single ===
+# a big orange cat
+name: a big orange cat
+=== grep_warm_single ===
+# a big orange cat
+name: a big orange cat
+=== grep_i ===
+# a big orange cat
+name: a big orange cat
+=== grep_n ===
+4:label: cat
+=== grep_v ===
+
+id: 1
+kind: big
+=== grep_c ===
+3
+=== grep_o ===
+cat
+cat
+cat
+=== grep_w ===
+# a big orange cat
+label: cat
+name: a big orange cat
+=== grep_F_literal ===
+id: 1
+=== grep_m1 ===
+# a big orange cat
+=== grep_A1 ===
+id: 1
+label: cat
+=== grep_B1 ===
+id: 1
+label: cat
+=== grep_C1 ===
+id: 1
+label: cat
+kind: big
+=== grep_multi ===
+/db/animals/cat/small/2.md:# a small grey cat
+/db/animals/cat/small/2.md:kind: small
+/db/animals/cat/small/2.md:name: a small grey cat
+/db/animals/dog/small/4.md:# a small white dog
+/db/animals/dog/small/4.md:kind: small
+/db/animals/dog/small/4.md:name: a small white dog
+=== grep_r_table ===
+/db/animals/cat/big/1.md:# a big orange cat
+/db/animals/cat/big/1.md:name: a big orange cat
+=== grep_r_multipath ===
+/db/animals/cat/small/2.md:# a small grey cat
+/db/animals/cat/small/2.md:kind: small
+/db/animals/cat/small/2.md:name: a small grey cat
+/db/animals/dog/small/4.md:# a small white dog
+/db/animals/dog/small/4.md:kind: small
+/db/animals/dog/small/4.md:name: a small white dog
+=== grep_rl ===
+/db/animals/cat/big/1.md
+/db/animals/cat/small/2.md
+=== grep_E_alt ===
+# a big orange cat
+name: a big orange cat
+=== pipe_grep_stdin ===
+# a big orange cat
+name: a big orange cat
+=== rg_basic ===
+# a big orange cat
+name: a big orange cat
+=== grep_q_match ===
+exit=0
+=== grep_q_no_match ===
+exit=1
+=== grep_no_match ===
+exit=1

--- a/python/mirage/commands/builtin/lancedb/grep.py
+++ b/python/mirage/commands/builtin/lancedb/grep.py
@@ -13,18 +13,11 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.lancedb import LanceDBAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import (compile_pattern, grep_lines,
-                                                 grep_recursive)
+from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.builtin.lancedb._provision import metadata_provision
-from mirage.commands.builtin.utils.output import (format_optional_records,
-                                                  format_records)
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.lancedb.glob import resolve_glob
@@ -65,8 +58,15 @@ async def grep(
     args_l: bool = False,
     w: bool = False,
     F: bool = False,
+    E: bool = False,
     o: bool = False,
     m: str | None = None,
+    q: bool = False,
+    H: bool = False,
+    args_h: bool = False,
+    A: str | None = None,
+    B: str | None = None,
+    C: str | None = None,
     e: str | None = None,
     prefix: str = "",
     index: IndexCacheStore = None,
@@ -78,51 +78,32 @@ async def grep(
         pattern = texts[0]
     else:
         raise ValueError("grep: usage: grep [flags] pattern [path]")
-    if not paths:
-        _resolve_source(stdin, "grep: missing operand")
-        raise ValueError("grep: missing operand")
-
     max_count = int(m) if m is not None else None
-    paths = await resolve_glob(accessor, paths, index=index)
-    file_prefix = paths[0].prefix if paths else ""
-    compiled = compile_pattern(pattern, i, F, w)
-    rd = partial(call_readdir,
-                 _readdir,
-                 accessor,
-                 index=index,
-                 prefix=file_prefix)
-    st = partial(call_stat, _stat, accessor, index=index, prefix=file_prefix)
-    rb = partial(call_read_bytes,
-                 lancedb_read,
-                 accessor,
-                 index=index,
-                 prefix=file_prefix)
-
-    if r or R:
-        warnings: list[str] = []
-        results = await grep_recursive(rd, st, rb, paths[0].original, compiled,
-                                       v, n, c, args_l, o, max_count, warnings)
-        stderr = format_optional_records(warnings)
-        if not results:
-            return b"", IOResult(exit_code=1, stderr=stderr)
-        return format_records(results), IOResult(stderr=stderr)
-
-    all_results: list[str] = []
-    multi = len(paths) > 1
-    for p in paths:
-        data = (await rb(p.original)).decode(errors="replace").splitlines()
-        hits = grep_lines(p.original, data, compiled, v, n, c, args_l, o,
-                          max_count)
-        if c:
-            if hits:
-                all_results.append(
-                    f"{p.original}:{hits[0]}" if multi else hits[0])
-        elif args_l:
-            all_results.extend(hits)
-        elif multi:
-            all_results.extend(f"{p.original}:{hit}" for hit in hits)
-        else:
-            all_results.extend(hits)
-    if not all_results:
-        return b"", IOResult(exit_code=1)
-    return format_records(all_results), IOResult()
+    after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
+    before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
+    resolved = await resolve_glob(accessor, paths,
+                                  index=index) if paths else []
+    return await generic_grep(
+        resolved,
+        pattern=pattern,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=lancedb_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        ignore_case=i,
+        invert=v,
+        line_numbers=n,
+        count_only=c,
+        files_only=args_l,
+        whole_word=w,
+        fixed_string=F,
+        only_matching=o,
+        quiet=q,
+        recursive=r or R,
+        max_count=max_count,
+        after_context=after_ctx,
+        before_context=before_ctx,
+        index=index,
+    )

--- a/python/tests/commands/builtin/lancedb/test_grep.py
+++ b/python/tests/commands/builtin/lancedb/test_grep.py
@@ -1,0 +1,129 @@
+import pytest
+
+from mirage.commands.builtin.lancedb.grep import grep
+from mirage.io.types import materialize
+from mirage.types import FileStat, FileType, PathSpec
+
+DOCS = {
+    "/db/animals/cat/1.md": b"alpha match\nctx one\nctx two\n",
+    "/db/animals/dog/2.md": b"gamma match\n",
+}
+
+DIRS = {
+    "/db/animals": ["/db/animals/cat", "/db/animals/dog"],
+    "/db/animals/cat": ["/db/animals/cat/1.md"],
+    "/db/animals/dog": ["/db/animals/dog/2.md"],
+}
+
+
+def _spec(path: str) -> PathSpec:
+    return PathSpec.from_str_path(path, "/db/")
+
+
+def _patch_backend(monkeypatch) -> None:
+    g = grep.__wrapped__.__globals__
+
+    async def fake_resolve_glob(accessor, paths, index=None):
+        return paths
+
+    async def fake_read(accessor, p, index=None):
+        return DOCS[p.original]
+
+    async def fake_readdir(accessor, p, index=None):
+        return DIRS[p.original]
+
+    async def fake_stat(accessor, p, index=None):
+        kind = FileType.DIRECTORY if p.original in DIRS else FileType.TEXT
+        return FileStat(name=p.original, type=kind)
+
+    monkeypatch.setitem(g, "resolve_glob", fake_resolve_glob)
+    monkeypatch.setitem(g, "lancedb_read", fake_read)
+    monkeypatch.setitem(g, "_readdir", fake_readdir)
+    monkeypatch.setitem(g, "_stat", fake_stat)
+
+
+async def _stdin() -> bytes:
+    return b"alpha line\nbeta line\n"
+
+
+@pytest.mark.asyncio
+async def test_single_file_prints_bare_lines(monkeypatch):
+    _patch_backend(monkeypatch)
+
+    output, io = await grep(object(), [_spec("/db/animals/cat/1.md")],
+                            "match",
+                            index=None)
+
+    assert await materialize(output) == b"alpha match\n"
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_multi_file_prefixes_filenames(monkeypatch):
+    _patch_backend(monkeypatch)
+
+    output, io = await grep(
+        object(),
+        [_spec("/db/animals/cat/1.md"),
+         _spec("/db/animals/dog/2.md")],
+        "match",
+        index=None)
+
+    assert await materialize(output) == (b"/db/animals/cat/1.md:alpha match\n"
+                                         b"/db/animals/dog/2.md:gamma match\n")
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_quiet_suppresses_output(monkeypatch):
+    _patch_backend(monkeypatch)
+
+    output, io = await grep(object(), [_spec("/db/animals/cat/1.md")],
+                            "match",
+                            q=True,
+                            index=None)
+
+    assert await materialize(output) == b""
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_after_context_includes_trailing_lines(monkeypatch):
+    _patch_backend(monkeypatch)
+
+    output, io = await grep(object(), [_spec("/db/animals/cat/1.md")],
+                            "match",
+                            A="1",
+                            index=None)
+
+    assert await materialize(output) == b"alpha match\nctx one\n"
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_stdin_searched_when_no_paths(monkeypatch):
+    _patch_backend(monkeypatch)
+
+    output, io = await grep(object(), [],
+                            "alpha",
+                            stdin=await _stdin(),
+                            index=None)
+
+    assert await materialize(output) == b"alpha line\n"
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_recursive_searches_all_paths(monkeypatch):
+    _patch_backend(monkeypatch)
+
+    output, io = await grep(
+        object(), [_spec("/db/animals/cat"),
+                   _spec("/db/animals/dog")],
+        "match",
+        r=True,
+        index=None)
+
+    assert await materialize(output) == (b"/db/animals/cat/1.md:alpha match\n"
+                                         b"/db/animals/dog/2.md:gamma match\n")
+    assert io.exit_code == 0

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.0.0
         version: 3.1033.0
+      '@lancedb/lancedb':
+        specifier: ^0.30.0
+        version: 0.30.0(apache-arrow@21.1.0)
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)


### PR DESCRIPTION
Replace the bespoke lancedb grep with delegation to the generic grep, matching the TS lancedb grep (grepGeneric) and the other py backends.

This also fixes gaps in the bespoke version: -q, -A/-B/-C, stdin input with no paths, and recursive search over multiple paths (previously only the first path was searched). Adds command-level tests.