### PR TITLE
fix: remove unsupported OneDrive ls argument

### DIFF
--- a/python/mirage/commands/builtin/onedrive/ls.py
+++ b/python/mirage/commands/builtin/onedrive/ls.py
@@ -76,5 +76,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/tests/commands/builtin/onedrive/test_ls.py
+++ b/python/tests/commands/builtin/onedrive/test_ls.py
@@ -1,0 +1,35 @@
+import pytest
+from pydantic import SecretStr
+
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.cache.index.config import IndexEntry
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.commands.builtin.onedrive.ls import ls
+from mirage.io.types import materialize
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def accessor():
+    return OneDriveAccessor(
+        OneDriveConfig(access_token=SecretStr("test-token")))
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+@pytest.mark.asyncio
+async def test_ls_lists_cached_onedrive_entries(accessor, index):
+    await index.set_dir(
+        "/",
+        [("file.txt",
+          IndexEntry(id="file-id", name="file.txt", resource_type="file"))],
+    )
+
+    stdout, io = await ls(accessor, [PathSpec(original="/", directory="/")],
+                          index=index)
+
+    assert await materialize(stdout) == b"file.txt\n"
+    assert io.exit_code == 0


### PR DESCRIPTION
Summary:
- Remove the unsupported `trailing_newline` keyword from the OneDrive `ls` wrapper when delegating to the generic `ls` implementation.
- Add a cached OneDrive listing regression test that exercises the wrapper without requiring live OneDrive credentials.

Tests:
- RED before fix: `uv run pytest tests/commands/builtin/onedrive/test_ls.py -q` failed with `TypeError: ls() got an unexpected keyword argument 'trailing_newline'`.\n- `uv run pytest tests/commands/builtin/onedrive/test_ls.py tests/commands/builtin/generic/test_ls.py tests/commands/builtin/gdrive/test_provision.py --no-cov -q`\n- `uv run python -c "import mirage.commands.builtin.onedrive.ls"`\n- `./python/.venv/bin/pre-commit run --files python/mirage/commands/builtin/onedrive/ls.py python/tests/commands/builtin/onedrive/test_ls.py`\n- `uv run pytest --no-cov --ignore tests/fuse --ignore tests/workspace/test_fuse.py` -> 7709 passed, 316 skipped, 2 warnings.\n- Full `uv run pytest --no-cov` is blocked locally by missing `libfuse` while collecting FUSE tests.\n\nFixes #350\n\nAI assistance was used under my direction.