### PR TITLE
fix: normalize awaitable read_stream in generic commands (gdrive cold crash)

### DIFF
--- a/python/mirage/commands/builtin/generic/awk.py
+++ b/python/mirage/commands/builtin/generic/awk.py
@@ -7,7 +7,8 @@ from mirage.commands.builtin.generic.awk_types import (CMP_OP_PATTERN,
                                                        PRINT_STMT, AwkBlock,
                                                        AwkBoolOp, AwkBuiltin,
                                                        AwkCmpOp)
-from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.builtin.utils.stream import (_open_read_stream,
+                                                  _resolve_source)
 from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -298,7 +299,7 @@ async def awk(
 
     cache: list[str] = []
     if data_paths:
-        source: AsyncIterator[bytes] = read_stream(accessor, data_paths[0])
+        source = await _open_read_stream(read_stream, accessor, data_paths[0])
         cache = [data_paths[0]]
     else:
         source = _resolve_source(stdin)

--- a/python/mirage/commands/builtin/generic/base64_cmd.py
+++ b/python/mirage/commands/builtin/generic/base64_cmd.py
@@ -1,7 +1,8 @@
 import base64 as b64lib
 from collections.abc import AsyncIterator, Callable
 
-from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.builtin.utils.stream import (_open_read_stream,
+                                                  _resolve_source)
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -44,7 +45,7 @@ async def base64_cmd(
 ) -> tuple[ByteSource | None, IOResult]:
     cache: list[str] = []
     if paths:
-        source: AsyncIterator[bytes] = read_stream(accessor, paths[0])
+        source = await _open_read_stream(read_stream, accessor, paths[0])
         cache = [paths[0].strip_prefix]
     else:
         source = _resolve_source(stdin)

--- a/python/mirage/commands/builtin/generic/cut.py
+++ b/python/mirage/commands/builtin/generic/cut.py
@@ -1,7 +1,8 @@
 from collections.abc import AsyncIterator, Callable
 
 from mirage.commands.builtin.cut_helper import cut_stream, parse_ranges
-from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.builtin.utils.stream import (_open_read_stream,
+                                                  _resolve_source)
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -22,7 +23,7 @@ async def cut(
     char_ranges = parse_ranges(c) if c is not None else None
     delim = d if d is not None else "\t"
     if paths:
-        source: AsyncIterator[bytes] = read_stream(accessor, paths[0])
+        source = await _open_read_stream(read_stream, accessor, paths[0])
     else:
         source = _resolve_source(stdin, "cut: missing operand")
     return cut_stream(source, delim, field_ranges, char_ranges, complement,

--- a/python/mirage/commands/builtin/generic/grep.py
+++ b/python/mirage/commands/builtin/generic/grep.py
@@ -10,7 +10,8 @@ from mirage.commands.builtin.grep_helper import (  # yapf: disable
 from mirage.commands.builtin.utils.lines import split_lines
 from mirage.commands.builtin.utils.output import (format_optional_records,
                                                   format_records)
-from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.builtin.utils.stream import (_open_read_stream,
+                                                  _resolve_source)
 from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
                                                 call_stat)
 from mirage.commands.errors import UsageError
@@ -269,7 +270,7 @@ async def grep(
             return b"", IOResult(exit_code=1, stderr=stderr)
 
         if read_stream is not None:
-            source: AsyncIterator[bytes] = read_stream(accessor, paths[0])
+            source = await _open_read_stream(read_stream, accessor, paths[0])
         else:
             data = await rb(paths[0].original)
             source = _wrap_bytes(data)

--- a/python/mirage/commands/builtin/generic/jq.py
+++ b/python/mirage/commands/builtin/generic/jq.py
@@ -1,5 +1,6 @@
 from collections.abc import AsyncIterator, Awaitable, Callable
 
+from mirage.commands.builtin.utils.stream import _open_read_stream
 from mirage.core.jq import (eval_jsonl_stream, format_jq_output, is_jsonl_path,
                             is_streamable_jsonl_expr, jq_eval, parse_json_auto,
                             parse_json_path)
@@ -34,7 +35,7 @@ async def jq(
     if paths:
         if is_jsonl_path(
                 paths[0].original) and is_streamable_jsonl_expr(expression):
-            source = read_stream(accessor, paths[0])
+            source = await _open_read_stream(read_stream, accessor, paths[0])
             return eval_jsonl_stream(source, expression, raw=r), IOResult()
         outputs: list[bytes] = []
         for p in paths:

--- a/python/mirage/commands/builtin/generic/nl.py
+++ b/python/mirage/commands/builtin/generic/nl.py
@@ -1,7 +1,8 @@
 import re
 from collections.abc import AsyncIterator, Callable
 
-from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.builtin.utils.stream import (_open_read_stream,
+                                                  _resolve_source)
 from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -49,7 +50,7 @@ async def _nl_multi(
     pattern: re.Pattern[str] | None,
 ) -> AsyncIterator[bytes]:
     for p in paths:
-        source = read_stream(accessor, p)
+        source = await _open_read_stream(read_stream, accessor, p)
         async for chunk in _nl_stream(source, body_numbering, start, increment,
                                       width, separator, pattern):
             yield chunk

--- a/python/mirage/commands/builtin/generic/rg.py
+++ b/python/mirage/commands/builtin/generic/rg.py
@@ -13,7 +13,8 @@ from mirage.commands.builtin.rg_helper import rg_full
 from mirage.commands.builtin.utils.lines import split_lines
 from mirage.commands.builtin.utils.output import (format_optional_records,
                                                   format_records)
-from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.builtin.utils.stream import (_open_read_stream,
+                                                  _resolve_source)
 from mirage.commands.builtin.utils.wrap import (call_read_bytes, call_readdir,
                                                 call_stat)
 from mirage.commands.errors import UsageError
@@ -221,7 +222,7 @@ async def rg(
             return format_records(all_results), IOResult()
 
         if read_stream is not None:
-            source: AsyncIterator[bytes] = read_stream(accessor, paths[0])
+            source = await _open_read_stream(read_stream, accessor, paths[0])
         else:
             data = await rb(paths[0].original)
             source = _wrap_bytes(data)

--- a/python/mirage/commands/builtin/generic/sha256sum.py
+++ b/python/mirage/commands/builtin/generic/sha256sum.py
@@ -2,7 +2,8 @@ import hashlib
 from collections.abc import AsyncIterator, Awaitable, Callable
 
 from mirage.commands.builtin.utils.lines import split_lines
-from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.builtin.utils.stream import (_open_read_stream,
+                                                  _resolve_source)
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -22,7 +23,8 @@ async def _sha256_multi(
 ) -> AsyncIterator[bytes]:
     for p in paths:
         h = hashlib.sha256()
-        async for chunk in read_stream(accessor, p):
+        source = await _open_read_stream(read_stream, accessor, p)
+        async for chunk in source:
             h.update(chunk)
         yield (h.hexdigest() + "  " + p.display + "\n").encode()
 
@@ -54,7 +56,8 @@ async def _sha256_check(
         expected_hash, filename = parts
         target = _resolve_check_target(filename, mount_prefix)
         h = hashlib.sha256()
-        async for chunk in read_stream(accessor, target):
+        source = await _open_read_stream(read_stream, accessor, target)
+        async for chunk in source:
             h.update(chunk)
         if h.hexdigest() == expected_hash:
             lines.append(f"{filename}: OK")

--- a/python/mirage/commands/builtin/generic/split.py
+++ b/python/mirage/commands/builtin/generic/split.py
@@ -1,6 +1,7 @@
 from collections.abc import AsyncIterator, Awaitable, Callable
 
-from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.builtin.utils.stream import (_open_read_stream,
+                                                  _resolve_source)
 from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -37,7 +38,7 @@ async def split(
     suffix_fn = _numeric_suffix if numeric_suffix else _alpha_suffix
 
     if paths:
-        source: AsyncIterator[bytes] = read_stream(accessor, paths[0])
+        source = await _open_read_stream(read_stream, accessor, paths[0])
     else:
         source = _resolve_source(stdin)
 

--- a/python/mirage/commands/builtin/generic/tac.py
+++ b/python/mirage/commands/builtin/generic/tac.py
@@ -1,6 +1,7 @@
 from collections.abc import AsyncIterator, Callable
 
-from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.builtin.utils.stream import (_open_read_stream,
+                                                  _resolve_source)
 from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -15,7 +16,7 @@ async def tac(
 ) -> tuple[ByteSource | None, IOResult]:
     cache: list[str] = []
     if paths:
-        source: AsyncIterator[bytes] = read_stream(accessor, paths[0])
+        source = await _open_read_stream(read_stream, accessor, paths[0])
         cache = [paths[0].strip_prefix]
     else:
         source = _resolve_source(stdin)

--- a/python/mirage/commands/builtin/generic/tee.py
+++ b/python/mirage/commands/builtin/generic/tee.py
@@ -1,6 +1,7 @@
 from collections.abc import AsyncIterator, Awaitable, Callable
 
-from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.builtin.utils.stream import (_open_read_stream,
+                                                  _read_stdin_async)
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -24,7 +25,8 @@ async def tee(
     if append:
         try:
             existing = b""
-            async for chunk in read_stream(accessor, paths[0]):
+            source = await _open_read_stream(read_stream, accessor, paths[0])
+            async for chunk in source:
                 existing += chunk
             write_data = existing + raw
         except FileNotFoundError:

--- a/python/mirage/commands/builtin/generic/tr.py
+++ b/python/mirage/commands/builtin/generic/tr.py
@@ -1,7 +1,8 @@
 from collections.abc import AsyncIterator, Callable
 
 from mirage.commands.builtin.utils.escapes import interpret_escapes
-from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.builtin.utils.stream import (_open_read_stream,
+                                                  _resolve_source)
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -83,7 +84,7 @@ async def tr(
 
     cache: list[str] = []
     if paths:
-        source: AsyncIterator[bytes] = read_stream(accessor, paths[0])
+        source = await _open_read_stream(read_stream, accessor, paths[0])
         cache = [paths[0].strip_prefix]
     else:
         source = _resolve_source(stdin)

--- a/python/mirage/commands/builtin/generic/xxd.py
+++ b/python/mirage/commands/builtin/generic/xxd.py
@@ -3,7 +3,8 @@ import re
 from collections.abc import AsyncIterator, Callable
 
 from mirage.commands.builtin.utils.lines import split_lines
-from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.builtin.utils.stream import (_open_read_stream,
+                                                  _resolve_source)
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
@@ -119,7 +120,7 @@ async def xxd(
 ) -> tuple[ByteSource | None, IOResult]:
     cache: list[str] = []
     if paths:
-        source: AsyncIterator[bytes] = read_stream(accessor, paths[0])
+        source = await _open_read_stream(read_stream, accessor, paths[0])
         cache = [paths[0].strip_prefix]
     else:
         source = _resolve_source(stdin)

--- a/python/tests/commands/builtin/generic/test_awaitable_read_stream.py
+++ b/python/tests/commands/builtin/generic/test_awaitable_read_stream.py
@@ -1,0 +1,44 @@
+import hashlib
+
+import pytest
+
+from mirage.commands.builtin.generic.cut import cut
+from mirage.commands.builtin.generic.sha256sum import sha256sum
+from mirage.types import PathSpec
+
+_DATA = b"a b c\nd e f\n"
+
+
+async def _gdrive_read_stream(accessor, path):
+    """Mimic gdrive: a plain ``async def`` resolving to ``bytes`` (not an
+    async generator), which crashed generic streaming commands cold."""
+    return _DATA
+
+
+async def _gdrive_read_bytes(accessor, path):
+    return _DATA
+
+
+def _path():
+    return PathSpec(original="/g/doc", directory="/g")
+
+
+@pytest.mark.asyncio
+async def test_cut_handles_awaitable_bytes_read_stream():
+    out, _ = await cut([_path()],
+                       read_stream=_gdrive_read_stream,
+                       accessor=None,
+                       f="1",
+                       d=" ")
+    collected = b"".join([chunk async for chunk in out])
+    assert collected == b"a\nd\n"
+
+
+@pytest.mark.asyncio
+async def test_sha256sum_handles_awaitable_bytes_read_stream():
+    out, _ = await sha256sum([_path()],
+                             read_bytes=_gdrive_read_bytes,
+                             read_stream=_gdrive_read_stream,
+                             accessor=None)
+    collected = b"".join([chunk async for chunk in out])
+    assert hashlib.sha256(_DATA).hexdigest().encode() in collected


### PR DESCRIPTION
## What

On a **cold cache**, every gdrive generic-routed streaming command crashed:

```
TypeError: 'async for' requires an object with __aiter__ method, got coroutine
```

gdrive's `core/gdrive/stream.py:read_stream` is a plain `async def` resolving to `bytes` (for gdoc/gsheet/gslide) or an `AsyncIterator`, unlike every other backend whose `read_stream` is an async generator. The generic commands called `read_stream(accessor, path)` **without awaiting** and handed the coroutine to `async for`. A warm cache routes through the generic RAM path and masks it, so it only reproduces cold.

## Fix

Route `read_stream` through the existing `_open_read_stream` helper (awaits awaitables, wraps bytes) — the same normalization `uniq` already uses. Applied to: cut, grep, rg, awk, tr, split, jq, base64, tee, sha256sum, nl, xxd, tac.

## Verification

- Regression test feeds a gdrive-style (bytes-returning) `read_stream` to `cut` (assigned form) and `sha256sum` (inline `async for` form); confirmed it **fails without** the fix (reproduces the exact crash) and passes with it.
- 486 generic + streaming tests green; pre-commit clean.
- TypeScript is unaffected (its gdrive stream is already an `AsyncIterable`); this is the py-side of the cold-vs-warm dispatch split (TS-only sibling is #335).