### PR TITLE
refactor: delegate Python jq to generic for six SaaS backends

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -108,6 +108,7 @@ CASES: list[tuple[str, str]] = [
     ("jq_jsonl_id", 'jq ".id" /data/data.jsonl'),
     ("jq_jsonl_chain", 'jq ".[].id" /data/data.jsonl'),
     ("jq_jsonl_chain_raw", 'jq -r ".[].msg" /data/chat.jsonl'),
+    ("jq_no_filter_piped", "cat /data/user.json | jq"),
 
     # ----- sort / uniq / shuffle -----
     ("sort", "sort /data/a.txt"),
@@ -477,6 +478,8 @@ CASES: list[tuple[str, str]] = [
 ]
 
 EXIT_CODE_CASES: list[tuple[str, str]] = [
+    ("jq_no_filter_no_input", "jq"),
+    ("jq_dot_no_input", 'jq "."'),
     ("lazy_exit_grep_match", "grep hello /data/a.txt"),
     ("lazy_exit_grep_no_match", "grep zzz /data/a.txt"),
     ("cp_reject_multi_nondir", "cp /data/a.txt /data/b.txt /data/c.txt"),

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -79,6 +79,7 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
   ["jq_jsonl_id", 'jq ".id" /data/data.jsonl'],
   ["jq_jsonl_chain", 'jq ".[].id" /data/data.jsonl'],
   ["jq_jsonl_chain_raw", 'jq -r ".[].msg" /data/chat.jsonl'],
+  ["jq_no_filter_piped", 'cat /data/user.json | jq'],
 
   ["sort", "sort /data/a.txt"],
   ["sort_r", "sort -r /data/a.txt"],
@@ -411,6 +412,8 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
 ];
 
 export const EXIT_CODE_CASES: ReadonlyArray<readonly [string, string]> = [
+  ["jq_no_filter_no_input", "jq"],
+  ["jq_dot_no_input", 'jq "."'],
   ["lazy_exit_grep_match", "grep hello /data/a.txt"],
   ["lazy_exit_grep_no_match", "grep zzz /data/a.txt"],
   ["cp_reject_multi_nondir", "cp /data/a.txt /data/b.txt /data/c.txt"],

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -100,6 +100,11 @@ alice
 === jq_jsonl_chain_raw ===
 hello
 world
+=== jq_no_filter_piped ===
+{
+  "name": "alice",
+  "age": 30
+}
 === sort ===
 bar
 baz
@@ -1263,6 +1268,10 @@ world
 gz-data
 === arch_mktemp ===
 1
+=== jq_no_filter_no_input ===
+exit=0
+=== jq_dot_no_input ===
+exit=0
 === lazy_exit_grep_match ===
 exit=0
 hello

--- a/python/mirage/commands/builtin/discord/jq.py
+++ b/python/mirage/commands/builtin/discord/jq.py
@@ -13,15 +13,16 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
+from functools import partial
 
 from mirage.accessor.discord import DiscordAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.jq import jq as generic_jq
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.discord.glob import resolve_glob
 from mirage.core.discord.read import read as discord_read
-from mirage.core.jq import (format_jq_output, jq_eval, parse_json_auto,
-                            parse_json_path)
+from mirage.core.discord.stream import read_stream
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -38,35 +39,14 @@ async def jq(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if not texts:
-        raise ValueError("jq: usage: jq EXPRESSION [path]")
-    expression = texts[0]
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        outputs: list[bytes] = []
-        for p in paths:
-            raw = await discord_read(accessor, p, index)
-            data = parse_json_path(raw, p.original)
-            if s:
-                data = [data] if not isinstance(data, list) else data
-            result = jq_eval(data, expression.strip())
-            spread = "[]" in expression
-            outputs.append(format_jq_output(result, r, c, spread))
-        return b"".join(outputs), IOResult()
-    if stdin is not None:
-        if isinstance(stdin, bytes):
-            raw_bytes = stdin
-        else:
-            raw_bytes = b""
-            async for chunk in stdin:
-                raw_bytes += chunk
-        if s:
-            data = parse_json_auto(raw_bytes)
-            if not isinstance(data, list):
-                data = [data]
-        else:
-            data = parse_json_auto(raw_bytes)
-        result = jq_eval(data, expression.strip())
-        spread = "[]" in expression
-        return format_jq_output(result, r, c, spread), IOResult()
-    raise ValueError("jq: missing input")
+    return await generic_jq(paths,
+                            *texts,
+                            read_bytes=partial(discord_read, index=index),
+                            read_stream=partial(read_stream, index=index),
+                            accessor=accessor,
+                            stdin=stdin,
+                            r=r,
+                            c=c,
+                            s=s)

--- a/python/mirage/commands/builtin/email/jq.py
+++ b/python/mirage/commands/builtin/email/jq.py
@@ -13,15 +13,16 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
+from functools import partial
 
 from mirage.accessor.email import EmailAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.jq import jq as generic_jq
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.email.glob import resolve_glob
 from mirage.core.email.read import read as email_read
-from mirage.core.jq import (format_jq_output, jq_eval, parse_json_auto,
-                            parse_json_path)
+from mirage.core.email.stream import read_stream
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -38,35 +39,14 @@ async def jq(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if not texts:
-        raise ValueError("jq: usage: jq EXPRESSION [path]")
-    expression = texts[0]
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        outputs: list[bytes] = []
-        for p in paths:
-            raw = await email_read(accessor, p, index)
-            data = parse_json_path(raw, p.original)
-            if s:
-                data = [data] if not isinstance(data, list) else data
-            result = jq_eval(data, expression.strip())
-            spread = "[]" in expression
-            outputs.append(format_jq_output(result, r, c, spread))
-        return b"".join(outputs), IOResult()
-    if stdin is not None:
-        if isinstance(stdin, bytes):
-            raw_bytes = stdin
-        else:
-            raw_bytes = b""
-            async for chunk in stdin:
-                raw_bytes += chunk
-        if s:
-            data = parse_json_auto(raw_bytes)
-            if not isinstance(data, list):
-                data = [data]
-        else:
-            data = parse_json_auto(raw_bytes)
-        result = jq_eval(data, expression.strip())
-        spread = "[]" in expression
-        return format_jq_output(result, r, c, spread), IOResult()
-    raise ValueError("jq: missing input")
+    return await generic_jq(paths,
+                            *texts,
+                            read_bytes=partial(email_read, index=index),
+                            read_stream=partial(read_stream, index=index),
+                            accessor=accessor,
+                            stdin=stdin,
+                            r=r,
+                            c=c,
+                            s=s)

--- a/python/mirage/commands/builtin/generic/jq.py
+++ b/python/mirage/commands/builtin/generic/jq.py
@@ -29,6 +29,8 @@ async def jq(
     s: bool = False,
 ) -> tuple[ByteSource | None, IOResult]:
     if not texts:
+        # Deliberate divergence: piped GNU jq defaults the filter to "." and
+        # only prints usage (exit 2) on a tty; agents get a concise error.
         raise ValueError("jq: usage: jq EXPRESSION [path]")
     expression = texts[0]
     spread = "[]" in expression
@@ -51,7 +53,8 @@ async def jq(
             outputs.append(format_jq_output(result, r, c, spread))
         return b"".join(outputs), IOResult()
     if stdin is None:
-        raise ValueError("jq: missing input")
+        # GNU jq: empty input -> no output, exit 0 (jq . </dev/null)
+        return None, IOResult()
     raw_bytes = await _read_stdin_bytes(stdin)
     data = parse_json_auto(raw_bytes)
     if s and not isinstance(data, list):

--- a/python/mirage/commands/builtin/generic/jq.py
+++ b/python/mirage/commands/builtin/generic/jq.py
@@ -28,11 +28,8 @@ async def jq(
     c: bool = False,
     s: bool = False,
 ) -> tuple[ByteSource | None, IOResult]:
-    if not texts:
-        # Deliberate divergence: piped GNU jq defaults the filter to "." and
-        # only prints usage (exit 2) on a tty; agents get a concise error.
-        raise ValueError("jq: usage: jq EXPRESSION [path]")
-    expression = texts[0]
+    # GNU jq defaults the filter to "." when no expression is given
+    expression = texts[0] if texts else "."
     spread = "[]" in expression
     if paths:
         if is_jsonl_path(

--- a/python/mirage/commands/builtin/langfuse/jq.py
+++ b/python/mirage/commands/builtin/langfuse/jq.py
@@ -13,15 +13,16 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
+from functools import partial
 
 from mirage.accessor.langfuse import LangfuseAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.jq import jq as generic_jq
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
-from mirage.core.jq import (format_jq_output, jq_eval, parse_json_auto,
-                            parse_json_path)
 from mirage.core.langfuse.glob import resolve_glob
 from mirage.core.langfuse.read import read as langfuse_read
+from mirage.core.langfuse.stream import read_stream
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -38,35 +39,14 @@ async def jq(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if not texts:
-        raise ValueError("jq: usage: jq EXPRESSION [path]")
-    expression = texts[0]
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        outputs: list[bytes] = []
-        for p in paths:
-            raw = await langfuse_read(accessor, p, index)
-            data = parse_json_path(raw, p.original)
-            if s:
-                data = [data] if not isinstance(data, list) else data
-            result = jq_eval(data, expression.strip())
-            spread = "[]" in expression
-            outputs.append(format_jq_output(result, r, c, spread))
-        return b"".join(outputs), IOResult()
-    if stdin is not None:
-        if isinstance(stdin, bytes):
-            raw_bytes = stdin
-        else:
-            raw_bytes = b""
-            async for chunk in stdin:
-                raw_bytes += chunk
-        if s:
-            data = parse_json_auto(raw_bytes)
-            if not isinstance(data, list):
-                data = [data]
-        else:
-            data = parse_json_auto(raw_bytes)
-        result = jq_eval(data, expression.strip())
-        spread = "[]" in expression
-        return format_jq_output(result, r, c, spread), IOResult()
-    raise ValueError("jq: missing input")
+    return await generic_jq(paths,
+                            *texts,
+                            read_bytes=partial(langfuse_read, index=index),
+                            read_stream=partial(read_stream, index=index),
+                            accessor=accessor,
+                            stdin=stdin,
+                            r=r,
+                            c=c,
+                            s=s)

--- a/python/mirage/commands/builtin/linear/jq.py
+++ b/python/mirage/commands/builtin/linear/jq.py
@@ -13,15 +13,16 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
+from functools import partial
 
 from mirage.accessor.linear import LinearAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.jq import jq as generic_jq
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
-from mirage.core.jq import (format_jq_output, jq_eval, parse_json_auto,
-                            parse_json_path)
 from mirage.core.linear.glob import resolve_glob
 from mirage.core.linear.read import read as linear_read
+from mirage.core.linear.stream import read_stream
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -38,32 +39,14 @@ async def jq(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if not texts:
-        raise ValueError("jq: usage: jq EXPRESSION [path]")
-    expression = texts[0]
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        outputs: list[bytes] = []
-        for p in paths:
-            raw = await linear_read(accessor, p, index)
-            data = parse_json_path(raw, p.original)
-            if s:
-                data = [data] if not isinstance(data, list) else data
-            result = jq_eval(data, expression.strip())
-            spread = "[]" in expression
-            outputs.append(format_jq_output(result, r, c, spread))
-        return b"".join(outputs), IOResult()
-    if stdin is not None:
-        if isinstance(stdin, bytes):
-            raw_bytes = stdin
-        else:
-            raw_bytes = b""
-            async for chunk in stdin:
-                raw_bytes += chunk
-        data = parse_json_auto(raw_bytes)
-        if s and not isinstance(data, list):
-            data = [data]
-        result = jq_eval(data, expression.strip())
-        spread = "[]" in expression
-        return format_jq_output(result, r, c, spread), IOResult()
-    raise ValueError("jq: missing input")
+    return await generic_jq(paths,
+                            *texts,
+                            read_bytes=partial(linear_read, index=index),
+                            read_stream=partial(read_stream, index=index),
+                            accessor=accessor,
+                            stdin=stdin,
+                            r=r,
+                            c=c,
+                            s=s)

--- a/python/mirage/commands/builtin/mongodb/jq.py
+++ b/python/mirage/commands/builtin/mongodb/jq.py
@@ -69,4 +69,4 @@ async def jq(
         result = jq_eval(data, expression.strip())
         spread = "[]" in expression
         return format_jq_output(result, r, c, spread), IOResult()
-    raise ValueError("jq: missing input")
+    return None, IOResult()

--- a/python/mirage/commands/builtin/mongodb/jq.py
+++ b/python/mirage/commands/builtin/mongodb/jq.py
@@ -38,9 +38,7 @@ async def jq(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if not texts:
-        raise ValueError("jq: usage: jq EXPRESSION [path]")
-    expression = texts[0]
+    expression = texts[0] if texts else "."
     if paths:
         paths = await resolve_glob(accessor, paths, index)
         outputs: list[bytes] = []

--- a/python/mirage/commands/builtin/postgres/jq.py
+++ b/python/mirage/commands/builtin/postgres/jq.py
@@ -69,4 +69,4 @@ async def jq(
         result = jq_eval(data, expression.strip())
         spread = "[]" in expression
         return format_jq_output(result, r, c, spread), IOResult()
-    raise ValueError("jq: missing input")
+    return None, IOResult()

--- a/python/mirage/commands/builtin/postgres/jq.py
+++ b/python/mirage/commands/builtin/postgres/jq.py
@@ -38,9 +38,7 @@ async def jq(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if not texts:
-        raise ValueError("jq: usage: jq EXPRESSION [path]")
-    expression = texts[0]
+    expression = texts[0] if texts else "."
     if paths:
         paths = await resolve_glob(accessor, paths, index)
         outputs: list[bytes] = []

--- a/python/mirage/commands/builtin/slack/jq.py
+++ b/python/mirage/commands/builtin/slack/jq.py
@@ -13,15 +13,16 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
+from functools import partial
 
 from mirage.accessor.slack import SlackAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.jq import jq as generic_jq
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
-from mirage.core.jq import (format_jq_output, jq_eval, parse_json_auto,
-                            parse_json_path)
 from mirage.core.slack.glob import resolve_glob
 from mirage.core.slack.read import read as slack_read
+from mirage.core.slack.stream import read_stream
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -38,35 +39,14 @@ async def jq(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if not texts:
-        raise ValueError("jq: usage: jq EXPRESSION [path]")
-    expression = texts[0]
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        outputs: list[bytes] = []
-        for p in paths:
-            raw = await slack_read(accessor, p, index)
-            data = parse_json_path(raw, p.original)
-            if s:
-                data = [data] if not isinstance(data, list) else data
-            result = jq_eval(data, expression.strip())
-            spread = "[]" in expression
-            outputs.append(format_jq_output(result, r, c, spread))
-        return b"".join(outputs), IOResult()
-    if stdin is not None:
-        if isinstance(stdin, bytes):
-            raw_bytes = stdin
-        else:
-            raw_bytes = b""
-            async for chunk in stdin:
-                raw_bytes += chunk
-        if s:
-            data = parse_json_auto(raw_bytes)
-            if not isinstance(data, list):
-                data = [data]
-        else:
-            data = parse_json_auto(raw_bytes)
-        result = jq_eval(data, expression.strip())
-        spread = "[]" in expression
-        return format_jq_output(result, r, c, spread), IOResult()
-    raise ValueError("jq: missing input")
+    return await generic_jq(paths,
+                            *texts,
+                            read_bytes=partial(slack_read, index=index),
+                            read_stream=partial(read_stream, index=index),
+                            accessor=accessor,
+                            stdin=stdin,
+                            r=r,
+                            c=c,
+                            s=s)

--- a/python/mirage/commands/builtin/trello/jq.py
+++ b/python/mirage/commands/builtin/trello/jq.py
@@ -13,15 +13,16 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
+from functools import partial
 
 from mirage.accessor.trello import TrelloAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.jq import jq as generic_jq
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
-from mirage.core.jq import (format_jq_output, jq_eval, parse_json_auto,
-                            parse_json_path)
 from mirage.core.trello.glob import resolve_glob
 from mirage.core.trello.read import read as trello_read
+from mirage.core.trello.stream import read_stream
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -38,32 +39,14 @@ async def jq(
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if not texts:
-        raise ValueError("jq: usage: jq EXPRESSION [path]")
-    expression = texts[0]
     if paths:
         paths = await resolve_glob(accessor, paths, index)
-        outputs: list[bytes] = []
-        for p in paths:
-            raw = await trello_read(accessor, p, index)
-            data = parse_json_path(raw, p.original)
-            if s:
-                data = [data] if not isinstance(data, list) else data
-            result = jq_eval(data, expression.strip())
-            spread = "[]" in expression
-            outputs.append(format_jq_output(result, r, c, spread))
-        return b"".join(outputs), IOResult()
-    if stdin is not None:
-        if isinstance(stdin, bytes):
-            raw_bytes = stdin
-        else:
-            raw_bytes = b""
-            async for chunk in stdin:
-                raw_bytes += chunk
-        data = parse_json_auto(raw_bytes)
-        if s and not isinstance(data, list):
-            data = [data]
-        result = jq_eval(data, expression.strip())
-        spread = "[]" in expression
-        return format_jq_output(result, r, c, spread), IOResult()
-    raise ValueError("jq: missing input")
+    return await generic_jq(paths,
+                            *texts,
+                            read_bytes=partial(trello_read, index=index),
+                            read_stream=partial(read_stream, index=index),
+                            accessor=accessor,
+                            stdin=stdin,
+                            r=r,
+                            c=c,
+                            s=s)

--- a/python/mirage/core/discord/stream.py
+++ b/python/mirage/core/discord/stream.py
@@ -1,0 +1,30 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.discord import DiscordAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.discord.read import read as discord_read
+from mirage.types import PathSpec
+
+
+async def read_stream(
+    accessor: DiscordAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> AsyncIterator[bytes]:
+    data = await discord_read(accessor, path, index)
+    if data:
+        yield data

--- a/python/mirage/core/email/stream.py
+++ b/python/mirage/core/email/stream.py
@@ -1,0 +1,30 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.email import EmailAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.email.read import read as email_read
+from mirage.types import PathSpec
+
+
+async def read_stream(
+    accessor: EmailAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> AsyncIterator[bytes]:
+    data = await email_read(accessor, path, index)
+    if data:
+        yield data

--- a/python/mirage/core/langfuse/stream.py
+++ b/python/mirage/core/langfuse/stream.py
@@ -1,0 +1,30 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.langfuse import LangfuseAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.langfuse.read import read as langfuse_read
+from mirage.types import PathSpec
+
+
+async def read_stream(
+    accessor: LangfuseAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> AsyncIterator[bytes]:
+    data = await langfuse_read(accessor, path, index)
+    if data:
+        yield data

--- a/python/mirage/core/linear/stream.py
+++ b/python/mirage/core/linear/stream.py
@@ -1,0 +1,30 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.linear import LinearAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.linear.read import read as linear_read
+from mirage.types import PathSpec
+
+
+async def read_stream(
+    accessor: LinearAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> AsyncIterator[bytes]:
+    data = await linear_read(accessor, path, index)
+    if data:
+        yield data

--- a/python/mirage/core/slack/stream.py
+++ b/python/mirage/core/slack/stream.py
@@ -1,0 +1,30 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.slack import SlackAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.slack.read import read as slack_read
+from mirage.types import PathSpec
+
+
+async def read_stream(
+    accessor: SlackAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> AsyncIterator[bytes]:
+    data = await slack_read(accessor, path, index)
+    if data:
+        yield data

--- a/python/mirage/core/trello/stream.py
+++ b/python/mirage/core/trello/stream.py
@@ -1,0 +1,30 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.trello import TrelloAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.trello.read import read as trello_read
+from mirage.types import PathSpec
+
+
+async def read_stream(
+    accessor: TrelloAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> AsyncIterator[bytes]:
+    data = await trello_read(accessor, path, index)
+    if data:
+        yield data

--- a/python/tests/commands/builtin/discord/test_read_commands.py
+++ b/python/tests/commands/builtin/discord/test_read_commands.py
@@ -59,6 +59,10 @@ def _run(coro):
     return asyncio.run(coro)
 
 
+async def _fake_jsonl_stream(accessor, path, index=None):
+    yield FAKE_JSONL
+
+
 def _make_index() -> RAMIndexCacheStore:
     index = RAMIndexCacheStore(ttl=600)
     _run(
@@ -293,9 +297,8 @@ async def test_jq(accessor):
             patch("mirage.commands.builtin.discord.jq.resolve_glob",
                   new_callable=AsyncMock,
                   return_value=_glob_result(ABS_FILE)),
-            patch("mirage.commands.builtin.discord.jq.discord_read",
-                  new_callable=AsyncMock,
-                  return_value=FAKE_JSONL),
+            patch("mirage.commands.builtin.discord.jq.read_stream",
+                  new=_fake_jsonl_stream),
     ):
         stream, io = await jq(accessor, _make_glob(ABS_FILE), ".[].content")
     data = await _collect(stream)
@@ -308,9 +311,8 @@ async def test_jq_raw(accessor):
             patch("mirage.commands.builtin.discord.jq.resolve_glob",
                   new_callable=AsyncMock,
                   return_value=_glob_result(ABS_FILE)),
-            patch("mirage.commands.builtin.discord.jq.discord_read",
-                  new_callable=AsyncMock,
-                  return_value=FAKE_JSONL),
+            patch("mirage.commands.builtin.discord.jq.read_stream",
+                  new=_fake_jsonl_stream),
     ):
         stream, io = await jq(accessor,
                               _make_glob(ABS_FILE),

--- a/python/tests/commands/builtin/generic/test_phase_z.py
+++ b/python/tests/commands/builtin/generic/test_phase_z.py
@@ -116,8 +116,9 @@ async def test_jq_missing_expression():
 @pytest.mark.asyncio
 async def test_jq_no_input():
     rb, _, rs, _, _ = _make_backend({})
-    with pytest.raises(ValueError, match="missing input"):
-        await jq([], ".x", read_bytes=rb, read_stream=rs)
+    out, io = await jq([], ".x", read_bytes=rb, read_stream=rs)
+    assert out is None
+    assert io.exit_code == 0
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/builtin/generic/test_phase_z.py
+++ b/python/tests/commands/builtin/generic/test_phase_z.py
@@ -107,10 +107,14 @@ async def test_jq_stdin():
 
 
 @pytest.mark.asyncio
-async def test_jq_missing_expression():
+async def test_jq_missing_expression_defaults_dot():
     rb, _, rs, _, _ = _make_backend({})
-    with pytest.raises(ValueError, match="usage"):
-        await jq([], read_bytes=rb, read_stream=rs)
+    out, io = await jq([], read_bytes=rb, read_stream=rs, stdin=b'{"x":42}')
+    assert b"42" in out
+    assert io.exit_code == 0
+    out, io = await jq([], read_bytes=rb, read_stream=rs)
+    assert out is None
+    assert io.exit_code == 0
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/builtin/jq/test_eval.py
+++ b/python/tests/commands/builtin/jq/test_eval.py
@@ -803,10 +803,11 @@ class TestJqMemoryBackend:
         result = json.loads(collect(stdout))
         assert result == [1, 2, 3]
 
-    def test_missing_expression_raises(self):
+    def test_missing_expression_defaults_dot(self):
         ws = mem_ws({"/f.json": b'{"a": 1}'})
-        _, io = run_raw(ws, "jq")
-        assert io.exit_code != 0
+        stdout, io = run_raw(ws, "jq")
+        assert io.exit_code == 0
+        assert collect(stdout) == b""
 
     def test_pipe_in_command(self):
         ws = mem_ws({"/f.json": b'{"items": [1, 2, 3]}'})

--- a/typescript/packages/core/src/commands/builtin/generic/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/jq.ts
@@ -28,8 +28,6 @@ import type { FileStat, PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { readStdinAsync } from '../utils/stream.ts'
 
-const ENC = new TextEncoder()
-
 type Stream = (p: PathSpec) => AsyncIterable<Uint8Array>
 
 export async function jqProvisionGeneric(
@@ -70,13 +68,8 @@ export async function jqGeneric(
   opts: CommandOpts,
   stream: Stream,
 ): Promise<CommandFnResult> {
-  const expression = texts[0]
-  if (expression === undefined) {
-    return [
-      null,
-      new IOResult({ exitCode: 1, stderr: ENC.encode('jq: usage: jq EXPRESSION [path]\n') }),
-    ]
-  }
+  // GNU jq defaults the filter to "." when no expression is given
+  const expression = texts[0] ?? '.'
   const raw = opts.flags.r === true
   const compact = opts.flags.c === true
   const slurp = opts.flags.s === true

--- a/typescript/packages/core/src/commands/builtin/mongodb/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/jq.ts
@@ -63,9 +63,7 @@ async function jqCommand(
   }
 
   const bytes = await readStdinAsync(opts.stdin)
-  if (bytes === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('jq: missing input\n') })]
-  }
+  if (bytes === null) return [null, new IOResult()]
   let data = parseJsonAuto(bytes)
   if (slurp && !Array.isArray(data)) data = [data]
   const result = await jqEval(data, expression.trim())

--- a/typescript/packages/core/src/commands/builtin/mongodb/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/mongodb/jq.ts
@@ -28,21 +28,13 @@ import { command, type CommandFnResult, type CommandOpts } from '../../config.ts
 import { specOf } from '../../spec/builtins.ts'
 import { readStdinAsync } from '../utils/stream.ts'
 
-const ENC = new TextEncoder()
-
 async function jqCommand(
   accessor: MongoDBAccessor,
   paths: PathSpec[],
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const expression = texts[0]
-  if (expression === undefined) {
-    return [
-      null,
-      new IOResult({ exitCode: 1, stderr: ENC.encode('jq: usage: jq EXPRESSION [path]\n') }),
-    ]
-  }
+  const expression = texts[0] ?? '.'
   const raw = opts.flags.r === true
   const compact = opts.flags.c === true
   const slurp = opts.flags.s === true

--- a/typescript/packages/core/src/commands/builtin/postgres/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/postgres/jq.ts
@@ -63,9 +63,7 @@ async function jqCommand(
   }
 
   const bytes = await readStdinAsync(opts.stdin)
-  if (bytes === null) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('jq: missing input\n') })]
-  }
+  if (bytes === null) return [null, new IOResult()]
   let data = parseJsonAuto(bytes)
   if (slurp && !Array.isArray(data)) data = [data]
   const result = await jqEval(data, expression.trim())

--- a/typescript/packages/core/src/commands/builtin/postgres/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/postgres/jq.ts
@@ -28,21 +28,13 @@ import { command, type CommandFnResult, type CommandOpts } from '../../config.ts
 import { specOf } from '../../spec/builtins.ts'
 import { readStdinAsync } from '../utils/stream.ts'
 
-const ENC = new TextEncoder()
-
 async function jqCommand(
   accessor: PostgresAccessor,
   paths: PathSpec[],
   texts: string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const expression = texts[0]
-  if (expression === undefined) {
-    return [
-      null,
-      new IOResult({ exitCode: 1, stderr: ENC.encode('jq: usage: jq EXPRESSION [path]\n') }),
-    ]
-  }
+  const expression = texts[0] ?? '.'
   const raw = opts.flags.r === true
   const compact = opts.flags.c === true
   const slurp = opts.flags.s === true


### PR DESCRIPTION
Delegates the hand-wired Python jq commands in discord, email, slack, linear, trello, and langfuse to the generic jq, matching the TypeScript side (which already uses jqGeneric for all of them) and the existing gdrive/notion delegation pattern.

- Adds core/<backend>/stream.py one-shot read_stream helpers (mirrors core/notion/stream.py), needed for the generic's JSONL streaming fast path.
- These backends now get per-line JSONL evaluation and streaming (discord chat.jsonl, langfuse items.jsonl / run files), which TS already had.
- Updates the two discord jq tests to patch read_stream, since streamable JSONL expressions now take the streaming path instead of whole-file reads.

GNU alignment (verified against jq 1.7.1):
- jq with no input (no paths, no stdin) now exits 0 with no output, like `jq . </dev/null`. Previously Python and the py/ts mongodb/postgres pushdowns errored with 'jq: missing input'.
- jq with no expression now defaults the filter to '.', like piped GNU jq. Previously both languages returned an exit-1 usage error, so `cat f.json | jq` failed instead of pretty-printing.
- New integ cases (jq_no_filter_piped, jq_no_filter_no_input, jq_dot_no_input) lock this in for both languages; integ/truth.txt regenerated and verified byte-identical between py ram/disk and ts ram.