### PR TITLE
refactor: delegate py databricks_volume to generics, add coreutils guards to generic cp/mv (py+ts)

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -72,6 +72,10 @@ SEED_FILES = {
     "world\nbar\n",
     "/data/patterns2.txt":
     "baz\n",
+    "/data/guard/g.txt":
+    "guard\n",
+    "/data/guard/sub/s.txt":
+    "inner\n",
 }
 
 CASES: list[tuple[str, str]] = [
@@ -557,6 +561,18 @@ EXIT_CODE_CASES: list[tuple[str, str]] = [
     # ----- grep directory operands (GNU: warn, files still match) -----
     ("grep_dir_operand", "grep hello /data/sub"),
     ("grep_dir_among_files", "grep hello /data/a.txt /data/sub"),
+
+    # ----- cp/mv coreutils guards (same-file, subtree, missing source) -----
+    ("guard_cp_same_file", "cp /data/guard/g.txt /data/guard/g.txt"),
+    ("guard_mv_same_file", "mv /data/guard/g.txt /data/guard/g.txt"),
+    ("guard_mv_same_file_intact", "cat /data/guard/g.txt"),
+    ("guard_mv_into_dir_where_file_lives",
+     "mv /data/guard/sub/s.txt /data/guard/sub"),
+    ("guard_cp_dir_into_itself", "cp -r /data/guard/sub /data/guard/sub"),
+    ("guard_mv_dir_into_own_subtree", "mv /data/guard /data/guard/sub"),
+    ("guard_cp_missing_source_continues",
+     "cp /data/missing.txt /data/guard/g.txt /data/guard/sub"),
+    ("guard_state_after", "find /data/guard -type f"),
 ]
 
 

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -45,6 +45,8 @@ export const SEED_FILES: Record<string, string> = {
   "/data/prefix_dup.txt": "1 apple\n2 apple\n3 banana\n",
   "/data/patterns.txt": "world\nbar\n",
   "/data/patterns2.txt": "baz\n",
+  "/data/guard/g.txt": "guard\n",
+  "/data/guard/sub/s.txt": "inner\n",
 };
 
 export const CASES: ReadonlyArray<readonly [string, string]> = [
@@ -81,7 +83,7 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
   ["jq_jsonl_id", 'jq ".id" /data/data.jsonl'],
   ["jq_jsonl_chain", 'jq ".[].id" /data/data.jsonl'],
   ["jq_jsonl_chain_raw", 'jq -r ".[].msg" /data/chat.jsonl'],
-  ["jq_no_filter_piped", 'cat /data/user.json | jq'],
+  ["jq_no_filter_piped", "cat /data/user.json | jq"],
 
   ["sort", "sort /data/a.txt"],
   ["sort_r", "sort -r /data/a.txt"],
@@ -486,6 +488,16 @@ export const EXIT_CODE_CASES: ReadonlyArray<readonly [string, string]> = [
   // ----- grep directory operands (GNU: warn on stderr, files still match) -----
   ["grep_dir_operand", "grep hello /data/sub"],
   ["grep_dir_among_files", "grep hello /data/a.txt /data/sub"],
+
+  // ----- cp/mv coreutils guards (same-file, subtree, missing source) -----
+  ["guard_cp_same_file", "cp /data/guard/g.txt /data/guard/g.txt"],
+  ["guard_mv_same_file", "mv /data/guard/g.txt /data/guard/g.txt"],
+  ["guard_mv_same_file_intact", "cat /data/guard/g.txt"],
+  ["guard_mv_into_dir_where_file_lives", "mv /data/guard/sub/s.txt /data/guard/sub"],
+  ["guard_cp_dir_into_itself", "cp -r /data/guard/sub /data/guard/sub"],
+  ["guard_mv_dir_into_own_subtree", "mv /data/guard /data/guard/sub"],
+  ["guard_cp_missing_source_continues", "cp /data/missing.txt /data/guard/g.txt /data/guard/sub"],
+  ["guard_state_after", "find /data/guard -type f"],
 ];
 
 const ENC = new TextEncoder();

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -238,6 +238,8 @@ a.txt
 /data/dup.txt
 /data/empty.txt
 /data/fields.txt
+/data/guard/g.txt
+/data/guard/sub/s.txt
 /data/mixed.txt
 /data/no_nl.txt
 /data/numbers.txt
@@ -266,6 +268,8 @@ a.txt
 /data/dup.txt
 /data/empty.txt
 /data/fields.txt
+/data/guard/g.txt
+/data/guard/sub/s.txt
 /data/mixed.txt
 /data/no_nl.txt
 /data/numbers.txt
@@ -296,6 +300,7 @@ data.jsonl
 dup.txt
 empty.txt
 fields.txt
+guard
 mixed.txt
 no_nl.txt
 numbers.txt
@@ -325,6 +330,7 @@ data.jsonl
 dup.txt
 empty.txt
 fields.txt
+guard
 mixed.txt
 no_nl.txt
 numbers.txt
@@ -434,6 +440,8 @@ baz
 /data/dup.txt
 /data/empty.txt
 /data/fields.txt
+/data/guard/g.txt
+/data/guard/sub/s.txt
 /data/mixed.txt
 /data/no_nl.txt
 /data/numbers.txt
@@ -529,7 +537,7 @@ world
       2 b
       1 c
 === find_pipe_wc ===
-22
+24
 === jq_pipe_wc ===
 3
 === cat_tr_sort ===
@@ -603,6 +611,8 @@ world
 === rg_c ===
 1
 === find_d ===
+/data/guard
+/data/guard/sub
 /data/sub
 /data/sub/deep
 === find_iname ===
@@ -612,6 +622,8 @@ world
 /data/dup.txt
 /data/empty.txt
 /data/fields.txt
+/data/guard/g.txt
+/data/guard/sub/s.txt
 /data/mixed.txt
 /data/no_nl.txt
 /data/numbers.txt
@@ -638,6 +650,8 @@ world
 /data/data.jsonl
 /data/dup.txt
 /data/fields.txt
+/data/guard
+/data/guard/sub
 /data/mixed.txt
 /data/no_nl.txt
 /data/numbers.txt
@@ -662,6 +676,8 @@ world
 /data/dup.txt
 /data/empty.txt
 /data/fields.txt
+/data/guard/g.txt
+/data/guard/sub/s.txt
 /data/mixed.txt
 /data/no_nl.txt
 /data/numbers.txt
@@ -679,6 +695,8 @@ world
 /data/sub/nested.txt
 /data/tabbed.txt
 === find_path_pattern ===
+/data/guard/sub
+/data/guard/sub/s.txt
 /data/sub
 /data/sub/deep
 /data/sub/deep/deeper.txt
@@ -960,6 +978,10 @@ baz,
 /data/dup.txt
 /data/empty.txt
 /data/fields.txt
+/data/guard
+/data/guard/g.txt
+/data/guard/sub
+/data/guard/sub/s.txt
 /data/mixed.txt
 /data/no_nl.txt
 /data/numbers.txt
@@ -987,6 +1009,8 @@ baz,
 /data/dup.txt
 /data/empty.txt
 /data/fields.txt
+/data/guard/g.txt
+/data/guard/sub/s.txt
 /data/mixed.txt
 /data/no_nl.txt
 /data/numbers.txt
@@ -1005,6 +1029,8 @@ baz,
 /data/tabbed.txt
 === find_size_lt ===
 /data/empty.txt
+/data/guard
+/data/guard/sub
 /data/one_byte.txt
 /data/patterns2.txt
 /data/sub
@@ -1022,6 +1048,8 @@ baz,
 /data/dup.txt
 /data/empty.txt
 /data/fields.txt
+/data/guard/g.txt
+/data/guard/sub/s.txt
 /data/mixed.txt
 /data/no_nl.txt
 /data/numbers.txt
@@ -1052,6 +1080,10 @@ baz,
 /data/dup.txt
 /data/empty.txt
 /data/fields.txt
+/data/guard
+/data/guard/g.txt
+/data/guard/sub
+/data/guard/sub/s.txt
 /data/mixed.txt
 /data/no_nl.txt
 /data/numbers.txt
@@ -1109,7 +1141,7 @@ baz,
 === du_file ===
 24	/data/a.txt
 === du_dir ===
-616	/data
+628	/data
 === du_h ===
 24B	/data/a.txt
 === tree ===
@@ -1498,3 +1530,23 @@ exit=1
 === grep_dir_among_files ===
 exit=0
 /data/a.txt:hello
+=== guard_cp_same_file ===
+exit=1
+=== guard_mv_same_file ===
+exit=1
+=== guard_mv_same_file_intact ===
+exit=0
+guard
+=== guard_mv_into_dir_where_file_lives ===
+exit=1
+=== guard_cp_dir_into_itself ===
+exit=1
+=== guard_mv_dir_into_own_subtree ===
+exit=1
+=== guard_cp_missing_source_continues ===
+exit=1
+=== guard_state_after ===
+exit=0
+/data/guard/g.txt
+/data/guard/sub/g.txt
+/data/guard/sub/s.txt

--- a/python/mirage/commands/builtin/databricks_volume/_helpers.py
+++ b/python/mirage/commands/builtin/databricks_volume/_helpers.py
@@ -17,12 +17,14 @@ from typing import Callable
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.find import parse_find_args, walk_find
 from mirage.commands.builtin.utils.wrap import (call_read_bytes,
                                                 call_read_stream)
-from mirage.core.databricks_volume.path import backend_path
 from mirage.core.databricks_volume.read import read_bytes as _read_bytes
+from mirage.core.databricks_volume.readdir import readdir as _readdir
+from mirage.core.databricks_volume.stat import stat as _stat
 from mirage.core.databricks_volume.stream import read_stream as _read_stream
-from mirage.types import PathSpec
+from mirage.types import FileType, PathSpec
 
 
 def path_prefix(paths: list[PathSpec],
@@ -34,16 +36,44 @@ def path_prefix(paths: list[PathSpec],
     return ""
 
 
-def same_backend_file(accessor: DatabricksVolumeAccessor, a: PathSpec,
-                      b: PathSpec) -> bool:
-    return backend_path(accessor.config, a) == backend_path(accessor.config, b)
+def is_dir_name(_child: str) -> bool | None:
+    # Databricks readdir returns slash-less paths, so classification always
+    # falls back to stat (which the walker resolves via the index cache).
+    return None
 
 
-def target_within_source(accessor: DatabricksVolumeAccessor, src: PathSpec,
-                         dst: PathSpec) -> bool:
-    src_key = backend_path(accessor.config, src)
-    dst_key = backend_path(accessor.config, dst)
-    return dst_key.startswith(src_key + "/")
+async def find_files(
+    accessor: DatabricksVolumeAccessor,
+    index: IndexCacheStore | None,
+    path: PathSpec | str,
+    *,
+    type: str | None = None,
+) -> list[str]:
+    """List paths beneath a search root in mount-relative form.
+
+    Args:
+        accessor (DatabricksVolumeAccessor): Databricks accessor.
+        index (IndexCacheStore | None): Index cache for readdir and stat.
+        path (PathSpec | str): Search root; a file root yields itself.
+        type (str | None): "f" (file) or "d" (directory) filter.
+    """
+    spec = path if isinstance(path, PathSpec) else PathSpec(original=path,
+                                                            directory=path)
+    file_stat = await _stat(accessor, spec, index)
+    if file_stat.type != FileType.DIRECTORY:
+        return [spec.strip_prefix]
+    args = parse_find_args((), type=type)
+    results = await walk_find(spec,
+                              readdir=partial(_readdir, accessor),
+                              stat=partial(_stat, accessor),
+                              is_dir_name=is_dir_name,
+                              index=index,
+                              args=args)
+    prefix = spec.prefix
+    return [
+        p[len(prefix):] if prefix and p.startswith(prefix) else p
+        for p in results
+    ]
 
 
 def read_bytes_with_index(index: IndexCacheStore | None,

--- a/python/mirage/commands/builtin/databricks_volume/cat.py
+++ b/python/mirage/commands/builtin/databricks_volume/cat.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cat import cat as generic_cat
 from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -23,19 +24,10 @@ from mirage.core.databricks_volume.glob import resolve_glob
 from mirage.core.databricks_volume.read import read_bytes
 from mirage.core.databricks_volume.stat import stat
 from mirage.core.databricks_volume.stream import read_stream
-from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.cachable_iterator import CachableAsyncIterator
 from mirage.io.stream import async_chain
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-
-
-async def _number_lines_stream(
-        source: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
-    line_number = 1
-    async for line in AsyncLineIterator(source):
-        yield f"     {line_number}\t".encode() + line + b"\n"
-        line_number += 1
 
 
 @command("cat", resource="databricks_volume", spec=SPECS["cat"])
@@ -73,9 +65,9 @@ async def cat(
             io = IOResult(reads=reads, cache=list(reads))
             source = async_chain(*parts)
         if n:
-            return _number_lines_stream(source), io
+            return generic_cat(source, number_lines=True), io
         return source, io
     source = _resolve_source(stdin, "cat: missing operand")
     if n:
-        return _number_lines_stream(source), IOResult()
+        return generic_cat(source, number_lines=True), IOResult()
     return source, IOResult()

--- a/python/mirage/commands/builtin/databricks_volume/cp.py
+++ b/python/mirage/commands/builtin/databricks_volume/cp.py
@@ -16,14 +16,13 @@ from functools import partial
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.databricks_volume._helpers import (
-    same_backend_file, target_within_source)
-from mirage.commands.builtin.utils.copy import (copy_targets, is_directory,
-                                                path_exists)
+from mirage.commands.builtin.databricks_volume._helpers import find_files
+from mirage.commands.builtin.generic.cp import cp as generic_cp
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.copy import copy as copy_core
 from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.path import backend_path
 from mirage.core.databricks_volume.stat import stat as stat_core
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -47,34 +46,13 @@ async def cp(
     if len(paths) < 2:
         raise ValueError("cp: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
-    recursive = r or R or a
-    stat = partial(stat_core, accessor)
-    *sources, dst = paths
-    dst_is_dir = await is_directory(stat, dst, index)
-    writes: dict[str, bytes] = {}
-    lines: list[str] = []
-    errors: list[str] = []
-    for src, target in copy_targets(sources, dst, dst_is_dir):
-        if not await path_exists(stat, src):
-            errors.append(f"cp: cannot stat '{src.original}': "
-                          "No such file or directory")
-            continue
-        if same_backend_file(accessor, src, target):
-            errors.append(f"cp: '{src.original}' and '{target.original}' "
-                          "are the same file")
-            continue
-        if recursive and target_within_source(accessor, src, target):
-            errors.append(f"cp: cannot copy a directory, '{src.original}', "
-                          f"into itself, '{target.original}'")
-            continue
-        if n and await path_exists(stat, target):
-            continue
-        await copy_core(accessor, src, target, index, recursive=recursive)
-        writes[target.strip_prefix] = b""
-        if v:
-            lines.append(f"'{src.original}' -> '{target.original}'")
-    output = ("\n".join(lines) + "\n").encode() if lines else None
-    stderr = ("\n".join(errors) + "\n").encode() if errors else None
-    return output, IOResult(writes=writes,
-                            stderr=stderr,
-                            exit_code=1 if errors else 0)
+    return await generic_cp(paths,
+                            copy=partial(copy_core, accessor, index=index),
+                            find=partial(find_files, accessor, index),
+                            find_type="f",
+                            stat=partial(stat_core, accessor),
+                            recursive=r or R or a,
+                            n=n,
+                            v=v,
+                            index=index,
+                            backend_key=partial(backend_path, accessor.config))

--- a/python/mirage/commands/builtin/databricks_volume/find.py
+++ b/python/mirage/commands/builtin/databricks_volume/find.py
@@ -12,70 +12,20 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import fnmatch
+from functools import partial
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.databricks_volume._helpers import is_dir_name
+from mirage.commands.builtin.generic.find import parse_find_args, walk_find
 from mirage.commands.builtin.utils.output import format_records
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
-from mirage.core.databricks_volume.readdir import readdir
-from mirage.core.databricks_volume.stat import stat
+from mirage.core.databricks_volume.readdir import readdir as _readdir
+from mirage.core.databricks_volume.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileStat, FileType, PathSpec
-
-
-def _matches_find(
-    path: PathSpec,
-    file_stat: FileStat,
-    name: str | None,
-    type_filter: str | None,
-) -> bool:
-    if type_filter == "file" and file_stat.type == FileType.DIRECTORY:
-        return False
-    if type_filter == "directory" and file_stat.type != FileType.DIRECTORY:
-        return False
-    if name is not None and not fnmatch.fnmatch(file_stat.name, name):
-        return False
-    return bool(path.original)
-
-
-async def _find_recurse(
-    accessor: DatabricksVolumeAccessor,
-    path: PathSpec,
-    name: str | None,
-    type_filter: str | None,
-    maxdepth: int | None,
-    depth: int,
-    index: IndexCacheStore | None,
-) -> list[str]:
-    results: list[str] = []
-    file_stat = await stat(accessor, path, index)
-    if depth > 0 and _matches_find(path, file_stat, name, type_filter):
-        results.append(path.original)
-    if file_stat.type != FileType.DIRECTORY:
-        return results
-    if maxdepth is not None and depth >= maxdepth:
-        return results
-    entries = await readdir(accessor, path, index)
-    for entry in entries:
-        entry_path = PathSpec(
-            original=entry,
-            directory=entry,
-            resolved=False,
-            prefix=path.prefix,
-        )
-        results.extend(await _find_recurse(
-            accessor,
-            entry_path,
-            name,
-            type_filter,
-            maxdepth,
-            depth + 1,
-            index,
-        ))
-    return results
+from mirage.types import PathSpec
 
 
 @command("find", resource="databricks_volume", spec=SPECS["find"])
@@ -87,19 +37,36 @@ async def find(
     name: str | None = None,
     type: str | None = None,
     maxdepth: str | None = None,
+    size: str | None = None,
+    mtime: str | None = None,
+    iname: str | None = None,
+    path: str | None = None,
+    mindepth: str | None = None,
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     paths = await resolve_glob(accessor, paths, index)
-    path = paths[0]
-    type_filter = None
-    if type == "d":
-        type_filter = "directory"
-    elif type == "f":
-        type_filter = "file"
-    elif type is not None:
-        type_filter = type
-    depth = int(maxdepth) if maxdepth is not None else None
-    results = await _find_recurse(accessor, path, name, type_filter, depth, 0,
-                                  index)
-    return format_records(results), IOResult()
+    p0 = paths[0] if paths else None
+    search_path = p0.original if p0 else "/"
+    search_prefix = p0.prefix if p0 else ""
+    args = parse_find_args(texts,
+                           name=name,
+                           type=type,
+                           size=size,
+                           mtime=mtime,
+                           maxdepth=maxdepth,
+                           iname=iname,
+                           path=path,
+                           mindepth=mindepth)
+    search_spec = PathSpec(original=search_path,
+                           directory=search_path,
+                           resolved=False,
+                           prefix=search_prefix)
+    results = await walk_find(search_spec,
+                              readdir=partial(_readdir, accessor),
+                              stat=partial(_stat, accessor),
+                              is_dir_name=is_dir_name,
+                              index=index,
+                              args=args)
+    output = format_records(results)
+    return output, IOResult()

--- a/python/mirage/commands/builtin/databricks_volume/grep.py
+++ b/python/mirage/commands/builtin/databricks_volume/grep.py
@@ -13,265 +13,41 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import (compile_pattern,
-                                                 grep_files_only, grep_lines,
-                                                 grep_recursive, grep_stream)
-from mirage.commands.builtin.utils.output import (format_optional_records,
-                                                  format_records)
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes,
-                                                call_read_stream, call_readdir,
-                                                call_stat)
+from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
 from mirage.core.databricks_volume.read import read_bytes as _read_bytes
 from mirage.core.databricks_volume.readdir import readdir as _readdir
 from mirage.core.databricks_volume.stat import stat as _stat
-from mirage.core.databricks_volume.stream import read_stream
-from mirage.io.stream import exit_on_empty, quiet_match
+from mirage.core.databricks_volume.stream import read_stream as _read_stream
 from mirage.io.types import ByteSource, IOResult
-from mirage.provision import ProvisionResult
-from mirage.types import FileType, PathSpec
+from mirage.types import PathSpec
 
 
-async def grep_provision(
-    accessor: DatabricksVolumeAccessor,
-    paths: list[PathSpec],
-    *texts: str,
-    r: bool = False,
-    R: bool = False,
-    index: IndexCacheStore = None,
-    **_extra: object,
-) -> ProvisionResult:
-    if not paths or accessor is None:
-        return ProvisionResult(command="grep " + " ".join(texts))
-    if not (r or R):
-        paths = await resolve_glob(accessor, paths, index)
-    if r or R:
-        mount_prefix = paths[0].prefix if paths else ""
-        entries = await _readdir(accessor, paths[0], index)
-        total = 0
-        ops = 0
-        for entry in entries:
-            try:
-                entry_spec = PathSpec(original=entry,
-                                      directory=entry,
-                                      resolved=False,
-                                      prefix=mount_prefix)
-                file_stat = await _stat(accessor, entry_spec, index)
-                if file_stat.size is not None:
-                    total += file_stat.size
-                    ops += 1
-            except FileNotFoundError:
-                continue
-        return ProvisionResult(
-            command=f"grep -r {texts[0] if texts else ''} {paths[0].original}",
-            network_read_low=total,
-            network_read_high=total,
-            read_ops=ops,
-        )
-    file_stat = await _stat(accessor, paths[0], index)
-    return ProvisionResult(
-        command=f"grep {texts[0] if texts else ''} {paths[0].original}",
-        network_read_low=file_stat.size or 0,
-        network_read_high=file_stat.size or 0,
-        read_ops=1,
-    )
-
-
-@command("grep",
-         resource="databricks_volume",
-         spec=SPECS["grep"],
-         provision=grep_provision)
+@command("grep", resource="databricks_volume", spec=SPECS["grep"])
 async def grep(
     accessor: DatabricksVolumeAccessor,
     paths: list[PathSpec],
     *texts: str,
     stdin: AsyncIterator[bytes] | bytes | None = None,
-    r: bool = False,
-    R: bool = False,
-    i: bool = False,
-    v: bool = False,
-    n: bool = False,
-    c: bool = False,
-    args_l: bool = False,
-    w: bool = False,
-    F: bool = False,
-    E: bool = False,
-    o: bool = False,
-    m: str | None = None,
-    q: bool = False,
-    H: bool = False,
-    args_h: bool = False,
-    A: str | None = None,
-    B: str | None = None,
-    C: str | None = None,
-    e: str | None = None,
     prefix: str = "",
     index: IndexCacheStore = None,
-    **_extra: object,
+    **flags: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if e is not None:
-        pattern = e
-    elif texts:
-        pattern = texts[0]
-    else:
-        raise ValueError("grep: usage: grep [flags] pattern [path]")
-    max_count = int(m) if m is not None else None
-    after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
-    before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
-
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        mount_prefix = paths[0].prefix if paths else ""
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-        rb = partial(call_read_bytes,
-                     _read_bytes,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-
-        if args_l:
-            warnings_l: list[str] = []
-            results = await grep_files_only(
-                rd,
-                st,
-                rb,
-                paths[0].original,
-                pattern,
-                recursive=r or R,
-                ignore_case=i,
-                invert=v,
-                line_numbers=n,
-                count_only=c,
-                fixed_string=F,
-                only_matching=o,
-                max_count=max_count,
-                whole_word=w,
-                warnings=warnings_l,
-                read_stream_fn=partial(call_read_stream,
-                                       read_stream,
-                                       accessor,
-                                       index=index,
-                                       prefix=mount_prefix),
-            )
-            stderr = format_optional_records(warnings_l)
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            return format_records(results), IOResult(stderr=stderr)
-
-        if r or R:
-            compiled = compile_pattern(pattern, i, F, w)
-            all_results: list[str] = []
-            warnings_r: list[str] = []
-            for path in paths:
-                file_stat = await _stat(accessor, path, index)
-                if file_stat.type == FileType.DIRECTORY:
-                    results = await grep_recursive(
-                        rd,
-                        st,
-                        rb,
-                        path.original,
-                        compiled,
-                        invert=v,
-                        line_numbers=n,
-                        count_only=c,
-                        files_only=False,
-                        only_matching=o,
-                        max_count=max_count,
-                        warnings=warnings_r,
-                        read_stream_fn=partial(call_read_stream,
-                                               read_stream,
-                                               accessor,
-                                               index=index,
-                                               prefix=mount_prefix),
-                    )
-                    all_results.extend(results)
-                else:
-                    data = (await _read_bytes(
-                        accessor, path,
-                        index)).decode(errors="replace").splitlines()
-                    hits = grep_lines(path.original, data, compiled, v, n, c,
-                                      args_l, o, max_count)
-                    if c and hits:
-                        all_results.append(f"{path.original}:{hits[0]}")
-                    else:
-                        all_results.extend(
-                            f"{path.original}:{line}" if len(paths) >
-                            1 else line for line in hits)
-            stderr = format_optional_records(warnings_r)
-            if not all_results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            return format_records(all_results), IOResult(stderr=stderr)
-
-        compiled = compile_pattern(pattern, i, F, w)
-
-        if len(paths) > 1:
-            all_results: list[str] = []
-            for path in paths:
-                data = (await _read_bytes(
-                    accessor, path,
-                    index)).decode(errors="replace").splitlines()
-                hits = grep_lines(path.original, data, compiled, v, n, c,
-                                  args_l, o, max_count)
-                if c:
-                    if hits:
-                        all_results.append(f"{path.original}:{hits[0]}")
-                elif args_l:
-                    all_results.extend(hits)
-                else:
-                    all_results.extend(f"{path.original}:{line}"
-                                       for line in hits)
-            if not all_results:
-                return b"", IOResult(exit_code=1)
-            return format_records(all_results), IOResult()
-
-        source = read_stream(accessor, paths[0], index)
-        stream = grep_stream(
-            source,
-            compiled,
-            invert=v,
-            line_numbers=n,
-            only_matching=o,
-            max_count=max_count,
-            count_only=c,
-            after_context=after_ctx,
-            before_context=before_ctx,
-        )
-        if q:
-            io = IOResult(exit_code=1)
-            return quiet_match(stream, io), io
-        io = IOResult()
-        return exit_on_empty(stream, io), io
-    source = _resolve_source(stdin, "grep: usage: grep [flags] pattern [path]")
-    compiled = compile_pattern(pattern, i, F, w)
-    stream = grep_stream(
-        source,
-        compiled,
-        invert=v,
-        line_numbers=n,
-        only_matching=o,
-        max_count=max_count,
-        count_only=c,
-        after_context=after_ctx,
-        before_context=before_ctx,
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
+    return await generic_grep(
+        resolved,
+        texts,
+        flags,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=_read_bytes,
+        read_stream=_read_stream,
+        accessor=accessor,
+        stdin=stdin,
+        index=index,
     )
-    if q:
-        io = IOResult(exit_code=1)
-        return quiet_match(stream, io), io
-    io = IOResult()
-    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/databricks_volume/ls.py
+++ b/python/mirage/commands/builtin/databricks_volume/ls.py
@@ -12,90 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.utils.formatting import _human_size
-from mirage.commands.builtin.utils.output import (format_optional_records,
-                                                  format_records)
+from mirage.commands.builtin.generic.ls import ls as generic_ls
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
 from mirage.core.databricks_volume.readdir import readdir
 from mirage.core.databricks_volume.stat import stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileStat, FileType, PathSpec
-
-
-async def _ls_entries(
-    accessor: DatabricksVolumeAccessor,
-    path: PathSpec,
-    all_files: bool,
-    sort_by: str,
-    reverse: bool,
-    recursive: bool,
-    list_dir: bool,
-    warnings: list[str],
-    index: IndexCacheStore | None = None,
-) -> list[FileStat]:
-    if list_dir:
-        return [await stat(accessor, path, index)]
-
-    try:
-        entries = await readdir(accessor, path, index)
-    except (FileNotFoundError, ValueError) as exc:
-        warnings.append(f"ls: cannot access '{path.original}': {exc}")
-        return []
-
-    stats: list[FileStat] = []
-    for entry in entries:
-        try:
-            entry_spec = PathSpec(
-                original=entry,
-                directory=entry,
-                resolved=False,
-                prefix=path.prefix,
-            )
-            entry_stat = await stat(accessor, entry_spec, index)
-        except (FileNotFoundError, ValueError) as exc:
-            warnings.append(f"ls: cannot access '{entry}': {exc}")
-            continue
-        if not all_files and entry_stat.name.startswith("."):
-            continue
-        stats.append(entry_stat)
-
-    if sort_by == "time":
-        stats.sort(key=lambda entry: entry.modified or "", reverse=not reverse)
-    elif sort_by == "size":
-        stats.sort(key=lambda entry: entry.size or 0, reverse=not reverse)
-    else:
-        stats.sort(key=lambda entry: entry.name, reverse=reverse)
-
-    if recursive:
-        sub_entries: list[FileStat] = []
-        for entry_stat in stats:
-            sub_entries.append(entry_stat)
-            if entry_stat.type == FileType.DIRECTORY:
-                entry_path = path.child(entry_stat.name)
-                entry_spec = PathSpec(
-                    original=entry_path,
-                    directory=entry_path,
-                    resolved=False,
-                    prefix=path.prefix,
-                )
-                sub_entries.extend(await _ls_entries(
-                    accessor,
-                    entry_spec,
-                    all_files,
-                    sort_by,
-                    reverse,
-                    recursive,
-                    False,
-                    warnings,
-                    index,
-                ))
-        return sub_entries
-
-    return stats
+from mirage.types import LsSortBy, PathSpec
 
 
 @command("ls", resource="databricks_volume", spec=SPECS["ls"])
@@ -117,58 +45,31 @@ async def ls(
     F: bool = False,
     index: IndexCacheStore = None,
     cwd: PathSpec | str = "/",
-    prefix: str = "",
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     if not paths:
         cwd_str = cwd.original if isinstance(cwd, PathSpec) else cwd
         cwd_prefix = cwd.prefix if isinstance(cwd, PathSpec) else ""
         paths = [
-            PathSpec(
-                original=cwd_str,
-                directory=cwd_str,
-                resolved=False,
-                prefix=cwd_prefix,
-            )
+            PathSpec(original=cwd_str,
+                     directory=cwd_str,
+                     resolved=False,
+                     prefix=cwd_prefix)
         ]
     paths = await resolve_glob(accessor, paths, index)
-    all_files = a or A
-    sort_by = "name"
-    if t:
-        sort_by = "time"
-    elif S:
-        sort_by = "size"
-    warnings: list[str] = []
-    results: list[str] = []
-    for path in paths:
-        try:
-            entries = await _ls_entries(
-                accessor,
-                path,
-                all_files,
-                sort_by,
-                r,
-                R,
-                d,
-                warnings,
-                index,
-            )
-        except (FileNotFoundError, ValueError) as exc:
-            warnings.append(f"ls: cannot access '{path.original}': {exc}")
-            continue
-        if args_l and not args_1:
-            for entry in entries:
-                size_str = _human_size(entry.size or 0) if h else str(
-                    entry.size or 0)
-                results.append(f"{entry.type or '-'}\t{size_str}\t"
-                               f"{entry.modified or ''}\t{entry.name}")
-        else:
-            for entry in entries:
-                is_dir = F and entry.type == FileType.DIRECTORY
-                results.append(entry.name + ("/" if is_dir else ""))
-    stderr = format_optional_records(warnings)
-    exit_code = 1 if warnings and not results else 0
-    return format_records(results), IOResult(
-        stderr=stderr,
-        exit_code=exit_code,
+    sort_by = LsSortBy.TIME if t else LsSortBy.SIZE if S else LsSortBy.NAME
+    return await generic_ls(
+        paths,
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        long=args_l,
+        one_per_line=args_1,
+        all_files=a or A,
+        human=h,
+        sort_by=sort_by,
+        reverse=r,
+        recursive=R,
+        list_dir=d,
+        classify=F,
+        index=index,
     )

--- a/python/mirage/commands/builtin/databricks_volume/mv.py
+++ b/python/mirage/commands/builtin/databricks_volume/mv.py
@@ -16,13 +16,11 @@ from functools import partial
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.databricks_volume._helpers import (
-    same_backend_file, target_within_source)
-from mirage.commands.builtin.utils.copy import (copy_targets, is_directory,
-                                                path_exists)
+from mirage.commands.builtin.generic.mv import mv as generic_mv
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.path import backend_path
 from mirage.core.databricks_volume.rename import rename as rename_core
 from mirage.core.databricks_volume.stat import stat as stat_core
 from mirage.io.types import ByteSource, IOResult
@@ -44,34 +42,10 @@ async def mv(
     if len(paths) < 2:
         raise ValueError("mv: requires src and dst")
     paths = await resolve_glob(accessor, paths, index)
-    stat = partial(stat_core, accessor)
-    *sources, dst = paths
-    dst_is_dir = await is_directory(stat, dst, index)
-    writes: dict[str, bytes] = {}
-    lines: list[str] = []
-    errors: list[str] = []
-    for src, target in copy_targets(sources, dst, dst_is_dir):
-        if not await path_exists(stat, src):
-            errors.append(f"mv: cannot stat '{src.original}': "
-                          "No such file or directory")
-            continue
-        if same_backend_file(accessor, src, target):
-            errors.append(f"mv: '{src.original}' and '{target.original}' "
-                          "are the same file")
-            continue
-        if target_within_source(accessor, src, target):
-            errors.append(f"mv: cannot move '{src.original}' to a "
-                          f"subdirectory of itself, '{target.original}'")
-            continue
-        if n and await path_exists(stat, target):
-            continue
-        await rename_core(accessor, src, target, index)
-        writes[src.strip_prefix] = b""
-        writes[target.strip_prefix] = b""
-        if v:
-            lines.append(f"'{src.original}' -> '{target.original}'")
-    output = ("\n".join(lines) + "\n").encode() if lines else None
-    stderr = ("\n".join(errors) + "\n").encode() if errors else None
-    return output, IOResult(writes=writes,
-                            stderr=stderr,
-                            exit_code=1 if errors else 0)
+    return await generic_mv(paths,
+                            rename=partial(rename_core, accessor, index=index),
+                            stat=partial(stat_core, accessor),
+                            n=n,
+                            v=v,
+                            index=index,
+                            backend_key=partial(backend_path, accessor.config))

--- a/python/mirage/commands/builtin/databricks_volume/rg.py
+++ b/python/mirage/commands/builtin/databricks_volume/rg.py
@@ -13,28 +13,19 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from functools import partial
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.grep_helper import (compile_pattern, grep_lines,
-                                                 grep_stream)
-from mirage.commands.builtin.rg_helper import rg_full
-from mirage.commands.builtin.utils.output import (format_optional_records,
-                                                  format_records)
-from mirage.commands.builtin.utils.stream import _resolve_source
-from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
-                                                call_stat)
+from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
 from mirage.core.databricks_volume.read import read_bytes as _read_bytes
 from mirage.core.databricks_volume.readdir import readdir as _readdir
 from mirage.core.databricks_volume.stat import stat as _stat
-from mirage.core.databricks_volume.stream import read_stream
-from mirage.io.stream import exit_on_empty
+from mirage.core.databricks_volume.stream import read_stream as _read_stream
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
+from mirage.types import PathSpec
 
 
 @command("rg", resource="databricks_volume", spec=SPECS["rg"])
@@ -42,151 +33,21 @@ async def rg(
     accessor: DatabricksVolumeAccessor,
     paths: list[PathSpec],
     *texts: str,
-    e: str | None = None,
     stdin: AsyncIterator[bytes] | bytes | None = None,
-    i: bool = False,
-    v: bool = False,
-    n: bool = False,
-    c: bool = False,
-    args_l: bool = False,
-    w: bool = False,
-    F: bool = False,
-    o: bool = False,
-    m: str | None = None,
-    A: str | None = None,
-    B: str | None = None,
-    C: str | None = None,
-    hidden: bool = False,
-    type: str | None = None,
-    glob: str | None = None,
     prefix: str = "",
     index: IndexCacheStore = None,
-    **_extra: object,
+    **flags: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if e is not None:
-        pattern = e
-    elif texts:
-        pattern = texts[0]
-    else:
-        raise ValueError("rg: usage: rg [flags] pattern [path]")
-    max_count = int(m) if m is not None else None
-    context_after = int(A) if A is not None else 0
-    context_before = int(B) if B is not None else 0
-    if C is not None:
-        context_before = context_after = int(C)
-
-    if paths:
-        paths = await resolve_glob(accessor, paths, index)
-        mount_prefix = paths[0].prefix if paths else ""
-        rd = partial(call_readdir,
-                     _readdir,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-        st = partial(call_stat,
-                     _stat,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-        rb = partial(call_read_bytes,
-                     _read_bytes,
-                     accessor,
-                     index=index,
-                     prefix=mount_prefix)
-
-        is_dir = False
-        try:
-            file_stat = await _stat(accessor, paths[0], index)
-            is_dir = file_stat.type == FileType.DIRECTORY
-        except (FileNotFoundError, ValueError):
-            try:
-                await _readdir(accessor, paths[0], index)
-                is_dir = True
-            except (FileNotFoundError, ValueError):
-                pass
-
-        needs_full = (is_dir or args_l or context_before or context_after
-                      or type or glob)
-        if needs_full:
-            warnings_f: list[str] = []
-            results = await rg_full(
-                rd,
-                st,
-                rb,
-                paths[0].original,
-                pattern,
-                ignore_case=i,
-                invert=v,
-                line_numbers=n,
-                count_only=c,
-                files_only=args_l,
-                fixed_string=F,
-                only_matching=o,
-                max_count=max_count,
-                whole_word=w,
-                context_before=context_before,
-                context_after=context_after,
-                file_type=type,
-                glob_pattern=glob,
-                hidden=hidden,
-                warnings=warnings_f,
-            )
-            stderr = format_optional_records(warnings_f)
-            if not results:
-                return b"", IOResult(exit_code=1, stderr=stderr)
-            if mount_prefix and args_l:
-                results = [mount_prefix + "/" + r.lstrip("/") for r in results]
-            return format_records(results), IOResult(stderr=stderr)
-
-        compiled = compile_pattern(pattern, i, F, w)
-
-        if len(paths) > 1:
-            all_results: list[str] = []
-            for path in paths:
-                data = (await _read_bytes(
-                    accessor, path,
-                    index)).decode(errors="replace").splitlines()
-                hits = grep_lines(path.original, data, compiled, v, n, c,
-                                  args_l, o, max_count)
-                if c:
-                    if hits:
-                        all_results.append(f"{path.original}:{hits[0]}")
-                elif args_l:
-                    all_results.extend(hits)
-                else:
-                    all_results.extend(f"{path.original}:{line}"
-                                       for line in hits)
-            if not all_results:
-                return b"", IOResult(exit_code=1)
-            if mount_prefix:
-                all_results = [
-                    mount_prefix + "/" + result.lstrip("/")
-                    for result in all_results
-                ]
-            return format_records(all_results), IOResult()
-
-        source = read_stream(accessor, paths[0], index)
-        stream = grep_stream(
-            source,
-            compiled,
-            invert=v,
-            line_numbers=n,
-            only_matching=o,
-            max_count=max_count,
-            count_only=c,
-        )
-        io = IOResult()
-        return exit_on_empty(stream, io), io
-    source = _resolve_source(stdin, "rg: usage: rg [flags] pattern path")
-    compiled = compile_pattern(pattern, i, F, w)
-    stream = grep_stream(
-        source,
-        compiled,
-        invert=v,
-        line_numbers=n,
-        only_matching=o,
-        max_count=max_count,
-        count_only=c,
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
+    return await generic_rg(
+        resolved,
+        texts,
+        flags,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=_read_bytes,
+        read_stream=_read_stream,
+        accessor=accessor,
+        stdin=stdin,
+        index=index,
     )
-    io = IOResult()
-    return exit_on_empty(stream, io), io

--- a/python/mirage/commands/builtin/databricks_volume/stat.py
+++ b/python/mirage/commands/builtin/databricks_volume/stat.py
@@ -12,52 +12,15 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import re
-from functools import partial
-
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.utils.output import format_records
+from mirage.commands.builtin.generic.stat import stat as generic_stat
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
-from mirage.core.databricks_volume.stat import stat as stat_impl
+from mirage.core.databricks_volume.stat import stat as stat_core
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileStat, FileType, PathSpec
-
-_FORMAT_RE = re.compile(r"%([nsFy]|.)")
-
-_TYPE_LABELS = {
-    FileType.DIRECTORY: "directory",
-    FileType.TEXT: "regular file",
-    FileType.BINARY: "regular file",
-    FileType.JSON: "regular file",
-    FileType.CSV: "regular file",
-}
-
-
-def _stat_type_label(file_stat: FileStat) -> str:
-    if file_stat.type is None:
-        return "regular file"
-    return _TYPE_LABELS.get(file_stat.type, "regular file")
-
-
-def _replace_stat_format(file_stat: FileStat, name: str,
-                         match: re.Match) -> str:
-    spec = match.group(1)
-    if spec == "n":
-        return name
-    if spec == "s":
-        return str(file_stat.size if file_stat.size is not None else 0)
-    if spec == "F":
-        return _stat_type_label(file_stat)
-    if spec == "y":
-        return file_stat.modified or ""
-    return "?"
-
-
-def _format_stat(fmt: str, file_stat: FileStat, name: str) -> str:
-    return _FORMAT_RE.sub(partial(_replace_stat_format, file_stat, name), fmt)
+from mirage.types import PathSpec
 
 
 @command("stat", resource="databricks_volume", spec=SPECS["stat"])
@@ -74,14 +37,9 @@ async def stat(
     if not paths:
         raise ValueError("stat: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    fmt = c if c is not None else f
-    lines: list[str] = []
-    for path in paths:
-        file_stat = await stat_impl(accessor, path, index)
-        if fmt is not None:
-            lines.append(_format_stat(fmt, file_stat, path.original))
-        else:
-            type_value = file_stat.type.value if file_stat.type else None
-            lines.append(f"name={file_stat.name} size={file_stat.size}"
-                         f" modified={file_stat.modified} type={type_value}")
-    return format_records(lines), IOResult()
+    return await generic_stat(paths,
+                              stat_fn=stat_core,
+                              accessor=accessor,
+                              c=c,
+                              f=f,
+                              index=index)

--- a/python/mirage/commands/builtin/databricks_volume/tree.py
+++ b/python/mirage/commands/builtin/databricks_volume/tree.py
@@ -12,77 +12,18 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.utils.output import (format_optional_records,
-                                                  format_records)
+from mirage.commands.builtin.generic.tree import tree as generic_tree
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.databricks_volume.glob import resolve_glob
 from mirage.core.databricks_volume.readdir import readdir
 from mirage.core.databricks_volume.stat import stat
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import FileType, PathSpec
-
-
-async def _tree_recurse(
-    accessor: DatabricksVolumeAccessor,
-    path: PathSpec,
-    prefix: str = "",
-    max_depth: int | None = None,
-    show_hidden: bool = False,
-    dirs_only: bool = False,
-    depth: int = 0,
-    warnings: list[str] | None = None,
-    index: IndexCacheStore | None = None,
-) -> list[str]:
-    lines: list[str] = []
-    try:
-        entries = await readdir(accessor, path, index)
-    except (FileNotFoundError, ValueError) as exc:
-        if warnings is not None:
-            warnings.append(f"tree: '{path.original}': {exc}")
-        return lines
-    filtered: list[tuple[PathSpec, str, FileType | None]] = []
-    for entry in entries:
-        try:
-            entry_spec = PathSpec(
-                original=entry,
-                directory=entry,
-                resolved=False,
-                prefix=path.prefix,
-            )
-            entry_stat = await stat(accessor, entry_spec, index)
-        except (FileNotFoundError, ValueError) as exc:
-            if warnings is not None:
-                warnings.append(f"tree: '{entry}': {exc}")
-            continue
-        if not show_hidden and entry_stat.name.startswith("."):
-            continue
-        if dirs_only and entry_stat.type != FileType.DIRECTORY:
-            continue
-        filtered.append((entry_spec, entry_stat.name, entry_stat.type))
-    for i, (entry_spec, name, file_type) in enumerate(filtered):
-        is_last = i == len(filtered) - 1
-        connector = "\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 "
-        lines.append(prefix + connector + name)
-        if file_type != FileType.DIRECTORY:
-            continue
-        if max_depth is not None and depth >= max_depth:
-            continue
-        extension = "    " if is_last else "\u2502   "
-        lines.extend(await _tree_recurse(
-            accessor,
-            entry_spec,
-            prefix + extension,
-            max_depth=max_depth,
-            show_hidden=show_hidden,
-            dirs_only=dirs_only,
-            depth=depth + 1,
-            warnings=warnings,
-            index=index,
-        ))
-    return lines
+from mirage.types import PathSpec
 
 
 @command("tree", resource="databricks_volume", spec=SPECS["tree"])
@@ -93,22 +34,21 @@ async def tree(
     stdin: bytes | None = None,
     L: str | None = None,
     a: bool = False,
+    args_I: str | None = None,
     d: bool = False,
+    P: str | None = None,
     index: IndexCacheStore = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     paths = await resolve_glob(accessor, paths, index)
-    path = paths[0]
-    max_depth = int(L) if L is not None else None
-    warnings: list[str] = []
-    results = await _tree_recurse(
-        accessor,
-        path,
-        max_depth=max_depth,
+    return await generic_tree(
+        paths[0],
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        max_depth=int(L) if L is not None else None,
         show_hidden=a,
+        ignore_pattern=args_I,
         dirs_only=d,
-        warnings=warnings,
+        match_pattern=P,
         index=index,
     )
-    stderr = format_optional_records(warnings)
-    return format_records(results), IOResult(stderr=stderr)

--- a/python/mirage/commands/builtin/generic/cp.py
+++ b/python/mirage/commands/builtin/generic/cp.py
@@ -15,7 +15,8 @@
 from typing import Awaitable, Callable
 
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.utils.copy import (copy_targets, is_directory,
+from mirage.commands.builtin.utils.copy import (backend_key_default,
+                                                copy_targets, is_directory,
                                                 path_exists)
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -32,6 +33,7 @@ async def cp(
     n: bool,
     v: bool,
     index: IndexCacheStore | None = None,
+    backend_key: Callable[[PathSpec], str] | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
     """Copy sources to a destination, fanning out into a directory.
 
@@ -45,15 +47,34 @@ async def cp(
         n (bool): No-clobber; skip targets that already exist.
         v (bool): Verbose; emit one ``src -> target`` line per write.
         index (IndexCacheStore | None): Cache for the destination dir probe.
+        backend_key (Callable | None): Maps a path to its backend storage key
+            for the same-file and into-own-subtree guards; defaults to the
+            normalized mount-relative path.
 
     Returns:
-        tuple[ByteSource | None, IOResult]: Verbose output and recorded writes.
+        tuple[ByteSource | None, IOResult]: Verbose output and recorded
+        writes, with per-source coreutils errors on stderr and exit code 1
+        when any source failed.
     """
+    key_of = backend_key if backend_key is not None else backend_key_default
     *sources, dst = paths
     dst_is_dir = await is_directory(stat, dst, index)
     writes: dict[str, bytes] = {}
     lines: list[str] = []
+    errors: list[str] = []
     for src, target in copy_targets(sources, dst, dst_is_dir):
+        if not await path_exists(stat, src):
+            errors.append(f"cp: cannot stat '{src.original}': "
+                          "No such file or directory")
+            continue
+        if key_of(src) == key_of(target):
+            errors.append(f"cp: '{src.original}' and '{target.original}' "
+                          "are the same file")
+            continue
+        if recursive and key_of(target).startswith(key_of(src) + "/"):
+            errors.append(f"cp: cannot copy a directory, '{src.original}', "
+                          f"into itself, '{target.original}'")
+            continue
         if recursive:
             src_base = src.strip_prefix.rstrip("/")
             dst_base = target.strip_prefix.rstrip("/")
@@ -64,13 +85,18 @@ async def cp(
                 await copy(entry, entry_dst)
                 writes[entry_dst] = b""
                 if v:
-                    lines.append(f"{entry} -> {entry_dst}")
+                    lines.append(f"'{entry}' -> '{entry_dst}'")
             continue
         if n and await path_exists(stat, target):
             continue
         await copy(src, target)
         writes[target.strip_prefix] = b""
         if v:
-            lines.append(f"{src.original} -> {target.original}")
+            lines.append(f"'{src.original}' -> '{target.original}'")
     output = "\n".join(lines) + "\n" if lines else None
-    return output.encode() if output else None, IOResult(writes=writes)
+    stderr = ("\n".join(errors) + "\n").encode() if errors else None
+    return output.encode() if output else None, IOResult(
+        writes=writes,
+        stderr=stderr,
+        exit_code=1 if errors else 0,
+    )

--- a/python/mirage/commands/builtin/generic/mv.py
+++ b/python/mirage/commands/builtin/generic/mv.py
@@ -15,7 +15,8 @@
 from typing import Awaitable, Callable
 
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.utils.copy import (copy_targets, is_directory,
+from mirage.commands.builtin.utils.copy import (backend_key_default,
+                                                copy_targets, is_directory,
                                                 path_exists)
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -29,6 +30,7 @@ async def mv(
     n: bool,
     v: bool,
     index: IndexCacheStore | None = None,
+    backend_key: Callable[[PathSpec], str] | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
     """Move sources to a destination, fanning out into a directory.
 
@@ -39,15 +41,34 @@ async def mv(
         n (bool): No-clobber; skip targets that already exist.
         v (bool): Verbose; emit one ``src -> target`` line per move.
         index (IndexCacheStore | None): Cache for the destination dir probe.
+        backend_key (Callable | None): Maps a path to its backend storage key
+            for the same-file and into-own-subtree guards; defaults to the
+            normalized mount-relative path.
 
     Returns:
-        tuple[ByteSource | None, IOResult]: Verbose output and recorded writes.
+        tuple[ByteSource | None, IOResult]: Verbose output and recorded
+        writes, with per-source coreutils errors on stderr and exit code 1
+        when any source failed.
     """
+    key_of = backend_key if backend_key is not None else backend_key_default
     *sources, dst = paths
     dst_is_dir = await is_directory(stat, dst, index)
     writes: dict[str, bytes] = {}
     lines: list[str] = []
+    errors: list[str] = []
     for src, target in copy_targets(sources, dst, dst_is_dir):
+        if not await path_exists(stat, src):
+            errors.append(f"mv: cannot stat '{src.original}': "
+                          "No such file or directory")
+            continue
+        if key_of(src) == key_of(target):
+            errors.append(f"mv: '{src.original}' and '{target.original}' "
+                          "are the same file")
+            continue
+        if key_of(target).startswith(key_of(src) + "/"):
+            errors.append(f"mv: cannot move '{src.original}' to a "
+                          f"subdirectory of itself, '{target.original}'")
+            continue
         if n and await path_exists(stat, target):
             continue
         await rename(src, target)
@@ -56,4 +77,9 @@ async def mv(
         if v:
             lines.append(f"'{src.original}' -> '{target.original}'")
     output = "\n".join(lines) + "\n" if lines else None
-    return output.encode() if output else None, IOResult(writes=writes)
+    stderr = ("\n".join(errors) + "\n").encode() if errors else None
+    return output.encode() if output else None, IOResult(
+        writes=writes,
+        stderr=stderr,
+        exit_code=1 if errors else 0,
+    )

--- a/python/mirage/commands/builtin/utils/copy.py
+++ b/python/mirage/commands/builtin/utils/copy.py
@@ -27,6 +27,10 @@ def child_path(parent: PathSpec, name: str) -> PathSpec:
     return PathSpec.from_str_path(f"{base}/{name}", parent.prefix)
 
 
+def backend_key_default(path: PathSpec) -> str:
+    return path.strip_prefix.rstrip("/")
+
+
 def copy_targets(sources: list[PathSpec], dst: PathSpec,
                  dst_is_dir: bool) -> list[tuple[PathSpec, PathSpec]]:
     """Map copy or move sources to their destination paths.

--- a/python/tests/commands/builtin/databricks_volume/test_cat.py
+++ b/python/tests/commands/builtin/databricks_volume/test_cat.py
@@ -1,0 +1,40 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_cat_single_file(databricks_text_workspace):
+    io = await databricks_text_workspace.execute("cat /dbx/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"beta\nalpha\nalpha\n"
+
+
+@pytest.mark.asyncio
+async def test_cat_multiple_files_concatenated(databricks_text_workspace):
+    io = await databricks_text_workspace.execute(
+        "cat /dbx/words.txt /dbx/more.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"beta\nalpha\nalpha\ndelta\n"
+
+
+@pytest.mark.asyncio
+async def test_cat_n_numbers_lines(databricks_text_workspace):
+    io = await databricks_text_workspace.execute("cat -n /dbx/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"     1\tbeta\n     2\talpha\n     3\talpha\n"

--- a/python/tests/commands/builtin/databricks_volume/test_find.py
+++ b/python/tests/commands/builtin/databricks_volume/test_find.py
@@ -1,0 +1,68 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, Workspace
+from tests.resource.databricks_volume.test_databricks_volume import (
+    FakeFiles, make_resource, seed_directory, seed_file)
+
+ROOT = "/Volumes/main/default/agent_files/root"
+
+
+@pytest.fixture
+def dbx_files() -> FakeFiles:
+    files = FakeFiles()
+    seed_directory(files, ROOT)
+    seed_file(files, f"{ROOT}/words.txt", b"beta\nalpha\nalpha\n")
+    seed_file(files, f"{ROOT}/notes.md", b"note\n")
+    files.create_directory(f"{ROOT}/sub")
+    seed_file(files, f"{ROOT}/sub/inner.txt", b"gamma\nalpha\n")
+    return files
+
+
+@pytest.fixture
+def ws(dbx_files: FakeFiles) -> Workspace:
+    return Workspace({"/dbx/": make_resource(dbx_files)}, mode=MountMode.READ)
+
+
+@pytest.mark.asyncio
+async def test_find_name_glob(ws):
+    io = await ws.execute("find /dbx/ -name '*.txt'")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "words.txt" in out
+    assert "inner.txt" in out
+    assert "notes.md" not in out
+
+
+@pytest.mark.asyncio
+async def test_find_type_d(ws):
+    io = await ws.execute("find /dbx/ -type d")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "sub" in out
+    assert "words.txt" not in out
+
+
+@pytest.mark.asyncio
+async def test_find_maxdepth(ws):
+    io = await ws.execute("find /dbx/ -maxdepth 1")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "words.txt" in out
+    assert "inner.txt" not in out

--- a/python/tests/commands/builtin/databricks_volume/test_grep.py
+++ b/python/tests/commands/builtin/databricks_volume/test_grep.py
@@ -1,0 +1,77 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, Workspace
+from tests.resource.databricks_volume.test_databricks_volume import (
+    FakeFiles, make_resource, seed_directory, seed_file)
+
+ROOT = "/Volumes/main/default/agent_files/root"
+
+
+@pytest.fixture
+def dbx_files() -> FakeFiles:
+    files = FakeFiles()
+    seed_directory(files, ROOT)
+    seed_file(files, f"{ROOT}/words.txt", b"beta\nalpha\nalpha\n")
+    files.create_directory(f"{ROOT}/sub")
+    seed_file(files, f"{ROOT}/sub/inner.txt", b"gamma\nalpha\n")
+    return files
+
+
+@pytest.fixture
+def ws(dbx_files: FakeFiles) -> Workspace:
+    return Workspace({"/dbx/": make_resource(dbx_files)}, mode=MountMode.READ)
+
+
+@pytest.mark.asyncio
+async def test_grep_single_file(ws):
+    io = await ws.execute("grep alpha /dbx/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"alpha\nalpha\n"
+
+
+@pytest.mark.asyncio
+async def test_grep_line_numbers(ws):
+    io = await ws.execute("grep -n alpha /dbx/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"2:alpha\n3:alpha\n"
+
+
+@pytest.mark.asyncio
+async def test_grep_count_only(ws):
+    io = await ws.execute("grep -c alpha /dbx/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"2\n"
+
+
+@pytest.mark.asyncio
+async def test_grep_recursive(ws):
+    io = await ws.execute("grep -r alpha /dbx/")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "words.txt" in out
+    assert "inner.txt" in out
+
+
+@pytest.mark.asyncio
+async def test_grep_no_match_exits_nonzero(ws):
+    io = await ws.execute("grep zeta /dbx/words.txt")
+
+    assert io.exit_code != 0

--- a/python/tests/commands/builtin/databricks_volume/test_ls.py
+++ b/python/tests/commands/builtin/databricks_volume/test_ls.py
@@ -1,0 +1,81 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, Workspace
+from tests.resource.databricks_volume.test_databricks_volume import (
+    FakeFiles, make_resource, seed_directory, seed_file)
+
+ROOT = "/Volumes/main/default/agent_files/root"
+
+
+@pytest.fixture
+def dbx_files() -> FakeFiles:
+    files = FakeFiles()
+    seed_directory(files, ROOT)
+    seed_file(files, f"{ROOT}/words.txt", b"beta\nalpha\nalpha\n")
+    seed_file(files, f"{ROOT}/.hidden", b"h\n")
+    files.create_directory(f"{ROOT}/sub")
+    seed_file(files, f"{ROOT}/sub/inner.txt", b"gamma\nalpha\n")
+    return files
+
+
+@pytest.fixture
+def ws(dbx_files: FakeFiles) -> Workspace:
+    return Workspace({"/dbx/": make_resource(dbx_files)}, mode=MountMode.READ)
+
+
+@pytest.mark.asyncio
+async def test_ls_lists_entries(ws):
+    io = await ws.execute("ls /dbx/")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "words.txt" in out
+    assert "sub" in out
+    assert ".hidden" not in out
+
+
+@pytest.mark.asyncio
+async def test_ls_a_includes_hidden(ws):
+    io = await ws.execute("ls -a /dbx/")
+
+    assert io.exit_code == 0
+    assert ".hidden" in io.stdout.decode()
+
+
+@pytest.mark.asyncio
+async def test_ls_long_includes_size(ws):
+    io = await ws.execute("ls -l /dbx/")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "words.txt" in out
+    assert "17" in out
+
+
+@pytest.mark.asyncio
+async def test_ls_recursive_descends_subdirs(ws):
+    io = await ws.execute("ls -R /dbx/")
+
+    assert io.exit_code == 0
+    assert "inner.txt" in io.stdout.decode()
+
+
+@pytest.mark.asyncio
+async def test_ls_missing_path_warns(ws):
+    io = await ws.execute("ls /dbx/missing")
+
+    assert io.exit_code != 0

--- a/python/tests/commands/builtin/databricks_volume/test_rg.py
+++ b/python/tests/commands/builtin/databricks_volume/test_rg.py
@@ -1,0 +1,61 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, Workspace
+from tests.resource.databricks_volume.test_databricks_volume import (
+    FakeFiles, make_resource, seed_directory, seed_file)
+
+ROOT = "/Volumes/main/default/agent_files/root"
+
+
+@pytest.fixture
+def dbx_files() -> FakeFiles:
+    files = FakeFiles()
+    seed_directory(files, ROOT)
+    seed_file(files, f"{ROOT}/words.txt", b"beta\nalpha\nalpha\n")
+    files.create_directory(f"{ROOT}/sub")
+    seed_file(files, f"{ROOT}/sub/inner.txt", b"gamma\nalpha\n")
+    return files
+
+
+@pytest.fixture
+def ws(dbx_files: FakeFiles) -> Workspace:
+    return Workspace({"/dbx/": make_resource(dbx_files)}, mode=MountMode.READ)
+
+
+@pytest.mark.asyncio
+async def test_rg_searches_path_recursively(ws):
+    io = await ws.execute("rg alpha /dbx/")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "words.txt" in out
+    assert "inner.txt" in out
+
+
+@pytest.mark.asyncio
+async def test_rg_count_only(ws):
+    io = await ws.execute("rg -c alpha /dbx/words.txt")
+
+    assert io.exit_code == 0
+    assert b"2" in io.stdout
+
+
+@pytest.mark.asyncio
+async def test_rg_no_match_exits_nonzero(ws):
+    io = await ws.execute("rg zeta /dbx/words.txt")
+
+    assert io.exit_code != 0

--- a/python/tests/commands/builtin/databricks_volume/test_stat.py
+++ b/python/tests/commands/builtin/databricks_volume/test_stat.py
@@ -1,0 +1,41 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_stat_default_format(databricks_text_workspace):
+    io = await databricks_text_workspace.execute("stat /dbx/words.txt")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "name=words.txt" in out
+    assert "size=17" in out
+
+
+@pytest.mark.asyncio
+async def test_stat_custom_format(databricks_text_workspace):
+    io = await databricks_text_workspace.execute(
+        "stat -c '%n %s' /dbx/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout.decode().strip() == "/dbx/words.txt 17"
+
+
+@pytest.mark.asyncio
+async def test_stat_missing_file_fails(databricks_text_workspace):
+    io = await databricks_text_workspace.execute("stat /dbx/missing.txt")
+
+    assert io.exit_code != 0

--- a/python/tests/commands/builtin/databricks_volume/test_tree.py
+++ b/python/tests/commands/builtin/databricks_volume/test_tree.py
@@ -1,0 +1,69 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, Workspace
+from tests.resource.databricks_volume.test_databricks_volume import (
+    FakeFiles, make_resource, seed_directory, seed_file)
+
+ROOT = "/Volumes/main/default/agent_files/root"
+
+
+@pytest.fixture
+def dbx_files() -> FakeFiles:
+    files = FakeFiles()
+    seed_directory(files, ROOT)
+    seed_file(files, f"{ROOT}/words.txt", b"beta\nalpha\nalpha\n")
+    files.create_directory(f"{ROOT}/sub")
+    seed_file(files, f"{ROOT}/sub/inner.txt", b"gamma\nalpha\n")
+    files.create_directory(f"{ROOT}/sub/deep")
+    seed_file(files, f"{ROOT}/sub/deep/leaf.txt", b"leaf\n")
+    return files
+
+
+@pytest.fixture
+def ws(dbx_files: FakeFiles) -> Workspace:
+    return Workspace({"/dbx/": make_resource(dbx_files)}, mode=MountMode.READ)
+
+
+@pytest.mark.asyncio
+async def test_tree_lists_nested_entries(ws):
+    io = await ws.execute("tree /dbx/")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "words.txt" in out
+    assert "inner.txt" in out
+
+
+@pytest.mark.asyncio
+async def test_tree_max_depth(ws):
+    io = await ws.execute("tree -L 1 /dbx/")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "sub" in out
+    assert "inner.txt" in out
+    assert "leaf.txt" not in out
+
+
+@pytest.mark.asyncio
+async def test_tree_dirs_only(ws):
+    io = await ws.execute("tree -d /dbx/")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "sub" in out
+    assert "words.txt" not in out

--- a/python/tests/commands/builtin/generic/test_cp.py
+++ b/python/tests/commands/builtin/generic/test_cp.py
@@ -122,7 +122,7 @@ async def test_recursive_into_directory():
 async def test_verbose_emits_arrow_lines():
     files = {"/a.txt": b"AAA"}
     out, _ = await _run(files, set(), ["/a.txt", "/copy.txt"], v=True)
-    assert out == b"/a.txt -> /copy.txt\n"
+    assert out == b"'/a.txt' -> '/copy.txt'\n"
 
 
 @pytest.mark.asyncio
@@ -130,3 +130,49 @@ async def test_records_writes_by_strip_prefix():
     files = {"/a.txt": b"AAA", "/b.txt": b"BBB", "/d/keep": b"K"}
     _, io = await _run(files, {"/d"}, ["/a.txt", "/b.txt", "/d"])
     assert set(io.writes) == {"/d/a.txt", "/d/b.txt"}
+
+
+@pytest.mark.asyncio
+async def test_missing_source_reports_cannot_stat_and_continues():
+    files = {"/b.txt": b"BBB", "/d/keep": b"K"}
+    _, io = await _run(files, {"/d"}, ["/missing.txt", "/b.txt", "/d"])
+    assert io.exit_code == 1
+    assert b"cp: cannot stat '/missing.txt'" in io.stderr
+    assert files["/d/b.txt"] == b"BBB"
+
+
+@pytest.mark.asyncio
+async def test_same_file_errors_and_preserves_content():
+    files = {"/a.txt": b"AAA"}
+    _, io = await _run(files, set(), ["/a.txt", "/a.txt"])
+    assert io.exit_code == 1
+    assert b"'/a.txt' and '/a.txt' are the same file" in io.stderr
+    assert files["/a.txt"] == b"AAA"
+
+
+@pytest.mark.asyncio
+async def test_same_file_via_directory_target_errors():
+    files = {"/d/a.txt": b"AAA", "/d/keep": b"K"}
+    _, io = await _run(files, {"/d"}, ["/d/a.txt", "/d"])
+    assert io.exit_code == 1
+    assert b"are the same file" in io.stderr
+    assert files["/d/a.txt"] == b"AAA"
+
+
+@pytest.mark.asyncio
+async def test_recursive_into_own_subtree_refused():
+    files = {"/d/a.txt": b"AAA"}
+    _, io = await _run(files, {"/d"}, ["/d", "/d"], recursive=True)
+    assert io.exit_code == 1
+    assert b"cp: cannot copy a directory, '/d', into itself" in io.stderr
+    assert set(files) == {"/d/a.txt"}
+
+
+@pytest.mark.asyncio
+async def test_recursive_into_nested_subtree_refused():
+    files = {"/d/a.txt": b"AAA"}
+    _, io = await _run(files, {"/d", "/d/sub"}, ["/d", "/d/sub"],
+                       recursive=True)
+    assert io.exit_code == 1
+    assert b"into itself" in io.stderr
+    assert set(files) == {"/d/a.txt"}

--- a/python/tests/commands/builtin/generic/test_mv.py
+++ b/python/tests/commands/builtin/generic/test_mv.py
@@ -101,3 +101,39 @@ async def test_records_writes_for_source_and_target():
     files = {"/a.txt": b"AAA", "/d/keep": b"K"}
     _, io = await _run(files, {"/d"}, ["/a.txt", "/d"])
     assert set(io.writes) == {"/a.txt", "/d/a.txt"}
+
+
+@pytest.mark.asyncio
+async def test_missing_source_reports_cannot_stat_and_continues():
+    files = {"/b.txt": b"BBB", "/d/keep": b"K"}
+    _, io = await _run(files, {"/d"}, ["/missing.txt", "/b.txt", "/d"])
+    assert io.exit_code == 1
+    assert b"mv: cannot stat '/missing.txt'" in io.stderr
+    assert files["/d/b.txt"] == b"BBB"
+
+
+@pytest.mark.asyncio
+async def test_same_file_errors_and_preserves_content():
+    files = {"/a.txt": b"AAA"}
+    _, io = await _run(files, set(), ["/a.txt", "/a.txt"])
+    assert io.exit_code == 1
+    assert b"'/a.txt' and '/a.txt' are the same file" in io.stderr
+    assert files["/a.txt"] == b"AAA"
+
+
+@pytest.mark.asyncio
+async def test_same_file_via_directory_target_errors():
+    files = {"/d/a.txt": b"AAA", "/d/keep": b"K"}
+    _, io = await _run(files, {"/d"}, ["/d/a.txt", "/d"])
+    assert io.exit_code == 1
+    assert b"are the same file" in io.stderr
+    assert files["/d/a.txt"] == b"AAA"
+
+
+@pytest.mark.asyncio
+async def test_into_own_subtree_refused():
+    files = {"/d/a.txt": b"AAA"}
+    _, io = await _run(files, {"/d", "/d/sub"}, ["/d", "/d/sub"])
+    assert io.exit_code == 1
+    assert b"mv: cannot move '/d' to a subdirectory of itself" in io.stderr
+    assert files["/d/a.txt"] == b"AAA"

--- a/python/tests/commands/builtin/ram/test_cp.py
+++ b/python/tests/commands/builtin/ram/test_cp.py
@@ -1,0 +1,53 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, RAMResource, Workspace
+
+
+@pytest.fixture
+def workspace():
+    return Workspace({"/": RAMResource()}, mode=MountMode.WRITE)
+
+
+@pytest.mark.asyncio
+async def test_cp_recursive_into_itself_refused(workspace):
+    await workspace.ops.mkdir("/d")
+    await workspace.ops.write("/d/a.txt", b"a")
+    io = await workspace.execute("cp -r /d /d", session_id="default")
+    assert io.exit_code != 0
+    assert b"into itself" in io.stderr
+    io = await workspace.execute("find /d -type f", session_id="default")
+    assert io.stdout.decode().split() == ["/d/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_cp_onto_same_path_errors(workspace):
+    await workspace.ops.write("/a.txt", b"keep")
+    io = await workspace.execute("cp /a.txt /a.txt", session_id="default")
+    assert io.exit_code != 0
+    assert b"are the same file" in io.stderr
+    assert await workspace.ops.read("/a.txt") == b"keep"
+
+
+@pytest.mark.asyncio
+async def test_cp_missing_source_continues_with_rest(workspace):
+    await workspace.ops.mkdir("/d")
+    await workspace.ops.write("/b.txt", b"b")
+    io = await workspace.execute("cp /missing.txt /b.txt /d",
+                                 session_id="default")
+    assert io.exit_code != 0
+    assert b"cannot stat" in io.stderr
+    assert await workspace.ops.read("/d/b.txt") == b"b"

--- a/python/tests/commands/builtin/ram/test_mv.py
+++ b/python/tests/commands/builtin/ram/test_mv.py
@@ -1,0 +1,50 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, RAMResource, Workspace
+
+
+@pytest.fixture
+def workspace():
+    return Workspace({"/": RAMResource()}, mode=MountMode.WRITE)
+
+
+@pytest.mark.asyncio
+async def test_mv_onto_same_path_errors_and_preserves_file(workspace):
+    await workspace.ops.write("/a.txt", b"keep")
+    io = await workspace.execute("mv /a.txt /a.txt", session_id="default")
+    assert io.exit_code != 0
+    assert b"are the same file" in io.stderr
+    assert await workspace.ops.read("/a.txt") == b"keep"
+
+
+@pytest.mark.asyncio
+async def test_mv_into_own_subtree_refused(workspace):
+    await workspace.ops.mkdir("/d")
+    await workspace.ops.write("/d/a.txt", b"a")
+    await workspace.ops.mkdir("/d/sub")
+    io = await workspace.execute("mv /d /d/sub", session_id="default")
+    assert io.exit_code != 0
+    assert b"subdirectory of itself" in io.stderr
+    assert await workspace.ops.read("/d/a.txt") == b"a"
+
+
+@pytest.mark.asyncio
+async def test_mv_missing_source_reports_cannot_stat(workspace):
+    io = await workspace.execute("mv /missing.txt /dst.txt",
+                                 session_id="default")
+    assert io.exit_code != 0
+    assert b"mv: cannot stat" in io.stderr

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/cp.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/cp.ts
@@ -17,6 +17,7 @@ import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { copy as dbxCopy } from '../../../core/databricks_volume/copy.ts'
 import { find as dbxFind } from '../../../core/databricks_volume/find.ts'
 import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { backendPath } from '../../../core/databricks_volume/path.ts'
 import { stat as dbxStat } from '../../../core/databricks_volume/stat.ts'
 import { IOResult } from '../../../io/types.ts'
 import type { FindOptions } from '../../../resource/base.ts'
@@ -47,6 +48,7 @@ async function cpCommand(
     opts.flags.n === true,
     opts.flags.v === true,
     opts.index ?? undefined,
+    (p: PathSpec) => backendPath(accessor.config, p),
   )
 }
 

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/mv.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/mv.ts
@@ -15,6 +15,7 @@
 import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
 import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { backendPath } from '../../../core/databricks_volume/path.ts'
 import { rename as dbxRename } from '../../../core/databricks_volume/rename.ts'
 import { stat as dbxStat } from '../../../core/databricks_volume/stat.ts'
 import { IOResult } from '../../../io/types.ts'
@@ -42,6 +43,7 @@ async function mvCommand(
     opts.flags.n === true,
     opts.flags.v === true,
     opts.index ?? undefined,
+    (p: PathSpec) => backendPath(accessor.config, p),
   )
 }
 

--- a/typescript/packages/core/src/commands/builtin/generic/cp.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cp.test.ts
@@ -1,0 +1,135 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import type { ByteSource, IOResult } from '../../../io/types.ts'
+import { FileStat, FileType, PathSpec } from '../../../types.ts'
+import { rstripSlash } from '../../../util/slash.ts'
+import { cpGeneric } from './cp.ts'
+
+const DEC = new TextDecoder()
+
+function key(p: PathSpec | string): string {
+  return rstripSlash(typeof p === 'string' ? p : p.original)
+}
+
+function spec(path: string): PathSpec {
+  return new PathSpec({ original: path, directory: path, resolved: false, prefix: '' })
+}
+
+function makeBackend(files: Map<string, Uint8Array>, dirs: Set<string>) {
+  const stat = (p: PathSpec): Promise<FileStat> => {
+    const k = key(p)
+    if (dirs.has(k)) {
+      return Promise.resolve(
+        new FileStat({ name: k.split('/').pop() ?? '', type: FileType.DIRECTORY }),
+      )
+    }
+    const data = files.get(k)
+    if (data === undefined) return Promise.reject(new Error(`not found: ${k}`))
+    return Promise.resolve(new FileStat({ name: k.split('/').pop() ?? '', type: FileType.TEXT }))
+  }
+  const copy = (src: PathSpec, dst: PathSpec): Promise<void> => {
+    const data = files.get(key(src))
+    if (data === undefined) return Promise.reject(new Error(`not found: ${key(src)}`))
+    files.set(key(dst), data)
+    return Promise.resolve()
+  }
+  const find = (p: PathSpec): Promise<string[]> => {
+    const base = key(p) + '/'
+    return Promise.resolve([...files.keys()].filter((k) => k.startsWith(base)).sort())
+  }
+  return { stat, copy, find }
+}
+
+async function run(
+  files: Map<string, Uint8Array>,
+  dirs: Set<string>,
+  paths: string[],
+  flags: { recursive?: boolean; n?: boolean; v?: boolean } = {},
+): Promise<[ByteSource | null, IOResult]> {
+  const { stat, copy, find } = makeBackend(files, dirs)
+  const result = await cpGeneric(
+    paths.map(spec),
+    copy,
+    find,
+    stat,
+    flags.recursive === true,
+    flags.n === true,
+    flags.v === true,
+  )
+  if (result === null) throw new Error('unexpected null result')
+  return result
+}
+
+describe('cpGeneric guards', () => {
+  it('copies a single source to a new path', async () => {
+    const files = new Map([['/a.txt', new Uint8Array([1])]])
+    const [, io] = await run(files, new Set(), ['/a.txt', '/copy.txt'])
+    expect(io.exitCode).toBe(0)
+    expect(files.has('/copy.txt')).toBe(true)
+  })
+
+  it('reports cannot stat for a missing source and continues', async () => {
+    const files = new Map([['/b.txt', new Uint8Array([2])]])
+    const [, io] = await run(files, new Set(['/d']), ['/missing.txt', '/b.txt', '/d'])
+    expect(io.exitCode).toBe(1)
+    expect(DEC.decode(io.stderr ?? new Uint8Array())).toContain("cp: cannot stat '/missing.txt'")
+    expect(files.has('/d/b.txt')).toBe(true)
+  })
+
+  it('refuses to copy a file onto itself', async () => {
+    const files = new Map([['/a.txt', new Uint8Array([1])]])
+    const [, io] = await run(files, new Set(), ['/a.txt', '/a.txt'])
+    expect(io.exitCode).toBe(1)
+    expect(DEC.decode(io.stderr ?? new Uint8Array())).toContain(
+      "cp: '/a.txt' and '/a.txt' are the same file",
+    )
+  })
+
+  it('refuses the same file via a directory target', async () => {
+    const files = new Map([['/d/a.txt', new Uint8Array([1])]])
+    const [, io] = await run(files, new Set(['/d']), ['/d/a.txt', '/d'])
+    expect(io.exitCode).toBe(1)
+    expect(DEC.decode(io.stderr ?? new Uint8Array())).toContain('are the same file')
+  })
+
+  it('refuses recursive copy of a directory into itself', async () => {
+    const files = new Map([['/d/a.txt', new Uint8Array([1])]])
+    const [, io] = await run(files, new Set(['/d']), ['/d', '/d'], { recursive: true })
+    expect(io.exitCode).toBe(1)
+    expect(DEC.decode(io.stderr ?? new Uint8Array())).toContain(
+      "cp: cannot copy a directory, '/d', into itself",
+    )
+    expect([...files.keys()]).toEqual(['/d/a.txt'])
+  })
+
+  it('refuses recursive copy into a nested subtree', async () => {
+    const files = new Map([['/d/a.txt', new Uint8Array([1])]])
+    const [, io] = await run(files, new Set(['/d', '/d/sub']), ['/d', '/d/sub'], {
+      recursive: true,
+    })
+    expect(io.exitCode).toBe(1)
+    expect(DEC.decode(io.stderr ?? new Uint8Array())).toContain('into itself')
+    expect([...files.keys()]).toEqual(['/d/a.txt'])
+  })
+
+  it('emits quoted verbose lines', async () => {
+    const files = new Map([['/a.txt', new Uint8Array([1])]])
+    const [out] = await run(files, new Set(), ['/a.txt', '/copy.txt'], { v: true })
+    expect(DEC.decode((out as Uint8Array | null) ?? new Uint8Array())).toBe(
+      "'/a.txt' -> '/copy.txt'\n",
+    )
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/generic/cp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cp.ts
@@ -17,7 +17,14 @@ import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { FindOptions } from '../../../resource/base.ts'
 import { PathSpec } from '../../../types.ts'
 import type { CommandFnResult } from '../../config.ts'
-import { copyTargets, isDirectory, pathExists, type StatFn } from '../utils/copy.ts'
+import {
+  backendKeyDefault,
+  copyTargets,
+  isDirectory,
+  pathExists,
+  type BackendKeyFn,
+  type StatFn,
+} from '../utils/copy.ts'
 import { rstripSlash } from '../../../util/slash.ts'
 
 const ENC = new TextEncoder()
@@ -34,14 +41,31 @@ export async function cpGeneric(
   noClobber: boolean,
   verbose: boolean,
   index?: IndexCacheStore,
+  backendKey?: BackendKeyFn,
 ): Promise<CommandFnResult> {
+  const keyOf = backendKey ?? backendKeyDefault
   const sources = paths.slice(0, -1)
   const dst = paths[paths.length - 1]
   if (dst === undefined) return [null, new IOResult()]
   const dstIsDir = await isDirectory(stat, dst, index)
   const writes: Record<string, ByteSource> = {}
   const lines: string[] = []
+  const errors: string[] = []
   for (const [src, target] of copyTargets(sources, dst, dstIsDir)) {
+    if (!(await pathExists(stat, src))) {
+      errors.push(`cp: cannot stat '${src.original}': No such file or directory`)
+      continue
+    }
+    if (keyOf(src) === keyOf(target)) {
+      errors.push(`cp: '${src.original}' and '${target.original}' are the same file`)
+      continue
+    }
+    if (recursive && keyOf(target).startsWith(keyOf(src) + '/')) {
+      errors.push(
+        `cp: cannot copy a directory, '${src.original}', into itself, '${target.original}'`,
+      )
+      continue
+    }
     if (recursive) {
       const srcBase = rstripSlash(src.stripPrefix)
       const dstBase = rstripSlash(target.stripPrefix)
@@ -51,15 +75,16 @@ export async function cpGeneric(
         if (noClobber && (await pathExists(stat, entryDstSpec))) continue
         await copy(PathSpec.fromStrPath(entry, src.prefix), entryDstSpec)
         writes[entryDst] = new Uint8Array()
-        if (verbose) lines.push(`${entry} -> ${entryDst}`)
+        if (verbose) lines.push(`'${entry}' -> '${entryDst}'`)
       }
       continue
     }
     if (noClobber && (await pathExists(stat, target))) continue
     await copy(src, target)
     writes[target.stripPrefix] = new Uint8Array()
-    if (verbose) lines.push(`${src.original} -> ${target.original}`)
+    if (verbose) lines.push(`'${src.original}' -> '${target.original}'`)
   }
   const output: ByteSource | null = lines.length > 0 ? ENC.encode(lines.join('\n') + '\n') : null
-  return [output, new IOResult({ writes })]
+  const stderr = errors.length > 0 ? ENC.encode(errors.join('\n') + '\n') : null
+  return [output, new IOResult({ writes, stderr, exitCode: errors.length > 0 ? 1 : 0 })]
 }

--- a/typescript/packages/core/src/commands/builtin/generic/mv.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/mv.test.ts
@@ -1,0 +1,109 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import type { ByteSource, IOResult } from '../../../io/types.ts'
+import { FileStat, FileType, PathSpec } from '../../../types.ts'
+import { rstripSlash } from '../../../util/slash.ts'
+import { mvGeneric } from './mv.ts'
+
+const DEC = new TextDecoder()
+
+function key(p: PathSpec | string): string {
+  return rstripSlash(typeof p === 'string' ? p : p.original)
+}
+
+function spec(path: string): PathSpec {
+  return new PathSpec({ original: path, directory: path, resolved: false, prefix: '' })
+}
+
+function makeBackend(files: Map<string, Uint8Array>, dirs: Set<string>) {
+  const stat = (p: PathSpec): Promise<FileStat> => {
+    const k = key(p)
+    if (dirs.has(k)) {
+      return Promise.resolve(
+        new FileStat({ name: k.split('/').pop() ?? '', type: FileType.DIRECTORY }),
+      )
+    }
+    const data = files.get(k)
+    if (data === undefined) return Promise.reject(new Error(`not found: ${k}`))
+    return Promise.resolve(new FileStat({ name: k.split('/').pop() ?? '', type: FileType.TEXT }))
+  }
+  const rename = (src: PathSpec, dst: PathSpec): Promise<void> => {
+    const data = files.get(key(src))
+    if (data === undefined) return Promise.reject(new Error(`not found: ${key(src)}`))
+    files.delete(key(src))
+    files.set(key(dst), data)
+    return Promise.resolve()
+  }
+  return { stat, rename }
+}
+
+async function run(
+  files: Map<string, Uint8Array>,
+  dirs: Set<string>,
+  paths: string[],
+  flags: { n?: boolean; v?: boolean } = {},
+): Promise<[ByteSource | null, IOResult]> {
+  const { stat, rename } = makeBackend(files, dirs)
+  const result = await mvGeneric(paths.map(spec), rename, stat, flags.n === true, flags.v === true)
+  if (result === null) throw new Error('unexpected null result')
+  return result
+}
+
+describe('mvGeneric guards', () => {
+  it('moves a single source', async () => {
+    const files = new Map([['/a.txt', new Uint8Array([1])]])
+    const [, io] = await run(files, new Set(), ['/a.txt', '/b.txt'])
+    expect(io.exitCode).toBe(0)
+    expect(files.has('/b.txt')).toBe(true)
+    expect(files.has('/a.txt')).toBe(false)
+  })
+
+  it('reports cannot stat for a missing source and continues', async () => {
+    const files = new Map([['/b.txt', new Uint8Array([2])]])
+    const [, io] = await run(files, new Set(['/d']), ['/missing.txt', '/b.txt', '/d'])
+    expect(io.exitCode).toBe(1)
+    expect(DEC.decode(io.stderr ?? new Uint8Array())).toContain("mv: cannot stat '/missing.txt'")
+    expect(files.has('/d/b.txt')).toBe(true)
+  })
+
+  it('refuses to move a file onto itself and preserves it', async () => {
+    const files = new Map([['/a.txt', new Uint8Array([1])]])
+    const [, io] = await run(files, new Set(), ['/a.txt', '/a.txt'])
+    expect(io.exitCode).toBe(1)
+    expect(DEC.decode(io.stderr ?? new Uint8Array())).toContain(
+      "mv: '/a.txt' and '/a.txt' are the same file",
+    )
+    expect(files.has('/a.txt')).toBe(true)
+  })
+
+  it('refuses the same file via a directory target', async () => {
+    const files = new Map([['/d/a.txt', new Uint8Array([1])]])
+    const [, io] = await run(files, new Set(['/d']), ['/d/a.txt', '/d'])
+    expect(io.exitCode).toBe(1)
+    expect(DEC.decode(io.stderr ?? new Uint8Array())).toContain('are the same file')
+    expect(files.has('/d/a.txt')).toBe(true)
+  })
+
+  it('refuses moving a directory into its own subtree', async () => {
+    const files = new Map([['/d/a.txt', new Uint8Array([1])]])
+    const [, io] = await run(files, new Set(['/d', '/d/sub']), ['/d', '/d/sub'])
+    expect(io.exitCode).toBe(1)
+    expect(DEC.decode(io.stderr ?? new Uint8Array())).toContain(
+      "mv: cannot move '/d' to a subdirectory of itself",
+    )
+    expect(files.has('/d/a.txt')).toBe(true)
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/generic/mv.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/mv.ts
@@ -16,7 +16,14 @@ import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult } from '../../config.ts'
-import { copyTargets, isDirectory, pathExists, type StatFn } from '../utils/copy.ts'
+import {
+  backendKeyDefault,
+  copyTargets,
+  isDirectory,
+  pathExists,
+  type BackendKeyFn,
+  type StatFn,
+} from '../utils/copy.ts'
 
 const ENC = new TextEncoder()
 
@@ -29,14 +36,31 @@ export async function mvGeneric(
   noClobber: boolean,
   verbose: boolean,
   index?: IndexCacheStore,
+  backendKey?: BackendKeyFn,
 ): Promise<CommandFnResult> {
+  const keyOf = backendKey ?? backendKeyDefault
   const sources = paths.slice(0, -1)
   const dst = paths[paths.length - 1]
   if (dst === undefined) return [null, new IOResult()]
   const dstIsDir = await isDirectory(stat, dst, index)
   const writes: Record<string, ByteSource> = {}
   const lines: string[] = []
+  const errors: string[] = []
   for (const [src, target] of copyTargets(sources, dst, dstIsDir)) {
+    if (!(await pathExists(stat, src))) {
+      errors.push(`mv: cannot stat '${src.original}': No such file or directory`)
+      continue
+    }
+    if (keyOf(src) === keyOf(target)) {
+      errors.push(`mv: '${src.original}' and '${target.original}' are the same file`)
+      continue
+    }
+    if (keyOf(target).startsWith(keyOf(src) + '/')) {
+      errors.push(
+        `mv: cannot move '${src.original}' to a subdirectory of itself, '${target.original}'`,
+      )
+      continue
+    }
     if (noClobber && (await pathExists(stat, target))) continue
     await rename(src, target)
     writes[src.stripPrefix] = new Uint8Array()
@@ -44,5 +68,6 @@ export async function mvGeneric(
     if (verbose) lines.push(`'${src.original}' -> '${target.original}'`)
   }
   const output: ByteSource | null = lines.length > 0 ? ENC.encode(lines.join('\n') + '\n') : null
-  return [output, new IOResult({ writes })]
+  const stderr = errors.length > 0 ? ENC.encode(errors.join('\n') + '\n') : null
+  return [output, new IOResult({ writes, stderr, exitCode: errors.length > 0 ? 1 : 0 })]
 }

--- a/typescript/packages/core/src/commands/builtin/utils/copy.ts
+++ b/typescript/packages/core/src/commands/builtin/utils/copy.ts
@@ -18,6 +18,12 @@ import { rstripSlash } from '../../../util/slash.ts'
 
 export type StatFn = (path: PathSpec, index?: IndexCacheStore) => Promise<FileStat>
 
+export type BackendKeyFn = (path: PathSpec) => string
+
+export function backendKeyDefault(path: PathSpec): string {
+  return rstripSlash(path.stripPrefix)
+}
+
 export function childPath(parent: PathSpec, name: string): PathSpec {
   const base = rstripSlash(parent.original)
   return PathSpec.fromStrPath(`${base}/${name}`, parent.prefix)


### PR DESCRIPTION
Closes #274.

## What

**py databricks_volume: 9 commands delegated to generics** (cat, stat, ls, tree, find, grep, rg, cp, mv), 12/24 -> 21/24, matching TS. Only mkdir/rm/touch stay bespoke (backend-specific directory semantics, same as s3 and TS). ~900 lines of duplicated engine code removed. Side fixes for free: `cat -n` uses GNU width-6 numbering, `find` gains -size/-mtime/-iname/-path/-mindepth.

**generic cp/mv guards, both languages.** Three per-source guards in coreutils order, before any write: missing source (`cannot stat`, continue with remaining sources), same file, directory into its own subtree. Errors accumulate on stderr with exit 1; `cp -v` output is now GNU-quoted. Guards compare backend storage keys via an injectable `backend_key` (default: mount-relative path; databricks passes `backend_path`). All 13 backend cp/mv wirings inherit the fix with no per-backend code: py ram/disk/redis/s3/ssh/nextcloud/databricks_volume, ts ram/s3(+aliases)/databricks_volume/disk/redis/ssh/opfs.

This is the command-layer half of #150 (`mv a a` no longer reaches the unguarded copy+delete rename). The core-layer s3/cross-mount guard remains #187. Recursive `cp -r` on databricks now fans out via find like every generic backend (empty subdirectories are not copied, the pre-existing generic-wide tradeoff).

## Tests

- generic guard unit tests (py + ts), ram E2E tests, 7 new databricks command test files (previously zero coverage for those commands)
- integ: 8 guard cases appended to the shared suite with dedicated /data/guard seeds; truth.txt regenerated and verified byte-identical on 9 runners locally (py ram/disk/ssh-mock/s3-moto/redis, ts ram/disk/opfs/redis)
- full suites green: py 7346, ts core 3040, ts node 1474; pre-commit clean