### PR TITLE
docs: home + quickstart cleanup and parity fixes

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -70,7 +70,7 @@
             "group": "Learn",
             "pages": [
               "home/architecture",
-              "home/shell",
+              "home/bash",
               "home/resource-matrix",
               "home/cache",
               "home/snapshot",
@@ -172,7 +172,7 @@
               },
               {
                 "group": "Knowledge",
-                "icon": "/images/dify-logo.svg",
+                "icon": "brain",
                 "pages": [
                   "home/setup/dify"
                 ]
@@ -316,7 +316,7 @@
               },
               {
                 "group": "Knowledge",
-                "icon": "/images/dify-logo.svg",
+                "icon": "brain",
                 "pages": [
                   "python/resource/dify"
                 ]

--- a/docs/home/architecture.mdx
+++ b/docs/home/architecture.mdx
@@ -25,7 +25,7 @@ The **Mirage Dispatcher** routes each operation to the mount that owns the path,
 
 ## 4. Infrastructure and Remote
 
-Whatever you mount: RAM, Disk, Redis, S3 / R2 / GCS / OCI / Supabase, Gmail / GDrive / GDocs / GSheets / GSlides, GitHub / Linear / Notion / Trello, Slack / Discord / Email, MongoDB, SSH, and more. Each speaks the same filesystem semantics from the agent's point of view.
+Whatever you mount: RAM, Disk, Redis, S3 / R2 / GCS / OCI / Supabase, Gmail / GDrive / GDocs / GSheets / GSlides, GitHub / Linear / Notion / Trello, Slack / Discord / Email, MongoDB / Postgres / LanceDB, SSH, and more. Each speaks the same filesystem semantics from the agent's point of view.
 
 Browse the [Resource Matrix](/home/resource-matrix) for the full list.
 

--- a/docs/home/bash.mdx
+++ b/docs/home/bash.mdx
@@ -1,56 +1,10 @@
 ---
-title: Shell
-description: The `execute()` API, per-call `cwd`/`env` overrides, and mid-flight cancellation.
+title: Bash
+description: Run bash commands with `execute()`, per-call `cwd`/`env` overrides, and mid-flight cancellation.
 icon: terminal
 ---
 
-The shell is how agents act on the workspace. `execute()` parses a bash-style command, looks up the target session, resolves mounts, runs the executor, applies I/O side effects, and records history.
-
-## `execute()`
-
-<Tabs>
-  <Tab title="Python" icon="/images/python-logo.svg">
-    ```python
-    async def execute(
-        self,
-        command: str,
-        session_id: str = DEFAULT_SESSION_ID,
-        stdin: AsyncIterator[bytes] | bytes | None = None,
-        provision: bool = False,
-        agent_id: str = DEFAULT_AGENT_ID,
-        native: bool | None = None,
-        cwd: str | None = None,
-        env: dict[str, str] | None = None,
-        cancel: asyncio.Event | None = None,
-    ) -> IOResult:
-        ...
-    ```
-  </Tab>
-  <Tab title="TypeScript" icon="/images/typescript-logo.svg">
-    ```typescript
-    interface ExecuteOptions {
-      stdin?: ByteSource | null
-      provision?: boolean
-      sessionId?: string
-      agentId?: string
-      native?: boolean
-      signal?: AbortSignal
-      noHistory?: boolean
-      cwd?: string
-      env?: Record<string, string>
-    }
-
-    async execute(command: string, options?: ExecuteOptions): Promise<ExecuteResult>
-    ```
-  </Tab>
-  <Tab title="CLI" icon="terminal">
-    ```bash
-    mirage execute --workspace demo --command "ls /data"
-    mirage execute --workspace demo --session agent-1 --command "pwd"
-    ```
-    Per-call `cwd` / `env` / `cancel` are SDK-only as named flags. From the CLI, use bash subshell syntax inside the command string for per-call scoping (see below) and `mirage job cancel` to stop background work.
-  </Tab>
-</Tabs>
+Mirage Bash is how agents act on the workspace. `execute()` parses a bash-style command, looks up the target session, resolves mounts, runs the executor, applies I/O side effects, and records history.
 
 ## Per-call overrides: `cwd`, `env`
 
@@ -90,6 +44,17 @@ Providing `cwd` or `env` runs the command in an ephemeral session clone, like a 
 </Tabs>
 
 This makes per-call overrides safe under concurrent calls on the same session. Two parallel `execute()` calls with different `cwd` see their own cwd without cross-contamination, even on the same session.
+
+## Subshells `(...)`
+
+Wrapping commands in `( ... )` runs them in an isolated copy of the session: `cd`, `export`, and other mutations inside the parens do not leak back. It is the same isolation as the `cwd` / `env` overrides above, and the CLI's stand-in for them (there are no `--cwd` / `--env` flags).
+
+```bash
+(cd /data && ls)              # cwd change scoped to the subshell
+(export TOKEN=xyz; printenv)  # env var gone once the parens close
+```
+
+The isolation holds under concurrency, and subshells are still covered by the per-session mount allowlist and the cancellation boundaries below.
 
 ## Mid-flight cancellation: `cancel` / `signal`
 
@@ -145,7 +110,7 @@ Both bindings support cooperative cancellation observed at recursion boundaries 
 
 ## Supported bash syntax
 
-The shell is a tree-sitter-bash parser plus a custom executor. It implements the constructs LLMs reach for most often. What is not supported returns a clear, parseable error so an agent can self-correct on its next turn.
+Mirage Bash is a tree-sitter-bash parser plus a custom executor. It implements the constructs LLMs reach for most often. What is not supported returns a clear, parseable error so an agent can self-correct on its next turn.
 
 ### Supported
 
@@ -217,7 +182,7 @@ The allowlist is a property of the session, so it covers every command issued un
 
 ## Agent Pattern
 
-Agent harnesses commonly fan out tool calls in parallel, each with its own `cwd`/`env`/`cancel`. The clone semantics make this race-free without per-call boilerplate.
+Agent harnesses commonly fan out tool calls in parallel, each with its own `cwd`/`env`/`cancel`. The clone semantics make this race-free without per-call boilerplate. From the CLI, a subshell per call gives the same isolation.
 
 <Tabs>
   <Tab title="Python​​​" icon="/images/python-logo.svg">
@@ -249,5 +214,12 @@ Agent harnesses commonly fan out tool calls in parallel, each with its own `cwd`
       toolCall("grep foo *.log", "/logs", { DEBUG: "1" }, 5000),
     ])
     ```
+  </Tab>
+  <Tab title="CLI" icon="terminal">
+    ```bash
+    # No --cwd/--env flags: isolate each parallel call in a subshell
+    mirage execute -w demo -c "(cd /data && export DEBUG=1 && ls) & (cd /logs && export DEBUG=1 && grep foo *.log) & wait"
+    ```
+    Each `( ... )` runs in its own scope, so the parallel `cd` / `export` don't collide. `&` backgrounds them inside Mirage Bash and `wait` joins.
   </Tab>
 </Tabs>

--- a/docs/home/cache.mdx
+++ b/docs/home/cache.mdx
@@ -18,7 +18,22 @@ Each layer is a pluggable store with two built-ins:
 - **RAM** (default): in-process, zero setup, 512 MB file cache and 10-minute index TTL. Best for single-process apps and notebooks.
 - **Redis**: shared across workers, processes, and machines. Best for serverless, multi-replica services, or for cache state that survives restarts.
 
-```ts
+<CodeGroup>
+
+```python Python
+from mirage import Workspace
+from mirage.cache.file.config import RedisCacheConfig
+from mirage.cache.index.config import RedisIndexConfig
+from mirage.resource.s3 import S3Config, S3Resource
+
+ws = Workspace(
+    {"/s3": S3Resource(S3Config(bucket="my-bucket"))},
+    cache=RedisCacheConfig(url="redis://localhost:6379/0", limit="8GB"),
+    index=RedisIndexConfig(url="redis://localhost:6379/0", ttl=600),
+)
+```
+
+```typescript TypeScript
 import { RedisFileCacheStore, S3Resource, Workspace } from '@struktoai/mirage-node'
 
 const ws = new Workspace(
@@ -30,9 +45,43 @@ const ws = new Workspace(
 )
 ```
 
+</CodeGroup>
+
+## Eviction & Limits
+
+The two layers are bounded differently:
+
+| Layer | Holds | Default | Bound | Eviction |
+| --- | --- | --- | --- | --- |
+| **File cache** | object bytes per virtual path | RAM, 512 MB | `cache_limit` (Py) / `cacheLimit` (TS) | LRU: least-recently-used bytes drop once the total exceeds the limit |
+| **Index cache** | directory listings + `FileStat` metadata | RAM, 10-min TTL | `ttl` (seconds) | time-based: entries expire after the TTL, then re-fetch on next access |
+
+Raising the file limit keeps more bytes warm at the cost of memory; lengthening the index TTL serves listings longer between API walks at the cost of staleness.
+
 ## Miss/Hit Lifecycle
 
-```ts
+<CodeGroup>
+
+```python Python
+from mirage import Workspace
+from mirage.resource.s3 import S3Config, S3Resource
+
+ws = Workspace({"/s3": S3Resource(S3Config(bucket="my-bucket"))})
+
+# 1. Index miss → S3 LIST. Listing stored in index cache.
+await ws.execute("ls /s3/data/")
+
+# 2. Index hit → 0 network calls.
+await ws.execute('find /s3/data/ -name "*.jsonl"')
+
+# 3. File miss → S3 GET. Bytes stored in file cache.
+await ws.execute("cat /s3/data/log.jsonl | wc -l")
+
+# 4. File hit → 0 network calls.
+await ws.execute("grep alert /s3/data/log.jsonl")
+```
+
+```typescript TypeScript
 import { S3Resource, Workspace } from '@struktoai/mirage-node'
 
 const ws = new Workspace({ '/s3': new S3Resource({ bucket: 'my-bucket' }) })
@@ -49,3 +98,9 @@ await ws.execute('cat /s3/data/log.jsonl | wc -l')
 // 4. File hit → 0 network calls.
 await ws.execute('grep alert /s3/data/log.jsonl')
 ```
+
+</CodeGroup>
+
+## Relationship To Snapshots
+
+The file cache is exactly what a [snapshot](/home/snapshot) serializes: `ws.snapshot()` writes the cached bytes for every touched path into the tar, and `Workspace.load()` restores them into the file cache so a replayed run reads from local state. The index cache is not snapshotted; it rebuilds lazily after load.

--- a/docs/home/cli.mdx
+++ b/docs/home/cli.mdx
@@ -16,28 +16,12 @@ save to file, or read it directly.
 
 ```bash
 curl -fsSL https://strukto.ai/mirage/install.sh | sh
-```
-
-Or via your package manager of choice:
-
-```bash
+# or
 npm install -g @struktoai/mirage-cli
-```
-
-```bash
-uv add mirage-ai
-```
-
-```bash
-pip install mirage-ai
-```
-
-```bash
+# or
 uvx mirage-ai
-```
-
-```bash
-npx mirage
+# or
+npx @struktoai/mirage-cli
 ```
 
 Verify:

--- a/docs/home/install.mdx
+++ b/docs/home/install.mdx
@@ -33,20 +33,12 @@ npm install @struktoai/mirage-agents    # OpenAI / Vercel AI / LangChain / Mastr
 
 ```bash
 curl -fsSL https://strukto.ai/mirage/install.sh | sh
-```
-
-Or via your package manager of choice:
-
-```bash
+# or
 npm install -g @struktoai/mirage-cli
-```
-
-```bash
-npx @struktoai/mirage-cli
-```
-
-```bash
+# or
 uvx mirage-ai
+# or
+npx @struktoai/mirage-cli
 ```
 
 ## More Details

--- a/docs/home/introduction.mdx
+++ b/docs/home/introduction.mdx
@@ -27,21 +27,23 @@ mode: "frame"
 <Tabs>
   <Tab title="Python" icon="/images/python-logo.svg">
     ```python
+    import os
+
     from mirage import Workspace
     from mirage.resource.ram import RAMResource
-    from mirage.resource.s3 import S3Resource
-    from mirage.resource.slack import SlackResource
+    from mirage.resource.s3 import S3Config, S3Resource
+    from mirage.resource.slack import SlackConfig, SlackResource
 
     ws = Workspace({
         "/data": RAMResource(),
-        "/s3": S3Resource(bucket="my-bucket"),
-        "/slack": SlackResource(),
+        "/s3": S3Resource(S3Config(bucket="my-bucket")),
+        "/slack": SlackResource(SlackConfig(token=os.environ["SLACK_BOT_TOKEN"])),
     })
 
     # Same shell vocabulary, three different backends.
     await ws.execute('echo "hello mirage" > /data/hello.txt')
     await ws.execute("ls /s3/reports/")
-    result = await ws.execute('grep -r "release" /slack/eng')
+    result = await ws.execute('grep -r "release" /slack/channels/eng__C04QX')
     print(await result.stdout_str())
     ```
   </Tab>
@@ -57,13 +59,13 @@ mode: "frame"
     const ws = new Workspace({
       '/data': new RAMResource(),
       '/s3': new S3Resource({ bucket: 'my-bucket' }),
-      '/slack': new SlackResource(),
+      '/slack': new SlackResource({ token: process.env.SLACK_BOT_TOKEN! }),
     })
 
     // Same shell vocabulary, three different backends.
     await ws.execute('echo "hello mirage" > /data/hello.txt')
     await ws.execute('ls /s3/reports/')
-    const res = await ws.execute('grep -r "release" /slack/eng')
+    const res = await ws.execute('grep -r "release" /slack/channels/eng__C04QX')
     console.log(new TextDecoder().decode(res.stdout))
     ```
   </Tab>
@@ -83,12 +85,14 @@ mode: "frame"
       /slack:
         resource: slack
         mode: READ
+        config:
+          token: ${SLACK_BOT_TOKEN}
     EOF
 
     mirage workspace create workspace.yaml --id demo
     mirage execute -w demo -c 'echo "hello mirage" > /data/hello.txt'
     mirage execute -w demo -c 'ls /s3/reports/'
-    mirage execute -w demo -c 'grep -r "release" /slack/eng'
+    mirage execute -w demo -c 'grep -r "release" /slack/channels/eng__C04QX'
     ```
   </Tab>
 </Tabs>
@@ -103,17 +107,17 @@ mode: "frame"
 
 <div className="max-w-none space-y-1 text-[15px] leading-7">
   <p className="my-0">
-    <img noZoom src="/images/mirage-icon-light.svg" alt="Mirage" className="inline-block h-4 align-middle mr-1 dark:hidden" /><img noZoom src="/images/mirage-icon-dark.svg" alt="Mirage" className="hidden h-4 align-middle mr-1 dark:inline-block" /><b>Mirage</b> is a <b>Unified Virtual Filesystem</b> for AI agents. It mounts your apps, services, and systems (S3, R2, GCS, Gmail, Google Drive, GitHub, Linear, Notion, Slack, Discord, MongoDB, Redis, SSH, local disk, and more) behind one filesystem interface. Agents reach every backend with the same handful of Unix-like tools, pipelines compose across services as naturally as on a local disk, and the workspace embeds in any application, sandbox, or coding agent runtime.
+    <img noZoom src="/images/mirage-icon-light.svg" alt="Mirage" className="inline-block h-4 align-middle mr-1 dark:hidden" /><img noZoom src="/images/mirage-icon-dark.svg" alt="Mirage" className="hidden h-4 align-middle mr-1 dark:inline-block" /><b>Mirage</b> is a <b>Unified Virtual Filesystem</b> for AI agents. It mounts your apps, services, and systems behind one filesystem interface, so an agent reaches every backend with the same handful of Unix-like tools instead of a new SDK per service.
   </p>
   <div className="space-y-3">
     <div>
-      <h4 className="text-lg font-bold mt-4 mb-1"><Icon icon="cubes" size={20} /> One Filesystem</h4>
+      <h4 className="text-lg font-bold mt-4 mb-1">One Filesystem</h4>
       <p className="my-0">
         Every service speaks the same filesystem semantics, so agents reason about one abstraction instead of N SDKs and M MCPs. S3, R2, Google Drive, GitHub, Linear, Notion, Slack, Discord, MongoDB, Redis, SSH, and more mount side-by-side under a single root.
       </p>
     </div>
     <div>
-      <h4 className="text-lg font-bold mt-4 mb-1"><Icon icon="terminal" size={20} /> Familiar Bash Tools</h4>
+      <h4 className="text-lg font-bold mt-4 mb-1">Familiar Bash Tools</h4>
       <p className="my-0">
         Agents reuse the same handful of Unix-like tools (<code>ls</code>, <code>find</code>, <code>grep</code>, <code>cat</code>, ...) instead of learning a new API per service. Pipelines compose across services as naturally as on a local disk, the exact corpus modern LLMs are most heavily trained on.
       </p>
@@ -125,21 +129,15 @@ grep -r "mirage" /slack /gmail /github
 
     </div>
     <div>
-      <h4 className="text-lg font-bold mt-4 mb-1"><Icon icon="box-archive" size={20} /> Portable Workspaces</h4>
+      <h4 className="text-lg font-bold mt-4 mb-1">Portable, Versioned Workspaces</h4>
       <p className="my-0">
-        Clone, snapshot, and version your environment. Move agent runs between machines without restarting or reconfiguring the system, and replay any past state on demand.
+        Snapshot, clone, and version a workspace the way git treats source. Move agent runs between machines without restarting, fork from any past state, and replay a run on demand.
       </p>
     </div>
     <div>
-      <h4 className="text-lg font-bold mt-4 mb-1"><Icon icon="puzzle-piece" size={20} /> Embed in Apps and Agents</h4>
+      <h4 className="text-lg font-bold mt-4 mb-1">Embed in Apps and Agents</h4>
       <p className="my-0">
         Python and TypeScript SDKs give your AI agents a virtual filesystem directly inside FastAPI, Express, browser apps, or any async runtime, no separate process required. Works with the major agent frameworks (OpenAI Agents SDK, Vercel AI SDK, LangChain, Pydantic AI, CAMEL, OpenHands) and a lightweight CLI plugs into coding agents like <img noZoom src="/images/claude-logo.svg" alt="" className="inline-block h-4 align-middle mr-1" />Claude Code and <img noZoom src="/images/openai-logo.svg" alt="" className="inline-block h-4 align-middle mr-1 brightness-0 dark:invert" />Codex.
-      </p>
-    </div>
-    <div>
-      <h4 className="text-lg font-bold mt-4 mb-1"><Icon icon="code-branch" size={20} /> Git-style Versioning</h4>
-      <p className="my-0">
-        Snapshot and clone your workspace the way git treats source. Fork from any past state and replay an agent run.
       </p>
     </div>
   </div>
@@ -256,7 +254,7 @@ grep -r "mirage" /slack /gmail /github
 
     <div className="max-w-none text-[15px] leading-7 mt-4 mb-4">
       <p className="my-0">
-        API preview. Runnable TypeScript example coming soon. See <a href="https://github.com/strukto-ai/mirage/blob/main/examples/typescript/agents/openai/multi_resource_agent.ts" target="_blank" rel="noopener noreferrer"><code>multi_resource_agent.ts</code></a> for the same shell-tool pattern over Slack + S3 today.
+        Runnable source: <a href="https://github.com/strukto-ai/mirage/blob/main/examples/typescript/agents/openai/multi_resource_agent.ts" target="_blank" rel="noopener noreferrer"><code>examples/typescript/agents/openai/multi_resource_agent.ts</code></a>, the same shell-tool pattern over Slack and S3.
       </p>
     </div>
   </Tab>

--- a/docs/home/snapshot.mdx
+++ b/docs/home/snapshot.mdx
@@ -55,6 +55,27 @@ cp = await ws.copy()
 
 Both `snapshot` and `copy` are `async` because fingerprint capture stats each touched path on a `SUPPORTS_SNAPSHOT` mount.
 
+## Versioning: commit, checkout, clone
+
+A tar snapshot is a *portable* capture you move between machines. Versioning is the in-place complement: a git-style history kept *with* the workspace, server-side and keyed by workspace id, so you can checkpoint, roll back, branch, and fork without writing a file. It is backed by a real git object store (dulwich) inside the daemon.
+
+This is a CLI / REST feature, not an SDK method (there is no `ws.commit()` in-process):
+
+```bash
+mirage workspace commit demo -m "before refactor"   # checkpoint the live state
+mirage workspace checkout demo <version>             # roll back in place
+mirage workspace clone demo --at <version>           # fork a past version
+```
+
+See the [CLI versioning reference](/home/cli#versioning) for `log`, `diff`, `branch`, and the full flag set.
+
+| | Tar snapshot | Versioning |
+| --- | --- | --- |
+| Output | a `.tar` you move or archive | history kept with the workspace (server) |
+| API | `ws.snapshot()` / `Workspace.load()` (SDK) | `mirage workspace commit` / `checkout` / `clone` (CLI + REST) |
+| Lineage | none, each tar stands alone | git-style commits, branches, diff |
+| Best for | reproducing a run on another machine | iterating in place with checkpoints to revert to |
+
 ## What Is And Isn't Captured
 
 <Columns cols={2}>

--- a/docs/python/quickstart.mdx
+++ b/docs/python/quickstart.mdx
@@ -129,4 +129,6 @@ block in the workspace YAML.
 
 ## Next Steps
 
-- See [Resource Docs](/python/resource/index) for the full list of supported data sources
+- See [Python Installation](/python/install) for resource extras and the `uv` workflow.
+- Browse [Python Agents](/python/agents/index) to wire Mirage into the OpenAI Agents SDK, LangChain, Pydantic AI, CAMEL, and OpenHands.
+- Pick a real backend from [Resource Docs](/python/resource/index), such as [S3](/python/resource/s3), [Slack](/python/resource/slack), or [GitHub](/python/resource/github).

--- a/docs/typescript/quickstart.mdx
+++ b/docs/typescript/quickstart.mdx
@@ -69,6 +69,50 @@ async function main(): Promise<void> {
 main()
 ```
 
+## Output Safeguards
+
+To keep huge reads from flooding an agent, `cat`, `grep`, `rg`, `head`,
+and `tail` cap their **final** output at 2000 lines by default. When a
+cap fires, the agent sees the truncated bytes plus a stderr notice
+(`output truncated at safeguard limit (2000 lines); ...`); the exit code
+stays 0.
+
+Caps fire only on the **terminal** command of a pipeline, so
+`cat big.txt | head -n 30` still shows 30 lines.
+
+### Configure per mount
+
+Pass a `commandSafeguards` option keyed by mount prefix, then command.
+Each `CommandSafeguard` sets `maxLines` / `maxBytes` (output cap) and/or
+`timeoutSeconds` (deadline); `onExceed` is `TRUNCATE` (default, exit 0
+plus notice) or `ERROR` (exit 1 plus notice):
+
+```ts
+import {
+  CommandSafeguard,
+  MountMode,
+  OnExceed,
+  RAMResource,
+  Workspace,
+} from '@struktoai/mirage-node'
+
+const ws = new Workspace(
+  { '/data': new RAMResource() },
+  {
+    mode: MountMode.WRITE,
+    commandSafeguards: {
+      '/data': {
+        head: new CommandSafeguard({ maxLines: 100 }), // cap, keep going
+        grep: new CommandSafeguard({ maxLines: 50, onExceed: OnExceed.ERROR }),
+        rg: new CommandSafeguard({ timeoutSeconds: 30 }), // deadline
+      },
+    },
+  },
+)
+```
+
+The same limits are available to the CLI as a `command_safeguards` block in the workspace YAML.
+
 ## Next Steps
 
 - See [TypeScript Installation](/typescript/install) for optional native peers (FUSE, Redis, Postgres, MongoDB, SSH, Email).


### PR DESCRIPTION
## What

Cleanup and accuracy pass over the `home/` docs and the Python/TypeScript quickstarts. Docs only, no source changes.

## Changes

- **introduction**: fix the Slack example (was a no-arg `SlackResource()` plus a non-existent `/slack/eng` path; now uses a token config and the real `/slack/channels/...` layout). Dedupe the repeated backend list, merge the two overlapping versioning cards, drop the "coming soon" caveat on the TS example, remove the feature-card icons.
- **Shell to Bash**: rename the page (nav slug `home/bash`), add a Subshells section, remove the `execute()` signature dump.
- **install + cli**: collapse the CLI install options into a single block.
- **architecture**: backend list parity (add Telegram, Postgres, LanceDB).
- **cache**: add Python examples (config + miss/hit lifecycle), an Eviction & Limits section, and a cross-link to snapshot.
- **snapshot**: add a short versioning section that points at the CLI versioning reference instead of duplicating it.
- **nav**: Knowledge group icon changed to `brain`.
- **quickstart**: add the Output Safeguards section to the TypeScript quickstart for parity with Python, and enrich the Python Next Steps.