### PR TITLE
fix(fuse): keep caller-owned mountpoints

### DIFF
--- a/integ/cli_fuse.sh
+++ b/integ/cli_fuse.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # CLI end-to-end FUSE parity. Drives the daemon-backed CLI to create a workspace
-# with TWO per-mount FUSE subtrees pinned to known OS paths, writes content
-# through the VFS, then reads it back THROUGH the kernel mountpoints. The daemon
-# hosts the mounts in its own process, so the reading shell never deadlocks.
-# Proves the CLI really mounts each subtree at its own path on both languages.
+# with TWO per-mount FUSE subtrees pinned to known OS paths plus ONE generated
+# mount (fuse: true), writes content through the VFS, then reads it back THROUGH
+# the kernel mountpoints. The daemon hosts the mounts in its own process, so the
+# reading shell never deadlocks. Proves the CLI really mounts each subtree on
+# both languages, and that close() cleanup is ownership-aware: caller-owned
+# (pinned) mountpoint directories survive unmount, while generated temp
+# directories are removed with an empty-dir rmdir.
 # Requires libfuse + /dev/fuse, so it runs only in the fuse CI job.
 #
 # Usage: cli_fuse.sh "<py-cli>" "<ts-cli>"
@@ -34,6 +37,9 @@ mounts:
   /logs:
     resource: ram
     fuse: $lmnt
+  /auto:
+    resource: ram
+    fuse: true
 YML
 
   $cli daemon stop >/dev/null 2>&1 </dev/null || true
@@ -53,23 +59,47 @@ YML
     sleep 0.2
   done
 
-  local detail data_mp logs_mp
+  local detail data_mp logs_mp auto_mp
   detail="$($cli workspace get cf </dev/null)"
   data_mp="$(printf '%s' "$detail" | points | jq -r '."/data" // empty')"
   logs_mp="$(printf '%s' "$detail" | points | jq -r '."/logs" // empty')"
+  auto_mp="$(printf '%s' "$detail" | points | jq -r '."/auto" // empty')"
+
+  # The generated mount got a temp mountpoint Mirage picked; exercise it through
+  # the kernel the same way as the pinned mounts.
+  $cli execute -w cf -c 'echo gamma > /auto/c.txt' </dev/null >/dev/null
+  for i in $(seq 1 50); do
+    [ -n "$auto_mp" ] && [ -f "$auto_mp/c.txt" ] && break
+    sleep 0.2
+  done
 
   echo "data_cat=$(cat "$dmnt/a.txt" 2>/dev/null)"
   echo "logs_cat=$(cat "$lmnt/b.txt" 2>/dev/null)"
+  echo "auto_cat=$(cat "$auto_mp/c.txt" 2>/dev/null)"
   echo "logs_size=$(wc -c < "$lmnt/b.txt" 2>/dev/null | tr -d ' ')"
   echo "mount_keys=$(printf '%s' "$detail" | points | jq -r 'keys | sort | join(",")')"
   echo "data_pinned=$([ "$data_mp" == "$dmnt" ] && echo yes || echo no)"
   echo "logs_pinned=$([ "$logs_mp" == "$lmnt" ] && echo yes || echo no)"
+  echo "auto_generated=$([ -n "$auto_mp" ] && [ "$auto_mp" != "$dmnt" ] && [ "$auto_mp" != "$lmnt" ] && echo yes || echo no)"
   echo "distinct=$([ -n "$data_mp" ] && [ "$data_mp" != "$logs_mp" ] && echo yes || echo no)"
 
+  # Deleting the workspace runs the daemon-side close() for every mount. Cleanup
+  # must keep caller-owned (pinned) directories and remove only the generated
+  # temp directory. Wait for the generated dir to disappear, then assert.
   $cli workspace delete cf >/dev/null 2>&1 </dev/null || true
+  for i in $(seq 1 25); do
+    [ -n "$auto_mp" ] && [ ! -d "$auto_mp" ] && break
+    sleep 0.2
+  done
+  echo "data_dir_survives=$([ -d "$dmnt" ] && echo yes || echo no)"
+  echo "logs_dir_survives=$([ -d "$lmnt" ] && echo yes || echo no)"
+  echo "gen_dir_removed=$([ -n "$auto_mp" ] && [ ! -d "$auto_mp" ] && echo yes || echo no)"
+
   $cli daemon stop >/dev/null 2>&1 </dev/null || true
   fusermount -u "$dmnt" 2>/dev/null || umount "$dmnt" 2>/dev/null || true
   fusermount -u "$lmnt" 2>/dev/null || umount "$lmnt" 2>/dev/null || true
+  [ -n "$auto_mp" ] && { fusermount -u "$auto_mp" 2>/dev/null || umount "$auto_mp" 2>/dev/null || true; }
+  rm -rf "$dmnt" "$lmnt" ${auto_mp:+"$auto_mp"}
 }
 
 echo "===== probing Python CLI ====="
@@ -105,11 +135,16 @@ expect() {
 }
 expect "data_cat" "alpha"
 expect "logs_cat" "beta"
+expect "auto_cat" "gamma"
 expect "logs_size" "5"
-expect "mount_keys" "/data,/logs"
+expect "mount_keys" "/auto,/data,/logs"
 expect "data_pinned" "yes"
 expect "logs_pinned" "yes"
+expect "auto_generated" "yes"
 expect "distinct" "yes"
+expect "data_dir_survives" "yes"
+expect "logs_dir_survives" "yes"
+expect "gen_dir_removed" "yes"
 
 if [ "$fail" != "0" ]; then
   echo
@@ -122,4 +157,4 @@ if [ "$fail" != "0" ]; then
   exit 1
 fi
 echo
-echo "CLI FUSE parity OK (two pinned per-mount FUSE subtrees read through the kernel; py == ts)."
+echo "CLI FUSE parity OK (two pinned + one generated FUSE subtree read through the kernel; ownership-aware cleanup; py == ts)."

--- a/python/mirage/workspace/fuse.py
+++ b/python/mirage/workspace/fuse.py
@@ -75,6 +75,7 @@ class FuseManager:
                 pass
         self._mountpoint = None
         self._owns_mountpoint = False
+        self._auto = False
 
     def close(self) -> None:
         if self._mountpoint and self._auto:

--- a/python/mirage/workspace/fuse.py
+++ b/python/mirage/workspace/fuse.py
@@ -25,6 +25,7 @@ class FuseManager:
         self._mountpoint: str | None = None
         self._thread: Thread | None = None
         self._auto: bool = False
+        # True only for tempfile mountpoints Mirage created and may delete.
         self._owns_mountpoint: bool = False
 
     @property
@@ -42,6 +43,9 @@ class FuseManager:
               mountpoint: str | None = None) -> None:
         from mirage.fuse.mount import mount_background
         if mountpoint:
+            # Caller/deployment-owned mountpoints may be reused across process
+            # restarts, container lifecycles, or volume mounts. Mirage should
+            # unmount them, but must not delete the directory itself.
             os.makedirs(mountpoint, exist_ok=True)
             self._mountpoint = mountpoint
             self._owns_mountpoint = False
@@ -64,6 +68,8 @@ class FuseManager:
                            capture_output=True)
         if self._owns_mountpoint:
             try:
+                # Empty-directory cleanup only. If the mount is still live or
+                # the directory has contents, leave it for the caller/admin.
                 os.rmdir(self._mountpoint)
             except OSError:
                 pass

--- a/python/mirage/workspace/fuse.py
+++ b/python/mirage/workspace/fuse.py
@@ -12,7 +12,10 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import os
+import subprocess
 import sys
+import tempfile
 from threading import Thread
 
 
@@ -22,6 +25,7 @@ class FuseManager:
         self._mountpoint: str | None = None
         self._thread: Thread | None = None
         self._auto: bool = False
+        self._owns_mountpoint: bool = False
 
     @property
     def mountpoint(self) -> str | None:
@@ -30,20 +34,20 @@ class FuseManager:
     @mountpoint.setter
     def mountpoint(self, path: str | None) -> None:
         self._mountpoint = path
+        self._owns_mountpoint = False
 
     def setup(self,
               ws: object,
               root_prefix: str = "",
               mountpoint: str | None = None) -> None:
-        import os
-        import tempfile
-
         from mirage.fuse.mount import mount_background
         if mountpoint:
             os.makedirs(mountpoint, exist_ok=True)
             self._mountpoint = mountpoint
+            self._owns_mountpoint = False
         else:
             self._mountpoint = tempfile.mkdtemp(prefix="mirage-")
+            self._owns_mountpoint = True
         self._thread = mount_background(ws,
                                         self._mountpoint,
                                         root_prefix=root_prefix)
@@ -52,19 +56,19 @@ class FuseManager:
     def unmount(self) -> None:
         if not self._mountpoint:
             return
-        import subprocess as _sp
         if sys.platform == "darwin":
-            _sp.run(["diskutil", "unmount", "force", self._mountpoint],
-                    capture_output=True)
+            subprocess.run(["diskutil", "unmount", "force", self._mountpoint],
+                           capture_output=True)
         else:
-            _sp.run(["fusermount", "-u", self._mountpoint],
-                    capture_output=True)
-        try:
-            import os as _os
-            _os.rmdir(self._mountpoint)
-        except OSError:
-            pass
+            subprocess.run(["fusermount", "-u", self._mountpoint],
+                           capture_output=True)
+        if self._owns_mountpoint:
+            try:
+                os.rmdir(self._mountpoint)
+            except OSError:
+                pass
         self._mountpoint = None
+        self._owns_mountpoint = False
 
     def close(self) -> None:
         if self._mountpoint and self._auto:

--- a/python/tests/workspace/test_fuse.py
+++ b/python/tests/workspace/test_fuse.py
@@ -41,6 +41,8 @@ class TestFuseManager:
         assert fm.mountpoint is None
 
     def test_close_keeps_caller_owned_mountpoint(self, monkeypatch, tmp_path):
+        # Regression: explicit mountpoints are caller-owned deployment paths.
+        # close() should unmount FUSE, not remove the directory the caller gave.
         monkeypatch.setattr(fuse_mount, "mount_background",
                             lambda *_args, **_kwargs: None)
         monkeypatch.setattr(subprocess, "run", lambda *_args, **_kwargs: None)

--- a/python/tests/workspace/test_fuse.py
+++ b/python/tests/workspace/test_fuse.py
@@ -42,7 +42,8 @@ class TestFuseManager:
 
     def test_close_keeps_caller_owned_mountpoint(self, monkeypatch, tmp_path):
         # Regression: explicit mountpoints are caller-owned deployment paths.
-        # close() should unmount FUSE, not remove the directory the caller gave.
+        # close() should unmount FUSE, not remove the directory given by the
+        # caller.
         monkeypatch.setattr(fuse_mount, "mount_background",
                             lambda *_args, **_kwargs: None)
         monkeypatch.setattr(subprocess, "run", lambda *_args, **_kwargs: None)

--- a/python/tests/workspace/test_fuse.py
+++ b/python/tests/workspace/test_fuse.py
@@ -13,8 +13,10 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import subprocess
+import tempfile
 
-import mirage.fuse.mount as fuse_mount
+import pytest
+
 from mirage.workspace.fuse import FuseManager
 
 
@@ -44,6 +46,7 @@ class TestFuseManager:
         # Regression: explicit mountpoints are caller-owned deployment paths.
         # close() should unmount FUSE, not remove the directory given by the
         # caller.
+        fuse_mount = pytest.importorskip("mirage.fuse.mount")
         monkeypatch.setattr(fuse_mount, "mount_background",
                             lambda *_args, **_kwargs: None)
         monkeypatch.setattr(subprocess, "run", lambda *_args, **_kwargs: None)
@@ -53,4 +56,23 @@ class TestFuseManager:
         fm.close()
 
         assert tmp_path.exists()
+        assert fm.mountpoint is None
+
+    def test_close_removes_generated_mountpoint(self, monkeypatch, tmp_path):
+        # Generated temp mountpoints are Mirage-owned, so close() removes the
+        # directory it created with an empty-directory rmdir.
+        fuse_mount = pytest.importorskip("mirage.fuse.mount")
+        generated = tmp_path / "mirage-generated"
+        generated.mkdir()
+        monkeypatch.setattr(fuse_mount, "mount_background",
+                            lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(subprocess, "run", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(tempfile, "mkdtemp",
+                            lambda *_args, **_kwargs: str(generated))
+
+        fm = FuseManager()
+        fm.setup(object())
+        fm.close()
+
+        assert not generated.exists()
         assert fm.mountpoint is None

--- a/python/tests/workspace/test_fuse.py
+++ b/python/tests/workspace/test_fuse.py
@@ -12,6 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import subprocess
+
+import mirage.fuse.mount as fuse_mount
 from mirage.workspace.fuse import FuseManager
 
 
@@ -35,4 +38,16 @@ class TestFuseManager:
     def test_close_without_mountpoint_does_nothing(self):
         fm = FuseManager()
         fm.close()
+        assert fm.mountpoint is None
+
+    def test_close_keeps_caller_owned_mountpoint(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(fuse_mount, "mount_background",
+                            lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(subprocess, "run", lambda *_args, **_kwargs: None)
+
+        fm = FuseManager()
+        fm.setup(object(), mountpoint=str(tmp_path))
+        fm.close()
+
+        assert tmp_path.exists()
         assert fm.mountpoint is None

--- a/typescript/packages/node/src/fuse/mount.ts
+++ b/typescript/packages/node/src/fuse/mount.ts
@@ -22,11 +22,13 @@ import { MirageFS } from './fs.ts'
 
 export interface FuseHandle {
   mountpoint: string
+  /** Whether Mirage created this mountpoint directory and may remove it later. */
   ownsMountpoint: boolean
   unmount: () => Promise<void>
 }
 
 export interface MountOptions {
+  /** Caller/deployment-owned mountpoint. Mirage mounts here but does not delete it. */
   mountpoint?: string
   agentId?: string
   /** Scope the mount to a single workspace mount prefix (subtree exposure). */
@@ -86,7 +88,7 @@ export async function mount(ws: Workspace, options: MountOptions = {}): Promise<
   let mountpoint: string
   let ownsMountpoint = false
   if (options.mountpoint !== undefined) {
-    // Pinned path: create it if missing, mirroring Python's os.makedirs.
+    // Pinned path: create if missing, but keep ownership with the caller.
     mkdirSync(options.mountpoint, { recursive: true })
     mountpoint = options.mountpoint
   } else {

--- a/typescript/packages/node/src/fuse/mount.ts
+++ b/typescript/packages/node/src/fuse/mount.ts
@@ -22,6 +22,7 @@ import { MirageFS } from './fs.ts'
 
 export interface FuseHandle {
   mountpoint: string
+  ownsMountpoint: boolean
   unmount: () => Promise<void>
 }
 
@@ -83,12 +84,14 @@ export function forceUnmount(mountpoint: string): void {
 export async function mount(ws: Workspace, options: MountOptions = {}): Promise<FuseHandle> {
   const Fuse = await loadFuse()
   let mountpoint: string
+  let ownsMountpoint = false
   if (options.mountpoint !== undefined) {
     // Pinned path: create it if missing, mirroring Python's os.makedirs.
     mkdirSync(options.mountpoint, { recursive: true })
     mountpoint = options.mountpoint
   } else {
     mountpoint = mkdtempSync(join(tmpdir(), 'mirage-fuse-'))
+    ownsMountpoint = true
   }
   const agentId = options.agentId
   const mfs = new MirageFS(ws, {
@@ -116,6 +119,7 @@ export async function mount(ws: Workspace, options: MountOptions = {}): Promise<
   })
   return {
     mountpoint,
+    ownsMountpoint,
     unmount: () =>
       new Promise<void>((resolve, reject) => {
         fuse.unmount((err) => {

--- a/typescript/packages/node/src/workspace/fuse.test.ts
+++ b/typescript/packages/node/src/workspace/fuse.test.ts
@@ -71,6 +71,8 @@ describe('FuseManager (without a real mount)', () => {
   })
 
   it('keeps caller-owned mountpoints after close', async () => {
+    // Regression: explicit mountpoints are deployment/caller-owned paths. The
+    // manager must unmount FUSE without deleting the directory it mounted on.
     const unmount = vi.fn(() => Promise.resolve())
     mocks.mount.mockResolvedValueOnce({
       mountpoint: '/tmp/caller-owned',
@@ -89,6 +91,8 @@ describe('FuseManager (without a real mount)', () => {
   })
 
   it('removes generated mountpoints with an empty-directory rmdir', async () => {
+    // Generated temp mountpoints are Mirage-owned, but cleanup is intentionally
+    // rmdir-only so a still-mounted FUSE tree is never recursively deleted.
     const unmount = vi.fn(() => Promise.resolve())
     mocks.mount.mockResolvedValueOnce({
       mountpoint: '/tmp/generated',

--- a/typescript/packages/node/src/workspace/fuse.test.ts
+++ b/typescript/packages/node/src/workspace/fuse.test.ts
@@ -12,10 +12,40 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it } from 'vitest'
+import type { Workspace } from '@struktoai/mirage-core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { FuseManager } from './fuse.ts'
 
+const mocks = vi.hoisted(() => ({
+  forceUnmount: vi.fn(),
+  mount: vi.fn(),
+  rmSync: vi.fn(),
+  rmdirSync: vi.fn(),
+}))
+
+vi.mock('../fuse/mount.ts', () => ({
+  forceUnmount: mocks.forceUnmount,
+  mount: mocks.mount,
+}))
+
+vi.mock('node:fs', () => ({
+  rmSync: mocks.rmSync,
+  rmdirSync: mocks.rmdirSync,
+}))
+
+function workspaceStub(): Workspace {
+  return {
+    setFuseMountpoint: vi.fn(),
+  } as unknown as Workspace
+}
+
 describe('FuseManager (without a real mount)', () => {
+  beforeEach(() => {
+    mocks.mount.mockReset()
+    mocks.rmSync.mockReset()
+    mocks.rmdirSync.mockReset()
+  })
+
   it('starts with mountpoint=null', () => {
     const fm = new FuseManager()
     expect(fm.mountpoint).toBeNull()
@@ -38,5 +68,41 @@ describe('FuseManager (without a real mount)', () => {
     const fm = new FuseManager()
     await fm.close()
     expect(fm.mountpoint).toBeNull()
+  })
+
+  it('keeps caller-owned mountpoints after close', async () => {
+    const unmount = vi.fn(() => Promise.resolve())
+    mocks.mount.mockResolvedValueOnce({
+      mountpoint: '/tmp/caller-owned',
+      ownsMountpoint: false,
+      unmount,
+    })
+    const ws = workspaceStub()
+    const fm = new FuseManager()
+
+    await fm.setup(ws, { mountpoint: '/tmp/caller-owned' })
+    await fm.close(ws)
+
+    expect(unmount).toHaveBeenCalledOnce()
+    expect(mocks.rmdirSync).not.toHaveBeenCalled()
+    expect(mocks.rmSync).not.toHaveBeenCalled()
+  })
+
+  it('removes generated mountpoints with an empty-directory rmdir', async () => {
+    const unmount = vi.fn(() => Promise.resolve())
+    mocks.mount.mockResolvedValueOnce({
+      mountpoint: '/tmp/generated',
+      ownsMountpoint: true,
+      unmount,
+    })
+    const ws = workspaceStub()
+    const fm = new FuseManager()
+
+    await fm.setup(ws)
+    await fm.close(ws)
+
+    expect(unmount).toHaveBeenCalledOnce()
+    expect(mocks.rmdirSync).toHaveBeenCalledWith('/tmp/generated')
+    expect(mocks.rmSync).not.toHaveBeenCalled()
   })
 })

--- a/typescript/packages/node/src/workspace/fuse.ts
+++ b/typescript/packages/node/src/workspace/fuse.ts
@@ -21,12 +21,15 @@ type Signal = (typeof SIGNALS)[number]
 interface CleanupEntry {
   mountpoint: string
   handle: FuseHandle
+  // Cleanup owns only generated temp directories, never explicit mountpoints.
   ownsMountpoint: boolean
 }
 
 function removeMountpointIfOwned(entry: { mountpoint: string; ownsMountpoint: boolean }): void {
   if (!entry.ownsMountpoint) return
   try {
+    // Empty-directory cleanup only. Recursive removal is unsafe because a
+    // still-mounted FUSE path can make deletes hit the mounted backend.
     rmdirSync(entry.mountpoint)
   } catch {
     // mountpoint may still be busy, non-empty, or already gone; caller can retry
@@ -112,6 +115,8 @@ export class FuseManager {
     this.cleanupEntry = {
       mountpoint: this.handle.mountpoint,
       handle: this.handle,
+      // Preserve the ownership decision made by mount(); unmount cleanup must
+      // not infer ownership from path shape or whether the directory exists.
       ownsMountpoint: this.handle.ownsMountpoint,
     }
     CLEANUP.register(this.cleanupEntry)

--- a/typescript/packages/node/src/workspace/fuse.ts
+++ b/typescript/packages/node/src/workspace/fuse.ts
@@ -18,7 +18,11 @@ import { forceUnmount, mount, type FuseHandle, type MountOptions } from '../fuse
 
 const SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP'] as const
 type Signal = (typeof SIGNALS)[number]
-type CleanupEntry = { mountpoint: string; handle: FuseHandle; ownsMountpoint: boolean }
+interface CleanupEntry {
+  mountpoint: string
+  handle: FuseHandle
+  ownsMountpoint: boolean
+}
 
 function removeMountpointIfOwned(entry: { mountpoint: string; ownsMountpoint: boolean }): void {
   if (!entry.ownsMountpoint) return

--- a/typescript/packages/node/src/workspace/fuse.ts
+++ b/typescript/packages/node/src/workspace/fuse.ts
@@ -12,12 +12,22 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { rmSync } from 'node:fs'
+import { rmdirSync } from 'node:fs'
 import type { Workspace } from '@struktoai/mirage-core'
 import { forceUnmount, mount, type FuseHandle, type MountOptions } from '../fuse/mount.ts'
 
 const SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP'] as const
 type Signal = (typeof SIGNALS)[number]
+type CleanupEntry = { mountpoint: string; handle: FuseHandle; ownsMountpoint: boolean }
+
+function removeMountpointIfOwned(entry: { mountpoint: string; ownsMountpoint: boolean }): void {
+  if (!entry.ownsMountpoint) return
+  try {
+    rmdirSync(entry.mountpoint)
+  } catch {
+    // mountpoint may still be busy, non-empty, or already gone; caller can retry
+  }
+}
 
 /**
  * Tracks auto-mounted FUSE handles and installs a single process-wide cleanup
@@ -26,16 +36,16 @@ type Signal = (typeof SIGNALS)[number]
  * KeyboardInterrupt → `diskutil unmount force` / `fusermount -u` in mount.py.
  */
 class FuseCleanupRegistry {
-  private readonly mounts = new Set<{ mountpoint: string; handle: FuseHandle }>()
+  private readonly mounts = new Set<CleanupEntry>()
   private installed = false
   private exiting = false
 
-  register(entry: { mountpoint: string; handle: FuseHandle }): void {
+  register(entry: CleanupEntry): void {
     this.mounts.add(entry)
     this.install()
   }
 
-  unregister(entry: { mountpoint: string; handle: FuseHandle }): void {
+  unregister(entry: CleanupEntry): void {
     this.mounts.delete(entry)
   }
 
@@ -67,11 +77,7 @@ class FuseCleanupRegistry {
   private drainSync(): void {
     for (const entry of this.mounts) {
       forceUnmount(entry.mountpoint)
-      try {
-        rmSync(entry.mountpoint, { recursive: true, force: true })
-      } catch {
-        // best-effort
-      }
+      removeMountpointIfOwned(entry)
     }
     this.mounts.clear()
   }
@@ -83,7 +89,7 @@ export class FuseManager {
   private handle: FuseHandle | null = null
   private externalMountpoint: string | null = null
   private auto = false
-  private cleanupEntry: { mountpoint: string; handle: FuseHandle } | null = null
+  private cleanupEntry: CleanupEntry | null = null
 
   get mountpoint(): string | null {
     if (this.handle !== null) return this.handle.mountpoint
@@ -99,7 +105,11 @@ export class FuseManager {
     this.handle = await mount(ws, options)
     this.auto = true
     this.externalMountpoint = null
-    this.cleanupEntry = { mountpoint: this.handle.mountpoint, handle: this.handle }
+    this.cleanupEntry = {
+      mountpoint: this.handle.mountpoint,
+      handle: this.handle,
+      ownsMountpoint: this.handle.ownsMountpoint,
+    }
     CLEANUP.register(this.cleanupEntry)
     ws.setFuseMountpoint(this.handle.mountpoint, { owned: true })
     return this.handle.mountpoint
@@ -115,18 +125,18 @@ export class FuseManager {
     try {
       await this.handle.unmount()
     } finally {
-      if (this.cleanupEntry !== null) {
-        CLEANUP.unregister(this.cleanupEntry)
+      const cleanupEntry = this.cleanupEntry
+      if (cleanupEntry !== null) {
+        CLEANUP.unregister(cleanupEntry)
         this.cleanupEntry = null
       }
       this.handle = null
       this.auto = false
       ws?.setFuseMountpoint(null)
-      try {
-        rmSync(mp, { recursive: true, force: true })
-      } catch {
-        // mountpoint may still be busy; caller can retry
-      }
+      removeMountpointIfOwned({
+        mountpoint: mp,
+        ownsMountpoint: cleanupEntry?.ownsMountpoint ?? false,
+      })
     }
   }
 


### PR DESCRIPTION
## Summary

Fixing bug: 
- Mirage treats the FUSE mountpoint directory as if Mirage always owns it. Cleanup could delete caller-owned FUSE mountpoint directories
- In TypeScript it could recursively delete through a still-mounted FUSE filesystem if unmount failed.

Removal is only true for auto temp mounts, it created that dir, so unmount may remove the empty dir
```
fuse=True -> /tmp/mirage-abc123
```
Wrong for fixed/ deployment mounts `mountpoint="/mirage/mnt"` (caller chooses the mount path instead of Mirage making a random dir.
```
Workspace(resources, fuse=FuseConfig(mountpoint="/mirage/mnt"))
```

Current bad clean up behavior
```
close()
  -> unmount
  -> delete /mirage/mnt
```
Should be
```
close()
  -> unmount
  -> leave /mirage/mnt alone
```

How?
- Track whether a FUSE mountpoint was generated by Mirage or supplied by the caller.
- Keep caller-owned mountpoint directories after unmount/close.
- Remove generated mountpoint directories only with empty-directory removal, never recursive deletion.
- Add Python and TypeScript regression coverage for caller-owned and generated mountpoint cleanup.

## Tests

- `cd python && uv run pytest tests/workspace/test_fuse.py`
- TS test
- precommit

