### PR TITLE
fix(security): resolve code-scanning alerts (path-injection, request-forgery)

### DIFF
--- a/examples/typescript/discord/discord_browser/server.ts
+++ b/examples/typescript/discord/discord_browser/server.ts
@@ -28,6 +28,14 @@ const PREFIX = '/api/discord/'
 const HOST = '127.0.0.1'
 const PORT = 8902
 const UPSTREAM_ORIGIN = 'https://discord.com'
+const SAFE_SEGMENT = /^[A-Za-z0-9._-]+$/
+
+function isSafeEndpoint(endpoint: string): boolean {
+  if (endpoint === '') return false
+  return endpoint
+    .split('/')
+    .every((seg) => seg !== '.' && seg !== '..' && SAFE_SEGMENT.test(seg))
+}
 
 async function readBody(req: IncomingMessage): Promise<Buffer> {
   const chunks: Buffer[] = []
@@ -46,14 +54,14 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
     return
   }
   const endpoint = url.pathname.slice(PREFIX.length)
-  const upstream = new URL(`${UPSTREAM_ORIGIN}/api/v10/${endpoint}`)
-  upstream.search = url.search
-  if (upstream.origin !== UPSTREAM_ORIGIN) {
+  if (!isSafeEndpoint(endpoint)) {
     res.statusCode = 400
     res.setHeader('content-type', 'application/json')
-    res.end(JSON.stringify({ error: 'upstream host not allowed' }))
+    res.end(JSON.stringify({ error: 'invalid discord api endpoint' }))
     return
   }
+  const upstream = new URL(`/api/v10/${endpoint}`, UPSTREAM_ORIGIN)
+  upstream.search = url.search
 
   const method = (req.method ?? 'GET').toUpperCase()
   const headers: Record<string, string> = {

--- a/examples/typescript/slack/slack_browser/server.ts
+++ b/examples/typescript/slack/slack_browser/server.ts
@@ -28,6 +28,14 @@ const PREFIX = '/api/slack/'
 const HOST = '127.0.0.1'
 const PORT = 8901
 const UPSTREAM_ORIGIN = 'https://slack.com'
+const SAFE_SEGMENT = /^[A-Za-z0-9._-]+$/
+
+function isSafeEndpoint(endpoint: string): boolean {
+  if (endpoint === '') return false
+  return endpoint
+    .split('/')
+    .every((seg) => seg !== '.' && seg !== '..' && SAFE_SEGMENT.test(seg))
+}
 
 async function readBody(req: IncomingMessage): Promise<Buffer> {
   const chunks: Buffer[] = []
@@ -46,14 +54,14 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
     return
   }
   const endpoint = url.pathname.slice(PREFIX.length)
-  const upstream = new URL(`${UPSTREAM_ORIGIN}/api/${endpoint}`)
-  upstream.search = url.search
-  if (upstream.origin !== UPSTREAM_ORIGIN) {
+  if (!isSafeEndpoint(endpoint)) {
     res.statusCode = 400
     res.setHeader('content-type', 'application/json')
-    res.end(JSON.stringify({ error: 'upstream host not allowed' }))
+    res.end(JSON.stringify({ error: 'invalid slack api endpoint' }))
     return
   }
+  const upstream = new URL(`/api/${endpoint}`, UPSTREAM_ORIGIN)
+  upstream.search = url.search
 
   const method = (req.method ?? 'GET').toUpperCase()
   const headers: Record<string, string> = {

--- a/python/mirage/server/paths.py
+++ b/python/mirage/server/paths.py
@@ -36,8 +36,7 @@ def resolve_within_root(root: str | Path, user_path: str) -> Path:
     """
     resolved_root = os.path.realpath(str(root))
     resolved = os.path.realpath(os.path.join(resolved_root, user_path))
-    if resolved != resolved_root and not resolved.startswith(resolved_root +
-                                                             os.sep):
+    if os.path.commonpath([resolved_root, resolved]) != resolved_root:
         raise PathOutsideRootError(
             f"path escapes the configured root: {user_path}")
     return Path(resolved)


### PR DESCRIPTION
Resolves the 4 open CodeQL code-scanning alerts. Each is defensively coded already; the fixes restructure the guards into forms CodeQL recognizes as sanitizers (and add real defense-in-depth).

## py/path-injection (#14, #15) - `mirage/server/paths.py`

`resolve_within_root()` already does `os.path.realpath` + a containment check, but CodeQL did not recognize the compound `!= ... and not startswith(...)` guard across the function return. Replaced it with `os.path.commonpath([root, resolved]) != root`, the canonical recognized path-containment barrier. Behavior is identical (root itself, traversal, absolute-outside, and sibling-prefix cases all preserved). The 2 sinks (`target.parent.mkdir`, `target.stat`) flow through this guard.

## js/request-forgery (#173, #174) - Slack/Discord browser proxy examples

The proxies interpolated the user path into a full URL string (`new URL(\`${ORIGIN}/api/${endpoint}\`)`) and re-checked `origin`, which CodeQL flagged because it could not prove the host was constant. Now:

- The endpoint is validated against an allowlist (`^[A-Za-z0-9._-]+$` per `/`-segment, rejecting empty/`.`/`..`), and
- The URL is built from the constant origin as the base: `new URL(\`/api/${endpoint}\`, UPSTREAM_ORIGIN)`, so the request host is provably the literal origin and cannot be influenced by user input.

Verified the host stays pinned and traversal / `//host` / `@host` / percent-encoded inputs are all rejected.

## Verification

- Python: `tests/server/test_paths.py` + `test_workspaces_router.py` - 28 passed.
- TS examples: `tsc --noEmit` clean; additions match the files' existing style.
- pre-commit (Python hooks) clean.

CodeQL re-scans on this PR; the alerts should clear once it runs.