### PR TITLE
feat: add in-memory xattr support to the FUSE layer

### DIFF
--- a/python/mirage/fuse/fs.py
+++ b/python/mirage/fuse/fs.py
@@ -31,6 +31,8 @@ from mirage.types import FileType
 _ENV_AGENT_ID = "MIRAGE_AGENT_ID"
 _MIRAGE_DIR = "/.mirage"
 _MIRAGE_WHOAMI = "/.mirage/whoami"
+# "attribute not found" errno: ENOATTR on macOS, ENODATA on Linux.
+_NO_XATTR = getattr(errno, "ENOATTR", None) or errno.ENODATA
 
 
 class MirageFS(fuse.Operations):
@@ -58,6 +60,9 @@ class MirageFS(fuse.Operations):
         else:
             self._prefixes = [m.prefix for m in self._ops._mounts]
         self._handles: dict[int, dict] = {}
+        # In-memory extended attributes, keyed by FUSE path. Backends have no
+        # POSIX xattrs, so these are advisory, not persisted (see setxattr).
+        self._xattrs: dict[str, dict[str, bytes]] = {}
         self._next_fh = 1
         self._loop = asyncio.new_event_loop()
         self._loop_thread = threading.Thread(target=self._loop.run_forever,
@@ -248,6 +253,7 @@ class MirageFS(fuse.Operations):
             raise fuse.FuseOSError(errno.EACCES)
         except FileNotFoundError:
             raise fuse.FuseOSError(errno.ENOENT)
+        self._xattrs.pop(path, None)
 
     def rename(self, old: str, new: str, flags: int = 0) -> None:
         try:
@@ -256,6 +262,9 @@ class MirageFS(fuse.Operations):
             raise fuse.FuseOSError(errno.EACCES)
         except (FileNotFoundError, ValueError):
             raise fuse.FuseOSError(errno.ENOENT)
+        moved = self._xattrs.pop(old, None)
+        if moved is not None:
+            self._xattrs[new] = moved
 
     def rmdir(self, path: str) -> None:
         try:
@@ -266,6 +275,7 @@ class MirageFS(fuse.Operations):
             raise fuse.FuseOSError(errno.ENOTEMPTY)
         except (FileNotFoundError, ValueError):
             raise fuse.FuseOSError(errno.ENOENT)
+        self._xattrs.pop(path, None)
 
     def statfs(self, path: str) -> dict:
         return {
@@ -291,6 +301,38 @@ class MirageFS(fuse.Operations):
 
     def access(self, path: str, amode: int) -> None:
         self.getattr(path)
+
+    def setxattr(self,
+                 path: str,
+                 name: str,
+                 value: bytes,
+                 options: int,
+                 position: int = 0) -> int:
+        # Mirage backends (S3, etc.) have no POSIX extended attributes, so
+        # there is nothing to persist xattrs to. We keep them in memory per
+        # mount so tools that probe or set xattrs (sandbox runtimes, rsync
+        # -aX, tar --xattrs, cp -p, macOS Finder writing com.apple.*) succeed
+        # instead of failing with ENOTSUP. The values live only for the
+        # mount's lifetime and are intentionally not written to the backend.
+        self.getattr(path)
+        self._xattrs.setdefault(path, {})[name] = bytes(value)
+        return 0
+
+    def getxattr(self, path: str, name: str, position: int = 0) -> bytes:
+        self.getattr(path)
+        attrs = self._xattrs.get(path)
+        if attrs is None or name not in attrs:
+            raise fuse.FuseOSError(_NO_XATTR)
+        return attrs[name]
+
+    def listxattr(self, path: str) -> list[str]:
+        self.getattr(path)
+        return list(self._xattrs.get(path, {}).keys())
+
+    def removexattr(self, path: str, name: str) -> int:
+        self.getattr(path)
+        self._xattrs.get(path, {}).pop(name, None)
+        return 0
 
     def flush(self, path: str, fh) -> None:
         ctx = self._handles.get(fh)

--- a/python/tests/fuse/test_fs.py
+++ b/python/tests/fuse/test_fs.py
@@ -408,3 +408,54 @@ async def test_mount_background_readable():
                 subprocess.run(["fusermount", "-u", mountpoint],
                                capture_output=True)
             t.join(timeout=3)
+
+
+@pytest.mark.asyncio
+async def test_xattr_set_get_roundtrip(seed_ws):
+    fs = MirageFS(seed_ws)
+    fs.setxattr("/a.txt", "user.test", b"value", 0)
+    assert fs.getxattr("/a.txt", "user.test") == b"value"
+
+
+@pytest.mark.asyncio
+async def test_xattr_get_missing_raises(seed_ws):
+    fs = MirageFS(seed_ws)
+    with pytest.raises(OSError) as exc:
+        fs.getxattr("/a.txt", "user.absent")
+    assert exc.value.errno in (errno.ENODATA,
+                               getattr(errno, "ENOATTR", errno.ENODATA))
+
+
+@pytest.mark.asyncio
+async def test_xattr_list_and_remove(seed_ws):
+    fs = MirageFS(seed_ws)
+    fs.setxattr("/a.txt", "user.one", b"1", 0)
+    fs.setxattr("/a.txt", "user.two", b"2", 0)
+    assert sorted(fs.listxattr("/a.txt")) == ["user.one", "user.two"]
+    fs.removexattr("/a.txt", "user.one")
+    assert fs.listxattr("/a.txt") == ["user.two"]
+
+
+@pytest.mark.asyncio
+async def test_xattr_probe_succeeds(seed_ws):
+    fs = MirageFS(seed_ws)
+    assert fs.setxattr("/a.txt", "user.containers._probe", b"x", 0) == 0
+    assert fs.removexattr("/a.txt", "user.containers._probe") == 0
+
+
+@pytest.mark.asyncio
+async def test_xattr_cleared_on_unlink(seed_ws):
+    fs = MirageFS(seed_ws)
+    fs.setxattr("/a.txt", "user.keep", b"v", 0)
+    fs.unlink("/a.txt")
+    assert fs.listxattr("/sub") == []
+    assert "/a.txt" not in fs._xattrs
+
+
+@pytest.mark.asyncio
+async def test_xattr_follows_rename(seed_ws):
+    fs = MirageFS(seed_ws)
+    fs.setxattr("/a.txt", "user.keep", b"v", 0)
+    fs.rename("/a.txt", "/renamed.txt")
+    assert fs.getxattr("/renamed.txt", "user.keep") == b"v"
+    assert "/a.txt" not in fs._xattrs

--- a/typescript/packages/node/src/fuse/fs.test.ts
+++ b/typescript/packages/node/src/fuse/fs.test.ts
@@ -341,3 +341,81 @@ describe('MirageFS — release does not auto-flush', () => {
     expect(new TextDecoder().decode(after)).toBe('CLOBBER world\n')
   })
 })
+
+describe('MirageFS — xattr', () => {
+  it('round-trips set and get', async () => {
+    const ws = await mkWs()
+    const mfs = new MirageFS(ws)
+    await callOp(mfs, 'setxattr', '/data/greeting.txt', 'user.test', Buffer.from('value'), 0, 0)
+    const [code, value] = await callOp<[number, Buffer?]>(
+      mfs,
+      'getxattr',
+      '/data/greeting.txt',
+      'user.test',
+      0,
+    )
+    expect(code).toBe(0)
+    expect(value?.toString()).toBe('value')
+  })
+
+  it('returns no value for a missing attribute', async () => {
+    const ws = await mkWs()
+    const mfs = new MirageFS(ws)
+    const [code, value] = await callOp<[number, Buffer?]>(
+      mfs,
+      'getxattr',
+      '/data/greeting.txt',
+      'user.absent',
+      0,
+    )
+    expect(code).toBe(0)
+    expect(value).toBeUndefined()
+  })
+
+  it('lists and removes attributes', async () => {
+    const ws = await mkWs()
+    const mfs = new MirageFS(ws)
+    await callOp(mfs, 'setxattr', '/data/greeting.txt', 'user.one', Buffer.from('1'), 0, 0)
+    await callOp(mfs, 'setxattr', '/data/greeting.txt', 'user.two', Buffer.from('2'), 0, 0)
+    const [, list] = await callOp<[number, string[]]>(mfs, 'listxattr', '/data/greeting.txt')
+    expect([...list].sort()).toEqual(['user.one', 'user.two'])
+    await callOp(mfs, 'removexattr', '/data/greeting.txt', 'user.one')
+    const [, after] = await callOp<[number, string[]]>(mfs, 'listxattr', '/data/greeting.txt')
+    expect(after).toEqual(['user.two'])
+  })
+
+  it('accepts the container probe attribute', async () => {
+    const ws = await mkWs()
+    const mfs = new MirageFS(ws)
+    const [setCode] = await callOp<[number]>(
+      mfs,
+      'setxattr',
+      '/data/greeting.txt',
+      'user.containers._probe',
+      Buffer.from('x'),
+      0,
+      0,
+    )
+    expect(setCode).toBe(0)
+  })
+
+  it('follows a rename and clears on unlink', async () => {
+    const ws = await mkWs()
+    const mfs = new MirageFS(ws)
+    await callOp(mfs, 'setxattr', '/data/greeting.txt', 'user.keep', Buffer.from('v'), 0, 0)
+    await callOp(mfs, 'rename', '/data/greeting.txt', '/data/renamed.txt')
+    const [, moved] = await callOp<[number, Buffer?]>(
+      mfs,
+      'getxattr',
+      '/data/renamed.txt',
+      'user.keep',
+      0,
+    )
+    expect(moved?.toString()).toBe('v')
+    await callOp(mfs, 'unlink', '/data/renamed.txt')
+    // A new file at the same path must not inherit the deleted file's xattrs.
+    await ws.execute("echo 'new' > /data/renamed.txt")
+    const [, list] = await callOp<[number, string[]]>(mfs, 'listxattr', '/data/renamed.txt')
+    expect(list).toEqual([])
+  })
+})

--- a/typescript/packages/node/src/fuse/fs.ts
+++ b/typescript/packages/node/src/fuse/fs.ts
@@ -110,6 +110,9 @@ export class MirageFS {
   private readonly root: string
   private readonly prefixes: string[]
   private readonly handles = new Map<number, Handle>()
+  // In-memory extended attributes, keyed by FUSE path. Backends have no POSIX
+  // xattrs, so these are advisory and never persisted; see setxattr.
+  private readonly xattrs = new Map<string, Map<string, Buffer>>()
   private readonly prefetchCache = new Map<string, PrefetchEntry>()
   private readonly prefetchInflight = new Map<string, Promise<Uint8Array | null>>()
   private nextFh = 1
@@ -277,6 +280,10 @@ export class MirageFS {
       chmod: this.chmod.bind(this),
       chown: this.chown.bind(this),
       access: this.access.bind(this),
+      setxattr: this.setxattr.bind(this),
+      getxattr: this.getxattr.bind(this),
+      listxattr: this.listxattr.bind(this),
+      removexattr: this.removexattr.bind(this),
       statfs: this.statfs.bind(this),
     }
   }
@@ -479,6 +486,7 @@ export class MirageFS {
     void (async () => {
       try {
         await this.ws.fs.unlink(this.resolve(path))
+        this.xattrs.delete(path)
         cb(0)
       } catch (err) {
         cb(classifyError(err))
@@ -490,6 +498,11 @@ export class MirageFS {
     void (async () => {
       try {
         await this.ws.fs.rename(this.resolve(src), this.resolve(dst))
+        const moved = this.xattrs.get(src)
+        if (moved !== undefined) {
+          this.xattrs.delete(src)
+          this.xattrs.set(dst, moved)
+        }
         cb(0)
       } catch (err) {
         cb(classifyError(err))
@@ -514,6 +527,7 @@ export class MirageFS {
           // error (e.g. ENOENT for missing path).
         }
         await this.ws.fs.rmdir(this.resolve(path))
+        this.xattrs.delete(path)
         cb(0)
       } catch (err) {
         cb(classifyError(err))
@@ -580,6 +594,73 @@ export class MirageFS {
 
   private access(path: string, _amode: number, cb: (code: number) => void): void {
     this.getattrValidate(path, cb)
+  }
+
+  // Mirage backends (S3, etc.) have no POSIX extended attributes, so there is
+  // nothing to persist xattrs to. We keep them in memory per mount so tools that
+  // probe or set xattrs (sandbox runtimes, rsync -aX, tar --xattrs, cp -p, macOS
+  // Finder writing com.apple.*) succeed instead of failing with ENOTSUP. The
+  // values live only for the mount's lifetime and are never written to the
+  // backend.
+  private setxattr(
+    path: string,
+    name: string,
+    value: Buffer,
+    _position: number,
+    _flags: number,
+    cb: (code: number) => void,
+  ): void {
+    this.getattr(path, (code) => {
+      if (code !== 0) {
+        cb(code)
+        return
+      }
+      let attrs = this.xattrs.get(path)
+      if (attrs === undefined) {
+        attrs = new Map()
+        this.xattrs.set(path, attrs)
+      }
+      attrs.set(name, Buffer.from(value))
+      cb(0)
+    })
+  }
+
+  private getxattr(
+    path: string,
+    name: string,
+    _position: number,
+    cb: (code: number, value?: Buffer) => void,
+  ): void {
+    this.getattr(path, (code) => {
+      if (code !== 0) {
+        cb(code)
+        return
+      }
+      // A missing value tells fuse-native to report ENOATTR/ENODATA.
+      cb(0, this.xattrs.get(path)?.get(name))
+    })
+  }
+
+  private listxattr(path: string, cb: (code: number, list?: string[]) => void): void {
+    this.getattr(path, (code) => {
+      if (code !== 0) {
+        cb(code)
+        return
+      }
+      const attrs = this.xattrs.get(path)
+      cb(0, attrs ? [...attrs.keys()] : [])
+    })
+  }
+
+  private removexattr(path: string, name: string, cb: (code: number) => void): void {
+    this.getattr(path, (code) => {
+      if (code !== 0) {
+        cb(code)
+        return
+      }
+      this.xattrs.get(path)?.delete(name)
+      cb(0)
+    })
   }
 
   private getattrValidate(path: string, cb: (code: number) => void): void {


### PR DESCRIPTION
Adds extended-attribute support (`setxattr`/`getxattr`/`listxattr`/`removexattr`) to the FUSE mount layer (`MirageFS`), Python and TypeScript.

## Why

Mirage backends (S3, etc.) have no POSIX extended attributes, so the FUSE mount currently reports xattrs as unsupported and any xattr operation fails with `ENOTSUP`/`EPERM`. That makes a Mirage FUSE mount misbehave with common tools that probe or set xattrs:

- sandbox/container runtimes that probe xattr support before bind-mounting
- `rsync -aX`, `tar --xattrs`, `cp -p`
- macOS Finder writing `com.apple.*` attributes

## What

- A small in-memory xattr store keyed by FUSE path. Values round-trip for the lifetime of the mount and are advisory only: backends have nothing to persist them to, so they are intentionally not written back.
- `getxattr` reports "attribute not found" with the platform errno (`ENOATTR` on macOS, `ENODATA` on Linux).
- Stale entries are cleared on `unlink`/`rmdir` and moved on `rename`, so a new file at a reused path never inherits a deleted file's attributes.
- Mirrored in Python (`MirageFS`) and TypeScript (`MirageFS` + `fuse-native` op wiring), with unit tests on both sides.

Scope note: this is a general FUSE-robustness improvement. It does not, on its own, make the microsandbox example work on macOS (that is blocked separately by libkrun's macOS virtio-fs requiring native stat-virtualization features macFUSE lacks).