### PR TITLE
fix(databricks-volume): prefer explicit token authentication

### DIFF
--- a/python/mirage/accessor/databricks_volume.py
+++ b/python/mirage/accessor/databricks_volume.py
@@ -46,6 +46,7 @@ class DatabricksVolumeAccessor(Accessor):
                 "host": self.config.host,
                 "token": self.config.token,
                 "profile": self.config.profile,
+                "auth_type": "pat" if self.config.token is not None else None,
                 "http_timeout_seconds": self.config.timeout,
             }
             sdk_config = WorkspaceConfig(**{

--- a/python/tests/resource/databricks_volume/test_accessor.py
+++ b/python/tests/resource/databricks_volume/test_accessor.py
@@ -44,3 +44,56 @@ def test_accessor_passes_timeout_to_workspace_client(monkeypatch):
     assert sdk_config.host == "https://example.cloud.databricks.com"
     assert sdk_config.token == "secret"
     assert sdk_config.http_timeout_seconds == 17
+
+
+def test_accessor_sets_pat_auth_type_for_explicit_token(monkeypatch):
+    FakeWorkspaceClient.calls = []
+    monkeypatch.setattr(
+        accessor_module,
+        "WorkspaceClient",
+        FakeWorkspaceClient,
+    )
+    monkeypatch.setattr(
+        accessor_module,
+        "WorkspaceConfig",
+        FakeWorkspaceConfig,
+    )
+    config = DatabricksVolumeConfig(
+        catalog="main",
+        schema="default",
+        volume="agent_files",
+        host="https://example.cloud.databricks.com",
+        token="request-token",
+    )
+    accessor = DatabricksVolumeAccessor(config)
+
+    assert accessor.files is not None
+    sdk_config = FakeWorkspaceClient.calls[0]["config"]
+    assert sdk_config.auth_type == "pat"
+    assert sdk_config.token == "request-token"
+
+
+def test_accessor_leaves_auth_type_unset_for_profile(monkeypatch):
+    FakeWorkspaceClient.calls = []
+    monkeypatch.setattr(
+        accessor_module,
+        "WorkspaceClient",
+        FakeWorkspaceClient,
+    )
+    monkeypatch.setattr(
+        accessor_module,
+        "WorkspaceConfig",
+        FakeWorkspaceConfig,
+    )
+    config = DatabricksVolumeConfig(
+        catalog="main",
+        schema="default",
+        volume="agent_files",
+        profile="default",
+    )
+    accessor = DatabricksVolumeAccessor(config)
+
+    assert accessor.files is not None
+    sdk_config = FakeWorkspaceClient.calls[0]["config"]
+    assert not hasattr(sdk_config, "auth_type")
+    assert sdk_config.profile == "default"


### PR DESCRIPTION
## What changed

- Tell the Databricks SDK to use `pat` authentication when `DatabricksVolumeConfig.token` is explicitly set.
- Leave profile and environment authentication selection unchanged when no token is provided.
- Add focused coverage for both paths.

## Why

Databricks Apps can inject service-principal OAuth environment variables. When Mirage also passes an explicit token, the SDK detects both `oauth` and `pat` and rejects the client configuration:

```text
ValueError: validate: more than one authorization method configured: oauth and pat
```

Selecting `pat` for the explicit-token path makes the caller-provided token authoritative without changing Mirage's public API.

## Scope

This is the minimal compatibility fix. The broader token-provider redesign remains in #293 and is tracked by #289 which might be in future release.

## Verification

- `PYTHONPATH=. /Users/son/code/mirage/python/.venv/bin/python -m pytest tests/core/databricks_volume tests/resource/databricks_volume -q --no-cov`
- Python pre-commit hooks
- Direct SDK validation reproduction for explicit token plus injected OAuth credentials
- Structured autoreview: clean
