### PR TITLE
fix(databricks): record mount-relative write keys in touch and mkdir

### DIFF
--- a/typescript/packages/core/src/commands/builtin/databricks_volume/commands.test.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/commands.test.ts
@@ -48,7 +48,7 @@ async function run(
   paths: PathSpec[],
   texts: string[] = [],
   flags: Record<string, string | boolean | string[]> = {},
-): Promise<{ stdout: string; exitCode: number }> {
+): Promise<{ stdout: string; exitCode: number; writes: string[] }> {
   const cmd = cmdOf(name)
   const result = await cmd.fn(makeAccessor(), paths, texts, {
     stdin: null,
@@ -57,7 +57,7 @@ async function run(
     cwd: '/',
     resource: null as unknown as Resource,
   })
-  if (result === null) return { stdout: '', exitCode: 0 }
+  if (result === null) return { stdout: '', exitCode: 0, writes: [] }
   const [out, io] = result
   let stdout = ''
   if (out !== null) {
@@ -65,7 +65,7 @@ async function run(
       out instanceof Uint8Array ? out : await materialize(out as AsyncIterable<Uint8Array>)
     stdout = DEC.decode(buf)
   }
-  return { stdout, exitCode: io.exitCode }
+  return { stdout, exitCode: io.exitCode, writes: Object.keys(io.writes) }
 }
 
 describe('databricks_volume commands registry', () => {
@@ -153,6 +153,32 @@ describe('grep', () => {
     const { stdout, exitCode } = await run('grep', [pathOf('/volume/notes.md')], ['TODO'])
     expect(exitCode).toBe(0)
     expect(stdout.trim()).toBe('TODO: beta')
+  })
+})
+
+describe('touch', () => {
+  it('records mount-relative write keys, not the mount-prefixed path', async () => {
+    const { fetch } = routedFetch((call: FetchCall) => {
+      if (call.method === 'HEAD' && call.url.includes('a.txt')) return notFoundResponse()
+      if (call.method === 'HEAD') return new Response(null, { status: 200 })
+      return new Response(null, { status: 204 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const { writes } = await run('touch', [pathOf('/volume/a.txt')])
+    expect(writes).toEqual(['/a.txt'])
+  })
+})
+
+describe('mkdir', () => {
+  it('records mount-relative write keys, not the mount-prefixed path', async () => {
+    const { fetch } = routedFetch((call: FetchCall) => {
+      if (call.method === 'PUT') return new Response(null, { status: 200 })
+      if (call.url.includes('newdir')) return notFoundResponse()
+      return new Response(null, { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetch)
+    const { writes } = await run('mkdir', [pathOf('/volume/newdir')])
+    expect(writes).toEqual(['/newdir'])
   })
 })
 

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/mkdir.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/mkdir.ts
@@ -37,7 +37,7 @@ async function mkdirCommand(
   const writes: Record<string, Uint8Array> = {}
   for (const path of resolved) {
     await dbxMkdir(accessor, path)
-    writes[path.original] = new Uint8Array()
+    writes[path.stripPrefix] = new Uint8Array()
     if (verbose) lines.push(`mkdir: created directory '${path.original}'`)
   }
   const output: ByteSource | null = lines.length > 0 ? ENC.encode(lines.join('\n') + '\n') : null

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/touch.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/touch.ts
@@ -39,7 +39,7 @@ async function touchCommand(
     if (createOnly) continue
     if (!(await dbxExists(accessor, p))) {
       await dbxWrite(accessor, p, new Uint8Array(0))
-      writes[p.original] = new Uint8Array()
+      writes[p.stripPrefix] = new Uint8Array()
     }
   }
   return [null, new IOResult({ writes })]


### PR DESCRIPTION
Mirrors the recorded-write-key fix from #354 (OneDrive, Python) on the TS side.

The TS workspace re-prefixes every command's `IOResult.writes` keys with the mount prefix (`prefixKeys` in `workspace/executor/command.ts`), so commands must return **mount-relative** keys. Two `databricks_volume` wrappers keyed writes on `path.original` (already mount-prefixed), producing doubled keys like `/databricks/databricks/...`. The sibling `rm.ts` and the generics already use `.stripPrefix`.

### Fix
- `databricks_volume/touch.ts`: `p.original` -> `p.stripPrefix`
- `databricks_volume/mkdir.ts`: `path.original` -> `path.stripPrefix` (the verbose `created directory '...'` message keeps `.original`, correct for display)

### Tests
Added `touch`/`mkdir` cases to `commands.test.ts` asserting mount-relative `io.writes` keys (`/a.txt`, `/newdir`). Verified they fail on the old code (`/volume/...`) and pass on the fix. All 75 databricks_volume tests pass.

### Scope
This was the only `.original` write key anywhere in the TS tree; all other backends were already correct. Python databricks already uses `strip_prefix`. The other three #354 bugs are OneDrive-wrapper-specific and have no TS counterpart (no OneDrive backend in TS).