### PR TITLE
refactor: make / a real, overridable virtual-root mount

### DIFF
--- a/.github/workflows/test_integ.yml
+++ b/.github/workflows/test_integ.yml
@@ -203,6 +203,9 @@ jobs:
       - name: Run cross-mount commands (ram -> ram/redis/s3 via moto)
         run: ./python/.venv/bin/python integ/cross_commands.py
 
+      - name: Run virtual-root mount switching (ram/disk/yaml)
+        run: ./python/.venv/bin/python integ/root.py
+
   integ-ts:
     needs: changes
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.ts == 'true') }}

--- a/docs/home/bash.mdx
+++ b/docs/home/bash.mdx
@@ -145,7 +145,7 @@ A session can be created with an explicit allowlist of mount prefixes. Any comma
 
 This is a soft boundary, enforced inside the daemon process, not an OS or process-level isolation. Use it to shrink the blast radius of prompt-injection in multi-agent workspaces: a Slack-only agent cannot pivot to read `/linear`, `/github`, or any other mount it was not given.
 
-The check fires for every code path that reaches a mount: shell commands (`cat`, `ls`, ...), redirects (`>`, `<`), cross-mount `cp`/`mv`, `wget -O`, `curl -o`, command substitution `$(...)`, subshells `(...)`, pipes, `&&`/`||` chains, background jobs, and the programmatic `ws.ops.read/write/...` API. Two infrastructure prefixes are always allowed regardless of the allowlist: the history view (`/.bash_history`, which the `history` builtin and the GNU histfile render from) and the cache mount (`/_default`, where stateless text-processing commands like `wc` live).
+The check fires for every code path that reaches a mount: shell commands (`cat`, `ls`, ...), redirects (`>`, `<`), cross-mount `cp`/`mv`, `wget -O`, `curl -o`, command substitution `$(...)`, subshells `(...)`, pipes, `&&`/`||` chains, background jobs, and the programmatic `ws.ops.read/write/...` API. Two infrastructure prefixes are always allowed regardless of the allowlist: the history view (`/.bash_history`, which the `history` builtin and the GNU histfile render from) and the virtual root (`/`, where stateless text-processing commands like `wc` resolve when given no path).
 
 <Tabs>
   <Tab title="Python" icon="/images/python-logo.svg">

--- a/examples/python/sharepoint/sharepoint.py
+++ b/examples/python/sharepoint/sharepoint.py
@@ -91,6 +91,9 @@ def build_tests(base: str, test_dir: str, test_file: str):
         ("rm link", f'rm "{test_dir}/link.txt"'),
         ("rm moved", f'rm "{test_dir}/moved.txt"'),
         ("cat > write2", f'echo "second file" > "{test_dir}/file2.txt"'),
+        ("sed -f", f"echo 's/hello/HELLO/' | tee \"{test_dir}/prog.sed\""
+         f" > /dev/null && sed -f \"{test_dir}/prog.sed\" \"{test_file}\""
+         f" && rm \"{test_dir}/prog.sed\""),
         ("grep -r", f'grep -r hello "{test_dir}"'),
         ("grep -rl", f'grep -rl hello "{test_dir}"'),
         ("find -name", f'find "{test_dir}" -name "*.txt"'),

--- a/integ/cases.py
+++ b/integ/cases.py
@@ -366,6 +366,19 @@ CASES: list[tuple[str, str]] = [
     # Multiple -e expressions apply in sequence; -e with a file argument.
     ("sed_multi_e", "echo a | sed -e 's/a/b/' -e 's/b/c/'"),
     ("sed_e_file", "sed -e s/world/EARTH/ /data/a.txt"),
+    # -f reads the script from a file (script lives on the data mount). The
+    # script file is created and removed inside the case so directory
+    # listings stay unpolluted.
+    ("sed_f_file", "echo 's/world/EARTH/' | tee /data/prog.sed > /dev/null "
+     "&& sed -f /data/prog.sed /data/a.txt && rm /data/prog.sed"),
+    ("sed_f_multi",
+     "echo 's/world/EARTH/;s/foo/FOO/' | tee /data/prog.sed > /dev/null "
+     "&& sed -f /data/prog.sed /data/a.txt && rm /data/prog.sed"),
+    ("sed_ef_combined", "echo 's/foo/FOO/' | tee /data/prog.sed > /dev/null "
+     "&& sed -e s/world/EARTH/ -f /data/prog.sed /data/a.txt "
+     "&& rm /data/prog.sed"),
+    ("sed_f_stdin", "echo 's/world/EARTH/' | tee /data/prog.sed > /dev/null "
+     "&& cat /data/a.txt | sed -f /data/prog.sed && rm /data/prog.sed"),
     # Broader GNU sed surface: & whole-match, s flags, addresses, hold/branch,
     # multi-command, alt delimiters, a/i/c forms.
     ("sed_amp", "sed 's/world/[&]/' /data/a.txt"),

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -298,6 +298,25 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
   // Multiple -e expressions apply in sequence; -e with a file argument.
   ['sed_multi_e', "echo a | sed -e 's/a/b/' -e 's/b/c/'"],
   ['sed_e_file', 'sed -e s/world/EARTH/ /data/a.txt'],
+  // -f reads the script from a file (script lives on the data mount). The
+  // script file is created and removed inside the case so directory listings
+  // stay unpolluted.
+  [
+    'sed_f_file',
+    "echo 's/world/EARTH/' | tee /data/prog.sed > /dev/null && sed -f /data/prog.sed /data/a.txt && rm /data/prog.sed",
+  ],
+  [
+    'sed_f_multi',
+    "echo 's/world/EARTH/;s/foo/FOO/' | tee /data/prog.sed > /dev/null && sed -f /data/prog.sed /data/a.txt && rm /data/prog.sed",
+  ],
+  [
+    'sed_ef_combined',
+    "echo 's/foo/FOO/' | tee /data/prog.sed > /dev/null && sed -e s/world/EARTH/ -f /data/prog.sed /data/a.txt && rm /data/prog.sed",
+  ],
+  [
+    'sed_f_stdin',
+    "echo 's/world/EARTH/' | tee /data/prog.sed > /dev/null && cat /data/a.txt | sed -f /data/prog.sed && rm /data/prog.sed",
+  ],
   // Broader GNU sed surface: & whole-match, s flags, addresses, hold/branch,
   // multi-command, alt delimiters, a/i/c forms.
   ['sed_amp', "sed 's/world/[&]/' /data/a.txt"],

--- a/integ/mongodb.py
+++ b/integ/mongodb.py
@@ -190,8 +190,6 @@ async def _run_follow(ws: Workspace, client: AsyncMongoClient) -> None:
 def _set_cat_safeguard(ws: Workspace, max_lines: int) -> None:
     sg = CommandSafeguard(max_lines=max_lines)
     mounts = list(ws._registry._mounts)
-    if ws._registry.root_mount is not None:
-        mounts.append(ws._registry.root_mount)
     for m in mounts:
         m.command_safeguards["cat"] = sg
 

--- a/integ/mongodb.py
+++ b/integ/mongodb.py
@@ -190,8 +190,8 @@ async def _run_follow(ws: Workspace, client: AsyncMongoClient) -> None:
 def _set_cat_safeguard(ws: Workspace, max_lines: int) -> None:
     sg = CommandSafeguard(max_lines=max_lines)
     mounts = list(ws._registry._mounts)
-    if ws._registry.default_mount is not None:
-        mounts.append(ws._registry.default_mount)
+    if ws._registry.root_mount is not None:
+        mounts.append(ws._registry.root_mount)
     for m in mounts:
         m.command_safeguards["cat"] = sg
 

--- a/integ/nextcloud.py
+++ b/integ/nextcloud.py
@@ -142,8 +142,6 @@ async def _measure(ws: Workspace, name: str, cmd: str) -> None:
 def _set_cat_safeguard(ws: Workspace, max_lines: int) -> None:
     sg = CommandSafeguard(max_lines=max_lines)
     mounts = list(ws._registry._mounts)
-    if ws._registry.root_mount is not None:
-        mounts.append(ws._registry.root_mount)
     for m in mounts:
         m.command_safeguards["cat"] = sg
 

--- a/integ/nextcloud.py
+++ b/integ/nextcloud.py
@@ -142,8 +142,8 @@ async def _measure(ws: Workspace, name: str, cmd: str) -> None:
 def _set_cat_safeguard(ws: Workspace, max_lines: int) -> None:
     sg = CommandSafeguard(max_lines=max_lines)
     mounts = list(ws._registry._mounts)
-    if ws._registry.default_mount is not None:
-        mounts.append(ws._registry.default_mount)
+    if ws._registry.root_mount is not None:
+        mounts.append(ws._registry.root_mount)
     for m in mounts:
         m.command_safeguards["cat"] = sg
 

--- a/integ/onedrive.py
+++ b/integ/onedrive.py
@@ -160,8 +160,6 @@ async def _run_exit(ws: Workspace, name: str, cmd: str) -> None:
 def _set_cat_safeguard(ws: Workspace, max_lines: int) -> None:
     sg = CommandSafeguard(max_lines=max_lines)
     mounts = list(ws._registry._mounts)
-    if ws._registry.root_mount is not None:
-        mounts.append(ws._registry.root_mount)
     for m in mounts:
         m.command_safeguards["cat"] = sg
 

--- a/integ/onedrive.py
+++ b/integ/onedrive.py
@@ -160,8 +160,8 @@ async def _run_exit(ws: Workspace, name: str, cmd: str) -> None:
 def _set_cat_safeguard(ws: Workspace, max_lines: int) -> None:
     sg = CommandSafeguard(max_lines=max_lines)
     mounts = list(ws._registry._mounts)
-    if ws._registry.default_mount is not None:
-        mounts.append(ws._registry.default_mount)
+    if ws._registry.root_mount is not None:
+        mounts.append(ws._registry.root_mount)
     for m in mounts:
         m.command_safeguards["cat"] = sg
 

--- a/integ/postgres.py
+++ b/integ/postgres.py
@@ -107,8 +107,8 @@ async def _run(ws: Workspace, name: str, cmd: str) -> None:
 def _set_cat_safeguard(ws: Workspace, max_lines: int) -> None:
     sg = CommandSafeguard(max_lines=max_lines)
     mounts = list(ws._registry._mounts)
-    if ws._registry.default_mount is not None:
-        mounts.append(ws._registry.default_mount)
+    if ws._registry.root_mount is not None:
+        mounts.append(ws._registry.root_mount)
     for m in mounts:
         m.command_safeguards["cat"] = sg
 

--- a/integ/postgres.py
+++ b/integ/postgres.py
@@ -107,8 +107,6 @@ async def _run(ws: Workspace, name: str, cmd: str) -> None:
 def _set_cat_safeguard(ws: Workspace, max_lines: int) -> None:
     sg = CommandSafeguard(max_lines=max_lines)
     mounts = list(ws._registry._mounts)
-    if ws._registry.root_mount is not None:
-        mounts.append(ws._registry.root_mount)
     for m in mounts:
         m.command_safeguards["cat"] = sg
 

--- a/integ/root.py
+++ b/integ/root.py
@@ -1,0 +1,152 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import os
+import sys
+import tempfile
+
+from mirage import MountMode, Workspace
+from mirage.config import load_config
+from mirage.resource.disk import DiskResource
+from mirage.resource.ram import RAMResource
+
+_fail = 0
+
+
+def check(label: str, cond: bool) -> None:
+    global _fail
+    if cond:
+        print(f"OK   {label}")
+    else:
+        _fail += 1
+        print(f"FAIL {label}")
+
+
+async def _out(ws: Workspace, cmd: str, stdin: bytes | None = None) -> str:
+    res = await ws.execute(cmd, stdin=stdin)
+    return await res.stdout_str()
+
+
+async def default_root_is_ram() -> None:
+    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
+    root = ws._registry.root_mount
+    check("default: root mounted at /", root is not None
+          and root.prefix == "/")
+    check("default: root backed by ram",
+          type(root.resource).__name__ == "RAMResource")
+    check("default: root is a normal mount entry", root
+          in ws._registry.mounts())
+    ls = await _out(ws, "ls /")
+    check("default: ls / lists child mounts", "data" in ls and "dev" in ls)
+    check("default: ls / hides dotfile mounts", ".bash_history" not in ls)
+    await ws.execute("echo scratch > /note.txt")
+    check("default: write to unmounted / lands on root scratch",
+          (await _out(ws, "cat /note.txt")).strip() == "scratch")
+    wc = await _out(ws, "wc -c", stdin=b"abcd")
+    check("default: arg-less command resolves at root", wc.strip() == "4")
+    await ws.close()
+
+
+async def ram_root_override() -> None:
+    ws = Workspace({
+        "/": RAMResource(),
+        "/sub/": RAMResource()
+    },
+                   mode=MountMode.WRITE)
+    root = ws._registry.root_mount
+    check(
+        "ram-root: / is the user mount (not duplicated)", root is not None
+        and root.prefix == "/"
+        and len([m for m in ws._registry.mounts() if m.prefix == "/"]) == 1)
+    await ws.execute("echo hi > /top.txt")
+    await ws.execute("echo deep > /sub/inner.txt")
+    check("ram-root: read file written at root",
+          (await _out(ws, "cat /top.txt")).strip() == "hi")
+    ls = await _out(ws, "ls /")
+    check("ram-root: ls / shows root file and child mount", "top.txt" in ls
+          and "sub" in ls)
+    check("ram-root: read through child mount",
+          (await _out(ws, "cat /sub/inner.txt")).strip() == "deep")
+    await ws.close()
+
+
+async def disk_root_override() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Workspace({"/": DiskResource(root=tmp)}, mode=MountMode.WRITE)
+        root = ws._registry.root_mount
+        check("disk-root: root backed by disk",
+              type(root.resource).__name__ == "DiskResource")
+        await ws.execute("echo persisted > /file.txt")
+        check("disk-root: read file back through root",
+              (await _out(ws, "cat /file.txt")).strip() == "persisted")
+        on_disk = os.path.join(tmp, "file.txt")
+        check("disk-root: write at / persisted to the real disk path",
+              os.path.exists(on_disk))
+        if os.path.exists(on_disk):
+            with open(on_disk) as f:
+                check("disk-root: on-disk content matches",
+                      f.read().strip() == "persisted")
+        await ws.close()
+
+
+async def yaml_controls_root() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg = load_config(
+            {"mounts": {
+                "/": {
+                    "resource": "disk",
+                    "config": {
+                        "root": tmp
+                    }
+                }
+            }})
+        kwargs = cfg.to_workspace_kwargs()
+        check("yaml: '/' mount present in resources", "/"
+              in kwargs["resources"])
+        ws = Workspace(**kwargs)
+        root = ws._registry.root_mount
+        check("yaml: root overridden to disk via config",
+              type(root.resource).__name__ == "DiskResource")
+        await ws.execute("echo fromyaml > /y.txt")
+        check("yaml: write at / persisted to disk",
+              os.path.exists(os.path.join(tmp, "y.txt")))
+        await ws.close()
+
+    ws = Workspace(**load_config({
+        "mounts": {
+            "/data": {
+                "resource": "ram"
+            }
+        }
+    }).to_workspace_kwargs())
+    root = ws._registry.root_mount
+    check("yaml: no '/' mount falls back to ram root",
+          type(root.resource).__name__ == "RAMResource")
+    await ws.close()
+
+
+async def main() -> None:
+    await default_root_is_ram()
+    await ram_root_override()
+    await disk_root_override()
+    await yaml_controls_root()
+    if _fail:
+        print(f"\n{_fail} check(s) failed")
+        sys.exit(1)
+    print("\nroot mount OK")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integ/s3.py
+++ b/integ/s3.py
@@ -253,8 +253,6 @@ async def _run_exit(ws: Workspace, name: str, cmd: str) -> None:
 def _set_cat_safeguard(ws: Workspace, max_lines: int) -> None:
     sg = CommandSafeguard(max_lines=max_lines)
     mounts = list(ws._registry._mounts)
-    if ws._registry.root_mount is not None:
-        mounts.append(ws._registry.root_mount)
     for m in mounts:
         m.command_safeguards["cat"] = sg
 

--- a/integ/s3.py
+++ b/integ/s3.py
@@ -253,8 +253,8 @@ async def _run_exit(ws: Workspace, name: str, cmd: str) -> None:
 def _set_cat_safeguard(ws: Workspace, max_lines: int) -> None:
     sg = CommandSafeguard(max_lines=max_lines)
     mounts = list(ws._registry._mounts)
-    if ws._registry.default_mount is not None:
-        mounts.append(ws._registry.default_mount)
+    if ws._registry.root_mount is not None:
+        mounts.append(ws._registry.root_mount)
     for m in mounts:
         m.command_safeguards["cat"] = sg
 

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -980,6 +980,30 @@ EARTH
 foo
 bar
 baz
+=== sed_f_file ===
+hello
+EARTH
+foo
+bar
+baz
+=== sed_f_multi ===
+hello
+EARTH
+FOO
+bar
+baz
+=== sed_ef_combined ===
+hello
+EARTH
+FOO
+bar
+baz
+=== sed_f_stdin ===
+hello
+EARTH
+foo
+bar
+baz
 === sed_amp ===
 hello
 [world]
@@ -1795,8 +1819,8 @@ disptree/d
 disptree/d/y.txt
 disptree/x.txt
 === history_last_two ===
-473  (cd /data && ls -R disptree)
-474  (cd /data && find disptree)
+477  (cd /data && ls -R disptree)
+478  (cd /data && find disptree)
 === bash_history_tail ===
 (cd /data && ls -R disptree)
 (cd /data && find disptree)

--- a/integ/truth_history.txt
+++ b/integ/truth_history.txt
@@ -96,5 +96,5 @@ ops_have_source=True
 s2_after_clear=['history', 'synthetic entry one', 'history -s synthetic entry one', 'history 3', 'history -d 1', 'history 3']
 default_first=echo marker-one
 === observer_not_mounted ===
-mounts=['/.bash_history/', '/data/', '/dev/']
+mounts=['/', '/.bash_history/', '/data/', '/dev/']
 recorder_mounted=False

--- a/python/mirage/commands/builtin/generic/sed_command.py
+++ b/python/mirage/commands/builtin/generic/sed_command.py
@@ -33,10 +33,14 @@ from mirage.types import PathSpec
 
 def _positional_as_paths(texts: tuple[str, ...],
                          cwd: PathSpec | None) -> list[PathSpec]:
-    """Treat positional operands as files (GNU rule when -e gives the script).
+    """Treat positional operands as files (GNU rule when -e/-f give script).
 
     The arg parser routes the first bare arg into the positional ``text``
     (script) slot, so recover it as a path operand carrying the mount prefix.
+
+    Args:
+        texts (tuple[str, ...]): positional operands that are really files.
+        cwd (PathSpec | None): current directory for relative resolution.
     """
     base = cwd.original if cwd is not None else "/"
     prefix = cwd.prefix if cwd is not None else ""
@@ -61,6 +65,31 @@ MakeRead = Callable[[object, IndexCacheStore | None, list[PathSpec]], Callable]
 GlobWhen = Callable[[object, IndexCacheStore | None], bool]
 
 
+async def _scripts_from_files(
+    make_read: MakeRead,
+    accessor: object,
+    index: IndexCacheStore | None,
+    f_files: list[PathSpec],
+) -> list[str]:
+    """Read each -f script file through the backend reader.
+
+    Args:
+        make_read (MakeRead): builds the backend read_bytes callable.
+        accessor (object): backend accessor.
+        index (IndexCacheStore | None): optional cache index.
+        f_files (list[PathSpec]): -f script-file paths.
+    """
+    out: list[str] = []
+    for pf in f_files:
+        reader = make_read(accessor, index, [pf])
+        data = await reader(accessor, pf)
+        text = data.decode(errors="replace")
+        if text.endswith("\n"):
+            text = text[:-1]
+        out.append(text)
+    return out
+
+
 def make_sed(
     *,
     resource: str | list[str],
@@ -79,24 +108,33 @@ def make_sed(
         stdin: AsyncIterator[bytes] | bytes | None = None,
         i: bool = False,
         e: object = None,
+        f: object = None,
         n: bool = False,
         E: bool = False,
         index: IndexCacheStore = None,
         **_extra: object,
     ) -> tuple[ByteSource | None, IOResult]:
-        # The script comes from -e expressions (joined with newlines) when any
-        # were given, otherwise from the first positional operand.
+        # The script comes from -e expressions and -f script files (joined
+        # with newlines, -e then -f as grep does) when any were given,
+        # otherwise from the first positional operand.
         e_list = e if isinstance(e,
                                  list) else ([e] if isinstance(e, str) else [])
-        script = "\n".join(e_list) if e_list else (texts[0] if texts else None)
+        f_files = f if isinstance(
+            f, list) else ([f] if isinstance(f, PathSpec) else [])
+        script_parts = list(e_list) + await _scripts_from_files(
+            make_read, accessor, index, f_files)
+        flag_script = bool(e_list or f_files)
+        if not flag_script and texts:
+            script_parts.append(texts[0])
+        script = "\n".join(script_parts) if script_parts else None
         if script is None:
             raise ValueError("sed: usage: sed EXPRESSION [path]")
         if inplace_error is not None and i:
             exc_type, message = inplace_error
             raise exc_type(message)
         operands = list(paths)
-        if e_list:
-            # With -e the positional operand is a file, not the script.
+        if flag_script:
+            # With -e/-f the positional operand is a file, not the script.
             cwd = _extra.get("cwd")
             operands = _positional_as_paths(
                 texts, cwd if isinstance(cwd, PathSpec) else None) + operands

--- a/python/mirage/commands/spec/builtin_specs/search.py
+++ b/python/mirage/commands/spec/builtin_specs/search.py
@@ -86,11 +86,26 @@ SPECS: dict[str, CommandSpec] = {
             Option(short="-i"),
             # -e takes a script and may repeat; joined with newlines.
             Option(short="-e", value_kind=OperandKind.TEXT, repeatable=True),
+            # -f reads the script from a file and may repeat (like grep -f);
+            # its value is a PATH so it routes and is read from the mount.
+            Option(short="-f", value_kind=OperandKind.PATH, repeatable=True),
             Option(short="-n"),
             Option(short="-E"),
             Option(short="-r"),
         ),
-        positional=(Operand(kind=OperandKind.TEXT, provided_by=("-e", )), ),
+        # provided_by lists the flags that can supply this positional slot's
+        # value; when any is present the parser skips the slot so the next
+        # word is not mis-grabbed. For sed the first operand is the script
+        # (TEXT), but only when neither -e nor -f gave one (GNU: "if no -e or
+        # -f, the first non-option argument is the script"). Examples:
+        #   sed 's/a/b/' f.txt        -> 's/a/b/' is the script; f.txt a file
+        #   sed -e 's/a/b/' f.txt     -> -e is the script; f.txt reflows to
+        #                                a file path in rest (slot skipped)
+        #   sed -f prog.sed f.txt     -> prog.sed is the script; f.txt a file
+        # Without provided_by, the -e/-f forms would mislabel f.txt as the
+        # script (TEXT) and never read it as a file.
+        positional=(Operand(kind=OperandKind.TEXT,
+                            provided_by=("-e", "-f")), ),
         rest=Operand(kind=OperandKind.PATH),
     ),
     'jq':

--- a/python/mirage/commands/spec/builtin_specs/search.py
+++ b/python/mirage/commands/spec/builtin_specs/search.py
@@ -90,7 +90,7 @@ SPECS: dict[str, CommandSpec] = {
             Option(short="-E"),
             Option(short="-r"),
         ),
-        positional=(Operand(kind=OperandKind.TEXT), ),
+        positional=(Operand(kind=OperandKind.TEXT, provided_by=("-e", )), ),
         rest=Operand(kind=OperandKind.PATH),
     ),
     'jq':

--- a/python/mirage/commands/spec/builtin_specs/text_proc.py
+++ b/python/mirage/commands/spec/builtin_specs/text_proc.py
@@ -160,7 +160,7 @@ SPECS: dict[str, CommandSpec] = {
     'csplit':
     CommandSpec(
         options=(
-            Option(short="-f", value_kind=OperandKind.TEXT),
+            Option(short="-f", value_kind=OperandKind.PATH),
             Option(short="-n", value_kind=OperandKind.TEXT),
             Option(short="-b", value_kind=OperandKind.TEXT),
             Option(short="-k"),

--- a/python/mirage/commands/spec/types.py
+++ b/python/mirage/commands/spec/types.py
@@ -61,7 +61,12 @@ class Operand:
             mount dispatch; TEXT operands pass through verbatim.
         provided_by (tuple[str, ...]): flags that supply this operand's
             value. When any is present the slot is skipped and remaining
-            args classify as rest (e.g. grep's pattern with -e/-f).
+            args classify as rest (e.g. grep's pattern with -e/-f). This is
+            the declarative form of the conditional real tools write by hand
+            (grep's ``if (!pattern_given)`` getopt loop); the same scenario
+            clap names ``required_unless_present`` and docopt expresses as
+            alternate usage patterns. It lives in the spec, not in command
+            code, because Mirage classifies args before a backend is chosen.
     """
     kind: OperandKind = OperandKind.PATH
     provided_by: tuple[str, ...] = ()

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -280,16 +280,26 @@ class Ops:
         return sum(r.bytes for r in self.records if r.is_cache)
 
     def is_mounted(self, path: str) -> bool:
-        """Check if a path is under a known mount.
+        """Check if a path is under an explicit mount.
+
+        Used by the open()/os interception to decide whether a path is a
+        workspace path (route through ops) or a real OS path (pass through).
+        The catch-all virtual root at ``/`` is skipped on purpose: it matches
+        every absolute path, so counting it would hijack real filesystem
+        paths (a FUSE mountpoint, ``/tmp``) into ops. Routing to the root for
+        ops themselves still happens via ``_resolve``; this gate is only about
+        what the interception should leave alone.
 
         Args:
             path (str): Virtual path.
 
         Returns:
-            bool: True if path matches a mount prefix.
+            bool: True if path is under a mount other than the virtual root.
         """
-        try:
-            self._resolve(path)
-            return True
-        except ValueError:
-            return False
+        norm = "/" + path.strip("/")
+        for m in self._mounts:
+            if m.prefix == "/":
+                continue
+            if norm == m.prefix.rstrip("/") or norm.startswith(m.prefix):
+                return True
+        return False

--- a/python/mirage/workspace/executor/command.py
+++ b/python/mirage/workspace/executor/command.py
@@ -446,7 +446,7 @@ async def handle_command(
                 io.exit_code = 1
 
     prefix = mount.prefix.rstrip("/")
-    if prefix and mount is not registry.default_mount:
+    if prefix:
         io.reads = {prefix + k: v for k, v in io.reads.items()}
         io.writes = {prefix + k: v for k, v in io.writes.items()}
         io.cache = [prefix + p for p in io.cache]

--- a/python/mirage/workspace/executor/command.py
+++ b/python/mirage/workspace/executor/command.py
@@ -171,10 +171,20 @@ def _parse_flags(
 
         # Recover PathSpec for PATH flag values; repeatable PATH flags
         # arrive as a list of resolved paths and become list[PathSpec].
+        # A relative PATH flag value cwd-resolved by parse_command (e.g.
+        # csplit -f part -> /data/part) is absent from scope_map, so build a
+        # PathSpec for it just like positional paths do, otherwise it never
+        # gets the mount prefix stripped.
         repeat_path_keys = {
             flag_kwarg_name(name)
             for opt in spec.options
             if opt.value_kind == OperandKind.PATH and opt.repeatable
+            for name in (opt.short, opt.long) if name
+        }
+        single_path_keys = {
+            flag_kwarg_name(name)
+            for opt in spec.options
+            if opt.value_kind == OperandKind.PATH and not opt.repeatable
             for name in (opt.short, opt.long) if name
         }
         for key, value in flag_kwargs.items():
@@ -186,6 +196,12 @@ def _parse_flags(
                                  directory=part[:part.rfind("/") + 1] or "/",
                                  resolved=True)) for part in value
                 ]
+            elif key in single_path_keys and isinstance(value, str):
+                flag_kwargs[key] = scope_map.get(
+                    value,
+                    PathSpec(original=value,
+                             directory=value[:value.rfind("/") + 1] or "/",
+                             resolved=True))
             elif isinstance(value, str) and value in scope_map:
                 flag_kwargs[key] = scope_map[value]
 

--- a/python/mirage/workspace/mount/registry.py
+++ b/python/mirage/workspace/mount/registry.py
@@ -43,7 +43,7 @@ class MountRegistry:
 
     def __init__(self) -> None:
         self._mounts: list[MountEntry] = []
-        self._root_mount: MountEntry | None = None
+        self._root: MountEntry | None = None
         self._consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY
         self._file_cache: FileCacheMixin | None = None
         self.mount(DEV_PREFIX, DevResource(), MountMode.WRITE)
@@ -56,8 +56,7 @@ class MountRegistry:
         CacheManagers.
 
         Called once by Workspace after the cache store exists. Mounts
-        added later get their manager in ``mount()`` /
-        ``set_root_mount()``.
+        added later get their manager in ``mount()``.
 
         Args:
             cache (FileCacheMixin | None): Workspace file cache store.
@@ -65,33 +64,10 @@ class MountRegistry:
         self._file_cache = cache
         for m in self._mounts:
             self._attach_manager(m)
-        if self._root_mount is not None:
-            self._attach_manager(self._root_mount)
 
     def _attach_manager(self, m: MountEntry) -> None:
         m.cache_manager = CacheManager(self._file_cache, m.resource.index,
                                        m.prefix, m.resource.caches_reads)
-
-    def set_root_mount(self, resource: BaseResource) -> None:
-        """Set the virtual root mount at ``/``.
-
-        Anchors root listing (``ls /``) and resolves commands with no
-        path args whose cwd matches no mount. Kept out of ``_mounts`` so
-        it never shadows a real mount in longest-prefix routing; it is the
-        neutral fallback only. The resource is an empty placeholder; the
-        file cache is a hidden store attached separately via
-        ``attach_file_cache``.
-        """
-        m = MountEntry("/", resource, MountMode.WRITE)
-        for cmd in resource.commands():
-            m.register(cmd)
-        for cmd in GENERAL_COMMANDS:
-            m.register_general(cmd)
-        for ro in resource.ops_list():
-            m.register_op(ro)
-        if self._file_cache is not None:
-            self._attach_manager(m)
-        self._root_mount = m
 
     def mount(
         self,
@@ -118,6 +94,8 @@ class MountRegistry:
             self._attach_manager(m)
         self._mounts.append(m)
         self._mounts.sort(key=lambda x: len(x.prefix), reverse=True)
+        if norm_prefix == "/":
+            self._root = m
         return m
 
     def unmount(self, prefix: str) -> MountEntry:
@@ -137,6 +115,8 @@ class MountRegistry:
         for i, m in enumerate(self._mounts):
             if m.prefix == norm_prefix:
                 del self._mounts[i]
+                if m is self._root:
+                    self._root = None
                 return m
         raise ValueError(f"no mount at prefix: {norm_prefix!r}")
 
@@ -232,10 +212,6 @@ class MountRegistry:
 
     def is_exec_allowed(self) -> bool:
         for m in self._mounts:
-            prefix_no_trail = m.prefix.rstrip("/") or "/"
-            if prefix_no_trail == "/":
-                return m.mode == MountMode.EXEC
-        for m in self._mounts:
             if m.prefix == DEV_PREFIX:
                 continue
             if m.mode == MountMode.EXEC:
@@ -247,9 +223,9 @@ class MountRegistry:
 
         Prefers the virtual root mount, then searches other mounts.
         """
-        if (self._root_mount is not None
-                and self._root_mount.resolve_command(cmd_name) is not None):
-            return self._root_mount
+        if (self._root is not None
+                and self._root.resolve_command(cmd_name) is not None):
+            return self._root
         for m in self._mounts:
             if m.resolve_command(cmd_name) is not None:
                 return m
@@ -339,7 +315,7 @@ class MountRegistry:
 
     @property
     def root_mount(self) -> MountEntry | None:
-        return self._root_mount
+        return self._root
 
     @property
     def file_cache(self) -> FileCacheMixin | None:

--- a/python/mirage/workspace/mount/registry.py
+++ b/python/mirage/workspace/mount/registry.py
@@ -43,7 +43,7 @@ class MountRegistry:
 
     def __init__(self) -> None:
         self._mounts: list[MountEntry] = []
-        self._default_mount: MountEntry | None = None
+        self._root_mount: MountEntry | None = None
         self._consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY
         self._file_cache: FileCacheMixin | None = None
         self.mount(DEV_PREFIX, DevResource(), MountMode.WRITE)
@@ -57,7 +57,7 @@ class MountRegistry:
 
         Called once by Workspace after the cache store exists. Mounts
         added later get their manager in ``mount()`` /
-        ``set_default_mount()``.
+        ``set_root_mount()``.
 
         Args:
             cache (FileCacheMixin | None): Workspace file cache store.
@@ -65,20 +65,24 @@ class MountRegistry:
         self._file_cache = cache
         for m in self._mounts:
             self._attach_manager(m)
-        if self._default_mount is not None:
-            self._attach_manager(self._default_mount)
+        if self._root_mount is not None:
+            self._attach_manager(self._root_mount)
 
     def _attach_manager(self, m: MountEntry) -> None:
         m.cache_manager = CacheManager(self._file_cache, m.resource.index,
                                        m.prefix, m.resource.caches_reads)
 
-    def set_default_mount(self, resource: BaseResource) -> None:
-        """Set a default fallback mount (cache resource).
+    def set_root_mount(self, resource: BaseResource) -> None:
+        """Set the virtual root mount at ``/``.
 
-        Used when a command has no path args and cwd
-        doesn't match any mount.
+        Anchors root listing (``ls /``) and resolves commands with no
+        path args whose cwd matches no mount. Kept out of ``_mounts`` so
+        it never shadows a real mount in longest-prefix routing; it is the
+        neutral fallback only. The resource is an empty placeholder; the
+        file cache is a hidden store attached separately via
+        ``attach_file_cache``.
         """
-        m = MountEntry("/_default/", resource, MountMode.WRITE)
+        m = MountEntry("/", resource, MountMode.WRITE)
         for cmd in resource.commands():
             m.register(cmd)
         for cmd in GENERAL_COMMANDS:
@@ -87,7 +91,7 @@ class MountRegistry:
             m.register_op(ro)
         if self._file_cache is not None:
             self._attach_manager(m)
-        self._default_mount = m
+        self._root_mount = m
 
     def mount(
         self,
@@ -241,12 +245,11 @@ class MountRegistry:
     def mount_for_command(self, cmd_name: str) -> MountEntry | None:
         """Find a mount that has this command registered.
 
-        Prefers the default mount (cache resource), then
-        searches other mounts.
+        Prefers the virtual root mount, then searches other mounts.
         """
-        if (self._default_mount is not None
-                and self._default_mount.resolve_command(cmd_name) is not None):
-            return self._default_mount
+        if (self._root_mount is not None
+                and self._root_mount.resolve_command(cmd_name) is not None):
+            return self._root_mount
         for m in self._mounts:
             if m.resolve_command(cmd_name) is not None:
                 return m
@@ -263,9 +266,10 @@ class MountRegistry:
         Resolution order:
         1. First PathSpec path (or cwd) → mount_for(path)
         2. If mount lacks the command → mount_for_command(cmd_name)
-        3. If a read-only command's paths are all cached → use cache
-           mount instead. Write commands always stay on the real mount
-           so mutations reach the backend rather than just the cache.
+        3. For a read-only command on a caching backend under ALWAYS
+           consistency, evict stale entries from the hidden file cache so
+           the in-place read-through serves fresh bytes. The command always
+           stays on its real mount; the cache is never a mount.
 
         Args:
             cmd_name (str): command name.
@@ -334,8 +338,8 @@ class MountRegistry:
                 await cache.remove(key)
 
     @property
-    def default_mount(self) -> MountEntry | None:
-        return self._default_mount
+    def root_mount(self) -> MountEntry | None:
+        return self._root_mount
 
     @property
     def file_cache(self) -> FileCacheMixin | None:

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -105,7 +105,6 @@ class Workspace:
             max_drain = cache.max_drain_bytes if cache is not None else None
             self._cache = RAMFileCacheStore(cache_limit=limit,
                                             max_drain_bytes=max_drain)
-        self._registry.set_root_mount(RAMResource())
         self._locked_paths: set[str] = set()
         self._closed = False
         self._drift_policy: DriftPolicy = DriftPolicy.OFF
@@ -148,6 +147,9 @@ class Workspace:
                 mount_obj.command_safeguards.update(mount_safeguards)
             if mount_fuse:
                 fuse_targets.append((prefix, mount_fuse))
+
+        if self._registry.root_mount is None:
+            self._registry.mount("/", RAMResource(), mode)
 
         self._fuse_mountpoints: dict[str, str] = {}
         self._fuse_managers: dict[str, FuseManager] = {}
@@ -226,10 +228,13 @@ class Workspace:
                              f"{HISTORY_PREFIX!r}")
         removed = self._registry.unmount(prefix)
         self._ops.unmount(prefix)
-        still_mounted = any(m.resource is removed.resource
-                            for m in self._registry.mounts())
-        if not still_mounted:
+        remaining = self._registry.mounts()
+        still_instance = any(m.resource is removed.resource for m in remaining)
+        still_kind = any(m.resource.name == removed.resource.name
+                         for m in remaining)
+        if not still_kind:
             self._ops._registry.unregister_resource(removed.resource.name)
+        if not still_instance:
             close = getattr(removed.resource, "close", None)
             if callable(close):
                 result = close()

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -105,7 +105,7 @@ class Workspace:
             max_drain = cache.max_drain_bytes if cache is not None else None
             self._cache = RAMFileCacheStore(cache_limit=limit,
                                             max_drain_bytes=max_drain)
-        self._registry.set_default_mount(RAMResource())
+        self._registry.set_root_mount(RAMResource())
         self._locked_paths: set[str] = set()
         self._closed = False
         self._drift_policy: DriftPolicy = DriftPolicy.OFF
@@ -184,12 +184,6 @@ class Workspace:
         return self._cache
 
     @property
-    def cache_mount(self) -> MountEntry:
-        m = self._registry.default_mount
-        assert m is not None, "cache mount is initialized in __init__"
-        return m
-
-    @property
     def max_drain_bytes(self) -> int | None:
         return self._cache.max_drain_bytes
 
@@ -223,8 +217,8 @@ class Workspace:
             raise RuntimeError("Workspace is closed")
         stripped = prefix.strip("/")
         norm = ("/" + stripped + "/" if stripped else "/")
-        if norm in ("/", "/_default/"):
-            raise ValueError(f"cannot unmount cache root: {prefix!r}")
+        if norm == "/":
+            raise ValueError(f"cannot unmount the virtual root: {prefix!r}")
         if norm == "/dev/":
             raise ValueError("cannot unmount reserved prefix: '/dev/'")
         if norm == HISTORY_PREFIX + "/":
@@ -516,16 +510,16 @@ class Workspace:
     def _infrastructure_mount_prefixes(self) -> set[str]:
         """Mount prefixes a session is always allowed to touch.
 
-        The cache mount (where text-processing commands like ``wc``
+        The virtual root (where text-processing commands like ``wc``
         without a path argument resolve), the device mount, and the
         history view are infrastructure: they hold no user
         credentials, and rejecting them would break common shell
         idioms or the history builtin.
         """
         prefixes = {"/dev", HISTORY_PREFIX}
-        default_mount = self._registry.default_mount
-        if default_mount is not None:
-            prefixes.add("/" + default_mount.prefix.strip("/"))
+        root_mount = self._registry.root_mount
+        if root_mount is not None:
+            prefixes.add("/" + root_mount.prefix.strip("/"))
         return prefixes
 
     def get_session(self, session_id: str) -> Session:

--- a/python/tests/commands/builtin/test_net.py
+++ b/python/tests/commands/builtin/test_net.py
@@ -97,13 +97,16 @@ async def test_curl_o_readonly_mount_fails(multi_mount_ws, mock_http):
 
 
 @pytest.mark.asyncio
-async def test_curl_o_no_mount_fails(multi_mount_ws, mock_http):
+async def test_curl_o_missing_parent_dir_fails(multi_mount_ws, mock_http):
+    # The virtual root catches any absolute path, so an unmounted target no
+    # longer fails with "no mount"; it routes to the root and fails because
+    # the parent directory does not exist there (no silent success).
     io = await multi_mount_ws.execute(
         "curl -s https://x.test/file -o /nope/foo.bin")
     assert io.exit_code == 1
     err = (io.stderr or b"").decode()
-    assert "no mount" in err
-    assert "/nope/foo.bin" in err
+    assert "parent directory does not exist" in err
+    assert "/nope" in err
 
 
 @pytest.mark.asyncio

--- a/python/tests/commands/native/test_sed.py
+++ b/python/tests/commands/native/test_sed.py
@@ -202,6 +202,35 @@ def test_sed_e_with_file(env):
         "sed -e s/hello/bye/ ef.txt")
 
 
+def test_sed_f_script_file(env):
+    env.create_file("prog.sed", b"s/hello/HI/\n")
+    env.create_file("inf.txt", b"hello world\n")
+    assert env.mirage("sed -f /data/prog.sed /data/inf.txt") == env.native(
+        "sed -f prog.sed inf.txt")
+
+
+def test_sed_f_multiple_commands(env):
+    env.create_file("prog2.sed", b"s/hello/HI/\ns/world/EARTH/\n")
+    env.create_file("inf2.txt", b"hello world\n")
+    assert env.mirage("sed -f /data/prog2.sed /data/inf2.txt") == env.native(
+        "sed -f prog2.sed inf2.txt")
+
+
+def test_sed_e_and_f_combined(env):
+    env.create_file("prog3.sed", b"s/world/EARTH/\n")
+    env.create_file("inf3.txt", b"hello world\n")
+    assert env.mirage(
+        "sed -e s/hello/HI/ -f /data/prog3.sed /data/inf3.txt") == env.native(
+            "sed -e s/hello/HI/ -f prog3.sed inf3.txt")
+
+
+def test_sed_f_stdin(env):
+    env.create_file("prog4.sed", b"s/hello/HI/\n")
+    data = b"hello world\n"
+    assert env.mirage("sed -f /data/prog4.sed",
+                      stdin=data) == env.native("sed -f prog4.sed", stdin=data)
+
+
 def test_sed_negate_line(env):
     data = b"a\nb\nc\n"
     assert env.mirage("sed '2!d'", stdin=data) == env.native("sed '2!d'",

--- a/python/tests/observe/test_workspace_observe.py
+++ b/python/tests/observe/test_workspace_observe.py
@@ -72,4 +72,4 @@ def test_observer_store_not_mounted():
     result = asyncio.run(ws.execute("ls /.sessions"))
     assert result.exit_code != 0
     prefixes = {m.prefix for m in ws._registry.mounts()}
-    assert prefixes == {"/data/", "/dev/", "/.bash_history/"}
+    assert prefixes == {"/", "/data/", "/dev/", "/.bash_history/"}

--- a/python/tests/workspace/mount/test_registry.py
+++ b/python/tests/workspace/mount/test_registry.py
@@ -315,7 +315,7 @@ def _remote_registry_with_cache():
     reg.mount("/ssh/", SSHResource(SSHConfig(host="example", root="/srv")),
               MountMode.WRITE)
     cache = RAMFileCacheStore()
-    reg.set_default_mount(cache)
+    reg.set_root_mount(cache)
     return reg, cache
 
 
@@ -358,7 +358,7 @@ def _path_bound_registry_with_default():
     reg.mount("/limited/", _LimitedResource(), MountMode.WRITE)
     fallback = _FallbackResource()
     fallback.register(_fallback_only)
-    reg.set_default_mount(fallback)
+    reg.set_root_mount(fallback)
     return reg
 
 
@@ -379,4 +379,4 @@ async def test_resolve_mount_allows_default_without_path_binding():
     reg = _path_bound_registry_with_default()
     mount = await reg.resolve_mount("fallback-only", [], "/limited")
     assert mount is not None
-    assert mount.prefix == "/_default/"
+    assert mount.prefix == "/"

--- a/python/tests/workspace/mount/test_registry.py
+++ b/python/tests/workspace/mount/test_registry.py
@@ -315,7 +315,7 @@ def _remote_registry_with_cache():
     reg.mount("/ssh/", SSHResource(SSHConfig(host="example", root="/srv")),
               MountMode.WRITE)
     cache = RAMFileCacheStore()
-    reg.set_root_mount(cache)
+    reg.attach_file_cache(cache)
     return reg, cache
 
 
@@ -358,7 +358,7 @@ def _path_bound_registry_with_default():
     reg.mount("/limited/", _LimitedResource(), MountMode.WRITE)
     fallback = _FallbackResource()
     fallback.register(_fallback_only)
-    reg.set_root_mount(fallback)
+    reg.mount("/", fallback, MountMode.WRITE)
     return reg
 
 

--- a/python/tests/workspace/node/test_run_tree.py
+++ b/python/tests/workspace/node/test_run_tree.py
@@ -31,7 +31,7 @@ def registry():
     """Minimal registry with a RAM mount at root."""
     reg = MountRegistry()
     res = RAMResource()
-    reg.set_default_mount(res)
+    reg.set_root_mount(res)
     reg.mount("/", res, MountMode.WRITE)
     return reg
 

--- a/python/tests/workspace/node/test_run_tree.py
+++ b/python/tests/workspace/node/test_run_tree.py
@@ -31,7 +31,6 @@ def registry():
     """Minimal registry with a RAM mount at root."""
     reg = MountRegistry()
     res = RAMResource()
-    reg.set_root_mount(res)
     reg.mount("/", res, MountMode.WRITE)
     return reg
 

--- a/python/tests/workspace/session/test_session.py
+++ b/python/tests/workspace/session/test_session.py
@@ -124,13 +124,13 @@ def test_fork_copies_every_field_including_allowed_mounts():
         shell_options={"errexit": True},
         readonly_vars={"HOME"},
         arrays={"ARGV": ["a", "b"]},
-        allowed_mounts=frozenset({"/s3", "/dev", "/_default"}),
+        allowed_mounts=frozenset({"/s3", "/dev", "/"}),
     )
     forked = original.fork()
     assert forked.session_id == "orig"
     assert forked.cwd == "/disk"
     assert forked.env == {"FOO": "bar"}
-    assert forked.allowed_mounts == frozenset({"/s3", "/dev", "/_default"})
+    assert forked.allowed_mounts == frozenset({"/s3", "/dev", "/"})
     assert forked.shell_options == {"errexit": True}
     assert "HOME" in forked.readonly_vars
     assert forked.arrays == {"ARGV": ["a", "b"]}

--- a/python/tests/workspace/test_cache_mount.py
+++ b/python/tests/workspace/test_cache_mount.py
@@ -43,14 +43,15 @@ async def stat_zzz_disk(
 @pytest.mark.asyncio
 async def test_cache_decoupled_from_root_mount():
     """The file cache is a hidden store reached via ``registry.file_cache``,
-    not the virtual root mount's resource. The root mount is a plain empty
-    anchor at ``/`` (used only as the neutral base for root listing and
-    arg-less command resolution) and never holds the cache."""
+    not the virtual root mount's resource. When no ``/`` is mounted the root
+    is an ordinary empty RAM mount at ``/`` (a normal entry in ``_mounts``)
+    and never holds the cache."""
     ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
     assert ws._registry.file_cache is ws.cache
     assert ws._registry.root_mount.resource is not ws.cache
     assert ws._registry.root_mount.resource.caches_reads is False
     assert ws._registry.root_mount.prefix == "/"
+    assert ws._registry.root_mount in ws._registry.mounts()
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/test_cache_mount.py
+++ b/python/tests/workspace/test_cache_mount.py
@@ -41,15 +41,16 @@ async def stat_zzz_disk(
 
 
 @pytest.mark.asyncio
-async def test_cache_decoupled_from_default_mount():
+async def test_cache_decoupled_from_root_mount():
     """The file cache is a hidden store reached via ``registry.file_cache``,
-    not the default mount's resource. The default mount is a plain empty
-    anchor (used only as the neutral base for root listing and arg-less
-    command resolution) and never holds the cache."""
+    not the virtual root mount's resource. The root mount is a plain empty
+    anchor at ``/`` (used only as the neutral base for root listing and
+    arg-less command resolution) and never holds the cache."""
     ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
     assert ws._registry.file_cache is ws.cache
-    assert ws._registry.default_mount.resource is not ws.cache
-    assert ws._registry.default_mount.resource.caches_reads is False
+    assert ws._registry.root_mount.resource is not ws.cache
+    assert ws._registry.root_mount.resource.caches_reads is False
+    assert ws._registry.root_mount.prefix == "/"
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/test_command_safeguard.py
+++ b/python/tests/workspace/test_command_safeguard.py
@@ -29,8 +29,6 @@ def _build_ws(n_lines: int) -> Workspace:
 
 def _override(ws: Workspace, name: str, safeguard: CommandSafeguard) -> None:
     mounts = list(ws._registry._mounts)
-    if ws._registry.root_mount is not None:
-        mounts.append(ws._registry.root_mount)
     for m in mounts:
         m.command_safeguards[name] = safeguard
 

--- a/python/tests/workspace/test_command_safeguard.py
+++ b/python/tests/workspace/test_command_safeguard.py
@@ -29,8 +29,8 @@ def _build_ws(n_lines: int) -> Workspace:
 
 def _override(ws: Workspace, name: str, safeguard: CommandSafeguard) -> None:
     mounts = list(ws._registry._mounts)
-    if ws._registry.default_mount is not None:
-        mounts.append(ws._registry.default_mount)
+    if ws._registry.root_mount is not None:
+        mounts.append(ws._registry.root_mount)
     for m in mounts:
         m.command_safeguards[name] = safeguard
 

--- a/python/tests/workspace/test_default_mount_cache_dedup.py
+++ b/python/tests/workspace/test_default_mount_cache_dedup.py
@@ -34,6 +34,6 @@ async def test_cache_hit_does_not_double_store():
 
         assert size_after_second == size_after_first
         assert keys_second == keys_first
-        assert all(not k.startswith("/_default/") for k in keys_second)
+        assert all(k.startswith("/r/") for k in keys_second)
     finally:
         await ws.close()

--- a/python/tests/workspace/test_workspace.py
+++ b/python/tests/workspace/test_workspace.py
@@ -2379,11 +2379,11 @@ def test_unmount_closes_resource_when_owned():
 
 
 def test_unmount_rejects_reserved_prefixes():
-    """unmount of cache root / history view / dev / unknown prefix raises."""
+    """unmount of virtual root / history view / dev / unknown prefix raises."""
     ws = _ws()
     import pytest
 
-    with pytest.raises(ValueError, match="cache root"):
+    with pytest.raises(ValueError, match="virtual root"):
         asyncio.run(ws.unmount("/"))
     with pytest.raises(ValueError, match="history view"):
         asyncio.run(ws.unmount("/.bash_history"))

--- a/typescript/packages/core/src/commands/builtin/generic/sed.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/sed.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
-import type { PathSpec } from '../../../types.ts'
+import { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { executeProgram, parseOneCommand, parseProgram, type SedCommand } from '../sed_helper.ts'
 import { readStdinAsync } from '../utils/stream.ts'
@@ -28,11 +28,23 @@ export async function sedGeneric(
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
 ): Promise<CommandFnResult> {
-  // The script comes from -e expressions (joined with newlines, GNU-style) when
-  // any were given, otherwise from the first positional operand.
+  // The script comes from -e expressions and -f script files (joined with
+  // newlines, -e then -f as grep does) when any were given, otherwise from the
+  // first positional operand.
   const eVals = opts.flags.e
   const eList = Array.isArray(eVals) ? eVals : typeof eVals === 'string' ? [eVals] : []
-  const script = eList.length > 0 ? eList.join('\n') : texts[0]
+  const fVals = opts.flags.f
+  const fList = Array.isArray(fVals) ? fVals : typeof fVals === 'string' ? [fVals] : []
+  const scriptParts = [...eList]
+  for (const filePath of fList) {
+    const spec = PathSpec.fromStrPath(filePath, paths[0]?.prefix ?? opts.mountPrefix ?? '')
+    let text = DEC.decode(await materialize(stream(spec)))
+    if (text.endsWith('\n')) text = text.slice(0, -1)
+    scriptParts.push(text)
+  }
+  const flagScript = eList.length > 0 || fList.length > 0
+  if (!flagScript && texts[0] !== undefined) scriptParts.push(texts[0])
+  const script = scriptParts.length > 0 ? scriptParts.join('\n') : undefined
   if (script === undefined) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('sed: missing script\n') })]
   }

--- a/typescript/packages/core/src/commands/builtin/generic/sed_command.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/sed_command.ts
@@ -24,8 +24,8 @@ import { sedGeneric } from './sed.ts'
 const ENC = new TextEncoder()
 
 /**
- * When the script is supplied via -e, GNU sed treats every bare argument as a
- * file. The arg parser instead routes the first bare arg into the positional
+ * When the script is supplied via -e/-f, GNU sed treats every bare argument as
+ * a file. The arg parser instead routes the first bare arg into the positional
  * `text` (script) slot, so recover it as a path operand here.
  */
 function positionalAsPaths(texts: string[], opts: CommandOpts): PathSpec[] {
@@ -84,9 +84,10 @@ export function makeSed<A extends Accessor>(backend: SedBackend<A>) {
           }),
         ]
       }
-      // With -e the positional operand is a file, not the script (see above).
+      // With -e/-f the positional operand is a file, not the script (see above).
       const usingE = opts.flags.e !== undefined && opts.flags.e !== false
-      const operands = usingE ? [...positionalAsPaths(texts, opts), ...paths] : paths
+      const usingF = opts.flags.f !== undefined && opts.flags.f !== false
+      const operands = usingE || usingF ? [...positionalAsPaths(texts, opts), ...paths] : paths
       const resolved =
         glob !== undefined && operands.length > 0 ? await glob(accessor, operands, opts) : operands
       const writeFn =

--- a/typescript/packages/core/src/commands/builtin/ram/sed.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/sed.test.ts
@@ -1,0 +1,90 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { materialize } from '../../../io/types.ts'
+import { RAMResource } from '../../../resource/ram/ram.ts'
+import { PathSpec } from '../../../types.ts'
+import { RAM_SED } from './sed.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+async function runSed(
+  resource: RAMResource,
+  texts: string[],
+  paths: PathSpec[],
+  flags: Record<string, string | boolean | string[]> = {},
+  stdin: Uint8Array | null = null,
+): Promise<string> {
+  const cmd = RAM_SED[0]
+  if (cmd === undefined) throw new Error('sed not registered')
+  const result = await cmd.fn(
+    (resource as { accessor?: unknown }).accessor as never,
+    paths,
+    texts,
+    { stdin, flags, filetypeFns: null, cwd: '/', resource },
+  )
+  if (result === null) return ''
+  const [out] = result
+  if (out === null) return ''
+  const buf = out instanceof Uint8Array ? out : await materialize(out as AsyncIterable<Uint8Array>)
+  return DEC.decode(buf)
+}
+
+describe('sed -f', () => {
+  it('reads the script from a file', async () => {
+    const resource = new RAMResource()
+    resource.store.files.set('/tmp/prog.sed', ENC.encode('s/hello/HI/\n'))
+    resource.store.files.set('/tmp/in.txt', ENC.encode('hello world\n'))
+    const out = await runSed(resource, [], [PathSpec.fromStrPath('/tmp/in.txt')], {
+      f: ['/tmp/prog.sed'],
+    })
+    expect(out).toBe('HI world\n')
+  })
+
+  it('applies multiple commands from the script file', async () => {
+    const resource = new RAMResource()
+    resource.store.files.set('/tmp/prog.sed', ENC.encode('s/hello/HI/\ns/world/EARTH/\n'))
+    resource.store.files.set('/tmp/in.txt', ENC.encode('hello world\n'))
+    const out = await runSed(resource, [], [PathSpec.fromStrPath('/tmp/in.txt')], {
+      f: ['/tmp/prog.sed'],
+    })
+    expect(out).toBe('HI EARTH\n')
+  })
+
+  it('combines -e and -f (e then f)', async () => {
+    const resource = new RAMResource()
+    resource.store.files.set('/tmp/prog.sed', ENC.encode('s/world/EARTH/\n'))
+    resource.store.files.set('/tmp/in.txt', ENC.encode('hello world\n'))
+    const out = await runSed(resource, [], [PathSpec.fromStrPath('/tmp/in.txt')], {
+      e: 's/hello/HI/',
+      f: ['/tmp/prog.sed'],
+    })
+    expect(out).toBe('HI EARTH\n')
+  })
+
+  it('reads the script file in stdin mode', async () => {
+    const resource = new RAMResource()
+    resource.store.files.set('/tmp/prog.sed', ENC.encode('s/hello/HI/\n'))
+    const out = await runSed(
+      resource,
+      [],
+      [],
+      { f: ['/tmp/prog.sed'] },
+      ENC.encode('hello world\n'),
+    )
+    expect(out).toBe('HI world\n')
+  })
+})

--- a/typescript/packages/core/src/commands/spec/builtins.ts
+++ b/typescript/packages/core/src/commands/spec/builtins.ts
@@ -302,11 +302,19 @@ export const BUILTIN_SPECS: Readonly<Record<string, CommandSpec>> = Object.freez
       new Option({ short: '-i' }),
       // -e takes a script and may repeat; multiple -e are joined with newlines.
       new Option({ short: '-e', valueKind: OperandKind.TEXT, repeatable: true }),
+      // -f reads the script from a file and may repeat (like grep -f); its value
+      // is a PATH so it routes and is read from the mount.
+      new Option({ short: '-f', valueKind: OperandKind.PATH, repeatable: true }),
       new Option({ short: '-n' }),
       new Option({ short: '-E' }),
       new Option({ short: '-r' }),
     ],
-    positional: [new Operand({ kind: OperandKind.TEXT })],
+    // providedBy lists the flags that can supply this positional slot's value;
+    // when any is present the parser skips the slot so the next word is not
+    // mis-grabbed. For sed the first operand is the script (TEXT) only when
+    // neither -e nor -f gave one (GNU). With -e/-f the slot is skipped and the
+    // first operand reflows to a file path in rest.
+    positional: [new Operand({ kind: OperandKind.TEXT, providedBy: ['-e', '-f'] })],
     rest: new Operand({ kind: OperandKind.PATH }),
   }),
   echo: new CommandSpec({

--- a/typescript/packages/core/src/commands/spec/types.ts
+++ b/typescript/packages/core/src/commands/spec/types.ts
@@ -66,7 +66,11 @@ export interface OperandInit {
   /**
    * Flags that supply this operand's value. When any is present the slot is
    * skipped and remaining args classify as rest (e.g. grep's pattern with
-   * -e/-f).
+   * -e/-f). This is the declarative form of the conditional real tools write
+   * by hand (grep's `if (!pattern_given)` getopt loop); the same scenario
+   * clap names `required_unless_present` and docopt expresses as alternate
+   * usage patterns. It lives in the spec, not in command code, because
+   * Mirage classifies args before a backend is chosen.
    */
   providedBy?: readonly string[]
 }


### PR DESCRIPTION
## What

Removes the `/_default` placeholder and makes the virtual root a **real, overridable mount at `/`**.

- If you mount `/` (programmatically `Workspace({\"/\": DiskResource(...)})` or via CLI YAML `mounts: { \"/\": { resource: disk, ... } }`), that resource **is** the root.
- Otherwise an empty RAM root is mounted internally. Default is ephemeral tmpfs; switch the backing to disk/redis just by mounting `/`.

The root is an ordinary catch-all mount (last in longest-prefix order), so resolution, ops routing, `ls /`, `find`, snapshots, and session allowlisting all treat it uniformly. No special "anchor" object, no `/_default` string anywhere.

## Why

`/_default` was a leftover from when the file cache was a mount (now a hidden store, #401). The name implied "cache", it leaked a phantom path, and the root was a magic out-of-band object. Making `/` a normal mount is the Unix model (`/` is rootfs, everything mounts under it) and gives configurable root backing for free.

## Key changes

- `set_root_mount`/`default_mount` removed; the registry tracks the `/` mount via `root_mount`. Workspace mounts an internal RAM `/` only when the user didn't.
- `is_exec_allowed` drops its `/` short-circuit (exec = any non-dev EXEC mount), so the internal root never gates exec.
- `unmount` unregisters ops by **kind-absence** (not instance), so unmounting a same-kind mount can't strip the root's ops.
- Writes to an unmounted absolute path now route to the root and fail on the missing parent dir (no silent success), instead of "no mount".

## Latent spec bugs surfaced and fixed

Before, the default `cwd=/` resolved to no mount, so spec-based arg classification was silently skipped from the root. Now `cwd=/` resolves to the root, which exposed:
- `csplit -f` was marked `TEXT`; it is a **PATH** (output prefix).
- `sed`'s script positional lacked `provided_by=(\"-e\",)`, so `sed -e ... file` mis-bound the file as the script (matches grep/awk now).
- single PATH-flag values are now recovered to `PathSpec` like positionals, so a cwd-resolved relative flag path (`csplit -f part`) still gets the mount prefix stripped.

## Tests / verification

- Full Python suite green (pre-existing live-net jina flake + qdrant missing-dep excluded).
- New `integ/root.py` (wired into CI): ram/disk/yaml root switching, child-mount injection, scratch writes, arg-less resolution.
- All offline integ match truth (history updated for the `/` mount line): ram, disk, s3, onedrive, dify, cross_commands.

TS parity remains a separate follow-up.