### PR TITLE
Fix compact Python JSON rendering

### DIFF
--- a/python/mirage/commands/builtin/discord/discord_add_reaction.py
+++ b/python/mirage/commands/builtin/discord/discord_add_reaction.py
@@ -45,6 +45,7 @@ async def discord_add_reaction(
     if not reaction or not isinstance(reaction, str):
         raise ValueError("--reaction is required")
     await add_reaction(accessor.config, channel_id, message_id, reaction)
-    out = json.dumps({"ok": True}, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+    out = json.dumps({
+        "ok": True
+    }, ensure_ascii=False, separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/discord/discord_add_reaction.py
+++ b/python/mirage/commands/builtin/discord/discord_add_reaction.py
@@ -45,5 +45,6 @@ async def discord_add_reaction(
     if not reaction or not isinstance(reaction, str):
         raise ValueError("--reaction is required")
     await add_reaction(accessor.config, channel_id, message_id, reaction)
-    out = json.dumps({"ok": True}, ensure_ascii=False).encode()
+    out = json.dumps({"ok": True}, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/discord/discord_get_server_info.py
+++ b/python/mirage/commands/builtin/discord/discord_get_server_info.py
@@ -37,5 +37,5 @@ async def discord_get_server_info(
         raise ValueError("--guild_id is required")
     result = await discord_get(accessor.config, f"/guilds/{guild_id}")
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/discord/discord_get_server_info.py
+++ b/python/mirage/commands/builtin/discord/discord_get_server_info.py
@@ -36,5 +36,6 @@ async def discord_get_server_info(
     if not guild_id or not isinstance(guild_id, str):
         raise ValueError("--guild_id is required")
     result = await discord_get(accessor.config, f"/guilds/{guild_id}")
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/discord/discord_list_members.py
+++ b/python/mirage/commands/builtin/discord/discord_list_members.py
@@ -42,5 +42,5 @@ async def discord_list_members(
         raise ValueError("--query is required")
     members = await search_members(accessor.config, guild_id, query)
     out = json.dumps(members, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/discord/discord_list_members.py
+++ b/python/mirage/commands/builtin/discord/discord_list_members.py
@@ -41,5 +41,6 @@ async def discord_list_members(
     if not query or not isinstance(query, str):
         raise ValueError("--query is required")
     members = await search_members(accessor.config, guild_id, query)
-    out = json.dumps(members, ensure_ascii=False).encode()
+    out = json.dumps(members, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/discord/discord_send_message.py
+++ b/python/mirage/commands/builtin/discord/discord_send_message.py
@@ -45,5 +45,5 @@ async def discord_send_message(
     ref = message_id if message_id and isinstance(message_id, str) else None
     result = await send_message(accessor.config, channel_id, text, ref)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/discord/discord_send_message.py
+++ b/python/mirage/commands/builtin/discord/discord_send_message.py
@@ -44,5 +44,6 @@ async def discord_send_message(
         raise ValueError("--text is required")
     ref = message_id if message_id and isinstance(message_id, str) else None
     result = await send_message(accessor.config, channel_id, text, ref)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/email/email_forward.py
+++ b/python/mirage/commands/builtin/email/email_forward.py
@@ -49,5 +49,5 @@ async def email_forward(
     original = await fetch_message(accessor, folder, uid)
     result = await forward_message(accessor.config, original, to)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/email/email_forward.py
+++ b/python/mirage/commands/builtin/email/email_forward.py
@@ -48,5 +48,6 @@ async def email_forward(
         raise ValueError("--to is required")
     original = await fetch_message(accessor, folder, uid)
     result = await forward_message(accessor.config, original, to)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/email/email_read.py
+++ b/python/mirage/commands/builtin/email/email_read.py
@@ -42,5 +42,6 @@ async def email_read(
     if not folder or not isinstance(folder, str):
         raise ValueError("--folder is required")
     processed = await fetch_message(accessor, folder, uid)
-    out = json.dumps(processed, ensure_ascii=False).encode()
+    out = json.dumps(processed, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/email/email_read.py
+++ b/python/mirage/commands/builtin/email/email_read.py
@@ -43,5 +43,5 @@ async def email_read(
         raise ValueError("--folder is required")
     processed = await fetch_message(accessor, folder, uid)
     out = json.dumps(processed, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/email/email_reply.py
+++ b/python/mirage/commands/builtin/email/email_reply.py
@@ -49,5 +49,5 @@ async def email_reply(
     original = await fetch_message(accessor, folder, uid)
     result = await reply_message(accessor.config, original, body)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/email/email_reply.py
+++ b/python/mirage/commands/builtin/email/email_reply.py
@@ -48,5 +48,6 @@ async def email_reply(
         raise ValueError("--body is required")
     original = await fetch_message(accessor, folder, uid)
     result = await reply_message(accessor.config, original, body)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/email/email_reply_all.py
+++ b/python/mirage/commands/builtin/email/email_reply_all.py
@@ -49,5 +49,5 @@ async def email_reply_all(
     original = await fetch_message(accessor, folder, uid)
     result = await reply_all_message(accessor.config, original, body)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/email/email_reply_all.py
+++ b/python/mirage/commands/builtin/email/email_reply_all.py
@@ -48,5 +48,6 @@ async def email_reply_all(
         raise ValueError("--body is required")
     original = await fetch_message(accessor, folder, uid)
     result = await reply_all_message(accessor.config, original, body)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/email/email_send.py
+++ b/python/mirage/commands/builtin/email/email_send.py
@@ -46,5 +46,6 @@ async def email_send(
     if not body or not isinstance(body, str):
         raise ValueError("--body is required")
     result = await send_message(accessor.config, to, subject, body)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/email/email_send.py
+++ b/python/mirage/commands/builtin/email/email_send.py
@@ -47,5 +47,5 @@ async def email_send(
         raise ValueError("--body is required")
     result = await send_message(accessor.config, to, subject, body)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/email/email_triage.py
+++ b/python/mirage/commands/builtin/email/email_triage.py
@@ -60,8 +60,10 @@ async def email_triage(
         max_results=max_results,
     )
     if not uids:
-        out = json.dumps([], ensure_ascii=False).encode()
+        out = json.dumps([], ensure_ascii=False,
+                 separators=(",", ":")).encode()
         return yield_bytes(out), IOResult()
     headers = await fetch_headers(accessor, folder, uids)
-    out = json.dumps(headers, ensure_ascii=False).encode()
+    out = json.dumps(headers, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/email/email_triage.py
+++ b/python/mirage/commands/builtin/email/email_triage.py
@@ -61,9 +61,9 @@ async def email_triage(
     )
     if not uids:
         out = json.dumps([], ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                         separators=(",", ":")).encode()
         return yield_bytes(out), IOResult()
     headers = await fetch_headers(accessor, folder, uids)
     out = json.dumps(headers, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/email/rg.py
+++ b/python/mirage/commands/builtin/email/rg.py
@@ -78,7 +78,8 @@ async def rg(
         file_prefix = paths[0].prefix if paths else ""
         for uid in uids:
             msg = await fetch_message(accessor, folder, uid)
-            msg_text = json.dumps(msg, ensure_ascii=False)
+            msg_text = json.dumps(msg, ensure_ascii=False,
+                      separators=(",", ":"))
             vfs_path = _build_vfs_path(file_prefix, folder, msg)
             lines = msg_text.splitlines()
             matched = grep_lines(vfs_path,

--- a/python/mirage/commands/builtin/email/rg.py
+++ b/python/mirage/commands/builtin/email/rg.py
@@ -78,8 +78,9 @@ async def rg(
         file_prefix = paths[0].prefix if paths else ""
         for uid in uids:
             msg = await fetch_message(accessor, folder, uid)
-            msg_text = json.dumps(msg, ensure_ascii=False,
-                      separators=(",", ":"))
+            msg_text = json.dumps(msg,
+                                  ensure_ascii=False,
+                                  separators=(",", ":"))
             vfs_path = _build_vfs_path(file_prefix, folder, msg)
             lines = msg_text.splitlines()
             matched = grep_lines(vfs_path,

--- a/python/mirage/commands/builtin/gdocs/gws_docs_documents_batchUpdate.py
+++ b/python/mirage/commands/builtin/gdocs/gws_docs_documents_batchUpdate.py
@@ -48,5 +48,6 @@ async def gws_docs_documents_batchUpdate(
     if not doc_id:
         raise ValueError("--params must contain documentId")
     result = await batch_update(accessor.token_manager, doc_id, json_str)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gdocs/gws_docs_documents_batchUpdate.py
+++ b/python/mirage/commands/builtin/gdocs/gws_docs_documents_batchUpdate.py
@@ -49,5 +49,5 @@ async def gws_docs_documents_batchUpdate(
         raise ValueError("--params must contain documentId")
     result = await batch_update(accessor.token_manager, doc_id, json_str)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gdocs/gws_docs_documents_create.py
+++ b/python/mirage/commands/builtin/gdocs/gws_docs_documents_create.py
@@ -46,5 +46,5 @@ async def gws_docs_documents_create(
         raise ValueError("JSON must contain 'title'")
     result = await create_doc(accessor.token_manager, title)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gdocs/gws_docs_documents_create.py
+++ b/python/mirage/commands/builtin/gdocs/gws_docs_documents_create.py
@@ -45,5 +45,6 @@ async def gws_docs_documents_create(
     if not title:
         raise ValueError("JSON must contain 'title'")
     result = await create_doc(accessor.token_manager, title)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gdocs/gws_docs_write.py
+++ b/python/mirage/commands/builtin/gdocs/gws_docs_write.py
@@ -43,5 +43,5 @@ async def gws_docs_write(
         raise ValueError("--text is required")
     result = await append_text(accessor.token_manager, doc_id, text)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gdocs/gws_docs_write.py
+++ b/python/mirage/commands/builtin/gdocs/gws_docs_write.py
@@ -42,5 +42,6 @@ async def gws_docs_write(
     if not text or not isinstance(text, str):
         raise ValueError("--text is required")
     result = await append_text(accessor.token_manager, doc_id, text)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gmail/gws_gmail_forward.py
+++ b/python/mirage/commands/builtin/gmail/gws_gmail_forward.py
@@ -50,5 +50,5 @@ async def gws_gmail_forward(
         raise ValueError("--to is required")
     result = await forward_message(accessor.token_manager, message_id, to)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gmail/gws_gmail_forward.py
+++ b/python/mirage/commands/builtin/gmail/gws_gmail_forward.py
@@ -49,5 +49,6 @@ async def gws_gmail_forward(
     if not to or not isinstance(to, str):
         raise ValueError("--to is required")
     result = await forward_message(accessor.token_manager, message_id, to)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gmail/gws_gmail_read.py
+++ b/python/mirage/commands/builtin/gmail/gws_gmail_read.py
@@ -42,5 +42,6 @@ async def gws_gmail_read(
     if not message_id or not isinstance(message_id, str):
         raise ValueError("--id is required")
     processed = await get_message_processed(accessor.token_manager, message_id)
-    out = json.dumps(processed, ensure_ascii=False).encode()
+    out = json.dumps(processed, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gmail/gws_gmail_read.py
+++ b/python/mirage/commands/builtin/gmail/gws_gmail_read.py
@@ -43,5 +43,5 @@ async def gws_gmail_read(
         raise ValueError("--id is required")
     processed = await get_message_processed(accessor.token_manager, message_id)
     out = json.dumps(processed, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gmail/gws_gmail_reply.py
+++ b/python/mirage/commands/builtin/gmail/gws_gmail_reply.py
@@ -50,5 +50,5 @@ async def gws_gmail_reply(
         raise ValueError("--body is required")
     result = await reply_message(accessor.token_manager, message_id, body)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gmail/gws_gmail_reply.py
+++ b/python/mirage/commands/builtin/gmail/gws_gmail_reply.py
@@ -49,5 +49,6 @@ async def gws_gmail_reply(
     if not body or not isinstance(body, str):
         raise ValueError("--body is required")
     result = await reply_message(accessor.token_manager, message_id, body)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gmail/gws_gmail_reply_all.py
+++ b/python/mirage/commands/builtin/gmail/gws_gmail_reply_all.py
@@ -50,5 +50,5 @@ async def gws_gmail_reply_all(
         raise ValueError("--body is required")
     result = await reply_all_message(accessor.token_manager, message_id, body)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gmail/gws_gmail_reply_all.py
+++ b/python/mirage/commands/builtin/gmail/gws_gmail_reply_all.py
@@ -49,5 +49,6 @@ async def gws_gmail_reply_all(
     if not body or not isinstance(body, str):
         raise ValueError("--body is required")
     result = await reply_all_message(accessor.token_manager, message_id, body)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gmail/gws_gmail_send.py
+++ b/python/mirage/commands/builtin/gmail/gws_gmail_send.py
@@ -55,5 +55,6 @@ async def gws_gmail_send(
     if not body or not isinstance(body, str):
         raise ValueError("--body is required")
     result = await send_message(accessor.token_manager, to, subject, body)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gmail/gws_gmail_send.py
+++ b/python/mirage/commands/builtin/gmail/gws_gmail_send.py
@@ -56,5 +56,5 @@ async def gws_gmail_send(
         raise ValueError("--body is required")
     result = await send_message(accessor.token_manager, to, subject, body)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gmail/gws_gmail_triage.py
+++ b/python/mirage/commands/builtin/gmail/gws_gmail_triage.py
@@ -63,5 +63,6 @@ async def gws_gmail_triage(
             "date": _extract_header(headers, "Date"),
             "snippet": raw.get("snippet", ""),
         })
-    out = json.dumps(summaries, ensure_ascii=False).encode()
+    out = json.dumps(summaries, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gmail/gws_gmail_triage.py
+++ b/python/mirage/commands/builtin/gmail/gws_gmail_triage.py
@@ -64,5 +64,5 @@ async def gws_gmail_triage(
             "snippet": raw.get("snippet", ""),
         })
     out = json.dumps(summaries, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gsheets/gws_sheets_append.py
+++ b/python/mirage/commands/builtin/gsheets/gws_sheets_append.py
@@ -58,5 +58,5 @@ async def gws_sheets_append(
     result = await append_values(accessor.token_manager, sheet_id, range_,
                                  values_json)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gsheets/gws_sheets_append.py
+++ b/python/mirage/commands/builtin/gsheets/gws_sheets_append.py
@@ -57,5 +57,6 @@ async def gws_sheets_append(
         range_ = "A1"
     result = await append_values(accessor.token_manager, sheet_id, range_,
                                  values_json)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gsheets/gws_sheets_spreadsheets_batchUpdate.py
+++ b/python/mirage/commands/builtin/gsheets/gws_sheets_spreadsheets_batchUpdate.py
@@ -49,5 +49,5 @@ async def gws_sheets_spreadsheets_batchUpdate(
         raise ValueError("--params must contain spreadsheetId")
     result = await batch_update(accessor.token_manager, sheet_id, json_str)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gsheets/gws_sheets_spreadsheets_batchUpdate.py
+++ b/python/mirage/commands/builtin/gsheets/gws_sheets_spreadsheets_batchUpdate.py
@@ -48,5 +48,6 @@ async def gws_sheets_spreadsheets_batchUpdate(
     if not sheet_id:
         raise ValueError("--params must contain spreadsheetId")
     result = await batch_update(accessor.token_manager, sheet_id, json_str)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gsheets/gws_sheets_spreadsheets_create.py
+++ b/python/mirage/commands/builtin/gsheets/gws_sheets_spreadsheets_create.py
@@ -46,5 +46,5 @@ async def gws_sheets_spreadsheets_create(
         raise ValueError("JSON must contain properties.title")
     result = await create_spreadsheet(accessor.token_manager, title)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gsheets/gws_sheets_spreadsheets_create.py
+++ b/python/mirage/commands/builtin/gsheets/gws_sheets_spreadsheets_create.py
@@ -45,5 +45,6 @@ async def gws_sheets_spreadsheets_create(
     if not title:
         raise ValueError("JSON must contain properties.title")
     result = await create_spreadsheet(accessor.token_manager, title)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gsheets/gws_sheets_write.py
+++ b/python/mirage/commands/builtin/gsheets/gws_sheets_write.py
@@ -62,5 +62,6 @@ async def gws_sheets_write(
         async with session.put(url, headers=headers, json=body) as resp:
             resp.raise_for_status()
             result = await resp.json()
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gsheets/gws_sheets_write.py
+++ b/python/mirage/commands/builtin/gsheets/gws_sheets_write.py
@@ -63,5 +63,5 @@ async def gws_sheets_write(
             resp.raise_for_status()
             result = await resp.json()
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gslides/gws_slides_presentations_batchUpdate.py
+++ b/python/mirage/commands/builtin/gslides/gws_slides_presentations_batchUpdate.py
@@ -48,5 +48,6 @@ async def gws_slides_presentations_batchUpdate(
     if not pres_id:
         raise ValueError("--params must contain presentationId")
     result = await batch_update(accessor.token_manager, pres_id, json_str)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gslides/gws_slides_presentations_batchUpdate.py
+++ b/python/mirage/commands/builtin/gslides/gws_slides_presentations_batchUpdate.py
@@ -49,5 +49,5 @@ async def gws_slides_presentations_batchUpdate(
         raise ValueError("--params must contain presentationId")
     result = await batch_update(accessor.token_manager, pres_id, json_str)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gslides/gws_slides_presentations_create.py
+++ b/python/mirage/commands/builtin/gslides/gws_slides_presentations_create.py
@@ -46,5 +46,5 @@ async def gws_slides_presentations_create(
         raise ValueError("JSON must contain 'title'")
     result = await create_presentation(accessor.token_manager, title)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/gslides/gws_slides_presentations_create.py
+++ b/python/mirage/commands/builtin/gslides/gws_slides_presentations_create.py
@@ -45,5 +45,6 @@ async def gws_slides_presentations_create(
     if not title:
         raise ValueError("JSON must contain 'title'")
     result = await create_presentation(accessor.token_manager, title)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/commands/builtin/langfuse/grep.py
+++ b/python/mirage/commands/builtin/langfuse/grep.py
@@ -44,7 +44,8 @@ def _filter_traces(
     lines: list[str] = []
     for t in traces:
         trace_id = t.get("id", "")
-        line_json = json.dumps(t, ensure_ascii=False)
+        line_json = json.dumps(t, ensure_ascii=False,
+                      separators=(",", ":"))
         if not pattern.search(line_json):
             continue
         line = f"traces/{trace_id}.json:{line_json}"
@@ -63,7 +64,8 @@ def _format_session_results(
         session_id = s.get("id", "")
         if not pattern.search(session_id):
             continue
-        line_json = json.dumps(s, ensure_ascii=False)
+        line_json = json.dumps(s, ensure_ascii=False,
+                      separators=(",", ":"))
         line = f"sessions/{session_id}:{line_json}"
         lines.append(line)
     if not lines:
@@ -84,7 +86,8 @@ def _format_prompt_results(
         if not pattern.search(prompt_name):
             continue
         seen.add(prompt_name)
-        line_json = json.dumps(p, ensure_ascii=False)
+        line_json = json.dumps(p, ensure_ascii=False,
+                      separators=(",", ":"))
         line = f"prompts/{prompt_name}:{line_json}"
         lines.append(line)
     if not lines:
@@ -101,7 +104,8 @@ def _format_dataset_results(
         dataset_name = d.get("name", "")
         if not pattern.search(dataset_name):
             continue
-        line_json = json.dumps(d, ensure_ascii=False)
+        line_json = json.dumps(d, ensure_ascii=False,
+                      separators=(",", ":"))
         line = f"datasets/{dataset_name}:{line_json}"
         lines.append(line)
     if not lines:

--- a/python/mirage/commands/builtin/langfuse/grep.py
+++ b/python/mirage/commands/builtin/langfuse/grep.py
@@ -44,8 +44,7 @@ def _filter_traces(
     lines: list[str] = []
     for t in traces:
         trace_id = t.get("id", "")
-        line_json = json.dumps(t, ensure_ascii=False,
-                      separators=(",", ":"))
+        line_json = json.dumps(t, ensure_ascii=False, separators=(",", ":"))
         if not pattern.search(line_json):
             continue
         line = f"traces/{trace_id}.json:{line_json}"
@@ -64,8 +63,7 @@ def _format_session_results(
         session_id = s.get("id", "")
         if not pattern.search(session_id):
             continue
-        line_json = json.dumps(s, ensure_ascii=False,
-                      separators=(",", ":"))
+        line_json = json.dumps(s, ensure_ascii=False, separators=(",", ":"))
         line = f"sessions/{session_id}:{line_json}"
         lines.append(line)
     if not lines:
@@ -86,8 +84,7 @@ def _format_prompt_results(
         if not pattern.search(prompt_name):
             continue
         seen.add(prompt_name)
-        line_json = json.dumps(p, ensure_ascii=False,
-                      separators=(",", ":"))
+        line_json = json.dumps(p, ensure_ascii=False, separators=(",", ":"))
         line = f"prompts/{prompt_name}:{line_json}"
         lines.append(line)
     if not lines:
@@ -104,8 +101,7 @@ def _format_dataset_results(
         dataset_name = d.get("name", "")
         if not pattern.search(dataset_name):
             continue
-        line_json = json.dumps(d, ensure_ascii=False,
-                      separators=(",", ":"))
+        line_json = json.dumps(d, ensure_ascii=False, separators=(",", ":"))
         line = f"datasets/{dataset_name}:{line_json}"
         lines.append(line)
     if not lines:

--- a/python/mirage/commands/builtin/linear/linear_issue_add_label.py
+++ b/python/mirage/commands/builtin/linear/linear_issue_add_label.py
@@ -61,4 +61,5 @@ async def linear_issue_add_label(
                                  label_ids=existing)
     return yield_bytes(
         json.dumps(normalize_issue(updated),
-                   ensure_ascii=False).encode()), IOResult()
+                   ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/linear/linear_issue_assign.py
+++ b/python/mirage/commands/builtin/linear/linear_issue_assign.py
@@ -61,4 +61,5 @@ async def linear_issue_assign(
                                assignee_id=assignee_id)
     return yield_bytes(
         json.dumps(normalize_issue(issue),
-                   ensure_ascii=False).encode()), IOResult()
+                   ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/linear/linear_issue_comment_add.py
+++ b/python/mirage/commands/builtin/linear/linear_issue_comment_add.py
@@ -61,4 +61,5 @@ async def linear_issue_comment_add(
     comment = await comment_create(config, issue_id=issue_id, body=body)
     payload = normalize_comment(comment, issue_id=issue_id, issue_key=None)
     return yield_bytes(json.dumps(payload,
-                                  ensure_ascii=False).encode()), IOResult()
+                                  ensure_ascii=False,
+                                  separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/linear/linear_issue_comment_add.py
+++ b/python/mirage/commands/builtin/linear/linear_issue_comment_add.py
@@ -60,6 +60,6 @@ async def linear_issue_comment_add(
     )
     comment = await comment_create(config, issue_id=issue_id, body=body)
     payload = normalize_comment(comment, issue_id=issue_id, issue_key=None)
-    return yield_bytes(json.dumps(payload,
-                                  ensure_ascii=False,
-                                  separators=(",", ":")).encode()), IOResult()
+    return yield_bytes(
+        json.dumps(payload, ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/linear/linear_issue_comment_update.py
+++ b/python/mirage/commands/builtin/linear/linear_issue_comment_update.py
@@ -65,4 +65,5 @@ async def linear_issue_comment_update(
     else:
         payload = comment
     return yield_bytes(json.dumps(payload,
-                                  ensure_ascii=False).encode()), IOResult()
+                                  ensure_ascii=False,
+                                  separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/linear/linear_issue_comment_update.py
+++ b/python/mirage/commands/builtin/linear/linear_issue_comment_update.py
@@ -64,6 +64,6 @@ async def linear_issue_comment_update(
                                     issue_key=issue.get("identifier"))
     else:
         payload = comment
-    return yield_bytes(json.dumps(payload,
-                                  ensure_ascii=False,
-                                  separators=(",", ":")).encode()), IOResult()
+    return yield_bytes(
+        json.dumps(payload, ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/linear/linear_issue_create.py
+++ b/python/mirage/commands/builtin/linear/linear_issue_create.py
@@ -68,4 +68,5 @@ async def linear_issue_create(
     )
     return yield_bytes(
         json.dumps(normalize_issue(issue),
-                   ensure_ascii=False).encode()), IOResult()
+                   ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/linear/linear_issue_set_priority.py
+++ b/python/mirage/commands/builtin/linear/linear_issue_set_priority.py
@@ -56,4 +56,5 @@ async def linear_issue_set_priority(
                                priority=int(priority))
     return yield_bytes(
         json.dumps(normalize_issue(issue),
-                   ensure_ascii=False).encode()), IOResult()
+                   ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/linear/linear_issue_set_project.py
+++ b/python/mirage/commands/builtin/linear/linear_issue_set_project.py
@@ -55,4 +55,5 @@ async def linear_issue_set_project(
                                project_id=project_id)
     return yield_bytes(
         json.dumps(normalize_issue(issue),
-                   ensure_ascii=False).encode()), IOResult()
+                   ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/linear/linear_issue_transition.py
+++ b/python/mirage/commands/builtin/linear/linear_issue_transition.py
@@ -80,4 +80,5 @@ async def linear_issue_transition(
                                state_id=state_id)
     return yield_bytes(
         json.dumps(normalize_issue(issue),
-                   ensure_ascii=False).encode()), IOResult()
+                   ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/linear/linear_issue_update.py
+++ b/python/mirage/commands/builtin/linear/linear_issue_update.py
@@ -71,4 +71,5 @@ async def linear_issue_update(
                                description=description)
     return yield_bytes(
         json.dumps(normalize_issue(issue),
-                   ensure_ascii=False).encode()), IOResult()
+                   ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/slack/slack_add_reaction.py
+++ b/python/mirage/commands/builtin/slack/slack_add_reaction.py
@@ -45,5 +45,6 @@ async def slack_react(
     if not reaction or not isinstance(reaction, str):
         raise ValueError("--reaction is required")
     result = await add_reaction(accessor.config, channel_id, ts, reaction)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/slack/slack_add_reaction.py
+++ b/python/mirage/commands/builtin/slack/slack_add_reaction.py
@@ -46,5 +46,5 @@ async def slack_react(
         raise ValueError("--reaction is required")
     result = await add_reaction(accessor.config, channel_id, ts, reaction)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/slack/slack_get_user_profile.py
+++ b/python/mirage/commands/builtin/slack/slack_get_user_profile.py
@@ -36,5 +36,6 @@ async def slack_get_user_profile_cmd(
     if not user_id or not isinstance(user_id, str):
         raise ValueError("--user_id is required")
     user = await get_user_profile(accessor.config, user_id)
-    out = json.dumps(user, ensure_ascii=False).encode()
+    out = json.dumps(user, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/slack/slack_get_user_profile.py
+++ b/python/mirage/commands/builtin/slack/slack_get_user_profile.py
@@ -36,6 +36,5 @@ async def slack_get_user_profile_cmd(
     if not user_id or not isinstance(user_id, str):
         raise ValueError("--user_id is required")
     user = await get_user_profile(accessor.config, user_id)
-    out = json.dumps(user, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+    out = json.dumps(user, ensure_ascii=False, separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/slack/slack_get_users.py
+++ b/python/mirage/commands/builtin/slack/slack_get_users.py
@@ -36,5 +36,6 @@ async def slack_get_users(
     if not query or not isinstance(query, str):
         raise ValueError("--query is required")
     users = await search_users(accessor.config, query)
-    out = json.dumps(users, ensure_ascii=False).encode()
+    out = json.dumps(users, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/slack/slack_get_users.py
+++ b/python/mirage/commands/builtin/slack/slack_get_users.py
@@ -36,6 +36,5 @@ async def slack_get_users(
     if not query or not isinstance(query, str):
         raise ValueError("--query is required")
     users = await search_users(accessor.config, query)
-    out = json.dumps(users, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+    out = json.dumps(users, ensure_ascii=False, separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/slack/slack_post_message.py
+++ b/python/mirage/commands/builtin/slack/slack_post_message.py
@@ -42,5 +42,5 @@ async def slack_post_message(
         raise ValueError("--text is required")
     result = await post_message(accessor.config, channel_id, text)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/slack/slack_post_message.py
+++ b/python/mirage/commands/builtin/slack/slack_post_message.py
@@ -41,5 +41,6 @@ async def slack_post_message(
     if not text or not isinstance(text, str):
         raise ValueError("--text is required")
     result = await post_message(accessor.config, channel_id, text)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/slack/slack_reply_to_thread.py
+++ b/python/mirage/commands/builtin/slack/slack_reply_to_thread.py
@@ -46,5 +46,5 @@ async def slack_reply(
         raise ValueError("--text is required")
     result = await reply_to_thread(accessor.config, channel_id, ts, text)
     out = json.dumps(result, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+                     separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/slack/slack_reply_to_thread.py
+++ b/python/mirage/commands/builtin/slack/slack_reply_to_thread.py
@@ -45,5 +45,6 @@ async def slack_reply(
     if not text or not isinstance(text, str):
         raise ValueError("--text is required")
     result = await reply_to_thread(accessor.config, channel_id, ts, text)
-    out = json.dumps(result, ensure_ascii=False).encode()
+    out = json.dumps(result, ensure_ascii=False,
+                 separators=(",", ":")).encode()
     return out, IOResult()

--- a/python/mirage/commands/builtin/trello/trello_card_assign.py
+++ b/python/mirage/commands/builtin/trello/trello_card_assign.py
@@ -46,4 +46,5 @@ async def trello_card_assign(
     card = await card_assign(config, card_id=card_id, member_id=member_id)
     return yield_bytes(
         json.dumps(normalize_card(card),
-                   ensure_ascii=False).encode()), IOResult()
+                   ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/trello/trello_card_comment_add.py
+++ b/python/mirage/commands/builtin/trello/trello_card_comment_add.py
@@ -55,6 +55,6 @@ async def trello_card_comment_add(
     )
     comment = await comment_create(config, card_id=card_id, text=text)
     payload = normalize_comment(comment, card_id=card_id)
-    return yield_bytes(json.dumps(payload,
-                                  ensure_ascii=False,
-                                  separators=(",", ":")).encode()), IOResult()
+    return yield_bytes(
+        json.dumps(payload, ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/trello/trello_card_comment_add.py
+++ b/python/mirage/commands/builtin/trello/trello_card_comment_add.py
@@ -56,4 +56,5 @@ async def trello_card_comment_add(
     comment = await comment_create(config, card_id=card_id, text=text)
     payload = normalize_comment(comment, card_id=card_id)
     return yield_bytes(json.dumps(payload,
-                                  ensure_ascii=False).encode()), IOResult()
+                                  ensure_ascii=False,
+                                  separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/trello/trello_card_comment_update.py
+++ b/python/mirage/commands/builtin/trello/trello_card_comment_update.py
@@ -65,6 +65,6 @@ async def trello_card_comment_update(
                                    comment_id=comment_id,
                                    text=text)
     payload = normalize_comment(comment, card_id=card_id)
-    return yield_bytes(json.dumps(payload,
-                                  ensure_ascii=False,
-                                  separators=(",", ":")).encode()), IOResult()
+    return yield_bytes(
+        json.dumps(payload, ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/trello/trello_card_comment_update.py
+++ b/python/mirage/commands/builtin/trello/trello_card_comment_update.py
@@ -66,4 +66,5 @@ async def trello_card_comment_update(
                                    text=text)
     payload = normalize_comment(comment, card_id=card_id)
     return yield_bytes(json.dumps(payload,
-                                  ensure_ascii=False).encode()), IOResult()
+                                  ensure_ascii=False,
+                                  separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/trello/trello_card_create.py
+++ b/python/mirage/commands/builtin/trello/trello_card_create.py
@@ -67,4 +67,5 @@ async def trello_card_create(
     )
     return yield_bytes(
         json.dumps(normalize_card(card),
-                   ensure_ascii=False).encode()), IOResult()
+                   ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/trello/trello_card_label_add.py
+++ b/python/mirage/commands/builtin/trello/trello_card_label_add.py
@@ -46,4 +46,5 @@ async def trello_card_label_add(
     card = await card_add_label(config, card_id=card_id, label_id=label_id)
     return yield_bytes(
         json.dumps(normalize_card(card),
-                   ensure_ascii=False).encode()), IOResult()
+                   ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/trello/trello_card_label_remove.py
+++ b/python/mirage/commands/builtin/trello/trello_card_label_remove.py
@@ -46,4 +46,5 @@ async def trello_card_label_remove(
     card = await card_remove_label(config, card_id=card_id, label_id=label_id)
     return yield_bytes(
         json.dumps(normalize_card(card),
-                   ensure_ascii=False).encode()), IOResult()
+                   ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/trello/trello_card_move.py
+++ b/python/mirage/commands/builtin/trello/trello_card_move.py
@@ -46,4 +46,5 @@ async def trello_card_move(
     card = await card_move(config, card_id=card_id, list_id=list_id)
     return yield_bytes(
         json.dumps(normalize_card(card),
-                   ensure_ascii=False).encode()), IOResult()
+                   ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/commands/builtin/trello/trello_card_update.py
+++ b/python/mirage/commands/builtin/trello/trello_card_update.py
@@ -74,4 +74,5 @@ async def trello_card_update(
     )
     return yield_bytes(
         json.dumps(normalize_card(card),
-                   ensure_ascii=False).encode()), IOResult()
+                   ensure_ascii=False,
+                   separators=(",", ":")).encode()), IOResult()

--- a/python/mirage/core/email/read.py
+++ b/python/mirage/core/email/read.py
@@ -65,4 +65,5 @@ async def read(
     folder = parts[1] if prefix else parts[0]
     uid = result.entry.id
     msg = await fetch_message(accessor, folder, uid)
-    return json.dumps(msg, ensure_ascii=False).encode()
+    return json.dumps(msg, ensure_ascii=False,
+                 separators=(",", ":")).encode()

--- a/python/mirage/core/email/read.py
+++ b/python/mirage/core/email/read.py
@@ -65,5 +65,4 @@ async def read(
     folder = parts[1] if prefix else parts[0]
     uid = result.entry.id
     msg = await fetch_message(accessor, folder, uid)
-    return json.dumps(msg, ensure_ascii=False,
-                 separators=(",", ":")).encode()
+    return json.dumps(msg, ensure_ascii=False, separators=(",", ":")).encode()

--- a/python/mirage/core/email/search.py
+++ b/python/mirage/core/email/search.py
@@ -101,8 +101,7 @@ async def search_and_format(
     pairs: list[tuple[str, str]] = []
     for uid in uids:
         msg = await fetch_message(accessor, folder, uid)
-        msg_text = json.dumps(msg, ensure_ascii=False,
-                      separators=(",", ":"))
+        msg_text = json.dumps(msg, ensure_ascii=False, separators=(",", ":"))
         vfs_path = _build_vfs_path(prefix, folder, msg)
         pairs.append((vfs_path, msg_text))
     return pairs

--- a/python/mirage/core/email/search.py
+++ b/python/mirage/core/email/search.py
@@ -101,7 +101,8 @@ async def search_and_format(
     pairs: list[tuple[str, str]] = []
     for uid in uids:
         msg = await fetch_message(accessor, folder, uid)
-        msg_text = json.dumps(msg, ensure_ascii=False)
+        msg_text = json.dumps(msg, ensure_ascii=False,
+                      separators=(",", ":"))
         vfs_path = _build_vfs_path(prefix, folder, msg)
         pairs.append((vfs_path, msg_text))
     return pairs

--- a/python/mirage/core/langfuse/read.py
+++ b/python/mirage/core/langfuse/read.py
@@ -30,7 +30,10 @@ def _json_bytes(data: dict) -> bytes:
 def _jsonl_bytes(items: list[dict]) -> bytes:
     if not items:
         return b""
-    lines = [json.dumps(item, ensure_ascii=False) for item in items]
+    lines = [
+        json.dumps(item, ensure_ascii=False, separators=(",", ":"))
+        for item in items
+    ]
     return ("\n".join(lines) + "\n").encode()
 
 

--- a/python/mirage/core/linear/normalize.py
+++ b/python/mirage/core/linear/normalize.py
@@ -149,5 +149,7 @@ def to_jsonl_bytes(rows: list[dict]) -> bytes:
     ordered = sorted(rows, key=lambda row: row.get("created_at") or "")
     if not ordered:
         return b""
-    text = "\n".join(json.dumps(row, ensure_ascii=False) for row in ordered)
+    text = "\n".join(
+        json.dumps(row, ensure_ascii=False, separators=(",", ":"))
+        for row in ordered)
     return text.encode() + b"\n"

--- a/python/mirage/core/trello/normalize.py
+++ b/python/mirage/core/trello/normalize.py
@@ -99,5 +99,7 @@ def to_jsonl_bytes(rows: list[dict]) -> bytes:
     ordered = sorted(rows, key=lambda row: row.get("created_at") or "")
     if not ordered:
         return b""
-    text = "\n".join(json.dumps(row, ensure_ascii=False) for row in ordered)
+    text = "\n".join(
+        json.dumps(row, ensure_ascii=False, separators=(",", ":"))
+        for row in ordered)
     return text.encode() + b"\n"


### PR DESCRIPTION
## Summary
- add compact JSON separators to Python single-line JSON renderers
- leave indented JSON output unchanged

## Test
- python3 -m compileall -q python/mirage/core python/mirage/commands/builtin
- git diff --check