### PR TITLE
fix(onedrive): repair ls, uniq, and recorded write-key bugs; add command test suite

### DIFF
--- a/python/mirage/commands/builtin/onedrive/cp.py
+++ b/python/mirage/commands/builtin/onedrive/cp.py
@@ -69,4 +69,4 @@ async def cp(
     output = None
     if v:
         output = f"{paths[0].original} -> {paths[1].original}\n".encode()
-    return output, IOResult(writes={paths[1].original: b""})
+    return output, IOResult(writes={paths[1].strip_prefix: b""})

--- a/python/mirage/commands/builtin/onedrive/grep.py
+++ b/python/mirage/commands/builtin/onedrive/grep.py
@@ -49,60 +49,20 @@ async def grep(
     paths: list[PathSpec],
     *texts: str,
     stdin: AsyncIterator[bytes] | bytes | None = None,
-    r: bool = False,
-    R: bool = False,
-    i: bool = False,
-    v: bool = False,
-    n: bool = False,
-    c: bool = False,
-    args_l: bool = False,
-    w: bool = False,
-    F: bool = False,
-    E: bool = False,
-    o: bool = False,
-    m: str | None = None,
-    q: bool = False,
-    H: bool = False,
-    args_h: bool = False,
-    A: str | None = None,
-    B: str | None = None,
-    C: str | None = None,
-    e: str | None = None,
     prefix: str = "",
     index: IndexCacheStore = None,
-    **_extra: object,
+    **flags: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if e is not None:
-        pattern = e
-    elif texts:
-        pattern = texts[0]
-    else:
-        raise ValueError("grep: usage: grep [flags] pattern [path]")
-    max_count = int(m) if m is not None else None
-    after_ctx = int(A) if A is not None else (int(C) if C is not None else 0)
-    before_ctx = int(B) if B is not None else (int(C) if C is not None else 0)
     resolved = await resolve_glob(accessor, paths, index) if paths else []
     return await generic_grep(
         resolved,
-        pattern=pattern,
+        texts,
+        flags,
         readdir=_readdir,
         stat=_stat,
         read_bytes=_read_bytes,
         read_stream=_read_stream,
         accessor=accessor,
         stdin=stdin,
-        ignore_case=i,
-        invert=v,
-        line_numbers=n,
-        count_only=c,
-        files_only=args_l,
-        whole_word=w,
-        fixed_string=F,
-        only_matching=o,
-        quiet=q,
-        recursive=r or R,
-        max_count=max_count,
-        after_context=after_ctx,
-        before_context=before_ctx,
         index=index,
     )

--- a/python/mirage/commands/builtin/onedrive/ls.py
+++ b/python/mirage/commands/builtin/onedrive/ls.py
@@ -76,5 +76,4 @@ async def ls(
         list_dir=d,
         classify=F,
         index=index,
-        trailing_newline=True,
     )

--- a/python/mirage/commands/builtin/onedrive/mkdir.py
+++ b/python/mirage/commands/builtin/onedrive/mkdir.py
@@ -40,7 +40,7 @@ async def mkdir(
     writes: dict[str, bytes] = {}
     for path in paths:
         await mkdir_impl(accessor, path)
-        writes[path.original] = b""
+        writes[path.strip_prefix] = b""
         if v:
             lines.append(f"mkdir: created directory '{path.original}'")
     output = ("\n".join(lines) + "\n").encode() if lines else None

--- a/python/mirage/commands/builtin/onedrive/mv.py
+++ b/python/mirage/commands/builtin/onedrive/mv.py
@@ -50,8 +50,8 @@ async def mv(
         return None, IOResult()
     await rename(accessor, paths[0], paths[1])
     writes = {
-        paths[0].original: b"",
-        paths[1].original: b"",
+        paths[0].strip_prefix: b"",
+        paths[1].strip_prefix: b"",
     }
     output = None
     if v:

--- a/python/mirage/commands/builtin/onedrive/rg.py
+++ b/python/mirage/commands/builtin/onedrive/rg.py
@@ -46,58 +46,21 @@ async def rg(
     paths: list[PathSpec],
     *texts: str,
     stdin: AsyncIterator[bytes] | bytes | None = None,
-    i: bool = False,
-    v: bool = False,
-    n: bool = False,
-    c: bool = False,
-    args_l: bool = False,
-    w: bool = False,
-    F: bool = False,
-    o: bool = False,
-    m: str | None = None,
-    A: str | None = None,
-    B: str | None = None,
-    C: str | None = None,
-    hidden: bool = False,
-    type: str | None = None,
-    glob: str | None = None,
     prefix: str = "",
     index: IndexCacheStore = None,
-    **_extra: object,
+    **flags: object,
 ) -> tuple[ByteSource | None, IOResult]:
-    if not texts:
-        raise ValueError("rg: usage: rg [flags] pattern [path]")
-    pattern = texts[0]
-    max_count = int(m) if m is not None else None
-    context_after = int(A) if A is not None else 0
-    context_before = int(B) if B is not None else 0
-    if C is not None:
-        context_before = context_after = int(C)
-
     resolved = await resolve_glob(accessor, paths, index) if paths else []
 
     return await generic_rg(
         resolved,
-        pattern=pattern,
+        texts,
+        flags,
         readdir=_readdir,
         stat=_stat,
         read_bytes=_read_bytes,
         read_stream=_read_stream,
         accessor=accessor,
         stdin=stdin,
-        ignore_case=i,
-        invert=v,
-        line_numbers=n,
-        count_only=c,
-        files_only=args_l,
-        whole_word=w,
-        fixed_string=F,
-        only_matching=o,
-        max_count=max_count,
-        context_before=context_before,
-        context_after=context_after,
-        hidden=hidden,
-        file_type=type,
-        glob_pattern=glob,
         index=index,
     )

--- a/python/mirage/commands/builtin/onedrive/touch.py
+++ b/python/mirage/commands/builtin/onedrive/touch.py
@@ -44,5 +44,5 @@ async def touch(
             continue
         if not await exists(accessor, p):
             await write_bytes(accessor, p, b"")
-            writes[p.original] = b""
+            writes[p.strip_prefix] = b""
     return None, IOResult(writes=writes)

--- a/python/mirage/commands/builtin/onedrive/uniq.py
+++ b/python/mirage/commands/builtin/onedrive/uniq.py
@@ -53,8 +53,8 @@ async def uniq(
         count=c,
         duplicates_only=d,
         unique_only=u,
-        skip_fields=int(f) if f else 0,
-        skip_chars=int(s) if s else 0,
+        skip_fields=f,
+        skip_chars=s,
         ignore_case=i,
-        check_chars=int(w) if w else None,
+        check_chars=w,
     )

--- a/python/mirage/commands/builtin/onedrive/uniq.py
+++ b/python/mirage/commands/builtin/onedrive/uniq.py
@@ -56,5 +56,5 @@ async def uniq(
         skip_fields=int(f) if f else 0,
         skip_chars=int(s) if s else 0,
         ignore_case=i,
-        check_chars=int(w) if w else 0,
+        check_chars=int(w) if w else None,
     )

--- a/python/tests/commands/builtin/onedrive/conftest.py
+++ b/python/tests/commands/builtin/onedrive/conftest.py
@@ -1,0 +1,306 @@
+import fnmatch
+import importlib
+import posixpath
+from collections.abc import AsyncIterator
+
+import pytest
+
+import mirage.resource.onedrive.onedrive as resource_mod
+from mirage import MountMode, Workspace
+from mirage.accessor.onedrive import OneDriveConfig
+from mirage.commands.builtin.find_eval import FindEntry, keep
+from mirage.resource.onedrive import OneDriveResource
+from mirage.types import FileStat, FileType, PathSpec
+from mirage.utils.filetype import guess_type
+
+TEXT_FIXTURE_FILES = {
+    "/words.txt": b"beta\nalpha\nalpha\n",
+    "/more.txt": b"delta\n",
+    "/table.csv": b"name,score\nann,2\nbob,3\n",
+    "/table_extra.csv": b"name,score\ncam,5\n",
+    "/data.json": b'{"name": "mirage"}\n',
+    "/data2.json": b'{"name": "agent"}\n',
+    "/events.jsonl": b'{"name": "first"}\n',
+    "/events_extra.jsonl": b'{"name": "second"}\n',
+    "/old.txt": b"same\nold\n",
+    "/new.txt": b"same\nnew\n",
+}
+
+PATCH_MODULES = (
+    "awk",
+    "cat",
+    "cp",
+    "cut",
+    "diff",
+    "find",
+    "grep",
+    "head",
+    "jq",
+    "ls",
+    "mkdir",
+    "mv",
+    "nl",
+    "rg",
+    "rm",
+    "sort",
+    "stat",
+    "tail",
+    "touch",
+    "tr",
+    "tree",
+    "uniq",
+    "wc",
+)
+
+
+class FakeOneDriveStore:
+
+    def __init__(self) -> None:
+        self.files: dict[str, bytes] = {}
+        self.dirs: set[str] = {"/"}
+
+    def seed_dir(self, path: str) -> None:
+        key = self.key(path)
+        current = ""
+        for part in key.strip("/").split("/"):
+            if not part:
+                continue
+            current = current + "/" + part
+            self.dirs.add(current)
+
+    def seed_file(self, path: str, data: bytes) -> None:
+        key = self.key(path)
+        self.seed_dir(posixpath.dirname(key) or "/")
+        self.files[key] = data
+
+    def key(self, path: PathSpec | str) -> str:
+        raw = path.original if isinstance(path, PathSpec) else str(path)
+        prefix = path.prefix if isinstance(path, PathSpec) else ""
+        if prefix and raw.startswith(prefix):
+            rest = raw[len(prefix):]
+            if prefix.endswith("/") or rest == "" or rest.startswith("/"):
+                raw = rest or "/"
+        if raw == "/onedrive":
+            raw = "/"
+        elif raw.startswith("/onedrive/"):
+            raw = raw[len("/onedrive"):]
+        raw = "/" + raw.strip("/")
+        return raw if raw != "/" else "/"
+
+    def prefixed(self, key: str, prefix: str) -> str:
+        key = self.key(key)
+        if not prefix:
+            return key
+        return prefix.rstrip("/") + ("" if key == "/" else key)
+
+    async def resolve_glob(self, accessor, paths, index):
+        resolved: list[PathSpec] = []
+        for path in paths:
+            if path.resolved or not path.pattern:
+                resolved.append(path)
+                continue
+            parent = self.key(path.dir)
+            for child in self.children(parent):
+                name = child.rsplit("/", 1)[-1]
+                if fnmatch.fnmatch(name, path.pattern):
+                    resolved.append(
+                        PathSpec.from_str_path(
+                            self.prefixed(child, path.prefix), path.prefix))
+        return resolved
+
+    def children(self, path: PathSpec | str) -> list[str]:
+        parent = self.key(path).rstrip("/") or "/"
+        if parent not in self.dirs:
+            if parent in self.files:
+                raise NotADirectoryError(parent)
+            raise FileNotFoundError(parent)
+        entries = set()
+        for dirname in self.dirs:
+            if dirname == parent:
+                continue
+            if posixpath.dirname(dirname) == parent:
+                entries.add(dirname)
+        for filename in self.files:
+            if posixpath.dirname(filename) == parent:
+                entries.add(filename)
+        return sorted(entries)
+
+    async def readdir(self, accessor, path, index=None) -> list[str]:
+        prefix = path.prefix if isinstance(path, PathSpec) else ""
+        return [self.prefixed(child, prefix) for child in self.children(path)]
+
+    async def stat(self, accessor, path, index=None) -> FileStat:
+        key = self.key(path)
+        if key in self.dirs:
+            name = key.rsplit("/", 1)[-1] or "/"
+            return FileStat(name=name, type=FileType.DIRECTORY)
+        if key in self.files:
+            name = key.rsplit("/", 1)[-1]
+            return FileStat(name=name,
+                            size=len(self.files[key]),
+                            type=guess_type(name))
+        raise FileNotFoundError(key)
+
+    async def read_bytes(self,
+                         accessor,
+                         path,
+                         index=None,
+                         *args,
+                         **kwargs) -> bytes:
+        key = self.key(path)
+        if key not in self.files:
+            raise FileNotFoundError(key)
+        return self.files[key]
+
+    async def read_stream(self,
+                          accessor,
+                          path,
+                          index=None,
+                          *args,
+                          **kwargs) -> AsyncIterator[bytes]:
+        yield await self.read_bytes(accessor, path, index, *args, **kwargs)
+
+    async def write_bytes(self, accessor, path, data: bytes) -> None:
+        self.seed_file(self.key(path), data)
+
+    async def exists(self, accessor, path) -> bool:
+        key = self.key(path)
+        return key in self.files or key in self.dirs
+
+    async def mkdir(self, accessor, path) -> None:
+        self.seed_dir(self.key(path))
+
+    async def copy(self, accessor, src, dst) -> None:
+        src_key = self.key(src)
+        dst_key = self.key(dst)
+        if src_key in self.files:
+            self.seed_file(dst_key, self.files[src_key])
+            return
+        if src_key not in self.dirs:
+            raise FileNotFoundError(src_key)
+        self.seed_dir(dst_key)
+        for key, data in list(self.files.items()):
+            if key.startswith(src_key.rstrip("/") + "/"):
+                suffix = key[len(src_key.rstrip("/")):]
+                self.seed_file(dst_key.rstrip("/") + suffix, data)
+
+    async def rename(self, accessor, src, dst) -> None:
+        await self.copy(accessor, src, dst)
+        await self.rm_r(accessor, src)
+
+    async def unlink(self, accessor, path) -> None:
+        key = self.key(path)
+        if key not in self.files:
+            raise FileNotFoundError(key)
+        del self.files[key]
+
+    async def rmdir(self, accessor, path) -> None:
+        key = self.key(path)
+        if self.children(key):
+            raise OSError(f"directory not empty: {key}")
+        self.dirs.remove(key)
+
+    async def rm_r(self, accessor, path) -> None:
+        key = self.key(path).rstrip("/") or "/"
+        for filename in list(self.files):
+            if filename == key or filename.startswith(key + "/"):
+                del self.files[filename]
+        for dirname in sorted(self.dirs, key=len, reverse=True):
+            if dirname != "/" and (dirname == key
+                                   or dirname.startswith(key + "/")):
+                self.dirs.remove(dirname)
+
+    async def find(self,
+                   accessor,
+                   path,
+                   name=None,
+                   type=None,
+                   maxdepth=None,
+                   mindepth=None,
+                   tree=None,
+                   **kwargs) -> list[str]:
+        base = self.key(path).rstrip("/") or "/"
+        results: list[str] = []
+        for key in sorted(self.dirs | set(self.files)):
+            if key == "/":
+                continue
+            if base != "/" and key != base and not key.startswith(base + "/"):
+                continue
+            rel = key[len(base):].strip("/") if base != "/" else key.strip("/")
+            depth = 0 if key == base else rel.count("/") + 1
+            if maxdepth is not None and depth > maxdepth:
+                continue
+            if mindepth is not None and depth < mindepth:
+                continue
+            is_dir = key in self.dirs
+            if type == "f" and is_dir:
+                continue
+            if type == "d" and not is_dir:
+                continue
+            if name and not fnmatch.fnmatch(key.rsplit("/", 1)[-1], name):
+                continue
+            if tree is not None:
+                entry = FindEntry(key=key,
+                                  name=key.rsplit("/", 1)[-1],
+                                  kind="d" if is_dir else "f",
+                                  depth=depth)
+                if not keep(entry, tree, mindepth):
+                    continue
+            results.append(key)
+        return results
+
+
+def patch_attr(monkeypatch, module, name: str, value) -> None:
+    if hasattr(module, name):
+        monkeypatch.setattr(module, name, value)
+
+
+def patch_module(monkeypatch, store: FakeOneDriveStore, name: str) -> None:
+    module = importlib.import_module(
+        f"mirage.commands.builtin.onedrive.{name}")
+    patch_attr(monkeypatch, module, "resolve_glob", store.resolve_glob)
+    patch_attr(monkeypatch, module, "readdir", store.readdir)
+    patch_attr(monkeypatch, module, "_readdir", store.readdir)
+    patch_attr(monkeypatch, module, "stat", store.stat)
+    patch_attr(monkeypatch, module, "_stat", store.stat)
+    patch_attr(monkeypatch, module, "stat_core", store.stat)
+    patch_attr(monkeypatch, module, "stat_impl", store.stat)
+    patch_attr(monkeypatch, module, "read_bytes", store.read_bytes)
+    patch_attr(monkeypatch, module, "_read_bytes", store.read_bytes)
+    patch_attr(monkeypatch, module, "read_stream", store.read_stream)
+    patch_attr(monkeypatch, module, "_read_stream", store.read_stream)
+    patch_attr(monkeypatch, module, "write_bytes", store.write_bytes)
+    patch_attr(monkeypatch, module, "mkdir_impl", store.mkdir)
+    patch_attr(monkeypatch, module, "copy", store.copy)
+    patch_attr(monkeypatch, module, "rename", store.rename)
+    patch_attr(monkeypatch, module, "unlink", store.unlink)
+    patch_attr(monkeypatch, module, "rmdir", store.rmdir)
+    patch_attr(monkeypatch, module, "rm_r", store.rm_r)
+    patch_attr(monkeypatch, module, "exists", store.exists)
+    patch_attr(monkeypatch, module, "find_impl", store.find)
+
+
+@pytest.fixture
+def onedrive_files(monkeypatch) -> FakeOneDriveStore:
+    store = FakeOneDriveStore()
+    for path, data in TEXT_FIXTURE_FILES.items():
+        store.seed_file(path, data)
+    store.seed_file("/.hidden", b"hidden\n")
+    store.seed_dir("/sub")
+    store.seed_file("/sub/inner.txt", b"gamma\nalpha\n")
+    for name in PATCH_MODULES:
+        patch_module(monkeypatch, store, name)
+    monkeypatch.setattr(resource_mod, "_resolve_glob", store.resolve_glob)
+    return store
+
+
+@pytest.fixture
+def onedrive_read_ws(onedrive_files) -> Workspace:
+    resource = OneDriveResource(OneDriveConfig(access_token="tok"))
+    return Workspace({"/onedrive/": resource}, mode=MountMode.READ)
+
+
+@pytest.fixture
+def onedrive_write_ws(onedrive_files) -> Workspace:
+    resource = OneDriveResource(OneDriveConfig(access_token="tok"))
+    return Workspace({"/onedrive/": resource}, mode=MountMode.WRITE)

--- a/python/tests/commands/builtin/onedrive/conftest.py
+++ b/python/tests/commands/builtin/onedrive/conftest.py
@@ -52,6 +52,28 @@ PATCH_MODULES = (
     "wc",
 )
 
+IO_HELPERS = frozenset({
+    "readdir",
+    "_readdir",
+    "stat",
+    "_stat",
+    "stat_core",
+    "stat_impl",
+    "read_bytes",
+    "_read_bytes",
+    "read_stream",
+    "_read_stream",
+    "write_bytes",
+    "mkdir_impl",
+    "copy",
+    "rename",
+    "unlink",
+    "rmdir",
+    "rm_r",
+    "exists",
+    "find_impl",
+})
+
 
 class FakeOneDriveStore:
 
@@ -250,34 +272,47 @@ class FakeOneDriveStore:
         return results
 
 
-def patch_attr(monkeypatch, module, name: str, value) -> None:
+def patch_attr(monkeypatch, module, name: str, value) -> bool:
     if hasattr(module, name):
         monkeypatch.setattr(module, name, value)
+        return True
+    return False
 
 
 def patch_module(monkeypatch, store: FakeOneDriveStore, name: str) -> None:
     module = importlib.import_module(
         f"mirage.commands.builtin.onedrive.{name}")
-    patch_attr(monkeypatch, module, "resolve_glob", store.resolve_glob)
-    patch_attr(monkeypatch, module, "readdir", store.readdir)
-    patch_attr(monkeypatch, module, "_readdir", store.readdir)
-    patch_attr(monkeypatch, module, "stat", store.stat)
-    patch_attr(monkeypatch, module, "_stat", store.stat)
-    patch_attr(monkeypatch, module, "stat_core", store.stat)
-    patch_attr(monkeypatch, module, "stat_impl", store.stat)
-    patch_attr(monkeypatch, module, "read_bytes", store.read_bytes)
-    patch_attr(monkeypatch, module, "_read_bytes", store.read_bytes)
-    patch_attr(monkeypatch, module, "read_stream", store.read_stream)
-    patch_attr(monkeypatch, module, "_read_stream", store.read_stream)
-    patch_attr(monkeypatch, module, "write_bytes", store.write_bytes)
-    patch_attr(monkeypatch, module, "mkdir_impl", store.mkdir)
-    patch_attr(monkeypatch, module, "copy", store.copy)
-    patch_attr(monkeypatch, module, "rename", store.rename)
-    patch_attr(monkeypatch, module, "unlink", store.unlink)
-    patch_attr(monkeypatch, module, "rmdir", store.rmdir)
-    patch_attr(monkeypatch, module, "rm_r", store.rm_r)
-    patch_attr(monkeypatch, module, "exists", store.exists)
-    patch_attr(monkeypatch, module, "find_impl", store.find)
+    targets = {
+        "resolve_glob": store.resolve_glob,
+        "readdir": store.readdir,
+        "_readdir": store.readdir,
+        "stat": store.stat,
+        "_stat": store.stat,
+        "stat_core": store.stat,
+        "stat_impl": store.stat,
+        "read_bytes": store.read_bytes,
+        "_read_bytes": store.read_bytes,
+        "read_stream": store.read_stream,
+        "_read_stream": store.read_stream,
+        "write_bytes": store.write_bytes,
+        "mkdir_impl": store.mkdir,
+        "copy": store.copy,
+        "rename": store.rename,
+        "unlink": store.unlink,
+        "rmdir": store.rmdir,
+        "rm_r": store.rm_r,
+        "exists": store.exists,
+        "find_impl": store.find,
+    }
+    patched = {
+        attr
+        for attr, value in targets.items()
+        if patch_attr(monkeypatch, module, attr, value)
+    }
+    assert patched & IO_HELPERS, (
+        f"onedrive.{name}: no known I/O helper was patched; the fake store is "
+        "not installed, so the test may reach the real OneDrive accessor. "
+        "Update IO_HELPERS/targets to match the module's imported helpers.")
 
 
 @pytest.fixture

--- a/python/tests/commands/builtin/onedrive/test_ls.py
+++ b/python/tests/commands/builtin/onedrive/test_ls.py
@@ -1,37 +1,45 @@
-from importlib import import_module
-
 import pytest
-
-from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
-from mirage.io.types import materialize
-from mirage.types import FileStat, FileType, PathSpec
-
-ls_mod = import_module("mirage.commands.builtin.onedrive.ls")
-
-
-def _accessor() -> OneDriveAccessor:
-    return OneDriveAccessor(OneDriveConfig(access_token="tok"))
-
-
-async def _resolve_paths(accessor, paths, index):
-    return paths
-
-
-async def _readdir(accessor, path, index):
-    return ["/Docs"]
-
-
-async def _stat(accessor, path, index):
-    return FileStat(name="Docs", type=FileType.DIRECTORY)
 
 
 @pytest.mark.asyncio
-async def test_ls_delegates_to_generic_without_extra_keywords(monkeypatch):
-    monkeypatch.setattr(ls_mod, "resolve_glob", _resolve_paths)
-    monkeypatch.setattr(ls_mod, "readdir", _readdir)
-    monkeypatch.setattr(ls_mod, "stat", _stat)
+async def test_ls_lists_entries(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("ls /onedrive/")
 
-    stdout, io = await ls_mod.ls(_accessor(), [PathSpec.from_str_path("/")])
-
-    assert await materialize(stdout) == b"Docs\n"
     assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "words.txt" in out
+    assert "sub" in out
+    assert ".hidden" not in out
+
+
+@pytest.mark.asyncio
+async def test_ls_a_includes_hidden(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("ls -a /onedrive/")
+
+    assert io.exit_code == 0
+    assert ".hidden" in io.stdout.decode()
+
+
+@pytest.mark.asyncio
+async def test_ls_long_includes_size(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("ls -l /onedrive/")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "words.txt" in out
+    assert "17" in out
+
+
+@pytest.mark.asyncio
+async def test_ls_recursive_descends_subdirs(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("ls -R /onedrive/")
+
+    assert io.exit_code == 0
+    assert "inner.txt" in io.stdout.decode()
+
+
+@pytest.mark.asyncio
+async def test_ls_missing_path_warns(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("ls /onedrive/missing")
+
+    assert io.exit_code != 0

--- a/python/tests/commands/builtin/onedrive/test_ls.py
+++ b/python/tests/commands/builtin/onedrive/test_ls.py
@@ -1,0 +1,37 @@
+from importlib import import_module
+
+import pytest
+
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.io.types import materialize
+from mirage.types import FileStat, FileType, PathSpec
+
+ls_mod = import_module("mirage.commands.builtin.onedrive.ls")
+
+
+def _accessor() -> OneDriveAccessor:
+    return OneDriveAccessor(OneDriveConfig(access_token="tok"))
+
+
+async def _resolve_paths(accessor, paths, index):
+    return paths
+
+
+async def _readdir(accessor, path, index):
+    return ["/Docs"]
+
+
+async def _stat(accessor, path, index):
+    return FileStat(name="Docs", type=FileType.DIRECTORY)
+
+
+@pytest.mark.asyncio
+async def test_ls_delegates_to_generic_without_extra_keywords(monkeypatch):
+    monkeypatch.setattr(ls_mod, "resolve_glob", _resolve_paths)
+    monkeypatch.setattr(ls_mod, "readdir", _readdir)
+    monkeypatch.setattr(ls_mod, "stat", _stat)
+
+    stdout, io = await ls_mod.ls(_accessor(), [PathSpec.from_str_path("/")])
+
+    assert await materialize(stdout) == b"Docs\n"
+    assert io.exit_code == 0

--- a/python/tests/commands/builtin/onedrive/test_ls.py
+++ b/python/tests/commands/builtin/onedrive/test_ls.py
@@ -26,8 +26,9 @@ async def test_ls_long_includes_size(onedrive_read_ws):
 
     assert io.exit_code == 0
     out = io.stdout.decode()
-    assert "words.txt" in out
-    assert "17" in out
+    words_rows = [line for line in out.splitlines() if "words.txt" in line]
+    assert words_rows, "words.txt row missing from ls -l output"
+    assert "17" in words_rows[0]
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/builtin/onedrive/test_metadata_commands.py
+++ b/python/tests/commands/builtin/onedrive/test_metadata_commands.py
@@ -1,0 +1,32 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_stat_reports_file_metadata(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("stat /onedrive/words.txt")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "words.txt" in out
+    assert "17" in out
+
+
+@pytest.mark.asyncio
+async def test_tree_renders_nested_entries(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("tree /onedrive/")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "words.txt" in out
+    assert "inner.txt" in out
+
+
+@pytest.mark.asyncio
+async def test_find_filters_by_name(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("find /onedrive/ -name '*.json'")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "/onedrive/data.json" in out
+    assert "/onedrive/data2.json" in out
+    assert "words.txt" not in out

--- a/python/tests/commands/builtin/onedrive/test_metadata_commands.py
+++ b/python/tests/commands/builtin/onedrive/test_metadata_commands.py
@@ -7,8 +7,8 @@ async def test_stat_reports_file_metadata(onedrive_read_ws):
 
     assert io.exit_code == 0
     out = io.stdout.decode()
-    assert "words.txt" in out
-    assert "17" in out
+    assert "name=words.txt" in out
+    assert "size=17" in out
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/builtin/onedrive/test_read_commands.py
+++ b/python/tests/commands/builtin/onedrive/test_read_commands.py
@@ -1,0 +1,60 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_cat_reads_single_file_and_records_mount_relative_read(
+        onedrive_read_ws):
+    io = await onedrive_read_ws.execute("cat /onedrive/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"beta\nalpha\nalpha\n"
+    assert "/onedrive/words.txt" in io.reads
+    assert "/onedrive/onedrive/words.txt" not in io.reads
+
+
+@pytest.mark.asyncio
+async def test_cat_reads_multiple_globbed_files(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("cat /onedrive/data*.json")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert '"mirage"' in out
+    assert '"agent"' in out
+
+
+@pytest.mark.asyncio
+async def test_head_and_tail_stream_file_content(onedrive_read_ws):
+    head = await onedrive_read_ws.execute("head -n 1 /onedrive/words.txt")
+    tail = await onedrive_read_ws.execute("tail -n 1 /onedrive/words.txt")
+
+    assert head.exit_code == 0
+    assert tail.exit_code == 0
+    assert head.stdout == b"beta\n"
+    assert tail.stdout == b"alpha\n"
+
+
+@pytest.mark.asyncio
+async def test_wc_counts_multiple_files(onedrive_read_ws):
+    io = await onedrive_read_ws.execute(
+        "wc /onedrive/words.txt /onedrive/more.txt")
+
+    assert io.exit_code == 0
+    out = io.stdout.decode()
+    assert "/onedrive/words.txt" in out
+    assert "/onedrive/more.txt" in out
+    assert "total" in out
+
+
+@pytest.mark.asyncio
+async def test_grep_searches_globbed_files(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("grep mirage /onedrive/*.json")
+
+    assert io.exit_code == 0
+    assert '"mirage"' in io.stdout.decode()
+
+
+@pytest.mark.asyncio
+async def test_rg_reports_no_match_exit_code(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("rg absent /onedrive/*.txt")
+
+    assert io.exit_code != 0

--- a/python/tests/commands/builtin/onedrive/test_registration.py
+++ b/python/tests/commands/builtin/onedrive/test_registration.py
@@ -1,0 +1,48 @@
+from mirage.commands.builtin.onedrive import COMMANDS
+
+READ_ONLY_COMMANDS = {
+    "cat",
+    "find",
+    "grep",
+    "head",
+    "jq",
+    "ls",
+    "rg",
+    "sort",
+    "stat",
+    "tail",
+    "tree",
+    "wc",
+}
+
+WRITE_COMMANDS = {
+    "cp",
+    "mkdir",
+    "mv",
+    "rm",
+    "touch",
+}
+
+
+def registered_onedrive_commands():
+    return [
+        registered for command in COMMANDS
+        for registered in command._registered_commands
+    ]
+
+
+def test_core_onedrive_commands_registered():
+    registered = registered_onedrive_commands()
+    names = {command.name for command in registered}
+
+    assert READ_ONLY_COMMANDS <= names
+    assert WRITE_COMMANDS <= names
+
+
+def test_onedrive_command_resources_and_write_flags():
+    for command in registered_onedrive_commands():
+        assert command.resource == "onedrive"
+        if command.name in WRITE_COMMANDS:
+            assert command.write
+        if command.name in READ_ONLY_COMMANDS:
+            assert not command.write

--- a/python/tests/commands/builtin/onedrive/test_text_commands.py
+++ b/python/tests/commands/builtin/onedrive/test_text_commands.py
@@ -1,0 +1,41 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_sort_orders_file_lines(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("sort /onedrive/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"alpha\nalpha\nbeta\n"
+
+
+@pytest.mark.asyncio
+async def test_cut_extracts_csv_field(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("cut -d, -f1 /onedrive/table.csv")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"name\nann\nbob\n"
+
+
+@pytest.mark.asyncio
+async def test_tr_translates_streamed_file(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("tr a A /onedrive/more.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"deltA\n"
+
+
+@pytest.mark.asyncio
+async def test_uniq_collapses_adjacent_lines(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("uniq /onedrive/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"beta\nalpha\n"
+
+
+@pytest.mark.asyncio
+async def test_jq_reads_json_file(onedrive_read_ws):
+    io = await onedrive_read_ws.execute("jq .name /onedrive/data.json")
+
+    assert io.exit_code == 0
+    assert "mirage" in io.stdout.decode()

--- a/python/tests/commands/builtin/onedrive/test_write_commands.py
+++ b/python/tests/commands/builtin/onedrive/test_write_commands.py
@@ -1,0 +1,83 @@
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cp /onedrive/words.txt /onedrive/copy.txt",
+        "mv /onedrive/words.txt /onedrive/moved.txt",
+        "rm /onedrive/words.txt",
+        "mkdir /onedrive/newdir",
+        "touch /onedrive/created.txt",
+    ],
+)
+async def test_write_commands_rejected_on_read_mount(onedrive_read_ws,
+                                                     onedrive_files, command):
+    io = await onedrive_read_ws.execute(command)
+
+    assert io.exit_code != 0
+    assert b"read-only" in io.stderr
+    assert "/copy.txt" not in onedrive_files.files
+    assert "/moved.txt" not in onedrive_files.files
+    assert "/created.txt" not in onedrive_files.files
+    assert "/newdir" not in onedrive_files.dirs
+    assert "/words.txt" in onedrive_files.files
+
+
+@pytest.mark.asyncio
+async def test_cp_copies_file_and_reports_mount_relative_write(
+        onedrive_write_ws, onedrive_files):
+    io = await onedrive_write_ws.execute(
+        "cp /onedrive/words.txt /onedrive/copy.txt")
+
+    assert io.exit_code == 0
+    assert onedrive_files.files["/copy.txt"] == b"beta\nalpha\nalpha\n"
+    assert "/onedrive/copy.txt" in io.writes
+    assert "/onedrive/onedrive/copy.txt" not in io.writes
+
+
+@pytest.mark.asyncio
+async def test_mv_moves_file(onedrive_write_ws, onedrive_files):
+    io = await onedrive_write_ws.execute(
+        "mv /onedrive/words.txt /onedrive/moved.txt")
+
+    assert io.exit_code == 0
+    assert "/words.txt" not in onedrive_files.files
+    assert onedrive_files.files["/moved.txt"] == b"beta\nalpha\nalpha\n"
+
+
+@pytest.mark.asyncio
+async def test_rm_recursive_removes_directory_tree(onedrive_write_ws,
+                                                   onedrive_files):
+    io = await onedrive_write_ws.execute("rm -r /onedrive/sub")
+
+    assert io.exit_code == 0
+    assert "/sub" not in onedrive_files.dirs
+    assert "/sub/inner.txt" not in onedrive_files.files
+    assert "/onedrive/sub" in io.writes
+
+
+@pytest.mark.asyncio
+async def test_plain_rm_on_directory_fails(onedrive_write_ws, onedrive_files):
+    io = await onedrive_write_ws.execute("rm /onedrive/sub")
+
+    assert io.exit_code != 0
+    assert "/sub" in onedrive_files.dirs
+    assert "/sub/inner.txt" in onedrive_files.files
+
+
+@pytest.mark.asyncio
+async def test_mkdir_creates_directory(onedrive_write_ws, onedrive_files):
+    io = await onedrive_write_ws.execute("mkdir /onedrive/newdir")
+
+    assert io.exit_code == 0
+    assert "/newdir" in onedrive_files.dirs
+
+
+@pytest.mark.asyncio
+async def test_touch_creates_missing_file(onedrive_write_ws, onedrive_files):
+    io = await onedrive_write_ws.execute("touch /onedrive/created.txt")
+
+    assert io.exit_code == 0
+    assert onedrive_files.files["/created.txt"] == b""

--- a/python/tests/commands/builtin/onedrive/test_write_commands.py
+++ b/python/tests/commands/builtin/onedrive/test_write_commands.py
@@ -45,6 +45,8 @@ async def test_mv_moves_file(onedrive_write_ws, onedrive_files):
     assert io.exit_code == 0
     assert "/words.txt" not in onedrive_files.files
     assert onedrive_files.files["/moved.txt"] == b"beta\nalpha\nalpha\n"
+    assert "/onedrive/moved.txt" in io.writes
+    assert "/onedrive/onedrive/moved.txt" not in io.writes
 
 
 @pytest.mark.asyncio
@@ -73,6 +75,8 @@ async def test_mkdir_creates_directory(onedrive_write_ws, onedrive_files):
 
     assert io.exit_code == 0
     assert "/newdir" in onedrive_files.dirs
+    assert "/onedrive/newdir" in io.writes
+    assert "/onedrive/onedrive/newdir" not in io.writes
 
 
 @pytest.mark.asyncio
@@ -81,3 +85,5 @@ async def test_touch_creates_missing_file(onedrive_write_ws, onedrive_files):
 
     assert io.exit_code == 0
     assert onedrive_files.files["/created.txt"] == b""
+    assert "/onedrive/created.txt" in io.writes
+    assert "/onedrive/onedrive/created.txt" not in io.writes


### PR DESCRIPTION
Fixes #350. Supersedes #353.

While fixing the `ls` crash from #350, an audit of the OneDrive command wrappers turned up three more correctness/parity bugs in the same area. This PR fixes all of them and adds the missing OneDrive command test suite that would have caught them.

#353 is a narrower fix for the same crash (removes the `trailing_newline` arg + one `ls` test); this PR includes that same fix plus the additional bugs below and a full command suite, so #353 can be closed in favor of this one.

### Fixes

- **`ls` crashes with `TypeError` (#350).** The wrapper passed `trailing_newline=True`, which `generic_ls` does not accept. Removed; no other backend passes it.
- **`uniq -w` default collapsed all output.** The wrapper passed `check_chars=int(w) if w else 0`. With `-w` absent it sent `0`, and the generic truncates each comparison key to `[:0]`, so every line compared equal and `uniq` emitted a single line. Now forwards raw `w`, so the generic's `_parse_count` yields `None` (no truncation).
- **Recorded write keys were double-prefixed.** `cp`/`mkdir`/`mv`/`touch` recorded `IOResult(writes=...)` under `path.original` (already mount-prefixed), producing doubled `/onedrive/onedrive/...` keys after the workspace re-prefix layer. Switched to mount-relative `path.strip_prefix`, matching `rm` and the s3/ram backends.

### Parity cleanup

- **`grep`/`rg`/`uniq` reduced to flag pass-through.** The wrappers pre-parsed and forwarded ~15 explicit kwargs; they now forward raw `texts` + the opaque `flags` bag and let the generics own parsing, per the "wrappers are wiring, generics own flags" convention and the disk/s3 wrappers. This also restores spec validation (a mistyped flag now raises instead of silently reading as `False`/`None`).

### Tests

New fake-store-backed OneDrive command suite (`conftest.py` plus read/write/text/metadata/ls/registration tests). Write-command tests assert mount-relative `io.writes` keys and the absence of the doubled prefix; size assertions are anchored to the target row/token. The conftest fails loudly if a command module's I/O fakes are not installed, guarding against a silent fall-through to the real (network) accessor on a future helper rename.

### Verification

All 32 OneDrive command tests pass.
