### PR TITLE
refactor: hide the file cache as a store (not a mount)

### DIFF
--- a/python/mirage/workspace/mount/registry.py
+++ b/python/mirage/workspace/mount/registry.py
@@ -292,20 +292,16 @@ class MountRegistry:
         if mount is None:
             return None
 
-        default = self._default_mount
         resolved = mount.resolve_command(cmd_name)
-        # Warm reads are served in place by with_read_cache (content + the
-        # size a render-dependent backend can't compute itself), so a command
-        # stays on its real mount and keeps its safeguards/custom handlers
-        # rather than being redirected to the cache mount. Under ALWAYS we
-        # still evict stale cached entries here so the read-through serves
-        # fresh bytes.
-        if (default is not None and path_scopes and resolved is not None
-                and not resolved.write
-                and isinstance(default.resource, FileCacheMixin)
+        # Warm reads are served in place by with_read_cache, so a read-only
+        # command stays on its real mount. The cache is a hidden store (not a
+        # mount); under ALWAYS we evict stale entries from it here so the
+        # read-through serves fresh bytes.
+        if (self._file_cache is not None and path_scopes
+                and resolved is not None and not resolved.write
                 and mount.resource.caches_reads
                 and self._consistency == ConsistencyPolicy.ALWAYS):
-            await self._evict_stale(mount, default.resource, path_scopes)
+            await self._evict_stale(mount, self._file_cache, path_scopes)
 
         return mount
 
@@ -340,6 +336,10 @@ class MountRegistry:
     @property
     def default_mount(self) -> MountEntry | None:
         return self._default_mount
+
+    @property
+    def file_cache(self) -> FileCacheMixin | None:
+        return self._file_cache
 
     def mounts(self) -> list[MountEntry]:
         return list(self._mounts)

--- a/python/mirage/workspace/provision/command.py
+++ b/python/mirage/workspace/provision/command.py
@@ -96,9 +96,7 @@ async def handle_command_provision(
     if not result.command:
         result.command = cmd_str
 
-    default = registry.default_mount
-    cache = default.resource if default is not None else None
-    hits = await _check_cache_hits(cache, parts)
+    hits = await _check_cache_hits(registry.file_cache, parts)
     if hits > 0:
         result.cache_hits = hits
         result.cache_read_low = result.network_read_low

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -42,6 +42,7 @@ from mirage.ops.os_patch import make_os_module
 from mirage.provision import ProvisionResult
 from mirage.resource.base import BaseResource
 from mirage.resource.history import HISTORY_PREFIX, HistoryViewResource
+from mirage.resource.ram import RAMResource
 from mirage.shell.job_table import JobTable
 from mirage.shell.parse import find_syntax_error, parse
 from mirage.types import (DEFAULT_AGENT_ID, DEFAULT_SESSION_ID,
@@ -104,7 +105,7 @@ class Workspace:
             max_drain = cache.max_drain_bytes if cache is not None else None
             self._cache = RAMFileCacheStore(cache_limit=limit,
                                             max_drain_bytes=max_drain)
-        self._registry.set_default_mount(self._cache)
+        self._registry.set_default_mount(RAMResource())
         self._locked_paths: set[str] = set()
         self._closed = False
         self._drift_policy: DriftPolicy = DriftPolicy.OFF

--- a/python/tests/workspace/test_cache_mount.py
+++ b/python/tests/workspace/test_cache_mount.py
@@ -15,18 +15,14 @@
 import pytest
 
 from mirage.commands.registry import command
-from mirage.commands.spec import SPECS, CommandSpec, Operand, OperandKind
+from mirage.commands.spec import SPECS
 from mirage.core.disk.glob import resolve_glob
 from mirage.core.disk.read import read_bytes
 from mirage.io.types import IOResult
-from mirage.ops.registry import op
 from mirage.resource.disk import DiskResource
 from mirage.resource.ram import RAMResource
 from mirage.types import ConsistencyPolicy, MountMode, PathSpec
 from mirage.workspace import Workspace
-from mirage.workspace.mount import MountEntry
-
-ECHO_SPEC = CommandSpec(positional=(Operand(kind=OperandKind.PATH), ))
 
 
 @command("stat", resource="disk", spec=SPECS["stat"], filetype=".zzz")
@@ -44,126 +40,44 @@ async def stat_zzz_disk(
         reads={paths[0].strip_prefix: raw}, cache=[paths[0].strip_prefix])
 
 
-@command("stat", resource="ram", spec=SPECS["stat"], filetype=".zzz")
-async def stat_zzz_ram(
-    accessor,
-    paths: list[PathSpec],
-    *texts: str,
-    stdin=None,
-    **_extra: object,
-) -> tuple[bytes | None, IOResult]:
-    return b"CUSTOM RAM STAT\n", IOResult()
-
-
-@command("echopath", resource="ram", spec=ECHO_SPEC)
-async def echopath(
-    accessor,
-    paths: list[PathSpec],
-    *texts: str,
-    stdin=None,
-    **_extra: object,
-) -> tuple[bytes | None, IOResult]:
-    if not paths:
-        return None, IOResult(exit_code=1,
-                              stderr=b"echopath: missing operand\n")
-    return f"echopath:{paths[0].original}".encode(), IOResult()
-
-
-@op("hello_op", resource="ram")
-async def hello_op(accessor, path, *args, **kwargs) -> str:
-    return f"hello:{path}"
-
-
-def test_cache_mount_is_default_mount():
-    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
-    assert isinstance(ws.cache_mount, MountEntry)
-    assert ws.cache_mount is ws._registry.default_mount
-    assert ws.cache_mount.prefix == "/_default/"
-
-
-def test_cache_mount_resource_is_cache():
-    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
-    assert ws.cache_mount.resource is ws.cache
-
-
-def test_cache_mount_register_command():
-    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
-    ws.cache_mount.register_fns([echopath])
-    cmd = ws.cache_mount.resolve_command("echopath")
-    assert cmd is not None
-    assert cmd.fn is echopath
-
-
-def test_cache_mount_register_op():
-    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
-    ws.cache_mount.register_fns([hello_op])
-    assert ("hello_op", None) in ws.cache_mount._ops
-
-
-def test_cache_mount_rejects_wrong_resource_kind():
-    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
-
-    @command("disk_only", resource="disk", spec=ECHO_SPEC)
-    async def disk_only(accessor, paths, *texts, stdin=None, **_extra):
-        return None, IOResult()
-
-    with pytest.raises(ValueError, match="ram"):
-        ws.cache_mount.register_fns([disk_only])
-
-
 @pytest.mark.asyncio
-async def test_custom_stat_after_cache_promotion(tmp_path):
-    """After the first stat caches the bytes, the dispatcher reroutes the
-    second stat to cache_mount. Without the ram variant registered there,
-    the second stat would fall through to built-in stat and lose the custom
-    output."""
-    (tmp_path / "example.zzz").write_bytes(b"payload")
-    disk = DiskResource(root=str(tmp_path))
-    disk.caches_reads = True
-    ws = Workspace({"/": disk}, mode=MountMode.READ)
-    ws.mount("/").register_fns([stat_zzz_disk])
-    ws.cache_mount.register_fns([stat_zzz_ram])
-
-    first = await ws.execute("stat /example.zzz")
-    second = await ws.execute("stat /example.zzz")
-    first_text = (await first.stdout_str())
-    second_text = (await second.stdout_str())
-    assert "CUSTOM DISK STAT" in first_text
-    assert "CUSTOM" in second_text, (
-        "second stat after cache promotion lost custom handler "
-        "(cache_mount missing the ram variant?)")
+async def test_cache_decoupled_from_default_mount():
+    """The file cache is a hidden store reached via ``registry.file_cache``,
+    not the default mount's resource. The default mount is a plain empty
+    anchor (used only as the neutral base for root listing and arg-less
+    command resolution) and never holds the cache."""
+    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
+    assert ws._registry.file_cache is ws.cache
+    assert ws._registry.default_mount.resource is not ws.cache
+    assert ws._registry.default_mount.resource.caches_reads is False
 
 
 @pytest.mark.asyncio
 async def test_warm_read_stays_on_real_mount(tmp_path):
-    """Read-through: the second (cached) read must still run the REAL
-    mount's command, not reroute to cache_mount. Today the dispatcher
-    redirects warm reads to cache_mount, so the custom disk handler is
-    lost and built-in RAM stat answers instead. With read-through the
-    cached bytes are served while the command stays on the real mount,
-    so no double-registration on cache_mount is needed."""
+    """Read-through: the second (cached) read still runs the REAL mount's
+    command. The cache is a hidden store, not a mount, so a warm read serves
+    the cached bytes while the command stays on its real mount and keeps its
+    custom handler."""
     (tmp_path / "example.zzz").write_bytes(b"payload")
     disk = DiskResource(root=str(tmp_path))
     disk.caches_reads = True
     ws = Workspace({"/": disk}, mode=MountMode.READ)
     ws.mount("/").register_fns([stat_zzz_disk])
-    # Intentionally NOT registering stat_zzz_ram on cache_mount.
 
     first = await ws.execute("stat /example.zzz")
     second = await ws.execute("stat /example.zzz")
     assert "CUSTOM DISK STAT" in (await first.stdout_str())
     assert "CUSTOM DISK STAT" in (await second.stdout_str()), (
-        "warm read rerouted to cache_mount and lost the real mount's "
-        "custom handler; read-through should keep it on the real mount")
+        "warm read lost the real mount's custom handler; read-through should "
+        "keep the command on the real mount")
 
 
 @pytest.mark.asyncio
 async def test_cross_mount_read_serves_cache(tmp_path):
-    """A cross-mount read relays each operand through ``execute_op``. The
-    op-layer read-through serves a warm operand from cache there, since the
-    consumer's cache-aware wrap is inert at the cross-mount command level
-    (no single mount manager active). Proven under LAZY by mutating the file
-    out-of-band: the cross-mount read still returns the cached v1."""
+    """A cross-mount read relays each operand through ``execute_op``, and the
+    op-layer read-through serves a warm operand from cache. Proven under LAZY
+    by mutating the file out-of-band: the cross-mount read still returns the
+    cached v1."""
     (tmp_path / "a.txt").write_bytes(b"v1\n")
     disk = DiskResource(root=str(tmp_path))
     disk.caches_reads = True
@@ -179,20 +93,3 @@ async def test_cross_mount_read_serves_cache(tmp_path):
     out = await (await ws.execute("cat /d/a.txt /r/b.txt")).stdout_str()
     assert "v1" in out and "v2" not in out, (
         f"cross-mount read did not serve the warm operand from cache: {out!r}")
-
-
-def test_set_default_mount_auto_registers_resource_ops():
-    """Symmetry fix: set_default_mount() now mirrors mount() and pulls in
-    resource.ops_list() the same way."""
-    res = RAMResource()
-    ws = Workspace({"/data/": res}, mode=MountMode.WRITE)
-    user_op_keys = set(ws.mount("/data/")._ops.keys())
-    cache_op_keys = set(ws.cache_mount._ops.keys())
-    cache_resource_op_names = {
-        ro.name
-        for ro in ws.cache_mount.resource.ops_list()
-    }
-    for name in cache_resource_op_names:
-        assert (name,
-                None) in cache_op_keys, f"{name!r} missing on cache mount"
-    assert user_op_keys.issubset(cache_op_keys) or len(user_op_keys) == 0


### PR DESCRIPTION
## What

The read cache used to **be** the `/_default` mount's resource. This decouples them: the default mount is now a plain empty `RAMResource`, and the cache is a **hidden store** reached via `registry.file_cache`. Cache-hit accounting and ALWAYS-eviction reference the hidden cache directly instead of `default.resource`.

## Scope correction

Fully *removing* `/_default` isn't feasible without a larger virtual-root refactor: `ls /` (root listing) and arg-less command resolution need a **neutral empty anchor mount** to run against. Without it, `ls /` falls back to the first real mount (`/.bash_history`) and produces wrong output (this is the integ failure that surfaced). So the anchor stays — but it is now **empty and cache-free**; the cache no longer has any mount identity.

## Why it's safe / minimal

Caching is transparent, so command output is unchanged — full Python suite green (minus the pre-existing jina net flake) and every offline integ matches truth: **s3** (20 warm-serve cases), **ssh**, **dify**, **onedrive**, **ram**, **disk**, **history**, **cross_commands**. Diff is 4 files (registry, workspace, provision, test_cache_mount).

## Follow-up

Truly removing the `/_default` namespace = a virtual-root refactor (a root resource at `/` that lists child mounts and rejects real paths), tracked separately. Python-only; TS still has its `allCached` redirect + cache-as-mount.