### PR TITLE
fix: align find with GNU coreutils across all backends (#312)

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -465,6 +465,9 @@ CASES: list[tuple[str, str]] = [
     # ----- find more -----
     ("find_empty", "find /data -empty"),
     ("find_not_name", 'find /data -not -name "*.txt"'),
+    ("find_name_start", "find /data -name data"),
+    ("find_maxdepth_zero", "find /data -maxdepth 0"),
+    ("find_mindepth_zero", "find /data -mindepth 0 -type d"),
     ("find_size_lt", "find /data -size -5c"),
     ("find_depth", "find /data -depth -type f"),
     ("find_mtime", "find /data -mtime +0 -o -mtime -1"),

--- a/integ/cases.py
+++ b/integ/cases.py
@@ -825,6 +825,8 @@ FIND_ARG_ERROR_CASES: list[tuple[str, str]] = [
     ("find_bad_size", "find /data -size abc"),
     ("find_empty_size", "find /data -size ''"),
     ("find_bad_mtime", "find /data -mtime abc"),
+    ("find_unknown_predicate", "find /data -regex '.*deep.*'"),
+    ("find_bogus_predicate", "find /data -boguspredicate"),
 ]
 
 SLEEP_CASES: list[tuple[str, str, float]] = [

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -703,6 +703,8 @@ export const FIND_ARG_ERROR_CASES: ReadonlyArray<readonly [string, string]> = [
   ['find_bad_size', 'find /data -size abc'],
   ['find_empty_size', "find /data -size ''"],
   ['find_bad_mtime', 'find /data -mtime abc'],
+  ['find_unknown_predicate', "find /data -regex '.*deep.*'"],
+  ['find_bogus_predicate', 'find /data -boguspredicate'],
 ];
 
 export const SLEEP_CASES: ReadonlyArray<readonly [string, string, number]> = [

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -387,6 +387,9 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
 
   ["find_empty", "find /data -empty"],
   ["find_not_name", 'find /data -not -name "*.txt"'],
+  ["find_name_start", "find /data -name data"],
+  ["find_maxdepth_zero", "find /data -maxdepth 0"],
+  ["find_mindepth_zero", "find /data -mindepth 0 -type d"],
   ["find_size_lt", "find /data -size -5c"],
   ["find_depth", "find /data -depth -type f"],
   ["find_mtime", "find /data -mtime +0 -o -mtime -1"],

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -1273,6 +1273,18 @@ baz,
 /data/sub/deep
 /data/user.json
 /data/users.json
+=== find_name_start ===
+/data
+=== find_maxdepth_zero ===
+/data
+=== find_mindepth_zero ===
+/data
+/data/disptree
+/data/disptree/d
+/data/guard
+/data/guard/sub
+/data/sub
+/data/sub/deep
 === find_size_lt ===
 /data
 /data/disptree
@@ -1783,8 +1795,8 @@ disptree/d
 disptree/d/y.txt
 disptree/x.txt
 === history_last_two ===
-470  (cd /data && ls -R disptree)
-471  (cd /data && find disptree)
+473  (cd /data && ls -R disptree)
+474  (cd /data && find disptree)
 === bash_history_tail ===
 (cd /data && ls -R disptree)
 (cd /data && find disptree)

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -685,6 +685,7 @@ world
 === rg_c ===
 1
 === find_d ===
+/data
 /data/disptree
 /data/disptree/d
 /data/guard
@@ -722,6 +723,7 @@ world
 /data/sub/nested.txt
 /data/tabbed.txt
 === find_size_gt ===
+/data
 /data/a.txt
 /data/abc.csv
 /data/anchors.txt
@@ -1257,6 +1259,7 @@ baz,
 === find_empty ===
 /data/empty.txt
 === find_not_name ===
+/data
 /data/abc.csv
 /data/binary.bin
 /data/chat.jsonl
@@ -1271,6 +1274,7 @@ baz,
 /data/user.json
 /data/users.json
 === find_size_lt ===
+/data
 /data/disptree
 /data/disptree/d
 /data/disptree/d/y.txt
@@ -1320,6 +1324,7 @@ baz,
 /data/user.json
 /data/users.json
 === find_mtime ===
+/data
 /data/a.txt
 /data/abc.csv
 /data/anchors.txt
@@ -2059,6 +2064,12 @@ find: invalid argument '' to '-size'
 === find_bad_mtime ===
 exit=1
 find: invalid argument 'abc' to '-mtime'
+=== find_unknown_predicate ===
+exit=1
+find: unknown predicate '-regex'
+=== find_bogus_predicate ===
+exit=1
+find: unknown predicate '-boguspredicate'
 === sleep_zero ===
 sleep_zero ok
 === sleep_fraction ===

--- a/python/mirage/commands/builtin/find_eval.py
+++ b/python/mirage/commands/builtin/find_eval.py
@@ -107,6 +107,16 @@ def tree_has_type(node: PredNode) -> bool:
     return False
 
 
+def tree_has_empty(node: PredNode) -> bool:
+    if isinstance(node, Empty):
+        return True
+    if isinstance(node, Not):
+        return tree_has_empty(node.kid)
+    if isinstance(node, (And, Or)):
+        return any(tree_has_empty(kid) for kid in node.kids)
+    return False
+
+
 def keep(entry: FindEntry, tree: PredNode, min_depth: int | None) -> bool:
     if min_depth is not None and entry.depth < min_depth:
         return False

--- a/python/mirage/commands/builtin/generic/find.py
+++ b/python/mirage/commands/builtin/generic/find.py
@@ -4,7 +4,8 @@ from datetime import datetime, timezone
 
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.find_eval import (FindEntry, PredNode,
-                                               args_to_tree, keep)
+                                               args_to_tree, keep,
+                                               tree_has_empty)
 from mirage.commands.builtin.find_helper import (_parse_depth, _parse_mtime,
                                                  _parse_size)
 from mirage.commands.builtin.find_parse import parse_find_expression
@@ -220,6 +221,28 @@ async def _stat_entry(
         return None
 
 
+async def _is_empty_entry(
+    readdir: Callable[[PathSpec, IndexCacheStore | None],
+                      Awaitable[list[str]]],
+    stat: Callable[[PathSpec, IndexCacheStore | None], Awaitable[FileStat]],
+    path: str,
+    is_dir: bool,
+    prefix: str,
+    index: IndexCacheStore | None,
+) -> bool:
+    if is_dir:
+        spec = PathSpec(original=path,
+                        directory=path,
+                        resolved=False,
+                        prefix=prefix)
+        try:
+            return len(await readdir(spec, index)) == 0
+        except FileNotFoundError:
+            return False
+    st = await _stat_entry(stat, path, prefix, index)
+    return st is not None and (st.size or 0) == 0
+
+
 async def _walk_collect(
     readdir: Callable[[PathSpec, IndexCacheStore | None],
                       Awaitable[list[str]]],
@@ -268,31 +291,38 @@ async def walk_find(
     args: FindArgs,
 ) -> list[str]:
     collected: list[tuple[str, bool]] = []
-    # GNU depth convention: the search root is depth 0, its children are
-    # depth 1, so the walk starts at 1 and -maxdepth 0 lists nothing.
-    await _walk_collect(readdir, stat, is_dir_name, search_path, index,
-                        args.maxdepth, 1, collected)
     prefix = search_path.prefix
     search_key = search_path.strip_prefix.strip("/")
-    base_depth = search_key.count("/") if search_key else -1
-    if search_key and (args.maxdepth is None or args.maxdepth >= 0):
-        try:
-            root_stat = await stat(search_path, index)
-        except FileNotFoundError:
-            root_stat = None
-        if root_stat is not None:
-            root_p = prefix + "/" + search_key if prefix else "/" + search_key
-            collected.append((root_p, root_stat.type == FileType.DIRECTORY))
+    root_path = (search_path.original.rstrip("/")
+                 if search_path.original != "/" else "/")
+    root_stat = await _stat_entry(stat, root_path, prefix, index)
+    if root_stat is not None:
+        collected.append((root_path, root_stat.type == FileType.DIRECTORY))
+    # GNU depth convention: the search root is depth 0, its children are
+    # depth 1.
+    await _walk_collect(readdir, stat, is_dir_name, search_path, index,
+                        args.maxdepth, 1, collected)
     tree = args_to_tree(args)
+    need_empty = tree_has_empty(tree)
     results: list[str] = []
     for p, is_dir in sorted(collected):
         entry_name = p.rsplit("/", 1)[-1]
         key = p[len(prefix):] if prefix and p.startswith(prefix) else p
-        depth = key.strip("/").count("/") - base_depth
+        rel = key.strip("/")
+        if search_key:
+            depth = 0 if rel == search_key else rel.count(
+                "/") - search_key.count("/")
+        else:
+            depth = 0 if rel == "" else rel.count("/") + 1
+        is_empty = None
+        if need_empty:
+            is_empty = await _is_empty_entry(readdir, stat, p, is_dir, prefix,
+                                             index)
         entry = FindEntry(key=key,
                           name=entry_name,
                           kind="d" if is_dir else "f",
-                          depth=depth)
+                          depth=depth,
+                          is_empty=is_empty)
         if not keep(entry, tree, args.mindepth):
             continue
         need_size = not is_dir and (args.min_size is not None

--- a/python/mirage/core/disk/find.py
+++ b/python/mirage/core/disk/find.py
@@ -47,6 +47,7 @@ def _find_sync(
     mindepth: int | None = None,
     empty: bool = False,
     tree: PredNode | None = None,
+    start_name: str = "",
 ) -> list[str]:
     p = _resolve(root, path)
     base = "/" + path.strip("/")
@@ -63,7 +64,7 @@ def _find_sync(
     if p.is_dir():
         root_empty = (not any(p.iterdir())) if empty else None
         root_entry = FindEntry(key=base,
-                               name=base.rsplit("/", 1)[-1],
+                               name=start_name or base.rsplit("/", 1)[-1],
                                kind="d",
                                depth=0,
                                is_empty=root_empty)
@@ -161,7 +162,9 @@ async def find(
 ) -> list[str]:
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
+    start_name = ""
     if isinstance(path, PathSpec):
+        start_name = path.original.rstrip("/").rsplit("/", 1)[-1]
         path = path.strip_prefix
     return await asyncio.to_thread(
         _find_sync,
@@ -181,4 +184,5 @@ async def find(
         mindepth,
         empty,
         tree,
+        start_name,
     )

--- a/python/mirage/core/disk/find.py
+++ b/python/mirage/core/disk/find.py
@@ -60,7 +60,7 @@ def _find_sync(
                                                     or_names=or_names,
                                                     empty=empty)
 
-    if base != "/" and p.is_dir():
+    if p.is_dir():
         root_empty = (not any(p.iterdir())) if empty else None
         root_entry = FindEntry(key=base,
                                name=base.rsplit("/", 1)[-1],

--- a/python/mirage/core/nextcloud/find.py
+++ b/python/mirage/core/nextcloud/find.py
@@ -27,6 +27,7 @@ async def find(
 ) -> list[str]:
     if isinstance(path, str):
         path = PathSpec.from_str_path(path)
+    start_name = path.original.rstrip("/").rsplit("/", 1)[-1]
     target = path.strip_prefix
     pfx = target.strip("/")
     scan_path = pfx + "/" if pfx else "/"
@@ -104,7 +105,7 @@ async def find(
         return []
     if (saw_descendant or dir_exists) and (maxdepth is None or maxdepth >= 0):
         root_entry = FindEntry(key=base,
-                               name=base.rsplit("/", 1)[-1],
+                               name=start_name or base.rsplit("/", 1)[-1],
                                kind="d",
                                depth=0,
                                is_empty=False)

--- a/python/mirage/core/nextcloud/find.py
+++ b/python/mirage/core/nextcloud/find.py
@@ -102,8 +102,7 @@ async def find(
                 results.append(ep)
     except NotFound:
         return []
-    if base != "/" and (saw_descendant or dir_exists) and (maxdepth is None
-                                                           or maxdepth >= 0):
+    if (saw_descendant or dir_exists) and (maxdepth is None or maxdepth >= 0):
         root_entry = FindEntry(key=base,
                                name=base.rsplit("/", 1)[-1],
                                kind="d",

--- a/python/mirage/core/onedrive/find.py
+++ b/python/mirage/core/onedrive/find.py
@@ -60,6 +60,8 @@ async def find(
     empty: bool = False,
     tree: PredNode | None = None,
 ) -> list[str]:
+    orig = path.original if isinstance(path, PathSpec) else str(path)
+    start_name = orig.rstrip("/").rsplit("/", 1)[-1]
     _, base = split_path(path)
     results: list[str] = []
     saw_descendant = False
@@ -106,7 +108,7 @@ async def find(
             dir_exists = False
     if dir_exists and (maxdepth is None or maxdepth >= 0):
         root_key = "/" + base if base else "/"
-        root_name = base.rsplit("/", 1)[-1] if base else ""
+        root_name = base.rsplit("/", 1)[-1] if base else start_name
         root_entry = FindEntry(key=root_key,
                                name=root_name,
                                kind="d",

--- a/python/mirage/core/onedrive/find.py
+++ b/python/mirage/core/onedrive/find.py
@@ -98,18 +98,20 @@ async def find(
                     continue
             results.append(full_path)
     dir_exists = saw_descendant
-    if base and not dir_exists:
+    if not dir_exists:
         try:
             dir_exists = (await stat(accessor,
                                      path)).type == FileType.DIRECTORY
         except FileNotFoundError:
             dir_exists = False
-    if base and dir_exists and (maxdepth is None or maxdepth >= 0):
-        root_entry = FindEntry(key="/" + base,
-                               name=base.rsplit("/", 1)[-1],
+    if dir_exists and (maxdepth is None or maxdepth >= 0):
+        root_key = "/" + base if base else "/"
+        root_name = base.rsplit("/", 1)[-1] if base else ""
+        root_entry = FindEntry(key=root_key,
+                               name=root_name,
                                kind="d",
                                depth=0,
                                is_empty=False if empty else None)
         if keep(root_entry, tree, mindepth):
-            results.append("/" + base)
+            results.append(root_key)
     return sorted(results)

--- a/python/mirage/core/ram/find.py
+++ b/python/mirage/core/ram/find.py
@@ -37,7 +37,9 @@ async def find(
 ) -> list[str]:
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
+    start_name = ""
     if isinstance(path, PathSpec):
+        start_name = path.original.rstrip("/").rsplit("/", 1)[-1]
         path = path.strip_prefix
     store = accessor.store
     p = norm(path)
@@ -76,7 +78,7 @@ async def find(
         if maxdepth is not None and depth > maxdepth:
             continue
 
-        basename = key.rsplit("/", 1)[-1]
+        basename = start_name if key == p else key.rsplit("/", 1)[-1]
         is_empty: bool | None = None
         if empty:
             is_empty = (len(store.files[key])

--- a/python/mirage/core/ram/find.py
+++ b/python/mirage/core/ram/find.py
@@ -42,7 +42,7 @@ async def find(
     store = accessor.store
     p = norm(path)
     prefix = p.rstrip("/") + "/"
-    base_depth = 0 if p == "/" else p.count("/")
+    base_depth = p.count("/")
     results: list[str] = []
     if tree is None:
         tree = build_tree(name=name,
@@ -62,14 +62,16 @@ async def find(
             candidates.append((key, "f"))
     if type != "f":
         for key in store.dirs:
-            if key != "/":
-                candidates.append((key, "d"))
+            candidates.append((key, "d"))
 
     for key, kind in candidates:
         if key != p and not key.startswith(prefix):
             continue
 
-        depth = key.count("/") - base_depth
+        if p == "/":
+            depth = 0 if key == "/" else key.strip("/").count("/") + 1
+        else:
+            depth = 0 if key == p else key.count("/") - base_depth
 
         if maxdepth is not None and depth > maxdepth:
             continue

--- a/python/mirage/core/redis/find.py
+++ b/python/mirage/core/redis/find.py
@@ -37,7 +37,9 @@ async def find(
 ) -> list[str]:
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
+    start_name = ""
     if isinstance(path, PathSpec):
+        start_name = path.original.rstrip("/").rsplit("/", 1)[-1]
         path = path.strip_prefix
     store = accessor.store
     p = norm(path)
@@ -76,7 +78,7 @@ async def find(
         if maxdepth is not None and depth > maxdepth:
             continue
 
-        basename = key.rsplit("/", 1)[-1]
+        basename = start_name if key == p else key.rsplit("/", 1)[-1]
         is_empty: bool | None = None
         if empty:
             is_empty = (await store.file_len(key)

--- a/python/mirage/core/redis/find.py
+++ b/python/mirage/core/redis/find.py
@@ -42,7 +42,7 @@ async def find(
     store = accessor.store
     p = norm(path)
     prefix = p.rstrip("/") + "/"
-    base_depth = 0 if p == "/" else p.count("/")
+    base_depth = p.count("/")
     results: list[str] = []
     tree = tree if tree is not None else build_tree(name=name,
                                                     iname=iname,
@@ -62,14 +62,16 @@ async def find(
             candidates.append((key, "f"))
     if type != "f":
         for key in all_dirs:
-            if key != "/":
-                candidates.append((key, "d"))
+            candidates.append((key, "d"))
 
     for key, kind in candidates:
         if key != p and not key.startswith(prefix):
             continue
 
-        depth = key.count("/") - base_depth
+        if p == "/":
+            depth = 0 if key == "/" else key.strip("/").count("/") + 1
+        else:
+            depth = 0 if key == p else key.count("/") - base_depth
 
         if maxdepth is not None and depth > maxdepth:
             continue

--- a/python/mirage/core/s3/find.py
+++ b/python/mirage/core/s3/find.py
@@ -58,7 +58,9 @@ async def find(
     """
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
+    start_name = ""
     if isinstance(path, PathSpec):
+        start_name = path.original.rstrip("/").rsplit("/", 1)[-1]
         path = path.strip_prefix
     config = accessor.config
     pfx = _prefix(path, config)
@@ -110,7 +112,7 @@ async def find(
     if (saw_descendant or dir_marker_seen) and (maxdepth is None
                                                 or maxdepth >= 0):
         root_key = "/" + stripped if stripped else "/"
-        root_name = stripped.rsplit("/", 1)[-1] if stripped else ""
+        root_name = stripped.rsplit("/", 1)[-1] if stripped else start_name
         root_entry = FindEntry(key=root_key,
                                name=root_name,
                                kind="d",

--- a/python/mirage/core/s3/find.py
+++ b/python/mirage/core/s3/find.py
@@ -107,13 +107,15 @@ async def find(
                         continue
                 results.append(full_path)
     stripped = path.strip("/")
-    if stripped and (saw_descendant or dir_marker_seen) and (maxdepth is None
-                                                             or maxdepth >= 0):
-        root_entry = FindEntry(key="/" + stripped,
-                               name=stripped.rsplit("/", 1)[-1],
+    if (saw_descendant or dir_marker_seen) and (maxdepth is None
+                                                or maxdepth >= 0):
+        root_key = "/" + stripped if stripped else "/"
+        root_name = stripped.rsplit("/", 1)[-1] if stripped else ""
+        root_entry = FindEntry(key=root_key,
+                               name=root_name,
                                kind="d",
                                depth=0,
                                is_empty=False if empty else None)
         if keep(root_entry, tree, mindepth):
-            results.append("/" + stripped)
+            results.append(root_key)
     return sorted(results)

--- a/python/mirage/core/ssh/find.py
+++ b/python/mirage/core/ssh/find.py
@@ -41,7 +41,9 @@ async def find(
 ) -> list[str]:
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
+    start_name = ""
     if isinstance(path, PathSpec):
+        start_name = path.original.rstrip("/").rsplit("/", 1)[-1]
         path = path.strip_prefix
     config = accessor.config
     sftp = await accessor.sftp()
@@ -60,7 +62,7 @@ async def find(
         if root_attrs is not None:
             is_dir = root_attrs.type == asyncssh.FILEXFER_TYPE_DIRECTORY
             root_entry = FindEntry(key=path,
-                                   name=path.rsplit("/", 1)[-1],
+                                   name=start_name or path.rsplit("/", 1)[-1],
                                    kind="d" if is_dir else "f",
                                    depth=0,
                                    is_empty=False if is_dir else

--- a/python/mirage/core/ssh/find.py
+++ b/python/mirage/core/ssh/find.py
@@ -52,7 +52,7 @@ async def find(
                                                     type=type,
                                                     name_exclude=name_exclude,
                                                     or_names=or_names)
-    if path.strip("/") and (maxdepth is None or maxdepth >= 0):
+    if maxdepth is None or maxdepth >= 0:
         try:
             root_attrs = await sftp.stat(_abs(config, path))
         except (asyncssh.SFTPError, OSError):

--- a/python/mirage/workspace/executor/fanout.py
+++ b/python/mirage/workspace/executor/fanout.py
@@ -214,6 +214,27 @@ async def _filter_under_prefixes(
     return ("\n".join(out_lines) + "\n").encode("utf-8") if out_lines else b""
 
 
+async def _drop_mount_root_line(stdout: ByteSource, mount_root: str) -> bytes:
+    """Drop a descendant find's own mount-root line.
+
+    A per-mount find now emits its start directory, so a descendant
+    mount's find yields its mount-root path. The mount-point entry is
+    instead synthesized centrally (with the mount's display name and the
+    full predicate tree applied), so the raw root line is dropped here to
+    avoid a duplicate that skips the name filter.
+
+    Args:
+        stdout (ByteSource): descendant find output.
+        mount_root (str): the descendant mount root path.
+    """
+    data = await materialize(stdout)
+    text = data.decode("utf-8", errors="replace")
+    out_lines = [
+        line for line in text.split("\n") if line != "" and line != mount_root
+    ]
+    return ("\n".join(out_lines) + "\n").encode("utf-8") if out_lines else b""
+
+
 async def _fan_out_traversal(
     cmd_name: str,
     paths: list[PathSpec],
@@ -280,6 +301,8 @@ async def _fan_out_traversal(
 
         if mount is primary_mount and descendant_prefixes and stdout:
             stdout = await _filter_under_prefixes(stdout, descendant_prefixes)
+        elif mount is not primary_mount and cmd_name == "find" and stdout:
+            stdout = await _drop_mount_root_line(stdout, mount_root)
 
         if stdout is not None:
             data = await materialize(stdout)

--- a/python/tests/commands/builtin/generic/test_find.py
+++ b/python/tests/commands/builtin/generic/test_find.py
@@ -84,6 +84,12 @@ def test_parse_find_args_unknown_type_left_as_string():
     assert parse_find_args((), type="symlink").type == "symlink"
 
 
+def test_parse_find_args_unknown_predicate_raises():
+    with pytest.raises(FindParseError,
+                       match="find: unknown predicate '-bogus'"):
+        parse_find_args(("-bogus", ))
+
+
 def test_parse_find_args_negation_builds_not_tree():
     args = parse_find_args(("-not", "-name", "*.pyc"))
     assert args.tree == Not(Name("*.pyc"))
@@ -204,7 +210,7 @@ def _root_spec() -> PathSpec:
 @pytest.mark.asyncio
 async def test_walk_find_tolerates_not_found_readdir():
     readdir = AsyncMock(side_effect=FileNotFoundError("/"))
-    stat = AsyncMock()
+    stat = AsyncMock(side_effect=FileNotFoundError("/"))
     results = await walk_find(_root_spec(),
                               readdir=readdir,
                               stat=stat,
@@ -212,6 +218,20 @@ async def test_walk_find_tolerates_not_found_readdir():
                               index=None,
                               args=FindArgs())
     assert results == []
+
+
+@pytest.mark.asyncio
+async def test_walk_find_emits_start_path_at_depth_zero():
+    readdir = AsyncMock(return_value=["/child.txt"])
+    stat = AsyncMock(return_value=FileStat(name="/", type=FileType.DIRECTORY))
+    results = await walk_find(_root_spec(),
+                              readdir=readdir,
+                              stat=stat,
+                              is_dir_name=lambda c: False,
+                              index=None,
+                              args=FindArgs(maxdepth=0))
+    assert results == ["/"]
+    readdir.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -238,6 +258,61 @@ async def test_walk_find_stat_fallback_treats_not_found_as_file():
                               index=None,
                               args=FindArgs(type=FindType.FILE))
     assert results == ["/mystery"]
+
+
+@pytest.mark.asyncio
+async def test_walk_find_empty_matches_empty_files_and_dirs():
+
+    async def readdir(spec: PathSpec, _index):
+        table = {
+            "/": ["/empty.txt", "/full.txt", "/empty-dir", "/full-dir"],
+            "/empty-dir": [],
+            "/full-dir": ["/full-dir/a.txt"],
+        }
+        return table[spec.original]
+
+    async def stat(spec: PathSpec, _index):
+        stats = {
+            "/": FileStat(name="/", type=FileType.DIRECTORY),
+            "/empty.txt": FileStat(name="empty.txt",
+                                   size=0,
+                                   type=FileType.TEXT),
+            "/full.txt": FileStat(name="full.txt", size=1, type=FileType.TEXT),
+            "/empty-dir": FileStat(name="empty-dir", type=FileType.DIRECTORY),
+            "/full-dir": FileStat(name="full-dir", type=FileType.DIRECTORY),
+            "/full-dir/a.txt": FileStat(name="a.txt",
+                                        size=1,
+                                        type=FileType.TEXT),
+        }
+        return stats[spec.original]
+
+    results = await walk_find(_root_spec(),
+                              readdir=readdir,
+                              stat=stat,
+                              is_dir_name=lambda c: c.endswith("dir"),
+                              index=None,
+                              args=parse_find_args(("-empty", )))
+    assert results == ["/empty-dir", "/empty.txt"]
+
+
+@pytest.mark.asyncio
+async def test_walk_find_not_negates_predicate():
+    readdir = AsyncMock(return_value=["/a.txt", "/b.md"])
+
+    async def stat(spec: PathSpec, _index):
+        if spec.original == "/":
+            return FileStat(name="/", type=FileType.DIRECTORY)
+        return FileStat(name=spec.original.rsplit("/", 1)[-1],
+                        size=1,
+                        type=FileType.TEXT)
+
+    results = await walk_find(_root_spec(),
+                              readdir=readdir,
+                              stat=stat,
+                              is_dir_name=lambda c: False,
+                              index=None,
+                              args=parse_find_args(("-not", "-name", "*.txt")))
+    assert results == ["/", "/b.md"]
 
 
 @pytest.mark.asyncio
@@ -322,3 +397,33 @@ def test_find_invalid_numeric_arg_exits_one_with_clean_stderr(expr):
     assert code == 1
     assert stderr.startswith("find: invalid argument ")
     assert stderr.endswith("\n")
+
+
+# ── Issue #312 parse-level regression tests ────────────────
+
+
+def test_parse_find_args_start_path_included():
+    args = parse_find_args(())
+    assert args.maxdepth is None
+
+
+def test_parse_find_args_maxdepth_zero():
+    args = parse_find_args(("-maxdepth", "0"))
+    assert args.maxdepth == 0
+
+
+def test_parse_find_args_empty_predicate():
+    args = parse_find_args(("-empty", ))
+    assert args.empty is True
+
+
+def test_parse_find_args_not_negation():
+    args = parse_find_args(("-not", "-name", "*.txt"))
+    assert isinstance(args.tree, Not)
+    assert isinstance(args.tree.kid, Name)
+    assert args.tree.kid.pattern == "*.txt"
+
+
+def test_parse_find_args_bogus_predicate_raises():
+    with pytest.raises(FindParseError, match="unknown predicate"):
+        parse_find_args(("-boguspredicate", ))

--- a/python/tests/core/nextcloud/test_find.py
+++ b/python/tests/core/nextcloud/test_find.py
@@ -12,7 +12,7 @@ async def test_find_root_returns_sorted_entries(make_acc):
         "data/c.json": b"c",
     })
     out = await find(acc, PathSpec.from_str_path("/"))
-    assert out == ["/a.json", "/b.json", "/data", "/data/c.json"]
+    assert out == ["/", "/a.json", "/b.json", "/data", "/data/c.json"]
 
 
 @pytest.mark.asyncio
@@ -53,7 +53,7 @@ async def test_find_type_filter(make_acc):
     files = await find(acc, PathSpec.from_str_path("/"), type="f")
     dirs = await find(acc, PathSpec.from_str_path("/"), type="d")
     assert files == ["/a.json", "/data/c.json"]
-    assert dirs == ["/data"]
+    assert dirs == ["/", "/data"]
 
 
 @pytest.mark.asyncio
@@ -64,4 +64,4 @@ async def test_find_maxdepth(make_acc):
         "data/sub/d.json": b"d",
     })
     out = await find(acc, PathSpec.from_str_path("/"), maxdepth=1)
-    assert out == ["/a.json", "/data"]
+    assert out == ["/", "/a.json", "/data"]

--- a/python/tests/core/onedrive/test_find_du.py
+++ b/python/tests/core/onedrive/test_find_du.py
@@ -68,7 +68,7 @@ async def test_find_returns_files_and_folders():
     with aioresponses() as m:
         _tree(m)
         out = await find(_accessor(), PathSpec.from_str_path("/"))
-    assert out == ["/a.txt", "/sub", "/sub/b.txt"]
+    assert out == ["/", "/a.txt", "/sub", "/sub/b.txt"]
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/ram/test_find.py
+++ b/python/tests/core/ram/test_find.py
@@ -55,6 +55,16 @@ async def test_find_by_name(store):
 
 
 @pytest.mark.asyncio
+async def test_find_name_matches_mount_root_start_path(store):
+    results = await find(store,
+                         PathSpec(original="/data",
+                                  directory="/data",
+                                  prefix="/data"),
+                         name="data")
+    assert results == ["/"]
+
+
+@pytest.mark.asyncio
 async def test_find_by_type_file(store):
     results = await find(store,
                          PathSpec(original="/src", directory="/src"),

--- a/typescript/packages/browser/src/core/opfs/find.test.ts
+++ b/typescript/packages/browser/src/core/opfs/find.test.ts
@@ -26,7 +26,7 @@ describe('opfs/find', () => {
     await mkdir(accessor, spec('/sub'))
     await writeBytes(accessor, spec('/sub/c.json'), new Uint8Array())
     const out = await find(accessor, spec('/'))
-    expect(out.sort()).toEqual(['/a.json', '/b.txt', '/sub', '/sub/c.json'])
+    expect(out.sort()).toEqual(['/', '/a.json', '/b.txt', '/sub', '/sub/c.json'])
   })
 
   it('filters by name pattern', async () => {

--- a/typescript/packages/browser/src/core/opfs/find.ts
+++ b/typescript/packages/browser/src/core/opfs/find.ts
@@ -157,7 +157,7 @@ export async function find(
     if (isNotFound(err)) return results
     throw err
   }
-  if (virtual !== '/' && (options.maxDepth == null || options.maxDepth >= 0)) {
+  if (options.maxDepth == null || options.maxDepth >= 0) {
     let rootEmpty: boolean | null = null
     if (options.empty === true) {
       rootEmpty = true

--- a/typescript/packages/browser/src/core/opfs/find.ts
+++ b/typescript/packages/browser/src/core/opfs/find.ts
@@ -15,7 +15,7 @@
 import type { PathSpec } from '@struktoai/mirage-core'
 import type { OPFSAccessor } from '../../accessor/opfs.ts'
 import { isNotFound, iterEntries, norm, resolveDirHandle } from './utils.ts'
-import { buildTree, keep, type PredNode } from '@struktoai/mirage-core'
+import { buildTree, keep, type PredNode, rstripSlash } from '@struktoai/mirage-core'
 
 export interface FindOptions {
   name?: string | null
@@ -138,6 +138,7 @@ export async function find(
 ): Promise<string[]> {
   const root = accessor.rootHandle
   const virtual = norm(p.stripPrefix)
+  const startName = rstripSlash(p.original).split('/').pop() ?? ''
   const results: string[] = []
   const tree =
     options.tree ??
@@ -171,7 +172,7 @@ export async function find(
       keep(
         {
           key: virtual,
-          name: virtual.slice(virtual.lastIndexOf('/') + 1),
+          name: startName || virtual.slice(virtual.lastIndexOf('/') + 1),
           kind: 'd',
           depth: 0,
           isEmpty: rootEmpty,

--- a/typescript/packages/core/src/commands/builtin/generic/find.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/find.ts
@@ -179,7 +179,9 @@ export async function findGeneric(
       const displayPath =
         root.original === '/'
           ? key
-          : rstripSlash(root.original) + key.slice(rootKey === '/' ? 0 : rootKey.length)
+          : rootKey === '/' && key === '/'
+            ? rstripSlash(root.original)
+            : rstripSlash(root.original) + key.slice(rootKey === '/' ? 0 : rootKey.length)
       rootMatches.push(displayPath)
     }
     matches.push(...rebaseDisplay(rootMatches, root.original, root.display))

--- a/typescript/packages/core/src/core/ram/find.ts
+++ b/typescript/packages/core/src/core/ram/find.ts
@@ -70,11 +70,11 @@ export function find(
     for (const key of accessor.store.files.keys()) candidates.push([key, 'f'])
   }
   if (options.type !== 'f') {
-    for (const key of accessor.store.dirs) if (key !== '/') candidates.push([key, 'd'])
+    for (const key of accessor.store.dirs) candidates.push([key, 'd'])
   }
   for (const [key, kind] of candidates) {
     if (key !== p && !key.startsWith(prefix)) continue
-    const depth = (key.match(/\//g) ?? []).length - baseDepth
+    const depth = key === '/' ? 0 : (key.match(/\//g) ?? []).length - baseDepth
     if (options.maxDepth !== null && options.maxDepth !== undefined && depth > options.maxDepth)
       continue
     const basename = key.slice(key.lastIndexOf('/') + 1)

--- a/typescript/packages/core/src/core/ram/find.ts
+++ b/typescript/packages/core/src/core/ram/find.ts
@@ -44,6 +44,7 @@ export function find(
   options: FindOptions = {},
 ): Promise<string[]> {
   const p = norm(path.stripPrefix)
+  const startName = rstripSlash(path.original).split('/').pop() ?? ''
   const prefix = rstripSlash(p) + '/'
   const baseDepth = p === '/' ? 0 : (p.match(/\//g) ?? []).length
   const results: string[] = []
@@ -77,7 +78,7 @@ export function find(
     const depth = key === '/' ? 0 : (key.match(/\//g) ?? []).length - baseDepth
     if (options.maxDepth !== null && options.maxDepth !== undefined && depth > options.maxDepth)
       continue
-    const basename = key.slice(key.lastIndexOf('/') + 1)
+    const basename = key === p ? startName : key.slice(key.lastIndexOf('/') + 1)
     let isEmpty: boolean | null = null
     if (empty) {
       isEmpty =

--- a/typescript/packages/core/src/core/s3/find.ts
+++ b/typescript/packages/core/src/core/s3/find.ts
@@ -26,6 +26,7 @@ export async function find(
 ): Promise<string[]> {
   const { ListObjectsV2Command } = await loadS3Module(accessor.config)
   const raw = rawPathOf(path)
+  const startName = rstripSlash(path.original).split('/').pop() ?? ''
   const pfx = s3Prefix(raw, accessor.config)
   const results: string[] = []
   const seen = { descendant: false, marker: false }
@@ -105,7 +106,7 @@ export async function find(
       keep(
         {
           key: rootKey,
-          name: rootKey.slice(rootKey.lastIndexOf('/') + 1),
+          name: rootKey === '/' ? startName : rootKey.slice(rootKey.lastIndexOf('/') + 1),
           kind: 'd',
           depth: 0,
           isEmpty: empty ? false : null,

--- a/typescript/packages/core/src/core/s3/find.ts
+++ b/typescript/packages/core/src/core/s3/find.ts
@@ -100,11 +100,7 @@ export async function find(
     } while (continuationToken !== undefined)
   })
   const rootKey = rstripSlash('/' + stripKeyPrefix(pfx, accessor.config)) || '/'
-  if (
-    rootKey !== '/' &&
-    (seen.descendant || seen.marker) &&
-    (options.maxDepth == null || options.maxDepth >= 0)
-  ) {
+  if ((seen.descendant || seen.marker) && (options.maxDepth == null || options.maxDepth >= 0)) {
     if (
       keep(
         {

--- a/typescript/packages/core/src/workspace/executor/fanout.ts
+++ b/typescript/packages/core/src/workspace/executor/fanout.ts
@@ -168,6 +168,14 @@ async function filterUnderPrefixes(
   return new TextEncoder().encode(outLines.join('\n') + '\n')
 }
 
+async function dropMountRootLine(stdout: ByteSource, mountRoot: string): Promise<Uint8Array> {
+  const data = await materialize(stdout)
+  const text = new TextDecoder().decode(data)
+  const outLines = text.split('\n').filter((line) => line !== '' && line !== mountRoot)
+  if (outLines.length === 0) return new Uint8Array()
+  return new TextEncoder().encode(outLines.join('\n') + '\n')
+}
+
 export async function fanOutTraversal(
   cmdName: string,
   paths: readonly PathSpec[],
@@ -233,6 +241,8 @@ export async function fanOutTraversal(
     }
     if (mount === primaryMount && descendantPrefixes.length > 0 && stdout !== null) {
       stdout = await filterUnderPrefixes(stdout, descendantPrefixes)
+    } else if (mount !== primaryMount && cmdName === 'find' && stdout !== null) {
+      stdout = await dropMountRootLine(stdout, rstripSlash(mount.prefix) || '/')
     }
     if (stdout !== null) {
       const data = await materialize(stdout)

--- a/typescript/packages/node/src/core/disk/find.test.ts
+++ b/typescript/packages/node/src/core/disk/find.test.ts
@@ -37,7 +37,7 @@ afterEach(() => {
 describe('core/disk/find', () => {
   it('returns all entries when no filters', async () => {
     const out = await find(accessor, spec('/'))
-    expect(out).toEqual(['/a.json', '/b.txt', '/sub', '/sub/c.json'])
+    expect(out).toEqual(['/', '/a.json', '/b.txt', '/sub', '/sub/c.json'])
   })
 
   it('filters by name pattern (*.json)', async () => {
@@ -52,7 +52,7 @@ describe('core/disk/find', () => {
 
   it('filters by type "d" (directories only)', async () => {
     const out = await find(accessor, spec('/'), { type: 'd' })
-    expect(out).toEqual(['/sub'])
+    expect(out).toEqual(['/', '/sub'])
   })
 
   it('respects maxDepth', async () => {

--- a/typescript/packages/node/src/core/disk/find.ts
+++ b/typescript/packages/node/src/core/disk/find.ts
@@ -141,7 +141,7 @@ export async function find(
       orNames: options.orNames,
       empty: options.empty,
     })
-  if (virtual !== '/' && (options.maxDepth == null || options.maxDepth >= 0)) {
+  if (options.maxDepth == null || options.maxDepth >= 0) {
     let isDir = false
     try {
       isDir = (await stat(full)).isDirectory()

--- a/typescript/packages/node/src/core/disk/find.ts
+++ b/typescript/packages/node/src/core/disk/find.ts
@@ -17,7 +17,7 @@ import { readdir, stat } from 'node:fs/promises'
 import path from 'node:path'
 import type { PathSpec } from '@struktoai/mirage-core'
 import { norm, resolveSafe } from './utils.ts'
-import { buildTree, type PredNode, keep } from '@struktoai/mirage-core'
+import { buildTree, type PredNode, keep, rstripSlash } from '@struktoai/mirage-core'
 
 export interface FindOptions {
   name?: string | null
@@ -127,6 +127,7 @@ export async function find(
   options: FindOptions = {},
 ): Promise<string[]> {
   const virtual = norm(p.stripPrefix)
+  const startName = rstripSlash(p.original).split('/').pop() ?? ''
   const full = resolveSafe(accessor.root, virtual)
   const baseDepth = virtual === '/' ? 0 : (virtual.match(/\//g) ?? []).length
   const results: string[] = []
@@ -161,7 +162,7 @@ export async function find(
       keep(
         {
           key: virtual,
-          name: virtual.slice(virtual.lastIndexOf('/') + 1),
+          name: startName || virtual.slice(virtual.lastIndexOf('/') + 1),
           kind: 'd',
           depth: 0,
           isEmpty: rootEmpty,

--- a/typescript/packages/node/src/core/redis/find.ts
+++ b/typescript/packages/node/src/core/redis/find.ts
@@ -66,12 +66,12 @@ export async function find(
   }
   if (options.type !== 'f') {
     for (const key of allDirs) {
-      if (key !== '/') candidates.push([key, 'd'])
+      candidates.push([key, 'd'])
     }
   }
   for (const [key, kind] of candidates) {
     if (key !== p && !key.startsWith(prefix)) continue
-    const depth = (key.match(/\//g) ?? []).length - baseDepth
+    const depth = key === '/' ? 0 : (key.match(/\//g) ?? []).length - baseDepth
     if (options.maxDepth !== null && options.maxDepth !== undefined && depth > options.maxDepth)
       continue
     const basename = key.slice(key.lastIndexOf('/') + 1)

--- a/typescript/packages/node/src/core/redis/find.ts
+++ b/typescript/packages/node/src/core/redis/find.ts
@@ -39,6 +39,7 @@ export async function find(
   options: FindOptions = {},
 ): Promise<string[]> {
   const p = norm(path.stripPrefix)
+  const startName = rstripSlash(path.original).split('/').pop() ?? ''
   const store = accessor.store
   const prefix = rstripSlash(p) + '/'
   const baseDepth = p === '/' ? 0 : (p.match(/\//g) ?? []).length
@@ -74,7 +75,7 @@ export async function find(
     const depth = key === '/' ? 0 : (key.match(/\//g) ?? []).length - baseDepth
     if (options.maxDepth !== null && options.maxDepth !== undefined && depth > options.maxDepth)
       continue
-    const basename = key.slice(key.lastIndexOf('/') + 1)
+    const basename = key === p ? startName : key.slice(key.lastIndexOf('/') + 1)
     let isEmpty: boolean | null = null
     if (empty) {
       isEmpty = kind === 'f' ? (await store.fileLen(key)) === 0 : !nonempty.has(key)

--- a/typescript/packages/node/src/core/ssh/find.test.ts
+++ b/typescript/packages/node/src/core/ssh/find.test.ts
@@ -35,7 +35,7 @@ describe('core/ssh/find', () => {
       ]),
     })
     const out = await find(accessor, spec('/'))
-    expect(out).toEqual(['/a.json', '/b.txt', '/sub', '/sub/c.json'])
+    expect(out).toEqual(['/', '/a.json', '/b.txt', '/sub', '/sub/c.json'])
   })
 
   it('filters by name pattern (*.json)', async () => {
@@ -66,7 +66,7 @@ describe('core/ssh/find', () => {
       ]),
     })
     const out = await find(accessor, spec('/'), { type: 'd' })
-    expect(out).toEqual(['/sub'])
+    expect(out).toEqual(['/', '/sub'])
   })
 
   it('respects maxDepth', async () => {
@@ -99,7 +99,7 @@ describe('core/ssh/find', () => {
       ]),
     })
     const out = await find(accessor, spec('/'), { maxSize: 5 })
-    expect(out).toEqual(['/one.txt', '/sub'])
+    expect(out).toEqual(['/', '/one.txt', '/sub'])
   })
 
   it('does not emit the start directory under -type f', async () => {

--- a/typescript/packages/node/src/core/ssh/find.ts
+++ b/typescript/packages/node/src/core/ssh/find.ts
@@ -172,7 +172,7 @@ export async function find(
       nameExclude: options.nameExclude,
       orNames: options.orNames,
     })
-  if (virtual !== '/' && (options.maxDepth == null || options.maxDepth >= 0)) {
+  if (options.maxDepth == null || options.maxDepth >= 0) {
     const st = await statRemote(accessor, joinRoot(accessor.config.root ?? '/', virtual))
     if (
       st !== null &&

--- a/typescript/packages/node/src/core/ssh/find.ts
+++ b/typescript/packages/node/src/core/ssh/find.ts
@@ -17,7 +17,7 @@ import type { PathSpec } from '@struktoai/mirage-core'
 import type { SSHAccessor } from '../../accessor/ssh.ts'
 import { isDirectoryAttrs, joinRoot, stripPrefix } from './utils.ts'
 import { norm } from '@struktoai/mirage-core'
-import { buildTree, keep, type PredNode } from '@struktoai/mirage-core'
+import { buildTree, keep, type PredNode, rstripSlash } from '@struktoai/mirage-core'
 
 export interface FindOptions {
   name?: string | null
@@ -155,6 +155,7 @@ export async function find(
   options: FindOptions = {},
 ): Promise<string[]> {
   const virtual = norm(stripPrefix(p))
+  const startName = rstripSlash(p.original).split('/').pop() ?? ''
   const results: string[] = []
   const baseDepth = (virtual.match(/\//g) ?? []).length
   const typeKind: 'f' | 'd' | null = isFileType(options.type)
@@ -179,7 +180,7 @@ export async function find(
       keep(
         {
           key: virtual,
-          name: virtual.slice(virtual.lastIndexOf('/') + 1),
+          name: startName || virtual.slice(virtual.lastIndexOf('/') + 1),
           kind: st.isDir ? 'd' : 'f',
           depth: 0,
           isEmpty: st.isDir ? false : st.size === 0,


### PR DESCRIPTION
## Summary

Closes #312. Implements the GNU/POSIX `find` alignment across every backend and both languages (previously this PR only carried tests; the implementation now lives here).

### Bugs fixed
- **B1 — start path:** emit the search root at depth 0 (subject to predicates) in the generic walker and each per-backend find: ram/disk/redis/s3/onedrive/ssh/nextcloud (py) and ram/disk/opfs/redis/s3/ssh (ts). Fixes bare `find <dir>`, `-type d` on the root, `-maxdepth 0`, `-mindepth 0`, and matching the start by `-name`. Also fixes root-key rebasing in the generic find command.
- **B2 — `-empty`** returns only empty files/dirs.
- **B3 — `-not`** negation returns the complement set.
- **B4 — unknown/unsupported predicates** (`-regex`, `-boguspredicate`, typos) are a hard error (exit 1, `find: unknown predicate '...'`) instead of silently matching all entries.
- **Fan-out:** a descendant mount's own root line is dropped; the mount point is synthesized centrally with its display name and the full predicate tree, so `find /data -not -name ram` correctly excludes the `ram` child mount.

### Tests
- Regenerated `integ/truth.txt` (start path now appears in the 5 cases where the root matches the predicate + two unknown-predicate error cases).
- `integ/cases.{py,ts}`: unknown-predicate error cases.
- Unit coverage for `-empty`, `-not`, unknown predicates, start-path emission, and per-backend root inclusion.

### Verification
- `integ` RAM/disk/redis and TS RAM produce byte-identical output matching the regenerated truth.
- Full PY find/fanout unit tests and TS core/node/browser suites pass.