### PR TITLE
refactor: grep-family review fixes (shared resolve_pattern, TS -f dedup, general grep conversion)

### DIFF
--- a/python/mirage/commands/builtin/general/grep.py
+++ b/python/mirage/commands/builtin/general/grep.py
@@ -17,9 +17,11 @@ from collections.abc import AsyncIterator
 
 from mirage.commands.builtin.grep_context import grep_context_lines
 from mirage.commands.builtin.grep_helper import (NEVER_MATCH, compile_pattern,
-                                                 merge_pattern_list)
+                                                 merge_pattern_list,
+                                                 pattern_arg)
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.spec.types import FlagView
 from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.stream import exit_on_empty, quiet_match
 from mirage.io.types import ByteSource, IOResult
@@ -94,42 +96,37 @@ async def grep(
     paths: list[PathSpec],
     *texts: str,
     stdin: AsyncIterator[bytes] | bytes | None = None,
-    r: bool = False,
-    R: bool = False,
-    i: bool = False,
-    v: bool = False,
-    n: bool = False,
-    c: bool = False,
-    args_l: bool = False,
-    w: bool = False,
-    F: bool = False,
-    E: bool = False,
-    o: bool = False,
-    m: str | None = None,
-    q: bool = False,
-    A: str | None = None,
-    B: str | None = None,
-    C: str | None = None,
-    e: str | None = None,
-    f: PathSpec | list[PathSpec] | None = None,
     prefix: str = "",
-    **_extra: object,
+    **flags: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    pattern: str | None
-    if e is not None:
-        pattern = e
-    elif texts:
-        pattern = texts[0]
-    elif f is not None:
-        pattern = None
-    else:
+    fl = FlagView(flags)
+    pattern = pattern_arg(texts, fl)
+    pattern_file = fl.raw("f")
+    if pattern is None and pattern_file is None:
         raise ValueError("grep: usage: grep [flags] pattern [path]")
+    i = fl.bool("i")
+    v = fl.bool("v")
+    n = fl.bool("n")
+    c = fl.bool("c")
+    args_l = fl.bool("args_l")
+    w = fl.bool("w")
+    F = fl.bool("F")
+    o = fl.bool("o")
+    q = fl.bool("q")
+    recursive = fl.bool("r") or fl.bool("R")
+    max_count = fl.int("m")
+    a_ctx = fl.int("A")
+    b_ctx = fl.int("B")
+    c_ctx = fl.int("C")
+    after_ctx = a_ctx if a_ctx is not None else (c_ctx or 0)
+    before_ctx = b_ctx if b_ctx is not None else (c_ctx or 0)
 
-    if f is not None:
+    if pattern_file is not None:
         if ops is None or "read_stream" not in ops:
             raise ValueError(
                 "grep: -f: pattern file requires filesystem context")
-        files = f if isinstance(f, list) else [f]
+        files = (pattern_file
+                 if isinstance(pattern_file, list) else [pattern_file])
         for pf in files:
             chunks = [chunk async for chunk in ops["read_stream"](pf)]
             pattern = merge_pattern_list(pattern, b"".join(chunks))
@@ -137,16 +134,12 @@ async def grep(
             pattern = NEVER_MATCH
             F = False
 
-    max_count = int(m) if m is not None else None
-    after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
-    before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
-
     if paths and ops is not None:
         if args_l and "grep" in ops:
             results = ops["grep"](
                 paths[0],
                 pattern=pattern,
-                recursive=r or R,
+                recursive=recursive,
                 ignore_case=i,
                 invert=v,
                 line_numbers=n,

--- a/python/mirage/commands/builtin/generic/grep.py
+++ b/python/mirage/commands/builtin/generic/grep.py
@@ -3,11 +3,10 @@ from collections.abc import (AsyncIterator, Awaitable, Callable, Mapping,
 from functools import partial
 
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import (NEVER_MATCH, compile_pattern,
+from mirage.commands.builtin.grep_helper import (compile_pattern,
                                                  grep_files_only, grep_lines,
                                                  grep_recursive, grep_stream,
-                                                 merge_pattern_list,
-                                                 pattern_arg)
+                                                 resolve_pattern)
 from mirage.commands.builtin.utils.lines import split_lines
 from mirage.commands.builtin.utils.output import (format_optional_records,
                                                   format_records)
@@ -18,50 +17,6 @@ from mirage.commands.spec.types import FlagView
 from mirage.io.stream import exit_on_empty, quiet_match
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import FileStat, FileType, PathSpec
-
-
-async def resolve_pattern(
-    texts: Sequence[str],
-    flags: FlagView,
-    read_bytes: Callable[..., Awaitable[bytes]],
-    accessor: object,
-    index: IndexCacheStore | None,
-    usage: str,
-) -> tuple[str, bool]:
-    """Resolve the search pattern from -e/positional/-f flag arguments.
-
-    Args:
-        texts (Sequence[str]): positional TEXT operands.
-        flags (FlagView): typed view over raw flag kwargs.
-        read_bytes (Callable[..., Awaitable[bytes]]): whole-file reader used
-            for -f pattern files.
-        accessor (object): backend accessor for read_bytes.
-        index (IndexCacheStore | None): optional cache index.
-        usage (str): usage error message when no pattern was supplied.
-
-    Returns:
-        tuple[str, bool]: (newline-separated pattern list, never_match) where
-            never_match is True when -f supplied zero patterns (GNU: match
-            nothing; -F escaping must be skipped for the sentinel).
-    """
-    pattern = pattern_arg(texts, flags)
-
-    pattern_file = flags.raw("f")
-    if isinstance(pattern_file, (PathSpec, list)):
-        files = (pattern_file
-                 if isinstance(pattern_file, list) else [pattern_file])
-        for pf in files:
-            file_data = await call_read_bytes(read_bytes,
-                                              accessor,
-                                              pf,
-                                              index=index,
-                                              prefix=pf.prefix)
-            pattern = merge_pattern_list(pattern, file_data)
-        if pattern is None:
-            return NEVER_MATCH, True
-    if pattern is None:
-        raise ValueError(usage)
-    return pattern, False
 
 
 async def grep(

--- a/python/mirage/commands/builtin/generic/rg.py
+++ b/python/mirage/commands/builtin/generic/rg.py
@@ -3,11 +3,11 @@ from collections.abc import (AsyncIterator, Awaitable, Callable, Mapping,
 from functools import partial
 
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.generic.grep import resolve_pattern
 from mirage.commands.builtin.grep_helper import (compile_pattern,
                                                  grep_count_has_matches,
                                                  grep_lines, grep_stream,
-                                                 nonzero_count_stream)
+                                                 nonzero_count_stream,
+                                                 resolve_pattern)
 from mirage.commands.builtin.rg_helper import rg_full
 from mirage.commands.builtin.utils.lines import split_lines
 from mirage.commands.builtin.utils.output import (format_optional_records,

--- a/python/mirage/commands/builtin/generic/zgrep.py
+++ b/python/mirage/commands/builtin/generic/zgrep.py
@@ -4,8 +4,8 @@ from collections.abc import (AsyncIterator, Awaitable, Callable, Mapping,
                              Sequence)
 from functools import partial
 
-from mirage.commands.builtin.generic.grep import resolve_pattern
-from mirage.commands.builtin.grep_helper import build_pattern_str
+from mirage.commands.builtin.grep_helper import (build_pattern_str,
+                                                 resolve_pattern)
 from mirage.commands.builtin.utils.lines import split_lines
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.commands.spec.types import FlagView

--- a/python/mirage/commands/builtin/grep_helper.py
+++ b/python/mirage/commands/builtin/grep_helper.py
@@ -13,16 +13,18 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import re
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 
+from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.constants import PatternType
 from mirage.commands.builtin.grep_context import grep_context_lines
 from mirage.commands.builtin.utils.types import (_AsyncReadBytes,
                                                  _AsyncReaddir, _AsyncStat)
+from mirage.commands.builtin.utils.wrap import call_read_bytes
 from mirage.commands.resolve import COMPOUND_EXTENSIONS
 from mirage.commands.spec.types import FlagView
 from mirage.io.async_line_iterator import AsyncLineIterator
-from mirage.types import FileType
+from mirage.types import FileType, PathSpec
 
 BINARY_EXTENSIONS = frozenset({
     ".parquet",
@@ -77,6 +79,50 @@ def pattern_arg(texts: Sequence[str], flags: FlagView) -> str | None:
     if texts:
         return texts[0]
     return None
+
+
+async def resolve_pattern(
+    texts: Sequence[str],
+    flags: FlagView,
+    read_bytes: Callable[..., Awaitable[bytes]],
+    accessor: object,
+    index: IndexCacheStore | None,
+    usage: str,
+) -> tuple[str, bool]:
+    """Resolve the search pattern from -e/positional/-f flag arguments.
+
+    Args:
+        texts (Sequence[str]): positional TEXT operands.
+        flags (FlagView): typed view over raw flag kwargs.
+        read_bytes (Callable[..., Awaitable[bytes]]): whole-file reader used
+            for -f pattern files.
+        accessor (object): backend accessor for read_bytes.
+        index (IndexCacheStore | None): optional cache index.
+        usage (str): usage error message when no pattern was supplied.
+
+    Returns:
+        tuple[str, bool]: (newline-separated pattern list, never_match) where
+            never_match is True when -f supplied zero patterns (GNU: match
+            nothing; -F escaping must be skipped for the sentinel).
+    """
+    pattern = pattern_arg(texts, flags)
+
+    pattern_file = flags.raw("f")
+    if isinstance(pattern_file, (PathSpec, list)):
+        files = (pattern_file
+                 if isinstance(pattern_file, list) else [pattern_file])
+        for pf in files:
+            file_data = await call_read_bytes(read_bytes,
+                                              accessor,
+                                              pf,
+                                              index=index,
+                                              prefix=pf.prefix)
+            pattern = merge_pattern_list(pattern, file_data)
+        if pattern is None:
+            return NEVER_MATCH, True
+    if pattern is None:
+        raise ValueError(usage)
+    return pattern, False
 
 
 def merge_pattern_list(

--- a/typescript/packages/core/src/commands/builtin/generic/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/grep.ts
@@ -17,15 +17,13 @@ import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { FileType, PathSpec, type FileStat } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import {
-  NEVER_MATCH,
   compilePattern,
   grepFilesOnly,
   type GrepFilesOnlyOptions,
   grepLines,
   grepRecursive,
   grepStream,
-  mergePatternList,
-  patternArg,
+  resolvePatternFromFlags,
 } from '../grep_helper.ts'
 import { resolveSource } from '../utils/stream.ts'
 
@@ -55,16 +53,6 @@ interface FlagSet {
   quiet: boolean
   afterContext: number
   beforeContext: number
-}
-
-function getPattern(
-  texts: readonly string[],
-  flags: Record<string, string | boolean | string[]>,
-): string | null {
-  const pattern = patternArg(texts, flags)
-  if (pattern !== null) return pattern
-  if (Array.isArray(flags.f)) return null
-  throw new Error('grep: usage: grep [flags] pattern [path]')
 }
 
 function parseFlags(flags: Record<string, string | boolean | string[]>): FlagSet {
@@ -123,37 +111,30 @@ export async function grepGeneric(
   scopeCheck?: ScopeCheck,
   showFilename = false,
 ): Promise<CommandFnResult> {
-  let pattern: string | null
-  try {
-    pattern = getPattern(texts, opts.flags)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return [null, new IOResult({ exitCode: 2, stderr: ENC.encode(`${msg}\n`) })]
+  const resolution = await resolvePatternFromFlags(
+    name,
+    texts,
+    opts.flags,
+    paths,
+    opts.mountPrefix,
+    stream,
+  )
+  if (resolution.error !== null) {
+    return [null, new IOResult({ exitCode: 2, stderr: ENC.encode(resolution.error) })]
+  }
+  const pattern = resolution.pattern
+  if (pattern === null) {
+    return [
+      null,
+      new IOResult({
+        exitCode: 2,
+        stderr: ENC.encode(`${name}: usage: ${name} [flags] pattern [path]\n`),
+      }),
+    ]
   }
   const f = parseFlags(opts.flags)
+  if (resolution.neverMatch) f.fixedString = false
   const recursive = opts.flags.r === true || opts.flags.R === true
-
-  if (Array.isArray(opts.flags.f)) {
-    // Repeatable -f arrives as a list of resolved paths; read each file.
-    for (const filePath of opts.flags.f) {
-      const patternSpec = PathSpec.fromStrPath(filePath, paths[0]?.prefix ?? opts.mountPrefix ?? '')
-      let fileData: Uint8Array
-      try {
-        fileData = await materialize(stream(patternSpec))
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err)
-        return [
-          null,
-          new IOResult({ exitCode: 2, stderr: ENC.encode(`${name}: ${filePath}: ${msg}\n`) }),
-        ]
-      }
-      pattern = mergePatternList(pattern, fileData)
-    }
-    if (pattern === null) {
-      pattern = NEVER_MATCH
-      f.fixedString = false
-    }
-  }
   if (pattern === null) {
     return [
       null,

--- a/typescript/packages/core/src/commands/builtin/generic/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/grep.ts
@@ -135,15 +135,6 @@ export async function grepGeneric(
   const f = parseFlags(opts.flags)
   if (resolution.neverMatch) f.fixedString = false
   const recursive = opts.flags.r === true || opts.flags.R === true
-  if (pattern === null) {
-    return [
-      null,
-      new IOResult({
-        exitCode: 2,
-        stderr: ENC.encode(`${name}: usage: ${name} [flags] pattern [path]\n`),
-      }),
-    ]
-  }
 
   if (paths.length > 0) {
     const first = paths[0]

--- a/typescript/packages/core/src/commands/builtin/generic/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/rg.ts
@@ -16,13 +16,7 @@ import { exitOnEmpty } from '../../../io/stream.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { FileType, PathSpec, type FileStat } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
-import {
-  NEVER_MATCH,
-  compilePattern,
-  grepStream,
-  mergePatternList,
-  patternArg,
-} from '../grep_helper.ts'
+import { compilePattern, grepStream, resolvePatternFromFlags } from '../grep_helper.ts'
 import { rgFolderFiletype, rgFull } from '../rg_helper.ts'
 import { resolveSource } from '../utils/stream.ts'
 import { grepGeneric } from './grep.ts'
@@ -93,37 +87,26 @@ export async function rgGeneric(
   stream: Stream,
   scopeCheck?: ScopeCheck,
 ): Promise<CommandFnResult> {
-  let exprText: string | undefined = patternArg(texts, opts.flags) ?? undefined
-  let neverMatch = false
-  if (Array.isArray(opts.flags.f)) {
-    // Repeatable -f arrives as a list of resolved paths; read each file.
-    for (const filePath of opts.flags.f) {
-      const patternSpec = PathSpec.fromStrPath(filePath, paths[0]?.prefix ?? opts.mountPrefix ?? '')
-      let fileData: Uint8Array
-      try {
-        fileData = await materialize(stream(patternSpec))
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err)
-        return [
-          null,
-          new IOResult({ exitCode: 2, stderr: ENC.encode(`rg: ${filePath}: ${msg}\n`) }),
-        ]
-      }
-      exprText = mergePatternList(exprText ?? null, fileData) ?? undefined
-    }
-    if (exprText === undefined) {
-      exprText = NEVER_MATCH
-      neverMatch = true
-    }
+  const resolution = await resolvePatternFromFlags(
+    'rg',
+    texts,
+    opts.flags,
+    paths,
+    opts.mountPrefix,
+    stream,
+  )
+  if (resolution.error !== null) {
+    return [null, new IOResult({ exitCode: 2, stderr: ENC.encode(resolution.error) })]
   }
-  if (exprText === undefined) {
+  const exprText = resolution.pattern
+  if (exprText === null) {
     return [
       null,
       new IOResult({ exitCode: 2, stderr: ENC.encode('rg: usage: rg [flags] pattern [path]\n') }),
     ]
   }
   const flags = parseRgFlags(opts.flags)
-  if (neverMatch) flags.fixedString = false
+  if (resolution.neverMatch) flags.fixedString = false
   const [first] = paths
 
   if (first === undefined) {

--- a/typescript/packages/core/src/commands/builtin/generic/zgrep.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/zgrep.ts
@@ -13,10 +13,10 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
-import { PathSpec } from '../../../types.ts'
+import type { PathSpec } from '../../../types.ts'
 import { gunzip } from '../../../utils/compress.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
-import { NEVER_MATCH, compilePattern, mergePatternList, patternArg } from '../grep_helper.ts'
+import { compilePattern, resolvePatternFromFlags } from '../grep_helper.ts'
 import { readStdinAsync } from '../utils/stream.ts'
 
 const ENC = new TextEncoder()
@@ -88,34 +88,19 @@ export async function zgrepGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
-  let rawPattern: string | null = patternArg(texts, opts.flags)
-  let neverMatch = false
-  if (Array.isArray(opts.flags.f)) {
-    // Repeatable -f arrives as a list of resolved paths; pattern files are
-    // plain text even though the search targets are gzipped.
-    for (const filePath of opts.flags.f) {
-      const patternSpec = PathSpec.fromStrPath(filePath, paths[0]?.prefix ?? opts.mountPrefix ?? '')
-      let fileData: Uint8Array
-      try {
-        fileData = await materialize(stream(patternSpec))
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err)
-        return [
-          null,
-          new IOResult({
-            exitCode: 2,
-            stderr: new TextEncoder().encode(`zgrep: ${filePath}: ${msg}\n`),
-          }),
-        ]
-      }
-      rawPattern = mergePatternList(rawPattern, fileData)
-    }
-    if (rawPattern === null) {
-      rawPattern = NEVER_MATCH
-      neverMatch = true
-    }
+  const resolution = await resolvePatternFromFlags(
+    'zgrep',
+    texts,
+    opts.flags,
+    paths,
+    opts.mountPrefix,
+    stream,
+  )
+  if (resolution.error !== null) {
+    return [null, new IOResult({ exitCode: 2, stderr: new TextEncoder().encode(resolution.error) })]
   }
-  rawPattern ??= ''
+  const neverMatch = resolution.neverMatch
+  const rawPattern = resolution.pattern ?? ''
   const extendedRegex = opts.flags.E === true
   const fixedString = opts.flags.F === true && !neverMatch
   const wholeWord = opts.flags.w === true

--- a/typescript/packages/core/src/commands/builtin/grep_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/grep_helper.ts
@@ -13,7 +13,8 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { AsyncLineIterator } from '../../io/async_line_iterator.ts'
-import { type FileStat, FileType } from '../../types.ts'
+import { materialize } from '../../io/types.ts'
+import { type FileStat, FileType, PathSpec } from '../../types.ts'
 import { getExtension } from '../resolve.ts'
 import { grepContextLines } from './grep_context.ts'
 
@@ -47,6 +48,46 @@ export function patternArg(
   if (typeof e === 'string') return e
   if (texts.length > 0 && texts[0] !== undefined) return texts[0]
   return null
+}
+
+export interface PatternResolution {
+  pattern: string | null
+  neverMatch: boolean
+  error: string | null
+}
+
+// Resolve the full pattern list from -e values, the positional, and -f
+// pattern files (read via the backend stream). Shared by the grep, rg, and
+// zgrep generics. When -f supplies zero patterns the NEVER_MATCH sentinel is
+// returned with neverMatch=true (callers must skip -F escaping for it).
+export async function resolvePatternFromFlags(
+  name: string,
+  texts: readonly string[],
+  flags: Record<string, string | boolean | string[]>,
+  paths: readonly PathSpec[],
+  mountPrefix: string | null | undefined,
+  stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
+): Promise<PatternResolution> {
+  let pattern = patternArg(texts, flags)
+  let neverMatch = false
+  if (Array.isArray(flags.f)) {
+    for (const filePath of flags.f) {
+      const patternSpec = PathSpec.fromStrPath(filePath, paths[0]?.prefix ?? mountPrefix ?? '')
+      let fileData: Uint8Array
+      try {
+        fileData = await materialize(stream(patternSpec))
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return { pattern: null, neverMatch: false, error: `${name}: ${filePath}: ${msg}\n` }
+      }
+      pattern = mergePatternList(pattern, fileData)
+    }
+    if (pattern === null) {
+      pattern = NEVER_MATCH
+      neverMatch = true
+    }
+  }
+  return { pattern, neverMatch, error: null }
 }
 
 export function mergePatternList(


### PR DESCRIPTION
Follow-up to #261 from its post-merge code review:
- `resolve_pattern` moves from `generic/grep.py` to `grep_helper.py`, removing the rg/zgrep → grep cross-generic import.
- TS: the triple-duplicated `-f` pattern-file read block in grepGeneric/rgGeneric/zgrepGeneric extracted to a shared `resolvePatternFromFlags` in `grep_helper.ts`.
- `general/grep.py` (unregistered fallback, dead code) converted to the flags-dict contract so it is no longer a latent crash if registered (`-e` now arrives as a list).
- Filed #283 for the per-parse spec lookup-set caching observed during review.

Behavior unchanged: full suites green both languages; shared integ byte-identical (py ram + TS ram verified).