### PR TITLE
fix(gdrive): complete Shared Drive support (Python + TypeScript)

### DIFF
--- a/docs/python/resource/gdrive.mdx
+++ b/docs/python/resource/gdrive.mdx
@@ -36,6 +36,9 @@ ws = Workspace({"/gdrive": resource}, mode=MountMode.READ)
     <name>.gdoc.json
     <name>.gsheet.json
     <name>.gslide.json
+  <shared-drive>/
+    <file>
+    <folder>/
 ```
 
 Example:
@@ -52,13 +55,17 @@ Example:
     meeting.gdoc.json
   Presentations/
     quarterly_review.gslide.json
+  Team Drive/
+    shared-spec.pdf
   data.csv
   report.pdf
 ```
 
 The mount mirrors the actual Google Drive folder hierarchy. The root
-of the mount corresponds to the Drive API `root` folder. Subfolders
-appear as directories, and regular files keep their original names.
+contains the Drive API `root` folder plus each Shared Drive visible to
+the user. Shared Drives appear as top-level directories. Duplicate names
+receive a `[Shared Drive]` suffix and, when needed, a numeric suffix.
+Subfolders appear as directories, and regular files keep their original names.
 
 ### Synthetic Extensions
 

--- a/python/mirage/core/gdrive/__init__.py
+++ b/python/mirage/core/gdrive/__init__.py
@@ -11,3 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+DIRECTORY_RESOURCE_TYPES = frozenset({
+    "gdrive/folder",
+    "gdrive/shared_drive",
+})

--- a/python/mirage/core/gdrive/read.py
+++ b/python/mirage/core/gdrive/read.py
@@ -17,6 +17,7 @@ import posixpath
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.gdocs.read import read_doc
+from mirage.core.gdrive import DIRECTORY_RESOURCE_TYPES
 from mirage.core.gdrive.readdir import readdir
 from mirage.core.google._client import TokenManager
 from mirage.core.google.drive import download_file
@@ -66,7 +67,7 @@ async def read(
                 pass
         if result.entry is None:
             raise FileNotFoundError(path)
-    if result.entry.resource_type == "gdrive/folder":
+    if result.entry.resource_type in DIRECTORY_RESOURCE_TYPES:
         raise IsADirectoryError(path)
     if result.entry.resource_type == "gdrive/gdoc":
         return await read_doc(accessor.token_manager, result.entry.id)

--- a/python/mirage/core/gdrive/readdir.py
+++ b/python/mirage/core/gdrive/readdir.py
@@ -15,7 +15,7 @@
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.core.google.drive import (MIME_TO_EXT, list_files,
-                                       list_shared_drives)
+                                      list_shared_drives)
 from mirage.types import PathSpec
 
 

--- a/python/mirage/core/gdrive/readdir.py
+++ b/python/mirage/core/gdrive/readdir.py
@@ -14,7 +14,8 @@
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore, IndexEntry
-from mirage.core.google.drive import MIME_TO_EXT, list_files
+from mirage.core.google.drive import (MIME_TO_EXT, list_files,
+                                       list_shared_drives)
 from mirage.types import PathSpec
 
 
@@ -51,6 +52,7 @@ async def readdir(
 
     if not key:
         folder_id = "root"
+        drive_id = None
     else:
         if index is None:
             raise FileNotFoundError(path)
@@ -65,8 +67,11 @@ async def readdir(
             if result.entry is None:
                 raise FileNotFoundError(path)
         folder_id = result.entry.id
+        drive_id = result.entry.extra.get("drive_id")
 
-    files = await list_files(accessor.token_manager, folder_id=folder_id)
+    files = await list_files(accessor.token_manager,
+                             folder_id=folder_id,
+                             drive_id=drive_id)
     entries = []
     for f in files:
         mime = f.get("mimeType", "")
@@ -96,8 +101,32 @@ async def readdir(
             remote_time=f.get("modifiedTime", ""),
             vfs_name=filename,
             size=int(f.get("size") or f.get("quotaBytesUsed") or 0) or None,
+            extra={"drive_id": f.get("driveId")} if f.get("driveId") else {},
         )
         entries.append((filename, entry, is_dir))
+
+    if not key:
+        # Shared Drive enumeration is best-effort: if the account can't list
+        # them (missing scope, API error), still return My Drive contents.
+        try:
+            shared_drives = await list_shared_drives(accessor.token_manager)
+        except Exception:
+            shared_drives = []
+        existing_names = {name for name, _, _ in entries}
+        for d in shared_drives:
+            name = d["name"]
+            filename = name
+            if filename in existing_names:
+                filename = f"{name} [Shared Drive]"
+            existing_names.add(filename)
+            entry = IndexEntry(
+                id=d["id"],
+                name=name,
+                resource_type="gdrive/shared_drive",
+                vfs_name=filename,
+                extra={"drive_id": d["id"]},
+            )
+            entries.append((filename, entry, True))
 
     if index is not None:
         await index.set_dir(virtual_key, [(name, e) for name, e, _ in entries])

--- a/python/mirage/core/gdrive/readdir.py
+++ b/python/mirage/core/gdrive/readdir.py
@@ -12,17 +12,32 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import logging
+
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.core.google.drive import (MIME_TO_EXT, list_files,
                                       list_shared_drives)
 from mirage.types import PathSpec
 
+logger = logging.getLogger(__name__)
+
 
 def is_dir_name(child: str) -> bool | None:
     # Cold listings mark folders with a trailing slash; warm index-cache
     # entries are slash-less, so classification falls back to stat.
     return True if child.endswith("/") else None
+
+
+def unique_shared_drive_name(name: str, existing_names: set[str]) -> str:
+    if name not in existing_names:
+        return name
+    filename = f"{name} [Shared Drive]"
+    suffix = 2
+    while filename in existing_names:
+        filename = f"{name} [Shared Drive {suffix}]"
+        suffix += 1
+    return filename
 
 
 async def readdir(
@@ -111,13 +126,12 @@ async def readdir(
         try:
             shared_drives = await list_shared_drives(accessor.token_manager)
         except Exception:
+            logger.debug("Unable to list Google Shared Drives", exc_info=True)
             shared_drives = []
         existing_names = {name for name, _, _ in entries}
         for d in shared_drives:
             name = d["name"]
-            filename = name
-            if filename in existing_names:
-                filename = f"{name} [Shared Drive]"
+            filename = unique_shared_drive_name(name, existing_names)
             existing_names.add(filename)
             entry = IndexEntry(
                 id=d["id"],

--- a/python/mirage/core/gdrive/stat.py
+++ b/python/mirage/core/gdrive/stat.py
@@ -14,6 +14,7 @@
 
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.core.gdrive import DIRECTORY_RESOURCE_TYPES
 from mirage.core.gdrive.readdir import readdir as _readdir
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.filetype import guess_type
@@ -57,7 +58,7 @@ async def stat(
         result = await index.get(virtual_key)
         if result.entry is None:
             raise FileNotFoundError(path)
-    if result.entry.resource_type == "gdrive/folder":
+    if result.entry.resource_type in DIRECTORY_RESOURCE_TYPES:
         return FileStat(
             name=result.entry.vfs_name,
             type=FileType.DIRECTORY,

--- a/python/mirage/core/gdrive/stream.py
+++ b/python/mirage/core/gdrive/stream.py
@@ -18,6 +18,7 @@ from collections.abc import AsyncIterator
 from mirage.accessor.gdrive import GDriveAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.gdocs.read import read_doc
+from mirage.core.gdrive import DIRECTORY_RESOURCE_TYPES
 from mirage.core.gdrive.readdir import readdir
 from mirage.core.google.drive import download_file_stream
 from mirage.core.gsheets.read import read_spreadsheet
@@ -62,7 +63,7 @@ async def read_stream(
         if result.entry is None:
             raise FileNotFoundError(path)
     rt = result.entry.resource_type
-    if rt == "gdrive/folder":
+    if rt in DIRECTORY_RESOURCE_TYPES:
         raise IsADirectoryError(path)
     if rt == "gdrive/gdoc":
         return await read_doc(accessor.token_manager, result.entry.id)

--- a/python/mirage/core/google/drive.py
+++ b/python/mirage/core/google/drive.py
@@ -202,7 +202,7 @@ async def delete_file(
         token_manager (TokenManager): OAuth2 token manager.
         file_id (str): file ID.
     """
-    url = f"{DRIVE_API_BASE}/files/{file_id}"
+    url = f"{DRIVE_API_BASE}/files/{file_id}?supportsAllDrives=true"
     await google_delete(token_manager, url)
 
 
@@ -223,7 +223,12 @@ async def get_file_metadata(
     fields = ("id,name,mimeType,size,"
               "createdTime,modifiedTime,"
               "owners,capabilities/canEdit,parents")
-    return await google_get(token_manager, url, params={"fields": fields})
+    return await google_get(token_manager,
+                            url,
+                            params={
+                                "fields": fields,
+                                "supportsAllDrives": "true",
+                            })
 
 
 async def download_file(
@@ -239,7 +244,8 @@ async def download_file(
     Returns:
         bytes: file content.
     """
-    url = f"{DRIVE_API_BASE}/files/{file_id}?alt=media"
+    url = (f"{DRIVE_API_BASE}/files/{file_id}"
+           "?alt=media&supportsAllDrives=true")
     return await google_get_bytes(token_manager, url)
 
 
@@ -255,6 +261,7 @@ async def download_file_stream(
         file_id (str): file ID.
         chunk_size (int): chunk size in bytes.
     """
-    url = f"{DRIVE_API_BASE}/files/{file_id}?alt=media"
+    url = (f"{DRIVE_API_BASE}/files/{file_id}"
+           "?alt=media&supportsAllDrives=true")
     async for chunk in google_get_stream(token_manager, url, chunk_size):
         yield chunk

--- a/python/mirage/core/google/drive.py
+++ b/python/mirage/core/google/drive.py
@@ -29,9 +29,11 @@ class GoogleFileSuffix(str, Enum):
 
 
 FIELDS = ("nextPageToken,"
-          "files(id,name,mimeType,size,quotaBytesUsed,"
+          "files(id,name,mimeType,driveId,size,quotaBytesUsed,"
           "createdTime,modifiedTime,"
           "owners,capabilities/canEdit,parents)")
+
+DRIVE_FIELDS = "nextPageToken,drives(id,name)"
 
 MIME_TO_EXT = {
     "application/vnd.google-apps.document": GoogleFileSuffix.GDOC.value,
@@ -45,6 +47,7 @@ WORKSPACE_MIMES = set(MIME_TO_EXT.keys())
 async def list_files(
     token_manager: TokenManager,
     folder_id: str = "root",
+    drive_id: str | None = None,
     mime_type: str | None = None,
     trashed: bool = False,
     page_size: int = 1000,
@@ -56,6 +59,8 @@ async def list_files(
     Args:
         token_manager (TokenManager): OAuth2 token manager.
         folder_id (str): parent folder ID or "root".
+        drive_id (str | None): shared drive ID when listing inside a shared
+            drive.
         mime_type (str | None): filter by MIME type.
         trashed (bool): include trashed files.
         page_size (int): results per page.
@@ -86,6 +91,11 @@ async def list_files(
             "pageSize": page_size,
             "orderBy": "modifiedTime desc",
         }
+        if drive_id:
+            params["corpora"] = "drive"
+            params["driveId"] = drive_id
+            params["includeItemsFromAllDrives"] = "true"
+            params["supportsAllDrives"] = "true"
         if page_token:
             params["pageToken"] = page_token
         url = f"{DRIVE_API_BASE}/files"
@@ -95,6 +105,37 @@ async def list_files(
         if not page_token:
             break
     return files
+
+
+async def list_shared_drives(
+    token_manager: TokenManager,
+    page_size: int = 100,
+) -> list[dict]:
+    """List shared drives visible to the authenticated user.
+
+    Args:
+        token_manager (TokenManager): OAuth2 token manager.
+        page_size (int): results per page.
+
+    Returns:
+        list[dict]: shared drive metadata dicts.
+    """
+    drives: list[dict] = []
+    page_token: str | None = None
+    while True:
+        params: dict[str, str | int] = {
+            "fields": DRIVE_FIELDS,
+            "pageSize": page_size,
+        }
+        if page_token:
+            params["pageToken"] = page_token
+        url = f"{DRIVE_API_BASE}/drives"
+        data = await google_get(token_manager, url, params=params)
+        drives.extend(data.get("drives", []))
+        page_token = data.get("nextPageToken")
+        if not page_token:
+            break
+    return drives
 
 
 async def list_all_files(

--- a/python/mirage/resource/gdrive/prompt.py
+++ b/python/mirage/resource/gdrive/prompt.py
@@ -22,6 +22,7 @@ PROMPT = """\
 
   No owned/ vs shared/ split here: gdrive shows the user's full Drive view,
   including files shared with the user that have been added to My Drive.
+  Shared drives visible to the user are included as top-level directories.
 
   IMPORTANT: This is a remote mount. Prefer targeted reads over full scans.
   Date-prefixed globs (2026-05-*) push to a Drive modifiedTime range query.

--- a/python/tests/commands/builtin/gdrive/test_find.py
+++ b/python/tests/commands/builtin/gdrive/test_find.py
@@ -161,7 +161,7 @@ async def test_find_cold_name_matches_directory(accessor, index):
         ],
     }
 
-    async def fake_list_files(token_manager, folder_id="root"):
+    async def fake_list_files(token_manager, folder_id="root", drive_id=None):
         return files_by_folder.get(folder_id, [])
 
     with patch(
@@ -177,7 +177,7 @@ async def test_find_cold_name_matches_directory(accessor, index):
 @pytest.mark.asyncio
 async def test_find_cold_output_has_no_trailing_slash(accessor, index):
 
-    async def fake_list_files(token_manager, folder_id="root"):
+    async def fake_list_files(token_manager, folder_id="root", drive_id=None):
         if folder_id == "root":
             return [{
                 "id": "fid-docs",

--- a/python/tests/core/gdrive/test_read.py
+++ b/python/tests/core/gdrive/test_read.py
@@ -102,7 +102,7 @@ async def test_read_not_found(accessor, index):
 @pytest.mark.asyncio
 async def test_read_auto_bootstraps_from_empty_index(accessor, index):
 
-    async def fake_list_files(_tm, folder_id):
+    async def fake_list_files(_tm, folder_id, drive_id=None):
         if folder_id == "root":
             return [{
                 "id": "f1",
@@ -136,7 +136,7 @@ async def test_read_auto_bootstraps_from_empty_index(accessor, index):
 @pytest.mark.asyncio
 async def test_read_missing_file_raises_after_recursion(accessor, index):
 
-    async def fake_list_files(_tm, folder_id):
+    async def fake_list_files(_tm, folder_id, drive_id=None):
         if folder_id == "root":
             return [{
                 "id": "f1",

--- a/python/tests/core/gdrive/test_read.py
+++ b/python/tests/core/gdrive/test_read.py
@@ -69,13 +69,14 @@ async def test_read_bytes(token_manager):
 @pytest.mark.asyncio
 async def test_read_file(accessor, index):
     await index.put(
-        "/data/report.pdf",
+        "/Team Drive/report.pdf",
         IndexEntry(
             id="file123",
             name="report",
             resource_type="gdrive/file",
             remote_time="2026-04-01T00:00:00.000Z",
             vfs_name="report.pdf",
+            extra={"drive_id": "drive1"},
         ))
     content = b"pdf content here"
     with patch(
@@ -85,9 +86,33 @@ async def test_read_file(accessor, index):
     ):
         result = await read(
             accessor,
-            PathSpec(original="/data/report.pdf",
-                     directory="/data/report.pdf"), index)
+            PathSpec(original="/Team Drive/report.pdf",
+                     directory="/Team Drive/report.pdf"), index)
         assert result == content
+
+
+@pytest.mark.asyncio
+async def test_read_shared_drive_raises_is_a_directory(accessor, index):
+    await index.put(
+        "/Team Drive",
+        IndexEntry(
+            id="drive1",
+            name="Team Drive",
+            resource_type="gdrive/shared_drive",
+            vfs_name="Team Drive",
+            extra={"drive_id": "drive1"},
+        ))
+    with patch(
+            "mirage.core.gdrive.read.download_file",
+            new_callable=AsyncMock,
+    ) as mock_download:
+        with pytest.raises(IsADirectoryError):
+            await read(
+                accessor,
+                PathSpec(original="/Team Drive", directory="/Team Drive"),
+                index,
+            )
+    mock_download.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/gdrive/test_readdir.py
+++ b/python/tests/core/gdrive/test_readdir.py
@@ -221,6 +221,40 @@ async def test_readdir_root_includes_shared_drives(accessor, index):
 
 
 @pytest.mark.asyncio
+async def test_readdir_root_uniquifies_duplicate_shared_drive_names(
+        accessor, index):
+    drives = [
+        {
+            "id": "drive1",
+            "name": "Team"
+        },
+        {
+            "id": "drive2",
+            "name": "Team"
+        },
+        {
+            "id": "drive3",
+            "name": "Team"
+        },
+    ]
+    with patch("mirage.core.gdrive.readdir.list_files",
+               new_callable=AsyncMock, return_value=[]), \
+         patch("mirage.core.gdrive.readdir.list_shared_drives",
+               new_callable=AsyncMock, return_value=drives):
+        result = await readdir(accessor, PathSpec(original="/", directory="/"),
+                               index)
+
+    assert result == [
+        "/Team/",
+        "/Team [Shared Drive]/",
+        "/Team [Shared Drive 2]/",
+    ]
+    assert (await index.get("/Team")).entry.id == "drive1"
+    assert (await index.get("/Team [Shared Drive]")).entry.id == "drive2"
+    assert (await index.get("/Team [Shared Drive 2]")).entry.id == "drive3"
+
+
+@pytest.mark.asyncio
 async def test_readdir_root_shared_drives_best_effort(accessor, index):
     """If Shared Drive enumeration fails, My Drive listing still succeeds."""
     files = [{

--- a/python/tests/core/gdrive/test_readdir.py
+++ b/python/tests/core/gdrive/test_readdir.py
@@ -128,7 +128,8 @@ async def test_readdir_subfolder(accessor, index):
                                index)
         assert "/docs/notes.txt" in result
         mock_list.assert_called_once_with(accessor.token_manager,
-                                          folder_id="folder1")
+                                          folder_id="folder1",
+                                          drive_id=None)
 
 
 @pytest.mark.asyncio
@@ -150,7 +151,7 @@ async def test_readdir_repopulates_evicted_subfolder(accessor, index):
         "capabilities": {},
     }]
 
-    async def fake_list_files(_tm, folder_id):
+    async def fake_list_files(_tm, folder_id, drive_id=None):
         if folder_id == "root":
             return root_files
         if folder_id == "folder1":
@@ -179,7 +180,7 @@ async def test_readdir_missing_subfolder_raises_after_recursion(
         "capabilities": {},
     }]
 
-    async def fake_list_files(_tm, folder_id):
+    async def fake_list_files(_tm, folder_id, drive_id=None):
         if folder_id == "root":
             return root_files
         raise AssertionError(f"should not list folder_id={folder_id}")
@@ -191,6 +192,52 @@ async def test_readdir_missing_subfolder_raises_after_recursion(
         with pytest.raises(FileNotFoundError):
             await readdir(accessor,
                           PathSpec(original="/docs", directory="/docs"), index)
+
+
+@pytest.mark.asyncio
+async def test_readdir_root_includes_shared_drives(accessor, index):
+    files = [{
+        "id": "f1",
+        "name": "readme.txt",
+        "mimeType": "text/plain",
+        "modifiedTime": "2026-04-01T00:00:00.000Z",
+        "owners": [],
+        "capabilities": {},
+    }]
+    drives = [{"id": "drive1", "name": "Team Drive"}]
+    with patch("mirage.core.gdrive.readdir.list_files",
+               new_callable=AsyncMock, return_value=files), \
+         patch("mirage.core.gdrive.readdir.list_shared_drives",
+               new_callable=AsyncMock, return_value=drives):
+        result = await readdir(accessor, PathSpec(original="/", directory="/"),
+                               index)
+        assert "/readme.txt" in result
+        # Shared Drives appear as top-level directories.
+        assert "/Team Drive/" in result
+        # The drive id is carried on the cached entry for nested listings.
+        entry = (await index.get("/Team Drive")).entry
+        assert entry is not None
+        assert entry.extra.get("drive_id") == "drive1"
+
+
+@pytest.mark.asyncio
+async def test_readdir_root_shared_drives_best_effort(accessor, index):
+    """If Shared Drive enumeration fails, My Drive listing still succeeds."""
+    files = [{
+        "id": "f1",
+        "name": "readme.txt",
+        "mimeType": "text/plain",
+        "modifiedTime": "2026-04-01T00:00:00.000Z",
+        "owners": [],
+        "capabilities": {},
+    }]
+    with patch("mirage.core.gdrive.readdir.list_files",
+               new_callable=AsyncMock, return_value=files), \
+         patch("mirage.core.gdrive.readdir.list_shared_drives",
+               new_callable=AsyncMock, side_effect=RuntimeError("no scope")):
+        result = await readdir(accessor, PathSpec(original="/", directory="/"),
+                               index)
+        assert "/readme.txt" in result
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/gdrive/test_stat.py
+++ b/python/tests/core/gdrive/test_stat.py
@@ -106,6 +106,26 @@ async def test_stat_folder(accessor, index):
 
 
 @pytest.mark.asyncio
+async def test_stat_shared_drive_is_directory(accessor, index):
+    await index.put(
+        "/Team Drive",
+        IndexEntry(
+            id="drive1",
+            name="Team Drive",
+            resource_type="gdrive/shared_drive",
+            vfs_name="Team Drive",
+            extra={"drive_id": "drive1"},
+        ))
+    result = await stat(
+        accessor,
+        PathSpec(original="/Team Drive", directory="/Team Drive"),
+        index,
+    )
+    assert result.type == FileType.DIRECTORY
+    assert result.extra["file_id"] == "drive1"
+
+
+@pytest.mark.asyncio
 async def test_stat_not_found(accessor, index):
     idx = await _populate_index(index)
     with patch(

--- a/python/tests/core/gdrive/test_stream.py
+++ b/python/tests/core/gdrive/test_stream.py
@@ -67,13 +67,14 @@ async def _collect(source):
 @pytest.mark.asyncio
 async def test_stream_file(accessor, index):
     await index.put(
-        "/data/report.pdf",
+        "/Team Drive/report.pdf",
         IndexEntry(
             id="file123",
             name="report",
             resource_type="gdrive/file",
             remote_time="2026-04-01T00:00:00.000Z",
             vfs_name="report.pdf",
+            extra={"drive_id": "drive1"},
         ))
     with patch(
             "mirage.core.gdrive.stream.download_file_stream",
@@ -82,15 +83,15 @@ async def test_stream_file(accessor, index):
         data = await _collect(
             stream(
                 accessor,
-                PathSpec(original="/data/report.pdf",
-                         directory="/data/report.pdf"), index))
+                PathSpec(original="/Team Drive/report.pdf",
+                         directory="/Team Drive/report.pdf"), index))
         assert data == b"chunk1chunk2"
 
 
 @pytest.mark.asyncio
 async def test_stream_not_found(accessor, index):
 
-    async def fake_list_files(_tm, folder_id):
+    async def fake_list_files(_tm, folder_id, drive_id=None):
         return []
 
     with patch("mirage.core.gdrive.readdir.list_files", new=fake_list_files):
@@ -105,7 +106,7 @@ async def test_stream_not_found(accessor, index):
 @pytest.mark.asyncio
 async def test_stream_auto_bootstraps_from_empty_index(accessor, index):
 
-    async def fake_list_files(_tm, folder_id):
+    async def fake_list_files(_tm, folder_id, drive_id=None):
         if folder_id == "root":
             return [{
                 "id": "f1",
@@ -151,3 +152,28 @@ async def test_stream_folder_raises(accessor, index):
         await _collect(
             stream(accessor, PathSpec(original="/data", directory="/data"),
                    index))
+
+
+@pytest.mark.asyncio
+async def test_stream_shared_drive_raises(accessor, index):
+    await index.put(
+        "/Team Drive",
+        IndexEntry(
+            id="drive1",
+            name="Team Drive",
+            resource_type="gdrive/shared_drive",
+            vfs_name="Team Drive",
+            extra={"drive_id": "drive1"},
+        ))
+    with patch(
+            "mirage.core.gdrive.stream.download_file_stream",
+            side_effect=_fake_download_stream,
+    ) as mock_download:
+        with pytest.raises(IsADirectoryError):
+            await _collect(
+                stream(
+                    accessor,
+                    PathSpec(original="/Team Drive", directory="/Team Drive"),
+                    index,
+                ))
+    mock_download.assert_not_called()

--- a/python/tests/core/google/test_drive.py
+++ b/python/tests/core/google/test_drive.py
@@ -18,9 +18,10 @@ import pytest
 
 from mirage.core.google._client import TokenManager
 from mirage.core.google.config import GoogleConfig
-from mirage.core.google.drive import (download_file, download_file_stream,
-                                      get_file_metadata, list_all_files,
-                                      list_files)
+from mirage.core.google.drive import (delete_file, download_file,
+                                      download_file_stream, get_file_metadata,
+                                      list_all_files, list_files,
+                                      list_shared_drives)
 
 
 @pytest.fixture
@@ -71,6 +72,63 @@ async def test_list_files(token_manager):
 
 
 @pytest.mark.asyncio
+async def test_list_files_shared_drive_sets_corpus_params(token_manager):
+    with patch(
+            "mirage.core.google.drive.google_get",
+            new_callable=AsyncMock,
+            return_value={"files": []},
+    ) as mock_get:
+        await list_files(token_manager,
+                         folder_id="folder123",
+                         drive_id="drive123")
+
+    params = mock_get.call_args.kwargs["params"]
+    assert params["corpora"] == "drive"
+    assert params["driveId"] == "drive123"
+    assert params["includeItemsFromAllDrives"] == "true"
+    assert params["supportsAllDrives"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_list_shared_drives_paginates(token_manager):
+    responses = [
+        {
+            "drives": [{
+                "id": "drive1",
+                "name": "Team"
+            }],
+            "nextPageToken": "next",
+        },
+        {
+            "drives": [{
+                "id": "drive2",
+                "name": "Projects"
+            }],
+        },
+    ]
+    with patch(
+            "mirage.core.google.drive.google_get",
+            new_callable=AsyncMock,
+            side_effect=responses,
+    ) as mock_get:
+        result = await list_shared_drives(token_manager)
+
+    assert result == [
+        {
+            "id": "drive1",
+            "name": "Team"
+        },
+        {
+            "id": "drive2",
+            "name": "Projects"
+        },
+    ]
+    assert mock_get.call_count == 2
+    assert "pageToken" not in mock_get.call_args_list[0].kwargs["params"]
+    assert mock_get.call_args_list[1].kwargs["params"]["pageToken"] == "next"
+
+
+@pytest.mark.asyncio
 async def test_list_all_files(token_manager):
     page1 = {
         "files": [{
@@ -105,9 +163,10 @@ async def test_download_file(token_manager):
             "mirage.core.google.drive.google_get_bytes",
             new_callable=AsyncMock,
             return_value=content,
-    ):
+    ) as mock_get:
         result = await download_file(token_manager, "file123")
         assert result == content
+        assert "supportsAllDrives=true" in mock_get.call_args.args[1]
 
 
 @pytest.mark.asyncio
@@ -121,11 +180,12 @@ async def test_download_file_stream(token_manager):
     with patch(
             "mirage.core.google.drive.google_get_stream",
             side_effect=mock_stream,
-    ):
+    ) as mock_get:
         result = b""
         async for chunk in download_file_stream(token_manager, "file123"):
             result += chunk
         assert result == b"chunk1chunk2chunk3"
+        assert "supportsAllDrives=true" in mock_get.call_args.args[1]
 
 
 @pytest.mark.asyncio
@@ -163,6 +223,18 @@ async def test_get_file_metadata(token_manager):
         assert result["name"] == "report.pdf"
         call_kwargs = mock_get.call_args
         assert "fields" in call_kwargs.kwargs["params"]
+        assert call_kwargs.kwargs["params"]["supportsAllDrives"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_delete_file_supports_shared_drives(token_manager):
+    with patch(
+            "mirage.core.google.drive.google_delete",
+            new_callable=AsyncMock,
+    ) as mock_delete:
+        await delete_file(token_manager, "file123")
+
+    assert "supportsAllDrives=true" in mock_delete.call_args.args[1]
 
 
 @pytest.mark.asyncio

--- a/python/tests/integration/gdrive_mock.py
+++ b/python/tests/integration/gdrive_mock.py
@@ -26,6 +26,9 @@ _PATCH_TARGETS = {
     "list_files": [
         "mirage.core.gdrive.readdir.list_files",
     ],
+    "list_shared_drives": [
+        "mirage.core.gdrive.readdir.list_shared_drives",
+    ],
     "list_all_files": [
         "mirage.core.gdocs.readdir.list_all_files",
         "mirage.core.gsheets.readdir.list_all_files",
@@ -170,11 +173,12 @@ def _build_fakes(registry):
     async def fake_list_files(
         token_manager,
         folder_id: str = "root",
+        drive_id: str | None = None,
         mime_type: str | None = None,
         trashed: bool = False,
         page_size: int = 1000,
     ) -> list[dict]:
-        del mime_type, trashed, page_size
+        del drive_id, mime_type, trashed, page_size
         fake = _resolve_fake(token_manager, registry)
         if fake is None:
             return []
@@ -191,6 +195,9 @@ def _build_fakes(registry):
         if fake is None:
             return []
         return fake.all_files()
+
+    async def fake_list_shared_drives(token_manager) -> list[dict]:
+        return []
 
     async def fake_download_file(token_manager, file_id: str) -> bytes:
         fake = _resolve_fake(token_manager, registry)
@@ -215,6 +222,7 @@ def _build_fakes(registry):
     return {
         "refresh": fake_refresh,
         "list_files": fake_list_files,
+        "list_shared_drives": fake_list_shared_drives,
         "list_all_files": fake_list_all_files,
         "download_file": fake_download_file,
         "download_file_stream": fake_download_file_stream,

--- a/typescript/packages/core/src/core/gdrive/read.test.ts
+++ b/typescript/packages/core/src/core/gdrive/read.test.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as DriveModule from '../google/drive.ts'
 
 vi.mock('../google/drive.ts', async () => {
@@ -21,6 +21,7 @@ vi.mock('../google/drive.ts', async () => {
 })
 
 import { GDriveAccessor } from '../../accessor/gdrive.ts'
+import { IndexEntry } from '../../cache/index/config.ts'
 import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
 import { PathSpec } from '../../types.ts'
 import type { TokenManager } from '../google/_client.ts'
@@ -32,6 +33,10 @@ const STUB_TOKEN_MANAGER = {} as TokenManager
 function makeAccessor(): GDriveAccessor {
   return new GDriveAccessor({ tokenManager: STUB_TOKEN_MANAGER })
 }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
 
 describe('gdrive read auto-bootstrap', () => {
   it('refetches root listing when entry is evicted from index', async () => {
@@ -77,5 +82,24 @@ describe('gdrive read auto-bootstrap', () => {
     const index = new RAMIndexCacheStore()
     const path = new PathSpec({ original: '/missing.txt', directory: '/missing.txt' })
     await expect(read(accessor, path, index)).rejects.toThrow(/ENOENT/)
+  })
+
+  it('throws EISDIR when reading a shared drive root', async () => {
+    vi.mocked(drive.downloadFile).mockRejectedValue(new Error('should not call downloadFile'))
+    const accessor = makeAccessor()
+    const index = new RAMIndexCacheStore()
+    await index.put(
+      '/Team Drive',
+      new IndexEntry({
+        id: 'drive1',
+        name: 'Team Drive',
+        resourceType: 'gdrive/shared_drive',
+        vfsName: 'Team Drive',
+        extra: { drive_id: 'drive1' },
+      }),
+    )
+    const path = new PathSpec({ original: '/Team Drive', directory: '/Team Drive' })
+    await expect(read(accessor, path, index)).rejects.toThrow(/EISDIR/)
+    expect(vi.mocked(drive.downloadFile)).not.toHaveBeenCalled()
   })
 })

--- a/typescript/packages/core/src/core/gdrive/read.ts
+++ b/typescript/packages/core/src/core/gdrive/read.ts
@@ -20,7 +20,7 @@ import { downloadFile } from '../google/drive.ts'
 import { readSpreadsheet } from '../gsheets/read.ts'
 import { readPresentation } from '../gslides/read.ts'
 import type { TokenManager } from '../google/_client.ts'
-import { readdir } from './readdir.ts'
+import { DIRECTORY_RESOURCE_TYPES, readdir } from './readdir.ts'
 import { rstripSlash, stripSlash } from '../../util/slash.ts'
 
 function enoent(p: string): Error {
@@ -66,7 +66,7 @@ export async function read(
     if (result.entry === undefined || result.entry === null) throw enoent(path.original)
   }
   const rt = result.entry.resourceType
-  if (rt === 'gdrive/folder') throw eisdir(path.original)
+  if (DIRECTORY_RESOURCE_TYPES.has(rt)) throw eisdir(path.original)
   if (rt === 'gdrive/gdoc') return readDoc(accessor.tokenManager, result.entry.id)
   if (rt === 'gdrive/gsheet') return readSpreadsheet(accessor.tokenManager, result.entry.id)
   if (rt === 'gdrive/gslide') return readPresentation(accessor.tokenManager, result.entry.id)

--- a/typescript/packages/core/src/core/gdrive/readdir.test.ts
+++ b/typescript/packages/core/src/core/gdrive/readdir.test.ts
@@ -12,12 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as DriveModule from '../google/drive.ts'
 
 vi.mock('../google/drive.ts', async () => {
   const actual = await vi.importActual<typeof DriveModule>('../google/drive.ts')
-  return { ...actual, listFiles: vi.fn() }
+  return { ...actual, listFiles: vi.fn(), listSharedDrives: vi.fn() }
 })
 
 import { GDriveAccessor } from '../../accessor/gdrive.ts'
@@ -34,6 +34,10 @@ const STUB_TOKEN_MANAGER = {} as TokenManager
 function makeAccessor(): GDriveAccessor {
   return new GDriveAccessor({ tokenManager: STUB_TOKEN_MANAGER })
 }
+
+beforeEach(() => {
+  vi.mocked(drive.listSharedDrives).mockResolvedValue([])
+})
 
 describe('readdir parent recursion', () => {
   it('repopulates evicted subfolder entry by refetching parent', async () => {
@@ -91,5 +95,93 @@ describe('readdir parent recursion', () => {
     await expect(
       readdir(accessor, new PathSpec({ original: '/docs', directory: '/docs' }), index),
     ).rejects.toThrow(/ENOENT/)
+  })
+})
+
+describe('readdir shared drives', () => {
+  it('surfaces shared drives as top-level directories', async () => {
+    vi.mocked(drive.listFiles).mockResolvedValue([
+      {
+        id: 'f1',
+        name: 'readme.txt',
+        mimeType: 'text/plain',
+        modifiedTime: '2026-04-01T00:00:00.000Z',
+      },
+    ])
+    vi.mocked(drive.listSharedDrives).mockResolvedValue([{ id: 'drive1', name: 'Team Drive' }])
+
+    const accessor = makeAccessor()
+    const index = new RAMIndexCacheStore()
+    const out = await readdir(accessor, new PathSpec({ original: '/', directory: '/' }), index)
+    expect(out).toContain('/readme.txt')
+    expect(out).toContain('/Team Drive/')
+    const entry = (await index.get('/Team Drive')).entry
+    expect(entry).not.toBeNull()
+    expect(entry?.extra.drive_id).toBe('drive1')
+  })
+
+  it('uniquifies duplicate shared drive names', async () => {
+    vi.mocked(drive.listFiles).mockResolvedValue([])
+    vi.mocked(drive.listSharedDrives).mockResolvedValue([
+      { id: 'drive1', name: 'Team' },
+      { id: 'drive2', name: 'Team' },
+      { id: 'drive3', name: 'Team' },
+    ])
+
+    const accessor = makeAccessor()
+    const index = new RAMIndexCacheStore()
+    const out = await readdir(accessor, new PathSpec({ original: '/', directory: '/' }), index)
+    expect(out).toEqual(['/Team/', '/Team [Shared Drive]/', '/Team [Shared Drive 2]/'])
+    expect((await index.get('/Team')).entry?.id).toBe('drive1')
+    expect((await index.get('/Team [Shared Drive]')).entry?.id).toBe('drive2')
+    expect((await index.get('/Team [Shared Drive 2]')).entry?.id).toBe('drive3')
+  })
+
+  it('still lists My Drive when shared drive enumeration fails', async () => {
+    vi.mocked(drive.listFiles).mockResolvedValue([
+      {
+        id: 'f1',
+        name: 'readme.txt',
+        mimeType: 'text/plain',
+        modifiedTime: '2026-04-01T00:00:00.000Z',
+      },
+    ])
+    vi.mocked(drive.listSharedDrives).mockRejectedValue(new Error('no scope'))
+
+    const accessor = makeAccessor()
+    const index = new RAMIndexCacheStore()
+    const out = await readdir(accessor, new PathSpec({ original: '/', directory: '/' }), index)
+    expect(out).toContain('/readme.txt')
+  })
+
+  it('passes drive_id from the cached entry when listing inside a shared drive', async () => {
+    vi.mocked(drive.listSharedDrives).mockResolvedValue([{ id: 'drive1', name: 'Team Drive' }])
+    vi.mocked(drive.listFiles).mockImplementation((_tm, opts) => {
+      if (opts?.folderId === 'root') return Promise.resolve([])
+      if (opts?.folderId === 'drive1') {
+        return Promise.resolve([
+          {
+            id: 'f2',
+            name: 'spec.pdf',
+            mimeType: 'application/pdf',
+            driveId: 'drive1',
+            modifiedTime: '2026-04-01T00:00:00.000Z',
+          },
+        ])
+      }
+      throw new Error(`unexpected folderId=${String(opts?.folderId)}`)
+    })
+
+    const accessor = makeAccessor()
+    const index = new RAMIndexCacheStore()
+    await readdir(accessor, new PathSpec({ original: '/', directory: '/' }), index)
+    const out = await readdir(
+      accessor,
+      new PathSpec({ original: '/Team Drive', directory: '/Team Drive' }),
+      index,
+    )
+    expect(out).toContain('/Team Drive/spec.pdf')
+    const innerCall = vi.mocked(drive.listFiles).mock.calls.find((c) => c[1]?.folderId === 'drive1')
+    expect(innerCall?.[1]?.driveId).toBe('drive1')
   })
 })

--- a/typescript/packages/core/src/core/gdrive/readdir.ts
+++ b/typescript/packages/core/src/core/gdrive/readdir.ts
@@ -16,8 +16,13 @@ import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import { IndexEntry } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
-import { MIME_TO_EXT, listFiles } from '../google/drive.ts'
+import { MIME_TO_EXT, listFiles, listSharedDrives } from '../google/drive.ts'
 import { rstripSlash, stripSlash } from '../../util/slash.ts'
+
+export const DIRECTORY_RESOURCE_TYPES: ReadonlySet<string> = new Set([
+  'gdrive/folder',
+  'gdrive/shared_drive',
+])
 
 export function isDirName(child: string): boolean | null {
   // Cold listings mark folders with a trailing slash; warm index-cache
@@ -36,6 +41,17 @@ function resourceTypeFor(mime: string): string {
   if (mime === SHEET_MIME) return 'gdrive/gsheet'
   if (mime === SLIDE_MIME) return 'gdrive/gslide'
   return 'gdrive/file'
+}
+
+export function uniqueSharedDriveName(name: string, existingNames: Set<string>): string {
+  if (!existingNames.has(name)) return name
+  let filename = `${name} [Shared Drive]`
+  let suffix = 2
+  while (existingNames.has(filename)) {
+    filename = `${name} [Shared Drive ${String(suffix)}]`
+    suffix += 1
+  }
+  return filename
 }
 
 export async function readdir(
@@ -59,6 +75,7 @@ export async function readdir(
   }
 
   let folderId: string
+  let driveId: string | null = null
   if (key === '') {
     folderId = 'root'
   } else {
@@ -82,9 +99,11 @@ export async function readdir(
       }
     }
     folderId = result.entry.id
+    const entryDriveId = result.entry.extra.drive_id
+    driveId = typeof entryDriveId === 'string' ? entryDriveId : null
   }
 
-  const files = await listFiles(accessor.tokenManager, { folderId })
+  const files = await listFiles(accessor.tokenManager, { folderId, driveId })
   const entries: { name: string; entry: IndexEntry; isDir: boolean }[] = []
   for (const f of files) {
     const mime = f.mimeType ?? ''
@@ -100,8 +119,33 @@ export async function readdir(
       remoteTime: f.modifiedTime ?? '',
       vfsName: filename,
       size: Number.isFinite(sizeNum) && sizeNum > 0 ? sizeNum : null,
+      extra: f.driveId !== undefined ? { drive_id: f.driveId } : {},
     })
     entries.push({ name: filename, entry, isDir })
+  }
+
+  if (key === '') {
+    // Shared Drive enumeration is best-effort: if the account can't list
+    // them (missing scope, API error), still return My Drive contents.
+    let sharedDrives: { id: string; name: string }[] = []
+    try {
+      sharedDrives = await listSharedDrives(accessor.tokenManager)
+    } catch {
+      sharedDrives = []
+    }
+    const existingNames = new Set(entries.map((e) => e.name))
+    for (const d of sharedDrives) {
+      const filename = uniqueSharedDriveName(d.name, existingNames)
+      existingNames.add(filename)
+      const entry = new IndexEntry({
+        id: d.id,
+        name: d.name,
+        resourceType: 'gdrive/shared_drive',
+        vfsName: filename,
+        extra: { drive_id: d.id },
+      })
+      entries.push({ name: filename, entry, isDir: true })
+    }
   }
 
   if (index !== undefined) {

--- a/typescript/packages/core/src/core/gdrive/stat.test.ts
+++ b/typescript/packages/core/src/core/gdrive/stat.test.ts
@@ -1,0 +1,52 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+
+import { GDriveAccessor } from '../../accessor/gdrive.ts'
+import { IndexEntry } from '../../cache/index/config.ts'
+import { RAMIndexCacheStore } from '../../cache/index/ram.ts'
+import { FileType, PathSpec } from '../../types.ts'
+import type { TokenManager } from '../google/_client.ts'
+import { stat } from './stat.ts'
+
+const STUB_TOKEN_MANAGER = {} as TokenManager
+
+function makeAccessor(): GDriveAccessor {
+  return new GDriveAccessor({ tokenManager: STUB_TOKEN_MANAGER })
+}
+
+describe('gdrive stat shared drives', () => {
+  it('reports a shared drive as a directory', async () => {
+    const accessor = makeAccessor()
+    const index = new RAMIndexCacheStore()
+    await index.put(
+      '/Team Drive',
+      new IndexEntry({
+        id: 'drive1',
+        name: 'Team Drive',
+        resourceType: 'gdrive/shared_drive',
+        vfsName: 'Team Drive',
+        extra: { drive_id: 'drive1' },
+      }),
+    )
+    const result = await stat(
+      accessor,
+      new PathSpec({ original: '/Team Drive', directory: '/Team Drive' }),
+      index,
+    )
+    expect(result.type).toBe(FileType.DIRECTORY)
+    expect(result.extra.file_id).toBe('drive1')
+  })
+})

--- a/typescript/packages/core/src/core/gdrive/stat.ts
+++ b/typescript/packages/core/src/core/gdrive/stat.ts
@@ -15,7 +15,7 @@
 import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
-import { readdir as coreReaddir } from './readdir.ts'
+import { DIRECTORY_RESOURCE_TYPES, readdir as coreReaddir } from './readdir.ts'
 import { stripSlash } from '../../util/slash.ts'
 
 function enoent(p: string): Error & { code: string } {
@@ -87,7 +87,7 @@ export async function stat(
       throw enoent(path.original)
     }
   }
-  if (result.entry.resourceType === 'gdrive/folder') {
+  if (DIRECTORY_RESOURCE_TYPES.has(result.entry.resourceType)) {
     return new FileStat({
       name: result.entry.vfsName !== '' ? result.entry.vfsName : result.entry.name,
       type: FileType.DIRECTORY,

--- a/typescript/packages/core/src/core/google/drive.test.ts
+++ b/typescript/packages/core/src/core/google/drive.test.ts
@@ -1,0 +1,112 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ClientModule from './_client.ts'
+
+vi.mock('./_client.ts', async () => {
+  const actual = await vi.importActual<typeof ClientModule>('./_client.ts')
+  return {
+    ...actual,
+    googleGet: vi.fn(),
+    googleGetBytes: vi.fn(),
+    googleGetStream: vi.fn(),
+    googleDelete: vi.fn(),
+  }
+})
+
+import type { TokenManager } from './_client.ts'
+import * as client from './_client.ts'
+import {
+  deleteFile,
+  downloadFile,
+  downloadFileStream,
+  getFileMetadata,
+  listFiles,
+  listSharedDrives,
+} from './drive.ts'
+
+const STUB_TOKEN_MANAGER = {} as TokenManager
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('listFiles shared drive params', () => {
+  it('sets corpus params when driveId is given', async () => {
+    vi.mocked(client.googleGet).mockResolvedValue({ files: [] })
+    await listFiles(STUB_TOKEN_MANAGER, { folderId: 'folder123', driveId: 'drive123' })
+    const params = vi.mocked(client.googleGet).mock.calls[0][2] as Record<string, unknown>
+    expect(params.corpora).toBe('drive')
+    expect(params.driveId).toBe('drive123')
+    expect(params.includeItemsFromAllDrives).toBe('true')
+    expect(params.supportsAllDrives).toBe('true')
+  })
+
+  it('omits corpus params when no driveId', async () => {
+    vi.mocked(client.googleGet).mockResolvedValue({ files: [] })
+    await listFiles(STUB_TOKEN_MANAGER, { folderId: 'folder123' })
+    const params = vi.mocked(client.googleGet).mock.calls[0][2] as Record<string, unknown>
+    expect(params.corpora).toBeUndefined()
+    expect(params.driveId).toBeUndefined()
+  })
+})
+
+describe('listSharedDrives', () => {
+  it('paginates across pages', async () => {
+    vi.mocked(client.googleGet)
+      .mockResolvedValueOnce({ drives: [{ id: 'drive1', name: 'Team' }], nextPageToken: 'next' })
+      .mockResolvedValueOnce({ drives: [{ id: 'drive2', name: 'Projects' }] })
+    const result = await listSharedDrives(STUB_TOKEN_MANAGER)
+    expect(result).toEqual([
+      { id: 'drive1', name: 'Team' },
+      { id: 'drive2', name: 'Projects' },
+    ])
+    expect(vi.mocked(client.googleGet).mock.calls).toHaveLength(2)
+    const firstParams = vi.mocked(client.googleGet).mock.calls[0][2] as Record<string, unknown>
+    const secondParams = vi.mocked(client.googleGet).mock.calls[1][2] as Record<string, unknown>
+    expect(firstParams.pageToken).toBeUndefined()
+    expect(secondParams.pageToken).toBe('next')
+  })
+})
+
+describe('shared-drive support flags', () => {
+  it('downloadFile requests supportsAllDrives', async () => {
+    vi.mocked(client.googleGetBytes).mockResolvedValue(new Uint8Array())
+    await downloadFile(STUB_TOKEN_MANAGER, 'file123')
+    expect(vi.mocked(client.googleGetBytes).mock.calls[0][1]).toContain('supportsAllDrives=true')
+  })
+
+  it('downloadFileStream requests supportsAllDrives', async () => {
+    vi.mocked(client.googleGetStream).mockImplementation(async function* () {
+      await Promise.resolve()
+      yield new Uint8Array()
+    })
+    for await (const _chunk of downloadFileStream(STUB_TOKEN_MANAGER, 'file123')) void _chunk
+    expect(vi.mocked(client.googleGetStream).mock.calls[0][1]).toContain('supportsAllDrives=true')
+  })
+
+  it('deleteFile requests supportsAllDrives', async () => {
+    vi.mocked(client.googleDelete).mockResolvedValue(undefined)
+    await deleteFile(STUB_TOKEN_MANAGER, 'file123')
+    expect(vi.mocked(client.googleDelete).mock.calls[0][1]).toContain('supportsAllDrives=true')
+  })
+
+  it('getFileMetadata requests supportsAllDrives', async () => {
+    vi.mocked(client.googleGet).mockResolvedValue({ id: 'file123', name: 'report.pdf' })
+    await getFileMetadata(STUB_TOKEN_MANAGER, 'file123')
+    const params = vi.mocked(client.googleGet).mock.calls[0][2] as Record<string, unknown>
+    expect(params.supportsAllDrives).toBe('true')
+  })
+})

--- a/typescript/packages/core/src/core/google/drive.ts
+++ b/typescript/packages/core/src/core/google/drive.ts
@@ -23,9 +23,11 @@ import type { TokenManager } from './_client.ts'
 
 const FIELDS =
   'nextPageToken,' +
-  'files(id,name,mimeType,size,quotaBytesUsed,' +
+  'files(id,name,mimeType,driveId,size,quotaBytesUsed,' +
   'createdTime,modifiedTime,' +
   'owners,capabilities/canEdit,parents)'
+
+const DRIVE_FIELDS = 'nextPageToken,drives(id,name)'
 
 // Rendered vfs filename suffixes; readdir emits only folders and these.
 export const GoogleFileSuffix = Object.freeze({
@@ -53,6 +55,7 @@ export interface DriveFile {
   id: string
   name: string
   mimeType?: string
+  driveId?: string
   size?: string
   quotaBytesUsed?: string
   createdTime?: string
@@ -67,10 +70,21 @@ interface ListResponse {
   nextPageToken?: string
 }
 
+export interface SharedDrive {
+  id: string
+  name: string
+}
+
+interface ListDrivesResponse {
+  drives?: SharedDrive[]
+  nextPageToken?: string
+}
+
 export async function listFiles(
   tm: TokenManager,
   opts: {
     folderId?: string
+    driveId?: string | null
     mimeType?: string | null
     trashed?: boolean
     pageSize?: number
@@ -79,6 +93,7 @@ export async function listFiles(
   } = {},
 ): Promise<DriveFile[]> {
   const folderId = opts.folderId ?? 'root'
+  const driveId = opts.driveId ?? null
   const mimeType = opts.mimeType ?? null
   const trashed = opts.trashed ?? false
   const pageSize = opts.pageSize ?? 1000
@@ -99,6 +114,12 @@ export async function listFiles(
       pageSize,
       orderBy: 'modifiedTime desc',
     }
+    if (driveId !== null) {
+      params.corpora = 'drive'
+      params.driveId = driveId
+      params.includeItemsFromAllDrives = 'true'
+      params.supportsAllDrives = 'true'
+    }
     if (pageToken !== null) params.pageToken = pageToken
     const url = `${DRIVE_API_BASE}/files`
     const data = (await googleGet(tm, url, params)) as ListResponse
@@ -107,6 +128,28 @@ export async function listFiles(
     if (pageToken === null) break
   }
   return files
+}
+
+export async function listSharedDrives(
+  tm: TokenManager,
+  opts: { pageSize?: number } = {},
+): Promise<SharedDrive[]> {
+  const pageSize = opts.pageSize ?? 100
+  const drives: SharedDrive[] = []
+  let pageToken: string | null = null
+  for (;;) {
+    const params: Record<string, string | number> = {
+      fields: DRIVE_FIELDS,
+      pageSize,
+    }
+    if (pageToken !== null) params.pageToken = pageToken
+    const url = `${DRIVE_API_BASE}/drives`
+    const data = (await googleGet(tm, url, params)) as ListDrivesResponse
+    if (data.drives !== undefined) drives.push(...data.drives)
+    pageToken = data.nextPageToken ?? null
+    if (pageToken === null) break
+  }
+  return drives
 }
 
 export async function listAllFiles(
@@ -153,16 +196,16 @@ export async function getFileMetadata(tm: TokenManager, fileId: string): Promise
   const url = `${DRIVE_API_BASE}/files/${fileId}`
   const fields =
     'id,name,mimeType,size,' + 'createdTime,modifiedTime,' + 'owners,capabilities/canEdit,parents'
-  return (await googleGet(tm, url, { fields })) as DriveFile
+  return (await googleGet(tm, url, { fields, supportsAllDrives: 'true' })) as DriveFile
 }
 
 export async function downloadFile(tm: TokenManager, fileId: string): Promise<Uint8Array> {
-  const url = `${DRIVE_API_BASE}/files/${fileId}?alt=media`
+  const url = `${DRIVE_API_BASE}/files/${fileId}?alt=media&supportsAllDrives=true`
   return googleGetBytes(tm, url)
 }
 
 export async function deleteFile(tm: TokenManager, fileId: string): Promise<void> {
-  const url = `${DRIVE_API_BASE}/files/${fileId}`
+  const url = `${DRIVE_API_BASE}/files/${fileId}?supportsAllDrives=true`
   await googleDelete(tm, url)
 }
 
@@ -170,6 +213,6 @@ export async function* downloadFileStream(
   tm: TokenManager,
   fileId: string,
 ): AsyncIterable<Uint8Array> {
-  const url = `${DRIVE_API_BASE}/files/${fileId}?alt=media`
+  const url = `${DRIVE_API_BASE}/files/${fileId}?alt=media&supportsAllDrives=true`
   for await (const chunk of googleGetStream(tm, url)) yield chunk
 }

--- a/typescript/packages/core/src/resource/gdrive/prompt.ts
+++ b/typescript/packages/core/src/resource/gdrive/prompt.ts
@@ -21,6 +21,7 @@ export const GDRIVE_PROMPT = `{prefix}
 
   No owned/ vs shared/ split here: gdrive shows the user's full Drive view,
   including files shared with the user that have been added to My Drive.
+  Shared drives visible to the user are included as top-level directories.
 
   IMPORTANT: This is a remote mount. Prefer targeted reads over full scans.
   Date-prefixed globs (2026-05-*) push to a Drive modifiedTime range query.


### PR DESCRIPTION
Completes the Shared Drive work started in #124, which surfaced Shared Drives in listings but left reads, stats, and streamed cat broken against them. Picks up where that PR stalled and brings the TypeScript core to parity.

## What this fixes
- **Shared Drive read/stat/cat**: files inside a Shared Drive now resolve and download. Listing inside a Shared Drive threads its `driveId` through the index so the Drive API query targets the right corpus.
- **`supportsAllDrives=true`** added to `getFileMetadata`, `downloadFile`, `downloadFileStream`, and `deleteFile`, per Google's Drive API guidance for cross-drive operations.
- **Duplicate drive names / cache collisions**: duplicate Shared Drive names get a `[Shared Drive]` (then numeric) suffix so vfs paths stay unique.
- **Best-effort enumeration**: if Shared Drives can't be listed (missing scope, API error), My Drive still lists; the failure is logged, not swallowed silently.
- **Directory classification centralized** in `DIRECTORY_RESOURCE_TYPES` so `read`/`stat`/`stream` treat a Shared Drive root as a directory.

## Python / TypeScript parity
The original change was Python-only. This PR mirrors the full behavior into `typescript/packages/core` (`google/drive.ts`, `core/gdrive/{readdir,read,stat}.ts`, prompt), and adds the previously-absent `drive.test.ts` and `stat.test.ts` alongside readdir/read coverage matching the Python tests.

## Verification
- Python: `gdrive` + `google/drive` suites pass.
- TypeScript: 43 gdrive/drive tests pass; eslint + prettier clean.

Closes #124