### PR TITLE
GNU output alignment: cmp newlines and octal, stat %n, grep directory operands

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -504,6 +504,10 @@ EXIT_CODE_CASES: list[tuple[str, str]] = [
     ("nl_pin_wc", "wc -l /data/b.txt | wc -c"),
     ("nl_pin_md5", "md5 /data/b.txt | wc -c"),
     ("nl_pin_cmp", "cmp /data/a.txt /data/b.txt | wc -c"),
+
+    # ----- grep directory operands (GNU: warn, files still match) -----
+    ("grep_dir_operand", "grep hello /data/sub"),
+    ("grep_dir_among_files", "grep hello /data/a.txt /data/sub"),
 ]
 
 

--- a/integ/cases.py
+++ b/integ/cases.py
@@ -494,6 +494,16 @@ EXIT_CODE_CASES: list[tuple[str, str]] = [
     ("zip_create", "zip /data/sub/arch.zip /data/sub/nested.txt"),
     ("lnzip_ls_after", "ls -1 /data/sub"),
     ("ln_read_back", "cat /data/sub/link.txt"),
+
+    # ----- trailing-newline pins (wc -c counts the final \n) -----
+    ("nl_pin_du", "du /data/b.txt | wc -c"),
+    ("nl_pin_stat", "stat -c %n /data/b.txt | wc -c"),
+    ("nl_pin_file", "file /data/b.txt | wc -c"),
+    ("nl_pin_tree", "tree /data/sub | wc -c"),
+    ("nl_pin_ls", "ls /data/sub | wc -c"),
+    ("nl_pin_wc", "wc -l /data/b.txt | wc -c"),
+    ("nl_pin_md5", "md5 /data/b.txt | wc -c"),
+    ("nl_pin_cmp", "cmp /data/a.txt /data/b.txt | wc -c"),
 ]
 
 

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -436,6 +436,10 @@ export const EXIT_CODE_CASES: ReadonlyArray<readonly [string, string]> = [
   ["nl_pin_wc", "wc -l /data/b.txt | wc -c"],
   ["nl_pin_md5", "md5 /data/b.txt | wc -c"],
   ["nl_pin_cmp", "cmp /data/a.txt /data/b.txt | wc -c"],
+
+  // ----- grep directory operands (GNU: warn on stderr, files still match) -----
+  ["grep_dir_operand", "grep hello /data/sub"],
+  ["grep_dir_among_files", "grep hello /data/a.txt /data/sub"],
 ];
 
 const ENC = new TextEncoder();

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -426,6 +426,16 @@ export const EXIT_CODE_CASES: ReadonlyArray<readonly [string, string]> = [
   ["zip_create", "zip /data/sub/arch.zip /data/sub/nested.txt"],
   ["lnzip_ls_after", "ls -1 /data/sub"],
   ["ln_read_back", "cat /data/sub/link.txt"],
+
+  // ----- trailing-newline pins (wc -c counts the final \n) -----
+  ["nl_pin_du", "du /data/b.txt | wc -c"],
+  ["nl_pin_stat", "stat -c %n /data/b.txt | wc -c"],
+  ["nl_pin_file", "file /data/b.txt | wc -c"],
+  ["nl_pin_tree", "tree /data/sub | wc -c"],
+  ["nl_pin_ls", "ls /data/sub | wc -c"],
+  ["nl_pin_wc", "wc -l /data/b.txt | wc -c"],
+  ["nl_pin_md5", "md5 /data/b.txt | wc -c"],
+  ["nl_pin_cmp", "cmp /data/a.txt /data/b.txt | wc -c"],
 ];
 
 const ENC = new TextEncoder();

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -1330,3 +1330,8 @@ exit=0
 === nl_pin_cmp ===
 exit=0
 47
+=== grep_dir_operand ===
+exit=1
+=== grep_dir_among_files ===
+exit=0
+/data/a.txt:hello

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -384,7 +384,7 @@ text
 === stat_size ===
 24
 === stat_name ===
-a.txt
+/data/a.txt
 === gzip_gunzip_pipe ===
 hello
 world
@@ -1311,7 +1311,7 @@ exit=0
 14
 === nl_pin_stat ===
 exit=0
-6
+12
 === nl_pin_file ===
 exit=0
 18

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -1306,3 +1306,27 @@ nested.txt
 exit=0
 nested
 content
+=== nl_pin_du ===
+exit=0
+14
+=== nl_pin_stat ===
+exit=0
+6
+=== nl_pin_file ===
+exit=0
+18
+=== nl_pin_tree ===
+exit=0
+145
+=== nl_pin_ls ===
+exit=0
+34
+=== nl_pin_wc ===
+exit=0
+14
+=== nl_pin_md5 ===
+exit=0
+46
+=== nl_pin_cmp ===
+exit=0
+47

--- a/integ/truth_chroma.txt
+++ b/integ/truth_chroma.txt
@@ -75,7 +75,7 @@ If you exceed the limit you receive HTTP 429 and must back off.
 === uniq_w0_auth ===
 Authentication uses bearer tokens via the Authorization header.
 === stat_name_auth ===
-auth.md
+/knowledge/guides/auth.md
 === cut_d_f1 ===
 Welcome
 Install

--- a/integ/truth_dify.txt
+++ b/integ/truth_dify.txt
@@ -22,7 +22,7 @@ quickstart
 /knowledge/policies/privacy
 /knowledge/policies/refunds
 === stat_fmt ===
-190 auth
+190 /knowledge/guides/auth
 === cat_auth ===
 Authentication uses bearer tokens via the Authorization header.
 Requests are rate limited to 100 calls per minute per token.

--- a/integ/truth_nextcloud.txt
+++ b/integ/truth_nextcloud.txt
@@ -14,7 +14,7 @@ example.parquet
 /nc/data/example.jsonl
 
 # ---- stat / wc ----
-15533 example.json
+15533 /nc/data/example.json
 5766 /nc/data/example.jsonl
 15533 /nc/data/example.json
 

--- a/integ/truth_s3.txt
+++ b/integ/truth_s3.txt
@@ -14,7 +14,7 @@ example.parquet
     ├── example.orc
     └── example.parquet
 === s3:stat ===
-15533 example.json
+15533 /s3/data/example.json
 === s3:cat_head ===
 {
   "company": "Strukto",
@@ -144,7 +144,7 @@ example.parquet
     ├── example.orc
     └── example.parquet
 === gcs:stat ===
-15533 example.json
+15533 /gcs/data/example.json
 === gcs:cat_head ===
 {
   "company": "Strukto",
@@ -274,7 +274,7 @@ example.parquet
     ├── example.orc
     └── example.parquet
 === minio:stat ===
-15533 example.json
+15533 /minio/data/example.json
 === minio:cat_head ===
 {
   "company": "Strukto",

--- a/integ/truth_s3_ts.txt
+++ b/integ/truth_s3_ts.txt
@@ -8,7 +8,7 @@ example.jsonl
     ├── example.json
     └── example.jsonl
 === s3:stat ===
-15533 example.json
+15533 /s3/data/example.json
 === s3:cat_head ===
 {
   "company": "Strukto",
@@ -108,7 +108,7 @@ example.jsonl
     ├── example.json
     └── example.jsonl
 === gcs:stat ===
-15533 example.json
+15533 /gcs/data/example.json
 === gcs:cat_head ===
 {
   "company": "Strukto",
@@ -208,7 +208,7 @@ example.jsonl
     ├── example.json
     └── example.jsonl
 === minio:stat ===
-15533 example.json
+15533 /minio/data/example.json
 === minio:cat_head ===
 {
   "company": "Strukto",

--- a/python/mirage/commands/builtin/databricks_volume/stat.py
+++ b/python/mirage/commands/builtin/databricks_volume/stat.py
@@ -42,10 +42,11 @@ def _stat_type_label(file_stat: FileStat) -> str:
     return _TYPE_LABELS.get(file_stat.type, "regular file")
 
 
-def _replace_stat_format(file_stat: FileStat, match: re.Match) -> str:
+def _replace_stat_format(file_stat: FileStat, name: str,
+                         match: re.Match) -> str:
     spec = match.group(1)
     if spec == "n":
-        return file_stat.name
+        return name
     if spec == "s":
         return str(file_stat.size if file_stat.size is not None else 0)
     if spec == "F":
@@ -55,8 +56,8 @@ def _replace_stat_format(file_stat: FileStat, match: re.Match) -> str:
     return "?"
 
 
-def _format_stat(fmt: str, file_stat: FileStat) -> str:
-    return _FORMAT_RE.sub(partial(_replace_stat_format, file_stat), fmt)
+def _format_stat(fmt: str, file_stat: FileStat, name: str) -> str:
+    return _FORMAT_RE.sub(partial(_replace_stat_format, file_stat, name), fmt)
 
 
 @command("stat", resource="databricks_volume", spec=SPECS["stat"])
@@ -78,7 +79,7 @@ async def stat(
     for path in paths:
         file_stat = await stat_impl(accessor, path, index)
         if fmt is not None:
-            lines.append(_format_stat(fmt, file_stat))
+            lines.append(_format_stat(fmt, file_stat, path.original))
         else:
             type_value = file_stat.type.value if file_stat.type else None
             lines.append(f"name={file_stat.name} size={file_stat.size}"

--- a/python/mirage/commands/builtin/generic/cmp.py
+++ b/python/mirage/commands/builtin/generic/cmp.py
@@ -35,8 +35,7 @@ async def cmp_cmd(
         out_lines: list[str] = []
         for idx in range(min(len(data1), len(data2))):
             if data1[idx] != data2[idx]:
-                out_lines.append(
-                    f"{idx + 1} {oct(data1[idx])} {oct(data2[idx])}")
+                out_lines.append(f"{idx + 1} {data1[idx]:o} {data2[idx]:o}")
         return format_records(out_lines), IOResult(exit_code=1)
     for idx in range(min(len(data1), len(data2))):
         if data1[idx] != data2[idx]:
@@ -44,8 +43,8 @@ async def cmp_cmd(
             msg = (f"{p0.original} {p1.original}"
                    f" differ: char {idx + 1}, line {line}")
             if print_bytes:
-                msg += (f" is {oct(data1[idx])} {chr(data1[idx])}"
-                        f" {oct(data2[idx])} {chr(data2[idx])}")
+                msg += (f" is {data1[idx]:o} {chr(data1[idx])}"
+                        f" {data2[idx]:o} {chr(data2[idx])}")
             return format_records([msg]), IOResult(exit_code=1)
     shorter = p0.original if len(data1) < len(data2) else p1.original
     msg = f"cmp: EOF on {shorter}"

--- a/python/mirage/commands/builtin/generic/grep.py
+++ b/python/mirage/commands/builtin/generic/grep.py
@@ -216,6 +216,11 @@ async def grep(
                 return b"", IOResult(exit_code=1, stderr=stderr)
             return format_records(all_results), IOResult(stderr=stderr)
 
+        first_stat = await st(paths[0].original)
+        if first_stat.type == FileType.DIRECTORY:
+            stderr = f"grep: {paths[0].original}: Is a directory\n".encode()
+            return b"", IOResult(exit_code=1, stderr=stderr)
+
         if read_stream is not None:
             source: AsyncIterator[bytes] = read_stream(accessor, paths[0])
         else:

--- a/python/mirage/commands/builtin/generic/stat.py
+++ b/python/mirage/commands/builtin/generic/stat.py
@@ -17,9 +17,9 @@ _TYPE_LABELS = {
 }
 
 
-def _replace_spec(spec: str, s: FileStat) -> str:
+def _replace_spec(spec: str, s: FileStat, name: str) -> str:
     if spec == "n":
-        return s.name
+        return name
     if spec == "s":
         return str(s.size if s.size is not None else 0)
     if spec == "F":
@@ -30,8 +30,8 @@ def _replace_spec(spec: str, s: FileStat) -> str:
     return "?"
 
 
-def _format_stat(fmt: str, s: FileStat) -> str:
-    return _FORMAT_RE.sub(lambda m: _replace_spec(m.group(1), s), fmt)
+def _format_stat(fmt: str, s: FileStat, name: str) -> str:
+    return _FORMAT_RE.sub(lambda m: _replace_spec(m.group(1), s, name), fmt)
 
 
 async def stat(
@@ -50,7 +50,7 @@ async def stat(
     for p in paths:
         s = await stat_fn(accessor, p, index)
         if fmt is not None:
-            lines.append(_format_stat(fmt, s))
+            lines.append(_format_stat(fmt, s, p.original))
         else:
             lines.append(f"name={s.name} size={s.size}"
                          f" modified={s.modified}"

--- a/python/tests/commands/builtin/dify/test_grep.py
+++ b/python/tests/commands/builtin/dify/test_grep.py
@@ -1,7 +1,9 @@
 import pytest
 
 from mirage.commands.builtin.dify.grep import grep
-from mirage.core.dify import read, tree
+from mirage.core.dify import read
+from mirage.core.dify import stat as stat_core
+from mirage.core.dify import tree
 from mirage.io.types import materialize
 
 from .conftest import document
@@ -25,6 +27,10 @@ async def get_alpha_segments(config, document_id):
     return [{"content": "alpha beta"}, {"content": "gamma alpha"}]
 
 
+async def get_detail(config, document_id):
+    return {"id": document_id, "updated_at": 1716285600}
+
+
 async def get_segments_should_not_be_used(config, document_id):
     raise AssertionError("read_bytes should not be used")
 
@@ -33,6 +39,7 @@ async def get_segments_should_not_be_used(config, document_id):
 async def test_grep_matches_streamed_segments(monkeypatch, dify_accessor,
                                               dify_index, guide_path):
     monkeypatch.setattr(tree, "list_all_documents", list_single_document)
+    monkeypatch.setattr(stat_core, "get_document_detail", get_detail)
     monkeypatch.setattr(read, "iter_segment_pages", iter_basic_pages)
 
     stdout, io = await grep(dify_accessor, [guide_path],
@@ -47,6 +54,7 @@ async def test_grep_matches_streamed_segments(monkeypatch, dify_accessor,
 async def test_grep_uses_read_stream(monkeypatch, dify_accessor, dify_index,
                                      guide_path):
     monkeypatch.setattr(tree, "list_all_documents", list_single_document)
+    monkeypatch.setattr(stat_core, "get_document_detail", get_detail)
     monkeypatch.setattr(read, "get_document_segments",
                         get_segments_should_not_be_used)
     monkeypatch.setattr(read, "iter_segment_pages", iter_basic_pages)
@@ -63,6 +71,7 @@ async def test_grep_uses_read_stream(monkeypatch, dify_accessor, dify_index,
 async def test_grep_supports_standard_flags(monkeypatch, dify_accessor,
                                             dify_index, guide_path):
     monkeypatch.setattr(tree, "list_all_documents", list_single_document)
+    monkeypatch.setattr(stat_core, "get_document_detail", get_detail)
     monkeypatch.setattr(read, "iter_segment_pages", iter_alpha_pages)
     monkeypatch.setattr(read, "get_document_segments", get_alpha_segments)
 

--- a/python/tests/commands/builtin/dify/test_stat.py
+++ b/python/tests/commands/builtin/dify/test_stat.py
@@ -50,4 +50,5 @@ async def test_stat_supports_format(monkeypatch, dify_accessor, dify_index,
                            c="%n %s %F",
                            index=dify_index)
 
-    assert await materialize(stdout) == b"quickstart.md 17 regular file\n"
+    assert await materialize(stdout) == (b"/knowledge/guides/quickstart.md"
+                                         b" 17 regular file\n")

--- a/python/tests/commands/builtin/gdrive/test_grep.py
+++ b/python/tests/commands/builtin/gdrive/test_grep.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from mirage.accessor.gdrive import GDriveAccessor
+from mirage.cache.index import IndexEntry
 from mirage.cache.index.ram import RAMIndexCacheStore
 from mirage.commands.builtin.gdrive.grep import grep
 from mirage.core.google._client import TokenManager
@@ -49,7 +50,14 @@ def accessor(config, token_manager):
 
 @pytest.fixture
 def index():
-    return RAMIndexCacheStore()
+    store = RAMIndexCacheStore()
+    store._entries["/test/file.txt"] = IndexEntry(
+        id="f1",
+        name="file.txt",
+        resource_type="gdrive/file",
+        size=42,
+    )
+    return store
 
 
 def _scope(path: str, prefix: str = "") -> PathSpec:

--- a/python/tests/commands/builtin/generic/test_grep.py
+++ b/python/tests/commands/builtin/generic/test_grep.py
@@ -123,6 +123,22 @@ async def test_grep_file_basic():
 
 
 @pytest.mark.asyncio
+async def test_grep_single_dir_operand_warns():
+    readdir, stat, rb, rs = _make_backend({"/d/a.txt": b"apple\n"})
+    output, io = await grep(
+        [_spec("/d")],
+        pattern="ap",
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+    )
+    assert await _drain_async(output) == b""
+    assert io.exit_code == 1
+    assert io.stderr == b"grep: /d: Is a directory\n"
+
+
+@pytest.mark.asyncio
 async def test_grep_ignore_case():
     readdir, stat, rb, rs = _make_backend({"/a.txt": b"Apple\nBANANA\n"})
     output, _ = await grep(

--- a/python/tests/commands/builtin/generic/test_phase_o.py
+++ b/python/tests/commands/builtin/generic/test_phase_o.py
@@ -150,7 +150,7 @@ async def test_cmp_verbose_lists_all_diffs():
     rb, _ = _make_backend({"/a.txt": b"abc", "/b.txt": b"axc"})
     output, io = await cmp_cmd(
         [_spec("/a.txt"), _spec("/b.txt")], read_bytes=rb, verbose=True)
-    assert b"2 0o142 0o170" in output
+    assert b"2 142 170" in output
     assert io.exit_code == 1
 
 

--- a/python/tests/commands/native/test_cmp.py
+++ b/python/tests/commands/native/test_cmp.py
@@ -55,7 +55,8 @@ def test_cmp_l(env):
     env.create_file("a.txt", b"abc")
     env.create_file("b.txt", b"axc")
     result = env.mirage("cmp -l /data/a.txt /data/b.txt")
-    assert len(result.strip()) > 0
+    native = env.native("cmp -l a.txt b.txt")
+    assert result.split() == native.split()
 
 
 def test_cmp_b(env):

--- a/typescript/packages/core/src/commands/builtin/discord/stat.test.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/stat.test.ts
@@ -86,7 +86,7 @@ describe('discord stat', () => {
       { c: '%n' },
       { index: idx },
     )
-    expect(out.stdout).toBe('general__C1\n')
+    expect(out.stdout).toBe('/mnt/discord/My Server__G1/channels/general__C1\n')
   })
 
   it('returns exit 1 with no operand', async () => {

--- a/typescript/packages/core/src/commands/builtin/generic/cmp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cmp.ts
@@ -20,7 +20,7 @@ import { formatRecords } from '../utils/output.ts'
 const ENC = new TextEncoder()
 
 function octal(n: number): string {
-  return '0o' + n.toString(8)
+  return n.toString(8)
 }
 
 function arraysEqual(a: Uint8Array, b: Uint8Array): boolean {

--- a/typescript/packages/core/src/commands/builtin/generic/cmp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cmp.ts
@@ -74,9 +74,9 @@ export async function cmpGeneric(
       if (opts.flags.b === true) {
         msg += ` is ${octal(data1[idx] ?? 0)} ${String.fromCharCode(data1[idx] ?? 0)} ${octal(data2[idx] ?? 0)} ${String.fromCharCode(data2[idx] ?? 0)}`
       }
-      return [ENC.encode(msg), new IOResult({ exitCode: 1 })]
+      return [ENC.encode(`${msg}\n`), new IOResult({ exitCode: 1 })]
     }
   }
   const shorter = data1.byteLength < data2.byteLength ? p0 : p1
-  return [ENC.encode(`cmp: EOF on ${shorter.original}`), new IOResult({ exitCode: 1 })]
+  return [ENC.encode(`cmp: EOF on ${shorter.original}\n`), new IOResult({ exitCode: 1 })]
 }

--- a/typescript/packages/core/src/commands/builtin/generic/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/grep.ts
@@ -257,7 +257,16 @@ export async function grepGeneric(
       return [out, new IOResult(multiStderr !== undefined ? { stderr: multiStderr } : {})]
     }
 
-    await stat(first)
+    const firstStat = await stat(first)
+    if (firstStat.type === FileType.DIRECTORY) {
+      return [
+        new Uint8Array(0),
+        new IOResult({
+          exitCode: 1,
+          stderr: ENC.encode(`grep: ${first.original}: Is a directory\n`),
+        }),
+      ]
+    }
     const source = stream(first)
     const matched = grepStream(source, pat, f)
     if (f.quiet) {

--- a/typescript/packages/core/src/commands/builtin/generic/grep_warnings.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/grep_warnings.test.ts
@@ -88,6 +88,13 @@ describe('grepGeneric recursive warnings', () => {
     expect(await decode(out)).toBe('/data/a.txt\n')
     expect(DEC.decode(io.stderr as Uint8Array)).toBe('grep: /data/bad.txt: boom\n')
   })
+
+  it('grep on a single directory operand warns and exits 1', async () => {
+    const [out, io] = await runGrep({})
+    expect(await decode(out)).toBe('')
+    expect(DEC.decode(io.stderr as Uint8Array)).toBe('grep: /data: Is a directory\n')
+    expect(io.exitCode).toBe(1)
+  })
 })
 
 describe('grepGeneric scopeCheck', () => {

--- a/typescript/packages/core/src/commands/builtin/generic/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/stat.ts
@@ -29,9 +29,9 @@ const TYPE_LABELS: Record<string, string> = {
   [FileType.CSV]: 'regular file',
 }
 
-function formatStat(fmt: string, s: FileStat): string {
+function formatStat(fmt: string, s: FileStat, name: string): string {
   return fmt.replace(/%(.)/g, (_, spec: string) => {
-    if (spec === 'n') return s.name
+    if (spec === 'n') return name
     if (spec === 's') return String(s.size ?? 0)
     if (spec === 'F') return s.type ? (TYPE_LABELS[s.type] ?? 'regular file') : 'regular file'
     if (spec === 'y') return s.modified ?? ''
@@ -69,7 +69,7 @@ export async function statGeneric(
   for (const p of paths) {
     const s = await stat(p)
     if (fmt !== null) {
-      lines.push(formatStat(fmt, s))
+      lines.push(formatStat(fmt, s, p.original))
     } else {
       const sizeStr = s.size === null ? 'None' : String(s.size)
       const modStr = s.modified ?? 'None'

--- a/typescript/packages/core/src/commands/builtin/slack/stat.test.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/stat.test.ts
@@ -84,7 +84,7 @@ describe('slack stat', () => {
       { c: '%n' },
       { index: idx },
     )
-    expect(out.stdout).toBe('general__C1\n')
+    expect(out.stdout).toBe('/mnt/slack/channels/general__C1\n')
   })
 
   it('returns exit 1 with no operand', async () => {

--- a/typescript/packages/core/src/workspace/workspace_parity_general.test.ts
+++ b/typescript/packages/core/src/workspace/workspace_parity_general.test.ts
@@ -237,6 +237,16 @@ describe('workspace: cross-mount commands (cp/mv/diff/cmp)', () => {
     expect(stdoutStr(io)).toContain('differ')
     await ws.close()
   })
+
+  it('cmp same-mount differ message ends with newline', async () => {
+    const { ws } = await makeWorkspace()
+    await ws.execute('echo xxx > /ram/a.txt')
+    await ws.execute('echo yyy > /ram/b.txt')
+    const io = await ws.execute('cmp /ram/a.txt /ram/b.txt')
+    expect(io.exitCode).toBe(1)
+    expect(stdoutStr(io)).toBe('/ram/a.txt /ram/b.txt differ: char 1, line 1\n')
+    await ws.close()
+  })
 })
 
 describe('workspace: grep -l / -m early termination', () => {


### PR DESCRIPTION
- cmp: differ/EOF messages end with a trailing newline like python; -l and -b print bare octal per POSIX (was 0o-prefixed in both languages); native test now compares values against the real cmp binary
- stat -c %n: prints the operand path as given, like GNU stat (was basename); fixed in generic py/ts and the databricks_volume copy
- grep on a single directory operand: warns "grep: <path>: Is a directory" on stderr and exits 1 in both languages, matching the existing multi-operand behavior
- integ: new shared cases pin trailing newlines (du/stat/file/tree/ls/wc/md5/cmp via wc -c) and the grep directory semantics; truth.txt regenerated and verified on py ram/disk/redis/s3/ssh and ts ram/disk/redis/opfs/ssh

🤖 Generated with [Claude Code](https://claude.com/claude-code)