### PR TITLE
feat(cross-mount): support recursive cp/mv across mounts (#130)

### DIFF
--- a/python/mirage/commands/builtin/cross_mount.py
+++ b/python/mirage/commands/builtin/cross_mount.py
@@ -210,7 +210,7 @@ async def _paste_cross(
     return output.encode(), IOResult()
 
 
-RESOURCES = ["ram", "s3", "disk"]
+RESOURCES = ["ram", "s3", "disk", "databricks_volume"]
 _RESOURCE_PAIRS = list(product(RESOURCES, repeat=2))
 
 _CROSS_FNS = [

--- a/python/mirage/workspace/executor/cross_mount.py
+++ b/python/mirage/workspace/executor/cross_mount.py
@@ -49,8 +49,10 @@ async def handle_cross_mount(
     Copy and move follow POSIX operand semantics: every path except the final
     path is a source, and the final path is the destination. An existing
     destination directory maps each source to ``destination/basename``;
-    multiple sources require that directory form. Source data is read before
-    mutation so validation or read failures do not partially modify targets.
+    multiple sources require that directory form. Flat-file sources are read
+    before mutation so a read failure does not partially modify targets;
+    directory sources (``cp -r``, directory ``mv``) walk the tree, create
+    destination directories, and copy per file.
 
     Examples:
         ``cp /ram/a.txt /disk/a.txt`` produces scopes
@@ -134,34 +136,123 @@ async def _cross_target_exists(target: PathSpec, dispatch) -> bool:
     return True
 
 
+def _cross_result(cmd_str, errors):
+    if errors:
+        err = ("\n".join(errors) + "\n").encode()
+        return None, IOResult(exit_code=1,
+                              stderr=err), ExecutionNode(command=cmd_str,
+                                                         exit_code=1,
+                                                         stderr=err)
+    return None, IOResult(), ExecutionNode(command=cmd_str, exit_code=0)
+
+
+async def _partition_sources(cmd, sources, targets, recursive, dispatch):
+    # Split sources into files and directories. cp without -r omits
+    # directories (coreutils prints an error and still copies the files);
+    # mv always moves directories.
+    file_srcs: list[PathSpec] = []
+    file_targets: list[PathSpec] = []
+    dir_pairs: list[tuple[PathSpec, PathSpec]] = []
+    errors: list[str] = []
+    for src, target in zip(sources, targets):
+        src_stat, _ = await dispatch("stat", src)
+        if src_stat.type == FileType.DIRECTORY:
+            if cmd == "cp" and not recursive:
+                errors.append("cp: -r not specified; omitting directory "
+                              f"'{src.original}'")
+                continue
+            dir_pairs.append((src, target))
+        else:
+            file_srcs.append(src)
+            file_targets.append(target)
+    return file_srcs, file_targets, dir_pairs, errors
+
+
+async def _copy_tree(src_dir, dst_dir, dispatch, no_clobber):
+    # Recreate the source subtree under the destination. Directories are
+    # created top-down so each parent exists before its children; an
+    # already-present destination directory is merged into (coreutils cp
+    # -r), so a FileExistsError from mkdir is expected, not a failure.
+    try:
+        await dispatch("mkdir", dst_dir)
+    except FileExistsError:
+        pass
+    children, _ = await dispatch("readdir", src_dir)
+    for child in children:
+        name = child.rstrip("/").rsplit("/", 1)[-1]
+        child_src = PathSpec.from_str_path(child, src_dir.prefix)
+        child_dst = PathSpec.from_str_path(dst_dir.child(name), dst_dir.prefix)
+        child_stat, _ = await dispatch("stat", child_src)
+        if child_stat.type == FileType.DIRECTORY:
+            await _copy_tree(child_src, child_dst, dispatch, no_clobber)
+            continue
+        if no_clobber and await _cross_target_exists(child_dst, dispatch):
+            continue
+        data, _ = await dispatch("read", child_src)
+        await dispatch("write", child_dst, data=data)
+
+
+async def _remove_tree(src_dir, dispatch):
+    # Delete a source directory after a cross-mount move. Walks bottom-up
+    # (children before the dir) using ops every backend exposes, since
+    # rm_recursive is not registered on all of them.
+    children, _ = await dispatch("readdir", src_dir)
+    for child in children:
+        child_src = PathSpec.from_str_path(child, src_dir.prefix)
+        child_stat, _ = await dispatch("stat", child_src)
+        if child_stat.type == FileType.DIRECTORY:
+            await _remove_tree(child_src, dispatch)
+        else:
+            await dispatch("unlink", child_src)
+    await dispatch("rmdir", src_dir)
+
+
 async def _cross_cp(scopes, flag_kwargs, dispatch, cmd_str):
     sources, targets = await _cross_targets(scopes, dispatch)
-    source_data = await _read_cross_sources(sources, dispatch)
+    recursive = bool(
+        flag_kwargs.get("r") or flag_kwargs.get("R") or flag_kwargs.get("a"))
     no_clobber = flag_kwargs.get("n") is True
-    for target, data in zip(targets, source_data):
+    file_srcs, file_targets, dir_pairs, errors = await _partition_sources(
+        "cp", sources, targets, recursive, dispatch)
+    # Pre-read flat-file sources before writing so a read failure cannot
+    # leave partial writes; directory trees stream per file during the walk.
+    source_data = await _read_cross_sources(file_srcs, dispatch)
+    for target, data in zip(file_targets, source_data):
         # Check immediately before writing: earlier sources may share this
         # basename and create the target during the same command.
         if no_clobber and await _cross_target_exists(target, dispatch):
             continue
         await dispatch("write", target, data=data)
-    return None, IOResult(), ExecutionNode(command=cmd_str, exit_code=0)
+    for src, target in dir_pairs:
+        await _copy_tree(src, target, dispatch, no_clobber)
+    return _cross_result(cmd_str, errors)
 
 
 async def _cross_mv(scopes, flag_kwargs, dispatch, cmd_str):
     sources, targets = await _cross_targets(scopes, dispatch)
-    source_data = await _read_cross_sources(sources, dispatch)
     no_clobber = flag_kwargs.get("n") is True
-    moved_sources = []
-    for src, target, data in zip(sources, targets, source_data):
+    file_srcs, file_targets, dir_pairs, errors = await _partition_sources(
+        "mv", sources, targets, True, dispatch)
+    source_data = await _read_cross_sources(file_srcs, dispatch)
+    moved_files: list[PathSpec] = []
+    for src, target, data in zip(file_srcs, file_targets, source_data):
         # A skipped no-clobber target must also preserve its source.
         if no_clobber and await _cross_target_exists(target, dispatch):
             continue
         await dispatch("write", target, data=data)
-        moved_sources.append(src)
-    # Delete only sources whose destination write completed.
-    for src in moved_sources:
+        moved_files.append(src)
+    moved_dirs: list[PathSpec] = []
+    for src, target in dir_pairs:
+        if no_clobber and await _cross_target_exists(target, dispatch):
+            continue
+        await _copy_tree(src, target, dispatch, no_clobber)
+        moved_dirs.append(src)
+    # Delete only sources whose destination copy completed.
+    for src in moved_files:
         await dispatch("unlink", src)
-    return None, IOResult(), ExecutionNode(command=cmd_str, exit_code=0)
+    for src in moved_dirs:
+        await _remove_tree(src, dispatch)
+    return _cross_result(cmd_str, errors)
 
 
 async def _cross_diff(scopes, dispatch, cmd_str):

--- a/python/tests/commands/builtin/databricks_volume/test_cross_mount.py
+++ b/python/tests/commands/builtin/databricks_volume/test_cross_mount.py
@@ -1,0 +1,87 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+from mirage import MountMode, Workspace
+from mirage.resource.ram import RAMResource
+from tests.resource.databricks_volume.test_databricks_volume import (
+    FakeFiles, make_resource, seed_file)
+
+ROOT = "/Volumes/main/default/agent_files/root"
+
+
+def _run(ws, cmd):
+
+    async def _inner():
+        io = await ws.execute(cmd)
+        return await io.stdout_str(), await io.stderr_str(), io.exit_code
+
+    return asyncio.run(_inner())
+
+
+def _ws_with_dbx_tree():
+    files = FakeFiles()
+    files.create_directory(ROOT)
+    files.create_directory(f"{ROOT}/tree")
+    files.create_directory(f"{ROOT}/tree/sub")
+    seed_file(files, f"{ROOT}/tree/a.txt", b"aaa\n")
+    seed_file(files, f"{ROOT}/tree/sub/b.txt", b"bbb\n")
+    dbx = make_resource(files)
+    ram = RAMResource()
+    ws = Workspace(
+        {
+            "/dbx": (dbx, MountMode.WRITE),
+            "/m": (ram, MountMode.WRITE),
+        }, )
+    return ws, files, ram
+
+
+def test_cp_recursive_databricks_to_ram():
+    ws, _files, ram = _ws_with_dbx_tree()
+    _out, _err, code = _run(ws, "cp -r /dbx/tree /m/copied")
+    assert code == 0
+    assert ram._store.files["/copied/a.txt"] == b"aaa\n"
+    assert ram._store.files["/copied/sub/b.txt"] == b"bbb\n"
+
+
+def test_cp_recursive_ram_to_databricks_creates_dirs():
+    ws, files, ram = _ws_with_dbx_tree()
+    ram._store.dirs.update({"/src", "/src/sub"})
+    ram._store.files["/src/x.txt"] = b"xxx\n"
+    ram._store.files["/src/sub/y.txt"] = b"yyy\n"
+    _out, _err, code = _run(ws, "cp -r /m/src /dbx/put")
+    assert code == 0
+    assert files.downloads[f"{ROOT}/put/x.txt"] == b"xxx\n"
+    assert files.downloads[f"{ROOT}/put/sub/y.txt"] == b"yyy\n"
+    assert f"{ROOT}/put/sub" in files.directory_metadata
+
+
+def test_mv_recursive_databricks_to_ram_removes_source():
+    ws, files, ram = _ws_with_dbx_tree()
+    _out, _err, code = _run(ws, "mv /dbx/tree /m/moved")
+    assert code == 0
+    assert ram._store.files["/moved/a.txt"] == b"aaa\n"
+    assert ram._store.files["/moved/sub/b.txt"] == b"bbb\n"
+    assert f"{ROOT}/tree/a.txt" not in files.downloads
+    assert f"{ROOT}/tree" not in files.directory_metadata
+
+
+def test_single_file_missing_parent_is_posix_error():
+    # Option B / POSIX: a single-file copy never creates the destination's
+    # parent directory; it errors like coreutils instead of mkdir -p.
+    ws, _files, ram = _ws_with_dbx_tree()
+    ram._store.files["/lone.txt"] = b"z\n"
+    _out, _err, code = _run(ws, "cp /m/lone.txt /dbx/nope/deep/lone.txt")
+    assert code == 1

--- a/python/tests/integration/test_cross_mount_matrix.py
+++ b/python/tests/integration/test_cross_mount_matrix.py
@@ -341,3 +341,37 @@ def test_mv_cross(cross):
         assert code != 0, (
             f"mv with read-only end ({cross.src_type}->{cross.dst_type}) "
             "should have failed")
+
+
+def test_cp_recursive_cross(cross):
+    if cross.src_type == "gdrive":
+        pytest.skip("gdrive recursive-source listing tracked as a follow-up")
+    cross.create_file(1, "tree/a.txt", b"aaa\n")
+    cross.create_file(1, "tree/sub/b.txt", b"bbb\n")
+    code = cross.exit("cp -r /m1/tree /m2/copied")
+    if _supports_write(cross.dst_type):
+        assert code == 0, (
+            f"cp -r failed for {cross.src_type}->{cross.dst_type}")
+        assert cross.run("cat /m2/copied/a.txt") == "aaa\n"
+        assert cross.run("cat /m2/copied/sub/b.txt") == "bbb\n"
+    else:
+        assert code != 0, (
+            f"cp -r into read-only {cross.dst_type} should have failed")
+
+
+def test_mv_recursive_cross(cross):
+    if cross.src_type == "gdrive":
+        pytest.skip("gdrive recursive-source listing tracked as a follow-up")
+    cross.create_file(1, "tree/a.txt", b"aaa\n")
+    cross.create_file(1, "tree/sub/b.txt", b"bbb\n")
+    code = cross.exit("mv /m1/tree /m2/moved")
+    if _supports_write(cross.dst_type) and _supports_delete(cross.src_type):
+        assert code == 0, (
+            f"mv -r failed for {cross.src_type}->{cross.dst_type}")
+        assert cross.run("cat /m2/moved/a.txt") == "aaa\n"
+        assert cross.run("cat /m2/moved/sub/b.txt") == "bbb\n"
+        assert cross.exit("cat /m1/tree/a.txt") != 0
+    else:
+        assert code != 0, (
+            f"mv -r with read-only end ({cross.src_type}->{cross.dst_type}) "
+            "should have failed")

--- a/python/tests/workspace/test_cross_mount_recursive.py
+++ b/python/tests/workspace/test_cross_mount_recursive.py
@@ -1,0 +1,93 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+from mirage.resource.ram import RAMResource
+from mirage.types import MountMode
+from mirage.workspace import Workspace
+
+
+def _make_ws():
+    src = RAMResource()
+    dst = RAMResource()
+    src._store.dirs.update({"/dir", "/dir/sub", "/dir/empty"})
+    src._store.files["/dir/a.txt"] = b"aaa\n"
+    src._store.files["/dir/sub/b.txt"] = b"bbb\n"
+    ws = Workspace(
+        {
+            "/a": (src, MountMode.WRITE),
+            "/b": (dst, MountMode.WRITE),
+        }, )
+    return ws, src, dst
+
+
+def _run(ws, cmd):
+
+    async def _inner():
+        io = await ws.execute(cmd)
+        return await io.stdout_str(), await io.stderr_str(), io.exit_code
+
+    return asyncio.run(_inner())
+
+
+def test_cp_recursive_copies_tree():
+    ws, _src, dst = _make_ws()
+    _out, _err, code = _run(ws, "cp -r /a/dir /b/copied")
+    assert code == 0
+    assert dst._store.files["/copied/a.txt"] == b"aaa\n"
+    assert dst._store.files["/copied/sub/b.txt"] == b"bbb\n"
+    assert "/copied/sub" in dst._store.dirs
+    assert "/copied/empty" in dst._store.dirs
+
+
+def test_cp_recursive_into_existing_dir():
+    ws, _src, dst = _make_ws()
+    dst._store.dirs.add("/into")
+    _out, _err, code = _run(ws, "cp -r /a/dir /b/into")
+    assert code == 0
+    assert dst._store.files["/into/dir/a.txt"] == b"aaa\n"
+    assert dst._store.files["/into/dir/sub/b.txt"] == b"bbb\n"
+
+
+def test_cp_directory_without_recursive_fails():
+    ws, _src, dst = _make_ws()
+    _out, err, code = _run(ws, "cp /a/dir /b/copied")
+    assert code == 1
+    assert "omitting directory" in err
+    assert "/copied" not in dst._store.dirs
+    assert not any(k.startswith("/copied") for k in dst._store.files)
+
+
+def test_mv_recursive_moves_tree_and_removes_source():
+    ws, src, dst = _make_ws()
+    _out, _err, code = _run(ws, "mv /a/dir /b/moved")
+    assert code == 0
+    assert dst._store.files["/moved/a.txt"] == b"aaa\n"
+    assert dst._store.files["/moved/sub/b.txt"] == b"bbb\n"
+    assert "/dir" not in src._store.dirs
+    assert "/dir/a.txt" not in src._store.files
+    assert "/dir/sub/b.txt" not in src._store.files
+
+
+def test_cp_recursive_no_clobber_skips_existing():
+    # /b/into exists, so `cp -r /a/dir /b/into` maps to /b/into/dir. Pre-seed
+    # that mapped tree with an existing a.txt so -n must skip it.
+    ws, _src, dst = _make_ws()
+    dst._store.dirs.update({"/into", "/into/dir"})
+    dst._store.files["/into/dir/a.txt"] = b"keep\n"
+    _out, _err, code = _run(ws, "cp -rn /a/dir /b/into")
+    assert code == 0
+    assert dst._store.files["/into/dir/a.txt"] == b"keep\n"
+    assert dst._store.files["/into/dir/sub/b.txt"] == b"bbb\n"


### PR DESCRIPTION
Closes the re-scoped parts of #130 (claim 3 was already fixed by #201).

## Problem

Cross-mount `cp`/`mv` (operands spanning two mounts) handled **only single files**: `_cross_cp`/`_cross_mv` honored only `-n`, dropped `-r`, and read each source as one file. So `cp -r /disk/dir /dbx/` failed (read on a directory) and directory `mv` was unsupported. This affected every mount pair, and became more visible once #116 added within-mount recursive cp/mv/rm for databricks.

## Changes

- **Recursive walk (executor)** — `cp -r` and directory `mv` now walk the source tree, create destination directories top-down, and copy per file. Directory `mv` then removes the source tree via a universal `readdir`+`unlink`+`rmdir` walk (`rm_recursive` is only registered on some backends).
- **POSIX semantics (issue option B)** —
  - `cp` without `-r` omits directories with the coreutils message (`cp: -r not specified; omitting directory '…'`) and still copies file args.
  - A single-file write into a **missing parent** stays strict (`FileNotFoundError`), matching coreutils — **not** `mkdir -p`. Recursive copy creates the destination subtree it mirrors, which is what coreutils `cp -r` does.
  - (Deliberately did not change `disk`/`databricks` `write` semantics. `disk` auto-creates parents on write, which is non-POSIX; reconciling that is noted below as a follow-up, not done here.)
- **Claim 4 (cosmetic)** — add `databricks_volume` to the `RESOURCES` list in `commands/builtin/cross_mount.py`. Note: that module's `CROSS_COMMANDS` is never registered — it's shadowed by the executor's `handle_cross_mount` — so this is purely for list consistency; full removal of the dead module is a separate cleanup.

## Tests

- `tests/workspace/test_cross_mount_recursive.py` (RAM↔RAM): `cp -r`, copy-into-existing-dir, `cp` without `-r` omits + writes nothing, directory `mv` removes source, `cp -rn` no-clobber.
- `tests/commands/builtin/databricks_volume/test_cross_mount.py` (databricks↔RAM): `cp -r` both directions (ram→databricks exercises databricks `mkdir` during the walk), directory `mv` removes the databricks source, and the POSIX single-file missing-parent error.
- `tests/integration/test_cross_mount_matrix.py`: recursive `cp`/`mv` added across the ram/disk/s3/gdrive matrix.

## Known follow-ups (out of scope)

- **gdrive recursive-source** listing returns nested children only after an `ls`-primed index; the recursive matrix tests skip gdrive-as-source. Tracked for a separate fix.
- **disk non-POSIX parent auto-create** (`core/disk/write.py`) diverges from coreutils; making it strict is a separate change.
- Cache invalidation for `mkdir` on indexed remote dests during the walk relies on per-file write invalidation; empty-dir-only cases may want explicit invalidation.