### PR TITLE
fix(databricks_volume): reject recursive cp/mv into own subtree

### DIFF
--- a/python/mirage/commands/builtin/databricks_volume/_helpers.py
+++ b/python/mirage/commands/builtin/databricks_volume/_helpers.py
@@ -39,6 +39,13 @@ def same_backend_file(accessor: DatabricksVolumeAccessor, a: PathSpec,
     return backend_path(accessor.config, a) == backend_path(accessor.config, b)
 
 
+def target_within_source(accessor: DatabricksVolumeAccessor, src: PathSpec,
+                         dst: PathSpec) -> bool:
+    src_key = backend_path(accessor.config, src)
+    dst_key = backend_path(accessor.config, dst)
+    return dst_key.startswith(src_key + "/")
+
+
 def read_bytes_with_index(index: IndexCacheStore | None,
                           prefix: str = "") -> Callable:
     return partial(call_read_bytes, _read_bytes, index=index, prefix=prefix)

--- a/python/mirage/commands/builtin/databricks_volume/cp.py
+++ b/python/mirage/commands/builtin/databricks_volume/cp.py
@@ -16,8 +16,8 @@ from functools import partial
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.databricks_volume._helpers import \
-    same_backend_file
+from mirage.commands.builtin.databricks_volume._helpers import (
+    same_backend_file, target_within_source)
 from mirage.commands.builtin.utils.copy import (copy_targets, is_directory,
                                                 path_exists)
 from mirage.commands.registry import command
@@ -55,9 +55,17 @@ async def cp(
     lines: list[str] = []
     errors: list[str] = []
     for src, target in copy_targets(sources, dst, dst_is_dir):
+        if not await path_exists(stat, src):
+            errors.append(f"cp: cannot stat '{src.original}': "
+                          "No such file or directory")
+            continue
         if same_backend_file(accessor, src, target):
             errors.append(f"cp: '{src.original}' and '{target.original}' "
                           "are the same file")
+            continue
+        if recursive and target_within_source(accessor, src, target):
+            errors.append(f"cp: cannot copy a directory, '{src.original}', "
+                          f"into itself, '{target.original}'")
             continue
         if n and await path_exists(stat, target):
             continue

--- a/python/mirage/commands/builtin/databricks_volume/mv.py
+++ b/python/mirage/commands/builtin/databricks_volume/mv.py
@@ -16,8 +16,8 @@ from functools import partial
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.databricks_volume._helpers import \
-    same_backend_file
+from mirage.commands.builtin.databricks_volume._helpers import (
+    same_backend_file, target_within_source)
 from mirage.commands.builtin.utils.copy import (copy_targets, is_directory,
                                                 path_exists)
 from mirage.commands.registry import command
@@ -51,9 +51,17 @@ async def mv(
     lines: list[str] = []
     errors: list[str] = []
     for src, target in copy_targets(sources, dst, dst_is_dir):
+        if not await path_exists(stat, src):
+            errors.append(f"mv: cannot stat '{src.original}': "
+                          "No such file or directory")
+            continue
         if same_backend_file(accessor, src, target):
             errors.append(f"mv: '{src.original}' and '{target.original}' "
                           "are the same file")
+            continue
+        if target_within_source(accessor, src, target):
+            errors.append(f"mv: cannot move '{src.original}' to a "
+                          f"subdirectory of itself, '{target.original}'")
             continue
         if n and await path_exists(stat, target):
             continue

--- a/python/mirage/core/databricks_volume/copy.py
+++ b/python/mirage/core/databricks_volume/copy.py
@@ -95,6 +95,12 @@ async def copy(
             return
         remote_src = backend_path(accessor.config, src)
         remote_dst = backend_path(accessor.config, dst)
+        if remote_dst.startswith(remote_src + "/"):
+            # Copying a directory into its own subtree creates the destination
+            # inside the source, so the walk would descend into the fresh copy
+            # forever. Refuse before any create_directory/upload.
+            raise ValueError(f"cannot copy a directory, '{src.strip_prefix}', "
+                             f"into itself, '{dst.strip_prefix}'")
         await asyncio.to_thread(_copy_tree_sync, accessor, remote_src,
                                 remote_dst)
         return

--- a/python/mirage/core/databricks_volume/rename.py
+++ b/python/mirage/core/databricks_volume/rename.py
@@ -34,13 +34,21 @@ async def rename(
     src = ensure_path_spec(src)
     dst = ensure_path_spec(dst)
     src_stat = await stat(accessor, src, index)
-    if backend_path(accessor.config,
-                    src) == backend_path(accessor.config, dst):
+    remote_src = backend_path(accessor.config, src)
+    remote_dst = backend_path(accessor.config, dst)
+    if remote_src == remote_dst:
         # rename(2) onto the same path is a no-op; copy + unlink here would
         # upload the file onto itself then delete it, destroying the data.
         # Guard runs after stat so a missing source still raises.
         return
     if src_stat.type == FileType.DIRECTORY:
+        if remote_dst.startswith(remote_src + "/"):
+            # Moving a directory into its own subtree would run away in the
+            # recursive copy and then rm_recursive would delete the original.
+            # Refuse before either side effect.
+            raise ValueError(
+                f"cannot move '{src.strip_prefix}' to a subdirectory of "
+                f"itself, '{dst.strip_prefix}'")
         await copy(accessor, src, dst, index, recursive=True)
         await rm_recursive(accessor, src, index)
     else:

--- a/python/tests/commands/builtin/databricks_volume/test_cp.py
+++ b/python/tests/commands/builtin/databricks_volume/test_cp.py
@@ -98,3 +98,26 @@ async def test_cp_multiple_sources_require_directory(write_ws, dbx_files):
     assert dbx_files.downloads[f"{ROOT}/a.txt"] == b"AAA"
     assert dbx_files.downloads[f"{ROOT}/b.txt"] == b"BBB"
     assert dbx_files.downloads[f"{ROOT}/target.txt"] == b"target"
+
+
+@pytest.mark.asyncio
+async def test_cp_missing_source_reports_cannot_stat(write_ws, dbx_files):
+    io = await write_ws.execute("cp /dbx/missing /dbx/missing")
+
+    assert io.exit_code != 0
+    assert b"cannot stat" in io.stderr
+    assert b"are the same file" not in io.stderr
+
+
+@pytest.mark.asyncio
+async def test_cp_recursive_into_itself_errors_and_preserves_tree(
+        write_ws, dbx_files):
+    seed_directory(dbx_files, f"{ROOT}/d")
+    seed_file(dbx_files, f"{ROOT}/d/a.txt", b"aaa")
+
+    io = await write_ws.execute("cp -r /dbx/d /dbx/d")
+
+    assert io.exit_code != 0
+    assert b"into itself" in io.stderr
+    assert dbx_files.downloads[f"{ROOT}/d/a.txt"] == b"aaa"
+    assert f"{ROOT}/d/d" not in dbx_files.directory_metadata

--- a/python/tests/commands/builtin/databricks_volume/test_mv.py
+++ b/python/tests/commands/builtin/databricks_volume/test_mv.py
@@ -131,3 +131,26 @@ async def test_mv_multiple_sources_require_directory(write_ws, dbx_files):
     assert dbx_files.downloads[f"{ROOT}/target.txt"] == b"target"
     assert f"{ROOT}/a.txt" not in dbx_files.delete_calls
     assert f"{ROOT}/b.txt" not in dbx_files.delete_calls
+
+
+@pytest.mark.asyncio
+async def test_mv_missing_source_reports_cannot_stat(write_ws, dbx_files):
+    io = await write_ws.execute("mv /dbx/missing /dbx/missing")
+
+    assert io.exit_code != 0
+    assert b"cannot stat" in io.stderr
+    assert b"are the same file" not in io.stderr
+
+
+@pytest.mark.asyncio
+async def test_mv_into_itself_errors_and_preserves_source(write_ws, dbx_files):
+    seed_directory(dbx_files, f"{ROOT}/d")
+    seed_file(dbx_files, f"{ROOT}/d/a.txt", b"aaa")
+
+    io = await write_ws.execute("mv /dbx/d /dbx/d")
+
+    assert io.exit_code != 0
+    assert b"subdirectory of itself" in io.stderr
+    assert dbx_files.downloads[f"{ROOT}/d/a.txt"] == b"aaa"
+    assert f"{ROOT}/d" in dbx_files.directory_metadata
+    assert f"{ROOT}/d/a.txt" not in dbx_files.delete_calls

--- a/python/tests/core/databricks_volume/test_copy.py
+++ b/python/tests/core/databricks_volume/test_copy.py
@@ -126,3 +126,22 @@ async def test_copy_recursive_tree(accessor, files, remote_root, index):
 
     assert f"{remote_root}/d2" in files.directory_metadata
     assert files.downloads[f"{remote_root}/d2/a.txt"] == b"aaa"
+
+
+@pytest.mark.asyncio
+async def test_copy_recursive_into_own_subtree_fails(accessor, files,
+                                                     remote_root, index):
+    _seed_directory(files, remote_root)
+    _seed_directory(files, f"{remote_root}/d")
+    _seed_file(files, f"{remote_root}/d/a.txt", b"aaa")
+
+    with pytest.raises(ValueError):
+        await copy(accessor,
+                   _path("/dbx/d"),
+                   _path("/dbx/d/d"),
+                   index,
+                   recursive=True)
+
+    assert files.create_directory_calls == []
+    assert files.upload_calls == []
+    assert files.downloads[f"{remote_root}/d/a.txt"] == b"aaa"

--- a/python/tests/core/databricks_volume/test_rename.py
+++ b/python/tests/core/databricks_volume/test_rename.py
@@ -95,3 +95,21 @@ async def test_rename_directory_moves_tree(accessor, files, remote_root,
 
     assert files.downloads[f"{remote_root}/d2/a.txt"] == b"aaa"
     assert f"{remote_root}/d" not in files.directory_metadata
+
+
+@pytest.mark.asyncio
+async def test_rename_into_own_subtree_fails(accessor, files, remote_root,
+                                             index):
+    _seed_directory(files, remote_root)
+    _seed_directory(files, f"{remote_root}/d")
+    _seed_file(files, f"{remote_root}/d/a.txt", b"aaa")
+
+    with pytest.raises(ValueError):
+        await rename(accessor, _path("/dbx/d"), _path("/dbx/d/d"), index)
+
+    assert files.downloads[f"{remote_root}/d/a.txt"] == b"aaa"
+    assert f"{remote_root}/d" in files.directory_metadata
+    assert files.create_directory_calls == []
+    assert files.upload_calls == []
+    assert files.delete_calls == []
+    assert files.delete_directory_calls == []

--- a/typescript/packages/core/src/core/databricks_volume/copy.ts
+++ b/typescript/packages/core/src/core/databricks_volume/copy.ts
@@ -80,7 +80,17 @@ export async function copy(
   if (srcStat.type === FileType.DIRECTORY) {
     if (!recursive) throw isADirectoryError(s.stripPrefix)
     if (samePath) return
-    await copyTree(accessor, backendPath(accessor.config, s), backendPath(accessor.config, d))
+    const remoteSrc = backendPath(accessor.config, s)
+    const remoteDst = backendPath(accessor.config, d)
+    if (remoteDst.startsWith(remoteSrc + '/')) {
+      // Copying a directory into its own subtree creates the destination
+      // inside the source, so the walk would descend into the fresh copy
+      // forever. Refuse before any create_directory/upload.
+      throw new Error(
+        `cannot copy a directory, '${s.stripPrefix}', into itself, '${d.stripPrefix}'`,
+      )
+    }
+    await copyTree(accessor, remoteSrc, remoteDst)
     return
   }
   if (samePath) {

--- a/typescript/packages/core/src/core/databricks_volume/copy_rename.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/copy_rename.test.ts
@@ -98,6 +98,23 @@ describe('copy', () => {
     )
     expect(puts.some((c) => c.url.includes('dir2/a.txt'))).toBe(true)
   })
+
+  it('refuses copying a directory into its own subtree before any write', async () => {
+    const { fetch, calls } = routedFetch((call) => {
+      if (call.method === 'HEAD' && call.url.includes('/fs/files/')) return notFoundResponse()
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const err = (await copy(
+      makeAccessor(),
+      spec('/volume/dir'),
+      spec('/volume/dir/sub'),
+      undefined,
+      true,
+    ).catch((e: unknown) => e)) as Error
+    expect(err.message).toContain('into itself')
+    expect(calls.filter((c) => c.method === 'PUT')).toHaveLength(0)
+  })
 })
 
 describe('rename', () => {
@@ -130,6 +147,20 @@ describe('rename', () => {
       spec('/volume/gone.txt'),
     ).catch((e: unknown) => e)) as Error & { code?: string }
     expect(err.code).toBe('ENOENT')
+  })
+
+  it('refuses moving a directory into its own subtree and never deletes', async () => {
+    const { fetch, calls } = routedFetch((call) => {
+      if (call.method === 'HEAD' && call.url.includes('/fs/files/')) return notFoundResponse()
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const err = (await rename(makeAccessor(), spec('/volume/dir'), spec('/volume/dir/sub')).catch(
+      (e: unknown) => e,
+    )) as Error
+    expect(err.message).toContain('subdirectory of itself')
+    expect(calls.filter((c) => c.method === 'PUT')).toHaveLength(0)
+    expect(calls.filter((c) => c.method === 'DELETE')).toHaveLength(0)
   })
 })
 

--- a/typescript/packages/core/src/core/databricks_volume/rename.ts
+++ b/typescript/packages/core/src/core/databricks_volume/rename.ts
@@ -33,13 +33,23 @@ export async function rename(
   const s = ensurePathSpec(src)
   const d = ensurePathSpec(dst)
   const srcStat = await stat(accessor, s, index)
-  if (backendPath(accessor.config, s) === backendPath(accessor.config, d)) {
+  const remoteSrc = backendPath(accessor.config, s)
+  const remoteDst = backendPath(accessor.config, d)
+  if (remoteSrc === remoteDst) {
     // rename(2) onto the same path is a no-op; copy + unlink here would
     // upload the file onto itself then delete it, destroying the data.
     // Guard runs after stat so a missing source still raises.
     return
   }
   if (srcStat.type === FileType.DIRECTORY) {
+    if (remoteDst.startsWith(remoteSrc + '/')) {
+      // Moving a directory into its own subtree would run away in the
+      // recursive copy and then rmRecursive would delete the original.
+      // Refuse before either side effect.
+      throw new Error(
+        `cannot move '${s.stripPrefix}' to a subdirectory of itself, '${d.stripPrefix}'`,
+      )
+    }
     await copy(accessor, s, d, index, true)
     await rmRecursive(accessor, s, index)
   } else {


### PR DESCRIPTION
Closes #141.

## Problem

A recursive `cp`/`mv` of a directory into its own subtree bypassed the exact-key same-path guard. `cp -r /dbx/d /dbx/d` resolves the directory target to the child `/dbx/d/d`, so `same_backend_file('/dbx/d', '/dbx/d/d')` is false and nothing fired. `_copy_tree_sync` creates `remote_dst` **before** listing `remote_src`, so the freshly-created child appears in the source listing and the walk descends into it forever — `RecursionError` against the mocked Files API, unbounded `create_directory` + uploads against real Databricks.

`mv` was worse: `rename` runs `copy(recursive=True)` then `rm_recursive(src)`, so after the runaway copy it recursively **deletes the source** — data loss.

## Fix

**Core (authoritative — covers `cp`, `mv`, and `ops.rename`, which all reach core directly):**
- `core/databricks_volume/copy.py` and `rename.py` refuse the recursive/dir branch **before any write** when the destination key is nested under the source key (`dst == src` or `dst.startswith(src + "/")`). `rename` checks before the copy+delete, so the source is untouched.

**Commands:**
- `cp.py` / `mv.py` render the coreutils messages:
  - `cp: cannot copy a directory, '<src>', into itself, '<dst>'`
  - `mv: cannot move '<src>' to a subdirectory of itself, '<dst>'`
- The same-path guard now runs **after** the source-existence check, so `cp missing missing` reports `cannot stat '<src>': No such file or directory` instead of `are the same file` (folds in the #152 ordering nit).

Sibling/outside recursive copies still work; prefix-siblings (`d` → `dd`) are not falsely flagged (the trailing `/` in the guard prevents that).

**TypeScript parity:** mirrored the core guards in `typescript/.../databricks_volume/copy.ts` and `rename.ts` (same data-loss path: `rename` → recursive `copy` → `rmRecursive`).

## Tests

- Core (py): `cp -r d d/…` and `mv d d/…` raise with zero `create_directory`/`upload`/`delete`; source intact for `mv`.
- Commands (py): into-itself messages for `cp -r`/`mv`, plus `cp/mv missing missing` → `cannot stat`.
- TS: equivalent core tests asserting no `PUT`/`DELETE` before the guard.

Python: 135 databricks_volume tests pass. TS: 12 `copy_rename` tests pass.

## Out of scope (tracked for #187)

The shared **generic** `cp` handler (`generic/cp.{py,ts}`, used by disk/s3/nextcloud) snapshots `find()` into a list before copying, so `cp -r d d` there yields a *bounded* spurious nested copy rather than a runaway — a milder coreutils divergence. The TS databricks `cp` command also routes through this generic handler (unlike Python's bespoke `cp.py`). A shared `target_within_source` guard in the generic handler would close these in both languages; that belongs to the cross-backend Fsafe umbrella (#187), per this issue's open question.