### PR TITLE
fix: databricks_volume stat reads content_length/last_modified

### DIFF
--- a/python/mirage/core/databricks_volume/stat.py
+++ b/python/mirage/core/databricks_volume/stat.py
@@ -14,6 +14,7 @@
 
 import asyncio
 from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
@@ -25,14 +26,22 @@ from mirage.utils.filetype import guess_type
 
 
 def _modified(value) -> str | None:
-    if value is None:
+    if value is None or value == "":
         return None
     if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
         return value.astimezone(timezone.utc).isoformat()
     if isinstance(value, (int, float)):
         timestamp = value / 1000 if value > 10_000_000_000 else value
         return datetime.fromtimestamp(timestamp, timezone.utc).isoformat()
-    return str(value)
+    try:
+        parsed = parsedate_to_datetime(str(value))
+    except (TypeError, ValueError):
+        return str(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).isoformat()
 
 
 def _is_directory(metadata) -> bool:
@@ -86,8 +95,8 @@ async def stat(
     name = _name_from_backend_path(remote_path)
     if _is_directory(metadata):
         return FileStat(name=name, type=FileType.DIRECTORY)
-    size = getattr(metadata, "file_size", None)
-    modified = _modified(getattr(metadata, "modification_time", None))
+    size = getattr(metadata, "content_length", None)
+    modified = _modified(getattr(metadata, "last_modified", None))
     return FileStat(name=name,
                     size=size,
                     modified=modified,

--- a/python/tests/core/databricks_volume/conftest.py
+++ b/python/tests/core/databricks_volume/conftest.py
@@ -243,11 +243,11 @@ def index() -> RAMIndexCacheStore:
     return RAMIndexCacheStore(ttl=600)
 
 
-def file_metadata(size: int = 0, modified: int | None = None) -> object:
+def file_metadata(size: int = 0, modified: str | None = None) -> object:
     return SimpleNamespace(
-        is_directory=False,
-        file_size=size,
-        modification_time=modified,
+        content_length=size,
+        content_type=None,
+        last_modified=modified,
     )
 
 

--- a/python/tests/core/databricks_volume/test_stat.py
+++ b/python/tests/core/databricks_volume/test_stat.py
@@ -1,11 +1,41 @@
 import asyncio
+from datetime import datetime, timezone
 
 import pytest
 
-from mirage.core.databricks_volume.stat import _name_from_backend_path, stat
+from mirage.core.databricks_volume.stat import (_modified,
+                                                _name_from_backend_path, stat)
 from mirage.types import FileType, PathSpec
 
 from .conftest import ToThreadRecorder, file_metadata
+
+
+def test_modified_none_and_empty_string_return_none():
+    assert _modified(None) is None
+    assert _modified("") is None
+
+
+def test_modified_parses_http_date_to_iso_utc():
+    assert _modified(
+        "Tue, 14 Nov 2023 22:13:20 GMT") == "2023-11-14T22:13:20+00:00"
+
+
+def test_modified_returns_unparseable_string_verbatim():
+    assert _modified("not a date") == "not a date"
+
+
+def test_modified_coerces_naive_datetime_to_utc():
+    naive = datetime(2023, 11, 14, 22, 13, 20)
+    assert _modified(naive) == "2023-11-14T22:13:20+00:00"
+
+
+def test_modified_converts_aware_datetime_to_utc():
+    aware = datetime(2023, 11, 14, 22, 13, 20, tzinfo=timezone.utc)
+    assert _modified(aware) == "2023-11-14T22:13:20+00:00"
+
+
+def test_modified_treats_large_int_as_epoch_milliseconds():
+    assert _modified(1_700_000_000_000) == "2023-11-14T22:13:20+00:00"
 
 
 def test_name_from_backend_path_file():
@@ -22,7 +52,7 @@ def test_name_from_backend_path_directory_with_trailing_slash():
 async def test_stat_file(accessor, files, remote_root):
     files.metadata[f"{remote_root}/reports/latest.md"] = file_metadata(
         size=6,
-        modified=1_700_000_000_000,
+        modified="Tue, 14 Nov 2023 22:13:20 GMT",
     )
     path = PathSpec.from_str_path("/volume/reports/latest.md", "/volume")
     result = await stat(accessor, path)

--- a/python/tests/core/databricks_volume/test_write_ops.py
+++ b/python/tests/core/databricks_volume/test_write_ops.py
@@ -37,8 +37,7 @@ def _seed_file(files, path: str, data: bytes) -> None:
         "Metadata",
         (),
         {
-            "is_directory": False,
-            "file_size": len(data),
+            "content_length": len(data),
         },
     )()
     files.directories.setdefault(parent, [])
@@ -73,7 +72,7 @@ async def test_write_overwrites_existing_file(accessor, files, remote_root,
     await write_bytes(accessor, _path("/dbx/new.txt"), b"new", index)
 
     assert files.downloads[f"{remote_root}/new.txt"] == b"new"
-    assert files.metadata[f"{remote_root}/new.txt"].file_size == 3
+    assert files.metadata[f"{remote_root}/new.txt"].content_length == 3
 
 
 @pytest.mark.asyncio

--- a/python/tests/resource/databricks_volume/test_databricks_volume.py
+++ b/python/tests/resource/databricks_volume/test_databricks_volume.py
@@ -110,8 +110,9 @@ class FakeFiles:
             raise IsADirectoryError(path)
         self.downloads[path] = data
         self.metadata[path] = SimpleNamespace(
-            is_directory=False,
-            file_size=len(data),
+            content_length=len(data),
+            content_type=None,
+            last_modified=None,
         )
         self._upsert_directory_entry(
             parent,
@@ -220,8 +221,9 @@ def seed_file(files: FakeFiles, path: str, data: bytes) -> None:
     parent = path.rsplit("/", 1)[0]
     files.downloads[path] = data
     files.metadata[path] = SimpleNamespace(
-        is_directory=False,
-        file_size=len(data),
+        content_length=len(data),
+        content_type=None,
+        last_modified=None,
     )
     files.directories.setdefault(parent, [])
     files.directories[parent].append(
@@ -308,9 +310,9 @@ async def test_read_stat_readdir_range_stream_and_exists():
     root = "/Volumes/main/default/agent_files/root"
     files.downloads[f"{root}/reports/latest.md"] = b"abcdef"
     files.metadata[f"{root}/reports/latest.md"] = SimpleNamespace(
-        is_directory=False,
-        file_size=6,
-        modification_time=1_700_000_000_000,
+        content_length=6,
+        content_type=None,
+        last_modified="Tue, 14 Nov 2023 22:13:20 GMT",
     )
     files.metadata[f"{root}/reports"] = SimpleNamespace(is_directory=True)
     files.directories[f"{root}/reports"] = [
@@ -339,6 +341,7 @@ async def test_read_stat_readdir_range_stream_and_exists():
         PathSpec.from_str_path("/volume/reports/latest.md", "/volume"))
     assert file_stat.name == "latest.md"
     assert file_stat.size == 6
+    assert file_stat.modified == "2023-11-14T22:13:20+00:00"
     assert await resource.exists(
         PathSpec.from_str_path("/volume/reports/latest.md", "/volume"))
     assert not await resource.exists(
@@ -356,8 +359,9 @@ async def test_workspace_read_mode_uses_registered_ops():
     root = "/Volumes/main/default/agent_files/root"
     files.downloads[f"{root}/latest.md"] = b"hello"
     files.metadata[f"{root}/latest.md"] = SimpleNamespace(
-        is_directory=False,
-        file_size=5,
+        content_length=5,
+        content_type=None,
+        last_modified=None,
     )
     ws = Workspace({"/volume": make_resource(files)}, mode=MountMode.READ)
 
@@ -555,8 +559,9 @@ async def test_workspace_execute_uses_databricks_volume_mount_for_ls():
     root = "/Volumes/main/default/agent_files/root"
     files.directory_metadata.add(root)
     files.metadata[f"{root}/debug_output.json"] = SimpleNamespace(
-        is_directory=False,
-        file_size=18,
+        content_length=18,
+        content_type=None,
+        last_modified=None,
     )
     files.directories[root] = [
         SimpleNamespace(
@@ -589,8 +594,9 @@ async def test_workspace_execute_databricks_volume_stat_and_cat():
     root = "/Volumes/main/default/agent_files/root"
     files.downloads[f"{root}/debug_output.json"] = b'{"ok": true}\nsecond\n'
     files.metadata[f"{root}/debug_output.json"] = SimpleNamespace(
-        is_directory=False,
-        file_size=20,
+        content_length=20,
+        content_type=None,
+        last_modified=None,
     )
     ws = Workspace({"/dbx/": make_resource(files)}, mode=MountMode.READ)
 
@@ -613,12 +619,14 @@ async def test_workspace_execute_databricks_volume_find_files():
     files.directory_metadata.update({root, f"{root}/nested"})
     files.metadata[f"{root}/nested"] = SimpleNamespace(is_directory=True)
     files.metadata[f"{root}/debug_output.json"] = SimpleNamespace(
-        is_directory=False,
-        file_size=2,
+        content_length=2,
+        content_type=None,
+        last_modified=None,
     )
     files.metadata[f"{root}/nested/result.txt"] = SimpleNamespace(
-        is_directory=False,
-        file_size=2,
+        content_length=2,
+        content_type=None,
+        last_modified=None,
     )
     files.directories[root] = [
         SimpleNamespace(
@@ -657,12 +665,14 @@ async def test_workspace_execute_databricks_volume_recursive_grep_and_rg():
     files.metadata[f"{root}/nested/deeper"] = SimpleNamespace(
         is_directory=True)
     files.metadata[f"{root}/nested/info.txt"] = SimpleNamespace(
-        is_directory=False,
-        file_size=17,
+        content_length=17,
+        content_type=None,
+        last_modified=None,
     )
     files.metadata[f"{root}/nested/deeper/notes.md"] = SimpleNamespace(
-        is_directory=False,
-        file_size=26,
+        content_length=26,
+        content_type=None,
+        last_modified=None,
     )
     files.downloads[f"{root}/nested/info.txt"] = b"alpha debug line\n"
     files.downloads[f"{root}/nested/deeper/notes.md"] = (


### PR DESCRIPTION
## Problem

`databricks_volume` `stat` read `file_size` and `modification_time` off the Databricks SDK's `GetMetadataResponse`. That type has neither field — it exposes `content_length` (int) and `last_modified` (an RFC 7231 HTTP-date string). Both reads returned `None`, so `ls -l` (which calls `stat` per entry) rendered size `0` and an epoch date for every file.

Those names belong to two unrelated SDK types: DBFS `FileInfo` (`file_size`/`modification_time`) and the listing `DirectoryEntry` (`file_size`/`last_modified` as epoch-ms). The Files API `get_metadata` returns `GetMetadataResponse`.

## Fix

- `core/databricks_volume/stat.py`: read `content_length` and `last_modified`.
- `_modified` parses the RFC 7231 HTTP-date into ISO-8601 UTC (the `ls` long-format renderer needs `fromisoformat`, so an unparsed HTTP-date would still have shown the epoch). Naive datetimes and epoch-ms ints normalize to UTC too; unparseable values pass through verbatim.

This brings Python to parity with the TypeScript core, which already reads the `content-length`/`last-modified` headers and converts the date.

`readdir`'s use of `file_size`/`last_modified` is left unchanged — correct for the `DirectoryEntry` listing API.

## Tests

- Realigned both `databricks_volume` test fakes and seed helpers to the real `GetMetadataResponse` shape (`content_length`/`last_modified`). They had mirrored the buggy attribute names, which is why the bug went uncaught. `DirectoryEntry` listing fakes keep `file_size`.
- Added direct `_modified` branch coverage (HTTP-date, unparseable string, empty/None, naive/aware datetime, epoch-ms int) and a resource-level mtime assertion.

## Verification

- `databricks_volume` suites (core + commands + resource): pass.