### PR TITLE
build(deps): bump pypdf 6.13.2 -> 6.13.3 (fix uv audit)

### DIFF
--- a/python/uv.lock
+++ b/python/uv.lock
@@ -8999,11 +8999,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.13.2"
+version = "6.13.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/0a/48fe05c6bb3aa4bb4d2a4079a383d33c0dfec1edf613a642f07d8b8b5c2e/pypdf-6.13.2.tar.gz", hash = "sha256:5a96a17dbdfbf9c2ab24c0a13fa0aba182be22ba6f283098712c16fc242f509f", size = 6479250, upload-time = "2026-06-10T16:42:34.5Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/18/9947cc201af9ccf76720fd3347bf4f70eb882ce3fcf4cb05f7443e4cf871/pypdf-6.13.3.tar.gz", hash = "sha256:f3cb822769725f1bac658c406cfc9460399043f3750c2d3e4650e0a85eacabd7", size = 6484063, upload-time = "2026-06-17T15:22:00.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/17/378943705992f74e451a06de3401ce68e3213763c81e44d0614559c45599/pypdf-6.13.2-py3-none-any.whl", hash = "sha256:6eeb9e57693f29d41bd01255d02660cbbb41fd7fc818a982677389a35e4f2083", size = 346555, upload-time = "2026-06-10T16:42:32.37Z" },
+    { url = "https://files.pythonhosted.org/packages/94/56/2967e621598987905fb8cdfadd8f8de6b5c68c9351f0523c4df8409f28f1/pypdf-6.13.3-py3-none-any.whl", hash = "sha256:c6e3f86afb625791510b02ad5480e94b63970bb957df75d44657c282ecc52224", size = 347288, upload-time = "2026-06-17T15:21:59.512Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bump `pypdf` 6.13.2 → 6.13.3 in `python/uv.lock`.

## Why

The `uv audit` CI step (`test_python.yml`) fails on:

```
pypdf 6.13.2 has 1 known vulnerability:
- GHSA-jm82-fx9c-mx94: Missing stream length values ignore defined limits
  Fixed in: 6.13.3
```

`pypdf` is a transitive dependency of the optional `openhands` extra:

```
mirage-ai[openhands] -> openhands-tools -> browser-use -> pypdf
```

`browser-use` declares `pypdf` with no version specifier, so this is a lockfile-only bump — no `pyproject.toml` change. Core Mirage and clients not installing `[openhands]` are unaffected.

