### PR TITLE
refactor: make github/uniq consistent, drop unused _open_read_stream

### DIFF
--- a/examples/python/github/github.py
+++ b/examples/python/github/github.py
@@ -198,6 +198,10 @@ async def main() -> None:
         "grep 'import' /github/python/mirage/types.py | sort | uniq")
     print(await r.stdout_str())
 
+    print("=== uniq (file path, streams via github read) ===")
+    r = await ws.execute("uniq /github/python/mirage/types.py")
+    print(await r.stdout_str())
+
     print("=== sha256sum ===")
     r = await ws.execute("sha256sum /github/python/mirage/types.py")
     print(await r.stdout_str())

--- a/examples/typescript/github/github.ts
+++ b/examples/typescript/github/github.ts
@@ -140,6 +140,7 @@ async function main(): Promise<void> {
     'sort | uniq',
     "grep 'import' /github/python/mirage/types.py | sort | uniq",
   )
+  await header(ws, 'uniq (file path, streams via github read)', 'uniq /github/python/mirage/types.py')
   await header(ws, 'sha256sum', 'sha256sum /github/python/mirage/types.py')
   await header(ws, 'file', 'file /github/python/mirage/types.py')
   await header(ws, 'basename', 'basename /github/python/mirage/core/s3/read.py')

--- a/python/mirage/commands/builtin/generic/uniq.py
+++ b/python/mirage/commands/builtin/generic/uniq.py
@@ -1,7 +1,6 @@
 from collections.abc import AsyncIterator, Callable
 
-from mirage.commands.builtin.utils.stream import (_open_read_stream,
-                                                  _resolve_source)
+from mirage.commands.builtin.utils.stream import _resolve_source
 from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -99,7 +98,7 @@ async def uniq(
 ) -> tuple[ByteSource | None, IOResult]:
     cache: list[str] = []
     if paths:
-        source = await _open_read_stream(read_stream, accessor, paths[0])
+        source: AsyncIterator[bytes] = read_stream(accessor, paths[0])
         cache = [paths[0].strip_prefix]
     else:
         source = _resolve_source(stdin, "uniq: missing operand")

--- a/python/mirage/commands/builtin/github/uniq.py
+++ b/python/mirage/commands/builtin/github/uniq.py
@@ -18,6 +18,7 @@ from functools import partial
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.uniq import uniq as generic_uniq
+from mirage.commands.builtin.utils.wrap import stream_from_bytes
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.github.glob import resolve_glob
@@ -48,7 +49,7 @@ async def uniq(
         paths = []
     return await generic_uniq(
         paths,
-        read_stream=partial(github_read, index=index),
+        read_stream=partial(stream_from_bytes, github_read, index=index),
         accessor=accessor,
         stdin=stdin,
         count=c,

--- a/python/mirage/commands/builtin/utils/stream.py
+++ b/python/mirage/commands/builtin/utils/stream.py
@@ -12,10 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import inspect
-from collections.abc import AsyncIterator, Callable
-
-from mirage.types import PathSpec
+from collections.abc import AsyncIterator
 
 
 async def _read_stdin_async(
@@ -49,18 +46,3 @@ def _resolve_source(
         raise error_cls(error_msg)
     # GNU semantics: no stdin behaves like empty input (/dev/null)
     return _wrap_bytes(b"")
-
-
-async def _open_read_stream(
-    read_stream: Callable[..., object],
-    accessor: object,
-    path: PathSpec,
-) -> AsyncIterator[bytes]:
-    # Accept both async-generator readers and plain async readers that
-    # resolve to bytes or an AsyncIterator (e.g. gdrive, github).
-    source = read_stream(accessor, path)
-    if inspect.isawaitable(source):
-        source = await source
-    if isinstance(source, bytes):
-        return _wrap_bytes(source)
-    return source

--- a/python/tests/commands/builtin/generic/test_uniq.py
+++ b/python/tests/commands/builtin/generic/test_uniq.py
@@ -8,10 +8,6 @@ def _unused_read_stream(_accessor, _path):
     raise AssertionError("read_stream should not be called for stdin input")
 
 
-async def _bytes_read_stream(_accessor, _path):
-    return b"dup\ndup\nsolo\n"
-
-
 async def _generator_read_stream(_accessor, _path):
     yield b"dup\ndup\nsolo\n"
 
@@ -100,15 +96,6 @@ async def test_ignore_case_folds_duplicates():
     data = b"Hello\nhello\n"
     out = await _collect(data, ignore_case=True)
     assert out == b"Hello\n"
-
-
-@pytest.mark.asyncio
-async def test_read_stream_returning_bytes():
-    # whole-read backends (github, gdrive gdoc) resolve to bytes
-    p = PathSpec(original="/x", directory="/x")
-    source, _io = await uniq([p], read_stream=_bytes_read_stream)
-    out = b"".join([chunk async for chunk in source])
-    assert out == b"dup\nsolo\n"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`github/uniq` was the only command wrapper in the repo passing a raw bytes-returning reader (`partial(github_read, ...)`) into a generic command. Every other backend (and every other github command) already wraps its reader in an async generator before passing it in.

This made the `_open_read_stream` helper exist solely to normalize that one wiring. The fix:

- `github/uniq` now wraps `github_read` in `stream_from_bytes`, matching `github/cut`/`github/awk`/etc.
- `generic/uniq` consumes `read_stream(accessor, p)` directly (like `generic/cut`); its type `Callable[..., AsyncIterator[bytes]]` is now accurate.
- `_open_read_stream` deleted from `utils/stream.py` (no remaining consumers).
- Dropped `test_read_stream_returning_bytes`, which covered the removed contract.

Net: one rule everywhere, backends always pass an async generator and generics never normalize. TS already follows this (uniqGeneric is typed to require a stream fn).

Replaces #344, which spread the helper to 13 generics to guard a reader shape no backend actually produces.