### PR TITLE
fix(fuse): surface startup worker failures

### DIFF
--- a/python/mirage/fuse/mount.py
+++ b/python/mirage/fuse/mount.py
@@ -12,16 +12,20 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import logging
 import os
 import subprocess
 import sys
 import threading
-import time
+from queue import Empty, SimpleQueue
 
 import mfusepy as fuse
 
 from mirage.fuse.fs import MirageFS
 from mirage.workspace import Workspace
+
+_STARTUP_TIMEOUT = 0.3
+logger = logging.getLogger(__name__)
 
 
 def _run_fuse(fs: MirageFS, mountpoint: str, foreground: bool) -> None:
@@ -32,16 +36,34 @@ def _run_fuse(fs: MirageFS, mountpoint: str, foreground: bool) -> None:
               direct_io=True)
 
 
-def mount_background(ws: Workspace,
-                     mountpoint: str,
-                     agent_id: str | None = None,
-                     root_prefix: str = "") -> threading.Thread:
+def _run_fuse_with_startup_report(fs: MirageFS, mountpoint: str,
+                                  foreground: bool,
+                                  errors: SimpleQueue[Exception]) -> None:
+    try:
+        _run_fuse(fs, mountpoint, foreground)
+    except Exception as exc:
+        errors.put(exc)
+        logger.exception("FUSE worker exited unexpectedly")
+
+
+def mount_background(
+        ws: Workspace,
+        mountpoint: str,
+        agent_id: str | None = None,
+        root_prefix: str = "",
+        startup_timeout: float = _STARTUP_TIMEOUT) -> threading.Thread:
     fs = MirageFS(ws, agent_id=agent_id, root_prefix=root_prefix)
-    t = threading.Thread(target=_run_fuse,
-                         args=(fs, mountpoint, True),
+    errors: SimpleQueue[Exception] = SimpleQueue()
+    t = threading.Thread(target=_run_fuse_with_startup_report,
+                         args=(fs, mountpoint, True, errors),
                          daemon=True)
     t.start()
-    time.sleep(0.3)
+    t.join(timeout=startup_timeout)
+    if not t.is_alive():
+        try:
+            raise errors.get_nowait()
+        except Empty as exc:
+            raise RuntimeError("FUSE worker exited during startup") from exc
     return t
 
 

--- a/python/mirage/workspace/fuse.py
+++ b/python/mirage/workspace/fuse.py
@@ -52,9 +52,20 @@ class FuseManager:
         else:
             self._mountpoint = tempfile.mkdtemp(prefix="mirage-")
             self._owns_mountpoint = True
-        self._thread = mount_background(ws,
-                                        self._mountpoint,
-                                        root_prefix=root_prefix)
+        try:
+            self._thread = mount_background(ws,
+                                            self._mountpoint,
+                                            root_prefix=root_prefix)
+        except Exception:
+            if self._owns_mountpoint:
+                try:
+                    os.rmdir(self._mountpoint)
+                except OSError:
+                    pass
+            self._mountpoint = None
+            self._owns_mountpoint = False
+            self._auto = False
+            raise
         self._auto = True
 
     def unmount(self) -> None:

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -153,13 +153,25 @@ class Workspace:
                         session_id=session_id)
 
         if fuse_mounts:
-            for prefix, target in fuse_mounts.items():
-                if not target:
-                    continue
-                manager = FuseManager()
-                point = target if isinstance(target, str) else None
-                manager.setup(self, root_prefix=prefix, mountpoint=point)
-                self._fuse_managers[prefix] = manager
+            try:
+                for prefix, target in fuse_mounts.items():
+                    if not target:
+                        continue
+                    manager = FuseManager()
+                    point = target if isinstance(target, str) else None
+                    manager.setup(self, root_prefix=prefix, mountpoint=point)
+                    self._fuse_managers[prefix] = manager
+            except Exception:
+                # __exit__ is never reached when __init__ raises. Unwind any
+                # earlier FUSE mounts from this constructor before re-raising.
+                for manager in self._fuse_managers.values():
+                    try:
+                        manager.close()
+                    except Exception:
+                        logger.exception(
+                            "Failed to close FUSE manager after setup failure")
+                self._fuse_managers.clear()
+                raise
 
     async def history(self) -> list[dict]:
         """Command events recorded by the hidden recorder.

--- a/python/tests/fuse/test_mount.py
+++ b/python/tests/fuse/test_mount.py
@@ -1,0 +1,47 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def _fail_mount(*_args, **_kwargs):
+    raise RuntimeError("fuse failed")
+
+
+def _load_mount_module(monkeypatch):
+    fake_fuse = types.SimpleNamespace(FUSE=_fail_mount, Operations=object)
+    monkeypatch.setitem(sys.modules, "mfusepy", fake_fuse)
+    sys.modules.pop("mirage.fuse.mount", None)
+    sys.modules.pop("mirage.fuse.fs", None)
+    return importlib.import_module("mirage.fuse.mount")
+
+
+def test_mount_background_propagates_worker_startup_exception(
+        monkeypatch, tmp_path):
+    # Regression: startup errors happen in the worker thread, but callers need
+    # them synchronously so setup can fail and clean up generated mountpoints.
+    fuse_mount = _load_mount_module(monkeypatch)
+    monkeypatch.setattr(fuse_mount, "MirageFS",
+                        lambda *_args, **_kwargs: object())
+
+    try:
+        with pytest.raises(RuntimeError, match="fuse failed"):
+            fuse_mount.mount_background(object(), str(tmp_path))
+    finally:
+        sys.modules.pop("mirage.fuse.mount", None)
+        sys.modules.pop("mirage.fuse.fs", None)

--- a/python/tests/workspace/test_fuse.py
+++ b/python/tests/workspace/test_fuse.py
@@ -19,11 +19,32 @@ import types
 
 import pytest
 
+import mirage.workspace.workspace as workspace_module
+from mirage.resource.ram import RAMResource
 from mirage.workspace.fuse import FuseManager
 
 
 def _fail_mount_startup(*_args, **_kwargs):
     raise RuntimeError("fuse failed")
+
+
+class _TrackingFuseManager:
+
+    created = []
+    setup_calls = 0
+
+    def __init__(self):
+        self.closed = False
+        self.mountpoint = "/tmp/fake-fuse"
+        self.created.append(self)
+
+    def setup(self, *_args, **_kwargs):
+        type(self).setup_calls += 1
+        if type(self).setup_calls == 2:
+            raise RuntimeError("fuse failed")
+
+    def close(self):
+        self.closed = True
 
 
 class TestFuseManager:
@@ -102,3 +123,36 @@ class TestFuseManager:
 
         assert not generated.exists()
         assert fm.mountpoint is None
+
+    def test_setup_keeps_caller_mountpoint_when_mount_startup_fails(
+            self, monkeypatch, tmp_path):
+        # Regression: caller-owned mountpoints must survive even when setup
+        # fails before FUSE is usable.
+        fake_mount = types.ModuleType("mirage.fuse.mount")
+        fake_mount.mount_background = _fail_mount_startup
+        monkeypatch.setitem(sys.modules, "mirage.fuse.mount", fake_mount)
+
+        fm = FuseManager()
+        with pytest.raises(RuntimeError, match="fuse failed"):
+            fm.setup(object(), mountpoint=str(tmp_path))
+
+        assert tmp_path.exists()
+        assert fm.mountpoint is None
+
+    def test_workspace_closes_prior_fuse_managers_when_later_setup_fails(
+            self, monkeypatch):
+        # Regression: Workspace.__init__ may raise now that setup failures are
+        # visible, so already-mounted prefixes need constructor-local cleanup.
+        _TrackingFuseManager.created = []
+        _TrackingFuseManager.setup_calls = 0
+        monkeypatch.setattr(workspace_module, "FuseManager",
+                            _TrackingFuseManager)
+
+        with pytest.raises(RuntimeError, match="fuse failed"):
+            workspace_module.Workspace({"/data": RAMResource()},
+                                       fuse_mounts={
+                                           "/one": True,
+                                           "/two": True,
+                                       })
+
+        assert _TrackingFuseManager.created[1].closed is True

--- a/python/tests/workspace/test_fuse.py
+++ b/python/tests/workspace/test_fuse.py
@@ -13,11 +13,17 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import subprocess
+import sys
 import tempfile
+import types
 
 import pytest
 
 from mirage.workspace.fuse import FuseManager
+
+
+def _fail_mount_startup(*_args, **_kwargs):
+    raise RuntimeError("fuse failed")
 
 
 class TestFuseManager:
@@ -73,6 +79,26 @@ class TestFuseManager:
         fm = FuseManager()
         fm.setup(object())
         fm.close()
+
+        assert not generated.exists()
+        assert fm.mountpoint is None
+
+    def test_setup_cleans_generated_mountpoint_when_mount_startup_fails(
+            self, monkeypatch, tmp_path):
+        # Regression: if FUSE never starts, Mirage still owns the generated
+        # temp mountpoint and should leave no stale manager state behind.
+        generated = tmp_path / "mirage-generated"
+        generated.mkdir()
+
+        fake_mount = types.ModuleType("mirage.fuse.mount")
+        fake_mount.mount_background = _fail_mount_startup
+        monkeypatch.setitem(sys.modules, "mirage.fuse.mount", fake_mount)
+        monkeypatch.setattr(tempfile, "mkdtemp",
+                            lambda *_args, **_kwargs: str(generated))
+
+        fm = FuseManager()
+        with pytest.raises(RuntimeError, match="fuse failed"):
+            fm.setup(object())
 
         assert not generated.exists()
         assert fm.mountpoint is None


### PR DESCRIPTION
## Summary

- propagate immediate Python FUSE worker startup failures back to the caller
- clean Mirage-owned generated mountpoints when startup fails
- add regression coverage for worker-thread startup errors and manager cleanup

## Tests

- `uv run pytest tests/fuse/test_mount.py tests/workspace/test_fuse.py`
- `./python/.venv/bin/pre-commit run --files python/mirage/fuse/mount.py python/mirage/workspace/fuse.py python/tests/fuse/test_mount.py python/tests/workspace/test_fuse.py`

