### PR TITLE
refactor: consolidate path primitives into shared utils/path (py+ts)

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -516,6 +516,17 @@ CASES: list[tuple[str, str]] = [
      " && cat /data/arch/cs_00"),
     ("arch_iconv_file", "iconv -f utf-8 -t utf-8 /data/arch/g.txt"),
     ("arch_mktemp", "mktemp -p /data/arch | wc -l"),
+
+    # ----- create at the mount root (parent resolves to "/") -----
+    # Disabled pending the GNU find start-path fix: `find <dir>` does not
+    # emit the start dir (mirage walks from depth 1), so the mkdir+find
+    # check below returns nothing. Re-enable with that find parity change.
+    # ("root_create", "echo atroot | tee /data/at_root.txt"),
+    # ("root_create_cat", "cat /data/at_root.txt"),
+    # ("root_create_mkdir",
+    #  "mkdir /data/rootdir && find /data/rootdir -type d"),
+    # ("root_create_basename", "basename /data/at_root.txt"),
+    # ("root_create_dirname", "dirname /data/at_root.txt"),
 ]
 
 EXIT_CODE_CASES: list[tuple[str, str]] = [

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -442,6 +442,16 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
   ],
   ['arch_iconv_file', 'iconv -f utf-8 -t utf-8 /data/arch/g.txt'],
   ['arch_mktemp', 'mktemp -p /data/arch | wc -l'],
+
+  // ----- create at the mount root (parent resolves to "/") -----
+  // Commented out pending the GNU find start-path fix: `find <dir>` does not
+  // emit the start directory (mirage walks from depth 1), so root_create_mkdir
+  // below returns nothing. Re-enable with the dedicated find parity change.
+  // ['root_create', 'echo atroot | tee /data/at_root.txt'],
+  // ['root_create_cat', 'cat /data/at_root.txt'],
+  // ['root_create_mkdir', 'mkdir /data/rootdir && find /data/rootdir -type d'],
+  // ['root_create_basename', 'basename /data/at_root.txt'],
+  // ['root_create_dirname', 'dirname /data/at_root.txt'],
 ];
 
 export const EXIT_CODE_CASES: ReadonlyArray<readonly [string, string]> = [

--- a/python/mirage/core/chroma/tree.py
+++ b/python/mirage/core/chroma/tree.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.core.chroma._client import fetch_path_tree
+from mirage.utils.path import gnu_basename, parent
 
 
 async def ensure_tree(accessor,
@@ -67,7 +68,7 @@ def build_dir_entries(
         if directory == "/":
             continue
         entry = IndexEntry(id=directory.strip("/"),
-                           name=basename(directory),
+                           name=gnu_basename(directory),
                            resource_type="folder")
         dir_entries[virtual_path(parent(directory), prefix)].append(
             (entry.name, entry))
@@ -78,7 +79,7 @@ def build_dir_entries(
         updated_at = metadata_or_none(metadata, "updated_at")
         entry = IndexEntry(
             id=slug,
-            name=basename(path),
+            name=gnu_basename(path),
             resource_type="file",
             size=size,
             remote_time=updated_at or "",
@@ -158,12 +159,3 @@ def virtual_path(path: str, prefix: str) -> str:
     if root == "/":
         return path
     return root + path
-
-
-def parent(path: str) -> str:
-    value = path.rsplit("/", 1)[0]
-    return value or "/"
-
-
-def basename(path: str) -> str:
-    return path.rstrip("/").rsplit("/", 1)[-1] or "/"

--- a/python/mirage/core/dify/tree.py
+++ b/python/mirage/core/dify/tree.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.core.dify._client import is_visible_document, list_all_documents
+from mirage.utils.path import gnu_basename, parent
 
 
 async def ensure_tree(accessor,
@@ -57,7 +58,7 @@ def build_dir_entries(
             continue
         entry = IndexEntry(
             id=directory.strip("/"),
-            name=basename(directory),
+            name=gnu_basename(directory),
             resource_type="folder",
         )
         dir_entries[virtual_path(parent(directory), prefix)].append(
@@ -66,7 +67,7 @@ def build_dir_entries(
     for path, document in sorted(files.items()):
         entry = IndexEntry(
             id=str(document["id"]),
-            name=basename(path),
+            name=gnu_basename(path),
             resource_type="file",
             size=extract_document_size(document),
             remote_time=timestamp_to_iso(document.get("created_at")),
@@ -170,12 +171,3 @@ def virtual_path(path: str, prefix: str) -> str:
     if root == "/":
         return path
     return root + path
-
-
-def parent(path: str) -> str:
-    value = path.rsplit("/", 1)[0]
-    return value or "/"
-
-
-def basename(path: str) -> str:
-    return path.rstrip("/").rsplit("/", 1)[-1] or "/"

--- a/python/mirage/core/ram/append.py
+++ b/python/mirage/core/ram/append.py
@@ -18,10 +18,7 @@ from mirage.accessor.ram import RAMAccessor
 from mirage.core.timeutil import now_iso
 from mirage.observe.context import record
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def append_bytes(accessor: RAMAccessor, path: PathSpec,
@@ -32,7 +29,7 @@ async def append_bytes(accessor: RAMAccessor, path: PathSpec,
         path = path.strip_prefix
     store = accessor.store
     start_ms = int(time.monotonic() * 1000)
-    p = _norm(path)
+    p = norm(path)
     if p in store.files:
         store.files[p] += data
     else:

--- a/python/mirage/core/ram/copy.py
+++ b/python/mirage/core/ram/copy.py
@@ -15,10 +15,7 @@
 from mirage.accessor.ram import RAMAccessor
 from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def copy(accessor: RAMAccessor, src: PathSpec, dst: PathSpec) -> None:
@@ -31,7 +28,7 @@ async def copy(accessor: RAMAccessor, src: PathSpec, dst: PathSpec) -> None:
     if isinstance(dst, PathSpec):
         dst = dst.strip_prefix
     store = accessor.store
-    s, d = _norm(src), _norm(dst)
+    s, d = norm(src), norm(dst)
     if s not in store.files:
         raise FileNotFoundError(s)
     store.files[d] = store.files[s]

--- a/python/mirage/core/ram/create.py
+++ b/python/mirage/core/ram/create.py
@@ -15,14 +15,11 @@
 from mirage.accessor.ram import RAMAccessor
 from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def create(accessor: RAMAccessor, path: PathSpec) -> None:
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     store.files[p] = b""
     store.modified[p] = now_iso()

--- a/python/mirage/core/ram/du.py
+++ b/python/mirage/core/ram/du.py
@@ -14,10 +14,7 @@
 
 from mirage.accessor.ram import RAMAccessor
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def du(accessor: RAMAccessor, path: PathSpec) -> int:
@@ -26,7 +23,7 @@ async def du(accessor: RAMAccessor, path: PathSpec) -> int:
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     prefix = p.rstrip("/") + "/"
     total = 0
     for key, data in store.files.items():
@@ -42,7 +39,7 @@ async def du_all(accessor: RAMAccessor,
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     prefix = p.rstrip("/") + "/"
     entries: list[tuple[str, int]] = []
     total = 0

--- a/python/mirage/core/ram/exists.py
+++ b/python/mirage/core/ram/exists.py
@@ -14,10 +14,7 @@
 
 from mirage.accessor.ram import RAMAccessor
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def exists(accessor: RAMAccessor, path: PathSpec) -> bool:
@@ -26,5 +23,5 @@ async def exists(accessor: RAMAccessor, path: PathSpec) -> bool:
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     return p in store.files or p in store.dirs

--- a/python/mirage/core/ram/find.py
+++ b/python/mirage/core/ram/find.py
@@ -16,10 +16,7 @@ from fnmatch import fnmatch
 
 from mirage.accessor.ram import RAMAccessor
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def find(
@@ -41,7 +38,7 @@ async def find(
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     prefix = p.rstrip("/") + "/"
     base_depth = 0 if p == "/" else p.count("/")
     results: list[str] = []

--- a/python/mirage/core/ram/mkdir.py
+++ b/python/mirage/core/ram/mkdir.py
@@ -15,15 +15,7 @@
 from mirage.accessor.ram import RAMAccessor
 from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
-
-
-def _parent(path: str) -> str:
-    parts = path.rsplit("/", 1)
-    return parts[0] or "/"
+from mirage.utils.path import norm, parent
 
 
 async def mkdir(accessor: RAMAccessor,
@@ -34,7 +26,7 @@ async def mkdir(accessor: RAMAccessor,
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     if parents:
         parts = p.strip("/").split("/")
         current = ""
@@ -45,8 +37,9 @@ async def mkdir(accessor: RAMAccessor,
             if current not in store.modified:
                 store.modified[current] = now
         return
-    parent = _parent(p)
-    if parent != "/" and parent not in store.dirs:
-        raise FileNotFoundError(f"parent directory does not exist: {parent}")
+    parent_dir = parent(p)
+    if parent_dir != "/" and parent_dir not in store.dirs:
+        raise FileNotFoundError(
+            f"parent directory does not exist: {parent_dir}")
     store.dirs.add(p)
     store.modified[p] = now_iso()

--- a/python/mirage/core/ram/mkdir_p.py
+++ b/python/mirage/core/ram/mkdir_p.py
@@ -15,15 +15,12 @@
 from mirage.accessor.ram import RAMAccessor
 from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def mkdir_p(accessor: RAMAccessor, path: PathSpec) -> None:
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     parts = p.strip("/").split("/")
     current = ""
     now = now_iso()

--- a/python/mirage/core/ram/read.py
+++ b/python/mirage/core/ram/read.py
@@ -19,10 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.observe.context import record
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def read_bytes(accessor: RAMAccessor, path: PathSpec) -> bytes:
@@ -33,7 +30,7 @@ async def read_bytes(accessor: RAMAccessor, path: PathSpec) -> bytes:
         path = path.strip_prefix
     store = accessor.store
     start_ms = int(time.monotonic() * 1000)
-    key = _norm(path)
+    key = norm(path)
     if key not in store.files:
         raise enoent(virtual)
     data = store.files[key]

--- a/python/mirage/core/ram/readdir.py
+++ b/python/mirage/core/ram/readdir.py
@@ -15,10 +15,7 @@
 from mirage.accessor.ram import RAMAccessor
 from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def readdir(accessor: RAMAccessor, path: PathSpec,
@@ -37,7 +34,7 @@ async def readdir(accessor: RAMAccessor, path: PathSpec,
     listing = await index.list_dir(virtual_key)
     if listing.entries is not None:
         return listing.entries
-    p = _norm(path)
+    p = norm(path)
     if p not in store.dirs:
         raise FileNotFoundError(p)
     dir_prefix = p.rstrip("/") + "/"

--- a/python/mirage/core/ram/rename.py
+++ b/python/mirage/core/ram/rename.py
@@ -15,10 +15,7 @@
 from mirage.accessor.ram import RAMAccessor
 from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def rename(accessor: RAMAccessor, src: PathSpec, dst: PathSpec) -> None:
@@ -31,7 +28,7 @@ async def rename(accessor: RAMAccessor, src: PathSpec, dst: PathSpec) -> None:
     if isinstance(dst, PathSpec):
         dst = dst.strip_prefix
     store = accessor.store
-    s, d = _norm(src), _norm(dst)
+    s, d = norm(src), norm(dst)
     now = now_iso()
     if s in store.files:
         store.files[d] = store.files.pop(s)

--- a/python/mirage/core/ram/rm.py
+++ b/python/mirage/core/ram/rm.py
@@ -14,10 +14,7 @@
 
 from mirage.accessor.ram import RAMAccessor
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def rm_r(accessor: RAMAccessor, path: PathSpec) -> None:
@@ -26,7 +23,7 @@ async def rm_r(accessor: RAMAccessor, path: PathSpec) -> None:
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     prefix = p.rstrip("/") + "/"
     for key in list(store.files):
         if key == p or key.startswith(prefix):

--- a/python/mirage/core/ram/rmdir.py
+++ b/python/mirage/core/ram/rmdir.py
@@ -14,10 +14,7 @@
 
 from mirage.accessor.ram import RAMAccessor
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def rmdir(accessor: RAMAccessor, path: PathSpec) -> None:
@@ -26,7 +23,7 @@ async def rmdir(accessor: RAMAccessor, path: PathSpec) -> None:
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     if p not in store.dirs:
         raise FileNotFoundError(p)
     prefix = p.rstrip("/") + "/"

--- a/python/mirage/core/ram/stat.py
+++ b/python/mirage/core/ram/stat.py
@@ -17,10 +17,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.errors import enoent
 from mirage.utils.filetype import guess_type
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def stat(accessor: RAMAccessor,
@@ -37,7 +34,7 @@ async def stat(accessor: RAMAccessor,
         if prefix.endswith("/") or rest == "" or rest.startswith("/"):
             path = rest or "/"
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     if p in store.dirs:
         return FileStat(
             name=p.rsplit("/", 1)[-1] or "/",

--- a/python/mirage/core/ram/stream.py
+++ b/python/mirage/core/ram/stream.py
@@ -19,10 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.observe.context import record_stream
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def stream(accessor: RAMAccessor,
@@ -38,7 +35,7 @@ async def stream(accessor: RAMAccessor,
             if prefix.endswith("/") or rest == "" or rest.startswith("/"):
                 path = rest or "/"
     store = accessor.store
-    key = _norm(path)
+    key = norm(path)
     if key not in store.files:
         raise enoent(virtual)
     data = store.files[key]

--- a/python/mirage/core/ram/truncate.py
+++ b/python/mirage/core/ram/truncate.py
@@ -15,15 +15,12 @@
 from mirage.accessor.ram import RAMAccessor
 from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def truncate(accessor: RAMAccessor, path: PathSpec, length: int) -> None:
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     if p in store.files:
         data = store.files[p]
     else:

--- a/python/mirage/core/ram/unlink.py
+++ b/python/mirage/core/ram/unlink.py
@@ -14,10 +14,7 @@
 
 from mirage.accessor.ram import RAMAccessor
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def unlink(accessor: RAMAccessor, path: PathSpec) -> None:
@@ -26,7 +23,7 @@ async def unlink(accessor: RAMAccessor, path: PathSpec) -> None:
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     if p not in store.files:
         raise FileNotFoundError(p)
     del store.files[p]

--- a/python/mirage/core/ram/write.py
+++ b/python/mirage/core/ram/write.py
@@ -18,15 +18,7 @@ from mirage.accessor.ram import RAMAccessor
 from mirage.core.timeutil import now_iso
 from mirage.observe.context import record
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
-
-
-def _parent(path: str) -> str:
-    parts = path.rsplit("/", 1)
-    return parts[0] or "/"
+from mirage.utils.path import norm, parent
 
 
 async def write_bytes(accessor: RAMAccessor, path: PathSpec,
@@ -37,10 +29,11 @@ async def write_bytes(accessor: RAMAccessor, path: PathSpec,
         path = path.strip_prefix
     store = accessor.store
     start_ms = int(time.monotonic() * 1000)
-    p = _norm(path)
-    parent = _parent(p)
-    if parent != "/" and parent not in store.dirs:
-        raise FileNotFoundError(f"parent directory does not exist: {parent}")
+    p = norm(path)
+    parent_dir = parent(p)
+    if parent_dir != "/" and parent_dir not in store.dirs:
+        raise FileNotFoundError(
+            f"parent directory does not exist: {parent_dir}")
     store.files[p] = data
     store.modified[p] = now_iso()
     record("write", path, "ram", len(data), start_ms)

--- a/python/mirage/core/redis/append.py
+++ b/python/mirage/core/redis/append.py
@@ -18,10 +18,7 @@ from mirage.accessor.redis import RedisAccessor
 from mirage.core.timeutil import now_iso
 from mirage.observe.context import record
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def append_bytes(
@@ -35,7 +32,7 @@ async def append_bytes(
         path = path.strip_prefix
     store = accessor.store
     start_ms = int(time.monotonic() * 1000)
-    p = _norm(path)
+    p = norm(path)
     existing = await store.get_file(p)
     if existing is not None:
         await store.set_file(p, existing + data)

--- a/python/mirage/core/redis/copy.py
+++ b/python/mirage/core/redis/copy.py
@@ -15,10 +15,7 @@
 from mirage.accessor.redis import RedisAccessor
 from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def copy(
@@ -35,7 +32,7 @@ async def copy(
     if isinstance(dst, PathSpec):
         dst = dst.strip_prefix
     store = accessor.store
-    s, d = _norm(src), _norm(dst)
+    s, d = norm(src), norm(dst)
     data = await store.get_file(s)
     if data is None:
         raise FileNotFoundError(s)

--- a/python/mirage/core/redis/create.py
+++ b/python/mirage/core/redis/create.py
@@ -15,14 +15,11 @@
 from mirage.accessor.redis import RedisAccessor
 from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def create(accessor: RedisAccessor, path: PathSpec) -> None:
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     await store.set_file(p, b"")
     await store.set_modified(p, now_iso())

--- a/python/mirage/core/redis/du.py
+++ b/python/mirage/core/redis/du.py
@@ -14,10 +14,7 @@
 
 from mirage.accessor.redis import RedisAccessor
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def du(accessor: RedisAccessor, path: PathSpec) -> int:
@@ -26,7 +23,7 @@ async def du(accessor: RedisAccessor, path: PathSpec) -> int:
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     prefix = p.rstrip("/") + "/"
     total = 0
     for key in await store.list_files():
@@ -42,7 +39,7 @@ async def du_all(accessor: RedisAccessor,
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     prefix = p.rstrip("/") + "/"
     entries: list[tuple[str, int]] = []
     total = 0

--- a/python/mirage/core/redis/exists.py
+++ b/python/mirage/core/redis/exists.py
@@ -14,10 +14,7 @@
 
 from mirage.accessor.redis import RedisAccessor
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def exists(accessor: RedisAccessor, path: PathSpec) -> bool:
@@ -26,5 +23,5 @@ async def exists(accessor: RedisAccessor, path: PathSpec) -> bool:
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     return await store.has_file(p) or await store.has_dir(p)

--- a/python/mirage/core/redis/find.py
+++ b/python/mirage/core/redis/find.py
@@ -16,10 +16,7 @@ from fnmatch import fnmatch
 
 from mirage.accessor.redis import RedisAccessor
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def find(
@@ -41,7 +38,7 @@ async def find(
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     prefix = p.rstrip("/") + "/"
     base_depth = 0 if p == "/" else p.count("/")
     results: list[str] = []

--- a/python/mirage/core/redis/mkdir.py
+++ b/python/mirage/core/redis/mkdir.py
@@ -15,15 +15,7 @@
 from mirage.accessor.redis import RedisAccessor
 from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
-
-
-def _parent(path: str) -> str:
-    parts = path.rsplit("/", 1)
-    return parts[0] or "/"
+from mirage.utils.path import norm, parent
 
 
 async def mkdir(
@@ -36,7 +28,7 @@ async def mkdir(
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     if parents:
         parts = p.strip("/").split("/")
         current = ""
@@ -48,8 +40,9 @@ async def mkdir(
             if mod is None:
                 await store.set_modified(current, now)
         return
-    parent = _parent(p)
-    if parent != "/" and not await store.has_dir(parent):
-        raise FileNotFoundError(f"parent directory does not exist: {parent}")
+    parent_dir = parent(p)
+    if parent_dir != "/" and not await store.has_dir(parent_dir):
+        raise FileNotFoundError(
+            f"parent directory does not exist: {parent_dir}")
     await store.add_dir(p)
     await store.set_modified(p, now_iso())

--- a/python/mirage/core/redis/mkdir_p.py
+++ b/python/mirage/core/redis/mkdir_p.py
@@ -15,15 +15,12 @@
 from mirage.accessor.redis import RedisAccessor
 from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def mkdir_p(accessor: RedisAccessor, path: PathSpec) -> None:
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     parts = p.strip("/").split("/")
     current = ""
     now = now_iso()

--- a/python/mirage/core/redis/read.py
+++ b/python/mirage/core/redis/read.py
@@ -19,10 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.observe.context import record
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def read_bytes(accessor: RedisAccessor, path: PathSpec) -> bytes:
@@ -33,7 +30,7 @@ async def read_bytes(accessor: RedisAccessor, path: PathSpec) -> bytes:
         path = path.strip_prefix
     store = accessor.store
     start_ms = int(time.monotonic() * 1000)
-    key = _norm(path)
+    key = norm(path)
     data = await store.get_file(key)
     if data is None:
         raise enoent(virtual)

--- a/python/mirage/core/redis/readdir.py
+++ b/python/mirage/core/redis/readdir.py
@@ -16,10 +16,7 @@ from mirage.accessor.redis import RedisAccessor
 from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def readdir(
@@ -42,7 +39,7 @@ async def readdir(
     listing = await index.list_dir(virtual_key)
     if listing.entries is not None:
         return listing.entries
-    p = _norm(path)
+    p = norm(path)
     if not await store.has_dir(p):
         raise enoent(virtual)
     dir_prefix = p.rstrip("/") + "/"

--- a/python/mirage/core/redis/rename.py
+++ b/python/mirage/core/redis/rename.py
@@ -15,10 +15,7 @@
 from mirage.accessor.redis import RedisAccessor
 from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def rename(
@@ -35,7 +32,7 @@ async def rename(
     if isinstance(dst, PathSpec):
         dst = dst.strip_prefix
     store = accessor.store
-    s, d = _norm(src), _norm(dst)
+    s, d = norm(src), norm(dst)
     now = now_iso()
     if await store.has_file(s):
         data = await store.get_file(s)

--- a/python/mirage/core/redis/rm.py
+++ b/python/mirage/core/redis/rm.py
@@ -14,10 +14,7 @@
 
 from mirage.accessor.redis import RedisAccessor
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def rm_r(accessor: RedisAccessor, path: PathSpec) -> None:
@@ -26,7 +23,7 @@ async def rm_r(accessor: RedisAccessor, path: PathSpec) -> None:
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     prefix = p.rstrip("/") + "/"
     for key in await store.list_files():
         if key == p or key.startswith(prefix):

--- a/python/mirage/core/redis/rmdir.py
+++ b/python/mirage/core/redis/rmdir.py
@@ -14,10 +14,7 @@
 
 from mirage.accessor.redis import RedisAccessor
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def rmdir(accessor: RedisAccessor, path: PathSpec) -> None:
@@ -26,7 +23,7 @@ async def rmdir(accessor: RedisAccessor, path: PathSpec) -> None:
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     if not await store.has_dir(p):
         raise FileNotFoundError(p)
     prefix = p.rstrip("/") + "/"

--- a/python/mirage/core/redis/stat.py
+++ b/python/mirage/core/redis/stat.py
@@ -17,10 +17,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.errors import enoent
 from mirage.utils.filetype import guess_type
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def stat(
@@ -39,7 +36,7 @@ async def stat(
         if prefix.endswith("/") or rest == "" or rest.startswith("/"):
             path = rest or "/"
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     if await store.has_dir(p):
         return FileStat(
             name=p.rsplit("/", 1)[-1] or "/",

--- a/python/mirage/core/redis/stream.py
+++ b/python/mirage/core/redis/stream.py
@@ -19,10 +19,7 @@ from mirage.cache.index import IndexCacheStore
 from mirage.observe.context import record_stream
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def stream(accessor: RedisAccessor,
@@ -38,7 +35,7 @@ async def stream(accessor: RedisAccessor,
             if prefix.endswith("/") or rest == "" or rest.startswith("/"):
                 path = rest or "/"
     store = accessor.store
-    key = _norm(path)
+    key = norm(path)
     data = await store.get_file(key)
     if data is None:
         raise enoent(virtual)

--- a/python/mirage/core/redis/truncate.py
+++ b/python/mirage/core/redis/truncate.py
@@ -15,16 +15,13 @@
 from mirage.accessor.redis import RedisAccessor
 from mirage.core.timeutil import now_iso
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def truncate(accessor: RedisAccessor, path: PathSpec,
                    length: int) -> None:
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     data = await store.get_file(p)
     if data is None:
         data = b""

--- a/python/mirage/core/redis/unlink.py
+++ b/python/mirage/core/redis/unlink.py
@@ -14,10 +14,7 @@
 
 from mirage.accessor.redis import RedisAccessor
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
+from mirage.utils.path import norm
 
 
 async def unlink(accessor: RedisAccessor, path: PathSpec) -> None:
@@ -26,7 +23,7 @@ async def unlink(accessor: RedisAccessor, path: PathSpec) -> None:
     if isinstance(path, PathSpec):
         path = path.strip_prefix
     store = accessor.store
-    p = _norm(path)
+    p = norm(path)
     if not await store.has_file(p):
         raise FileNotFoundError(p)
     await store.del_file(p)

--- a/python/mirage/core/redis/write.py
+++ b/python/mirage/core/redis/write.py
@@ -18,15 +18,7 @@ from mirage.accessor.redis import RedisAccessor
 from mirage.core.timeutil import now_iso
 from mirage.observe.context import record
 from mirage.types import PathSpec
-
-
-def _norm(path: str) -> str:
-    return "/" + path.strip("/")
-
-
-def _parent(path: str) -> str:
-    parts = path.rsplit("/", 1)
-    return parts[0] or "/"
+from mirage.utils.path import norm, parent
 
 
 async def write_bytes(
@@ -40,10 +32,11 @@ async def write_bytes(
         path = path.strip_prefix
     store = accessor.store
     start_ms = int(time.monotonic() * 1000)
-    p = _norm(path)
-    parent = _parent(p)
-    if parent != "/" and not await store.has_dir(parent):
-        raise FileNotFoundError(f"parent directory does not exist: {parent}")
+    p = norm(path)
+    parent_dir = parent(p)
+    if parent_dir != "/" and not await store.has_dir(parent_dir):
+        raise FileNotFoundError(
+            f"parent directory does not exist: {parent_dir}")
     await store.set_file(p, data)
     await store.set_modified(p, now_iso())
     record("write", path, "redis", len(data), start_ms)

--- a/python/mirage/utils/path.py
+++ b/python/mirage/utils/path.py
@@ -15,6 +15,33 @@
 import posixpath
 
 
+def norm(path: str) -> str:
+    """Normalize a virtual path to a leading-slash, no-trailing-slash key.
+
+    Args:
+        path: A virtual path string.
+
+    Returns:
+        The path with surrounding slashes collapsed to a single leading
+        slash (``"foo/bar/"`` -> ``"/foo/bar"``, ``""`` -> ``"/"``).
+    """
+    return "/" + path.strip("/")
+
+
+def parent(path: str) -> str:
+    """Return the parent directory of a normalized virtual key.
+
+    Args:
+        path: A normalized virtual path (leading slash, no trailing slash).
+
+    Returns:
+        The path with its last segment removed (``"/a/b"`` -> ``"/a"``),
+        or ``"/"`` when there is no parent segment.
+    """
+    i = path.rfind("/")
+    return path[:i] if i > 0 else "/"
+
+
 def resolve_path(path: str, cwd: str) -> str:
     """Resolve a relative path against cwd.
 

--- a/python/tests/core/dify/test_tree.py
+++ b/python/tests/core/dify/test_tree.py
@@ -111,7 +111,7 @@ def test_tree_slug_and_timestamp_helpers():
     assert tree.timestamp_to_iso(None) == ""
     assert tree.virtual_path("/a", "/knowledge/") == "/knowledge/a"
     assert tree.parent("/a/b") == "/a"
-    assert tree.basename("/a/b") == "b"
+    assert tree.gnu_basename("/a/b") == "b"
 
 
 def test_normalize_slug_rejects_invalid_segments():

--- a/python/tests/utils/test_path.py
+++ b/python/tests/utils/test_path.py
@@ -12,7 +12,23 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.utils.path import gnu_basename, gnu_dirname, resolve_path
+from mirage.utils.path import (gnu_basename, gnu_dirname, norm, parent,
+                               resolve_path)
+
+
+def test_norm_strips_and_adds_leading_slash():
+    assert norm("a/b") == "/a/b"
+    assert norm("/a/b/") == "/a/b"
+    assert norm("///a///") == "/a"
+    assert norm("") == "/"
+    assert norm("/") == "/"
+
+
+def test_parent_of_normalized_key():
+    assert parent("/a/b") == "/a"
+    assert parent("/a") == "/"
+    assert parent("/") == "/"
+    assert parent("/a/b/c") == "/a/b"
 
 
 def test_basename_simple():

--- a/typescript/packages/agents/src/langchain/backend.ts
+++ b/typescript/packages/agents/src/langchain/backend.ts
@@ -29,7 +29,7 @@ import type {
   WriteResult,
 } from 'deepagents'
 import { ioToExecuteResponse, ioToFileInfos, ioToGrepMatches } from './convert.ts'
-import { rstripSlash } from '@struktoai/mirage-core'
+import { gnuDirname } from '@struktoai/mirage-core'
 
 const TEXT_EXTENSIONS = new Set([
   'txt',
@@ -76,16 +76,9 @@ function shellQuote(s: string): string {
   return `'${s.replaceAll(`'`, `'\\''`)}'`
 }
 
-function parentOf(path: string): string {
-  const trimmed = rstripSlash(path)
-  const idx = trimmed.lastIndexOf('/')
-  if (idx <= 0) return '/'
-  return trimmed.slice(0, idx)
-}
-
 async function ensureParent(ws: Workspace, path: string): Promise<void> {
-  const parent = parentOf(path)
-  if (parent === '/' || parent === '') return
+  const parent = gnuDirname(path)
+  if (parent === '/' || parent === '' || parent === '.') return
   if (await ws.fs.exists(parent)) return
   await ensureParent(ws, parent)
   try {

--- a/typescript/packages/agents/src/mastra/index.ts
+++ b/typescript/packages/agents/src/mastra/index.ts
@@ -15,18 +15,11 @@
 import type { Workspace } from '@struktoai/mirage-core'
 import { createTool } from '@mastra/core/tools'
 import { z } from 'zod'
-import { rstripSlash } from '@struktoai/mirage-core'
-
-function parentOf(path: string): string {
-  const trimmed = rstripSlash(path)
-  const idx = trimmed.lastIndexOf('/')
-  if (idx <= 0) return '/'
-  return trimmed.slice(0, idx)
-}
+import { gnuDirname } from '@struktoai/mirage-core'
 
 async function ensureParent(ws: Workspace, path: string): Promise<void> {
-  const parent = parentOf(path)
-  if (parent === '/' || parent === '') return
+  const parent = gnuDirname(path)
+  if (parent === '/' || parent === '' || parent === '.') return
   if (await ws.fs.exists(parent)) return
   await ensureParent(ws, parent)
   try {

--- a/typescript/packages/agents/src/openai/editor.test.ts
+++ b/typescript/packages/agents/src/openai/editor.test.ts
@@ -52,6 +52,20 @@ describe('MirageEditor', () => {
     expect(await ws.fs.readFileText('/data/sub/file.txt')).toBe('content\n')
   })
 
+  it('createFile handles a root-level relative path without recursing on "."', async () => {
+    const ws = mkWs()
+    const editor = new MirageEditor(ws)
+
+    const result = await editor.createFile({
+      type: 'create_file',
+      path: 'bare.txt',
+      diff: '+bare\n',
+    })
+
+    expect(result).toEqual({ status: 'completed' })
+    expect(await ws.fs.readFileText('bare.txt')).toBe('bare')
+  })
+
   it('createFile is idempotent on existing parent', async () => {
     const ws = mkWs()
     await ws.fs.mkdir('/data')

--- a/typescript/packages/agents/src/openai/editor.ts
+++ b/typescript/packages/agents/src/openai/editor.ts
@@ -15,18 +15,11 @@
 import type { Workspace } from '@struktoai/mirage-core'
 import { applyDiff } from '@openai/agents'
 import type { ApplyPatchOperation, ApplyPatchResult, Editor } from '@openai/agents'
-import { rstripSlash } from '@struktoai/mirage-core'
-
-function parentOf(path: string): string {
-  const trimmed = rstripSlash(path)
-  const idx = trimmed.lastIndexOf('/')
-  if (idx <= 0) return '/'
-  return trimmed.slice(0, idx)
-}
+import { gnuDirname } from '@struktoai/mirage-core'
 
 async function ensureParent(ws: Workspace, path: string): Promise<void> {
-  const parent = parentOf(path)
-  if (parent === '/' || parent === '') return
+  const parent = gnuDirname(path)
+  if (parent === '/' || parent === '' || parent === '.') return
   if (await ws.fs.exists(parent)) return
   await ensureParent(ws, parent)
   try {

--- a/typescript/packages/agents/src/opencode/index.ts
+++ b/typescript/packages/agents/src/opencode/index.ts
@@ -14,7 +14,7 @@
 
 import type { Workspace } from '@struktoai/mirage-node'
 import { z } from 'zod'
-import { rstripSlash } from '@struktoai/mirage-core'
+import { gnuDirname } from '@struktoai/mirage-core'
 
 export interface ToolContext {
   sessionID: string
@@ -44,16 +44,9 @@ async function resolveWs(ws: WsLike, ctx: ToolContext): Promise<Workspace> {
   return isResolver(ws) ? ws(ctx) : ws
 }
 
-function parentOf(path: string): string {
-  const trimmed = rstripSlash(path)
-  const idx = trimmed.lastIndexOf('/')
-  if (idx <= 0) return '/'
-  return trimmed.slice(0, idx)
-}
-
 async function ensureParent(ws: Workspace, path: string): Promise<void> {
-  const parent = parentOf(path)
-  if (parent === '/' || parent === '') return
+  const parent = gnuDirname(path)
+  if (parent === '/' || parent === '' || parent === '.') return
   if (await ws.fs.exists(parent)) return
   await ensureParent(ws, parent)
   try {

--- a/typescript/packages/agents/src/vercel/index.ts
+++ b/typescript/packages/agents/src/vercel/index.ts
@@ -12,21 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { encodeBase64, rstripSlash } from '@struktoai/mirage-core'
+import { encodeBase64, gnuDirname } from '@struktoai/mirage-core'
 import type { Workspace } from '@struktoai/mirage-node'
 import { tool } from 'ai'
 import { z } from 'zod'
 
-function parentOf(path: string): string {
-  const trimmed = rstripSlash(path)
-  const idx = trimmed.lastIndexOf('/')
-  if (idx <= 0) return '/'
-  return trimmed.slice(0, idx)
-}
-
 async function ensureParent(ws: Workspace, path: string): Promise<void> {
-  const parent = parentOf(path)
-  if (parent === '/' || parent === '') return
+  const parent = gnuDirname(path)
+  if (parent === '/' || parent === '' || parent === '.') return
   if (await ws.fs.exists(parent)) return
   await ensureParent(ws, parent)
   try {

--- a/typescript/packages/browser/src/core/opfs/glob.ts
+++ b/typescript/packages/browser/src/core/opfs/glob.ts
@@ -17,10 +17,7 @@ import type { OPFSAccessor } from '../../accessor/opfs.ts'
 import { SCOPE_ERROR } from './constants.ts'
 import { readdir } from './readdir.ts'
 import { fnmatch } from '@struktoai/mirage-core'
-
-function basenameOf(p: string): string {
-  return p.slice(p.lastIndexOf('/') + 1)
-}
+import { gnuBasename } from '@struktoai/mirage-core'
 
 export async function resolveGlob(
   accessor: OPFSAccessor,
@@ -40,7 +37,7 @@ export async function resolveGlob(
       const entries = await readdir(accessor, dirSpec)
       const matched: PathSpec[] = []
       for (const e of entries) {
-        if (fnmatch(basenameOf(e), p.pattern)) {
+        if (fnmatch(gnuBasename(e), p.pattern)) {
           matched.push(
             new PathSpec({
               original: e,

--- a/typescript/packages/browser/src/core/opfs/utils.ts
+++ b/typescript/packages/browser/src/core/opfs/utils.ts
@@ -12,22 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { stripSlash } from '@struktoai/mirage-core'
-
-export function norm(p: string): string {
-  return `/${stripSlash(p)}`
-}
-
-export function parent(p: string): string {
-  const i = p.lastIndexOf('/')
-  if (i <= 0) return '/'
-  return p.slice(0, i)
-}
-
-export function basename(p: string): string {
-  const tail = p.split('/').pop()
-  return tail !== undefined && tail.length > 0 ? tail : '/'
-}
+export { norm, parent, gnuBasename as basename } from '@struktoai/mirage-core'
 
 export function dirname(p: string): string {
   const i = p.lastIndexOf('/')

--- a/typescript/packages/core/src/commands/builtin/generic/zip_cmd.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/zip_cmd.ts
@@ -17,6 +17,7 @@ import type { PathSpec } from '../../../types.ts'
 import { deflateRaw } from '../../../utils/compress.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { lstripSlash } from '../../../utils/slash.ts'
+import { gnuBasename } from '../../../utils/path.ts'
 
 const ENC = new TextEncoder()
 
@@ -59,11 +60,6 @@ interface ZipItem {
   crc: number
   method: number
   localOffset: number
-}
-
-function basename(path: string): string {
-  const idx = path.lastIndexOf('/')
-  return idx >= 0 ? path.slice(idx + 1) : path
 }
 
 function concat(chunks: readonly Uint8Array[]): Uint8Array {
@@ -167,7 +163,7 @@ export async function zipGeneric(
     const raw = await materialize(stream(p))
     const data = new Uint8Array(raw.byteLength)
     data.set(raw)
-    const arcname = junkPaths ? basename(p.original) : lstripSlash(p.original)
+    const arcname = junkPaths ? gnuBasename(p.original) : lstripSlash(p.original)
     const compressed = await deflateRaw(data)
     items.push({
       name: arcname,

--- a/typescript/packages/core/src/commands/builtin/rg_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/rg_helper.ts
@@ -15,6 +15,7 @@
 import type { FileStat } from '../../types.ts'
 import { FileType } from '../../types.ts'
 import { rstripSlash } from '../../utils/slash.ts'
+import { gnuBasename } from '../../utils/path.ts'
 import { getExtension } from '../resolve.ts'
 import { BINARY_EXTENSIONS, compilePattern, grepLines } from './grep_helper.ts'
 import { fnmatch } from '../../utils/fnmatch.ts'
@@ -52,18 +53,13 @@ export interface RgFilterOptions {
   hidden: boolean
 }
 
-function basename(path: string): string {
-  const i = path.lastIndexOf('/')
-  return i === -1 ? path : path.slice(i + 1)
-}
-
 export function rgMatchesFilter(
   entry: string,
   fileType: string | null,
   globPattern: string | null,
   hidden: boolean,
 ): boolean {
-  const base = basename(entry)
+  const base = gnuBasename(entry)
   if (!hidden && base.startsWith('.')) return false
   if (fileType !== null) {
     const exts = TYPE_EXTENSIONS[fileType] ?? [`.${fileType}`]
@@ -196,7 +192,7 @@ export async function rgFull(
       // box/dropbox readdir marks folders with a trailing slash; strip it so
       // basename sees the real directory name (hidden-dir skip).
       const child = rstripSlash(entry)
-      const base = basename(child)
+      const base = gnuBasename(child)
       if (!opts.hidden && base.startsWith('.')) continue
       const sub = await rgFull(readdirFn, statFn, readBytesFn, child, pattern, opts, warnings)
       results.push(...sub)

--- a/typescript/packages/core/src/core/chroma/tree.ts
+++ b/typescript/packages/core/src/core/chroma/tree.ts
@@ -18,6 +18,7 @@ import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { decodeBase64 } from '../../utils/base64.ts'
 import { gunzip } from '../../utils/compress.ts'
 import { rstripSlash, stripSlash } from '../../utils/slash.ts'
+import { gnuBasename, parent } from '../../utils/path.ts'
 import { fetchPathTree } from './_client.ts'
 
 const DEC = new TextDecoder('utf-8', { fatal: false })
@@ -90,7 +91,7 @@ export function buildDirEntries(
     if (directory === '/') continue
     const entry = new IndexEntry({
       id: stripSlash(directory),
-      name: basename(directory),
+      name: gnuBasename(directory),
       resourceType: 'folder',
     })
     dirEntries.get(virtualPath(parent(directory), prefix))?.push([entry.name, entry])
@@ -103,7 +104,7 @@ export function buildDirEntries(
     const updatedAt = metadataOrNull(metadata, 'updated_at')
     const entry = new IndexEntry({
       id: slug,
-      name: basename(path),
+      name: gnuBasename(path),
       resourceType: 'file',
       size,
       remoteTime: updatedAt ?? '',
@@ -185,16 +186,4 @@ export function virtualPath(path: string, prefix: string): string {
   if (path === '/') return root
   if (root === '/') return path
   return root + path
-}
-
-export function parent(path: string): string {
-  const idx = path.lastIndexOf('/')
-  const value = idx <= 0 ? '' : path.slice(0, idx)
-  return value !== '' ? value : '/'
-}
-
-export function basename(path: string): string {
-  const stripped = rstripSlash(path)
-  const last = stripped.split('/').pop()
-  return last !== undefined && last !== '' ? last : '/'
 }

--- a/typescript/packages/core/src/core/gmail/read.ts
+++ b/typescript/packages/core/src/core/gmail/read.ts
@@ -17,7 +17,8 @@ import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
 import { getAttachment, getMessageProcessed } from './messages.ts'
 import { readdir } from './readdir.ts'
-import { rstripSlash, stripSlash } from '../../utils/slash.ts'
+import { stripSlash } from '../../utils/slash.ts'
+import { gnuDirname } from '../../utils/path.ts'
 import { enoent } from '../../utils/errors.ts'
 
 const ENC = new TextEncoder()
@@ -26,13 +27,6 @@ function eisdir(p: string): Error {
   const e = new Error(`EISDIR: ${p}`) as Error & { code: string }
   e.code = 'EISDIR'
   return e
-}
-
-function dirname(p: string): string {
-  const norm = rstripSlash(p)
-  const idx = norm.lastIndexOf('/')
-  if (idx <= 0) return '/'
-  return norm.slice(0, idx)
 }
 
 export async function read(
@@ -48,7 +42,7 @@ export async function read(
   const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`
   let result = await index.get(virtualKey)
   if (result.entry === undefined || result.entry === null) {
-    const parentKey = dirname(virtualKey)
+    const parentKey = gnuDirname(virtualKey)
     if (parentKey !== virtualKey) {
       const parentPath = PathSpec.fromStrPath(parentKey, prefix)
       try {
@@ -65,7 +59,7 @@ export async function read(
     throw eisdir(path.original)
   }
   if (rt === 'gmail/attachment') {
-    const parentKey = dirname(virtualKey)
+    const parentKey = gnuDirname(virtualKey)
     const parentResult = await index.get(parentKey)
     if (parentResult.entry === undefined || parentResult.entry === null) {
       throw enoent(path.original)

--- a/typescript/packages/core/src/core/ram/glob.ts
+++ b/typescript/packages/core/src/core/ram/glob.ts
@@ -18,10 +18,7 @@ import { PathSpec } from '../../types.ts'
 import { SCOPE_ERROR } from './constants.ts'
 import { readdir } from './readdir.ts'
 import { fnmatch } from '../../utils/fnmatch.ts'
-
-function basenameOf(p: string): string {
-  return p.slice(p.lastIndexOf('/') + 1)
-}
+import { gnuBasename } from '../../utils/path.ts'
 
 export async function resolveGlob(
   accessor: RAMAccessor,
@@ -42,7 +39,7 @@ export async function resolveGlob(
       const entries = await readdir(accessor, dirSpec, index)
       const matched: PathSpec[] = []
       for (const e of entries) {
-        if (fnmatch(basenameOf(e), p.pattern)) {
+        if (fnmatch(gnuBasename(e), p.pattern)) {
           matched.push(
             new PathSpec({
               original: e,

--- a/typescript/packages/core/src/core/ram/utils.ts
+++ b/typescript/packages/core/src/core/ram/utils.ts
@@ -12,22 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { stripSlash } from '../../utils/slash.ts'
-
-export function norm(path: string): string {
-  return `/${stripSlash(path)}`
-}
-
-export function parent(path: string): string {
-  const i = path.lastIndexOf('/')
-  if (i <= 0) return '/'
-  return path.slice(0, i)
-}
-
-export function basename(path: string): string {
-  const tail = path.split('/').pop()
-  return tail !== undefined && tail.length > 0 ? tail : '/'
-}
+export { norm, parent, gnuBasename as basename } from '../../utils/path.ts'
 
 export function nowIso(): string {
   return new Date().toISOString()

--- a/typescript/packages/core/src/core/s3/stat.ts
+++ b/typescript/packages/core/src/core/s3/stat.ts
@@ -18,13 +18,8 @@ import { guessType } from '../../utils/filetype.ts'
 import type { S3Accessor } from '../../accessor/s3.ts'
 import { createS3Client, isNotFoundError, loadS3Module, s3Key } from './_client.ts'
 import { rstripSlash, stripSlash } from '../../utils/slash.ts'
+import { gnuBasename } from '../../utils/path.ts'
 import { enoent } from '../../utils/errors.ts'
-
-function basename(path: string): string {
-  const stripped = rstripSlash(path)
-  const idx = stripped.lastIndexOf('/')
-  return idx >= 0 ? stripped.slice(idx + 1) : stripped
-}
 
 export async function stat(
   accessor: S3Accessor,
@@ -95,7 +90,7 @@ export async function stat(
         }),
       )) as { CommonPrefixes?: unknown[]; Contents?: unknown[] }
       if ((listResp.CommonPrefixes?.length ?? 0) > 0 || (listResp.Contents?.length ?? 0) > 0) {
-        return new FileStat({ name: basename(rawPath) || '/', type: FileType.DIRECTORY })
+        return new FileStat({ name: gnuBasename(rawPath) || '/', type: FileType.DIRECTORY })
       }
       throw enoent(path)
     }
@@ -114,7 +109,7 @@ export async function stat(
       let revision = resp.VersionId ?? null
       if (revision === 'null') revision = null
       return new FileStat({
-        name: basename(rawPath),
+        name: gnuBasename(rawPath),
         size: resp.ContentLength ?? null,
         modified,
         fingerprint: etag !== '' ? etag : null,
@@ -137,7 +132,7 @@ export async function stat(
       }),
     )) as { CommonPrefixes?: unknown[]; Contents?: unknown[] }
     if ((listResp.CommonPrefixes?.length ?? 0) > 0 || (listResp.Contents?.length ?? 0) > 0) {
-      return new FileStat({ name: basename(rawPath) || '/', type: FileType.DIRECTORY })
+      return new FileStat({ name: gnuBasename(rawPath) || '/', type: FileType.DIRECTORY })
     }
 
     throw enoent(path)

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -273,7 +273,7 @@ export { fmtGeneric } from './commands/builtin/generic/fmt.ts'
 export { headStream } from './commands/builtin/generic/head.ts'
 export { basenameFn } from './commands/builtin/generic/basename.ts'
 export { dirnameFn } from './commands/builtin/generic/dirname.ts'
-export { gnuBasename, gnuDirname } from './utils/path.ts'
+export { gnuBasename, gnuDirname, norm, parent } from './utils/path.ts'
 export { detectFileType, FILE_MIME_MAP, formatFileResult } from './commands/builtin/file_helper.ts'
 export {
   type AggregateResult,

--- a/typescript/packages/core/src/utils/path.ts
+++ b/typescript/packages/core/src/utils/path.ts
@@ -12,6 +12,18 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { stripSlash } from './slash.ts'
+
+export function norm(path: string): string {
+  return `/${stripSlash(path)}`
+}
+
+export function parent(path: string): string {
+  const i = path.lastIndexOf('/')
+  if (i <= 0) return '/'
+  return path.slice(0, i)
+}
+
 export function gnuBasename(path: string, suffix?: string): string {
   let i = path.length
   while (i > 0 && path[i - 1] === '/') i--

--- a/typescript/packages/node/src/core/disk/glob.ts
+++ b/typescript/packages/node/src/core/disk/glob.ts
@@ -17,10 +17,7 @@ import { type IndexCacheStore, PathSpec } from '@struktoai/mirage-core'
 import { SCOPE_ERROR } from './constants.ts'
 import { readdir } from './readdir.ts'
 import { fnmatch } from '@struktoai/mirage-core'
-
-function basenameOf(p: string): string {
-  return p.slice(p.lastIndexOf('/') + 1)
-}
+import { gnuBasename } from '@struktoai/mirage-core'
 
 export async function resolveGlob(
   accessor: DiskAccessor,
@@ -41,7 +38,7 @@ export async function resolveGlob(
       const entries = await readdir(accessor, dirSpec, index)
       const matched: PathSpec[] = []
       for (const e of entries) {
-        if (fnmatch(basenameOf(e), p.pattern)) {
+        if (fnmatch(gnuBasename(e), p.pattern)) {
           matched.push(
             new PathSpec({
               original: e,

--- a/typescript/packages/node/src/core/disk/utils.ts
+++ b/typescript/packages/node/src/core/disk/utils.ts
@@ -13,7 +13,9 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import path from 'node:path'
-import { lstripSlash, stripSlash } from '@struktoai/mirage-core'
+import { lstripSlash } from '@struktoai/mirage-core'
+
+export { norm, parent, gnuBasename as basename } from '@struktoai/mirage-core'
 
 export function resolveSafe(root: string, virtual: string): string {
   const relative = lstripSlash(virtual)
@@ -23,19 +25,4 @@ export function resolveSafe(root: string, virtual: string): string {
     throw new Error(`path escapes root: ${virtual}`)
   }
   return resolved
-}
-
-export function norm(p: string): string {
-  return `/${stripSlash(p)}`
-}
-
-export function parent(p: string): string {
-  const i = p.lastIndexOf('/')
-  if (i <= 0) return '/'
-  return p.slice(0, i)
-}
-
-export function basename(p: string): string {
-  const tail = p.split('/').pop()
-  return tail !== undefined && tail.length > 0 ? tail : '/'
 }

--- a/typescript/packages/node/src/core/email/read.ts
+++ b/typescript/packages/node/src/core/email/read.ts
@@ -15,7 +15,7 @@
 import type { IndexCacheStore, PathSpec } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../accessor/email.ts'
 import { fetchAttachment, fetchMessage } from './_client.ts'
-import { rstripSlash, stripSlash } from '@struktoai/mirage-core'
+import { gnuDirname, stripSlash } from '@struktoai/mirage-core'
 
 const ENC = new TextEncoder()
 
@@ -29,13 +29,6 @@ function eisdir(p: string): Error {
   const e = new Error(`EISDIR: ${p}`) as Error & { code: string }
   e.code = 'EISDIR'
   return e
-}
-
-function dirname(p: string): string {
-  const norm = rstripSlash(p)
-  const idx = norm.lastIndexOf('/')
-  if (idx <= 0) return '/'
-  return norm.slice(0, idx)
 }
 
 export async function read(
@@ -56,7 +49,7 @@ export async function read(
     throw eisdir(path.original)
   }
   if (rt === 'email/attachment') {
-    const parentKey = dirname(virtualKey)
+    const parentKey = gnuDirname(virtualKey)
     const parentResult = await index.get(parentKey)
     if (parentResult.entry === undefined || parentResult.entry === null) {
       throw enoent(path.original)

--- a/typescript/packages/node/src/core/redis/glob.ts
+++ b/typescript/packages/node/src/core/redis/glob.ts
@@ -17,10 +17,7 @@ import type { RedisAccessor } from '../../accessor/redis.ts'
 import { SCOPE_ERROR } from './constants.ts'
 import { readdir } from './readdir.ts'
 import { fnmatch } from '@struktoai/mirage-core'
-
-function basenameOf(p: string): string {
-  return p.slice(p.lastIndexOf('/') + 1)
-}
+import { gnuBasename } from '@struktoai/mirage-core'
 
 export async function resolveGlob(
   accessor: RedisAccessor,
@@ -41,7 +38,7 @@ export async function resolveGlob(
       const entries = await readdir(accessor, dirSpec, index)
       const matched: PathSpec[] = []
       for (const e of entries) {
-        if (fnmatch(basenameOf(e), p.pattern)) {
+        if (fnmatch(gnuBasename(e), p.pattern)) {
           matched.push(
             new PathSpec({
               original: e,

--- a/typescript/packages/node/src/core/redis/utils.ts
+++ b/typescript/packages/node/src/core/redis/utils.ts
@@ -12,22 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { stripSlash } from '@struktoai/mirage-core'
-
-export function norm(path: string): string {
-  return `/${stripSlash(path)}`
-}
-
-export function parent(path: string): string {
-  const i = path.lastIndexOf('/')
-  if (i <= 0) return '/'
-  return path.slice(0, i)
-}
-
-export function basename(path: string): string {
-  const tail = path.split('/').pop()
-  return tail !== undefined && tail.length > 0 ? tail : '/'
-}
+export { norm, parent, gnuBasename as basename } from '@struktoai/mirage-core'
 
 export function nowIso(): string {
   return new Date().toISOString()

--- a/typescript/packages/node/src/core/ssh/du.ts
+++ b/typescript/packages/node/src/core/ssh/du.ts
@@ -16,11 +16,7 @@ import type { FileEntryWithStats } from 'ssh2'
 import type { PathSpec } from '@struktoai/mirage-core'
 import type { SSHAccessor } from '../../accessor/ssh.ts'
 import { isDirectoryAttrs, isFileAttrs, joinRoot, stripPrefix } from './utils.ts'
-import { stripSlash } from '@struktoai/mirage-core'
-
-function norm(p: string): string {
-  return `/${stripSlash(p)}`
-}
+import { norm } from '@struktoai/mirage-core'
 
 async function readRemoteDir(
   accessor: SSHAccessor,

--- a/typescript/packages/node/src/core/ssh/find.ts
+++ b/typescript/packages/node/src/core/ssh/find.ts
@@ -16,7 +16,7 @@ import type { FileEntryWithStats } from 'ssh2'
 import type { PathSpec } from '@struktoai/mirage-core'
 import type { SSHAccessor } from '../../accessor/ssh.ts'
 import { isDirectoryAttrs, joinRoot, stripPrefix } from './utils.ts'
-import { stripSlash } from '@struktoai/mirage-core'
+import { norm } from '@struktoai/mirage-core'
 import { fnmatch } from '@struktoai/mirage-core'
 
 export interface FindOptions {
@@ -39,10 +39,6 @@ interface WalkCtx {
   options: FindOptions
   results: string[]
   baseDepth: number
-}
-
-function norm(p: string): string {
-  return `/${stripSlash(p)}`
 }
 
 function isFileType(t: FindOptions['type']): boolean {

--- a/typescript/packages/node/src/core/ssh/glob.ts
+++ b/typescript/packages/node/src/core/ssh/glob.ts
@@ -17,10 +17,7 @@ import type { SSHAccessor } from '../../accessor/ssh.ts'
 import { SCOPE_ERROR } from '../disk/constants.ts'
 import { readdir } from './readdir.ts'
 import { fnmatch } from '@struktoai/mirage-core'
-
-function basenameOf(p: string): string {
-  return p.slice(p.lastIndexOf('/') + 1)
-}
+import { gnuBasename } from '@struktoai/mirage-core'
 
 export async function resolveGlob(
   accessor: SSHAccessor,
@@ -40,7 +37,7 @@ export async function resolveGlob(
       const entries = await readdir(accessor, dirSpec)
       const matched: PathSpec[] = []
       for (const e of entries) {
-        if (fnmatch(basenameOf(e), p.pattern)) {
+        if (fnmatch(gnuBasename(e), p.pattern)) {
           matched.push(
             new PathSpec({
               original: e,


### PR DESCRIPTION
## What

Consolidates the duplicated path-helper functions scattered across backends into the canonical set in \`utils/path\` (both languages): \`norm\`, \`parent\`, \`gnuBasename\`, \`gnuDirname\`. Backends now import them instead of redefining their own.

## Why

Investigation found ~6 reimplementations of 2 real operations (\`norm\` and \`basename\`/\`parent\`/\`dirname\`). Truth-table comparison showed the variants only diverge on edge inputs (trailing slash, root, relative) that never reach them because inputs are pre-normalized — i.e. the "lazy" copies were latent edge-case bugs masked by clean input, not intentional behavior. TypeScript already had the cleaner shape for \`norm\`; Python centralized \`gnu_basename\`/\`gnu_dirname\`. This merges the best of both so both sides converge.

## Changes

- **python**: ram+redis drop 36 local \`_norm\` + 4 \`_parent\`; chroma/dify use shared \`parent\` + \`gnu_basename\`; \`norm\`/\`parent\` added to \`utils/path.py\`.
- **typescript**: ram/redis/disk/opfs \`utils.ts\` re-export shared \`norm\`/\`parent\`/\`gnuBasename\`; ssh \`norm\`, s3/chroma/gmail/email \`dirname\`, glob \`basenameOf\`, rg_helper/zip_cmd \`basename\`, and 5 agent \`parentOf\` all converge to the canonical helpers (now exported from the core barrel).
- **agents bug fix**: converging \`parentOf\`→\`gnuDirname\` exposed a recursion in \`ensureParent\` for a root-relative path (\`gnuDirname('foo.txt')\` is \`.\`, which the guard missed → infinite recursion + spurious \`mkdir('.')\`). Added \`'.'\` to the guard and a regression test. The new helper is GNU-correct; the old non-GNU \`parentOf\` returned \`/\` for a bare filename.

## Verification

- Net **−224 lines**, behavior-preserving.
- python full suite **8048 passed**; ts **core 3141 / node 1477 / browser 163 / agents 124**; pre-commit clean.
- integ \`ram.py\` output is **byte-identical** to \`truth.txt\` (refactor is integ-clean).

## Follow-ups (out of scope, noted)

- A commented-out \`root_create\` integ block marks a deferred **GNU find start-path fix**: \`find <dir>\` does not emit the start directory (mirage walks from depth 1; \`find -maxdepth 0\` lists nothing) — a systemic divergence across all backends, to be fixed in a dedicated PR.
- The dead per-op \`str\`→\`PathSpec\` coercion and the enoent \`virtual=\` stragglers remain, to pair with the #306 ops-table work.