### PR TITLE
docs(databricks): bring volume resource docs to s3 parity

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -279,7 +279,8 @@
                 "group": "Cloud Files",
                 "icon": "folder-open",
                 "pages": [
-                  "python/resource/nextcloud"
+                  "python/resource/nextcloud",
+                  "python/resource/databricks_volume"
                 ]
               },
               {

--- a/docs/python/resource/databricks_volume.mdx
+++ b/docs/python/resource/databricks_volume.mdx
@@ -79,8 +79,8 @@ Reads: `readdir`, `stat`, `exists`, `read_bytes`, `read_stream`,
 `range_read`, and glob resolution. Writes: `write`, `create`, `mkdir`,
 `rmdir`, `unlink`, recursive `rm`, `cp`, and `mv`.
 
-`mv`/`cp` are non-atomic download + upload (the Files API has no server-side
-rename); moving a path onto itself is a no-op and never deletes the file.
+`mv`/`cp` are non-atomic download + upload — the Files API has no server-side
+rename.
 
 ## Shell Commands
 

--- a/docs/python/resource/databricks_volume.mdx
+++ b/docs/python/resource/databricks_volume.mdx
@@ -79,11 +79,58 @@ Reads: `readdir`, `stat`, `exists`, `read_bytes`, `read_stream`,
 `range_read`, and glob resolution. Writes: `write`, `create`, `mkdir`,
 `rmdir`, `unlink`, recursive `rm`, `cp`, and `mv`.
 
-Standard shell commands like `ls`, `cat`, `head`, `tail`, `grep`, `rg`,
-`find`, `tree`, `touch`, `mkdir`, `rm`, `cp`, and `mv` work through those
-primitives. `mv`/`cp` are non-atomic download + upload (the Files API has no
-server-side rename); moving a path onto itself is a no-op and never deletes
-the file.
+`mv`/`cp` are non-atomic download + upload (the Files API has no server-side
+rename); moving a path onto itself is a no-op and never deletes the file.
+
+## Shell Commands
+
+The Databricks Volume resource supports shell commands that operate on real
+file content. Reads use the Files API with range requests, so commands like
+`head -c BYTES` avoid downloading the whole object. The supported set is
+scoped to commands that work over the volume API (no compression, encoding,
+or local-only utilities).
+
+### Read Commands
+
+| Command         | Notes                                      |
+| --------------- | ------------------------------------------ |
+| `cat`           | Read file content                          |
+| `head` / `tail` | First/last N lines                         |
+| `grep` / `rg`   | Pattern search (file or directory level)   |
+| `jq`            | Query JSON fields                          |
+| `wc`            | Line/word/byte counts                      |
+| `stat`          | File metadata (name, size, type, modified) |
+| `find`          | Recursive search with `-name`, `-maxdepth` |
+| `tree`          | Directory tree view                        |
+| `nl`            | Number lines                               |
+
+### Text Processing
+
+| Command | Notes                            |
+| ------- | -------------------------------- |
+| `awk`   | Pattern scanning and processing  |
+| `sed`   | Stream editor                    |
+| `tr`    | Translate or delete characters   |
+| `sort`  | Sort lines                       |
+| `uniq`  | Remove duplicate lines           |
+| `cut`   | Extract fields/columns           |
+| `diff`  | Compare files line by line       |
+
+### File Operations
+
+| Command | Notes                                                |
+| ------- | ---------------------------------------------------- |
+| `cp`    | Copy files (non-atomic download + upload)            |
+| `mv`    | Move/rename files (non-atomic download + upload)     |
+| `rm`    | Remove files (recursive for directories)             |
+| `mkdir` | Create directories                                   |
+| `touch` | Create empty file or update timestamp                |
+
+### Path Utilities
+
+| Command | Notes                   |
+| ------- | ----------------------- |
+| `ls`    | List directory contents |
 
 ## Snapshot behavior
 
@@ -151,3 +198,14 @@ See:
 
 - `examples/python/databricks_volume/databricks_volume.py`
 - `examples/python/agents/langchain/databricks_volume_deepagent.py`
+
+## Use Cases
+
+- **Agents in Databricks Apps**: mount a Unity Catalog volume in-process so an
+  agent can read and write governed files without FUSE or hardcoded credentials.
+- **Reading governed datasets**: expose a reports or dataset subtree through
+  `root_path` and query it with shell commands.
+- **Sandboxed volume access**: scope an agent to a single volume (and optional
+  `root_path`) so it cannot read or write outside that subtree.
+- **Writing agent outputs back**: persist generated files to the volume with
+  `write`, `cp`, and `mv`.

--- a/docs/python/setup/databricks.mdx
+++ b/docs/python/setup/databricks.mdx
@@ -78,6 +78,6 @@ ws = Workspace({"/dbx/": resource}, mode=MountMode.READ)
 
 ## Notes
 
-- The resource is read-only in this branch.
+- Supports both read and write mount modes (`MountMode.READ` / `MountMode.WRITE`).
 - Auth falls through to the Databricks SDK defaults when `host`, `token`, and `profile` are omitted.
 - `root_path` is normalized and cannot contain `..`.

--- a/docs/typescript/setup/databricks_volume.mdx
+++ b/docs/typescript/setup/databricks_volume.mdx
@@ -83,9 +83,8 @@ recursive `rm`, `cp`, and `mv`.
 
 Standard shell commands like `ls`, `cat`, `head`, `tail`, `grep`, `rg`,
 `find`, `tree`, `touch`, `mkdir`, `rm`, `cp`, and `mv` work through those
-primitives. `mv`/`cp` are non-atomic download + upload (the Files API has no
-server-side rename); moving a path onto itself is a no-op and never deletes
-the file.
+primitives. `mv`/`cp` are non-atomic download + upload — the Files API has no
+server-side rename.
 
 ## Snapshot behavior
 


### PR DESCRIPTION
## What

Brings the Databricks Volume docs up to the same structure/depth as the reference object/file-storage backends (`s3`, `gcs`, `oci`, `nextcloud`). Follow-up to #61.

## Changes

- **Nav fix (`docs/docs.json`)**: add `python/resource/databricks_volume` to the "Cloud Files" group. It was the **only** one of 44 `python/resource/*` pages missing from the sidebar — previously reachable only via the resource-matrix table link.
- **Resource page (`python/resource/databricks_volume.mdx`)**: replace the one-paragraph "Supported operations" blurb with proper `## Shell Commands` tables (Read / Text Processing / File Operations / Path Utilities), scoped to the **24** commands the backend actually supports, and add a `## Use Cases` section — matching the s3/gcs/oci/nextcloud page shape. Kept the read/write primitives note and the non-atomic `mv`/`cp` caveat.
- **Stale-bug fix (`python/setup/databricks.mdx`)**: "The resource is read-only in this branch" → "Supports both read and write mount modes". Write support landed in #93.

## Deliberately not changed

- No `## Cache` section — peers have one, but the Databricks resource doesn't cache (verified in the impl), so adding it would be inaccurate.
- The separate `python/setup/databricks.mdx` page stays inline-linked (not in sidebar) — that matches 15 of 16 backend setup pages; it's the convention, not an orphan.

## Related

- Closes the docs portion of #61.
- Command-parity gap (39 commands still missing vs s3) tracked separately in #264.