### PR TITLE
fix: stat-guard ssh du for file operands

### DIFF
--- a/python/mirage/core/ssh/du.py
+++ b/python/mirage/core/ssh/du.py
@@ -16,17 +16,23 @@ import asyncssh
 
 from mirage.accessor.ssh import SSHAccessor
 from mirage.core.ssh._client import _abs
-from mirage.types import PathSpec
+from mirage.core.ssh.stat import stat
+from mirage.types import FileType, PathSpec
 
 
 async def du(accessor: SSHAccessor, path: PathSpec) -> int:
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
-    if isinstance(path, PathSpec):
-        path = path.strip_prefix
+    try:
+        info = await stat(accessor, path)
+    except FileNotFoundError:
+        info = None
+    if info is not None and info.type != FileType.DIRECTORY:
+        return info.size or 0
+    target = path.strip_prefix if isinstance(path, PathSpec) else path
     config = accessor.config
     sftp = await accessor.sftp()
-    return await _du_walk(sftp, _abs(config, path))
+    return await _du_walk(sftp, _abs(config, target))
 
 
 async def du_all(
@@ -35,12 +41,17 @@ async def du_all(
 ) -> tuple[list[tuple[str, int]], int]:
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
-    if isinstance(path, PathSpec):
-        path = path.strip_prefix
+    try:
+        info = await stat(accessor, path)
+    except FileNotFoundError:
+        info = None
+    if info is not None and info.type != FileType.DIRECTORY:
+        return [], info.size or 0
+    target = path.strip_prefix if isinstance(path, PathSpec) else path
     config = accessor.config
     sftp = await accessor.sftp()
     entries: list[tuple[str, int]] = []
-    total = await _du_walk_all(sftp, config, path, entries)
+    total = await _du_walk_all(sftp, config, target, entries)
     entries.sort()
     return entries, total
 


### PR DESCRIPTION
## What

`du <file>` / `du_all` on ssh ran `sftp.readdir()` on a file (which raises), so it produced empty output instead of the file's size. Stat-guard both helpers so a non-directory operand returns its own size, mirroring the existing nextcloud/onedrive/sharepoint/hf file-case fix.

## Why this regressed on main

#378 removed the cache-mount redirect, which had been masking this latent file-case bug for ssh (the redirect served `du <file>` from RAM). The du-fix in #378 stat-guarded the other remote backends but **missed ssh** (s3 happens to work via prefix-listing; disk/ram/redis are local and never used the redirect).

**Why CI didn't catch it pre-merge:** `integ-ssh` is path-filtered to ssh-specific files; #378 only touched the shared generic/cache/registry layer, so the job was skipped on the PR and only ran (unconditionally) on push to main. Follow-up worth considering: trigger all integ jobs when the shared read/cache/generic layer changes.

## Coverage

`integ/ssh.py` (`du_multi`, `nl_pin_du`) now matches the shared `truth.txt`. (No SFTP-mock unit fixture exists for ssh; the integ is the end-to-end check.)

## Parity note

TS ssh still has the `allCached` redirect masking the same latent bug; when that redirect is removed in the TS port, TS ssh du will need the same stat-guard.