### PR TITLE
Reject unsupported path-bound dispatch

### DIFF
--- a/python/mirage/workspace/executor/command.py
+++ b/python/mirage/workspace/executor/command.py
@@ -37,7 +37,7 @@ from mirage.workspace.executor.find_action_dispatch import _apply_find_actions
 from mirage.workspace.executor.fs_error import format_fs_error
 from mirage.workspace.executor.jobs import (handle_jobs, handle_kill,
                                             handle_ps, handle_wait)
-from mirage.workspace.mount import MountRegistry
+from mirage.workspace.mount import MountCommandUnsupported, MountRegistry
 from mirage.workspace.session import Session, assert_mount_allowed
 from mirage.workspace.types import ExecutionNode
 
@@ -355,7 +355,15 @@ async def handle_command(
                 stderr=err.encode(),
             ), ExecutionNode(command=cmd_str, exit_code=1)
 
-    mount = await registry.resolve_mount(cmd_name, path_scopes, session.cwd)
+    try:
+        mount = await registry.resolve_mount(cmd_name, path_scopes,
+                                             session.cwd)
+    except MountCommandUnsupported as exc:
+        err = f"{exc}\n".encode()
+        return None, IOResult(exit_code=1,
+                              stderr=err), ExecutionNode(command=cmd_str,
+                                                         exit_code=1,
+                                                         stderr=err)
     if mount is None:
         return None, IOResult(
             exit_code=127,

--- a/python/mirage/workspace/mount/__init__.py
+++ b/python/mirage/workspace/mount/__init__.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.workspace.mount.mount import Mount
-from mirage.workspace.mount.registry import MountRegistry
+from mirage.workspace.mount.registry import (MountCommandUnsupported,
+                                             MountRegistry)
 
-__all__ = ["Mount", "MountRegistry"]
+__all__ = ["Mount", "MountCommandUnsupported", "MountRegistry"]

--- a/python/mirage/workspace/mount/registry.py
+++ b/python/mirage/workspace/mount/registry.py
@@ -24,6 +24,15 @@ from mirage.workspace.mount.mount import Mount
 DEV_PREFIX = "/dev/"
 
 
+class MountCommandUnsupported(Exception):
+    """Raised when a path-bound command is unsupported by its backend."""
+
+    def __init__(self, cmd_name: str, backend: str) -> None:
+        self.cmd_name = cmd_name
+        self.backend = backend
+        super().__init__(f"{cmd_name}: not supported on the {backend} backend")
+
+
 class MountRegistry:
     """Longest-prefix-match router.
 
@@ -273,7 +282,11 @@ class MountRegistry:
         except ValueError:
             mount = None
 
-        if mount is None or mount.resolve_command(cmd_name) is None:
+        if mount is not None and mount.resolve_command(cmd_name) is None:
+            if path_scopes:
+                raise MountCommandUnsupported(cmd_name, mount.resource.name)
+            mount = self.mount_for_command(cmd_name)
+        elif mount is None:
             mount = self.mount_for_command(cmd_name)
 
         if mount is None:

--- a/python/tests/workspace/mount/test_registry.py
+++ b/python/tests/workspace/mount/test_registry.py
@@ -15,10 +15,14 @@
 import pytest
 
 from mirage.cache.file.ram import RAMFileCacheStore
+from mirage.commands.registry import command
+from mirage.commands.spec.types import CommandSpec
+from mirage.io.types import IOResult
+from mirage.resource.base import BaseResource
 from mirage.resource.ram import RAMResource
 from mirage.resource.ssh import SSHConfig, SSHResource
 from mirage.types import MountMode, PathSpec
-from mirage.workspace.mount import MountRegistry
+from mirage.workspace.mount import MountCommandUnsupported, MountRegistry
 
 # ── mount_for ──────────────────────────────────
 
@@ -331,3 +335,45 @@ async def test_resolve_mount_keeps_cached_write_on_remote():
     scope = PathSpec(original="/ssh/a.txt", directory="/ssh", resolved=True)
     mount = await reg.resolve_mount("rm", [scope], "/ssh")
     assert mount.prefix == "/ssh/"
+
+
+class _LimitedResource(BaseResource):
+    name = "limited"
+
+
+class _FallbackResource(BaseResource):
+    name = "fallback"
+
+
+@command("fallback-only", resource="fallback", spec=CommandSpec())
+async def _fallback_only(_store, paths, *texts, **kw):
+    return b"fallback", IOResult()
+
+
+def _path_bound_registry_with_default():
+    reg = MountRegistry()
+    reg.mount("/limited/", _LimitedResource(), MountMode.WRITE)
+    fallback = _FallbackResource()
+    fallback.register(_fallback_only)
+    reg.set_default_mount(fallback)
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_resolve_mount_rejects_path_bound_unsupported_command():
+    reg = _path_bound_registry_with_default()
+    scope = PathSpec(original="/limited/file.txt",
+                     directory="/limited",
+                     resolved=True)
+    with pytest.raises(
+            MountCommandUnsupported,
+            match="fallback-only: not supported on the limited backend"):
+        await reg.resolve_mount("fallback-only", [scope], "/limited")
+
+
+@pytest.mark.asyncio
+async def test_resolve_mount_allows_default_without_path_binding():
+    reg = _path_bound_registry_with_default()
+    mount = await reg.resolve_mount("fallback-only", [], "/limited")
+    assert mount is not None
+    assert mount.prefix == "/_default/"


### PR DESCRIPTION
## Summary

Closes #383. Scope: the mount-registry dispatch fix only. (The find changes that were previously bundled here have moved to #393.)

When a command's path operand resolves to a concrete mount X, but X does not register that command, `resolve_mount` no longer falls back to the hidden `/_default/` mount (which ran against its own empty namespace and reported a misleading `No such file` for a file that exists). Instead it raises `MountCommandUnsupported`, surfaced as exit 1 with `"<cmd>: not supported on the <backend> backend"`.

Path-less general commands (`echo`, `seq`, `bc`, ...) still fall back to `/_default/`.

## Changes
- `mount/registry.py`: add `MountCommandUnsupported`; gate the `/_default/` fallback on whether the command is path-bound.
- `executor/command.py`: map the exception to exit 1.
- `mount/__init__.py`: export the exception.
- `tests/workspace/mount/test_registry.py`: regression coverage for path-bound (rejected) vs path-less (fallback).