### PR TITLE
Delegate gdrive cut/sed to generics in Python

### DIFF
--- a/examples/python/gdrive/gdrive.py
+++ b/examples/python/gdrive/gdrive.py
@@ -106,6 +106,18 @@ async def main() -> None:
         result = await ws.execute(f'rg title "{gdoc}"')
         print((await result.stdout_str())[:300])
 
+        print(f"=== cut -c 1-40 {gdoc} ===")
+        result = await ws.execute(f'cut -c 1-40 "{gdoc}"')
+        print((await result.stdout_str())[:300])
+
+        print(f"=== sed -n 2p {gdoc} ===")
+        result = await ws.execute(f'sed -n 2p "{gdoc}"')
+        print((await result.stdout_str())[:300])
+
+        print(f"=== sed s/title/TITLE/g {gdoc} ===")
+        result = await ws.execute(f'sed "s/title/TITLE/g" "{gdoc}"')
+        print((await result.stdout_str())[:300])
+
         print(f"=== realpath {gdoc} ===")
         result = await ws.execute(f'realpath "{gdoc}"')
         print(await result.stdout_str())

--- a/examples/typescript/gdrive/gdrive.ts
+++ b/examples/typescript/gdrive/gdrive.ts
@@ -111,6 +111,15 @@ async function main(): Promise<void> {
       const rg = await run(ws, `rg title "${firstDoc}"`)
       printOut(`rg title ${firstDoc}`, rg.out, rg.err, 300)
 
+      const cut = await run(ws, `cut -c 1-40 "${firstDoc}"`)
+      printOut(`cut -c 1-40 ${firstDoc}`, cut.out, cut.err, 300)
+
+      const sedPrint = await run(ws, `sed -n 2p "${firstDoc}"`)
+      printOut(`sed -n 2p ${firstDoc}`, sedPrint.out, sedPrint.err, 300)
+
+      const sedSub = await run(ws, `sed "s/title/TITLE/g" "${firstDoc}"`)
+      printOut(`sed s/title/TITLE/g ${firstDoc}`, sedSub.out, sedSub.err, 300)
+
       const realpath = await run(ws, `realpath "${firstDoc}"`)
       printOut(`realpath ${firstDoc}`, realpath.out, realpath.err)
     }

--- a/python/mirage/commands/builtin/gdrive/cut.py
+++ b/python/mirage/commands/builtin/gdrive/cut.py
@@ -13,16 +13,15 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
+from functools import partial
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.cut_helper import (cut_record, parse_ranges,
-                                                split_records)
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.generic.cut import cut as generic_cut
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdrive.glob import resolve_glob
-from mirage.core.gdrive.read import read as gdrive_read
+from mirage.core.gdrive.stream import stream
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -41,19 +40,14 @@ async def cut(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    field_ranges = parse_ranges(f) if f is not None else None
-    char_ranges = parse_ranges(c) if c is not None else None
-    delim = d if d is not None else "\t"
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        raw = await gdrive_read(accessor, paths[0], index)
-    else:
-        raw = await _read_stdin_async(stdin)
-        if raw is None:
-            raise ValueError("cut: missing operand")
-    sep = b"\x00" if z else b"\n"
-    out = [
-        cut_record(rec, delim, field_ranges, char_ranges, complement) + sep
-        for rec in split_records(raw, z)
-    ]
-    return b"".join(out), IOResult()
+    return await generic_cut(paths,
+                             read_stream=partial(stream, index=index),
+                             accessor=accessor,
+                             stdin=stdin,
+                             f=f,
+                             d=d,
+                             c=c,
+                             complement=complement,
+                             z=z)

--- a/python/mirage/commands/builtin/gdrive/sed.py
+++ b/python/mirage/commands/builtin/gdrive/sed.py
@@ -12,21 +12,24 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import re
 from collections.abc import AsyncIterator
+from functools import partial
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.sed_helper import (_execute_program,
-                                                _parse_one_command,
-                                                _parse_program)
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.generic.sed import sed as generic_sed
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gdrive.glob import resolve_glob
 from mirage.core.gdrive.read import read as gdrive_read
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
+
+
+async def _write_readonly(accessor: GDriveAccessor, path: PathSpec,
+                          data: bytes) -> None:
+    raise PermissionError(
+        "sed -i not supported on read-only Google Drive mount")
 
 
 @command("sed", resource="gdrive", spec=SPECS["sed"])
@@ -44,45 +47,19 @@ async def sed(
 ) -> tuple[ByteSource | None, IOResult]:
     if i:
         raise PermissionError(
-            "sed -i not supported on read-only Google Docs mount")
+            "sed -i not supported on read-only Google Drive mount")
     if not texts:
         raise ValueError("sed: usage: sed EXPRESSION [path]")
-
-    if ";" in texts[0] or "{" in texts[0]:
-        commands = _parse_program(texts[0])
-    else:
-        commands = [_parse_one_command(texts[0])[0]]
-
-    is_simple_sub = (len(commands) == 1 and commands[0]["cmd"] == "s"
-                     and commands[0].get("addr_start") is None and not n)
-
-    if is_simple_sub and paths:
-        parsed = commands[0]
-        re_flags = re.IGNORECASE if "i" in parsed["expr_flags"] else 0
-        count = 0 if "g" in parsed["expr_flags"] else 1
-        outputs: list[str] = []
-        for p in paths:
-            data = await gdrive_read(accessor, p, index)
-            text = data.decode(errors="replace")
-            new_text = re.sub(parsed["pattern"],
-                              parsed["replacement"],
-                              text,
-                              flags=re_flags,
-                              count=count)
-            outputs.append(new_text)
-        return "".join(outputs).encode(), IOResult()
-
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        p = paths[0]
-        data = await gdrive_read(accessor, p, index)
-        text = data.decode(errors="replace")
-        result = _execute_program(text, commands, suppress=n)
-        return result.encode(), IOResult()
-
-    raw = await _read_stdin_async(stdin)
-    if raw is None:
-        raise ValueError("sed: usage: sed EXPRESSION path")
-    text = raw.decode(errors="replace")
-    result = _execute_program(text, commands, suppress=n)
-    return result.encode(), IOResult()
+    return await generic_sed(
+        paths,
+        texts[0],
+        read_bytes=partial(gdrive_read, index=index),
+        write_bytes=_write_readonly,
+        accessor=accessor,
+        stdin=stdin,
+        in_place=i,
+        suppress=n,
+        index=index,
+    )

--- a/python/mirage/core/gdrive/read.py
+++ b/python/mirage/core/gdrive/read.py
@@ -53,6 +53,8 @@ async def read(
     virtual_key = prefix + "/" + key if prefix else "/" + key
     result = await index.get(virtual_key)
     if result.entry is None:
+        # cold index: list the parent directory to populate the entry,
+        # then retry
         parent_key = posixpath.dirname(virtual_key) or "/"
         if parent_key != virtual_key:
             parent_path = PathSpec.from_str_path(parent_key, prefix=prefix)
@@ -60,6 +62,7 @@ async def read(
                 await readdir(accessor, parent_path, index)
                 result = await index.get(virtual_key)
             except Exception:
+                # parent refresh failed; fall through to FileNotFoundError
                 pass
         if result.entry is None:
             raise FileNotFoundError(path)

--- a/python/mirage/core/gdrive/stream.py
+++ b/python/mirage/core/gdrive/stream.py
@@ -12,11 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import posixpath
 from collections.abc import AsyncIterator
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.gdocs.read import read_doc
+from mirage.core.gdrive.readdir import readdir
 from mirage.core.google.drive import download_file_stream
 from mirage.core.gsheets.read import read_spreadsheet
 from mirage.core.gslides.read import read_presentation
@@ -46,8 +48,19 @@ async def read_stream(
     virtual_key = prefix + "/" + key if prefix else "/" + key
     result = await index.get(virtual_key)
     if result.entry is None:
-        raise FileNotFoundError(path)
+        parent_key = posixpath.dirname(virtual_key) or "/"
+        if parent_key != virtual_key:
+            parent_path = PathSpec.from_str_path(parent_key, prefix=prefix)
+            try:
+                await readdir(accessor, parent_path, index)
+                result = await index.get(virtual_key)
+            except Exception:
+                pass
+        if result.entry is None:
+            raise FileNotFoundError(path)
     rt = result.entry.resource_type
+    if rt == "gdrive/folder":
+        raise IsADirectoryError(path)
     if rt == "gdrive/gdoc":
         return await read_doc(accessor.token_manager, result.entry.id)
     if rt == "gdrive/gsheet":

--- a/python/mirage/core/gdrive/stream.py
+++ b/python/mirage/core/gdrive/stream.py
@@ -48,6 +48,8 @@ async def read_stream(
     virtual_key = prefix + "/" + key if prefix else "/" + key
     result = await index.get(virtual_key)
     if result.entry is None:
+        # cold index: list the parent directory to populate the entry,
+        # then retry
         parent_key = posixpath.dirname(virtual_key) or "/"
         if parent_key != virtual_key:
             parent_path = PathSpec.from_str_path(parent_key, prefix=prefix)
@@ -55,6 +57,7 @@ async def read_stream(
                 await readdir(accessor, parent_path, index)
                 result = await index.get(virtual_key)
             except Exception:
+                # parent refresh failed; fall through to FileNotFoundError
                 pass
         if result.entry is None:
             raise FileNotFoundError(path)

--- a/python/tests/commands/builtin/gdrive/test_cut.py
+++ b/python/tests/commands/builtin/gdrive/test_cut.py
@@ -1,0 +1,144 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import patch
+
+import pytest
+
+from mirage.accessor.gdrive import GDriveAccessor
+from mirage.cache.index.config import IndexEntry
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.commands.builtin.gdrive.cut import cut
+from mirage.core.google._client import TokenManager
+from mirage.core.google.config import GoogleConfig
+from mirage.io.stream import materialize
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def config():
+    return GoogleConfig(
+        client_id="test-id",
+        client_secret="test-secret",
+        refresh_token="test-refresh",
+    )
+
+
+@pytest.fixture
+def token_manager(config):
+    mgr = TokenManager(config)
+    mgr._access_token = "fake-token"
+    mgr._expires_at = 9999999999
+    return mgr
+
+
+@pytest.fixture
+def accessor(config, token_manager):
+    return GDriveAccessor(config=config, token_manager=token_manager)
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+def _scope(path: str, prefix: str = "") -> PathSpec:
+    return PathSpec(original=path,
+                    directory=path.rsplit("/", 1)[0] or "/",
+                    prefix=prefix)
+
+
+async def _mock_stream(*args, **kwargs):
+    yield b"a,b,c\n1,2,3\n"
+
+
+@pytest.mark.asyncio
+async def test_cut_fields(accessor, index):
+    await index.put(
+        "/test/file.csv",
+        IndexEntry(
+            id="file123",
+            name="file.csv",
+            resource_type="gdrive/file",
+            remote_time="2026-01-01T00:00:00Z",
+            vfs_name="file.csv",
+            size=100,
+        ))
+    with patch(
+            "mirage.core.google.drive.google_get_stream",
+            side_effect=_mock_stream,
+    ):
+        result, io = await cut(
+            accessor,
+            [_scope("/test/file.csv")],
+            d=",",
+            f="2",
+            index=index,
+        )
+        data = await materialize(result)
+        assert data == b"b\n2\n"
+        assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_cut_chars(accessor, index):
+    await index.put(
+        "/test/file.txt",
+        IndexEntry(
+            id="file456",
+            name="file.txt",
+            resource_type="gdrive/file",
+            remote_time="2026-01-01T00:00:00Z",
+            vfs_name="file.txt",
+            size=100,
+        ))
+
+    async def mock_lines(*args, **kwargs):
+        yield b"hello\nworld\n"
+
+    with patch(
+            "mirage.core.google.drive.google_get_stream",
+            side_effect=mock_lines,
+    ):
+        result, io = await cut(
+            accessor,
+            [_scope("/test/file.txt")],
+            c="1-3",
+            index=index,
+        )
+        data = await materialize(result)
+        assert data == b"hel\nwor\n"
+        assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_cut_stdin(accessor, index):
+    result, io = await cut(
+        accessor,
+        [],
+        stdin=b"x:y:z\n",
+        d=":",
+        f="1,3",
+        index=index,
+    )
+    data = await materialize(result)
+    assert data == b"x:z\n"
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_cut_missing_operand(accessor, index):
+    with pytest.raises(ValueError, match="cut: missing operand"):
+        result, _io = await cut(accessor, [], f="1", index=index)
+        await materialize(result)

--- a/python/tests/commands/builtin/gdrive/test_sed.py
+++ b/python/tests/commands/builtin/gdrive/test_sed.py
@@ -1,0 +1,148 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mirage.accessor.gdrive import GDriveAccessor
+from mirage.cache.index.config import IndexEntry
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.commands.builtin.gdrive.sed import sed
+from mirage.core.google._client import TokenManager
+from mirage.core.google.config import GoogleConfig
+from mirage.io.stream import materialize
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def config():
+    return GoogleConfig(
+        client_id="test-id",
+        client_secret="test-secret",
+        refresh_token="test-refresh",
+    )
+
+
+@pytest.fixture
+def token_manager(config):
+    mgr = TokenManager(config)
+    mgr._access_token = "fake-token"
+    mgr._expires_at = 9999999999
+    return mgr
+
+
+@pytest.fixture
+def accessor(config, token_manager):
+    return GDriveAccessor(config=config, token_manager=token_manager)
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+def _scope(path: str, prefix: str = "") -> PathSpec:
+    return PathSpec(original=path,
+                    directory=path.rsplit("/", 1)[0] or "/",
+                    prefix=prefix)
+
+
+@pytest.mark.asyncio
+async def test_sed_simple_substitution(accessor, index):
+    await index.put(
+        "/test/file.txt",
+        IndexEntry(
+            id="file123",
+            name="file.txt",
+            resource_type="gdrive/file",
+            remote_time="2026-01-01T00:00:00Z",
+            vfs_name="file.txt",
+            size=100,
+        ))
+    with patch(
+            "mirage.core.google.drive.google_get_bytes",
+            new_callable=AsyncMock,
+            return_value=b"hello world\nhello again\n",
+    ):
+        result, io = await sed(
+            accessor,
+            [_scope("/test/file.txt")],
+            "s/hello/bye/g",
+            index=index,
+        )
+        data = await materialize(result)
+        assert data == b"bye world\nbye again\n"
+        assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_sed_print_program(accessor, index):
+    await index.put(
+        "/test/file.txt",
+        IndexEntry(
+            id="file123",
+            name="file.txt",
+            resource_type="gdrive/file",
+            remote_time="2026-01-01T00:00:00Z",
+            vfs_name="file.txt",
+            size=100,
+        ))
+    with patch(
+            "mirage.core.google.drive.google_get_bytes",
+            new_callable=AsyncMock,
+            return_value=b"one\ntwo\nthree\n",
+    ):
+        result, io = await sed(
+            accessor,
+            [_scope("/test/file.txt")],
+            "2p",
+            n=True,
+            index=index,
+        )
+        data = await materialize(result)
+        assert data == b"two\n"
+        assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_sed_stdin(accessor, index):
+    result, io = await sed(
+        accessor,
+        [],
+        "s/a/b/g",
+        stdin=b"banana\n",
+        index=index,
+    )
+    data = await materialize(result)
+    assert data == b"bbnbnb\n"
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_sed_in_place_rejected(accessor, index):
+    with pytest.raises(PermissionError, match="read-only Google Drive"):
+        await sed(
+            accessor,
+            [_scope("/test/file.txt")],
+            "s/a/b/",
+            i=True,
+            index=index,
+        )
+
+
+@pytest.mark.asyncio
+async def test_sed_missing_expression(accessor, index):
+    with pytest.raises(ValueError, match="sed: usage"):
+        await sed(accessor, [], index=index)

--- a/python/tests/core/gdrive/test_stream.py
+++ b/python/tests/core/gdrive/test_stream.py
@@ -1,0 +1,153 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import patch
+
+import pytest
+
+from mirage.accessor.gdrive import GDriveAccessor
+from mirage.cache.index.config import IndexEntry
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.core.gdrive.stream import stream
+from mirage.core.google._client import TokenManager
+from mirage.core.google.config import GoogleConfig
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def config():
+    return GoogleConfig(
+        client_id="test-id",
+        client_secret="test-secret",
+        refresh_token="test-refresh",
+    )
+
+
+@pytest.fixture
+def token_manager(config):
+    mgr = TokenManager(config)
+    mgr._access_token = "fake-token"
+    mgr._expires_at = 9999999999
+    return mgr
+
+
+@pytest.fixture
+def accessor(config, token_manager):
+    return GDriveAccessor(config=config, token_manager=token_manager)
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+async def _fake_download_stream(*args, **kwargs):
+    yield b"chunk1"
+    yield b"chunk2"
+
+
+async def _collect(source):
+    data = b""
+    async for chunk in source:
+        data += chunk
+    return data
+
+
+@pytest.mark.asyncio
+async def test_stream_file(accessor, index):
+    await index.put(
+        "/data/report.pdf",
+        IndexEntry(
+            id="file123",
+            name="report",
+            resource_type="gdrive/file",
+            remote_time="2026-04-01T00:00:00.000Z",
+            vfs_name="report.pdf",
+        ))
+    with patch(
+            "mirage.core.gdrive.stream.download_file_stream",
+            side_effect=_fake_download_stream,
+    ):
+        data = await _collect(
+            stream(
+                accessor,
+                PathSpec(original="/data/report.pdf",
+                         directory="/data/report.pdf"), index))
+        assert data == b"chunk1chunk2"
+
+
+@pytest.mark.asyncio
+async def test_stream_not_found(accessor, index):
+
+    async def fake_list_files(_tm, folder_id):
+        return []
+
+    with patch("mirage.core.gdrive.readdir.list_files", new=fake_list_files):
+        with pytest.raises(FileNotFoundError):
+            await _collect(
+                stream(
+                    accessor,
+                    PathSpec(original="/missing/file.txt",
+                             directory="/missing/file.txt"), index))
+
+
+@pytest.mark.asyncio
+async def test_stream_auto_bootstraps_from_empty_index(accessor, index):
+
+    async def fake_list_files(_tm, folder_id):
+        if folder_id == "root":
+            return [{
+                "id": "f1",
+                "name": "report.pdf",
+                "mimeType": "application/pdf",
+                "modifiedTime": "2026-04-01T00:00:00.000Z",
+                "owners": [],
+                "capabilities": {},
+            }]
+        raise AssertionError(f"unexpected folder_id={folder_id}")
+
+    with (
+            patch(
+                "mirage.core.gdrive.readdir.list_files",
+                new=fake_list_files,
+            ),
+            patch(
+                "mirage.core.gdrive.stream.download_file_stream",
+                side_effect=_fake_download_stream,
+            ),
+    ):
+        data = await _collect(
+            stream(
+                accessor,
+                PathSpec(original="/report.pdf", directory="/report.pdf"),
+                index,
+            ))
+        assert data == b"chunk1chunk2"
+
+
+@pytest.mark.asyncio
+async def test_stream_folder_raises(accessor, index):
+    await index.put(
+        "/data",
+        IndexEntry(
+            id="folder1",
+            name="data",
+            resource_type="gdrive/folder",
+            remote_time="2026-04-01T00:00:00.000Z",
+            vfs_name="data",
+        ))
+    with pytest.raises(IsADirectoryError):
+        await _collect(
+            stream(accessor, PathSpec(original="/data", directory="/data"),
+                   index))

--- a/typescript/packages/core/src/commands/builtin/gdrive/cut.test.ts
+++ b/typescript/packages/core/src/commands/builtin/gdrive/cut.test.ts
@@ -1,0 +1,122 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it, vi } from 'vitest'
+import type * as DriveModule from '../../../core/google/drive.ts'
+
+vi.mock('../../../core/google/drive.ts', async () => {
+  const actual = await vi.importActual<typeof DriveModule>('../../../core/google/drive.ts')
+  return { ...actual, downloadFile: vi.fn() }
+})
+
+import { GDriveAccessor } from '../../../accessor/gdrive.ts'
+import { IndexEntry } from '../../../cache/index/config.ts'
+import { RAMIndexCacheStore } from '../../../cache/index/ram.ts'
+import type { TokenManager } from '../../../core/google/_client.ts'
+import * as drive from '../../../core/google/drive.ts'
+import { materialize } from '../../../io/types.ts'
+import type { Resource } from '../../../resource/base.ts'
+import { PathSpec } from '../../../types.ts'
+import type { CommandFnResult, CommandOpts } from '../../config.ts'
+import { GDRIVE_CUT } from './cut.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+function makeAccessor(): GDriveAccessor {
+  return new GDriveAccessor({ tokenManager: {} as TokenManager })
+}
+
+function makeOpts(partial: Partial<CommandOpts>): CommandOpts {
+  return {
+    stdin: null,
+    flags: {},
+    filetypeFns: null,
+    cwd: '/',
+    resource: {} as Resource,
+    ...partial,
+  }
+}
+
+async function outText(result: CommandFnResult): Promise<string> {
+  if (result === null) return ''
+  const [out] = result
+  if (out === null) return ''
+  const buf = out instanceof Uint8Array ? out : await materialize(out)
+  return DEC.decode(buf)
+}
+
+describe('gdrive cut', () => {
+  it('-f with -d on an indexed file', async () => {
+    vi.mocked(drive.downloadFile).mockResolvedValue(ENC.encode('a,b,c\n1,2,3\n'))
+    const index = new RAMIndexCacheStore()
+    await index.put(
+      '/test/file.csv',
+      new IndexEntry({
+        id: 'file123',
+        name: 'file.csv',
+        resourceType: 'gdrive/file',
+        remoteTime: '2026-01-01T00:00:00Z',
+        vfsName: 'file.csv',
+        size: 100,
+      }),
+    )
+    const cmd = GDRIVE_CUT[0]
+    if (cmd === undefined) throw new Error('cut not registered')
+    const result = await cmd.fn(
+      makeAccessor() as never,
+      [new PathSpec({ original: '/test/file.csv', directory: '/test' })],
+      [],
+      makeOpts({ flags: { d: ',', f: '2' }, index }),
+    )
+    expect(await outText(result)).toBe('b\n2\n')
+  })
+
+  it('-c char range on an indexed file', async () => {
+    vi.mocked(drive.downloadFile).mockResolvedValue(ENC.encode('hello\nworld\n'))
+    const index = new RAMIndexCacheStore()
+    await index.put(
+      '/test/file.txt',
+      new IndexEntry({
+        id: 'file456',
+        name: 'file.txt',
+        resourceType: 'gdrive/file',
+        remoteTime: '2026-01-01T00:00:00Z',
+        vfsName: 'file.txt',
+        size: 100,
+      }),
+    )
+    const cmd = GDRIVE_CUT[0]
+    if (cmd === undefined) throw new Error('cut not registered')
+    const result = await cmd.fn(
+      makeAccessor() as never,
+      [new PathSpec({ original: '/test/file.txt', directory: '/test' })],
+      [],
+      makeOpts({ flags: { c: '1-3' }, index }),
+    )
+    expect(await outText(result)).toBe('hel\nwor\n')
+  })
+
+  it('reads stdin when no paths', async () => {
+    const cmd = GDRIVE_CUT[0]
+    if (cmd === undefined) throw new Error('cut not registered')
+    const result = await cmd.fn(
+      makeAccessor() as never,
+      [],
+      [],
+      makeOpts({ stdin: ENC.encode('x:y:z\n'), flags: { d: ':', f: '1,3' } }),
+    )
+    expect(await outText(result)).toBe('x:z\n')
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/gdrive/sed.test.ts
+++ b/typescript/packages/core/src/commands/builtin/gdrive/sed.test.ts
@@ -1,0 +1,134 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it, vi } from 'vitest'
+import type * as DriveModule from '../../../core/google/drive.ts'
+
+vi.mock('../../../core/google/drive.ts', async () => {
+  const actual = await vi.importActual<typeof DriveModule>('../../../core/google/drive.ts')
+  return { ...actual, downloadFile: vi.fn() }
+})
+
+import { GDriveAccessor } from '../../../accessor/gdrive.ts'
+import { IndexEntry } from '../../../cache/index/config.ts'
+import { RAMIndexCacheStore } from '../../../cache/index/ram.ts'
+import type { TokenManager } from '../../../core/google/_client.ts'
+import * as drive from '../../../core/google/drive.ts'
+import { materialize } from '../../../io/types.ts'
+import type { Resource } from '../../../resource/base.ts'
+import { PathSpec } from '../../../types.ts'
+import type { CommandFnResult, CommandOpts } from '../../config.ts'
+import { GDRIVE_SED } from './sed.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+function makeAccessor(): GDriveAccessor {
+  return new GDriveAccessor({ tokenManager: {} as TokenManager })
+}
+
+function makeOpts(partial: Partial<CommandOpts>): CommandOpts {
+  return {
+    stdin: null,
+    flags: {},
+    filetypeFns: null,
+    cwd: '/',
+    resource: {} as Resource,
+    ...partial,
+  }
+}
+
+async function putFile(index: RAMIndexCacheStore, key: string, name: string): Promise<void> {
+  await index.put(
+    key,
+    new IndexEntry({
+      id: 'file123',
+      name,
+      resourceType: 'gdrive/file',
+      remoteTime: '2026-01-01T00:00:00Z',
+      vfsName: name,
+      size: 100,
+    }),
+  )
+}
+
+async function outText(result: CommandFnResult): Promise<string> {
+  if (result === null) return ''
+  const [out] = result
+  if (out === null) return ''
+  const buf = out instanceof Uint8Array ? out : await materialize(out)
+  return DEC.decode(buf)
+}
+
+describe('gdrive sed', () => {
+  it('simple substitution on an indexed file', async () => {
+    vi.mocked(drive.downloadFile).mockResolvedValue(ENC.encode('hello world\nhello again\n'))
+    const index = new RAMIndexCacheStore()
+    await putFile(index, '/test/file.txt', 'file.txt')
+    const cmd = GDRIVE_SED[0]
+    if (cmd === undefined) throw new Error('sed not registered')
+    const result = await cmd.fn(
+      makeAccessor() as never,
+      [new PathSpec({ original: '/test/file.txt', directory: '/test' })],
+      ['s/hello/bye/g'],
+      makeOpts({ index }),
+    )
+    expect(await outText(result)).toBe('bye world\nbye again\n')
+  })
+
+  it('-n with print program', async () => {
+    vi.mocked(drive.downloadFile).mockResolvedValue(ENC.encode('one\ntwo\nthree\n'))
+    const index = new RAMIndexCacheStore()
+    await putFile(index, '/test/file.txt', 'file.txt')
+    const cmd = GDRIVE_SED[0]
+    if (cmd === undefined) throw new Error('sed not registered')
+    const result = await cmd.fn(
+      makeAccessor() as never,
+      [new PathSpec({ original: '/test/file.txt', directory: '/test' })],
+      ['2p'],
+      makeOpts({ flags: { n: true }, index }),
+    )
+    expect(await outText(result)).toBe('two\n')
+  })
+
+  it('reads stdin when no paths', async () => {
+    const cmd = GDRIVE_SED[0]
+    if (cmd === undefined) throw new Error('sed not registered')
+    const result = await cmd.fn(
+      makeAccessor() as never,
+      [],
+      ['s/a/b/g'],
+      makeOpts({ stdin: ENC.encode('banana\n') }),
+    )
+    expect(await outText(result)).toBe('bbnbnb\n')
+  })
+
+  it('rejects -i on read-only mount', async () => {
+    const index = new RAMIndexCacheStore()
+    await putFile(index, '/test/file.txt', 'file.txt')
+    const cmd = GDRIVE_SED[0]
+    if (cmd === undefined) throw new Error('sed not registered')
+    const result = await cmd.fn(
+      makeAccessor() as never,
+      [new PathSpec({ original: '/test/file.txt', directory: '/test' })],
+      ['s/a/b/'],
+      makeOpts({ flags: { i: true }, index }),
+    )
+    if (result === null) throw new Error('expected a result')
+    const [out, io] = result
+    expect(out).toBeNull()
+    expect(io.exitCode).toBe(1)
+    expect(DEC.decode(io.stderr ?? new Uint8Array())).toContain('read-only Google Drive mount')
+  })
+})

--- a/typescript/packages/core/src/core/gdrive/read.ts
+++ b/typescript/packages/core/src/core/gdrive/read.ts
@@ -52,6 +52,7 @@ export async function read(
   const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`
   let result = await index.get(virtualKey)
   if (result.entry === undefined || result.entry === null) {
+    // cold index: list the parent directory to populate the entry, then retry
     const parentKey = rstripSlash(virtualKey).replace(/\/[^/]+$/, '') || '/'
     if (parentKey !== virtualKey) {
       const parentPath = PathSpec.fromStrPath(parentKey, prefix)


### PR DESCRIPTION
- Python gdrive `cut`/`sed` were bespoke; now they resolve globs and delegate to the shared generics with injected gdrive stream/read, matching the TS wrappers. `sed -i` error message aligned to TS ("read-only Google Drive mount").
- Fix: Python `read_stream` now bootstraps the index from the parent listing on a cold index, like `read` and like TS. Previously `cat`/`cut` failed with ENOENT before any `ls`.
- Tests: gdrive cut/sed unit tests added in both languages with identical expected bytes, plus `test_stream.py` for the bootstrap.
- Examples: `cut -c`, `sed -n 2p`, `sed s///g` sections added to both gdrive examples. Verified live: py and TS byte-identical, and identical to GNU coreutils `cut`/`sed` on the same file bytes.