### PR TITLE
feat: Add a Qdrant resource (py + ts)

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -124,6 +124,7 @@ jobs:
           - { extra: langfuse, module: mirage.resource.langfuse }
           - { extra: chroma, module: mirage.resource.chroma }
           - { extra: lancedb, module: mirage.resource.lancedb }
+          - { extra: qdrant, module: mirage.resource.qdrant }
           - { extra: databricks, module: mirage.resource.databricks_volume }
           - { extra: pydantic-ai, module: mirage.agents.pydantic_ai }
           - { extra: openai, module: mirage.agents.openai_agents }

--- a/.github/workflows/test_integ.yml
+++ b/.github/workflows/test_integ.yml
@@ -70,6 +70,13 @@ jobs:
               - 'python/mirage/core/chroma/**'
               - 'python/mirage/commands/builtin/chroma/**'
               - 'python/mirage/resource/chroma/**'
+              - 'integ/qdrant.py'
+              - 'integ/qdrant.ts'
+              - 'integ/truth_qdrant.txt'
+              - 'python/mirage/accessor/qdrant.py'
+              - 'python/mirage/core/qdrant/**'
+              - 'python/mirage/commands/builtin/qdrant/**'
+              - 'python/mirage/resource/qdrant/**'
               - 'typescript/**'
               - '.github/workflows/test_integ.yml'
             data:
@@ -355,6 +362,10 @@ jobs:
         image: chromadb/chroma:latest
         ports:
           - 8000:8000
+      qdrant:
+        image: qdrant/qdrant:latest
+        ports:
+          - 6333:6333
     env:
       MONGODB_URI: mongodb://localhost:27017/?replicaSet=rs0
       POSTGRES_DSN: postgres://mirage:mirage@localhost:5432/mirage_integ
@@ -382,6 +393,15 @@ jobs:
             sleep 1
           done
           echo "ChromaDB did not become healthy" >&2
+          exit 1
+
+      - name: Wait for Qdrant
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:6333/readyz && exit 0
+            sleep 1
+          done
+          echo "Qdrant did not become healthy" >&2
           exit 1
 
       - name: Start MongoDB replica set
@@ -418,6 +438,11 @@ jobs:
           ./python/.venv/bin/python integ/chroma.py > /tmp/chroma.out
           diff integ/truth_chroma.txt /tmp/chroma.out
 
+      - name: Run qdrant integ and diff against truth
+        run: |
+          ./python/.venv/bin/python integ/qdrant.py > /tmp/qdrant.out
+          diff integ/truth_qdrant.txt /tmp/qdrant.out
+
   integ-database-ts:
     needs: changes
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.database == 'true') }}
@@ -440,6 +465,10 @@ jobs:
         image: chromadb/chroma:latest
         ports:
           - 8000:8000
+      qdrant:
+        image: qdrant/qdrant:latest
+        ports:
+          - 6333:6333
     env:
       MONGODB_URI: mongodb://localhost:27017/?replicaSet=rs0
       POSTGRES_DSN: postgres://mirage:mirage@localhost:5432/mirage_integ
@@ -492,6 +521,15 @@ jobs:
             sleep 1
           done
 
+      - name: Wait for Qdrant
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:6333/readyz && exit 0
+            sleep 1
+          done
+          echo "Qdrant did not become healthy" >&2
+          exit 1
+
       - name: Run MongoDB backend (TS) and check against truth
         shell: bash
         working-directory: integ
@@ -513,6 +551,12 @@ jobs:
         run: |
           pnpm exec tsx chroma.ts > /tmp/ts-chroma.out
           diff truth_chroma.txt /tmp/ts-chroma.out
+
+      - name: Run TS qdrant integ and diff against truth
+        working-directory: integ
+        run: |
+          pnpm exec tsx qdrant.ts > /tmp/ts-qdrant.out
+          diff truth_qdrant.txt /tmp/ts-qdrant.out
 
   integ-data:
     needs: changes

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ await ws.execute('cat /s3/events/2026-05-06.parquet | jq .user')
 ## About
 
 - **One interface instead of N SDKs and M MCPs.** Every service speaks the same filesystem semantics, and pipelines compose across services as naturally as on a local disk.
-- **Around 50 built-in backends:** RAM, Disk, Redis, S3 / R2 / OCI / Supabase / GCS, Gmail / GDrive / GDocs / GSheets / GSlides, GitHub / Linear / Notion / Trello, Slack / Discord / Telegram / Email, MongoDB / Postgres / LanceDB, SSH, and more, mounted side-by-side under a single root.
+- **Around 50 built-in backends:** RAM, Disk, Redis, S3 / R2 / OCI / Supabase / GCS, Gmail / GDrive / GDocs / GSheets / GSlides, GitHub / Linear / Notion / Trello, Slack / Discord / Telegram / Email, MongoDB / Postgres / LanceDB / Qdrant, SSH, and more, mounted side-by-side under a single root.
 - **Portable workspaces:** clone, snapshot, and version a workspace; agent runs move between machines without restarting or reconfiguring the system.
 - **Embeddable:** the Python and TypeScript SDKs run in-process inside FastAPI, Express, browser apps, or any async runtime; no separate process required.
 - **Agent integrations:** OpenAI Agents SDK, Vercel AI SDK, LangChain, Pydantic AI, CAMEL, and OpenHands via the SDKs; coding agents like Claude Code and Codex via the lightweight CLI + daemon.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -177,7 +177,8 @@
                   "home/setup/mongodb",
                   "home/setup/postgres",
                   "home/setup/chroma",
-                  "home/setup/lancedb"
+                  "home/setup/lancedb",
+                  "home/setup/qdrant"
                 ]
               },
               {
@@ -331,7 +332,8 @@
                   "python/resource/mongodb",
                   "python/resource/postgres",
                   "python/resource/chroma",
-                  "python/resource/lancedb"
+                  "python/resource/lancedb",
+                  "python/resource/qdrant"
                 ]
               },
               {
@@ -482,7 +484,8 @@
                   "typescript/setup/mongodb",
                   "typescript/setup/postgres",
                   "typescript/setup/chroma",
-                  "typescript/setup/lancedb"
+                  "typescript/setup/lancedb",
+                  "typescript/setup/qdrant"
                 ]
               },
               {

--- a/docs/home/architecture.mdx
+++ b/docs/home/architecture.mdx
@@ -25,7 +25,7 @@ The **Mirage Dispatcher** routes each operation to the mount that owns the path,
 
 ## 4. Infrastructure and Remote
 
-Whatever you mount: RAM, Disk, Redis, S3 / R2 / GCS / OCI / Supabase, Gmail / GDrive / GDocs / GSheets / GSlides, GitHub / Linear / Notion / Trello, Slack / Discord / Email, MongoDB / Postgres / LanceDB, SSH, and more. Each speaks the same filesystem semantics from the agent's point of view.
+Whatever you mount: RAM, Disk, Redis, S3 / R2 / GCS / OCI / Supabase, Gmail / GDrive / GDocs / GSheets / GSlides, GitHub / Linear / Notion / Trello, Slack / Discord / Email, MongoDB / Postgres / LanceDB / Qdrant, SSH, and more. Each speaks the same filesystem semantics from the agent's point of view.
 
 Browse the [Resource Matrix](/home/resource-matrix) for the full list.
 

--- a/docs/home/resource-matrix.mdx
+++ b/docs/home/resource-matrix.mdx
@@ -91,6 +91,7 @@ No external setup, these run locally or against a connection string you already 
 | MongoDB | read | [MongoDB](/home/setup/mongodb) | [<Icon icon="python" />](/python/resource/mongodb) [<Icon icon="node-js" />](/typescript/setup/mongodb) [<Icon icon="globe" />](/typescript/setup/mongodb) | Collection-backed views |
 | Postgres | read | [Postgres](/home/setup/postgres) | [<Icon icon="python" />](/python/resource/postgres) [<Icon icon="node-js" />](/typescript/setup/postgres) [<Icon icon="globe" />](/typescript/setup/postgres) | SQL tables exposed as paths |
 | LanceDB | read | [LanceDB](/home/setup/lancedb) | [<Icon icon="python" />](/python/resource/lancedb) [<Icon icon="node-js" />](/typescript/setup/lancedb) | Label folders + semantic search command |
+| Qdrant | read | [Qdrant](/home/setup/qdrant) | [<Icon icon="python" />](/python/resource/qdrant) [<Icon icon="node-js" />](/typescript/setup/qdrant) [<Icon icon="globe" />](/typescript/setup/qdrant) | Collections as folders + semantic search command |
 
 ## Knowledge
 

--- a/docs/home/setup/qdrant.mdx
+++ b/docs/home/setup/qdrant.mdx
@@ -1,0 +1,60 @@
+---
+title: Qdrant
+icon: database
+description: Set up a Qdrant connection for the Qdrant resource.
+---
+
+[Qdrant](https://qdrant.tech/) mounts a collection as a read-only filesystem: group-by payload fields
+become nested folders, each point is a `.json` payload file (plus a `.txt` text
+file and an optional blob), and semantic search is the `search` command.
+
+## Connection
+
+### Local / self-hosted
+
+Point `host`/`port` at a running Qdrant (defaults `localhost:6333`):
+
+```bash
+# .env.development
+QDRANT_HOST=localhost
+QDRANT_PORT=6333
+```
+
+### Qdrant Cloud
+
+Use `url` plus an `api_key`:
+
+```bash
+# .env.development
+QDRANT_URL=https://xyz.us-east4-0.gcp.cloud.qdrant.io
+QDRANT_API_KEY=...
+```
+
+## Search
+
+Search is the `search "<query>" <path>` command. It returns ranked points as
+their canonical `<id>.txt` (or `<id>.json`) file paths plus a similarity score,
+so results compose with `cat`, `wc`, and pipes (`grep`/`rg` stay lexical).
+
+The query text is turned into a vector two ways:
+
+- **Local (default):** the `qdrant-client[fastembed]` extra embeds the query in
+  process with `embedding_model` (default `sentence-transformers/all-MiniLM-L6-v2`).
+- **Server-side:** set `cloud_inference` to let a Qdrant Cloud (inference-enabled)
+  cluster embed the query. The TypeScript backend always uses this path.
+
+Either way the collection must already store vectors produced by the same model.
+
+## Limits
+
+The resource is read-only and bounds how much an agent can pull:
+
+- `search_limit` (10): default top-k returned by `search`.
+- `max_rows` (1,000): hard ceiling on points listed per folder.
+
+Folder listings filter on payload fields. A filtered listing scrolls first and
+only creates keyword payload indexes for the `group_by` fields if Qdrant reports
+one is required. `max_rows` caps how many points are scanned per folder.
+
+See the [Python](/python/resource/qdrant) and [TypeScript](/typescript/setup/qdrant)
+resource pages for full config.

--- a/docs/python/resource/index.mdx
+++ b/docs/python/resource/index.mdx
@@ -51,6 +51,7 @@ Each page describes a Python-supported resource: what config it needs, what the 
 - [MongoDB](/python/resource/mongodb)
 - [Postgres](/python/resource/postgres)
 - [LanceDB](/python/resource/lancedb)
+- [Qdrant](/python/resource/qdrant)
 
 ## Knowledge
 

--- a/docs/python/resource/qdrant.mdx
+++ b/docs/python/resource/qdrant.mdx
@@ -1,0 +1,130 @@
+---
+title: Qdrant
+description: Mount a Qdrant collection as a Mirage filesystem, with payload folders, multimodal blobs, and a semantic search command for Python agents.
+icon: database
+---
+
+The Qdrant resource exposes a [Qdrant](https://qdrant.tech/) collection as a virtual filesystem mounted
+at some prefix such as `/q/`. Group-by payload fields become nested folders,
+each point becomes a `.json` payload file (plus a `.txt` text file and an optional blob), and semantic search is the
+`search` command, which returns ranked points as canonical file paths.
+
+For connection setup (self-hosted, Qdrant Cloud, search), see
+[Qdrant Setup](/python/setup/qdrant).
+
+## Config
+
+```python
+from mirage import MountMode, Workspace
+from mirage.resource.qdrant import QdrantConfig, QdrantResource
+
+config = QdrantConfig(
+    url="https://xyz.cloud.qdrant.io",
+    api_key="...",
+    collection="fashion",
+    group_by=["gender", "articleType", "baseColour"],
+    id_field="id",
+    text_field="productDisplayName",
+    blob_field="image_b64",
+    blob_ext="jpg",
+    search_limit=5,
+)
+resource = QdrantResource(config)
+ws = Workspace({"/fashion/": resource}, mode=MountMode.READ)
+```
+
+The mapping is config-driven; nothing about the dataset is hardcoded. Point
+`group_by` at different payload fields and the folder tree changes.
+
+## Filesystem layout
+
+Every path is translated into a Qdrant query. Descending a folder adds one
+payload filter; the leaf level lists points.
+
+```text
+/                                  # list collections (omitted when `collection` is pinned)
+/<collection>/                     # distinct group_by[0] values
+  <v1>/                            # distinct group_by[1] where group_by[0]=v1
+    .../<vN>/                      # all group-by fields bound -> point files
+      <id>.json                    # full payload (the metadata)
+      <id>.txt                     # embedded source text (when text_field set)
+      <id>.<ext>                   # raw blob / image bytes (when blob_field set)
+```
+
+`<id>` is the Qdrant point id. When `collection` is set the collection level is
+elided, so the mount root is that collection:
+
+```text
+/fashion/
+  Men/
+    Shoes/
+      White/
+        3.json
+        3.txt
+        3.jpg
+```
+
+### Point files
+
+A point is shown as its underlying data in its original format, never as the
+embedding vector:
+
+- `<id>.txt` is the embedded source text (the `text_field` value), exactly what
+  the vector was built from.
+- `<id>.json` is the full payload as compact JSON (the metadata), with the vector
+  and the raw blob omitted.
+- `<id>.<ext>` is the raw blob bytes when `blob_field` is configured.
+
+```text
+$ cat /fashion/Men/Shoes/White/3.txt
+Nike Men White Running Sneakers
+
+$ cat /fashion/Men/Shoes/White/3.json
+{"gender":"Men","articleType":"Shoes","baseColour":"White","productDisplayName":"Nike Men White Running Sneakers","id":3}
+```
+
+## Semantic search
+
+Search is a command, not a path. It returns each ranked point as its **canonical
+content path** (the `<id>.txt`, or `<id>.json` when no `text_field` is set)
+annotated with the similarity score, followed by the content:
+
+```text
+$ search "white running sneakers" /fashion
+/fashion/Men/Shoes/White/3.txt:0.7421
+Nike Men White Running Sneakers
+```
+
+Flags: `--top-k <n>` (default `search_limit`), `--threshold <min-score>`,
+`--method semantic` (the only supported method; `grep`/`rg` stay lexical).
+
+## Supported commands
+
+All commands delegate to Mirage's shared implementations.
+
+| Command       | Behaviour on a Qdrant mount                                   |
+| ------------- | ------------------------------------------------------------- |
+| `ls`          | list collections, payload folders, or point files            |
+| `cd`          | navigate (each level narrows the filter)                      |
+| `tree`        | render the folder hierarchy                                   |
+| `cat`         | print a point's text/JSON, or dump raw blob/image bytes       |
+| `stat`        | directory vs file, blob size, image mime type                 |
+| `find`        | walk the tree (e.g. `find /fashion -name '*.txt'`)            |
+| `grep` / `rg` | lexical search over the text/JSON files                       |
+| `search`      | semantic (vector) search -> ranked content paths + score      |
+| `head` / `tail` | first/last lines of a file                                  |
+| `wc`          | count lines/bytes of a file                                   |
+
+## Access pattern
+
+The mount is **read-only** (`MountMode.READ`); writes are not supported. The two
+read modes are:
+
+- **Browse** by payload folders: scroll filters on `group_by` fields, no embedding.
+- **Search** by meaning: `search "<query>" <path>` runs vector search and returns
+  canonical point paths.
+
+Folder listings are capped by `max_rows`. A filtered listing scrolls first and
+only creates keyword payload indexes for the `group_by` fields if Qdrant reports
+one is required, so already-indexed collections work under read-only keys. Keep
+`group_by` to low-cardinality fields for large collections.

--- a/docs/python/setup/qdrant.mdx
+++ b/docs/python/setup/qdrant.mdx
@@ -1,0 +1,112 @@
+---
+title: Qdrant
+icon: database
+description: Set up the Qdrant resource in Python, including self-hosted Qdrant and Qdrant Cloud, with local or server-side semantic search.
+---
+
+The Qdrant resource mounts a [Qdrant](https://qdrant.tech/) collection as a filesystem: group-by payload
+fields become folders, points become files, and semantic search is the `search`
+command. See [Qdrant Resource](/python/resource/qdrant) for the full layout and
+command list.
+
+## Dependencies
+
+```bash
+uv add 'mirage-ai[qdrant]'
+```
+
+The `qdrant` extra installs `qdrant-client[fastembed]`. `fastembed` powers
+local, in-process query embedding for the `search` command; filesystem browsing
+(`ls`/`cat`/`find`/`grep`) needs only the base client.
+
+## Connection
+
+The same `QdrantConfig` works for self-hosted and cloud.
+
+### Self-hosted
+
+```python
+from mirage import MountMode, Workspace
+from mirage.resource.qdrant import QdrantConfig, QdrantResource
+
+config = QdrantConfig(
+    host="localhost",
+    port=6333,
+    collection="fashion",
+    group_by=["gender", "articleType", "baseColour"],
+    id_field="id",
+    text_field="productDisplayName",
+    blob_field="image_b64",
+    blob_ext="jpg",
+)
+ws = Workspace({"/fashion/": QdrantResource(config)}, mode=MountMode.READ)
+```
+
+### Qdrant Cloud
+
+Use `url` plus an `api_key`:
+
+```python
+import os
+
+config = QdrantConfig(
+    url="https://xyz.cloud.qdrant.io",
+    api_key=os.environ["QDRANT_API_KEY"],
+    collection="fashion",
+    group_by=["gender", "articleType", "baseColour"],
+    id_field="id",
+)
+ws = Workspace({"/fashion/": QdrantResource(config)}, mode=MountMode.READ)
+```
+
+## Search setup
+
+The `search` command embeds the query and runs Qdrant vector search. The
+collection must already store vectors produced by the same model
+(`embedding_model`, default `sentence-transformers/all-MiniLM-L6-v2`). Query
+embedding happens one of two ways:
+
+- **Local (default):** `fastembed` embeds the query in process.
+- **Server-side:** set `cloud_inference=True` to have an inference-enabled
+  Qdrant Cloud cluster embed the query. The query text is sent to the server
+  instead of being embedded locally.
+
+```python
+config = QdrantConfig(
+    url="https://xyz.cloud.qdrant.io",
+    api_key=os.environ["QDRANT_API_KEY"],
+    collection="fashion",
+    group_by=["gender"],
+    cloud_inference=True,
+    embedding_model="sentence-transformers/all-MiniLM-L6-v2",
+)
+```
+
+```bash
+search "red running shoes" /fashion          # ranked <path>.txt:score + content
+cat /fashion/Men/Shoes/White/3.txt            # follow a result to the real file
+```
+
+## Config reference
+
+| Field              | Required | Default                                     | Description                                                  |
+| ------------------ | -------- | ------------------------------------------- | ------------------------------------------------------------ |
+| `url`              | No       |                                             | Qdrant URL (Cloud or self-hosted); overrides `host`/`port`   |
+| `host`             | No       | `localhost`                                 | Host when `url` is unset                                     |
+| `port`             | No       | `6333`                                      | Port when `url` is unset                                     |
+| `https`            | No       | `false`                                     | Use TLS for `host`/`port` connections                        |
+| `api_key`          | No       |                                             | Qdrant Cloud API key                                         |
+| `collection`       | No       |                                             | Pin one collection; the mount root becomes that collection   |
+| `group_by`         | No       | `[]`                                        | Payload fields that become nested folder levels              |
+| `id_field`         | No       | `id`                                        | Field name shown for the point id; names point files         |
+| `text_field`       | No       |                                             | Payload field served as the `<id>.txt` embedded source text  |
+| `blob_field`       | No       |                                             | Payload field served as the raw blob/image file              |
+| `blob_ext`         | No       | `bin`                                       | Extension for the blob file (`jpg`, `png`, ...)              |
+| `vector_field`     | No       |                                             | Payload field holding a vector, omitted from `<id>.json`     |
+| `search_limit`     | No       | `10`                                        | Default top-k returned by `search`                           |
+| `max_rows`         | No       | `1000`                                      | Cap on points scanned per folder listing                     |
+| `embedding_model`  | No       | `sentence-transformers/all-MiniLM-L6-v2`    | Model used to embed the query                                |
+| `cloud_inference` | No       | `false`                                     | Embed the query server-side instead of with local fastembed  |
+
+The mount is read-only. See [Qdrant Resource](/python/resource/qdrant) for the
+filesystem layout and supported commands.

--- a/docs/typescript/install.mdx
+++ b/docs/typescript/install.mdx
@@ -60,6 +60,13 @@ Mirage keeps native and network-heavy dependencies as **optional peers** so cons
     pnpm add @lancedb/lancedb
     ```
   </Tab>
+  <Tab title="Qdrant">
+    Required for `QdrantResource`.
+
+    ```bash
+    pnpm add @qdrant/js-client-rest
+    ```
+  </Tab>
   <Tab title="SSH">
     Required for `SSHResource`.
 

--- a/docs/typescript/setup/qdrant.mdx
+++ b/docs/typescript/setup/qdrant.mdx
@@ -1,0 +1,74 @@
+---
+title: Qdrant
+icon: database
+description: Mount a Qdrant collection as a Mirage filesystem in TypeScript, with payload folders and a semantic search command.
+---
+
+`QdrantResource` exposes a [Qdrant](https://qdrant.tech/) collection as a read-only filesystem: group-by
+payload fields become nested folders, each point is a `.json` payload file (plus
+a `.txt` text file and an optional blob), and semantic search is the `search`
+command. The TypeScript backend mirrors the [Python one](/python/resource/qdrant)
+and returns identical results.
+
+## Install
+
+The client is browser-safe, so the resource ships in `core` and is available
+from both the Node and browser packages:
+
+```bash
+pnpm add @struktoai/mirage-node @qdrant/js-client-rest
+```
+
+```ts
+import { QdrantResource, MountMode, Workspace } from '@struktoai/mirage-node'
+
+const fashion = new QdrantResource({
+  config: {
+    url: 'https://xyz.cloud.qdrant.io',
+    apiKey: process.env.QDRANT_API_KEY,
+    collection: 'fashion',
+    groupBy: ['gender', 'articleType', 'baseColour'],
+    idField: 'id',
+    textField: 'productDisplayName',
+    blobField: 'image_b64',
+    blobExt: 'jpg',
+    searchLimit: 5,
+  },
+})
+
+const ws = new Workspace({ '/fashion/': fashion }, { mode: MountMode.READ })
+
+await ws.execute('ls /fashion/Men/Shoes/White')
+await ws.execute('search "red running shoes" /fashion') // ranked paths + score + content
+```
+
+## Filesystem layout
+
+```text
+/fashion/<gender>/<articleType>/<baseColour>/<id>.json  # full payload (metadata)
+/fashion/<gender>/<articleType>/<baseColour>/<id>.txt   # embedded source text
+/fashion/<gender>/<articleType>/<baseColour>/<id>.jpg   # raw blob bytes
+```
+
+`<id>` is the Qdrant point id. Semantic search is the `search` command, not a
+path: it returns ranked points as the canonical `<id>.txt` (or `<id>.json`) paths
+above, annotated with the similarity score.
+
+## Search embedding
+
+The query is embedded **server-side**: the TypeScript client sends the query
+text to Qdrant, so the cluster must have inference enabled (Qdrant Cloud) and
+store vectors from the same `embeddingModel`
+(default `sentence-transformers/all-MiniLM-L6-v2`). Browsing
+(`ls`/`cat`/`find`/`grep`) needs no embedding.
+
+## Supported commands
+
+`ls`, `cd`, `tree`, `cat`, `stat`, `find`, `wc`, `head`, `tail`, and `search`. `grep`/`rg` stay
+lexical; `search "<query>" <path>` is the semantic command, returning ranked
+points as canonical `<id>.txt` (or `<id>.json`) paths plus a score, so results
+compose with `cat`, `wc`, and pipes. Flags: `--top-k`, `--threshold`, `--method semantic`.
+
+Folder listings filter on payload fields. A filtered listing scrolls first and
+only creates keyword payload indexes for the `groupBy` fields if Qdrant reports
+one is required. `maxRows` caps how many points are scanned per folder.

--- a/examples/python/qdrant/build_collection.py
+++ b/examples/python/qdrant/build_collection.py
@@ -1,0 +1,70 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import base64
+
+from fastembed import TextEmbedding
+from qdrant_client import QdrantClient, models
+
+MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+_PRODUCTS = [
+    ("Men", "Tshirts", "Blue", "Roadster Men Blue Casual Tshirt"),
+    ("Men", "Tshirts", "Black", "HRX Men Black Sports Tshirt"),
+    ("Men", "Shoes", "White", "Nike Men White Running Sneakers"),
+    ("Men", "Shoes", "Black", "Puma Men Black Formal Shoes"),
+    ("Men", "Jeans", "Blue", "Levis Men Blue Casual Jeans"),
+    ("Women", "Tshirts", "Red", "Roadster Women Red Casual Tshirt"),
+    ("Women", "Shoes", "Red", "Steve Madden Women Red Heels"),
+    ("Women", "Shoes", "White", "Adidas Women White Running Sneakers"),
+    ("Women", "Dress", "Black", "Zara Women Black Formal Dress"),
+    ("Women", "Jeans", "Blue", "H&M Women Blue Summer Jeans"),
+]
+
+
+def build_collection(client: QdrantClient,
+                     collection: str = "fashion") -> None:
+    embedder = TextEmbedding(MODEL)
+    names = [name for _, _, _, name in _PRODUCTS]
+    vectors = [list(map(float, vector)) for vector in embedder.embed(names)]
+    if client.collection_exists(collection):
+        client.delete_collection(collection)
+    client.create_collection(
+        collection,
+        vectors_config=models.VectorParams(size=len(vectors[0]),
+                                           distance=models.Distance.COSINE),
+    )
+    points = []
+    for idx, ((gender, article, colour, name),
+              vector) in enumerate(zip(_PRODUCTS, vectors), start=1):
+        image = b"\xff\xd8\xff" + name.encode()
+        points.append(
+            models.PointStruct(
+                id=idx,
+                vector=vector,
+                payload={
+                    "gender": gender,
+                    "articleType": article,
+                    "baseColour": colour,
+                    "productDisplayName": name,
+                    "image_b64": base64.b64encode(image).decode(),
+                },
+            ))
+    client.upsert(collection, points=points)
+    for field in ("gender", "articleType", "baseColour"):
+        client.create_payload_index(
+            collection,
+            field_name=field,
+            field_schema=models.PayloadSchemaType.KEYWORD,
+        )

--- a/examples/python/qdrant/qdrant_resource.py
+++ b/examples/python/qdrant/qdrant_resource.py
@@ -1,0 +1,82 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import os
+
+from build_collection import MODEL, build_collection
+from qdrant_client import QdrantClient
+
+from mirage import MountMode, Workspace
+from mirage.resource.qdrant import QdrantConfig, QdrantResource
+
+
+def _client() -> QdrantClient:
+    url = os.environ.get("QDRANT_URL")
+    if url:
+        return QdrantClient(url=url, api_key=os.environ.get("QDRANT_API_KEY"))
+    return QdrantClient(host=os.environ.get("QDRANT_HOST", "localhost"),
+                        port=int(os.environ.get("QDRANT_PORT", "6333")))
+
+
+async def show(ws: Workspace, cmd: str) -> None:
+    print(f"\n=== {cmd} ===")
+    result = await ws.execute(cmd)
+    print((await result.stdout_str()).rstrip())
+
+
+async def main() -> None:
+    client = _client()
+    build_collection(client, "fashion")
+
+    config = QdrantConfig(
+        url=os.environ.get("QDRANT_URL"),
+        api_key=os.environ.get("QDRANT_API_KEY"),
+        host=os.environ.get("QDRANT_HOST", "localhost"),
+        port=int(os.environ.get("QDRANT_PORT", "6333")),
+        collection="fashion",
+        group_by=["gender", "articleType", "baseColour"],
+        id_field="id",
+        text_field="productDisplayName",
+        blob_field="image_b64",
+        blob_ext="jpg",
+        embedding_model=MODEL,
+        search_limit=4,
+    )
+    ws = Workspace({"/fashion/": QdrantResource(config)}, mode=MountMode.READ)
+
+    print("=== mounted Qdrant collection 'fashion' at /fashion/ ===")
+
+    await show(ws, "ls /fashion/")
+    await show(ws, "tree -L 2 /fashion/")
+    await show(ws, "ls /fashion/Men/Shoes/White")
+    await show(ws, "cat /fashion/Men/Shoes/White/3.txt")
+    await show(ws, "cat /fashion/Men/Shoes/White/3.json")
+
+    print("\n=== stat /fashion/Men/Shoes/White/3.jpg (raw image bytes) ===")
+    r = await ws.execute("stat -c '%s' /fashion/Men/Shoes/White/3.jpg")
+    print(f"  image size: {(await r.stdout_str()).strip()} bytes")
+
+    await show(ws, 'search "white running sneakers" /fashion')
+
+    await show(ws, "grep -ril blue /fashion/Women")
+    await show(ws, "rg -li running /fashion/Men")
+
+    print("\n=== find /fashion -name '*.txt' | wc -l ===")
+    r = await ws.execute("find /fashion -name '*.txt' | wc -l")
+    print(f"  products: {(await r.stdout_str()).strip()}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integ/package.json
+++ b/integ/package.json
@@ -17,11 +17,13 @@
     "safeguard": "tsx safeguard.ts",
     "chroma": "tsx chroma.ts",
     "lancedb": "tsx lancedb.ts",
+    "qdrant": "tsx qdrant.ts",
     "ssh": "tsx ssh.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.0.0",
     "@lancedb/lancedb": "^0.30.0",
+    "@qdrant/js-client-rest": "^1.18.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "chromadb": "^3.4.3",
     "@struktoai/mirage-browser": "workspace:*",

--- a/integ/qdrant.py
+++ b/integ/qdrant.py
@@ -1,0 +1,153 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from qdrant_client import AsyncQdrantClient, models  # noqa: E402
+
+from mirage import MountMode, Workspace  # noqa: E402
+from mirage.resource.qdrant import QdrantConfig, QdrantResource  # noqa: E402
+
+QDRANT_URL = os.environ.get("QDRANT_URL")
+QDRANT_API_KEY = os.environ.get("QDRANT_API_KEY")
+QDRANT_HOST = os.environ.get("QDRANT_HOST", "localhost")
+QDRANT_PORT = int(os.environ.get("QDRANT_PORT", "6333"))
+EMBED_DIM = 8
+COLLECTION = "mirage_integ"
+MOUNT = "/db/"
+
+ROWS = [
+    (1, "cat", "big", "a big orange cat"),
+    (2, "cat", "small", "a small grey cat"),
+    (3, "dog", "big", "a big brown dog"),
+    (4, "dog", "small", "a small white dog"),
+]
+
+CASES: list[tuple[str, str]] = [
+    ("ls_root", "ls {root}"),
+    ("ls_group", "ls {root}cat"),
+    ("ls_leaf", "ls {root}cat/big"),
+    ("tree", "tree {root}"),
+    ("find_txt", "find {root} -name '*.txt'"),
+    ("find_json", "find {root} -name '*.json'"),
+    ("cat_txt", "cat {root}cat/big/1.txt"),
+    ("cat_json", "cat {root}cat/big/1.json"),
+    ("wc_c_txt", "wc -c {root}cat/big/1.txt"),
+    ("grep_text", "grep orange {root}cat/big/1.txt"),
+    ("grep_json_field", "grep label {root}cat/big/1.json"),
+    ("grep_i", "grep -i ORANGE {root}cat/big/1.txt"),
+    ("grep_n", "grep -n cat {root}cat/big/1.json"),
+    ("grep_c", "grep -c cat {root}cat/big/1.json"),
+    ("grep_o", "grep -o cat {root}cat/big/1.json"),
+    ("grep_w", "grep -w big {root}cat/big/1.json"),
+    ("grep_F_literal", "grep -F 'orange cat' {root}cat/big/1.txt"),
+    ("grep_E_alt", 'grep -E "orange|brown" {root}cat/big/1.txt'),
+    ("grep_v", "grep -v zebra {root}cat/big/1.txt"),
+    ("grep_multi", "grep small {root}cat/small/2.json {root}dog/small/4.json"),
+    ("grep_r_group", "grep -r orange {root}cat"),
+    ("grep_rl", "grep -rl cat {root}"),
+    ("pipe_grep_stdin", "cat {root}cat/big/1.json | grep orange"),
+    ("rg_basic", "rg orange {root}cat/big/1.txt"),
+]
+
+EXIT_CODE_CASES: list[tuple[str, str]] = [
+    ("grep_q_match", "grep -q cat {root}cat/big/1.txt"),
+    ("grep_q_no_match", "grep -q zebra {root}cat/big/1.txt"),
+    ("grep_no_match", "grep zebra {root}cat/big/1.txt"),
+]
+
+
+async def run_cases(ws: Workspace) -> None:
+    for name, tmpl in CASES:
+        result = await ws.execute(tmpl.format(root=MOUNT))
+        out = await result.stdout_str()
+        print(f"=== {name} ===")
+        print(out, end="" if out.endswith("\n") else "\n")
+    for name, tmpl in EXIT_CODE_CASES:
+        result = await ws.execute(tmpl.format(root=MOUNT))
+        out = await result.stdout_str()
+        print(f"=== {name} ===")
+        print(f"exit={result.exit_code}")
+        if out:
+            print(out, end="" if out.endswith("\n") else "\n")
+    nf_target = f"{MOUNT.rstrip('/')}/cat/big/__nf_missing__.json"
+    for nf_name, nf_prog in (("nf_cat", "cat"), ("nf_head", "head"),
+                             ("nf_tail", "tail"), ("nf_wc", "wc"),
+                             ("nf_stat", "stat"), ("nf_grep", "grep x")):
+        result = await ws.execute(f"{nf_prog} {nf_target}")
+        err = (await result.stderr_str()).strip()
+        print(f"=== {nf_name} ===")
+        print(f"exit={result.exit_code}")
+        if err:
+            print(err)
+
+
+def _client() -> AsyncQdrantClient:
+    if QDRANT_URL:
+        return AsyncQdrantClient(url=QDRANT_URL, api_key=QDRANT_API_KEY)
+    return AsyncQdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+
+
+async def seed(client: AsyncQdrantClient) -> None:
+    await client.delete_collection(COLLECTION)
+    await client.create_collection(COLLECTION,
+                                   vectors_config=models.VectorParams(
+                                       size=EMBED_DIM,
+                                       distance=models.Distance.COSINE))
+    await client.upsert(COLLECTION,
+                        points=[
+                            models.PointStruct(id=i,
+                                               vector=[0.1] * EMBED_DIM,
+                                               payload={
+                                                   "label": label,
+                                                   "kind": kind,
+                                                   "name": name
+                                               })
+                            for i, label, kind, name in ROWS
+                        ])
+    for field in ("label", "kind"):
+        await client.create_payload_index(
+            COLLECTION,
+            field_name=field,
+            field_schema=models.PayloadSchemaType.KEYWORD)
+    await asyncio.sleep(2)
+
+
+async def main() -> None:
+    client = _client()
+    try:
+        await seed(client)
+        config = QdrantConfig(
+            url=QDRANT_URL,
+            api_key=QDRANT_API_KEY,
+            host=QDRANT_HOST,
+            port=QDRANT_PORT,
+            collection=COLLECTION,
+            group_by=["label", "kind"],
+            id_field="id",
+            text_field="name",
+        )
+        ws = Workspace({MOUNT: QdrantResource(config)}, mode=MountMode.READ)
+        await run_cases(ws)
+    finally:
+        await client.delete_collection(COLLECTION)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integ/qdrant.ts
+++ b/integ/qdrant.ts
@@ -1,0 +1,161 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { QdrantClient } from "@qdrant/js-client-rest";
+import { QdrantResource, MountMode, Workspace } from "@struktoai/mirage-node";
+
+const QDRANT_URL = process.env.QDRANT_URL;
+const QDRANT_API_KEY = process.env.QDRANT_API_KEY;
+const QDRANT_HOST = process.env.QDRANT_HOST ?? "localhost";
+const QDRANT_PORT = Number(process.env.QDRANT_PORT ?? "6333");
+const EMBED_DIM = 8;
+const COLLECTION = "mirage_integ";
+const MOUNT = "/db/";
+
+const DEC = new TextDecoder();
+
+const ROWS: [number, string, string, string][] = [
+  [1, "cat", "big", "a big orange cat"],
+  [2, "cat", "small", "a small grey cat"],
+  [3, "dog", "big", "a big brown dog"],
+  [4, "dog", "small", "a small white dog"],
+];
+
+const CASES: [string, string][] = [
+  ["ls_root", "ls {root}"],
+  ["ls_group", "ls {root}cat"],
+  ["ls_leaf", "ls {root}cat/big"],
+  ["tree", "tree {root}"],
+  ["find_txt", "find {root} -name '*.txt'"],
+  ["find_json", "find {root} -name '*.json'"],
+  ["cat_txt", "cat {root}cat/big/1.txt"],
+  ["cat_json", "cat {root}cat/big/1.json"],
+  ["wc_c_txt", "wc -c {root}cat/big/1.txt"],
+  ["grep_text", "grep orange {root}cat/big/1.txt"],
+  ["grep_json_field", "grep label {root}cat/big/1.json"],
+  ["grep_i", "grep -i ORANGE {root}cat/big/1.txt"],
+  ["grep_n", "grep -n cat {root}cat/big/1.json"],
+  ["grep_c", "grep -c cat {root}cat/big/1.json"],
+  ["grep_o", "grep -o cat {root}cat/big/1.json"],
+  ["grep_w", "grep -w big {root}cat/big/1.json"],
+  ["grep_F_literal", "grep -F 'orange cat' {root}cat/big/1.txt"],
+  ["grep_E_alt", 'grep -E "orange|brown" {root}cat/big/1.txt'],
+  ["grep_v", "grep -v zebra {root}cat/big/1.txt"],
+  ["grep_multi", "grep small {root}cat/small/2.json {root}dog/small/4.json"],
+  ["grep_r_group", "grep -r orange {root}cat"],
+  ["grep_rl", "grep -rl cat {root}"],
+  ["pipe_grep_stdin", "cat {root}cat/big/1.json | grep orange"],
+  ["rg_basic", "rg orange {root}cat/big/1.txt"],
+];
+
+const EXIT_CODE_CASES: [string, string][] = [
+  ["grep_q_match", "grep -q cat {root}cat/big/1.txt"],
+  ["grep_q_no_match", "grep -q zebra {root}cat/big/1.txt"],
+  ["grep_no_match", "grep zebra {root}cat/big/1.txt"],
+];
+
+const NOT_FOUND_PROGS: [string, string][] = [
+  ["nf_cat", "cat"],
+  ["nf_head", "head"],
+  ["nf_tail", "tail"],
+  ["nf_wc", "wc"],
+  ["nf_stat", "stat"],
+  ["nf_grep", "grep x"],
+];
+
+async function runCases(ws: Workspace): Promise<void> {
+  for (const [name, tmpl] of CASES) {
+    const result = await ws.execute(tmpl.replaceAll("{root}", MOUNT));
+    const out = DEC.decode(result.stdout);
+    process.stdout.write(`=== ${name} ===\n`);
+    process.stdout.write(out.endsWith("\n") ? out : out + "\n");
+  }
+  for (const [name, tmpl] of EXIT_CODE_CASES) {
+    const result = await ws.execute(tmpl.replaceAll("{root}", MOUNT));
+    const out = DEC.decode(result.stdout);
+    process.stdout.write(`=== ${name} ===\n`);
+    process.stdout.write(`exit=${result.exitCode}\n`);
+    if (out) process.stdout.write(out.endsWith("\n") ? out : out + "\n");
+  }
+  const target = `${MOUNT.replace(/\/+$/, "")}/cat/big/__nf_missing__.json`;
+  for (const [name, prog] of NOT_FOUND_PROGS) {
+    const result = await ws.execute(`${prog} ${target}`);
+    const err = DEC.decode(result.stderr).trim();
+    process.stdout.write(`=== ${name} ===\n`);
+    process.stdout.write(`exit=${result.exitCode}\n`);
+    if (err) process.stdout.write(err + "\n");
+  }
+}
+
+function client(): QdrantClient {
+  if (QDRANT_URL !== undefined && QDRANT_URL !== "") {
+    return new QdrantClient({ url: QDRANT_URL, apiKey: QDRANT_API_KEY });
+  }
+  return new QdrantClient({ host: QDRANT_HOST, port: QDRANT_PORT });
+}
+
+async function seed(c: QdrantClient): Promise<void> {
+  await c.deleteCollection(COLLECTION).catch(() => {});
+  await c.createCollection(COLLECTION, {
+    vectors: { size: EMBED_DIM, distance: "Cosine" },
+  });
+  await c.upsert(COLLECTION, {
+    points: ROWS.map(([id, label, kind, name]) => ({
+      id,
+      vector: Array(EMBED_DIM).fill(0.1),
+      payload: { label, kind, name },
+    })),
+  });
+  for (const field of ["label", "kind"]) {
+    await c.createPayloadIndex(COLLECTION, {
+      field_name: field,
+      field_schema: "keyword",
+    });
+  }
+  await new Promise((r) => setTimeout(r, 2000));
+}
+
+async function main(): Promise<void> {
+  const c = client();
+  try {
+    await seed(c);
+    const ws = new Workspace(
+      {
+        [MOUNT]: new QdrantResource({
+          url: QDRANT_URL,
+          apiKey: QDRANT_API_KEY,
+          host: QDRANT_HOST,
+          port: QDRANT_PORT,
+          collection: COLLECTION,
+          groupBy: ["label", "kind"],
+          idField: "id",
+          textField: "name",
+        }),
+      },
+      { mode: MountMode.READ },
+    );
+    try {
+      await runCases(ws);
+    } finally {
+      await ws.close();
+    }
+  } finally {
+    await c.deleteCollection(COLLECTION).catch(() => {});
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(String(err) + "\n");
+  process.exit(1);
+});

--- a/integ/truth_qdrant.txt
+++ b/integ/truth_qdrant.txt
@@ -1,0 +1,100 @@
+=== ls_root ===
+cat
+dog
+=== ls_group ===
+big
+small
+=== ls_leaf ===
+1.json
+1.txt
+=== tree ===
+├── cat
+│   ├── big
+│   │   ├── 1.json
+│   │   └── 1.txt
+│   └── small
+│       ├── 2.json
+│       └── 2.txt
+└── dog
+    ├── big
+    │   ├── 3.json
+    │   └── 3.txt
+    └── small
+        ├── 4.json
+        └── 4.txt
+=== find_txt ===
+/db/cat/big/1.txt
+/db/cat/small/2.txt
+/db/dog/big/3.txt
+/db/dog/small/4.txt
+=== find_json ===
+/db/cat/big/1.json
+/db/cat/small/2.json
+/db/dog/big/3.json
+/db/dog/small/4.json
+=== cat_txt ===
+a big orange cat
+=== cat_json ===
+{"label":"cat","kind":"big","name":"a big orange cat","id":1}
+=== wc_c_txt ===
+17 /db/cat/big/1.txt
+=== grep_text ===
+a big orange cat
+=== grep_json_field ===
+{"label":"cat","kind":"big","name":"a big orange cat","id":1}
+=== grep_i ===
+a big orange cat
+=== grep_n ===
+1:{"label":"cat","kind":"big","name":"a big orange cat","id":1}
+=== grep_c ===
+1
+=== grep_o ===
+cat
+cat
+=== grep_w ===
+{"label":"cat","kind":"big","name":"a big orange cat","id":1}
+=== grep_F_literal ===
+a big orange cat
+=== grep_E_alt ===
+a big orange cat
+=== grep_v ===
+a big orange cat
+=== grep_multi ===
+/db/cat/small/2.json:{"label":"cat","kind":"small","name":"a small grey cat","id":2}
+/db/dog/small/4.json:{"label":"dog","kind":"small","name":"a small white dog","id":4}
+=== grep_r_group ===
+/db/cat/big/1.json:{"label":"cat","kind":"big","name":"a big orange cat","id":1}
+/db/cat/big/1.txt:a big orange cat
+=== grep_rl ===
+/db/cat/big/1.json
+/db/cat/big/1.txt
+/db/cat/small/2.json
+/db/cat/small/2.txt
+=== pipe_grep_stdin ===
+{"label":"cat","kind":"big","name":"a big orange cat","id":1}
+=== rg_basic ===
+a big orange cat
+=== grep_q_match ===
+exit=0
+=== grep_q_no_match ===
+exit=1
+=== grep_no_match ===
+exit=1
+=== nf_cat ===
+exit=1
+cat: /db/cat/big/__nf_missing__.json: No such file or directory
+=== nf_head ===
+exit=1
+head: /db/cat/big/__nf_missing__.json: No such file or directory
+=== nf_tail ===
+exit=1
+tail: /db/cat/big/__nf_missing__.json: No such file or directory
+=== nf_wc ===
+exit=1
+wc: /db/cat/big/__nf_missing__.json: No such file or directory
+=== nf_stat ===
+exit=1
+stat: /db/cat/big/__nf_missing__.json: No such file or directory
+=== nf_grep ===
+exit=1
+grep: /db/cat/big/__nf_missing__.json: No such file or directory

--- a/python/README.md
+++ b/python/README.md
@@ -57,7 +57,7 @@ await ws.execute('cat /s3/events/2026-05-06.parquet | jq .user')
 ## About
 
 - **One interface instead of N SDKs and M MCPs.** Every service speaks the same filesystem semantics, and pipelines compose across services as naturally as on a local disk.
-- **Around 50 built-in backends:** RAM, Disk, Redis, S3 / R2 / OCI / Supabase / GCS, Gmail / GDrive / GDocs / GSheets / GSlides, GitHub / Linear / Notion / Trello, Slack / Discord / Telegram / Email, MongoDB / Postgres / LanceDB, SSH, and more, mounted side-by-side under a single root.
+- **Around 50 built-in backends:** RAM, Disk, Redis, S3 / R2 / OCI / Supabase / GCS, Gmail / GDrive / GDocs / GSheets / GSlides, GitHub / Linear / Notion / Trello, Slack / Discord / Telegram / Email, MongoDB / Postgres / LanceDB / Qdrant, SSH, and more, mounted side-by-side under a single root.
 - **Portable workspaces:** clone, snapshot, and version a workspace; agent runs move between machines without restarting or reconfiguring the system.
 - **Embeddable:** the Python and TypeScript SDKs run in-process inside FastAPI, Express, browser apps, or any async runtime; no separate process required.
 - **Agent integrations:** OpenAI Agents SDK, Vercel AI SDK, LangChain, Pydantic AI, CAMEL, and OpenHands via the SDKs; coding agents like Claude Code and Codex via the lightweight CLI + daemon.

--- a/python/mirage/accessor/qdrant.py
+++ b/python/mirage/accessor/qdrant.py
@@ -1,0 +1,65 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+from typing import Any
+
+from qdrant_client import AsyncQdrantClient
+
+from mirage.accessor.base import Accessor
+from mirage.resource.qdrant.config import QdrantConfig
+from mirage.resource.secrets import reveal_secret
+
+
+class QdrantAccessor(Accessor):
+
+    def __init__(self, config: QdrantConfig) -> None:
+        self.config = config
+        self._clients: dict[int, Any] = {}
+        self._search_cache: dict[tuple[str, str, int], list[dict]] = {}
+        self._indexes_ensured: set[str] = set()
+
+    def _loop_key(self) -> int:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return 0
+        return id(loop)
+
+    async def client(self) -> Any:
+        key = self._loop_key()
+        client = self._clients.get(key)
+        if client is None:
+            api_key = (reveal_secret(self.config.api_key)
+                       if self.config.api_key is not None else None)
+            kwargs: dict = {
+                "api_key": api_key,
+                "cloud_inference": self.config.cloud_inference
+            }
+            if self.config.url:
+                kwargs["url"] = self.config.url
+            else:
+                kwargs["host"] = self.config.host
+                kwargs["port"] = self.config.port
+                kwargs["https"] = self.config.https
+            client = AsyncQdrantClient(**kwargs)
+            self._clients[key] = client
+        return client
+
+    def cached_search(self, key: tuple[str, str, int]) -> list[dict] | None:
+        return self._search_cache.get(key)
+
+    def store_search(self, key: tuple[str, str, int],
+                     rows: list[dict]) -> None:
+        self._search_cache[key] = rows

--- a/python/mirage/commands/builtin/qdrant/__init__.py
+++ b/python/mirage/commands/builtin/qdrant/__init__.py
@@ -1,0 +1,39 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.commands.builtin.qdrant.cat import cat
+from mirage.commands.builtin.qdrant.find import find
+from mirage.commands.builtin.qdrant.grep import grep
+from mirage.commands.builtin.qdrant.head import head
+from mirage.commands.builtin.qdrant.ls import ls
+from mirage.commands.builtin.qdrant.rg import rg
+from mirage.commands.builtin.qdrant.search import search
+from mirage.commands.builtin.qdrant.stat import stat
+from mirage.commands.builtin.qdrant.tail import tail
+from mirage.commands.builtin.qdrant.tree import tree
+from mirage.commands.builtin.qdrant.wc import wc
+
+COMMANDS = [
+    cat,
+    find,
+    grep,
+    head,
+    ls,
+    rg,
+    search,
+    stat,
+    tail,
+    tree,
+    wc,
+]

--- a/python/mirage/commands/builtin/qdrant/_provision.py
+++ b/python/mirage/commands/builtin/qdrant/_provision.py
@@ -1,0 +1,25 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.provision.types import Precision, ProvisionResult
+
+
+async def metadata_provision(command: str) -> ProvisionResult:
+    return ProvisionResult(
+        command=command,
+        network_read_low=0,
+        network_read_high=0,
+        read_ops=0,
+        precision=Precision.EXACT,
+    )

--- a/python/mirage/commands/builtin/qdrant/cat.py
+++ b/python/mirage/commands/builtin/qdrant/cat.py
@@ -1,0 +1,66 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.cat import cat as generic_cat
+from mirage.commands.builtin.qdrant._provision import metadata_provision
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.qdrant.glob import resolve_glob
+from mirage.core.qdrant.read import read as qdrant_read
+from mirage.io.stream import async_chain
+from mirage.io.types import ByteSource, IOResult
+from mirage.provision.types import ProvisionResult
+from mirage.types import PathSpec
+
+
+async def cat_provision(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    return await metadata_provision("cat " + " ".join(
+        p.original if isinstance(p, PathSpec) else p for p in paths))
+
+
+@command("cat", resource="qdrant", spec=SPECS["cat"], provision=cat_provision)
+async def cat(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    n: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        reads: dict[str, ByteSource] = {}
+        parts: list[bytes] = []
+        for p in paths:
+            data = await qdrant_read(accessor, p, index)
+            reads[p.strip_prefix] = data
+            parts.append(data)
+        io = IOResult(reads=reads, cache=list(reads))
+        source: ByteSource = parts[0] if len(parts) == 1 else async_chain(
+            *parts)
+        return (generic_cat(source, number_lines=True) if n else source), io
+    source = _resolve_source(stdin, "cat: missing operand")
+    return (generic_cat(source, number_lines=True)
+            if n else source), IOResult()

--- a/python/mirage/commands/builtin/qdrant/find.py
+++ b/python/mirage/commands/builtin/qdrant/find.py
@@ -1,0 +1,89 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from functools import partial
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.find import parse_find_args, walk_find
+from mirage.commands.builtin.qdrant._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.qdrant.glob import resolve_glob
+from mirage.core.qdrant.readdir import is_dir_name
+from mirage.core.qdrant.readdir import readdir as _readdir
+from mirage.core.qdrant.stat import stat as _stat
+from mirage.io.types import ByteSource, IOResult
+from mirage.provision.types import ProvisionResult
+from mirage.types import PathSpec
+
+
+async def find_provision(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    return await metadata_provision("find " + " ".join(
+        p.original if isinstance(p, PathSpec) else p for p in paths))
+
+
+@command("find",
+         resource="qdrant",
+         spec=SPECS["find"],
+         provision=find_provision)
+async def find(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    name: str | None = None,
+    type: str | None = None,
+    maxdepth: str | None = None,
+    size: str | None = None,
+    mtime: str | None = None,
+    iname: str | None = None,
+    path: str | None = None,
+    mindepth: str | None = None,
+    prefix: str = "",
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    paths = await resolve_glob(accessor, paths, index)
+    p0 = paths[0] if paths else None
+    search_path = p0.original if p0 else "/"
+    search_prefix = p0.prefix if p0 else ""
+    args = parse_find_args(texts,
+                           name=name,
+                           type=type,
+                           size=size,
+                           mtime=mtime,
+                           maxdepth=maxdepth,
+                           iname=iname,
+                           path=path,
+                           mindepth=mindepth)
+    search_spec = PathSpec(original=search_path,
+                           directory=search_path,
+                           resolved=False,
+                           prefix=search_prefix)
+    results = await walk_find(search_spec,
+                              readdir=partial(_readdir, accessor),
+                              stat=partial(_stat, accessor),
+                              is_dir_name=partial(is_dir_name,
+                                                  config=accessor.config),
+                              index=index,
+                              args=args)
+    output = format_records(results)
+    return output, IOResult()

--- a/python/mirage/commands/builtin/qdrant/grep.py
+++ b/python/mirage/commands/builtin/qdrant/grep.py
@@ -1,0 +1,69 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.grep import grep as generic_grep
+from mirage.commands.builtin.qdrant._provision import metadata_provision
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.qdrant.glob import resolve_glob
+from mirage.core.qdrant.read import read as qdrant_read
+from mirage.core.qdrant.readdir import readdir as _readdir
+from mirage.core.qdrant.stat import stat as _stat
+from mirage.io.types import ByteSource, IOResult
+from mirage.provision.types import ProvisionResult
+from mirage.types import PathSpec
+
+
+async def grep_provision(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    return await metadata_provision("grep " +
+                                    " ".join(texts +
+                                             tuple(str(p) for p in paths)))
+
+
+@command("grep",
+         resource="qdrant",
+         spec=SPECS["grep"],
+         provision=grep_provision)
+async def grep(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    prefix: str = "",
+    index: IndexCacheStore = None,
+    **flags: object,
+) -> tuple[ByteSource | None, IOResult]:
+    resolved = await resolve_glob(accessor, paths,
+                                  index=index) if paths else []
+    return await generic_grep(
+        resolved,
+        texts,
+        flags,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=qdrant_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/qdrant/head.py
+++ b/python/mirage/commands/builtin/qdrant/head.py
@@ -1,0 +1,68 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.head import head as generic_head
+from mirage.commands.builtin.generic.head import head_multi
+from mirage.commands.builtin.qdrant._provision import metadata_provision
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.qdrant.glob import resolve_glob
+from mirage.core.qdrant.read import read as qdrant_read
+from mirage.io.types import ByteSource, IOResult
+from mirage.provision.types import ProvisionResult
+from mirage.types import PathSpec
+
+
+async def head_provision(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    return await metadata_provision("head " + " ".join(
+        p.original if isinstance(p, PathSpec) else p for p in paths))
+
+
+@command("head",
+         resource="qdrant",
+         spec=SPECS["head"],
+         provision=head_provision)
+async def head(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    n: str | None = None,
+    c: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    n_int = int(n) if n is not None else None
+    c_int = int(c) if c is not None else None
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        return head_multi(paths,
+                          read=qdrant_read,
+                          accessor=accessor,
+                          index=index,
+                          n=n_int,
+                          c=c_int,
+                          show_headers=len(paths) > 1), IOResult()
+    source = _resolve_source(stdin, "head: missing operand")
+    return generic_head(source, n=n_int, c=c_int), IOResult()

--- a/python/mirage/commands/builtin/qdrant/ls.py
+++ b/python/mirage/commands/builtin/qdrant/ls.py
@@ -1,0 +1,82 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from functools import partial
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.ls import ls as generic_ls
+from mirage.commands.builtin.qdrant._provision import metadata_provision
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.qdrant.glob import resolve_glob
+from mirage.core.qdrant.readdir import readdir
+from mirage.core.qdrant.stat import stat
+from mirage.io.types import ByteSource, IOResult
+from mirage.provision.types import ProvisionResult
+from mirage.types import LsSortBy, PathSpec
+
+
+async def ls_provision(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    return await metadata_provision("ls " + " ".join(
+        p.original if isinstance(p, PathSpec) else p for p in paths))
+
+
+@command("ls", resource="qdrant", spec=SPECS["ls"], provision=ls_provision)
+async def ls(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    args_l: bool = False,
+    args_1: bool = False,
+    a: bool = False,
+    A: bool = False,
+    h: bool = False,
+    t: bool = False,
+    S: bool = False,
+    r: bool = False,
+    R: bool = False,
+    d: bool = False,
+    F: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        cwd = _extra.get("cwd", "/")
+        paths = [cwd] if isinstance(cwd, PathSpec) else [
+            PathSpec(original=cwd, directory=cwd, resolved=False)
+        ]
+    paths = await resolve_glob(accessor, paths, index)
+    sort_by = LsSortBy.TIME if t else LsSortBy.SIZE if S else LsSortBy.NAME
+    return await generic_ls(
+        paths,
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        long=args_l,
+        one_per_line=args_1,
+        all_files=a or A,
+        human=h,
+        sort_by=sort_by,
+        reverse=r,
+        recursive=R,
+        list_dir=d,
+        classify=F,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/qdrant/rg.py
+++ b/python/mirage/commands/builtin/qdrant/rg.py
@@ -1,0 +1,53 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.rg import rg as generic_rg
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.qdrant.glob import resolve_glob
+from mirage.core.qdrant.read import read as qdrant_read
+from mirage.core.qdrant.readdir import readdir as _readdir
+from mirage.core.qdrant.stat import stat as _stat
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("rg", resource="qdrant", spec=SPECS["rg"])
+async def rg(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    prefix: str = "",
+    index: IndexCacheStore = None,
+    **flags: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index=index)
+    return await generic_rg(
+        paths,
+        texts,
+        flags,
+        readdir=_readdir,
+        stat=_stat,
+        read_bytes=qdrant_read,
+        read_stream=None,
+        accessor=accessor,
+        stdin=stdin,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/qdrant/search.py
+++ b/python/mirage/commands/builtin/qdrant/search.py
@@ -1,0 +1,74 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.commands.builtin.qdrant._provision import metadata_provision
+from mirage.commands.errors import UsageError
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.qdrant.search import search_rows_output
+from mirage.io.types import ByteSource, IOResult
+from mirage.provision.types import ProvisionResult
+from mirage.types import PathSpec
+
+
+def _default_paths(paths: list[PathSpec],
+                   cwd: PathSpec | None) -> list[PathSpec]:
+    if paths:
+        return paths
+    if cwd is not None:
+        return [cwd]
+    return [PathSpec(original="/", directory="/")]
+
+
+async def search_provision(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    return await metadata_provision("search " + " ".join(texts))
+
+
+@command("search",
+         resource="qdrant",
+         spec=SPECS["search"],
+         provision=search_provision)
+async def search(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    method: str = "semantic",
+    top_k: str | int | None = None,
+    threshold: str | float = 0.0,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not texts:
+        raise UsageError("search: query is required")
+    if method != "semantic":
+        raise UsageError("search: only the 'semantic' method is supported")
+    query = texts[0]
+    cwd = _extra.get("cwd")
+    target_paths = _default_paths(paths,
+                                  cwd if isinstance(cwd, PathSpec) else None)
+    mount_prefix = target_paths[0].prefix if target_paths else ""
+    limit = int(top_k) if top_k is not None else accessor.config.search_limit
+    output = await search_rows_output(accessor,
+                                      query,
+                                      target_paths,
+                                      top_k=limit,
+                                      threshold=float(threshold),
+                                      mount_prefix=mount_prefix)
+    return output, IOResult()

--- a/python/mirage/commands/builtin/qdrant/stat.py
+++ b/python/mirage/commands/builtin/qdrant/stat.py
@@ -1,0 +1,60 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.stat import stat as generic_stat
+from mirage.commands.builtin.qdrant._provision import metadata_provision
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.qdrant.glob import resolve_glob
+from mirage.core.qdrant.stat import stat as stat_impl
+from mirage.io.types import ByteSource, IOResult
+from mirage.provision.types import ProvisionResult
+from mirage.types import PathSpec
+
+
+async def stat_provision(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    return await metadata_provision("stat " + " ".join(
+        p.original if isinstance(p, PathSpec) else p for p in paths))
+
+
+@command("stat",
+         resource="qdrant",
+         spec=SPECS["stat"],
+         provision=stat_provision)
+async def stat(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    c: str | None = None,
+    f: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if not paths:
+        raise ValueError("stat: missing operand")
+    paths = await resolve_glob(accessor, paths, index)
+    return await generic_stat(paths,
+                              stat_fn=stat_impl,
+                              accessor=accessor,
+                              c=c,
+                              f=f,
+                              index=index)

--- a/python/mirage/commands/builtin/qdrant/tail.py
+++ b/python/mirage/commands/builtin/qdrant/tail.py
@@ -1,0 +1,82 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tail import tail as generic_tail
+from mirage.commands.builtin.generic.tail import tail_multi
+from mirage.commands.builtin.qdrant._provision import metadata_provision
+from mirage.commands.builtin.tail_helper import _parse_n
+from mirage.commands.builtin.utils.stream import _resolve_source
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.qdrant.glob import resolve_glob
+from mirage.core.qdrant.read import read as qdrant_read
+from mirage.io.types import ByteSource, IOResult
+from mirage.provision.types import ProvisionResult
+from mirage.types import PathSpec
+
+
+async def tail_provision(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    return await metadata_provision("tail " + " ".join(
+        p.original if isinstance(p, PathSpec) else p for p in paths))
+
+
+@command("tail",
+         resource="qdrant",
+         spec=SPECS["tail"],
+         provision=tail_provision)
+async def tail(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    n: str | None = None,
+    c: str | None = None,
+    q: bool = False,
+    v: bool = False,
+    f: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    n_int: int | None = None
+    from_line: int | None = None
+    if n is not None:
+        lines, plus_mode = _parse_n(n)
+        if plus_mode:
+            from_line = lines
+        else:
+            n_int = lines
+    c_int = int(c) if c is not None else None
+    if paths:
+        paths = await resolve_glob(accessor, paths, index=index)
+        show_headers = (v or len(paths) > 1) and not q
+        return tail_multi(paths,
+                          read=qdrant_read,
+                          accessor=accessor,
+                          index=index,
+                          n=n_int,
+                          c=c_int,
+                          from_line=from_line,
+                          show_headers=show_headers), IOResult()
+    source = _resolve_source(stdin, "tail: missing operand")
+    return generic_tail(source, n=n_int, c=c_int,
+                        from_line=from_line), IOResult()

--- a/python/mirage/commands/builtin/qdrant/tree.py
+++ b/python/mirage/commands/builtin/qdrant/tree.py
@@ -1,0 +1,54 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from functools import partial
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.tree import tree as generic_tree
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.qdrant.glob import resolve_glob
+from mirage.core.qdrant.readdir import readdir
+from mirage.core.qdrant.stat import stat
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("tree", resource="qdrant", spec=SPECS["tree"])
+async def tree(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: bytes | None = None,
+    L: str | None = None,
+    a: bool = False,
+    args_I: str | None = None,
+    d: bool = False,
+    P: str | None = None,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    paths = await resolve_glob(accessor, paths, index)
+    return await generic_tree(
+        paths[0],
+        readdir=partial(readdir, accessor),
+        stat=partial(stat, accessor),
+        max_depth=int(L) if L is not None else None,
+        show_hidden=a,
+        ignore_pattern=args_I,
+        dirs_only=d,
+        match_pattern=P,
+        index=index,
+    )

--- a/python/mirage/commands/builtin/qdrant/wc.py
+++ b/python/mirage/commands/builtin/qdrant/wc.py
@@ -1,0 +1,77 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import AsyncIterator
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.generic.wc import (WCCounts, format_wc,
+                                                format_wc_lines)
+from mirage.commands.builtin.generic.wc import wc as generic_wc
+from mirage.commands.builtin.qdrant._provision import metadata_provision
+from mirage.commands.builtin.utils.output import format_records
+from mirage.commands.builtin.utils.stream import _read_stdin_async
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.core.qdrant.glob import resolve_glob
+from mirage.core.qdrant.read import read as qdrant_read
+from mirage.io.types import ByteSource, IOResult
+from mirage.provision.types import ProvisionResult
+from mirage.types import PathSpec
+
+
+async def wc_provision(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    **_extra: object,
+) -> ProvisionResult:
+    return await metadata_provision("wc " + " ".join(
+        p.original if isinstance(p, PathSpec) else p for p in paths))
+
+
+@command("wc", resource="qdrant", spec=SPECS["wc"], provision=wc_provision)
+async def wc(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: AsyncIterator[bytes] | bytes | None = None,
+    args_l: bool = False,
+    w: bool = False,
+    c: bool = False,
+    m: bool = False,
+    L: bool = False,
+    index: IndexCacheStore = None,
+    **_extra: object,
+) -> tuple[ByteSource | None, IOResult]:
+    if paths:
+        paths = await resolve_glob(accessor, paths, index)
+        rows: list[tuple[WCCounts, str | None]] = []
+        totals = WCCounts()
+        for p in paths:
+            data = await qdrant_read(accessor, p, index)
+            counts = await generic_wc(data)
+            rows.append((counts, p.original))
+            totals.merge(counts)
+        if len(paths) > 1:
+            rows.append((totals, "total"))
+        return format_records(
+            format_wc_lines(rows, args_l=args_l, w=w, c=c, m=m,
+                            L=L)), IOResult()
+    data = await _read_stdin_async(stdin)
+    if data is None:
+        raise ValueError("wc: missing operand")
+    counts = await generic_wc(data)
+    return format_wc(counts, args_l=args_l, w=w, c=c, m=m,
+                     L=L).encode() + b"\n", IOResult()

--- a/python/mirage/core/qdrant/__init__.py
+++ b/python/mirage/core/qdrant/__init__.py
@@ -1,0 +1,13 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========

--- a/python/mirage/core/qdrant/glob.py
+++ b/python/mirage/core/qdrant/glob.py
@@ -1,0 +1,60 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import fnmatch
+import logging
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.constants import SCOPE_ERROR
+from mirage.core.qdrant.readdir import readdir
+from mirage.types import PathSpec
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_glob(
+    accessor: QdrantAccessor,
+    paths: list[PathSpec],
+    index: IndexCacheStore = None,
+) -> list[PathSpec]:
+    result: list[PathSpec] = []
+    for p in paths:
+        if isinstance(p, str):
+            result.append(PathSpec(original=p, directory=p))
+            continue
+        if p.resolved:
+            result.append(p)
+        elif p.pattern:
+            entries = await readdir(accessor, p.dir, index)
+            matched = [
+                PathSpec(
+                    original=e,
+                    directory=p.directory,
+                    prefix=p.prefix,
+                ) for e in entries
+                if fnmatch.fnmatch(e.rsplit("/", 1)[-1], p.pattern)
+            ]
+            if len(matched) > SCOPE_ERROR:
+                logger.warning(
+                    "%s: %d matches exceeds limit (%d), truncating",
+                    p.directory,
+                    len(matched),
+                    SCOPE_ERROR,
+                )
+                matched = matched[:SCOPE_ERROR]
+            result.extend(matched)
+        else:
+            result.append(p)
+    return result

--- a/python/mirage/core/qdrant/query.py
+++ b/python/mirage/core/qdrant/query.py
@@ -1,0 +1,180 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import logging
+import uuid
+from typing import Any
+
+from qdrant_client import models
+from qdrant_client.http.exceptions import UnexpectedResponse
+
+from mirage.accessor.qdrant import QdrantAccessor
+
+logger = logging.getLogger(__name__)
+
+SCROLL_BATCH = 256
+
+
+def _coerce(value: str) -> Any:
+    if value.lstrip("-").isdigit():
+        as_int = int(value)
+        if str(as_int) == value:
+            return as_int
+    return value
+
+
+def _filter(filters: dict[str, str]) -> models.Filter | None:
+    if not filters:
+        return None
+    return models.Filter(must=[
+        models.FieldCondition(key=column,
+                              match=models.MatchValue(value=_coerce(value)))
+        for column, value in filters.items()
+    ])
+
+
+def _point_to_row(point: Any, id_field: str) -> dict:
+    payload = point.payload if isinstance(point.payload, dict) else {}
+    row = dict(payload)
+    row[id_field] = point.id
+    return row
+
+
+def _candidate_ids(row_id: str) -> list[Any]:
+    if row_id.lstrip("-").isdigit():
+        return [int(row_id)]
+    try:
+        uuid.UUID(row_id)
+    except ValueError:
+        return []
+    return [row_id]
+
+
+async def _scroll_raw(client: Any, collection: str, flt: models.Filter | None,
+                      limit: int) -> list[Any]:
+    points: list[Any] = []
+    offset: Any = None
+    while len(points) < limit:
+        batch, offset = await client.scroll(
+            collection_name=collection,
+            scroll_filter=flt,
+            limit=min(SCROLL_BATCH, limit - len(points)),
+            offset=offset,
+            with_payload=True,
+            with_vectors=False,
+        )
+        points.extend(batch)
+        if offset is None:
+            break
+    return points[:limit]
+
+
+def _is_index_required(exc: UnexpectedResponse) -> bool:
+    content = exc.content
+    text = content.decode() if isinstance(content, bytes) else str(content)
+    return exc.status_code == 400 and "index required" in text.lower()
+
+
+async def _ensure_indexes(client: Any, accessor: QdrantAccessor,
+                          collection: str) -> None:
+    if collection in accessor._indexes_ensured:
+        return
+    for field in accessor.config.group_by:
+        await client.create_payload_index(
+            collection_name=collection,
+            field_name=field,
+            field_schema="keyword",
+        )
+    accessor._indexes_ensured.add(collection)
+
+
+async def _scroll_all(accessor: QdrantAccessor, collection: str,
+                      filters: dict[str, str], limit: int) -> list[Any]:
+    client = await accessor.client()
+    if not filters:
+        return await _scroll_raw(client, collection, None, limit)
+    flt = _filter(filters)
+    try:
+        return await _scroll_raw(client, collection, flt, limit)
+    except UnexpectedResponse as exc:
+        if not _is_index_required(exc):
+            raise
+    await _ensure_indexes(client, accessor, collection)
+    return await _scroll_raw(client, collection, flt, limit)
+
+
+async def list_tables(accessor: QdrantAccessor) -> list[str]:
+    client = await accessor.client()
+    result = await client.get_collections()
+    return sorted(item.name for item in result.collections)
+
+
+async def table_exists(accessor: QdrantAccessor, name: str) -> bool:
+    client = await accessor.client()
+    return await client.collection_exists(name)
+
+
+async def distinct_values(accessor: QdrantAccessor, table: str, column: str,
+                          filters: dict[str, str], limit: int) -> list[str]:
+    points = await _scroll_all(accessor, table, filters, limit)
+    values = {
+        str(payload[column])
+        for point in points
+        if (payload := point.payload or {}).get(column) is not None
+    }
+    return sorted(values)
+
+
+async def rows_matching(accessor: QdrantAccessor, table: str,
+                        filters: dict[str, str], limit: int) -> list[dict]:
+    points = await _scroll_all(accessor, table, filters, limit)
+    return [_point_to_row(point, accessor.config.id_field) for point in points]
+
+
+async def row_record(accessor: QdrantAccessor, table: str, id_field: str,
+                     row_id: str) -> dict | None:
+    ids = _candidate_ids(row_id)
+    if not ids:
+        return None
+    client = await accessor.client()
+    found = await client.retrieve(collection_name=table,
+                                  ids=ids,
+                                  with_payload=True,
+                                  with_vectors=False)
+    if not found:
+        return None
+    return _point_to_row(found[0], id_field)
+
+
+async def search_rows(accessor: QdrantAccessor, table: str, query_text: str,
+                      limit: int) -> list[dict]:
+    key = (table, query_text, limit)
+    cached = accessor.cached_search(key)
+    if cached is not None:
+        return cached
+    client = await accessor.client()
+    response = await client.query_points(
+        collection_name=table,
+        query=models.Document(text=query_text,
+                              model=accessor.config.embedding_model),
+        limit=limit,
+        with_payload=True,
+    )
+    rows: list[dict] = []
+    for point in response.points:
+        row = _point_to_row(point, accessor.config.id_field)
+        row["_score"] = point.score
+        rows.append(row)
+    accessor.store_search(key, rows)
+    return rows

--- a/python/mirage/core/qdrant/read.py
+++ b/python/mirage/core/qdrant/read.py
@@ -1,0 +1,66 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import base64
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.qdrant.query import row_record
+from mirage.core.qdrant.render import render_json, render_text
+from mirage.core.qdrant.scope import ScopeLevel, detect_scope
+from mirage.types import PathSpec
+from mirage.utils.errors import enoent
+
+
+async def _resolve_row(accessor: QdrantAccessor, scope, config,
+                       virtual: str) -> dict:
+    row = await row_record(accessor, scope.table, config.id_field,
+                           scope.row_id)
+    if row is None:
+        raise enoent(virtual)
+    return row
+
+
+def _blob_bytes(value: object) -> bytes:
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        return base64.b64decode(value)
+    raise ValueError("blob column is not bytes or base64 str")
+
+
+async def read(
+    accessor: QdrantAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> bytes:
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    config = accessor.config
+    scope = detect_scope(path, config)
+    if scope.level != ScopeLevel.ROW:
+        raise enoent(path)
+    row = await _resolve_row(accessor, scope, config, path.original)
+    if scope.kind == "blob":
+        if not config.blob_field:
+            raise enoent(path)
+        value = row.get(config.blob_field)
+        if value is None:
+            raise enoent(path)
+        return _blob_bytes(value)
+    if scope.kind == "txt":
+        if not config.text_field or row.get(config.text_field) is None:
+            raise enoent(path)
+        return render_text(row, config)
+    return render_json(row, config)

--- a/python/mirage/core/qdrant/readdir.py
+++ b/python/mirage/core/qdrant/readdir.py
@@ -1,0 +1,76 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.qdrant.query import (distinct_values, list_tables,
+                                      rows_matching)
+from mirage.core.qdrant.scope import ScopeLevel, detect_scope
+from mirage.types import PathSpec
+
+
+def is_dir_name(child: str, config) -> bool:
+    # Row files are recognized by extension, so classification never needs
+    # the stat fallback.
+    name = child.rsplit("/", 1)[-1]
+    if name.endswith(".json"):
+        return False
+    if config.text_field and name.endswith(".txt"):
+        return False
+    if config.blob_field and name.endswith("." + config.blob_ext):
+        return False
+    return True
+
+
+def _row_files(rows: list[dict], config) -> list[str]:
+    names: list[str] = []
+    for row in rows:
+        rid = row[config.id_field]
+        names.append(f"{rid}.json")
+        if config.text_field and row.get(config.text_field) is not None:
+            names.append(f"{rid}.txt")
+        if config.blob_field and row.get(config.blob_field) is not None:
+            names.append(f"{rid}.{config.blob_ext}")
+    return names
+
+
+async def readdir(
+    accessor: QdrantAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> list[str]:
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    config = accessor.config
+    scope = detect_scope(path, config)
+    base = path.original.rstrip("/")
+
+    if scope.level == ScopeLevel.ROOT:
+        names = await list_tables(accessor)
+        return [f"{base}/{name}" for name in names]
+
+    if scope.level == ScopeLevel.GROUP_DIR:
+        depth = len(scope.filters)
+        total = len(config.group_by)
+        if depth < total:
+            names = await distinct_values(accessor, scope.table,
+                                          config.group_by[depth],
+                                          scope.filters, config.max_rows)
+        else:
+            rows = await rows_matching(accessor, scope.table, scope.filters,
+                                       config.max_rows)
+            names = _row_files(rows, config)
+        return [f"{base}/{name}" for name in names]
+
+    raise FileNotFoundError(path.original)

--- a/python/mirage/core/qdrant/render.py
+++ b/python/mirage/core/qdrant/render.py
@@ -1,0 +1,36 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import json
+
+from mirage.resource.qdrant.config import QdrantConfig
+
+_SKIP_KEYS = {"_distance", "_rowid", "_score"}
+
+
+def render_json(row: dict, config: QdrantConfig) -> bytes:
+    data = {
+        key: value
+        for key, value in row.items() if key not in _SKIP_KEYS
+        and key != config.vector_field and key != config.blob_field
+    }
+    return (json.dumps(data, separators=(",", ":"), ensure_ascii=False) +
+            "\n").encode()
+
+
+def render_text(row: dict, config: QdrantConfig) -> bytes:
+    value = row.get(config.text_field) if config.text_field else None
+    if value is None:
+        return b""
+    return (str(value) + "\n").encode()

--- a/python/mirage/core/qdrant/scope.py
+++ b/python/mirage/core/qdrant/scope.py
@@ -1,0 +1,86 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from mirage.resource.qdrant.config import QdrantConfig
+from mirage.types import PathSpec
+
+
+class ScopeLevel(str, Enum):
+    ROOT = "root"
+    GROUP_DIR = "group_dir"
+    ROW = "row"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class QdrantScope:
+    level: ScopeLevel
+    table: str | None = None
+    filters: dict[str, str] = field(default_factory=dict)
+    row_id: str | None = None
+    kind: str | None = None
+    resource_path: str = "/"
+
+
+def _parse_row_file(name: str, config: QdrantConfig) -> tuple[str, str] | None:
+    if name.endswith(".json"):
+        return name[:-len(".json")], "json"
+    if config.text_field and name.endswith(".txt"):
+        return name[:-len(".txt")], "txt"
+    if config.blob_field:
+        suffix = "." + config.blob_ext
+        if name.endswith(suffix):
+            return name[:-len(suffix)], "blob"
+    return None
+
+
+def detect_scope(path, config: QdrantConfig) -> QdrantScope:
+    raw = path.strip_prefix if isinstance(path, PathSpec) else path
+    key = raw.strip("/")
+    segs = key.split("/") if key else []
+
+    if config.collection:
+        table = config.collection
+        rest = segs
+    else:
+        if not segs:
+            return QdrantScope(level=ScopeLevel.ROOT, resource_path=raw)
+        table = segs[0]
+        rest = segs[1:]
+
+    gb = config.group_by
+    n = len(gb)
+
+    if len(rest) <= n:
+        filters = {gb[i]: rest[i] for i in range(len(rest))}
+        return QdrantScope(level=ScopeLevel.GROUP_DIR,
+                           table=table,
+                           filters=filters,
+                           resource_path=raw)
+
+    if len(rest) == n + 1:
+        filters = {gb[i]: rest[i] for i in range(n)}
+        parsed = _parse_row_file(rest[n], config)
+        if parsed is not None:
+            return QdrantScope(level=ScopeLevel.ROW,
+                               table=table,
+                               filters=filters,
+                               row_id=parsed[0],
+                               kind=parsed[1],
+                               resource_path=raw)
+
+    return QdrantScope(level=ScopeLevel.UNKNOWN, resource_path=raw)

--- a/python/mirage/core/qdrant/search.py
+++ b/python/mirage/core/qdrant/search.py
@@ -1,0 +1,89 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.core.qdrant.query import search_rows
+from mirage.core.qdrant.render import render_json, render_text
+from mirage.resource.qdrant.config import QdrantConfig
+from mirage.types import PathSpec
+
+
+def _content_ext(row: dict, config: QdrantConfig) -> str:
+    if config.text_field and row.get(config.text_field) is not None:
+        return "txt"
+    return "json"
+
+
+def _target_table(paths: list[PathSpec], config: QdrantConfig) -> str | None:
+    if config.collection:
+        return config.collection
+    for path in paths:
+        raw = path.strip_prefix if isinstance(path, PathSpec) else path
+        key = raw.strip("/")
+        if key:
+            return key.split("/")[0]
+    return None
+
+
+def _canonical_path(row: dict, config: QdrantConfig, table: str,
+                    mount_prefix: str) -> str:
+    segs: list[str] = []
+    if not config.collection:
+        segs.append(str(table))
+    for column in config.group_by:
+        if column in row and row[column] is not None:
+            segs.append(str(row[column]))
+    segs.append(f"{row[config.id_field]}.{_content_ext(row, config)}")
+    prefix = mount_prefix.rstrip("/")
+    return prefix + "/" + "/".join(segs)
+
+
+def _block(row: dict, config: QdrantConfig, table: str,
+           mount_prefix: str) -> str:
+    path = _canonical_path(row, config, table, mount_prefix)
+    score = row.get("_score")
+    header = path if score is None else f"{path}:{float(score):.4f}"
+    body_row = {k: v for k, v in row.items() if k != "_score"}
+    if _content_ext(row, config) == "txt":
+        content = render_text(body_row, config).decode().rstrip("\n")
+    else:
+        content = render_json(body_row, config).decode().rstrip("\n")
+    return f"{header}\n{content}"
+
+
+async def search_rows_output(
+    accessor: QdrantAccessor,
+    query: str,
+    paths: list[PathSpec],
+    top_k: int,
+    threshold: float,
+    mount_prefix: str,
+) -> bytes:
+    if not query:
+        raise ValueError("search: query is required")
+    if top_k <= 0:
+        raise ValueError("search: top-k must be positive")
+    table = _target_table(paths, accessor.config)
+    if table is None:
+        raise FileNotFoundError("search: no table to search")
+    rows = await search_rows(accessor, table, query, top_k)
+    blocks: list[str] = []
+    for row in rows:
+        score = row.get("_score")
+        if threshold > 0 and score is not None and float(score) < threshold:
+            continue
+        blocks.append(_block(row, accessor.config, table, mount_prefix))
+    if not blocks:
+        return b""
+    return ("\n".join(blocks) + "\n").encode()

--- a/python/mirage/core/qdrant/stat.py
+++ b/python/mirage/core/qdrant/stat.py
@@ -1,0 +1,59 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.qdrant.query import table_exists
+from mirage.core.qdrant.read import read
+from mirage.core.qdrant.scope import ScopeLevel, detect_scope
+from mirage.types import FileStat, FileType, PathSpec
+
+_IMAGE_TYPES = {
+    "png": FileType.IMAGE_PNG,
+    "jpg": FileType.IMAGE_JPEG,
+    "jpeg": FileType.IMAGE_JPEG,
+    "gif": FileType.IMAGE_GIF,
+}
+
+
+def _name_of(path: PathSpec) -> str:
+    stripped = path.original.rstrip("/")
+    return stripped.rsplit("/", 1)[-1] or "/"
+
+
+async def stat(
+    accessor: QdrantAccessor,
+    path: PathSpec,
+    index: IndexCacheStore = None,
+) -> FileStat:
+    if isinstance(path, str):
+        path = PathSpec(original=path, directory=path)
+    config = accessor.config
+    scope = detect_scope(path, config)
+
+    if scope.level == ScopeLevel.UNKNOWN:
+        raise FileNotFoundError(path.original)
+
+    if scope.table and not await table_exists(accessor, scope.table):
+        raise FileNotFoundError(path.original)
+
+    if scope.level in (ScopeLevel.ROOT, ScopeLevel.GROUP_DIR):
+        return FileStat(name=_name_of(path), type=FileType.DIRECTORY)
+
+    data = await read(accessor, path, index)
+    if scope.kind == "blob":
+        file_type = _IMAGE_TYPES.get(config.blob_ext, FileType.BINARY)
+    else:
+        file_type = FileType.TEXT
+    return FileStat(name=_name_of(path), size=len(data), type=file_type)

--- a/python/mirage/ops/qdrant/__init__.py
+++ b/python/mirage/ops/qdrant/__init__.py
@@ -1,0 +1,19 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.ops.qdrant.read import read
+from mirage.ops.qdrant.readdir import readdir
+from mirage.ops.qdrant.stat import stat
+
+OPS = [read, readdir, stat]

--- a/python/mirage/ops/qdrant/read.py
+++ b/python/mirage/ops/qdrant/read.py
@@ -1,0 +1,24 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.core.qdrant.read import read as core_read
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("read", resource="qdrant")
+async def read(accessor: QdrantAccessor, path: PathSpec, *, index,
+               **kwargs) -> bytes:
+    return await core_read(accessor, path, index)

--- a/python/mirage/ops/qdrant/readdir.py
+++ b/python/mirage/ops/qdrant/readdir.py
@@ -1,0 +1,24 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.core.qdrant.readdir import readdir as core_readdir
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("readdir", resource="qdrant")
+async def readdir(accessor: QdrantAccessor, path: PathSpec, *, index,
+                  **kwargs) -> list[str]:
+    return await core_readdir(accessor, path, index)

--- a/python/mirage/ops/qdrant/stat.py
+++ b/python/mirage/ops/qdrant/stat.py
@@ -1,0 +1,24 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.core.qdrant.stat import stat as core_stat
+from mirage.ops.registry import op
+from mirage.types import FileStat, PathSpec
+
+
+@op("stat", resource="qdrant")
+async def stat(accessor: QdrantAccessor, path: PathSpec, *, index,
+               **kwargs) -> FileStat:
+    return await core_stat(accessor, path, index)

--- a/python/mirage/resource/qdrant/__init__.py
+++ b/python/mirage/resource/qdrant/__init__.py
@@ -1,0 +1,24 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.resource.qdrant.config import QdrantConfig
+
+__all__ = ["QdrantConfig", "QdrantResource"]
+
+
+def __getattr__(name: str):
+    if name == "QdrantResource":
+        from mirage.resource.qdrant.qdrant import QdrantResource
+        return QdrantResource
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/mirage/resource/qdrant/config.py
+++ b/python/mirage/resource/qdrant/config.py
@@ -1,0 +1,34 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from pydantic import BaseModel, SecretStr
+
+
+class QdrantConfig(BaseModel):
+    url: str | None = None
+    host: str = "localhost"
+    port: int = 6333
+    https: bool = False
+    api_key: SecretStr | None = None
+    collection: str | None = None
+    group_by: list[str] = []
+    id_field: str = "id"
+    text_field: str | None = None
+    blob_field: str | None = None
+    blob_ext: str = "bin"
+    vector_field: str | None = None
+    search_limit: int = 10
+    max_rows: int = 1000
+    embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2"
+    cloud_inference: bool = False

--- a/python/mirage/resource/qdrant/prompt.py
+++ b/python/mirage/resource/qdrant/prompt.py
@@ -1,0 +1,32 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+PROMPT = """\
+This mount is a Qdrant vector database exposed as a filesystem.
+
+Layout:
+- At the root, each directory is a Qdrant collection (unless a single collection
+  is pinned in config).
+- Inside a collection, directories are the configured group-by payload fields.
+  Descending narrows a filter, e.g. `ls products/Men/Tshirts` lists points where
+  category=Men, type=Tshirts.
+- Each matching point appears as files named by its id: `<id>.json` (the full
+  payload as JSON), `<id>.txt` (the embedded source text) when a text field is
+  configured, and `<id>.<ext>` (raw blob bytes) when a blob field is configured.
+  `<id>` is the Qdrant point id. The embedding vector itself is never shown.
+- Semantic search is the `search` command: `search "red running shoes"` returns
+  the top matching points as their content file paths with a similarity score.
+
+Use ls/cd/cat/tree/find/grep as usual. Quote queries that contain spaces.\
+"""

--- a/python/mirage/resource/qdrant/qdrant.py
+++ b/python/mirage/resource/qdrant/qdrant.py
@@ -1,0 +1,52 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.qdrant import QdrantAccessor
+from mirage.core.qdrant.glob import resolve_glob as _resolve_glob
+from mirage.resource.base import BaseResource
+from mirage.resource.qdrant.config import QdrantConfig
+from mirage.resource.qdrant.prompt import PROMPT
+from mirage.types import ResourceName
+
+
+class QdrantResource(BaseResource):
+
+    name: str = ResourceName.QDRANT
+    is_remote: bool = True
+    PROMPT: str = PROMPT
+    SUPPORTS_SNAPSHOT: bool = False
+
+    def __init__(self, config: QdrantConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.accessor = QdrantAccessor(self.config)
+        from mirage.commands.builtin.qdrant import COMMANDS
+        from mirage.ops.qdrant import OPS as QDRANT_OPS
+
+        for fn in COMMANDS:
+            self.register(fn)
+        for fn in QDRANT_OPS:
+            self.register_op(fn)
+
+    async def resolve_glob(self, paths, prefix: str = ""):
+        return await _resolve_glob(self.accessor, paths, index=self._index)
+
+    async def fingerprint(self, path: str) -> str | None:
+        return None
+
+    def get_state(self) -> dict:
+        return self.config_state(self.config)
+
+    def load_state(self, state: dict) -> None:
+        pass

--- a/python/mirage/resource/registry.py
+++ b/python/mirage/resource/registry.py
@@ -158,6 +158,9 @@ REGISTRY: dict[str, ResourceEntry] = {
     "lancedb":
     ResourceEntry("mirage.resource.lancedb:LanceDBResource",
                   "mirage.resource.lancedb:LanceDBConfig"),
+    "qdrant":
+    ResourceEntry("mirage.resource.qdrant:QdrantResource",
+                  "mirage.resource.qdrant:QdrantConfig"),
 }
 
 

--- a/python/mirage/types.py
+++ b/python/mirage/types.py
@@ -186,6 +186,7 @@ class ResourceName(str, Enum):
     NEXTCLOUD = "nextcloud"
     LANCEDB = "lancedb"
     ONEDRIVE = "onedrive"
+    QDRANT = "qdrant"
     SHAREPOINT = "sharepoint"
 
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -109,6 +109,9 @@ langfuse = ["langfuse>=4.2.0"]
 # thin HTTP-only client; the accessor uses AsyncHttpClient exclusively
 chroma   = ["chromadb-client>=1.0.0"]
 
+# --- qdrant ---
+qdrant   = ["qdrant-client[fastembed]>=1.18.0"]
+
 # --- anthropic ---
 anthropic   = ["anthropic>=0.88"]
 
@@ -163,6 +166,7 @@ all = [
     "mirage-ai[pdf]",
     "mirage-ai[langfuse]",
     "mirage-ai[chroma]",
+    "mirage-ai[qdrant]",
     "mirage-ai[anthropic]",
     "mirage-ai[openai]",
     "mirage-ai[pydantic-ai]",

--- a/python/tests/commands/builtin/qdrant/test_grep.py
+++ b/python/tests/commands/builtin/qdrant/test_grep.py
@@ -1,0 +1,129 @@
+import pytest
+
+from mirage.commands.builtin.qdrant.grep import grep
+from mirage.io.types import materialize
+from mirage.types import FileStat, FileType, PathSpec
+
+DOCS = {
+    "/db/animals/cat/1.md": b"alpha match\nctx one\nctx two\n",
+    "/db/animals/dog/2.md": b"gamma match\n",
+}
+
+DIRS = {
+    "/db/animals": ["/db/animals/cat", "/db/animals/dog"],
+    "/db/animals/cat": ["/db/animals/cat/1.md"],
+    "/db/animals/dog": ["/db/animals/dog/2.md"],
+}
+
+
+def _spec(path: str) -> PathSpec:
+    return PathSpec.from_str_path(path, "/db/")
+
+
+def _patch_backend(monkeypatch) -> None:
+    g = grep.__wrapped__.__globals__
+
+    async def fake_resolve_glob(accessor, paths, index=None):
+        return paths
+
+    async def fake_read(accessor, p, index=None):
+        return DOCS[p.original]
+
+    async def fake_readdir(accessor, p, index=None):
+        return DIRS[p.original]
+
+    async def fake_stat(accessor, p, index=None):
+        kind = FileType.DIRECTORY if p.original in DIRS else FileType.TEXT
+        return FileStat(name=p.original, type=kind)
+
+    monkeypatch.setitem(g, "resolve_glob", fake_resolve_glob)
+    monkeypatch.setitem(g, "qdrant_read", fake_read)
+    monkeypatch.setitem(g, "_readdir", fake_readdir)
+    monkeypatch.setitem(g, "_stat", fake_stat)
+
+
+async def _stdin() -> bytes:
+    return b"alpha line\nbeta line\n"
+
+
+@pytest.mark.asyncio
+async def test_single_file_prints_bare_lines(monkeypatch):
+    _patch_backend(monkeypatch)
+
+    output, io = await grep(object(), [_spec("/db/animals/cat/1.md")],
+                            "match",
+                            index=None)
+
+    assert await materialize(output) == b"alpha match\n"
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_multi_file_prefixes_filenames(monkeypatch):
+    _patch_backend(monkeypatch)
+
+    output, io = await grep(
+        object(),
+        [_spec("/db/animals/cat/1.md"),
+         _spec("/db/animals/dog/2.md")],
+        "match",
+        index=None)
+
+    assert await materialize(output) == (b"/db/animals/cat/1.md:alpha match\n"
+                                         b"/db/animals/dog/2.md:gamma match\n")
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_quiet_suppresses_output(monkeypatch):
+    _patch_backend(monkeypatch)
+
+    output, io = await grep(object(), [_spec("/db/animals/cat/1.md")],
+                            "match",
+                            q=True,
+                            index=None)
+
+    assert await materialize(output) == b""
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_after_context_includes_trailing_lines(monkeypatch):
+    _patch_backend(monkeypatch)
+
+    output, io = await grep(object(), [_spec("/db/animals/cat/1.md")],
+                            "match",
+                            A="1",
+                            index=None)
+
+    assert await materialize(output) == b"alpha match\nctx one\n"
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_stdin_searched_when_no_paths(monkeypatch):
+    _patch_backend(monkeypatch)
+
+    output, io = await grep(object(), [],
+                            "alpha",
+                            stdin=await _stdin(),
+                            index=None)
+
+    assert await materialize(output) == b"alpha line\n"
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_recursive_searches_all_paths(monkeypatch):
+    _patch_backend(monkeypatch)
+
+    output, io = await grep(
+        object(), [_spec("/db/animals/cat"),
+                   _spec("/db/animals/dog")],
+        "match",
+        r=True,
+        index=None)
+
+    assert await materialize(output) == (b"/db/animals/cat/1.md:alpha match\n"
+                                         b"/db/animals/dog/2.md:gamma match\n")
+    assert io.exit_code == 0

--- a/python/tests/core/qdrant/conftest.py
+++ b/python/tests/core/qdrant/conftest.py
@@ -1,0 +1,156 @@
+import base64
+from difflib import SequenceMatcher
+from types import SimpleNamespace
+
+import pytest
+
+from mirage.resource.qdrant.config import QdrantConfig
+
+COLLECTION = "animals"
+
+_ROWS = [
+    {
+        "id": 1,
+        "label": "cat",
+        "kind": "big",
+        "name": "a big orange cat"
+    },
+    {
+        "id": 2,
+        "label": "cat",
+        "kind": "small",
+        "name": "a small grey cat"
+    },
+    {
+        "id": 3,
+        "label": "dog",
+        "kind": "big",
+        "name": "a big brown dog"
+    },
+    {
+        "id": 4,
+        "label": "dog",
+        "kind": "small",
+        "name": "a small white dog"
+    },
+]
+
+
+def _points() -> list[SimpleNamespace]:
+    points = []
+    for row in _ROWS:
+        payload = {
+            "label": row["label"],
+            "kind": row["kind"],
+            "name": row["name"],
+            "image_bytes":
+            base64.b64encode(f"PNG-{row['id']}".encode()).decode(),
+        }
+        points.append(SimpleNamespace(id=row["id"], payload=payload))
+    return points
+
+
+def _match(point: SimpleNamespace, scroll_filter) -> bool:
+    if scroll_filter is None:
+        return True
+    for condition in scroll_filter.must:
+        value = (point.payload or {}).get(condition.key)
+        if str(value) != str(condition.match.value):
+            return False
+    return True
+
+
+class FakeQdrantClient:
+
+    def __init__(self) -> None:
+        self.points = _points()
+
+    async def get_collections(self):
+        return SimpleNamespace(collections=[SimpleNamespace(name=COLLECTION)])
+
+    async def collection_exists(self, name: str) -> bool:
+        return name == COLLECTION
+
+    async def scroll(self,
+                     collection_name,
+                     scroll_filter=None,
+                     limit=10,
+                     offset=None,
+                     with_payload=True,
+                     with_vectors=False):
+        matched = [p for p in self.points if _match(p, scroll_filter)]
+        start = offset or 0
+        window = matched[start:start + limit]
+        nxt = start + limit if start + limit < len(matched) else None
+        return window, nxt
+
+    async def retrieve(self,
+                       collection_name,
+                       ids,
+                       with_payload=True,
+                       with_vectors=False):
+        return [p for p in self.points if p.id in ids]
+
+    async def create_payload_index(self,
+                                   collection_name,
+                                   field_name,
+                                   field_schema=None):
+        pass
+
+    async def query_points(self,
+                           collection_name,
+                           query=None,
+                           limit=10,
+                           with_payload=True):
+        text = query.text if query is not None else ""
+        ranked = sorted(
+            self.points,
+            key=lambda p: SequenceMatcher(
+                None, text, str((p.payload or {}).get("name", ""))).ratio(),
+            reverse=True,
+        )
+        scored = []
+        for point in ranked[:limit]:
+            ratio = SequenceMatcher(None, text,
+                                    str((point.payload
+                                         or {}).get("name", ""))).ratio()
+            scored.append(
+                SimpleNamespace(id=point.id,
+                                payload=point.payload,
+                                score=ratio))
+        return SimpleNamespace(points=scored)
+
+
+class FakeAccessor:
+
+    def __init__(self, config: QdrantConfig, client: FakeQdrantClient) -> None:
+        self.config = config
+        self._client = client
+        self._search_cache: dict = {}
+        self._indexes_ensured: set[str] = set()
+
+    async def client(self):
+        return self._client
+
+    def cached_search(self, key):
+        return self._search_cache.get(key)
+
+    def store_search(self, key, rows):
+        self._search_cache[key] = rows
+
+
+@pytest.fixture
+def qdrant_config() -> QdrantConfig:
+    return QdrantConfig(
+        group_by=["label", "kind"],
+        id_field="id",
+        text_field="name",
+        blob_field="image_bytes",
+        blob_ext="png",
+        vector_field="vector",
+    )
+
+
+@pytest.fixture
+def accessor(qdrant_config) -> FakeAccessor:
+    return FakeAccessor(qdrant_config, FakeQdrantClient())

--- a/python/tests/core/qdrant/test_query.py
+++ b/python/tests/core/qdrant/test_query.py
@@ -1,0 +1,127 @@
+from types import SimpleNamespace
+
+import pytest
+from qdrant_client.http.exceptions import UnexpectedResponse
+
+from mirage.core.qdrant import query
+from mirage.resource.qdrant.config import QdrantConfig
+
+
+def test_coerce_numeric_only():
+    assert query._coerce("12") == 12
+    assert query._coerce("-3") == -3
+    assert query._coerce("cat") == "cat"
+
+
+def test_coerce_keeps_lossy_numeric_strings():
+    assert query._coerce("007") == "007"
+    assert query._coerce("05") == "05"
+    assert query._coerce("-0") == "-0"
+
+
+def test_candidate_ids_by_type():
+    assert query._candidate_ids("7") == [7]
+    uid = "11111111-1111-1111-1111-111111111111"
+    assert query._candidate_ids(uid) == [uid]
+    assert query._candidate_ids("__nf_missing__") == []
+
+
+class _StrictClient:
+
+    def __init__(self) -> None:
+        self.points = [
+            SimpleNamespace(id=1, payload={
+                "code": "100",
+                "name": "a"
+            }),
+            SimpleNamespace(id=2, payload={
+                "code": "200",
+                "name": "b"
+            }),
+        ]
+        self.filtered_calls = 0
+        self.index_calls = 0
+        self._indexed = False
+
+    async def scroll(self,
+                     collection_name,
+                     scroll_filter=None,
+                     limit=10,
+                     offset=None,
+                     with_payload=True,
+                     with_vectors=False):
+        if scroll_filter is not None and not self._indexed:
+            self.filtered_calls += 1
+            raise UnexpectedResponse(
+                400, "Bad Request",
+                b'{"status":{"error":"Index required but not found"}}', {})
+        pts = self.points
+        if scroll_filter is not None:
+            conds = {c.key: c.match.value for c in scroll_filter.must}
+            pts = [
+                p for p in pts if all(
+                    str(p.payload.get(k)) == str(v) for k, v in conds.items())
+            ]
+        start = offset or 0
+        window = pts[start:start + limit]
+        nxt = start + limit if start + limit < len(pts) else None
+        return window, nxt
+
+    async def create_payload_index(self,
+                                   collection_name,
+                                   field_name,
+                                   field_schema=None):
+        self.index_calls += 1
+        self._indexed = True
+
+
+class _StrictAccessor:
+
+    def __init__(self, client) -> None:
+        self.config = QdrantConfig(collection="c",
+                                   group_by=["code"],
+                                   id_field="id",
+                                   max_rows=1000)
+        self._client = client
+        self._indexes_ensured: set[str] = set()
+
+    async def client(self):
+        return self._client
+
+
+@pytest.mark.asyncio
+async def test_creates_indexes_on_index_required_then_retries():
+    client = _StrictClient()
+    accessor = _StrictAccessor(client)
+
+    rows = await query.rows_matching(accessor, "c", {"code": "100"}, 100)
+
+    assert [r["id"] for r in rows] == [1]
+    assert client.filtered_calls == 1
+    assert client.index_calls == 1
+    assert "c" in accessor._indexes_ensured
+
+
+@pytest.mark.asyncio
+async def test_does_not_recreate_indexes_on_subsequent_calls():
+    client = _StrictClient()
+    accessor = _StrictAccessor(client)
+
+    await query.distinct_values(accessor, "c", "code", {"code": "100"}, 100)
+    await query.distinct_values(accessor, "c", "code", {"code": "100"}, 100)
+
+    assert client.index_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_non_index_error_propagates():
+    client = _StrictClient()
+
+    async def boom(**kwargs):
+        raise UnexpectedResponse(500, "err", b"boom", {})
+
+    client.scroll = boom
+    accessor = _StrictAccessor(client)
+
+    with pytest.raises(UnexpectedResponse):
+        await query.rows_matching(accessor, "c", {"code": "100"}, 100)

--- a/python/tests/core/qdrant/test_read.py
+++ b/python/tests/core/qdrant/test_read.py
@@ -1,0 +1,39 @@
+import json
+
+import pytest
+
+from mirage.core.qdrant.read import read
+from mirage.types import PathSpec
+
+
+def _ps(path: str) -> PathSpec:
+    return PathSpec(original=path, directory=path)
+
+
+@pytest.mark.asyncio
+async def test_read_json_returns_payload(accessor):
+    data = (await read(accessor, _ps("/animals/cat/big/1.json"))).decode()
+    payload = json.loads(data)
+    assert payload["label"] == "cat"
+    assert payload["name"] == "a big orange cat"
+    assert payload["id"] == 1
+    assert "vector" not in payload
+    assert "image_bytes" not in payload
+
+
+@pytest.mark.asyncio
+async def test_read_text_returns_source_text(accessor):
+    data = (await read(accessor, _ps("/animals/cat/big/1.txt"))).decode()
+    assert data == "a big orange cat\n"
+
+
+@pytest.mark.asyncio
+async def test_read_blob_returns_raw_bytes(accessor):
+    data = await read(accessor, _ps("/animals/cat/big/1.png"))
+    assert data == b"PNG-1"
+
+
+@pytest.mark.asyncio
+async def test_read_missing_row_raises(accessor):
+    with pytest.raises(FileNotFoundError):
+        await read(accessor, _ps("/animals/cat/big/999.json"))

--- a/python/tests/core/qdrant/test_readdir.py
+++ b/python/tests/core/qdrant/test_readdir.py
@@ -1,0 +1,49 @@
+import pytest
+
+from mirage.core.qdrant.readdir import is_dir_name, readdir
+from mirage.resource.qdrant.config import QdrantConfig
+from mirage.types import PathSpec
+
+
+def _ps(path: str) -> PathSpec:
+    return PathSpec(original=path, directory=path)
+
+
+def _names(paths: list[str]) -> set[str]:
+    return {p.rsplit("/", 1)[-1] for p in paths}
+
+
+@pytest.mark.asyncio
+async def test_root_lists_collection(accessor):
+    out = await readdir(accessor, _ps("/"))
+    assert _names(out) == {"animals"}
+
+
+@pytest.mark.asyncio
+async def test_collection_lists_groups(accessor):
+    out = await readdir(accessor, _ps("/animals"))
+    assert _names(out) == {"cat", "dog"}
+
+
+@pytest.mark.asyncio
+async def test_group_lists_next_level(accessor):
+    out = await readdir(accessor, _ps("/animals/cat"))
+    assert _names(out) == {"big", "small"}
+
+
+@pytest.mark.asyncio
+async def test_leaf_lists_row_files(accessor):
+    out = await readdir(accessor, _ps("/animals/cat/big"))
+    assert _names(out) == {"1.json", "1.txt", "1.png"}
+
+
+def test_is_dir_name_classifies_row_files():
+    cfg = QdrantConfig(text_field="name", blob_field="img", blob_ext="png")
+    assert is_dir_name("/animals/cat", config=cfg) is True
+    assert is_dir_name("/animals/cat/big/1.json", config=cfg) is False
+    assert is_dir_name("/animals/cat/big/1.txt", config=cfg) is False
+    assert is_dir_name("/animals/cat/big/1.png", config=cfg) is False
+    no_extra = QdrantConfig()
+    assert is_dir_name("/animals/cat/big/1.png", config=no_extra) is True
+    assert is_dir_name("/animals/cat/big/1.txt", config=no_extra) is True
+    assert is_dir_name("/animals/cat/big/1.json", config=no_extra) is False

--- a/python/tests/core/qdrant/test_render.py
+++ b/python/tests/core/qdrant/test_render.py
@@ -1,0 +1,38 @@
+import json
+
+from mirage.core.qdrant.render import render_json, render_text
+from mirage.resource.qdrant.config import QdrantConfig
+
+
+def _cfg() -> QdrantConfig:
+    return QdrantConfig(id_field="id",
+                        text_field="name",
+                        blob_field="image_bytes",
+                        blob_ext="png",
+                        vector_field="vector")
+
+
+def test_render_json_omits_vector_and_blob():
+    row = {
+        "id": 3,
+        "name": "a big brown dog",
+        "label": "dog",
+        "image_bytes": "UE5HLTM=",
+        "vector": [0.1, 0.2],
+    }
+    payload = json.loads(render_json(row, _cfg()).decode())
+    assert payload == {"id": 3, "name": "a big brown dog", "label": "dog"}
+
+
+def test_render_json_is_compact():
+    out = render_json({"id": 1, "name": "x"}, _cfg()).decode()
+    assert out == '{"id":1,"name":"x"}\n'
+
+
+def test_render_text_returns_source_text():
+    out = render_text({"id": 3, "name": "a big brown dog"}, _cfg()).decode()
+    assert out == "a big brown dog\n"
+
+
+def test_render_text_empty_when_field_missing():
+    assert render_text({"id": 3}, _cfg()) == b""

--- a/python/tests/core/qdrant/test_scope.py
+++ b/python/tests/core/qdrant/test_scope.py
@@ -1,0 +1,71 @@
+from mirage.core.qdrant.scope import ScopeLevel, detect_scope
+from mirage.resource.qdrant.config import QdrantConfig
+from mirage.types import PathSpec
+
+
+def _cfg(**kw) -> QdrantConfig:
+    base = dict(group_by=["label", "kind"],
+                id_field="id",
+                text_field="name",
+                blob_field="image_bytes",
+                blob_ext="png",
+                vector_field="vector")
+    base.update(kw)
+    return QdrantConfig(**base)
+
+
+def _ps(path: str) -> PathSpec:
+    return PathSpec(original=path, directory=path)
+
+
+def test_root_multi_collection():
+    s = detect_scope(_ps("/"), _cfg())
+    assert s.level == ScopeLevel.ROOT
+
+
+def test_collection_group_dir():
+    s = detect_scope(_ps("/animals"), _cfg())
+    assert s.level == ScopeLevel.GROUP_DIR
+    assert s.table == "animals"
+    assert s.filters == {}
+
+
+def test_nested_group_dir():
+    s = detect_scope(_ps("/animals/cat"), _cfg())
+    assert s.level == ScopeLevel.GROUP_DIR
+    assert s.filters == {"label": "cat"}
+
+
+def test_leaf_group_dir():
+    s = detect_scope(_ps("/animals/cat/big"), _cfg())
+    assert s.level == ScopeLevel.GROUP_DIR
+    assert s.filters == {"label": "cat", "kind": "big"}
+
+
+def test_row_json():
+    s = detect_scope(_ps("/animals/cat/big/3.json"), _cfg())
+    assert s.level == ScopeLevel.ROW
+    assert s.row_id == "3"
+    assert s.kind == "json"
+    assert s.filters == {"label": "cat", "kind": "big"}
+
+
+def test_row_text():
+    s = detect_scope(_ps("/animals/cat/big/3.txt"), _cfg())
+    assert s.level == ScopeLevel.ROW
+    assert s.row_id == "3"
+    assert s.kind == "txt"
+
+
+def test_row_blob():
+    s = detect_scope(_ps("/animals/cat/big/3.png"), _cfg())
+    assert s.level == ScopeLevel.ROW
+    assert s.row_id == "3"
+    assert s.kind == "blob"
+
+
+def test_single_collection_pin_elides_collection():
+    s = detect_scope(_ps("/cat/big"), _cfg(collection="animals"))
+    assert s.level == ScopeLevel.GROUP_DIR
+    assert s.table == "animals"
+    assert s.filters == {"label": "cat", "kind": "big"}

--- a/python/tests/core/qdrant/test_search.py
+++ b/python/tests/core/qdrant/test_search.py
@@ -1,0 +1,52 @@
+import pytest
+
+from mirage.core.qdrant.search import search_rows_output
+from mirage.types import PathSpec
+
+
+def _ps(path: str) -> PathSpec:
+    return PathSpec(original=path, directory=path, prefix="/db")
+
+
+@pytest.mark.asyncio
+async def test_search_emits_canonical_path_with_score(accessor):
+    out = (await search_rows_output(accessor,
+                                    "a small white dog", [_ps("/db/animals")],
+                                    top_k=2,
+                                    threshold=0.0,
+                                    mount_prefix="/db")).decode()
+    first = out.splitlines()[0]
+    assert first.startswith("/db/animals/dog/small/4.txt:")
+
+
+@pytest.mark.asyncio
+async def test_search_body_is_source_text(accessor):
+    out = (await search_rows_output(accessor,
+                                    "a small white dog", [_ps("/db/animals")],
+                                    top_k=1,
+                                    threshold=0.0,
+                                    mount_prefix="/db")).decode()
+    assert "a small white dog" in out
+    assert "label:" not in out
+    assert "score:" not in out
+
+
+@pytest.mark.asyncio
+async def test_search_top_k_limits_results(accessor):
+    out = (await search_rows_output(accessor,
+                                    "a small white dog", [_ps("/db/animals")],
+                                    top_k=1,
+                                    threshold=0.0,
+                                    mount_prefix="/db")).decode()
+    headers = [ln for ln in out.splitlines() if ln.startswith("/db/")]
+    assert len(headers) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_empty_query_raises(accessor):
+    with pytest.raises(ValueError):
+        await search_rows_output(accessor,
+                                 "", [_ps("/db/animals")],
+                                 top_k=2,
+                                 threshold=0.0,
+                                 mount_prefix="/db")

--- a/python/tests/core/qdrant/test_stat.py
+++ b/python/tests/core/qdrant/test_stat.py
@@ -1,0 +1,42 @@
+import pytest
+
+from mirage.core.qdrant.stat import stat
+from mirage.types import FileType, PathSpec
+
+
+def _ps(path: str) -> PathSpec:
+    return PathSpec(original=path, directory=path)
+
+
+@pytest.mark.asyncio
+async def test_stat_group_dir_is_directory(accessor):
+    s = await stat(accessor, _ps("/animals/cat"))
+    assert s.type == FileType.DIRECTORY
+    assert s.name == "cat"
+
+
+@pytest.mark.asyncio
+async def test_stat_json_is_text_with_size(accessor):
+    s = await stat(accessor, _ps("/animals/cat/big/1.json"))
+    assert s.type == FileType.TEXT
+    assert s.size and s.size > 0
+
+
+@pytest.mark.asyncio
+async def test_stat_txt_is_text_with_size(accessor):
+    s = await stat(accessor, _ps("/animals/cat/big/1.txt"))
+    assert s.type == FileType.TEXT
+    assert s.size and s.size > 0
+
+
+@pytest.mark.asyncio
+async def test_stat_blob_is_image(accessor):
+    s = await stat(accessor, _ps("/animals/cat/big/1.png"))
+    assert s.type == FileType.IMAGE_PNG
+    assert s.size == len(b"PNG-1")
+
+
+@pytest.mark.asyncio
+async def test_stat_unknown_raises(accessor):
+    with pytest.raises(FileNotFoundError):
+        await stat(accessor, _ps("/animals/cat/big/1.weird/x"))

--- a/python/tests/resource/qdrant/test_resource.py
+++ b/python/tests/resource/qdrant/test_resource.py
@@ -1,0 +1,41 @@
+from mirage.resource.qdrant import QdrantConfig, QdrantResource
+from mirage.resource.registry import REGISTRY, build_resource
+
+
+def _resource(**kw) -> QdrantResource:
+    base = dict(collection="animals", group_by=["label"], id_field="id")
+    base.update(kw)
+    return QdrantResource(QdrantConfig(**base))
+
+
+def test_resource_name_and_remote():
+    res = _resource()
+    assert res.name == "qdrant"
+    assert res.is_remote is True
+    assert res.SUPPORTS_SNAPSHOT is False
+
+
+def test_resource_registers_ops():
+    res = _resource()
+    assert {"read", "readdir", "stat"} <= {o.name for o in res.ops_list()}
+
+
+def test_resource_registers_commands():
+    res = _resource()
+    expected = {
+        "cat", "find", "grep", "head", "ls", "rg", "search", "stat", "tail",
+        "tree", "wc"
+    }
+    assert expected <= {c.name for c in res.commands()}
+
+
+def test_resource_in_registry():
+    assert "qdrant" in REGISTRY
+    res = build_resource("qdrant", {"collection": "docs"})
+    assert res.name == "qdrant"
+
+
+def test_resource_get_state_redacts_api_key():
+    res = _resource(api_key="secret-value")
+    state = res.get_state()
+    assert "secret-value" not in str(state)

--- a/python/tests/resource/test_registry.py
+++ b/python/tests/resource/test_registry.py
@@ -50,6 +50,7 @@ EXPECTED_RESOURCES = {
     "mongodb",
     "postgres",
     "lancedb",
+    "qdrant",
     "notion",
     "langfuse",
     "ssh",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1153,7 +1153,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly" },
+    { name = "humanfriendly", marker = "python_full_version < '3.13' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -1694,6 +1694,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4e/d9/e66315807e41e69e7f6a1b42a162dada2f249c5f06ad3f1a95f84ab336ef/fastapi-0.136.0.tar.gz", hash = "sha256:cf08e067cc66e106e102d9ba659463abfac245200752f8a5b7b1e813de4ff73e", size = 396607, upload-time = "2026-04-16T11:47:13.623Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/a3/0bd5f0cdb0bbc92650e8dc457e9250358411ee5d1b65e42b6632387daf81/fastapi-0.136.0-py3-none-any.whl", hash = "sha256:8793d44ec7378e2be07f8a013cf7f7aa47d6327d0dfe9804862688ec4541a6b4", size = 117556, upload-time = "2026-04-16T11:47:11.922Z" },
+]
+
+[[package]]
+name = "fastembed"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "loguru" },
+    { name = "mmh3" },
+    { name = "numpy" },
+    { name = "onnxruntime", version = "1.20.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "pillow" },
+    { name = "py-rust-stemmers" },
+    { name = "requests" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/25/58865e36b6e8a9a0d0ff905b5601aa30db97956327c0df42ec4ed6accc21/fastembed-0.8.0.tar.gz", hash = "sha256:75966edfa8b006ee78514c726bd7f6a50721dadc89305279052be9db72fd53e8", size = 75115, upload-time = "2026-03-23T16:34:41.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e8/26b7d78bb8972498c467ca34cb12ee2e60d26ba5eae6d8443189a1af37a5/fastembed-0.8.0-py3-none-any.whl", hash = "sha256:40bee672657574a1009e35ec50030a55f2b426842cb011845379817641bbbbd0", size = 116572, upload-time = "2026-03-23T16:34:40.69Z" },
 ]
 
 [[package]]
@@ -2580,16 +2602,16 @@ name = "huggingface-hub"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version >= '3.12'" },
-    { name = "filelock", marker = "python_full_version >= '3.12'" },
-    { name = "fsspec", marker = "python_full_version >= '3.12'" },
-    { name = "hf-xet", marker = "(python_full_version >= '3.12' and platform_machine == 'AMD64') or (python_full_version >= '3.12' and platform_machine == 'aarch64') or (python_full_version >= '3.12' and platform_machine == 'amd64') or (python_full_version >= '3.12' and platform_machine == 'arm64') or (python_full_version >= '3.12' and platform_machine == 'x86_64')" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
-    { name = "tqdm", marker = "python_full_version >= '3.12'" },
-    { name = "typer", marker = "python_full_version >= '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/11/9b6e439cb2417c479c3da108b38363232a1554721de9f8ef4836cb07422b/huggingface_hub-1.16.4.tar.gz", hash = "sha256:023bacd155f837d3fa56379ac8e23dababe6d6d87b04f8dacc258a44a38abe01", size = 792585, upload-time = "2026-05-26T17:19:09.971Z" }
 wheels = [
@@ -2601,7 +2623,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "(python_full_version < '3.13' and sys_platform == 'win32') or (python_full_version >= '3.13' and extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (python_full_version >= '3.13' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (python_full_version >= '3.13' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (python_full_version >= '3.13' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai') or (sys_platform != 'win32' and extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (sys_platform != 'win32' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (sys_platform != 'win32' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (sys_platform != 'win32' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -3447,6 +3469,19 @@ wheels = [
 ]
 
 [[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
 name = "lupa"
 version = "2.8"
 source = { registry = "https://pypi.org/simple" }
@@ -3609,13 +3644,48 @@ wheels = [
 
 [[package]]
 name = "magika"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "click", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
+    { name = "numpy", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/8fdd991142ad3e037179a494b153f463024e5a211ef3ad948b955c26b4de/magika-0.6.2.tar.gz", hash = "sha256:37eb6ae8020f6e68f231bc06052c0a0cbe8e6fa27492db345e8dc867dbceb067", size = 3036634, upload-time = "2025-05-02T14:54:18.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/07/4f7748f34279f2852068256992377474f9700b6fbad6735d6be58605178f/magika-0.6.2-py3-none-any.whl", hash = "sha256:5ef72fbc07723029b3684ef81454bc224ac5f60986aa0fc5a28f4456eebcb5b2", size = 2967609, upload-time = "2025-05-02T14:54:09.696Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6d/0783af677e601d8a42258f0fbc47663abf435f927e58a8d2928296743099/magika-0.6.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9109309328a1553886c8ff36c2ee9a5e9cfd36893ad81b65bf61a57debdd9d0e", size = 12404787, upload-time = "2025-05-02T14:54:16.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ad/42e39748ddc4bbe55c2dc1093ce29079c04d096ac0d844f8ae66178bc3ed/magika-0.6.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:57cd1d64897634d15de552bd6b3ae9c6ff6ead9c60d384dc46497c08288e4559", size = 15091089, upload-time = "2025-05-02T14:54:11.59Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1f/28e412d0ccedc068fbccdae6a6233faaa97ec3e5e2ffd242e49655b10064/magika-0.6.2-py3-none-win_amd64.whl", hash = "sha256:711f427a633e0182737dcc2074748004842f870643585813503ff2553b973b9f", size = 12385740, upload-time = "2025-05-02T14:54:14.096Z" },
+]
+
+[[package]]
+name = "magika"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "click" },
-    { name = "numpy" },
-    { name = "onnxruntime" },
-    { name = "python-dotenv" },
+    { name = "click", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "numpy", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "onnxruntime", version = "1.20.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and sys_platform != 'win32' and extra == 'extra-9-mirage-ai-camel') or (python_full_version < '3.13' and extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (python_full_version < '3.13' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (python_full_version < '3.13' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (python_full_version < '3.13' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai') or (sys_platform == 'win32' and extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (sys_platform == 'win32' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (sys_platform == 'win32' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (sys_platform == 'win32' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "python-dotenv", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/f3/3d1dcdd7b9c41d589f5cff252d32ed91cdf86ba84391cfc81d9d8773571d/magika-0.6.3.tar.gz", hash = "sha256:7cc52aa7359af861957043e2bf7265ed4741067251c104532765cd668c0c0cb1", size = 3042784, upload-time = "2025-10-30T15:22:34.499Z" }
 wheels = [
@@ -3658,7 +3728,8 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "charset-normalizer" },
     { name = "defusedxml" },
-    { name = "magika" },
+    { name = "magika", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-9-mirage-ai-camel') or (python_full_version < '3.13' and extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (python_full_version < '3.13' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (python_full_version < '3.13' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (python_full_version < '3.13' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai') or (sys_platform != 'win32' and extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (sys_platform != 'win32' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (sys_platform != 'win32' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (sys_platform != 'win32' and extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "magika", version = "0.6.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-9-mirage-ai-camel') or (sys_platform != 'win32' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
     { name = "markdownify" },
     { name = "requests" },
 ]
@@ -3838,7 +3909,8 @@ all = [
     { name = "pydantic-ai-slim" },
     { name = "pymongo" },
     { name = "pypdfium2" },
-    { name = "redis", extra = ["hiredis"], marker = "extra == 'extra-9-mirage-ai-all' or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "qdrant-client", extra = ["fastembed"], marker = "extra == 'extra-9-mirage-ai-all' or extra != 'extra-9-mirage-ai-camel' or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "redis", extra = ["hiredis"], marker = "extra == 'extra-9-mirage-ai-all' or extra != 'extra-9-mirage-ai-camel' or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
     { name = "tables" },
 ]
 anthropic = [
@@ -3923,6 +3995,9 @@ pydantic-ai = [
     { name = "pydantic-ai-slim" },
     { name = "pypdfium2" },
 ]
+qdrant = [
+    { name = "qdrant-client", extra = ["fastembed"] },
+]
 r2 = [
     { name = "aioboto3" },
 ]
@@ -4003,6 +4078,7 @@ requires-dist = [
     { name = "mirage-ai", extras = ["pdf"], marker = "extra == 'pydantic-ai'" },
     { name = "mirage-ai", extras = ["postgres"], marker = "extra == 'all'" },
     { name = "mirage-ai", extras = ["pydantic-ai"], marker = "extra == 'all'" },
+    { name = "mirage-ai", extras = ["qdrant"], marker = "extra == 'all'" },
     { name = "mirage-ai", extras = ["r2"], marker = "extra == 'all'" },
     { name = "mirage-ai", extras = ["redis"], marker = "extra == 'all'" },
     { name = "mirage-ai", extras = ["s3"], marker = "extra == 'all'" },
@@ -4025,6 +4101,7 @@ requires-dist = [
     { name = "pypdfium2", marker = "extra == 'pdf'", specifier = ">=5.7.0" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "qdrant-client", extras = ["fastembed"], marker = "extra == 'qdrant'", specifier = ">=1.18.0" },
     { name = "redis", extras = ["hiredis"], marker = "extra == 'redis'", specifier = ">=5.0" },
     { name = "tables", marker = "extra == 'hdf5'", specifier = ">=3.11.1" },
     { name = "tree-sitter", specifier = ">=0.25.2" },
@@ -4032,7 +4109,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
 ]
-provides-extras = ["s3", "r2", "gcs", "oci", "databricks", "ssh", "nextcloud", "hf", "fuse", "mongodb", "postgres", "redis", "email", "parquet", "hdf5", "pdf", "langfuse", "chroma", "anthropic", "openai", "pydantic-ai", "deepagents", "openhands", "agno", "claude-agent-sdk", "camel", "daytona", "all", "lancedb"]
+provides-extras = ["s3", "r2", "gcs", "oci", "databricks", "ssh", "nextcloud", "hf", "fuse", "mongodb", "postgres", "redis", "email", "parquet", "hdf5", "pdf", "langfuse", "chroma", "qdrant", "anthropic", "openai", "pydantic-ai", "deepagents", "openhands", "agno", "claude-agent-sdk", "camel", "daytona", "all", "lancedb"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4046,6 +4123,104 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-httpx", specifier = ">=0.36.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+]
+
+[[package]]
+name = "mmh3"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/1a/edb23803a168f070ded7a3014c6d706f63b90c84ccc024f89d794a3b7a6d/mmh3-5.2.1.tar.gz", hash = "sha256:bbea5b775f0ac84945191fb83f845a6fd9a21a03ea7f2e187defac7e401616ad", size = 33775, upload-time = "2026-03-05T15:55:57.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/d7/3312a59df3c1cdd783f4cf0c4ee8e9decff9c5466937182e4cc7dbbfe6c5/mmh3-5.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dae0f0bd7d30c0ad61b9a504e8e272cb8391eed3f1587edf933f4f6b33437450", size = 56082, upload-time = "2026-03-05T15:53:59.702Z" },
+    { url = "https://files.pythonhosted.org/packages/61/96/6f617baa098ca0d2989bfec6d28b5719532cd8d8848782662f5b755f657f/mmh3-5.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9aeaf53eaa075dd63e81512522fd180097312fb2c9f476333309184285c49ce0", size = 40458, upload-time = "2026-03-05T15:54:01.548Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b4/9cd284bd6062d711e13d26c04d4778ab3f690c1c38a4563e3c767ec8802e/mmh3-5.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0634581290e6714c068f4aa24020acf7880927d1f0084fa753d9799ae9610082", size = 40079, upload-time = "2026-03-05T15:54:02.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/09/a806334ce1d3d50bf782b95fcee8b3648e1e170327d4bb7b4bad2ad7d956/mmh3-5.2.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e080c0637aea036f35507e803a4778f119a9b436617694ae1c5c366805f1e997", size = 97242, upload-time = "2026-03-05T15:54:04.536Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/93/723e317dd9e041c4dc4566a2eb53b01ad94de31750e0b834f1643905e97c/mmh3-5.2.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:db0562c5f71d18596dcd45e854cf2eeba27d7543e1a3acdafb7eef728f7fe85d", size = 103082, upload-time = "2026-03-05T15:54:06.387Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/f96121e69cc48696075071531cf574f112e1ffd08059f4bffb41210e6fc5/mmh3-5.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d9f9a3ce559a5267014b04b82956993270f63ec91765e13e9fd73daf2d2738e", size = 106054, upload-time = "2026-03-05T15:54:07.506Z" },
+    { url = "https://files.pythonhosted.org/packages/82/49/192b987ec48d0b2aecf8ac285a9b11fbc00030f6b9c694664ae923458dde/mmh3-5.2.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:960b1b3efa39872ac8b6cc3a556edd6fb90ed74f08c9c45e028f1005b26aa55d", size = 112910, upload-time = "2026-03-05T15:54:09.403Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a1/03e91fd334ed0144b83343a76eb11f17434cd08f746401488cfeafb2d241/mmh3-5.2.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d30b650595fdbe32366b94cb14f30bb2b625e512bd4e1df00611f99dc5c27fd4", size = 120551, upload-time = "2026-03-05T15:54:10.587Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/b89a71d2ff35c3a764d1c066c7313fc62c7cc48fa48a4b3b0304a4a0146f/mmh3-5.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:82f3802bfc4751f420d591c5c864de538b71cea117fce67e4595c2afede08a15", size = 99096, upload-time = "2026-03-05T15:54:11.76Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b5/613772c1c6ed5f7b63df55eb131e887cc43720fec392777b95a79d34e640/mmh3-5.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:915e7a2418f10bd1151b1953df06d896db9783c9cfdb9a8ee1f9b3a4331ab503", size = 98524, upload-time = "2026-03-05T15:54:13.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0e/1524566fe8eaf871e4f7bc44095929fcd2620488f402822d848df19d679c/mmh3-5.2.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:fc78739b5ec6e4fb02301984a3d442a91406e7700efbe305071e7fd1c78278f2", size = 106239, upload-time = "2026-03-05T15:54:14.601Z" },
+    { url = "https://files.pythonhosted.org/packages/04/94/21adfa7d90a7a697137ad6de33eeff6445420ca55e433a5d4919c79bc3b5/mmh3-5.2.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:41aac7002a749f08727cb91babff1daf8deac317c0b1f317adc69be0e6c375d1", size = 109797, upload-time = "2026-03-05T15:54:15.819Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e6/1aacc3a219e1aa62fa65669995d4a3562b35be5200ec03680c7e4bec9676/mmh3-5.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9d8089d853c7963a8ce87fff93e2a67075c0bc08684a08ea6ad13577c38ffc38", size = 97228, upload-time = "2026-03-05T15:54:16.992Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b9/5e4cca8dcccf298add0a27f3c357bc8cf8baf821d35cdc6165e4bd5a48b0/mmh3-5.2.1-cp311-cp311-win32.whl", hash = "sha256:baeb47635cb33375dee4924cd93d7f5dcaa786c740b08423b0209b824a1ee728", size = 40751, upload-time = "2026-03-05T15:54:18.714Z" },
+    { url = "https://files.pythonhosted.org/packages/72/fc/5b11d49247f499bcda591171e9cf3b6ee422b19e70aa2cef2e0ae65ca3b9/mmh3-5.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:1e4ecee40ba19e6975e1120829796770325841c2f153c0e9aecca927194c6a2a", size = 41517, upload-time = "2026-03-05T15:54:19.764Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/5f/2a511ee8a1c2a527c77726d5231685b72312c5a1a1b7639ad66a9652aa84/mmh3-5.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:c302245fd6c33d96bd169c7ccf2513c20f4c1e417c07ce9dce107c8bc3f8411f", size = 39287, upload-time = "2026-03-05T15:54:20.904Z" },
+    { url = "https://files.pythonhosted.org/packages/92/94/bc5c3b573b40a328c4d141c20e399039ada95e5e2a661df3425c5165fd84/mmh3-5.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0cc21533878e5586b80d74c281d7f8da7932bc8ace50b8d5f6dbf7e3935f63f1", size = 56087, upload-time = "2026-03-05T15:54:21.92Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/80/64a02cc3e95c3af0aaa2590849d9ed24a9f14bb93537addde688e039b7c3/mmh3-5.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4eda76074cfca2787c8cf1bec603eaebdddd8b061ad5502f85cddae998d54f00", size = 40500, upload-time = "2026-03-05T15:54:22.953Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/72/e6d6602ce18adf4ddcd0e48f2e13590cc92a536199e52109f46f259d3c46/mmh3-5.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:eee884572b06bbe8a2b54f424dbd996139442cf83c76478e1ec162512e0dd2c7", size = 40034, upload-time = "2026-03-05T15:54:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/59/c2/bf4537a8e58e21886ef16477041238cab5095c836496e19fafc34b7445d2/mmh3-5.2.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0d0b7e803191db5f714d264044e06189c8ccd3219e936cc184f07106bd17fd7b", size = 97292, upload-time = "2026-03-05T15:54:25.335Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e2/51ed62063b44d10b06d975ac87af287729eeb5e3ed9772f7584a17983e90/mmh3-5.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e6c219e375f6341d0959af814296372d265a8ca1af63825f65e2e87c618f006", size = 103274, upload-time = "2026-03-05T15:54:26.44Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ce/12a7524dca59eec92e5b31fdb13ede1e98eda277cf2b786cf73bfbc24e81/mmh3-5.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26fb5b9c3946bf7f1daed7b37e0c03898a6f062149127570f8ede346390a0825", size = 106158, upload-time = "2026-03-05T15:54:28.578Z" },
+    { url = "https://files.pythonhosted.org/packages/86/1f/d3ba6dd322d01ab5d44c46c8f0c38ab6bbbf9b5e20e666dfc05bf4a23604/mmh3-5.2.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3c38d142c706201db5b2345166eeef1e7740e3e2422b470b8ba5c8727a9b4c7a", size = 113005, upload-time = "2026-03-05T15:54:29.767Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/a9/15d6b6f913294ea41b44d901741298e3718e1cb89ee626b3694625826a43/mmh3-5.2.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50885073e2909251d4718634a191c49ae5f527e5e1736d738e365c3e8be8f22b", size = 120744, upload-time = "2026-03-05T15:54:30.931Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/70b73923fd0284c439860ff5c871b20210dfdbe9a6b9dd0ee6496d77f174/mmh3-5.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b3f99e1756fc48ad507b95e5d86f2fb21b3d495012ff13e6592ebac14033f166", size = 99111, upload-time = "2026-03-05T15:54:32.353Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/38/99f7f75cd27d10d8b899a1caafb9d531f3903e4d54d572220e3d8ac35e89/mmh3-5.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62815d2c67f2dd1be76a253d88af4e1da19aeaa1820146dec52cf8bee2958b16", size = 98623, upload-time = "2026-03-05T15:54:33.801Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/68/6e292c0853e204c44d2f03ea5f090be3317a0e2d9417ecb62c9eb27687df/mmh3-5.2.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8f767ba0911602ddef289404e33835a61168314ebd3c729833db2ed685824211", size = 106437, upload-time = "2026-03-05T15:54:35.177Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/fedd7284c459cfb58721d461fcf5607a4c1f5d9ab195d113d51d10164d16/mmh3-5.2.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:67e41a497bac88cc1de96eeba56eeb933c39d54bc227352f8455aa87c4ca4000", size = 110002, upload-time = "2026-03-05T15:54:36.673Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ac/ca8e0c19a34f5b71390171d2ff0b9f7f187550d66801a731bb68925126a4/mmh3-5.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d74a03fb57757ece25aa4b3c1c60157a1cece37a020542785f942e2f827eed5", size = 97507, upload-time = "2026-03-05T15:54:37.804Z" },
+    { url = "https://files.pythonhosted.org/packages/df/94/6ebb9094cfc7ac5e7950776b9d13a66bb4a34f83814f32ba2abc9494fc68/mmh3-5.2.1-cp312-cp312-win32.whl", hash = "sha256:7374d6e3ef72afe49697ecd683f3da12f4fc06af2d75433d0580c6746d2fa025", size = 40773, upload-time = "2026-03-05T15:54:40.077Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/cd3527198cf159495966551c84a5f36805a10ac17b294f41f67b83f6a4d6/mmh3-5.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:3a9fed49c6ce4ed7e73f13182760c65c816da006debe67f37635580dfb0fae00", size = 41560, upload-time = "2026-03-05T15:54:41.148Z" },
+    { url = "https://files.pythonhosted.org/packages/15/96/6fe5ebd0f970a076e3ed5512871ce7569447b962e96c125528a2f9724470/mmh3-5.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:bbfcb95d9a744e6e2827dfc66ad10e1020e0cac255eb7f85652832d5a264c2fc", size = 39313, upload-time = "2026-03-05T15:54:42.171Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a5/9daa0508a1569a54130f6198d5462a92deda870043624aa3ea72721aa765/mmh3-5.2.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:723b2681ed4cc07d3401bbea9c201ad4f2a4ca6ba8cddaff6789f715dd2b391e", size = 40832, upload-time = "2026-03-05T15:54:43.212Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6b/3230c6d80c1f4b766dedf280a92c2241e99f87c1504ff74205ec8cebe451/mmh3-5.2.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:3619473a0e0d329fd4aec8075628f8f616be2da41605300696206d6f36920c3d", size = 41964, upload-time = "2026-03-05T15:54:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/62/fb/648bfddb74a872004b6ee751551bfdda783fe6d70d2e9723bad84dbe5311/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:e48d4dbe0f88e53081da605ae68644e5182752803bbc2beb228cca7f1c4454d6", size = 39114, upload-time = "2026-03-05T15:54:45.205Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c2/ab7901f87af438468b496728d11264cb397b3574d41506e71b92128e0373/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a482ac121de6973897c92c2f31defc6bafb11c83825109275cffce54bb64933f", size = 39819, upload-time = "2026-03-05T15:54:46.509Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/ed/6f88dda0df67de1612f2e130ffea34cf84aaee5bff5b0aff4dbff2babe34/mmh3-5.2.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:17fbb47f0885ace8327ce1235d0416dc86a211dcd8cc1e703f41523be32cfec8", size = 40330, upload-time = "2026-03-05T15:54:47.864Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/66/7516d23f53cdf90f43fce24ab80c28f45e6851d78b46bef8c02084edf583/mmh3-5.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d51fde50a77f81330523562e3c2734ffdca9c4c9e9d355478117905e1cfe16c6", size = 56078, upload-time = "2026-03-05T15:54:48.9Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/34/4d152fdf4a91a132cb226b671f11c6b796eada9ab78080fb5ce1e95adaab/mmh3-5.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:19bbd3b841174ae6ed588536ab5e1b1fe83d046e668602c20266547298d939a9", size = 40498, upload-time = "2026-03-05T15:54:49.942Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4c/8e3af1b6d85a299767ec97bd923f12b06267089c1472c27c1696870d1175/mmh3-5.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be77c402d5e882b6fbacfd90823f13da8e0a69658405a39a569c6b58fdb17b03", size = 40033, upload-time = "2026-03-05T15:54:50.994Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f2/966ea560e32578d453c9e9db53d602cbb1d0da27317e232afa7c38ceba11/mmh3-5.2.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fd96476f04db5ceba1cfa0f21228f67c1f7402296f0e73fee3513aa680ad237b", size = 97320, upload-time = "2026-03-05T15:54:52.072Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/0d/2c5f9893b38aeb6b034d1a44ecd55a010148054f6a516abe53b5e4057297/mmh3-5.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:707151644085dd0f20fe4f4b573d28e5130c4aaa5f587e95b60989c5926653b5", size = 103299, upload-time = "2026-03-05T15:54:53.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fc/2ebaef4a4d4376f89761274dc274035ffd96006ab496b4ee5af9b08f21a9/mmh3-5.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3737303ca9ea0f7cb83028781148fcda4f1dac7821db0c47672971dabcf63593", size = 106222, upload-time = "2026-03-05T15:54:55.092Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/ea7ffe126d0ba0406622602a2d05e1e1a6841cc92fc322eb576c95b27fad/mmh3-5.2.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2778fed822d7db23ac5008b181441af0c869455b2e7d001f4019636ac31b6fe4", size = 113048, upload-time = "2026-03-05T15:54:56.305Z" },
+    { url = "https://files.pythonhosted.org/packages/85/57/9447032edf93a64aa9bef4d9aa596400b1756f40411890f77a284f6293ca/mmh3-5.2.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d57dea657357230cc780e13920d7fa7db059d58fe721c80020f94476da4ca0a1", size = 120742, upload-time = "2026-03-05T15:54:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/53/82/a86cc87cc88c92e9e1a598fee509f0409435b57879a6129bf3b3e40513c7/mmh3-5.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:169e0d178cb59314456ab30772429a802b25d13227088085b0d49b9fe1533104", size = 99132, upload-time = "2026-03-05T15:54:58.583Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f7/6b16eb1b40ee89bb740698735574536bc20d6cdafc65ae702ea235578e05/mmh3-5.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7e4e1f580033335c6f76d1e0d6b56baf009d1a64d6a4816347e4271ba951f46d", size = 98686, upload-time = "2026-03-05T15:55:00.078Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/88/a601e9f32ad1410f438a6d0544298ea621f989bd34a0731a7190f7dec799/mmh3-5.2.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2bd9f19f7f1fcebd74e830f4af0f28adad4975d40d80620be19ffb2b2af56c9f", size = 106479, upload-time = "2026-03-05T15:55:01.532Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/ce29ae3dfc4feec4007a437a1b7435fb9507532a25147602cd5b52be86db/mmh3-5.2.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c88653877aeb514c089d1b3d473451677b8b9a6d1497dbddf1ae7934518b06d2", size = 110030, upload-time = "2026-03-05T15:55:02.934Z" },
+    { url = "https://files.pythonhosted.org/packages/13/30/ae444ef2ff87c805d525da4fa63d27cda4fe8a48e77003a036b8461cfd5c/mmh3-5.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fceef7fe67c81e1585198215e42ad3fdba3a25644beda8fbdaf85f4d7b93175a", size = 97536, upload-time = "2026-03-05T15:55:04.135Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f9/dc3787ee5c813cc27fe79f45ad4500d9b5437f23a7402435cc34e07c7718/mmh3-5.2.1-cp313-cp313-win32.whl", hash = "sha256:54b64fb2433bc71488e7a449603bf8bd31fbcf9cb56fbe1eb6d459e90b86c37b", size = 40769, upload-time = "2026-03-05T15:55:05.277Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/850e0b5a1e97799822ebfc4ca0e8c6ece3ed8baf7dcdf64de817dfdda2ca/mmh3-5.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:cae6383181f1e345317742d2ddd88f9e7d2682fa4c9432e3a74e47d92dce0229", size = 41563, upload-time = "2026-03-05T15:55:06.283Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/98c90b28e1da5458e19fbfaf4adb5289208d3bfccd45dd14eab216a2f0bb/mmh3-5.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:022aa1a528604e6c83d0a7705fdef0b5355d897a9e0fa3a8d26709ceaa06965d", size = 39310, upload-time = "2026-03-05T15:55:07.323Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b4/65bc1fb2bb7f83e91c30865023b1847cf89a5f237165575e8c83aa536584/mmh3-5.2.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:d771f085fcdf4035786adfb1d8db026df1eb4b41dac1c3d070d1e49512843227", size = 40794, upload-time = "2026-03-05T15:55:09.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/86/7168b3d83be8eb553897b1fac9da8bbb06568e5cfe555ffc329ebb46f59d/mmh3-5.2.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:7f196cd7910d71e9d9860da0ff7a77f64d22c1ad931f1dd18559a06e03109fc0", size = 41923, upload-time = "2026-03-05T15:55:10.924Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9b/b653ab611c9060ce8ff0ba25c0226757755725e789292f3ca138a58082cd/mmh3-5.2.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b1f12bd684887a0a5d55e6363ca87056f361e45451105012d329b86ec19dbe0b", size = 39131, upload-time = "2026-03-05T15:55:11.961Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b4/5a2e0d34ab4d33543f01121e832395ea510132ea8e52cdf63926d9d81754/mmh3-5.2.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:d106493a60dcb4aef35a0fac85105e150a11cf8bc2b0d388f5a33272d756c966", size = 39825, upload-time = "2026-03-05T15:55:13.013Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/69/81699a8f39a3f8d368bec6443435c0c392df0d200ad915bf0d222b588e03/mmh3-5.2.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:44983e45310ee5b9f73397350251cdf6e63a466406a105f1d16cb5baa659270b", size = 40344, upload-time = "2026-03-05T15:55:14.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b3/71c8c775807606e8fd8acc5c69016e1caf3200d50b50b6dd4b40ce10b76c/mmh3-5.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:368625fb01666655985391dbad3860dc0ba7c0d6b9125819f3121ee7292b4ac8", size = 56291, upload-time = "2026-03-05T15:55:15.137Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/75/2c24517d4b2ce9e4917362d24f274d3d541346af764430249ddcc4cb3a08/mmh3-5.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:72d1cc63bcc91e14933f77d51b3df899d6a07d184ec515ea7f56bff659e124d7", size = 40575, upload-time = "2026-03-05T15:55:16.518Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/e4a360164365ac9f07a25f0f7928e3a66eb9ecc989384060747aa170e6aa/mmh3-5.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e8b4b5580280b9265af3e0409974fb79c64cf7523632d03fbf11df18f8b0181e", size = 40052, upload-time = "2026-03-05T15:55:17.735Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ca/120d92223a7546131bbbc31c9174168ee7a73b1366f5463ffe69d9e691fe/mmh3-5.2.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4cbbde66f1183db040daede83dd86c06d663c5bb2af6de1142b7c8c37923dd74", size = 97311, upload-time = "2026-03-05T15:55:18.959Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/71/c1a60c1652b8813ef9de6d289784847355417ee0f2980bca002fe87f4ae5/mmh3-5.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8ff038d52ef6aa0f309feeba00c5095c9118d0abf787e8e8454d6048db2037fc", size = 103279, upload-time = "2026-03-05T15:55:20.448Z" },
+    { url = "https://files.pythonhosted.org/packages/48/29/ad97f4be1509cdcb28ae32c15593ce7c415db47ace37f8fad35b493faa9a/mmh3-5.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4130d0b9ce5fad6af07421b1aecc7e079519f70d6c05729ab871794eded8617", size = 106290, upload-time = "2026-03-05T15:55:21.6Z" },
+    { url = "https://files.pythonhosted.org/packages/77/29/1f86d22e281bd8827ba373600a4a8b0c0eae5ca6aa55b9a8c26d2a34decc/mmh3-5.2.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6e0bfe77d238308839699944164b96a2eeccaf55f2af400f54dc20669d8d5f2", size = 113116, upload-time = "2026-03-05T15:55:22.826Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7c/339971ea7ed4c12d98f421f13db3ea576a9114082ccb59d2d1a0f00ccac1/mmh3-5.2.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f963eafc0a77a6c0562397da004f5876a9bcf7265a7bcc3205e29636bc4a1312", size = 120740, upload-time = "2026-03-05T15:55:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/3c7c4bdb8e926bb3c972d1e2907d77960c1c4b250b41e8366cf20c6e4373/mmh3-5.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:92883836caf50d5255be03d988d75bc93e3f86ba247b7ca137347c323f731deb", size = 99143, upload-time = "2026-03-05T15:55:25.456Z" },
+    { url = "https://files.pythonhosted.org/packages/df/0a/33dd8706e732458c8375eae63c981292de07a406bad4ec03e5269654aa2c/mmh3-5.2.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:57b52603e89355ff318025dd55158f6e71396c0f1f609d548e9ea9c94cc6ce0a", size = 98703, upload-time = "2026-03-05T15:55:26.723Z" },
+    { url = "https://files.pythonhosted.org/packages/51/04/76bbce05df76cbc3d396f13b2ea5b1578ef02b6a5187e132c6c33f99d596/mmh3-5.2.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f40a95186a72fa0b67d15fef0f157bfcda00b4f59c8a07cbe5530d41ac35d105", size = 106484, upload-time = "2026-03-05T15:55:28.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8f/c6e204a2c70b719c1f62ffd9da27aef2dddcba875ea9c31ca0e87b975a46/mmh3-5.2.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:58370d05d033ee97224c81263af123dea3d931025030fd34b61227a768a8858a", size = 110012, upload-time = "2026-03-05T15:55:29.532Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/37/7181efd8e39db386c1ebc3e6b7d1f702a09d7c1197a6f2742ed6b5c16597/mmh3-5.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7be6dfb49e48fd0a7d91ff758a2b51336f1cd21f9d44b20f6801f072bd080cdd", size = 97508, upload-time = "2026-03-05T15:55:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/42/0f/afa7ca2615fd85e1469474bb860e381443d0b868c083b62b41cb1d7ca32f/mmh3-5.2.1-cp314-cp314-win32.whl", hash = "sha256:54fe8518abe06a4c3852754bfd498b30cc58e667f376c513eac89a244ce781a4", size = 41387, upload-time = "2026-03-05T15:55:32.403Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0d/46d42a260ee1357db3d486e6c7a692e303c017968e14865e00efa10d09fc/mmh3-5.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:3f796b535008708846044c43302719c6956f39ca2d93f2edda5319e79a29efbb", size = 42101, upload-time = "2026-03-05T15:55:33.646Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7b/848a8378059d96501a41159fca90d6a99e89736b0afbe8e8edffeac8c74b/mmh3-5.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:cd471ede0d802dd936b6fab28188302b2d497f68436025857ca72cd3810423fe", size = 39836, upload-time = "2026-03-05T15:55:35.026Z" },
+    { url = "https://files.pythonhosted.org/packages/27/61/1dabea76c011ba8547c25d30c91c0ec22544487a8750997a27a0c9e1180b/mmh3-5.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5174a697ce042fa77c407e05efe41e03aa56dae9ec67388055820fb48cf4c3ba", size = 57727, upload-time = "2026-03-05T15:55:36.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/32/731185950d1cf2d5e28979cc8593016ba1619a295faba10dda664a4931b5/mmh3-5.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0a3984146e414684a6be2862d84fcb1035f4984851cb81b26d933bab6119bf00", size = 41308, upload-time = "2026-03-05T15:55:37.254Z" },
+    { url = "https://files.pythonhosted.org/packages/76/aa/66c76801c24b8c9418b4edde9b5e57c75e72c94e29c48f707e3962534f18/mmh3-5.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bd6e7d363aa93bd3421b30b6af97064daf47bc96005bddba67c5ffbc6df426b8", size = 40758, upload-time = "2026-03-05T15:55:38.61Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/bb/79a1f638a02f0ae389f706d13891e2fbf7d8c0a22ecde67ba828951bb60a/mmh3-5.2.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:113f78e7463a36dbbcea05bfe688efd7fa759d0f0c56e73c974d60dcfec3dfcc", size = 109670, upload-time = "2026-03-05T15:55:40.13Z" },
+    { url = "https://files.pythonhosted.org/packages/26/94/8cd0e187a288985bcfc79bf5144d1d712df9dee74365f59d26e3a1865be6/mmh3-5.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7e8ec5f606e0809426d2440e0683509fb605a8820a21ebd120dcdba61b74ef7f", size = 117399, upload-time = "2026-03-05T15:55:42.076Z" },
+    { url = "https://files.pythonhosted.org/packages/42/94/dfea6059bd5c5beda565f58a4096e43f4858fb6d2862806b8bbd12cbb284/mmh3-5.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22b0f9971ec4e07e8223f2beebe96a6cfc779d940b6f27d26604040dd74d3a44", size = 120386, upload-time = "2026-03-05T15:55:43.481Z" },
+    { url = "https://files.pythonhosted.org/packages/47/cb/f9c45e62aaa67220179f487772461d891bb582bb2f9783c944832c60efd9/mmh3-5.2.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:85ffc9920ffc39c5eee1e3ac9100c913a0973996fbad5111f939bbda49204bb7", size = 125924, upload-time = "2026-03-05T15:55:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/fe54a4a7c11bc9f623dfc1707decd034245602b076dfc1dcc771a4163170/mmh3-5.2.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7aec798c2b01aaa65a55f1124f3405804184373abb318a3091325aece235f67c", size = 135280, upload-time = "2026-03-05T15:55:45.866Z" },
+    { url = "https://files.pythonhosted.org/packages/97/67/fe7e9e9c143daddd210cd22aef89cbc425d58ecf238d2b7d9eb0da974105/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55dbbd8ffbc40d1697d5e2d0375b08599dae8746b0b08dea05eee4ce81648fac", size = 110050, upload-time = "2026-03-05T15:55:47.074Z" },
+    { url = "https://files.pythonhosted.org/packages/43/c4/6d4b09fcbef80794de447c9378e39eefc047156b290fa3dd2d5257ca8227/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:6c85c38a279ca9295a69b9b088a2e48aa49737bb1b34e6a9dc6297c110e8d912", size = 111158, upload-time = "2026-03-05T15:55:48.239Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a6/ca51c864bdb30524beb055a6d8826db3906af0834ec8c41d097a6e8573d5/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:6290289fa5fb4c70fd7f72016e03633d60388185483ff3b162912c81205ae2cf", size = 116890, upload-time = "2026-03-05T15:55:49.405Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/04/5a1fe2e2ad843d03e89af25238cbc4f6840a8bb6c4329a98ab694c71deda/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:4fc6cd65dc4d2fdb2625e288939a3566e36127a84811a4913f02f3d5931da52d", size = 123121, upload-time = "2026-03-05T15:55:50.61Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4d/3c820c6f4897afd25905270a9f2330a23f77a207ea7356f7aadace7273c0/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:623f938f6a039536cc02b7582a07a080f13fdfd48f87e63201d92d7e34d09a18", size = 110187, upload-time = "2026-03-05T15:55:52.143Z" },
+    { url = "https://files.pythonhosted.org/packages/21/54/1d71cd143752361c0aebef16ad3f55926a6faf7b112d355745c1f8a25f7f/mmh3-5.2.1-cp314-cp314t-win32.whl", hash = "sha256:29bc3973676ae334412efdd367fcd11d036b7be3efc1ce2407ef8676dabfeb82", size = 41934, upload-time = "2026-03-05T15:55:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e4/63a2a88f31d93dea03947cccc2a076946857e799ea4f7acdecbf43b324aa/mmh3-5.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:28cfab66577000b9505a0d068c731aee7ca85cd26d4d63881fab17857e0fe1fb", size = 43036, upload-time = "2026-03-05T15:55:55.252Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0f/59204bf136d1201f8d7884cfbaf7498c5b4674e87a4c693f9bde63741ce1/mmh3-5.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:dfd51b4c56b673dfbc43d7d27ef857dd91124801e2806c69bb45585ce0fa019b", size = 40391, upload-time = "2026-03-05T15:55:56.697Z" },
 ]
 
 [[package]]
@@ -4587,13 +4762,21 @@ wheels = [
 name = "onnxruntime"
 version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "coloredlogs" },
-    { name = "flatbuffers" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
+    { name = "coloredlogs", marker = "python_full_version < '3.13' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "flatbuffers", marker = "python_full_version < '3.13' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "numpy", marker = "python_full_version < '3.13' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "packaging", marker = "python_full_version < '3.13' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "protobuf", marker = "python_full_version < '3.13' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "sympy", marker = "python_full_version < '3.13' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/8d/2634e2959b34aa8a0037989f4229e9abcfa484e9c228f99633b3241768a6/onnxruntime-1.20.1-cp311-cp311-macosx_13_0_universal2.whl", hash = "sha256:06bfbf02ca9ab5f28946e0f912a562a5f005301d0c419283dc57b3ed7969bb7b", size = 30998725, upload-time = "2024-11-21T00:48:51.013Z" },
@@ -4612,6 +4795,51 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/e0/50db43188ca1c945decaa8fc2a024c33446d31afed40149897d4f9de505f/onnxruntime-1.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:d30367df7e70f1d9fc5a6a68106f5961686d39b54d3221f760085524e8d38e16", size = 11331758, upload-time = "2024-11-21T00:49:31.417Z" },
     { url = "https://files.pythonhosted.org/packages/d8/55/3821c5fd60b52a6c82a00bba18531793c93c4addfe64fbf061e235c5617a/onnxruntime-1.20.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9158465745423b2b5d97ed25aa7740c7d38d2993ee2e5c3bfacb0c4145c49d8", size = 11950342, upload-time = "2024-11-21T00:49:34.164Z" },
     { url = "https://files.pythonhosted.org/packages/14/56/fd990ca222cef4f9f4a9400567b9a15b220dee2eafffb16b2adbc55c8281/onnxruntime-1.20.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0df6f2df83d61f46e842dbcde610ede27218947c33e994545a22333491e72a3b", size = 13337040, upload-time = "2024-11-21T00:49:37.271Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "flatbuffers", marker = "python_full_version >= '3.13' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "numpy", marker = "python_full_version >= '3.13' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "packaging", marker = "python_full_version >= '3.13' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "protobuf", marker = "python_full_version >= '3.13' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/e4/5353d7e09ced4a8f473f843223fc75d726b2b5519dcefc12f22a6c92852d/onnxruntime-1.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8ba14a38c570087f3cdb8cfba33f7a38a1e826c1e5b29e17c28ceda0cc910016", size = 18416484, upload-time = "2026-06-15T22:43:43.894Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1f/a2117aa3f144fce88774efa37440d0ca72d0c9144854dfc0961f2b04c6fc/onnxruntime-1.27.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2eb083321af8a236a84c7c140a7f4cecbfa2a987a18c07c78db471c20cd390ef", size = 16419330, upload-time = "2026-06-15T22:42:37.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/cd/74bb804170ceb622fda9111df31a07b3024f7491472256d3a90b5391a4d2/onnxruntime-1.27.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4f7b0e90d2d212e2c2deaa6c8291616183ab815d3ec558ea12d3ac8b26d36f4", size = 18636930, upload-time = "2026-06-15T22:43:01.584Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8f/5b8e2b85e81735696887175dbaf6409f215683f5ca9d4928fbb038211d32/onnxruntime-1.27.0-cp311-cp311-win_amd64.whl", hash = "sha256:ff050e4f6bf7f12918fa14dcb047c0b02e295f35e86d42532552be4b3d54e977", size = 13356110, upload-time = "2026-06-15T22:43:32.172Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3a/4f568de678126b6a371a93862f015a82138359decd97fcac61fc84b5b774/onnxruntime-1.27.0-cp311-cp311-win_arm64.whl", hash = "sha256:75fbc1e1fb43a39a856c8209c544cca7817b5de7ac16b15b1bdf55d1cc67b9df", size = 13098635, upload-time = "2026-06-15T22:43:19.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/dd3a524ed93a820dff1af902d0412957ab12499953333e9daa01af5bc480/onnxruntime-1.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a14c2ce45312def86b77aea651f46565e45960cf5f0721bfdff449165086ab76", size = 18433506, upload-time = "2026-06-15T22:43:47.026Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/c3b6b17745a1997d784dadc9bd88d713d2e6721139a5a0e885b28cfb79b1/onnxruntime-1.27.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6fddce0539a4898c7bef35b052ffd37935b2190e35488eab99ce91887743ea1", size = 16438140, upload-time = "2026-06-15T22:42:40.666Z" },
+    { url = "https://files.pythonhosted.org/packages/26/81/24dd9b31b0fb912ee19ca53ac1c9764bfd79d58a2ccef564eb693be831a5/onnxruntime-1.27.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c65a7438632d55dfbc8a02ee60bd6cf7dd9d1ba05a43d4b851452f32338e194", size = 18658316, upload-time = "2026-06-15T22:43:04.012Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/88/8ec9db1a4d126bb8b758992beb40d1249df171917d75f44a327eb5f20dda/onnxruntime-1.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:20c321cf187ba496e648acf6b4cf90b4d398b0d17c2a77fdaeba365b908cc1c1", size = 13358769, upload-time = "2026-06-15T22:43:34.581Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/9f/fdad359dfcba7e7cd8815569b304a596531d4efa77a75d77f8b4981891a2/onnxruntime-1.27.0-cp312-cp312-win_arm64.whl", hash = "sha256:d0d1f68868e2ef30ef70998ba9bbbc5c305e9b17041e3936751c1b8aa6aade06", size = 13104440, upload-time = "2026-06-15T22:43:22.893Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/2b/54208fd03ad410480bc17edf4869376362da8bbf46fe186ddf4cb5cc20fe/onnxruntime-1.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:b3e5b58b8c89c2b20e086e890aa9527377e5c240dc3ecc1640d18e07705eeb1c", size = 18432958, upload-time = "2026-06-15T22:42:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/24fc51fcbb126da6d032372314e47b55c3faad58f2aa78c0e199ccd20b9c/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48b3d87eb560ff6a772240506f3c78d6d27c63cafedd5c775672e1194f968cfd", size = 16438180, upload-time = "2026-06-15T22:42:43.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/19/14929c3c2fe0b79b41cce24463062bf3afa4cdd3c19dccf00319caa92bff/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6872443f236a554921cda6f318c900e2d0c226792cf3534d00e5057c6926e5d2", size = 18658445, upload-time = "2026-06-15T22:43:08.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/76/59ed932b0244acd7bbbd6449480053a6d958ea66357f022f932872e19287/onnxruntime-1.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:760021bca514d64a811837820d351a08a41741f16f8b4c26450da708fecf14e6", size = 13357856, upload-time = "2026-06-15T22:43:37.315Z" },
+    { url = "https://files.pythonhosted.org/packages/79/51/d1ec60ec7b1e2ae2d7340ba52b8a13529140039cd4407ba8dddbbc046582/onnxruntime-1.27.0-cp313-cp313-win_arm64.whl", hash = "sha256:2fdfa9df40a0ded0028ce6f9cd863264237f3970559dea2b81456e9ac4622b94", size = 13104412, upload-time = "2026-06-15T22:43:27.457Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/e6bb1c6445c94f708c38cd8fbb7bf0264108c33498b9445c93e60fe6d329/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54c0c4e9202c36c4ecdb1f3443f5dfbfd5ee3b54d1362c4b4c6134110e74fb32", size = 16443331, upload-time = "2026-06-15T22:42:45.649Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/b18b31e806eabc41077810199fbbb36fbc2d5f19912416e5ccfbf73053d1/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b215aa662c8f983f7d6dedafe65a9be72c26e5338e0fe98b3e0422c32c85428", size = 18670967, upload-time = "2026-06-15T22:43:10.621Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/37/48ab79c39b58a7c9f6f5aac1fa0ff2b993eb2643393d6ed9e839ddb6f347/onnxruntime-1.27.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:0874edc171f470fc4dd2bbb60bc0989612ed1a8b89b365cda016630a93227f13", size = 18433941, upload-time = "2026-06-15T22:42:58.867Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/24/d535ca8a09dbf697f853377c8dc0820dbcaae5f334316b400b953afbcba8/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5b51c014cf1a4fcd93c29a97eac8071fa27710dae05a4d0380bb60a66d60a62c", size = 16439970, upload-time = "2026-06-15T22:42:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b1/ea9ee80c0bdaa4efb13f29f8c236f3740f6655e8c092a2d119515a5a652c/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:445fb702ea5241ba813a3ce2febe2e9408a64f6ad2eb610924322c536165f7cd", size = 18659240, upload-time = "2026-06-15T22:43:13.165Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f2/1404507d76a21940e8bf46f414e3d1abd94dc888cb89a30f4a540275846f/onnxruntime-1.27.0-cp314-cp314-win_amd64.whl", hash = "sha256:49e416be0d717338b6d041b99911b716d70c397d277056450724f93bdded3fc2", size = 13685306, upload-time = "2026-06-15T22:43:40.416Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e5/ca5cf012ccccb806c70e94aadfebca5606acc62b33eb88cec13352d0778f/onnxruntime-1.27.0-cp314-cp314-win_arm64.whl", hash = "sha256:856032937dd3bc7a7c141909c8d7ae4fde3e3f59bddf061ae627b9a051bda95c", size = 13456280, upload-time = "2026-06-15T22:43:29.693Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7b/dca330a8397e9d816c976d7aed4e24a4a2d279bb1e551e3d0221d1389b1d/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6197a02e3f620c4dc13cff51b80672409fc1ffab3aa2593911b19fd322ff48b", size = 16443274, upload-time = "2026-06-15T22:42:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f6/2bac21f722aa45d876d4a51f26bd0ef30e704068a3cd5021a5a7cd784271/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:370d211e1ceeac4cd5f45301655463ac59e27cdc74d9f7aeb2d19ff4b7a76715", size = 18670781, upload-time = "2026-06-15T22:43:17.151Z" },
 ]
 
 [[package]]
@@ -5265,7 +5493,7 @@ name = "portalocker"
 version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-9-mirage-ai-all' and extra == 'extra-9-mirage-ai-camel') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ed/d3/c6c64067759e87af98cc668c1cc75171347d0f1577fab7ca3749134e3cd4/portalocker-2.10.1.tar.gz", hash = "sha256:ef1bf844e878ab08aee7e40184156e1151f228f103aa5c6bd0724cc330960f8f", size = 40891, upload-time = "2024-07-13T23:15:34.86Z" }
 wheels = [
@@ -5550,6 +5778,58 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
+]
+
+[[package]]
+name = "py-rust-stemmers"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/c1/9763f9fb1cd73f9c317a83feeed6e0d4af320c6bbddab47b4a94f3a47d0c/py_rust_stemmers-0.1.8.tar.gz", hash = "sha256:6b0f6f48bc54d607aed802de872fcd5a71bae969a6760976dc78ce55e8eaf3da", size = 9732, upload-time = "2026-05-22T11:00:24.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5b/fcc991636129fb2840fd1c7560112798046f26fa085b7a377382d50d2679/py_rust_stemmers-0.1.8-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4b1159a38a198eabeabd908015f9425c4220b61b42c6603c58870481ff2b50bb", size = 290471, upload-time = "2026-05-22T10:59:32.033Z" },
+    { url = "https://files.pythonhosted.org/packages/48/0a/c88c9a7b5c94acc1175a33964637aff9cf8fa4c2e595846ab1df04c1f0bf/py_rust_stemmers-0.1.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1686fc009869ff8bcc1d5a305f071eeb8c3b3612a9827bcadd4e61fdb5727179", size = 275775, upload-time = "2026-05-22T10:59:32.979Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/e2/e685cd31655a1ac56ebe0d571d221c199b1971eb5a2fdad88c889dc25983/py_rust_stemmers-0.1.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:769f37882905da2311cb720681b112eb70a4e6bd56fb424d473427b5379c8396", size = 314523, upload-time = "2026-05-22T10:59:34.436Z" },
+    { url = "https://files.pythonhosted.org/packages/65/93/a6c0f30109c259199ac171cb6a0c69addefdba454ee0a8d51bb94e767c11/py_rust_stemmers-0.1.8-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3007ad4ec51e0c352ae410234a24a9ac75fab0c1e06c585fbac9fcced69385f8", size = 318808, upload-time = "2026-05-22T10:59:35.719Z" },
+    { url = "https://files.pythonhosted.org/packages/59/87/ecaffed03e4b78d35ffb44740ca779e57d9f49d7d764f3f56b633b1e1c8c/py_rust_stemmers-0.1.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a1e11d22a240318dc917266eb3c85919455b6ea834445b95997712d9ede6b93", size = 319990, upload-time = "2026-05-22T10:59:36.84Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0d/2976bb288240e25110be687e6be5ecb0623a17f667f186e07033e429985f/py_rust_stemmers-0.1.8-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:08c258deab6d994551a92e9468ce88e58f97e636e73d9c5763978a57d7675a13", size = 320291, upload-time = "2026-05-22T10:59:38.263Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fb/7b1a93f63600633b2c741714f0f6024b2caff54e5aed77c5f6e0be384947/py_rust_stemmers-0.1.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eee4af7ada2ce9cb3ec59ffe8458148c3933a86507d816bf954ee506a0e45b61", size = 492171, upload-time = "2026-05-22T10:59:39.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3b/8e829e709542f928beb0613f4dffca4797a817f740c1be07eabd11bd2db4/py_rust_stemmers-0.1.8-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f16deb1557b8253d8c11693047bec4ed67d6b09ae0f84c8b896ea03ac2fc8925", size = 595398, upload-time = "2026-05-22T10:59:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8b/b3972f0fc14e6bfc602a9260a1747742aaf86737ad57872998b085a2f1aa/py_rust_stemmers-0.1.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:870afb2d1d4731bd2d74b715b34439b29734e4dc94c55342096f07669f7f9fa0", size = 537820, upload-time = "2026-05-22T10:59:42.307Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/90/54c2949cc4fef544810305526e0fd658e2bc87abcc046283379a7044abec/py_rust_stemmers-0.1.8-cp311-cp311-win_amd64.whl", hash = "sha256:13b25ce65509ff7e37725bd38c62704f32ae0604ac0899f43c8cce41d5543212", size = 208396, upload-time = "2026-05-22T10:59:43.335Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/39080bc8f4a441a35378c0faeeb834fb27974997f40d51342574e70f9662/py_rust_stemmers-0.1.8-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:6a9a4b8733d0b307bd0879ab7e321aa8a0bfd054a75a5cb23c647df5ca7d17c3", size = 290230, upload-time = "2026-05-22T10:59:44.551Z" },
+    { url = "https://files.pythonhosted.org/packages/73/15/ae60b9010924adac465f418822d9c514690aba6846edd67b6e2b5c227745/py_rust_stemmers-0.1.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:51d0042d2a92ef0f7048bfc06b6c2a02306af31ea47f09d24b34e4b7e63c4e80", size = 275449, upload-time = "2026-05-22T10:59:45.547Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7c/94be8b932179823d66e0d2be03a94706132a7d16a640d5e5710de1cb1b8f/py_rust_stemmers-0.1.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89d3d34094b9b6078a8ea6fe1c7044e5fd32f14e76c94818c5008f49ae075f08", size = 316676, upload-time = "2026-05-22T10:59:46.522Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a4/8bd5c9f31207136830457d819e3f98bb21c54c0cdc40d6f1845ce4efdf7c/py_rust_stemmers-0.1.8-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:40c86be90cee4a709ad84fde4db7f11ca44d65630a56b77ec86fe84c23adfc09", size = 319458, upload-time = "2026-05-22T10:59:47.914Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/95/95da2b353b164a3a2b8a1c799866a58060693be4f1dc21065663dc67dc17/py_rust_stemmers-0.1.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:515884bcfb47b10335146648f276930d0c1201ae5e8b7b400fb46d8ea05c0ec2", size = 323541, upload-time = "2026-05-22T10:59:48.894Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ce/f34403b68808519dfa3220e1d94a40f26d5025f27e28893e2388ab9cfde5/py_rust_stemmers-0.1.8-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:fa42f5f8feb694aaaa869eedf477fcaf66f67a192cd64d94302d06920c33864a", size = 323873, upload-time = "2026-05-22T10:59:49.872Z" },
+    { url = "https://files.pythonhosted.org/packages/57/01/fb8527f6474d576975415405c985a97260e0403829e062103d334230b7d2/py_rust_stemmers-0.1.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2e86ad68fe297a6652f0f0390625ea81858b6f27862fd4c5ee1214bf5af29b9d", size = 494761, upload-time = "2026-05-22T10:59:51.021Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ac/73816237dbec20a7299abf901e2f7b6061d238754e033b48e423603f5336/py_rust_stemmers-0.1.8-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4b90fc81411943b114e8eb4988a876ba3b12bd2d20741559803eddc4131575dc", size = 596141, upload-time = "2026-05-22T10:59:52.122Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0a/dd48debf386a206ee1c6ad75a0827eac89428441291c90d98bc3803fccf1/py_rust_stemmers-0.1.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56cc2c2df742fa6529285b7d204720f34b7da789ed78eb578442f93c6de97d89", size = 541633, upload-time = "2026-05-22T10:59:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ca/ebb707ab280636b8f46d040ccb051d1a9ddbc1f1ca2d90cdba626872f405/py_rust_stemmers-0.1.8-cp312-cp312-win_amd64.whl", hash = "sha256:dd967eea2f808a1e73aa71ecccef0f4925a4cca4eb02ced94057afe3303153ef", size = 212134, upload-time = "2026-05-22T10:59:54.245Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/98/f078f3930311e7b6154ccdf9166c4e30a416c7d199e136b5f09265d58a35/py_rust_stemmers-0.1.8-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5bd15b89203ecd886960e237124d1aa6e55498d76418c36c967d3b12168d43dc", size = 290427, upload-time = "2026-05-22T10:59:55.316Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/46/21d784a3f1db6a23051ffd5826d8ee667d26a64587c1cfbda0443ed87fff/py_rust_stemmers-0.1.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6c92733b020534470ca5a0d7fe8b85c85622ff383d4f37fec75a1c677aa84921", size = 275628, upload-time = "2026-05-22T10:59:56.687Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d5/701c73a4f6a7fecfd96a6588f0cafe98d6b0acde93adf8a2e45535f3d1d5/py_rust_stemmers-0.1.8-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ab605a86c950ba7e8ab1392cf91296c0bec3084babb897a4aecf90a10c82395", size = 316656, upload-time = "2026-05-22T10:59:57.67Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0d/c58fe98153cfdb6abf4dfb6ac335c923000d4af4e736080c3a3045b7aea7/py_rust_stemmers-0.1.8-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:21ed8055cec1f78d666afad8ffd7a51775ba419d2c615b8a1df7b32ca7f33e2b", size = 319377, upload-time = "2026-05-22T10:59:58.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/d7/e60d04849e90aa3ad457211cc4999c30401f433341f9a5588c12b81f9877/py_rust_stemmers-0.1.8-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae773e1d01e9aa328d175f461475d0cd7074a82bfcc71de6dc5765e51f1cc9f7", size = 323719, upload-time = "2026-05-22T10:59:59.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/48/c0e4fb955db784cc354e0756354602f7043ff4c10fcbd9d901a2f8fe3239/py_rust_stemmers-0.1.8-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5cc8fab9d0f1b274a26935a632362b8278f03e81b65e8b8644d5ca3f62a5a1a4", size = 324110, upload-time = "2026-05-22T11:00:01.26Z" },
+    { url = "https://files.pythonhosted.org/packages/48/eb/981b26baff37cf7a26ee206763cc4d2fb3e1db8f0f86ec030074431fae05/py_rust_stemmers-0.1.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:35570098da02eb439afcd7270a12bf850bbe874b85cb912e0fb2d87a6e703920", size = 494645, upload-time = "2026-05-22T11:00:02.737Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/af/f16e805b7aefc2257b192b83a89300c8360b0fdffd3dfefa92dee4ec9b15/py_rust_stemmers-0.1.8-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:0a68745d4b3c7f5abc778ca967e8711df6154873abcfe4e62a6631fa2363cc32", size = 596124, upload-time = "2026-05-22T11:00:04.499Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/e7a2c940ba00e0792ae346aed5e755d51d37cf6d6853f6b141e5380e285d/py_rust_stemmers-0.1.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7cc0cc0b8eb45d2158c28ea43e2f338c110aad63052ad3bd00bc7446a595e12f", size = 541771, upload-time = "2026-05-22T11:00:06.081Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a0/dd7c5fc6ade6d2a2a49e49937f06f2d488511454e8ab1b313d277ee8c3b1/py_rust_stemmers-0.1.8-cp313-cp313-win_amd64.whl", hash = "sha256:15af4e12e1288de2e5241eec375afc6ad6be4c125a28ca010599d9f92db23f01", size = 212438, upload-time = "2026-05-22T11:00:07.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/7e/f4346adfd44acbd7eaedcbd7d21b7f40ec9712e6c699e71fddad8dae6f8d/py_rust_stemmers-0.1.8-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:526b58958c6ffa36c4a805326cfb624ecbd665d16ba435027dbed0bcbcaa09d2", size = 290379, upload-time = "2026-05-22T11:00:08.192Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d8/988fc3f5dc0dbbd4bf5909f50ff953ab55ee8b5f79a835d00e57847d3123/py_rust_stemmers-0.1.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2b607f0b270951fb66479baf4b68716cc63a981585cbd898b0b6b5c359efde7e", size = 275458, upload-time = "2026-05-22T11:00:09.522Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/94/e04c8b6a8364bca1b368785cef143755dd2d1ffe74df8f8b47b075bb1043/py_rust_stemmers-0.1.8-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b0327b151ab8a338fb54fdac114ba34394327fc1e2c4c425ad1caf2013e5de3", size = 314711, upload-time = "2026-05-22T11:00:10.878Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/cb/f59f9a80caa099cb6625a46c9a8e6e7e80bb3ed284f17e80245c8240a66e/py_rust_stemmers-0.1.8-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dadd0e369703817fc7026987b3093f461f9f58d8dde74e689d546184bc8f3451", size = 319370, upload-time = "2026-05-22T11:00:11.961Z" },
+    { url = "https://files.pythonhosted.org/packages/06/59/8211cd0f56e53f7770debd9a78de37985fb5662ae66e3b7b380f4c79888b/py_rust_stemmers-0.1.8-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:245e2c61c52e073341893a9682cd1396b61047154548aee30bb1af3d8ed4b4cc", size = 321373, upload-time = "2026-05-22T11:00:13.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/72/fe33e614c114264d1ba54d39da4b5a4abeb6aedd0d26e5a8fd0637d6ddba/py_rust_stemmers-0.1.8-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:451ee1c02a3f5cf1e161b46ba9032cdda4ba10a8b03ff9ee61c1d34d42a0bc81", size = 321707, upload-time = "2026-05-22T11:00:14.177Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f9/3cd18902fe2fa54557d3fe9132552256372d381c7aca71346163055d78b1/py_rust_stemmers-0.1.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d396dd25c473c1bc4248c79cd223f4b36356b55a124652f015c6a001547f81ac", size = 492457, upload-time = "2026-05-22T11:00:15.245Z" },
+    { url = "https://files.pythonhosted.org/packages/90/d7/32c6d3995e7036b73683389de2771f4dbbf40de192b7efe73c2528ee1eb5/py_rust_stemmers-0.1.8-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:479c77c32d8be692f3cfcde7e19273f02ac81d6f45c6aef49887ef95cab7abbb", size = 596085, upload-time = "2026-05-22T11:00:16.404Z" },
+    { url = "https://files.pythonhosted.org/packages/00/8c/e68fa5d862ea6a27fced3535c25ea4eaa26ba1ce00dfef5841924c74b167/py_rust_stemmers-0.1.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c786235275c5c2abb7f206b8236aee3ca0bc53c7497daf7fb7b01d3491469547", size = 539747, upload-time = "2026-05-22T11:00:17.414Z" },
+    { url = "https://files.pythonhosted.org/packages/44/48/aa584cf3772e01231641c95dc1aa73327a7d986c562639d78d0013733acf/py_rust_stemmers-0.1.8-cp314-cp314-win_amd64.whl", hash = "sha256:931d13570962b093417e5443a9d1bd63d73fa239ebb81e5b1d346663571403e4", size = 209636, upload-time = "2026-05-22T11:00:18.662Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/8c/7c6d581412a6f33d316e72a8f3442ae0c61a7b6190ca30e1a06ee17ea234/py_rust_stemmers-0.1.8-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c03f51280d5d72f7f9b07101ad248845279dc1c82c47a74149303d25937464b7", size = 290748, upload-time = "2026-05-22T11:00:19.794Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fe/04436ffe3aa4c02a40500835fc1a80d52375c738aa7ef66ebe0c4ccc2900/py_rust_stemmers-0.1.8-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:234fdcb58f4d907877ed03c9358668a149b5a66d096abcf43c324a4f5697d36d", size = 276111, upload-time = "2026-05-22T11:00:21.026Z" },
+    { url = "https://files.pythonhosted.org/packages/45/24/6b32c86dd4eecdc309bfe6c15529a11e90b1e2c7af015366498c14e925f7/py_rust_stemmers-0.1.8-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dca0ae40715238582d6f1824b61d09ea3982359a061b69798ab5732b3ba0d4c5", size = 314816, upload-time = "2026-05-22T11:00:22.207Z" },
+    { url = "https://files.pythonhosted.org/packages/22/78/3bf351dbcc7f51eb03a506c0bcf8aead8b1401cf26aaa1328968471531aa/py_rust_stemmers-0.1.8-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfc185b599e646a0e39d11df3f5e6d15edefb110496601556385d33b55fed5de", size = 320180, upload-time = "2026-05-22T11:00:23.387Z" },
 ]
 
 [[package]]
@@ -9280,6 +9560,30 @@ wheels = [
 ]
 
 [[package]]
+name = "qdrant-client"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy" },
+    { name = "portalocker" },
+    { name = "protobuf" },
+    { name = "pydantic", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-mirage-ai-camel'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-mirage-ai-all' or extra != 'extra-9-mirage-ai-camel' or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openai') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-openhands') or (extra == 'extra-9-mirage-ai-camel' and extra == 'extra-9-mirage-ai-pydantic-ai')" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/45/5b1bdd15a3c7730eefb9c113600829e20d689b82b5a23f9e07d107094004/qdrant_client-1.18.0.tar.gz", hash = "sha256:52e8ece1a7d40519801bf0b70713bfa0f6b7ae28c7275bbe0b0286fbed7f6db4", size = 352580, upload-time = "2026-05-11T14:12:38.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/10/c437bd2ac41ef30d3019063e6ce537dc111e9214473b337ee88f7fa6359a/qdrant_client-1.18.0-py3-none-any.whl", hash = "sha256:093aa8cf8a420ee3ad2a68b007e1378d7992b2600e0b53c193fc172674f659cd", size = 398126, upload-time = "2026-05-11T14:12:36.998Z" },
+]
+
+[package.optional-dependencies]
+fastembed = [
+    { name = "fastembed" },
+]
+
+[[package]]
 name = "redis"
 version = "7.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -9868,7 +10172,7 @@ name = "tokenizers"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", marker = "python_full_version >= '3.12'" },
+    { name = "huggingface-hub" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
 wheels = [
@@ -10402,6 +10706,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/f1/ee81806690a87dab5f5653c1f146c92bc066d7f4cebc603ef88eb9e13957/werkzeug-3.1.6.tar.gz", hash = "sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25", size = 864736, upload-time = "2026-02-19T15:17:18.884Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl", hash = "sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131", size = 225166, upload-time = "2026-02-19T15:17:17.475Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]
 
 [[package]]

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.0.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "@qdrant/js-client-rest": "^1.18.0",
     "chromadb": "^3.4.3",
     "hyparquet-writer": "^0.13.0",
     "pyodide": "^0.29.3",
@@ -71,11 +72,15 @@
     "zod": "^4.3.6"
   },
   "peerDependencies": {
+    "@qdrant/js-client-rest": "^1.18.0",
     "chromadb": "^3.4.3",
     "pyodide": "^0.29.0",
     "redis": "^5.0.0"
   },
   "peerDependenciesMeta": {
+    "@qdrant/js-client-rest": {
+      "optional": true
+    },
     "chromadb": {
       "optional": true
     },

--- a/typescript/packages/core/src/accessor/qdrant.test.ts
+++ b/typescript/packages/core/src/accessor/qdrant.test.ts
@@ -1,0 +1,111 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+
+import { resolveQdrantConfig } from '../resource/qdrant/config.ts'
+import { QdrantAccessor } from './qdrant.ts'
+
+interface ScrollOpts {
+  filter?: unknown
+}
+
+function indexRequiredError(): Error {
+  const e = new Error('Bad Request') as Error & { status: number; data: unknown }
+  e.status = 400
+  e.data = { status: { error: 'Bad request: Index required but not found for "code"' } }
+  return e
+}
+
+const ALL_POINTS = [
+  { id: 10, payload: { code: '100', name: 'alpha' } },
+  { id: 20, payload: { code: '200', name: 'beta' } },
+]
+
+function fakeClient(counts: { filtered: number; indexed: number }) {
+  let indexCreated = false
+  return {
+    scroll(_collection: string, opts: ScrollOpts) {
+      if (opts.filter !== undefined && !indexCreated) {
+        counts.filtered += 1
+        throw indexRequiredError()
+      }
+      const filter = opts.filter as
+        | { must?: { key: string; match: { value: unknown } }[] }
+        | undefined
+      const must = filter?.must
+      const pts = must
+        ? ALL_POINTS.filter((p) =>
+            must.every((c) => p.payload[c.key as keyof typeof p.payload] === String(c.match.value)),
+          )
+        : ALL_POINTS
+      return Promise.resolve({ points: pts, next_page_offset: null })
+    },
+    createPayloadIndex(_collection: string, _opts: object) {
+      counts.indexed += 1
+      indexCreated = true
+      return Promise.resolve()
+    },
+  }
+}
+
+function accessorWith(client: unknown): QdrantAccessor {
+  const acc = new QdrantAccessor(
+    resolveQdrantConfig({ url: 'http://x', collection: 'c', groupBy: ['code'], idField: 'id' }),
+  )
+  ;(acc as unknown as { client: unknown }).client = client
+  return acc
+}
+
+describe('QdrantAccessor index auto-create', () => {
+  it('creates index on index-required error then retries', async () => {
+    const counts = { filtered: 0, indexed: 0 }
+    const acc = accessorWith(fakeClient(counts))
+
+    const rows = await acc.rowsMatching('c', { code: '100' }, [], 100)
+
+    expect(rows.map((r) => r.id)).toEqual([10])
+    expect(counts.filtered).toBe(1)
+    expect(counts.indexed).toBe(1)
+  })
+
+  it('does not re-create indexes on subsequent calls', async () => {
+    const counts = { filtered: 0, indexed: 0 }
+    const acc = accessorWith(fakeClient(counts))
+
+    await acc.distinct('c', 'code', { code: '100' }, 100)
+    await acc.distinct('c', 'code', { code: '100' }, 100)
+
+    expect(counts.indexed).toBe(1)
+  })
+
+  it('propagates non-index errors', async () => {
+    const client = {
+      createPayloadIndex(_c: string, _opts: object) {
+        return Promise.resolve()
+      },
+      scroll(_c: string, opts: ScrollOpts) {
+        if (opts.filter !== undefined) {
+          const e = new Error('boom') as Error & { status: number }
+          e.status = 500
+          throw e
+        }
+        return Promise.resolve({ points: [], next_page_offset: null })
+      },
+    }
+    const acc = accessorWith(client)
+
+    await expect(acc.rowsMatching('c', { code: '100' }, [], 100)).rejects.toThrow('boom')
+  })
+})

--- a/typescript/packages/core/src/accessor/qdrant.ts
+++ b/typescript/packages/core/src/accessor/qdrant.ts
@@ -1,0 +1,190 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantClient } from '@qdrant/js-client-rest'
+import { Accessor } from './base.ts'
+import { loadOptionalPeer } from '../utils/optional_peer.ts'
+import {
+  buildFilter,
+  candidateIds,
+  pointToRow,
+  SCROLL_BATCH,
+  type QdrantPoint,
+  type QdrantRow,
+} from '../core/qdrant/_client.ts'
+import type { QdrantConfigResolved } from '../resource/qdrant/config.ts'
+
+type QdrantClientCtor = new (opts: {
+  url?: string
+  host?: string
+  port?: number
+  https?: boolean
+  apiKey?: string
+}) => QdrantClient
+
+export class QdrantAccessor extends Accessor {
+  readonly config: QdrantConfigResolved
+  private client: QdrantClient | null = null
+  private readonly indexesEnsured = new Set<string>()
+  private readonly searchCache = new Map<string, QdrantRow[]>()
+
+  constructor(config: QdrantConfigResolved) {
+    super()
+    this.config = config
+  }
+
+  private async getClient(): Promise<QdrantClient> {
+    if (this.client === null) {
+      const mod = (await loadOptionalPeer(
+        () => import(/* @vite-ignore */ '@qdrant/js-client-rest'),
+        { feature: 'QdrantResource', packageName: '@qdrant/js-client-rest' },
+      )) as { QdrantClient: QdrantClientCtor }
+      const auth = this.config.apiKey !== null ? { apiKey: this.config.apiKey } : {}
+      this.client = new mod.QdrantClient(
+        this.config.url !== null
+          ? { url: this.config.url, ...auth }
+          : { host: this.config.host, port: this.config.port, https: this.config.https, ...auth },
+      )
+    }
+    return this.client
+  }
+
+  private async scrollRaw(
+    collection: string,
+    filter: Record<string, unknown> | undefined,
+    limit: number,
+  ): Promise<QdrantPoint[]> {
+    const client = await this.getClient()
+    const points: QdrantPoint[] = []
+    let offset: string | number | null = null
+    while (points.length < limit) {
+      const res = (await client.scroll(collection, {
+        ...(filter !== undefined ? { filter } : {}),
+        limit: Math.min(SCROLL_BATCH, limit - points.length),
+        offset,
+        with_payload: true,
+        with_vector: false,
+      })) as { points: QdrantPoint[]; next_page_offset?: string | number | null }
+      points.push(...res.points)
+      const next = res.next_page_offset
+      if (next === null || next === undefined) break
+      offset = next
+    }
+    return points.slice(0, limit)
+  }
+
+  private async ensureIndexes(collection: string): Promise<void> {
+    if (this.indexesEnsured.has(collection)) return
+    const client = await this.getClient()
+    for (const field of this.config.groupBy) {
+      await (
+        client as unknown as { createPayloadIndex: (c: string, o: object) => Promise<void> }
+      ).createPayloadIndex(collection, { field_name: field, field_schema: 'keyword' })
+    }
+    this.indexesEnsured.add(collection)
+  }
+
+  private isIndexRequired(err: unknown): boolean {
+    if (typeof err !== 'object' || err === null) return false
+    const e = err as { status?: number; data?: unknown; message?: string }
+    if (e.status !== 400) return false
+    const text = `${JSON.stringify(e.data ?? '')} ${e.message ?? ''}`.toLowerCase()
+    return text.includes('index required')
+  }
+
+  private async scrollFiltered(
+    collection: string,
+    filters: Record<string, string>,
+    limit: number,
+  ): Promise<QdrantPoint[]> {
+    if (Object.keys(filters).length === 0) return this.scrollRaw(collection, undefined, limit)
+    const filter = buildFilter(filters)
+    try {
+      return await this.scrollRaw(collection, filter, limit)
+    } catch (err) {
+      if (!this.isIndexRequired(err)) throw err
+    }
+    await this.ensureIndexes(collection)
+    return this.scrollRaw(collection, filter, limit)
+  }
+
+  async listTables(): Promise<string[]> {
+    const client = await this.getClient()
+    const res = (await client.getCollections()) as { collections: { name: string }[] }
+    return res.collections.map((c) => c.name).sort()
+  }
+
+  async tableExists(name: string): Promise<boolean> {
+    const client = await this.getClient()
+    const res = (await client.collectionExists(name)) as { exists: boolean }
+    return res.exists
+  }
+
+  async distinct(
+    table: string,
+    column: string,
+    filters: Record<string, string>,
+    limit: number,
+  ): Promise<string[]> {
+    const points = await this.scrollFiltered(table, filters, limit)
+    const values = new Set<string>()
+    for (const point of points) {
+      const value = point.payload?.[column]
+      if (value !== null && value !== undefined)
+        values.add(String(value as string | number | boolean))
+    }
+    return [...values].sort()
+  }
+
+  async rowsMatching(
+    table: string,
+    filters: Record<string, string>,
+    _columns: string[],
+    limit: number,
+  ): Promise<QdrantRow[]> {
+    const points = await this.scrollFiltered(table, filters, limit)
+    return points.map((point) => pointToRow(point, this.config.idField))
+  }
+
+  async rowRecord(table: string, idField: string, rowId: string): Promise<QdrantRow | null> {
+    const ids = candidateIds(rowId)
+    if (ids.length === 0) return null
+    const client = await this.getClient()
+    const found = (await client.retrieve(table, {
+      ids,
+      with_payload: true,
+      with_vector: false,
+    })) as QdrantPoint[]
+    return found[0] !== undefined ? pointToRow(found[0], idField) : null
+  }
+
+  async searchRows(table: string, query: string, limit: number): Promise<QdrantRow[]> {
+    const key = JSON.stringify([table, query, limit])
+    const hit = this.searchCache.get(key)
+    if (hit !== undefined) return hit
+    const client = await this.getClient()
+    const res = (await client.query(table, {
+      query: { text: query, model: this.config.embeddingModel },
+      limit,
+      with_payload: true,
+    })) as { points: QdrantPoint[] }
+    const rows = res.points.map((point) => {
+      const row = pointToRow(point, this.config.idField)
+      row._score = point.score
+      return row
+    })
+    this.searchCache.set(key, rows)
+    return rows
+  }
+}

--- a/typescript/packages/core/src/commands/builtin/qdrant/cat.ts
+++ b/typescript/packages/core/src/commands/builtin/qdrant/cat.ts
@@ -1,0 +1,46 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../../accessor/qdrant.ts'
+import { resolveGlob } from '../../../core/qdrant/glob.ts'
+import { stat as qdrantStat } from '../../../core/qdrant/stat.ts'
+import { stream as qdrantStream } from '../../../core/qdrant/stream.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { catGeneric } from '../generic/cat.ts'
+
+async function catCommand(
+  accessor: QdrantAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return catGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => qdrantStat(accessor, p, opts.index ?? undefined),
+    (p) => qdrantStream(accessor, p, opts.index ?? undefined),
+  )
+}
+
+export const QDRANT_CAT = command({
+  name: 'cat',
+  resource: ResourceName.QDRANT,
+  spec: specOf('cat'),
+  fn: catCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/qdrant/find.ts
+++ b/typescript/packages/core/src/commands/builtin/qdrant/find.ts
@@ -1,0 +1,28 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../../accessor/qdrant.ts'
+import { find as qdrantFind } from '../../../core/qdrant/find.ts'
+import { ResourceName } from '../../../types.ts'
+import { command } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { findGeneric } from '../generic/find.ts'
+
+export const QDRANT_FIND = command({
+  name: 'find',
+  resource: ResourceName.QDRANT,
+  spec: specOf('find'),
+  fn: (accessor: QdrantAccessor, paths, texts, opts) =>
+    findGeneric(paths, texts, opts, (root, options) => qdrantFind(accessor, root, options)),
+})

--- a/typescript/packages/core/src/commands/builtin/qdrant/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/qdrant/grep.ts
@@ -1,0 +1,48 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../../accessor/qdrant.ts'
+import { resolveGlob } from '../../../core/qdrant/glob.ts'
+import { readdir as qdrantReaddir } from '../../../core/qdrant/readdir.ts'
+import { stat as qdrantStat } from '../../../core/qdrant/stat.ts'
+import { stream as qdrantStream } from '../../../core/qdrant/stream.ts'
+import { type FileStat, ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { prefixAggregate } from '../aggregators.ts'
+import { grepGeneric } from '../generic/grep.ts'
+
+async function grepCommand(
+  accessor: QdrantAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  const stat = (p: PathSpec): Promise<FileStat> => qdrantStat(accessor, p, opts.index ?? undefined)
+  const readdir = (p: PathSpec): Promise<string[]> =>
+    qdrantReaddir(accessor, p, opts.index ?? undefined)
+  return grepGeneric('grep', resolved, texts, opts, stat, readdir, (p) =>
+    qdrantStream(accessor, p, opts.index ?? undefined),
+  )
+}
+
+export const QDRANT_GREP = command({
+  name: 'grep',
+  resource: ResourceName.QDRANT,
+  spec: specOf('grep'),
+  fn: grepCommand,
+  aggregate: prefixAggregate,
+})

--- a/typescript/packages/core/src/commands/builtin/qdrant/head.ts
+++ b/typescript/packages/core/src/commands/builtin/qdrant/head.ts
@@ -1,0 +1,46 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../../accessor/qdrant.ts'
+import { resolveGlob } from '../../../core/qdrant/glob.ts'
+import { stat as qdrantStat } from '../../../core/qdrant/stat.ts'
+import { stream as qdrantStream } from '../../../core/qdrant/stream.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { headGeneric } from '../generic/head.ts'
+
+async function headCommand(
+  accessor: QdrantAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return headGeneric(
+    resolved,
+    texts,
+    opts,
+    (p) => qdrantStat(accessor, p, opts.index ?? undefined),
+    (p) => qdrantStream(accessor, p, opts.index ?? undefined),
+  )
+}
+
+export const QDRANT_HEAD = command({
+  name: 'head',
+  resource: ResourceName.QDRANT,
+  spec: specOf('head'),
+  fn: headCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/qdrant/index.ts
+++ b/typescript/packages/core/src/commands/builtin/qdrant/index.ts
@@ -1,0 +1,40 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { RegisteredCommand } from '../../config.ts'
+import { QDRANT_CAT } from './cat.ts'
+import { QDRANT_FIND } from './find.ts'
+import { QDRANT_GREP } from './grep.ts'
+import { QDRANT_HEAD } from './head.ts'
+import { QDRANT_LS } from './ls.ts'
+import { QDRANT_RG } from './rg.ts'
+import { QDRANT_SEARCH } from './search.ts'
+import { QDRANT_STAT } from './stat.ts'
+import { QDRANT_TAIL } from './tail.ts'
+import { QDRANT_TREE } from './tree.ts'
+import { QDRANT_WC } from './wc.ts'
+
+export const QDRANT_COMMANDS: readonly RegisteredCommand[] = [
+  ...QDRANT_LS,
+  ...QDRANT_STAT,
+  ...QDRANT_CAT,
+  ...QDRANT_TREE,
+  ...QDRANT_WC,
+  ...QDRANT_FIND,
+  ...QDRANT_SEARCH,
+  ...QDRANT_GREP,
+  ...QDRANT_RG,
+  ...QDRANT_HEAD,
+  ...QDRANT_TAIL,
+]

--- a/typescript/packages/core/src/commands/builtin/qdrant/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/qdrant/ls.ts
@@ -1,0 +1,45 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../../accessor/qdrant.ts'
+import { resolveGlob } from '../../../core/qdrant/glob.ts'
+import { readdir as qdrantReaddir } from '../../../core/qdrant/readdir.ts'
+import { stat as qdrantStat } from '../../../core/qdrant/stat.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { lsGeneric } from '../generic/ls.ts'
+
+async function lsCommand(
+  accessor: QdrantAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return lsGeneric(
+    resolved,
+    opts,
+    (p) => qdrantReaddir(accessor, p, opts.index ?? undefined),
+    (p) => qdrantStat(accessor, p, opts.index ?? undefined),
+  )
+}
+
+export const QDRANT_LS = command({
+  name: 'ls',
+  resource: ResourceName.QDRANT,
+  spec: specOf('ls'),
+  fn: lsCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/qdrant/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/qdrant/rg.ts
@@ -1,0 +1,46 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../../accessor/qdrant.ts'
+import { resolveGlob } from '../../../core/qdrant/glob.ts'
+import { readdir as qdrantReaddir } from '../../../core/qdrant/readdir.ts'
+import { stat as qdrantStat } from '../../../core/qdrant/stat.ts'
+import { stream as qdrantStream } from '../../../core/qdrant/stream.ts'
+import { type FileStat, ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { rgGeneric } from '../generic/rg.ts'
+
+async function rgCommand(
+  accessor: QdrantAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  const stat = (p: PathSpec): Promise<FileStat> => qdrantStat(accessor, p, opts.index ?? undefined)
+  const readdir = (p: PathSpec): Promise<string[]> =>
+    qdrantReaddir(accessor, p, opts.index ?? undefined)
+  return rgGeneric(resolved, texts, opts, stat, readdir, (p) =>
+    qdrantStream(accessor, p, opts.index ?? undefined),
+  )
+}
+
+export const QDRANT_RG = command({
+  name: 'rg',
+  resource: ResourceName.QDRANT,
+  spec: specOf('rg'),
+  fn: rgCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/qdrant/search.ts
+++ b/typescript/packages/core/src/commands/builtin/qdrant/search.ts
@@ -1,0 +1,70 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../../accessor/qdrant.ts'
+import { searchRowsOutput } from '../../../core/qdrant/search.ts'
+import { IOResult } from '../../../io/types.ts'
+import { PathSpec, ResourceName } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+
+const ENC = new TextEncoder()
+
+function defaultPaths(paths: PathSpec[], cwd: string): PathSpec[] {
+  if (paths.length > 0) return paths
+  return [PathSpec.fromStrPath(cwd)]
+}
+
+async function searchCommand(
+  accessor: QdrantAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const query = texts[0]
+  if (query === undefined || query === '') {
+    return [null, new IOResult({ exitCode: 2, stderr: ENC.encode('search: query is required\n') })]
+  }
+  const method = typeof opts.flags.method === 'string' ? opts.flags.method : 'semantic'
+  if (method !== 'semantic') {
+    return [
+      null,
+      new IOResult({
+        exitCode: 2,
+        stderr: ENC.encode("search: only the 'semantic' method is supported\n"),
+      }),
+    ]
+  }
+  const target = defaultPaths(paths, opts.cwd)
+  const mountPrefix = target[0]?.prefix ?? opts.mountPrefix ?? ''
+  const topK =
+    typeof opts.flags.top_k === 'string'
+      ? parseInt(opts.flags.top_k, 10)
+      : accessor.config.searchLimit
+  const threshold = typeof opts.flags.threshold === 'string' ? Number(opts.flags.threshold) : 0
+  try {
+    const out = await searchRowsOutput(accessor, query, target, topK, threshold, mountPrefix)
+    return [out, new IOResult()]
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
+  }
+}
+
+export const QDRANT_SEARCH = command({
+  name: 'search',
+  resource: ResourceName.QDRANT,
+  spec: specOf('search'),
+  fn: searchCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/qdrant/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/qdrant/stat.ts
@@ -1,0 +1,39 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../../accessor/qdrant.ts'
+import { resolveGlob } from '../../../core/qdrant/glob.ts'
+import { stat as qdrantStat } from '../../../core/qdrant/stat.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { statGeneric } from '../generic/stat.ts'
+
+async function statCommand(
+  accessor: QdrantAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return statGeneric(resolved, opts, (p) => qdrantStat(accessor, p, opts.index ?? undefined))
+}
+
+export const QDRANT_STAT = command({
+  name: 'stat',
+  resource: ResourceName.QDRANT,
+  spec: specOf('stat'),
+  fn: statCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/qdrant/tail.ts
+++ b/typescript/packages/core/src/commands/builtin/qdrant/tail.ts
@@ -1,0 +1,41 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../../accessor/qdrant.ts'
+import { resolveGlob } from '../../../core/qdrant/glob.ts'
+import { stream as qdrantStream } from '../../../core/qdrant/stream.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { tailGeneric } from '../generic/tail.ts'
+
+async function tailCommand(
+  accessor: QdrantAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return tailGeneric(resolved, texts, opts, (p) =>
+    qdrantStream(accessor, p, opts.index ?? undefined),
+  )
+}
+
+export const QDRANT_TAIL = command({
+  name: 'tail',
+  resource: ResourceName.QDRANT,
+  spec: specOf('tail'),
+  fn: tailCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/qdrant/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/qdrant/tree.ts
@@ -1,0 +1,44 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../../accessor/qdrant.ts'
+import { resolveGlob } from '../../../core/qdrant/glob.ts'
+import { readdir as qdrantReaddir } from '../../../core/qdrant/readdir.ts'
+import { stat as qdrantStat } from '../../../core/qdrant/stat.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { treeGeneric } from '../generic/tree.ts'
+
+async function treeCommand(
+  accessor: QdrantAccessor,
+  paths: PathSpec[],
+  _texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved = await resolveGlob(accessor, paths, opts.index ?? undefined)
+  return treeGeneric(
+    resolved,
+    opts,
+    (p) => qdrantReaddir(accessor, p, opts.index ?? undefined),
+    (p) => qdrantStat(accessor, p, opts.index ?? undefined),
+  )
+}
+
+export const QDRANT_TREE = command({
+  name: 'tree',
+  resource: ResourceName.QDRANT,
+  spec: specOf('tree'),
+  fn: treeCommand,
+})

--- a/typescript/packages/core/src/commands/builtin/qdrant/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/qdrant/wc.ts
@@ -1,0 +1,39 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../../accessor/qdrant.ts'
+import { resolveGlob } from '../../../core/qdrant/glob.ts'
+import { stream as qdrantStream } from '../../../core/qdrant/stream.ts'
+import { ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { wcGeneric } from '../generic/wc.ts'
+
+async function wcCommand(
+  accessor: QdrantAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  const resolved =
+    paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
+  return wcGeneric(resolved, texts, opts, (p) => qdrantStream(accessor, p, opts.index ?? undefined))
+}
+
+export const QDRANT_WC = command({
+  name: 'wc',
+  resource: ResourceName.QDRANT,
+  spec: specOf('wc'),
+  fn: wcCommand,
+})

--- a/typescript/packages/core/src/core/qdrant/_client.test.ts
+++ b/typescript/packages/core/src/core/qdrant/_client.test.ts
@@ -1,0 +1,53 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+
+import { buildFilter, candidateIds, coerce, pointToRow } from './_client.ts'
+
+describe('qdrant _client helpers', () => {
+  it('coerces numeric strings only', () => {
+    expect(coerce('5')).toBe(5)
+    expect(coerce('-3')).toBe(-3)
+    expect(coerce('cat')).toBe('cat')
+  })
+
+  it('keeps numeric strings that would not round-trip', () => {
+    expect(coerce('007')).toBe('007')
+    expect(coerce('05')).toBe('05')
+    expect(coerce('-0')).toBe('-0')
+  })
+
+  it('builds a match filter, undefined when empty', () => {
+    expect(buildFilter({})).toBeUndefined()
+    expect(buildFilter({ label: 'cat', n: '2' })).toEqual({
+      must: [
+        { key: 'label', match: { value: 'cat' } },
+        { key: 'n', match: { value: 2 } },
+      ],
+    })
+  })
+
+  it('maps a point to a row keyed by the point id', () => {
+    const row = pointToRow({ id: 7, payload: { label: 'cat' } }, 'id')
+    expect(row).toEqual({ label: 'cat', id: 7 })
+  })
+
+  it('produces id candidates by type, none for invalid ids', () => {
+    expect(candidateIds('7')).toEqual([7])
+    const uid = '11111111-1111-1111-1111-111111111111'
+    expect(candidateIds(uid)).toEqual([uid])
+    expect(candidateIds('__nf_missing__')).toEqual([])
+  })
+})

--- a/typescript/packages/core/src/core/qdrant/_client.ts
+++ b/typescript/packages/core/src/core/qdrant/_client.ts
@@ -1,0 +1,54 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+export type QdrantRow = Record<string, unknown>
+
+export interface QdrantPoint {
+  id: string | number
+  payload?: Record<string, unknown> | null
+  score?: number
+}
+
+export const SCROLL_BATCH = 256
+
+export function coerce(value: string): string | number {
+  if (/^-?\d+$/.test(value)) {
+    const n = Number.parseInt(value, 10)
+    if (String(n) === value) return n
+  }
+  return value
+}
+
+export function buildFilter(filters: Record<string, string>): Record<string, unknown> | undefined {
+  const keys = Object.keys(filters)
+  if (keys.length === 0) return undefined
+  return {
+    must: keys.map((key) => ({ key, match: { value: coerce(filters[key] ?? '') } })),
+  }
+}
+
+export function pointToRow(point: QdrantPoint, idField: string): QdrantRow {
+  const payload = point.payload ?? {}
+  const row: QdrantRow = { ...payload }
+  row[idField] = point.id
+  return row
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function candidateIds(rowId: string): (string | number)[] {
+  if (/^-?\d+$/.test(rowId)) return [Number.parseInt(rowId, 10)]
+  if (UUID_RE.test(rowId)) return [rowId]
+  return []
+}

--- a/typescript/packages/core/src/core/qdrant/find.test.ts
+++ b/typescript/packages/core/src/core/qdrant/find.test.ts
@@ -1,0 +1,127 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ReaddirModule from './readdir.ts'
+import type * as StatModule from './stat.ts'
+
+vi.mock('./readdir.ts', async () => {
+  const actual = await vi.importActual<typeof ReaddirModule>('./readdir.ts')
+  return { ...actual, readdir: vi.fn() }
+})
+
+vi.mock('./stat.ts', async () => {
+  const actual = await vi.importActual<typeof StatModule>('./stat.ts')
+  return { ...actual, stat: vi.fn() }
+})
+
+import { QdrantAccessor } from '../../accessor/qdrant.ts'
+import type { QdrantConfigResolved } from '../../resource/qdrant/config.ts'
+import { FileStat, FileType, PathSpec } from '../../types.ts'
+import { find } from './find.ts'
+import * as readdirMod from './readdir.ts'
+import * as statMod from './stat.ts'
+
+function makeAccessor(): QdrantAccessor {
+  const config = { blobField: null, blobExt: 'bin' } as QdrantConfigResolved
+  return new QdrantAccessor(config)
+}
+
+function enoent(p: string): Error {
+  const e = new Error(`ENOENT: ${p}`) as Error & { code: string }
+  e.code = 'ENOENT'
+  return e
+}
+
+function mockTree(tree: Record<string, string[]>): void {
+  vi.mocked(readdirMod.readdir).mockImplementation((_accessor, spec) => {
+    const key = typeof spec === 'string' ? spec : spec.original
+    const children = tree[key]
+    if (children === undefined) return Promise.reject(enoent(key))
+    return Promise.resolve(children)
+  })
+}
+
+function mockStats(stats: Record<string, { size?: number; modified?: string }>): void {
+  vi.mocked(statMod.stat).mockImplementation((_accessor, spec) => {
+    const key = typeof spec === 'string' ? spec : spec.original
+    const entry = stats[key]
+    if (entry === undefined) return Promise.reject(enoent(key))
+    const name = key.split('/').pop() ?? ''
+    return Promise.resolve(
+      new FileStat({
+        name,
+        size: entry.size ?? null,
+        modified: entry.modified ?? null,
+        type: entry.size === undefined ? FileType.DIRECTORY : FileType.TEXT,
+      }),
+    )
+  })
+}
+
+const TREE: Record<string, string[]> = {
+  '/': ['/col'],
+  '/col': ['/col/grp', '/col/b.json', '/col/a.json'],
+  '/col/grp': ['/col/grp/c.json'],
+}
+
+const ROOT = new PathSpec({ original: '/', directory: '/' })
+
+describe('qdrant core find', () => {
+  beforeEach(() => {
+    vi.mocked(readdirMod.readdir).mockReset()
+    vi.mocked(statMod.stat).mockReset()
+  })
+
+  it('walks recursively classifying row files by extension', async () => {
+    mockTree(TREE)
+    const out = await find(makeAccessor(), ROOT)
+    expect(out).toEqual(['/col', '/col/a.json', '/col/b.json', '/col/grp', '/col/grp/c.json'])
+    const files = await find(makeAccessor(), ROOT, { type: 'f' })
+    expect(files).toEqual(['/col/a.json', '/col/b.json', '/col/grp/c.json'])
+    const dirs = await find(makeAccessor(), ROOT, { type: 'd' })
+    expect(dirs).toEqual(['/col', '/col/grp'])
+  })
+
+  it('never stats entries for classification', async () => {
+    mockTree(TREE)
+    await find(makeAccessor(), ROOT)
+    expect(vi.mocked(statMod.stat)).not.toHaveBeenCalled()
+  })
+
+  it('keeps a child whose readdir raises ENOENT but stops descending', async () => {
+    mockTree({ '/': ['/ghost'] })
+    const out = await find(makeAccessor(), ROOT)
+    expect(out).toEqual(['/ghost'])
+  })
+
+  it('propagates non-ENOENT readdir errors', async () => {
+    vi.mocked(readdirMod.readdir).mockImplementation((_accessor, spec) => {
+      const key = typeof spec === 'string' ? spec : spec.original
+      if (key === '/') return Promise.resolve(['/bad'])
+      return Promise.reject(new Error('rate limited'))
+    })
+    await expect(find(makeAccessor(), ROOT)).rejects.toThrow('rate limited')
+  })
+
+  it('parses naive modified timestamps as UTC', async () => {
+    mockTree({ '/': ['/naive.json'] })
+    mockStats({ '/naive.json': { size: 1, modified: '2026-01-05T00:00:00' } })
+    const out = await find(makeAccessor(), ROOT, {
+      mtimeMin: Date.parse('2026-01-04T23:30:00Z') / 1000,
+      mtimeMax: Date.parse('2026-01-05T00:30:00Z') / 1000,
+    })
+    expect(out).toEqual(['/naive.json'])
+  })
+})

--- a/typescript/packages/core/src/core/qdrant/find.ts
+++ b/typescript/packages/core/src/core/qdrant/find.ts
@@ -1,0 +1,45 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../accessor/qdrant.ts'
+import type { FindOptions } from '../../resource/base.ts'
+import type { PathSpec } from '../../types.ts'
+import { walkFind } from '../generic/find.ts'
+import { readdir } from './readdir.ts'
+import { stat } from './stat.ts'
+
+function isRowFile(name: string, config: QdrantAccessor['config']): boolean {
+  if (name.endsWith('.json')) return true
+  if (config.textField !== null && name.endsWith('.txt')) return true
+  if (config.blobField !== null && name.endsWith(`.${config.blobExt}`)) return true
+  return false
+}
+
+export async function find(
+  accessor: QdrantAccessor,
+  path: PathSpec,
+  options: FindOptions = {},
+): Promise<string[]> {
+  return walkFind(
+    path,
+    {
+      readdir: (spec) => readdir(accessor, spec),
+      stat: (spec, idx) => stat(accessor, spec, idx),
+      // Row files are recognized by extension, so classification never
+      // needs the stat fallback.
+      isDirName: (child) => !isRowFile(child.split('/').pop() ?? '', accessor.config),
+    },
+    options,
+  )
+}

--- a/typescript/packages/core/src/core/qdrant/glob.ts
+++ b/typescript/packages/core/src/core/qdrant/glob.ts
@@ -1,0 +1,45 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../accessor/qdrant.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { PathSpec } from '../../types.ts'
+import { readdir } from './readdir.ts'
+import { fnmatch } from '../../utils/fnmatch.ts'
+
+const SCOPE_ERROR = 1024
+
+export async function resolveGlob(
+  accessor: QdrantAccessor,
+  paths: readonly PathSpec[],
+  index?: IndexCacheStore,
+): Promise<PathSpec[]> {
+  const result: PathSpec[] = []
+  for (const p of paths) {
+    if (p.resolved) {
+      result.push(p)
+    } else if (p.pattern !== null) {
+      const entries = await readdir(accessor, p.dir, index)
+      const pat = p.pattern
+      const matched = entries
+        .filter((e) => fnmatch(e.split('/').pop() ?? '', pat))
+        .slice(0, SCOPE_ERROR)
+        .map((e) => new PathSpec({ original: e, directory: p.directory, prefix: p.prefix }))
+      result.push(...matched)
+    } else {
+      result.push(p)
+    }
+  }
+  return result
+}

--- a/typescript/packages/core/src/core/qdrant/read.ts
+++ b/typescript/packages/core/src/core/qdrant/read.ts
@@ -1,0 +1,69 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../accessor/qdrant.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import type { QdrantRow } from './_client.ts'
+import { PathSpec } from '../../types.ts'
+import { decodeBase64 } from '../../utils/base64.ts'
+import { enoent } from '../../utils/errors.ts'
+import { renderJson, renderText } from './render.ts'
+import { type QdrantScope, ScopeLevel, detectScope } from './scope.ts'
+
+async function resolveRow(
+  accessor: QdrantAccessor,
+  scope: QdrantScope,
+  notFoundPath: string,
+): Promise<QdrantRow> {
+  const config = accessor.config
+  if (scope.table === null || scope.rowId === null) throw enoent(notFoundPath)
+  const row = await accessor.rowRecord(scope.table, config.idField, scope.rowId)
+  if (row === null) throw enoent(notFoundPath)
+  return row
+}
+
+function blobBytes(value: unknown): Uint8Array {
+  if (value instanceof Uint8Array) return value
+  if (typeof value === 'string') return decodeBase64(value)
+  throw new Error('blob column is not bytes or base64 string')
+}
+
+export async function read(
+  accessor: QdrantAccessor,
+  path: PathSpec | string,
+  _index?: IndexCacheStore,
+): Promise<Uint8Array> {
+  const spec = typeof path === 'string' ? PathSpec.fromStrPath(path) : path
+  const config = accessor.config
+  const scope = detectScope(spec, config)
+  if (scope.level !== ScopeLevel.ROW) throw enoent(spec.original)
+  const row = await resolveRow(accessor, scope, spec.original)
+  if (scope.kind === 'blob') {
+    if (config.blobField === null) throw enoent(spec.original)
+    const blobValue = row[config.blobField]
+    if (blobValue === null || blobValue === undefined) throw enoent(spec.original)
+    return blobBytes(blobValue)
+  }
+  if (scope.kind === 'txt') {
+    if (
+      config.textField === null ||
+      row[config.textField] === null ||
+      row[config.textField] === undefined
+    ) {
+      throw enoent(spec.original)
+    }
+    return renderText(row, config)
+  }
+  return renderJson(row, config)
+}

--- a/typescript/packages/core/src/core/qdrant/readdir.ts
+++ b/typescript/packages/core/src/core/qdrant/readdir.ts
@@ -1,0 +1,83 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../accessor/qdrant.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import type { QdrantRow } from './_client.ts'
+import { PathSpec } from '../../types.ts'
+import { enoent } from '../../utils/errors.ts'
+import { rstripSlash } from '../../utils/slash.ts'
+import { ScopeLevel, detectScope } from './scope.ts'
+
+function rowFiles(rows: QdrantRow[], config: QdrantAccessor['config']): string[] {
+  const names: string[] = []
+  for (const row of rows) {
+    const id = String(row[config.idField])
+    names.push(`${id}.json`)
+    if (
+      config.textField !== null &&
+      row[config.textField] !== null &&
+      row[config.textField] !== undefined
+    )
+      names.push(`${id}.txt`)
+    if (
+      config.blobField !== null &&
+      row[config.blobField] !== null &&
+      row[config.blobField] !== undefined
+    )
+      names.push(`${id}.${config.blobExt}`)
+  }
+  return names
+}
+
+export async function readdir(
+  accessor: QdrantAccessor,
+  path: PathSpec | string,
+  _index?: IndexCacheStore,
+): Promise<string[]> {
+  const spec = typeof path === 'string' ? PathSpec.fromStrPath(path) : path
+  const config = accessor.config
+  const scope = detectScope(spec, config)
+  const base = rstripSlash(spec.original)
+
+  if (scope.level === ScopeLevel.ROOT) {
+    const tables = await accessor.listTables()
+    return tables.map((name) => `${base}/${name}`)
+  }
+
+  if (scope.level === ScopeLevel.GROUP_DIR && scope.table !== null) {
+    const depth = Object.keys(scope.filters).length
+    const total = config.groupBy.length
+    let names: string[]
+    if (depth < total) {
+      names = await accessor.distinct(
+        scope.table,
+        config.groupBy[depth] ?? '',
+        scope.filters,
+        config.maxRows,
+      )
+    } else {
+      const rows = await accessor.rowsMatching(
+        scope.table,
+        scope.filters,
+        [config.idField],
+        config.maxRows,
+      )
+      names = rowFiles(rows, config)
+    }
+    return names.map((name) => `${base}/${name}`)
+  }
+
+  throw enoent(spec.original)
+}

--- a/typescript/packages/core/src/core/qdrant/render.test.ts
+++ b/typescript/packages/core/src/core/qdrant/render.test.ts
@@ -1,0 +1,63 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+
+import { resolveQdrantConfig } from '../../resource/qdrant/config.ts'
+import { renderJson, renderText } from './render.ts'
+
+const DEC = new TextDecoder()
+
+const config = resolveQdrantConfig({
+  idField: 'id',
+  textField: 'name',
+  blobField: 'image_bytes',
+  blobExt: 'png',
+  vectorField: 'vector',
+})
+
+describe('qdrant render', () => {
+  it('renderJson omits the vector and blob fields', () => {
+    const out = DEC.decode(
+      renderJson(
+        {
+          id: 3,
+          name: 'a big brown dog',
+          label: 'dog',
+          image_bytes: 'UE5HLTM=',
+          vector: [0.1, 0.2],
+        },
+        config,
+      ),
+    )
+    const payload = JSON.parse(out) as Record<string, unknown>
+    expect(payload).toEqual({ id: 3, name: 'a big brown dog', label: 'dog' })
+    expect(out).not.toContain('vector')
+    expect(out).not.toContain('UE5HLTM=')
+  })
+
+  it('renderJson is compact with a trailing newline', () => {
+    const out = DEC.decode(renderJson({ id: 1, name: 'x' }, config))
+    expect(out).toBe('{"id":1,"name":"x"}\n')
+  })
+
+  it('renderText returns the source text', () => {
+    const out = DEC.decode(renderText({ id: 3, name: 'a big brown dog' }, config))
+    expect(out).toBe('a big brown dog\n')
+  })
+
+  it('renderText is empty when the text field is missing', () => {
+    expect(renderText({ id: 3 }, config).length).toBe(0)
+  })
+})

--- a/typescript/packages/core/src/core/qdrant/render.ts
+++ b/typescript/packages/core/src/core/qdrant/render.ts
@@ -1,0 +1,39 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantRow } from './_client.ts'
+import type { QdrantConfigResolved } from '../../resource/qdrant/config.ts'
+
+const ENC = new TextEncoder()
+const SKIP_KEYS = new Set(['_score', '_rowid', '_distance'])
+
+export function renderJson(row: QdrantRow, config: QdrantConfigResolved): Uint8Array {
+  const data: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(row)) {
+    if (SKIP_KEYS.has(key)) continue
+    if (key === config.vectorField || key === config.blobField) continue
+    data[key] = value
+  }
+  return ENC.encode(JSON.stringify(data) + '\n')
+}
+
+export function renderText(row: QdrantRow, config: QdrantConfigResolved): Uint8Array {
+  const value = config.textField !== null ? row[config.textField] : undefined
+  if (value === undefined || value === null) return new Uint8Array()
+  const text =
+    typeof value === 'object'
+      ? JSON.stringify(value)
+      : String(value as string | number | boolean | bigint)
+  return ENC.encode(text + '\n')
+}

--- a/typescript/packages/core/src/core/qdrant/scope.test.ts
+++ b/typescript/packages/core/src/core/qdrant/scope.test.ts
@@ -1,0 +1,78 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+
+import { resolveQdrantConfig } from '../../resource/qdrant/config.ts'
+import { PathSpec } from '../../types.ts'
+import { ScopeLevel, detectScope } from './scope.ts'
+
+const config = resolveQdrantConfig({
+  groupBy: ['label', 'kind'],
+  idField: 'id',
+  textField: 'name',
+  blobField: 'image_bytes',
+  blobExt: 'png',
+  vectorField: 'vector',
+})
+
+function ps(p: string): PathSpec {
+  return new PathSpec({ original: p, directory: p })
+}
+
+describe('qdrant scope', () => {
+  it('root in multi-collection mode', () => {
+    expect(detectScope(ps('/'), config).level).toBe(ScopeLevel.ROOT)
+  })
+
+  it('collection is a group dir', () => {
+    const s = detectScope(ps('/animals'), config)
+    expect(s.level).toBe(ScopeLevel.GROUP_DIR)
+    expect(s.table).toBe('animals')
+    expect(s.filters).toEqual({})
+  })
+
+  it('nested group dir binds a filter', () => {
+    expect(detectScope(ps('/animals/cat'), config).filters).toEqual({ label: 'cat' })
+  })
+
+  it('row json', () => {
+    const s = detectScope(ps('/animals/cat/big/3.json'), config)
+    expect(s.level).toBe(ScopeLevel.ROW)
+    expect(s.rowId).toBe('3')
+    expect(s.kind).toBe('json')
+    expect(s.filters).toEqual({ label: 'cat', kind: 'big' })
+  })
+
+  it('row text', () => {
+    const s = detectScope(ps('/animals/cat/big/3.txt'), config)
+    expect(s.kind).toBe('txt')
+  })
+
+  it('row blob', () => {
+    const s = detectScope(ps('/animals/cat/big/3.png'), config)
+    expect(s.kind).toBe('blob')
+  })
+
+  it('single-collection pin elides the collection level', () => {
+    const pinned = resolveQdrantConfig({
+      collection: 'animals',
+      groupBy: ['label', 'kind'],
+      idField: 'id',
+    })
+    const s = detectScope(ps('/cat/big'), pinned)
+    expect(s.level).toBe(ScopeLevel.GROUP_DIR)
+    expect(s.filters).toEqual({ label: 'cat', kind: 'big' })
+  })
+})

--- a/typescript/packages/core/src/core/qdrant/scope.ts
+++ b/typescript/packages/core/src/core/qdrant/scope.ts
@@ -1,0 +1,99 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantConfigResolved } from '../../resource/qdrant/config.ts'
+import { PathSpec } from '../../types.ts'
+import { stripSlash } from '../../utils/slash.ts'
+
+export const ScopeLevel = Object.freeze({
+  ROOT: 'root',
+  GROUP_DIR: 'group_dir',
+  ROW: 'row',
+  UNKNOWN: 'unknown',
+} as const)
+
+export type ScopeLevel = (typeof ScopeLevel)[keyof typeof ScopeLevel]
+
+export interface QdrantScope {
+  level: ScopeLevel
+  table: string | null
+  filters: Record<string, string>
+  rowId: string | null
+  kind: string | null
+  resourcePath: string
+}
+
+function parseRowFile(name: string, config: QdrantConfigResolved): [string, string] | null {
+  if (name.endsWith('.json')) return [name.slice(0, -'.json'.length), 'json']
+  if (config.textField !== null && name.endsWith('.txt')) {
+    return [name.slice(0, -'.txt'.length), 'txt']
+  }
+  if (config.blobField !== null) {
+    const suffix = `.${config.blobExt}`
+    if (name.endsWith(suffix)) return [name.slice(0, -suffix.length), 'blob']
+  }
+  return null
+}
+
+function make(
+  level: ScopeLevel,
+  resourcePath: string,
+  over: Partial<QdrantScope> = {},
+): QdrantScope {
+  return {
+    level,
+    table: over.table ?? null,
+    filters: over.filters ?? {},
+    rowId: over.rowId ?? null,
+    kind: over.kind ?? null,
+    resourcePath,
+  }
+}
+
+export function detectScope(path: PathSpec | string, config: QdrantConfigResolved): QdrantScope {
+  const raw = path instanceof PathSpec ? path.stripPrefix : path
+  const key = stripSlash(raw)
+  const segs = key === '' ? [] : key.split('/')
+
+  let table: string
+  let rest: string[]
+  if (config.collection !== null) {
+    table = config.collection
+    rest = segs
+  } else {
+    if (segs.length === 0) return make(ScopeLevel.ROOT, raw)
+    table = segs[0] ?? ''
+    rest = segs.slice(1)
+  }
+
+  const gb = config.groupBy
+  const n = gb.length
+
+  if (rest.length <= n) {
+    const filters: Record<string, string> = {}
+    for (let i = 0; i < rest.length; i++) filters[gb[i] ?? ''] = rest[i] ?? ''
+    return make(ScopeLevel.GROUP_DIR, raw, { table, filters })
+  }
+
+  if (rest.length === n + 1) {
+    const filters: Record<string, string> = {}
+    for (let i = 0; i < n; i++) filters[gb[i] ?? ''] = rest[i] ?? ''
+    const parsed = parseRowFile(rest[n] ?? '', config)
+    if (parsed !== null) {
+      return make(ScopeLevel.ROW, raw, { table, filters, rowId: parsed[0], kind: parsed[1] })
+    }
+  }
+
+  return make(ScopeLevel.UNKNOWN, raw)
+}

--- a/typescript/packages/core/src/core/qdrant/search.ts
+++ b/typescript/packages/core/src/core/qdrant/search.ts
@@ -1,0 +1,111 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../accessor/qdrant.ts'
+import type { QdrantRow } from './_client.ts'
+import type { QdrantConfigResolved } from '../../resource/qdrant/config.ts'
+import type { PathSpec } from '../../types.ts'
+import { rstripSlash, stripSlash } from '../../utils/slash.ts'
+import { renderJson, renderText } from './render.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+function toStr(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value as string | number | boolean | bigint)
+}
+
+function contentExt(row: QdrantRow, config: QdrantConfigResolved): string {
+  if (
+    config.textField !== null &&
+    row[config.textField] !== null &&
+    row[config.textField] !== undefined
+  ) {
+    return 'txt'
+  }
+  return 'json'
+}
+
+function targetTable(paths: PathSpec[], config: QdrantConfigResolved): string | null {
+  if (config.collection !== null) return config.collection
+  for (const path of paths) {
+    const key = stripSlash(path.stripPrefix)
+    if (key !== '') return key.split('/')[0] ?? null
+  }
+  return null
+}
+
+function canonicalPath(
+  row: QdrantRow,
+  config: QdrantConfigResolved,
+  table: string,
+  mountPrefix: string,
+): string {
+  const segs: string[] = []
+  if (config.collection === null) segs.push(table)
+  for (const column of config.groupBy) {
+    const value = row[column]
+    if (value !== null && value !== undefined) segs.push(toStr(value))
+  }
+  segs.push(`${toStr(row[config.idField])}.${contentExt(row, config)}`)
+  const prefix = rstripSlash(mountPrefix)
+  return `${prefix}/${segs.join('/')}`
+}
+
+function block(
+  row: QdrantRow,
+  config: QdrantConfigResolved,
+  table: string,
+  mountPrefix: string,
+): string {
+  const path = canonicalPath(row, config, table, mountPrefix)
+  const score = row._score
+  const header =
+    score === null || score === undefined ? path : `${path}:${Number(score).toFixed(4)}`
+  const bodyRow: QdrantRow = { ...row }
+  delete bodyRow._score
+  const rendered =
+    contentExt(bodyRow, config) === 'txt'
+      ? renderText(bodyRow, config)
+      : renderJson(bodyRow, config)
+  const content = DEC.decode(rendered).replace(/\n+$/, '')
+  return `${header}\n${content}`
+}
+
+export async function searchRowsOutput(
+  accessor: QdrantAccessor,
+  query: string,
+  paths: PathSpec[],
+  topK: number,
+  threshold: number,
+  mountPrefix: string,
+): Promise<Uint8Array> {
+  if (query === '') throw new Error('search: query is required')
+  if (topK <= 0) throw new Error('search: top-k must be positive')
+  const table = targetTable(paths, accessor.config)
+  if (table === null) throw new Error('search: no table to search')
+  const rows = await accessor.searchRows(table, query, topK)
+  const blocks: string[] = []
+  for (const row of rows) {
+    const score = row._score
+    if (threshold > 0 && score !== null && score !== undefined && Number(score) < threshold) {
+      continue
+    }
+    blocks.push(block(row, accessor.config, table, mountPrefix))
+  }
+  if (blocks.length === 0) return new Uint8Array()
+  return ENC.encode(blocks.join('\n') + '\n')
+}

--- a/typescript/packages/core/src/core/qdrant/stat.ts
+++ b/typescript/packages/core/src/core/qdrant/stat.ts
@@ -1,0 +1,59 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../accessor/qdrant.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import { FileStat, FileType, PathSpec } from '../../types.ts'
+import { enoent } from '../../utils/errors.ts'
+import { rstripSlash } from '../../utils/slash.ts'
+import { read } from './read.ts'
+import { ScopeLevel, detectScope } from './scope.ts'
+
+const IMAGE_TYPES: Record<string, FileType> = {
+  png: FileType.IMAGE_PNG,
+  jpg: FileType.IMAGE_JPEG,
+  jpeg: FileType.IMAGE_JPEG,
+  gif: FileType.IMAGE_GIF,
+}
+
+function nameOf(spec: PathSpec): string {
+  const stripped = rstripSlash(spec.original)
+  const last = stripped.split('/').pop()
+  return last === undefined || last === '' ? '/' : last
+}
+
+export async function stat(
+  accessor: QdrantAccessor,
+  path: PathSpec | string,
+  index?: IndexCacheStore,
+): Promise<FileStat> {
+  const spec = typeof path === 'string' ? PathSpec.fromStrPath(path) : path
+  const config = accessor.config
+  const scope = detectScope(spec, config)
+
+  if (scope.level === ScopeLevel.UNKNOWN) throw enoent(spec.original)
+
+  if (scope.table !== null) {
+    if (!(await accessor.tableExists(scope.table))) throw enoent(spec.original)
+  }
+
+  if (scope.level === ScopeLevel.ROOT || scope.level === ScopeLevel.GROUP_DIR) {
+    return new FileStat({ name: nameOf(spec), type: FileType.DIRECTORY })
+  }
+
+  const data = await read(accessor, spec, index)
+  const fileType =
+    scope.kind === 'blob' ? (IMAGE_TYPES[config.blobExt] ?? FileType.BINARY) : FileType.TEXT
+  return new FileStat({ name: nameOf(spec), size: data.length, type: fileType })
+}

--- a/typescript/packages/core/src/core/qdrant/stream.ts
+++ b/typescript/packages/core/src/core/qdrant/stream.ts
@@ -1,0 +1,26 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../accessor/qdrant.ts'
+import type { IndexCacheStore } from '../../cache/index/store.ts'
+import type { PathSpec } from '../../types.ts'
+import { read } from './read.ts'
+
+export async function* stream(
+  accessor: QdrantAccessor,
+  path: PathSpec,
+  index?: IndexCacheStore,
+): AsyncIterable<Uint8Array> {
+  yield await read(accessor, path, index)
+}

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -1088,6 +1088,22 @@ export { readdir as chromaReaddir } from './core/chroma/readdir.ts'
 export { stat as chromaStat } from './core/chroma/stat.ts'
 export { resolveGlob as resolveChromaGlob } from './core/chroma/glob.ts'
 export { searchSegments as chromaSearch } from './core/chroma/search.ts'
+export type { QdrantPoint, QdrantRow } from './core/qdrant/_client.ts'
+export { QdrantAccessor } from './accessor/qdrant.ts'
+export {
+  resolveQdrantConfig,
+  type QdrantConfig,
+  type QdrantConfigResolved,
+} from './resource/qdrant/config.ts'
+export { QDRANT_PROMPT } from './resource/qdrant/prompt.ts'
+export { QDRANT_OPS } from './ops/qdrant/index.ts'
+export { QDRANT_COMMANDS } from './commands/builtin/qdrant/index.ts'
+export { QdrantResource, type QdrantResourceOptions } from './resource/qdrant/qdrant.ts'
+export { read as qdrantRead } from './core/qdrant/read.ts'
+export { readdir as qdrantReaddir } from './core/qdrant/readdir.ts'
+export { stat as qdrantStat } from './core/qdrant/stat.ts'
+export { resolveGlob as resolveQdrantGlob } from './core/qdrant/glob.ts'
+export { searchRowsOutput as qdrantSearch } from './core/qdrant/search.ts'
 export { scoreFromDistance } from './utils/score.ts'
 export {
   countDocuments as mongoCountDocuments,

--- a/typescript/packages/core/src/ops/qdrant/index.ts
+++ b/typescript/packages/core/src/ops/qdrant/index.ts
@@ -1,0 +1,22 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { RegisteredOp } from '../registry.ts'
+import { readOp } from './read.ts'
+import { readdirOp } from './readdir.ts'
+import { statOp } from './stat.ts'
+
+export const QDRANT_OPS: readonly RegisteredOp[] = [readOp, readdirOp, statOp]
+
+export { readOp, readdirOp, statOp }

--- a/typescript/packages/core/src/ops/qdrant/read.ts
+++ b/typescript/packages/core/src/ops/qdrant/read.ts
@@ -1,0 +1,28 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../accessor/qdrant.ts'
+import { read as coreRead } from '../../core/qdrant/read.ts'
+import { ResourceName } from '../../types.ts'
+import type { OpKwargs, RegisteredOp } from '../registry.ts'
+
+export const readOp: RegisteredOp = {
+  name: 'read',
+  resource: ResourceName.QDRANT,
+  filetype: null,
+  write: false,
+  fn: (accessor, path, _args, kwargs: OpKwargs) => {
+    return coreRead(accessor as QdrantAccessor, path, kwargs.index)
+  },
+}

--- a/typescript/packages/core/src/ops/qdrant/readdir.ts
+++ b/typescript/packages/core/src/ops/qdrant/readdir.ts
@@ -1,0 +1,28 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../accessor/qdrant.ts'
+import { readdir as coreReaddir } from '../../core/qdrant/readdir.ts'
+import { ResourceName } from '../../types.ts'
+import type { OpKwargs, RegisteredOp } from '../registry.ts'
+
+export const readdirOp: RegisteredOp = {
+  name: 'readdir',
+  resource: ResourceName.QDRANT,
+  filetype: null,
+  write: false,
+  fn: (accessor, path, _args, kwargs: OpKwargs) => {
+    return coreReaddir(accessor as QdrantAccessor, path, kwargs.index)
+  },
+}

--- a/typescript/packages/core/src/ops/qdrant/stat.ts
+++ b/typescript/packages/core/src/ops/qdrant/stat.ts
@@ -1,0 +1,28 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { QdrantAccessor } from '../../accessor/qdrant.ts'
+import { stat as coreStat } from '../../core/qdrant/stat.ts'
+import { ResourceName } from '../../types.ts'
+import type { OpKwargs, RegisteredOp } from '../registry.ts'
+
+export const statOp: RegisteredOp = {
+  name: 'stat',
+  resource: ResourceName.QDRANT,
+  filetype: null,
+  write: false,
+  fn: (accessor, path, _args, kwargs: OpKwargs) => {
+    return coreStat(accessor as QdrantAccessor, path, kwargs.index)
+  },
+}

--- a/typescript/packages/core/src/resource/qdrant/config.ts
+++ b/typescript/packages/core/src/resource/qdrant/config.ts
@@ -1,0 +1,69 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+export interface QdrantConfig {
+  url?: string
+  host?: string
+  port?: number
+  https?: boolean
+  apiKey?: string
+  collection?: string
+  groupBy?: string[]
+  idField?: string
+  textField?: string
+  blobField?: string
+  blobExt?: string
+  vectorField?: string
+  searchLimit?: number
+  maxRows?: number
+  embeddingModel?: string
+}
+
+export interface QdrantConfigResolved {
+  url: string | null
+  host: string
+  port: number
+  https: boolean
+  apiKey: string | null
+  collection: string | null
+  groupBy: string[]
+  idField: string
+  textField: string | null
+  blobField: string | null
+  blobExt: string
+  vectorField: string | null
+  searchLimit: number
+  maxRows: number
+  embeddingModel: string
+}
+
+export function resolveQdrantConfig(config: QdrantConfig): QdrantConfigResolved {
+  return {
+    url: config.url ?? null,
+    host: config.host ?? 'localhost',
+    port: config.port ?? 6333,
+    https: config.https ?? false,
+    apiKey: config.apiKey ?? null,
+    collection: config.collection ?? null,
+    groupBy: config.groupBy ?? [],
+    idField: config.idField ?? 'id',
+    textField: config.textField ?? null,
+    blobField: config.blobField ?? null,
+    blobExt: config.blobExt ?? 'bin',
+    vectorField: config.vectorField ?? null,
+    searchLimit: config.searchLimit ?? 10,
+    maxRows: config.maxRows ?? 1000,
+    embeddingModel: config.embeddingModel ?? 'sentence-transformers/all-MiniLM-L6-v2',
+  }
+}

--- a/typescript/packages/core/src/resource/qdrant/prompt.ts
+++ b/typescript/packages/core/src/resource/qdrant/prompt.ts
@@ -1,0 +1,27 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+export const QDRANT_PROMPT = `This mount is a Qdrant vector database exposed as a filesystem.
+
+At the root each directory is a collection (unless a single collection is pinned
+in config). Inside a collection, directories are the configured group-by payload
+fields; descending narrows a filter. Each matching point appears as files named
+by its id: <id>.json (the full payload), <id>.txt (the embedded source text)
+when a text field is configured, and <id>.<ext> (raw blob bytes) when a blob
+field is configured, where <id> is the Qdrant point id. The embedding vector is
+never shown. For semantic search use the search command, which returns ranked
+points as their content file paths with a similarity score, e.g.
+search "red running shoes" /mount then cat one of the returned files.
+Use ls/cd/cat/tree/find/wc as usual; grep/rg stay lexical. Quote queries that
+contain spaces.`

--- a/typescript/packages/core/src/resource/qdrant/qdrant.ts
+++ b/typescript/packages/core/src/resource/qdrant/qdrant.ts
@@ -1,0 +1,83 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { QdrantAccessor } from '../../accessor/qdrant.ts'
+import { QDRANT_COMMANDS } from '../../commands/builtin/qdrant/index.ts'
+import type { RegisteredCommand } from '../../commands/config.ts'
+import { resolveGlob } from '../../core/qdrant/glob.ts'
+import { read } from '../../core/qdrant/read.ts'
+import { readdir as qdrantReaddir } from '../../core/qdrant/readdir.ts'
+import { stat as qdrantStat } from '../../core/qdrant/stat.ts'
+import { QDRANT_OPS } from '../../ops/qdrant/index.ts'
+import type { RegisteredOp } from '../../ops/registry.ts'
+import { ResourceName, type FileStat, type PathSpec } from '../../types.ts'
+import { BaseResource, type Resource } from '../base.ts'
+import { resolveQdrantConfig, type QdrantConfig, type QdrantConfigResolved } from './config.ts'
+import { QDRANT_PROMPT } from './prompt.ts'
+
+export interface QdrantResourceOptions {
+  config: QdrantConfig
+}
+
+export class QdrantResource extends BaseResource implements Resource {
+  readonly kind: string = ResourceName.QDRANT
+  readonly isRemote: boolean = true
+  readonly supportsSnapshot: boolean = false
+  readonly prompt: string = QDRANT_PROMPT
+  readonly config: QdrantConfigResolved
+  readonly accessor: QdrantAccessor
+
+  constructor(options: QdrantResourceOptions | QdrantConfig) {
+    super()
+    const config = 'config' in options ? options.config : options
+    this.config = resolveQdrantConfig(config)
+    this.accessor = new QdrantAccessor(this.config)
+  }
+
+  open(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  ops(): readonly RegisteredOp[] {
+    return QDRANT_OPS
+  }
+
+  commands(): readonly RegisteredCommand[] {
+    return QDRANT_COMMANDS
+  }
+
+  glob(paths: readonly PathSpec[], _prefix = ''): Promise<PathSpec[]> {
+    return resolveGlob(this.accessor, paths, this.index)
+  }
+
+  readFile(p: PathSpec): Promise<Uint8Array> {
+    return read(this.accessor, p, this.index)
+  }
+
+  readdir(p: PathSpec): Promise<string[]> {
+    return qdrantReaddir(this.accessor, p, this.index)
+  }
+
+  stat(p: PathSpec): Promise<FileStat> {
+    return qdrantStat(this.accessor, p, this.index)
+  }
+
+  fingerprint(_path: PathSpec): Promise<string | null> {
+    return Promise.resolve(null)
+  }
+}

--- a/typescript/packages/core/src/types.test.ts
+++ b/typescript/packages/core/src/types.test.ts
@@ -86,8 +86,8 @@ describe('ResourceName', () => {
     expect(ResourceName.QINGSTOR).toBe('qingstor')
   })
 
-  it('contains exactly 47 entries', () => {
-    expect(Object.keys(ResourceName)).toHaveLength(47)
+  it('contains exactly 48 entries', () => {
+    expect(Object.keys(ResourceName)).toHaveLength(48)
   })
 
   it('is frozen at runtime', () => {

--- a/typescript/packages/core/src/types.ts
+++ b/typescript/packages/core/src/types.ts
@@ -139,6 +139,7 @@ export const ResourceName = Object.freeze({
   POSTGRES: 'postgres',
   LANCEDB: 'lancedb',
   CHROMA: 'chroma',
+  QDRANT: 'qdrant',
   HF_BUCKETS: 'hf_buckets',
   HF_DATASETS: 'hf_datasets',
   HF_MODELS: 'hf_models',

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@qdrant/js-client-rest':
+        specifier: ^1.18.0
+        version: 1.18.0(typescript@6.0.3)
       '@struktoai/mirage-browser':
         specifier: workspace:*
         version: link:../typescript/packages/browser
@@ -387,6 +390,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@qdrant/js-client-rest':
+        specifier: ^1.18.0
+        version: 1.18.0(typescript@6.0.3)
       chromadb:
         specifier: ^3.4.3
         version: 3.4.3
@@ -1986,6 +1992,16 @@ packages:
 
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@qdrant/js-client-rest@1.18.0':
+    resolution: {integrity: sha512-/0dqX5uV9chC1DnYSnU4gNMrDqse/pt6hHg3Rqqpl5isH7xl1xSNvffjzBoxycDD79luWn7Ho6Rh/61sOs5DNw==}
+    engines: {node: '>=18.17.0', pnpm: '>=8'}
+    peerDependencies:
+      typescript: '>=4.7'
+
+  '@qdrant/openapi-typescript-fetch@1.2.6':
+    resolution: {integrity: sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==}
+    engines: {node: '>=18.0.0', pnpm: '>=8'}
 
   '@redis/bloom@5.12.1':
     resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
@@ -5577,6 +5593,10 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+    engines: {node: '>=18.17'}
+
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
@@ -8009,6 +8029,14 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
+
+  '@qdrant/js-client-rest@1.18.0(typescript@6.0.3)':
+    dependencies:
+      '@qdrant/openapi-typescript-fetch': 1.2.6
+      typescript: 6.0.3
+      undici: 6.27.0
+
+  '@qdrant/openapi-typescript-fetch@1.2.6': {}
 
   '@redis/bloom@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))':
     dependencies:
@@ -11963,6 +11991,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
+
+  undici@6.27.0: {}
 
   undici@7.28.0: {}
 


### PR DESCRIPTION
## Description

This PR adds a Qdrant resource.

[Qdrant](https://qdrant.tech/) is an open-source vector search engine for high-performance and massive scale.

With this resource, we can mount a Qdrant collection as a filesystem and use standard shell commands to browse it. The `search` command runs vector search and returns results as file paths, so you can pipe them straight into `cat` or `grep` without any extra glue.

For creating vector embeddings, Python supports both [Qdrant Cloud Inference](https://qdrant.tech/documentation/inference/) (`cloud_inference=True`) and local [FastEmbed](https://github.com/qdrant/fastembed) (`cloud_inference=False`, default). TypeScript has no local embedding option. it always uses Qdrant Cloud Inference.

You can get a free forever Qdrant instance with inference at https://cloud.qdrant.io/.

I've tested the implementation end-to-end with a Qdrant cloud instance of mine. Unit tests have been added to the CI.