### PR TITLE
Narrow github grep/rg via code search on subdirs and regex; add -l short-circuit

### DIFF
--- a/examples/python/github/github.py
+++ b/examples/python/github/github.py
@@ -136,6 +136,50 @@ async def main() -> None:
         for line in lines[:3]:
             print(f"  {line[:150]}")
 
+    # ── subdir + regex narrowing + -l short-circuit (issue #404) ──
+    # A large subdir (>100 files) is what makes the per-file fallback slow;
+    # these cases narrow via GitHub code search instead of fetching each file.
+    big_dir = "/github/python/mirage/"
+    print(f"\n=== grep -rln BaseResource {big_dir} "
+          "(subdir narrowing, -l short-circuit) ===")
+    ms, out = await _timed(ws, f"grep -rln BaseResource {big_dir}")
+    files = out.strip().splitlines() if out.strip() else []
+    print(f"  {ms:.0f}ms  files-with-matches: {len(files)}")
+    for line in files[:3]:
+        print(f"  {line}")
+
+    print(f"\n=== grep -rn 'async def .*self' {big_dir} "
+          "(regex narrows via required literal 'async def ') ===")
+    ms, out = await _timed(ws, f"grep -rn 'async def .*self' {big_dir}")
+    lines = out.strip().splitlines() if out.strip() else []
+    print(f"  {ms:.0f}ms  matches: {len(lines)}")
+    for line in lines[:3]:
+        print(f"  {line[:150]}")
+
+    print(f"\n=== rg -l GitHubAccessor {big_dir} "
+          "(rg subdir narrowing, -l short-circuit) ===")
+    ms, out = await _timed(ws, f"rg -l GitHubAccessor {big_dir}")
+    files = out.strip().splitlines() if out.strip() else []
+    print(f"  {ms:.0f}ms  files-with-matches: {len(files)}")
+    for line in files[:3]:
+        print(f"  {line}")
+
+    print(f"\n=== rg -l --glob '*.py' GitHubAccessor {big_dir} "
+          "(file filter applied to narrowed set) ===")
+    ms, out = await _timed(ws, f"rg -l --glob '*.py' GitHubAccessor {big_dir}")
+    files = out.strip().splitlines() if out.strip() else []
+    print(f"  {ms:.0f}ms  files-with-matches: {len(files)}")
+    for line in files[:3]:
+        print(f"  {line}")
+
+    print(f"\n=== rg -l --type py GitHubAccessor {big_dir} "
+          "(--type filter applied to narrowed set) ===")
+    ms, out = await _timed(ws, f"rg -l --type py GitHubAccessor {big_dir}")
+    files = out.strip().splitlines() if out.strip() else []
+    print(f"  {ms:.0f}ms  files-with-matches: {len(files)}")
+    for line in files[:3]:
+        print(f"  {line}")
+
     print("=== find -type d ===")
     r = await ws.execute("find /github/python/mirage/core -type d")
     print(await r.stdout_str())

--- a/python/mirage/commands/builtin/github/grep.py
+++ b/python/mirage/commands/builtin/github/grep.py
@@ -16,19 +16,16 @@ from collections.abc import AsyncIterator
 
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.constants import PatternType
 from mirage.commands.builtin.generic.grep import grep as generic_grep
-from mirage.commands.builtin.grep_helper import classify_pattern, pattern_arg
+from mirage.commands.builtin.github.narrow import (files_only_shortcircuit,
+                                                   narrow_scope)
+from mirage.commands.builtin.grep_helper import pattern_arg
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.commands.spec.types import FlagView
-from mirage.core.github.constants import SCOPE_ERROR, SCOPE_WARN
-from mirage.core.github.glob import resolve_glob
+from mirage.core.github.constants import SCOPE_ERROR
 from mirage.core.github.read import read as github_read
 from mirage.core.github.readdir import readdir as github_readdir
-from mirage.core.github.scope import (count_scope_files, is_repo_root,
-                                      scope_relative_key, should_use_search)
-from mirage.core.github.search import narrow_paths
 from mirage.core.github.stat import stat as github_stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.provision import ProvisionResult
@@ -105,30 +102,21 @@ async def grep(
 
     resolved: list[PathSpec] = []
     if paths and index is not None:
-        key = scope_relative_key(paths[0])
-        file_count = count_scope_files(index._entries, key)
-        # -f-only invocations have no literal yet (files are read inside the
-        # generic); treat as regex so the search narrowing is skipped.
-        is_regex = (pattern is None or classify_pattern(pattern, fl.bool("F"))
-                    == PatternType.REGEX)
-        use_search = (should_use_search(
-            is_regex=is_regex,
+        resolved, file_count, used_search = await narrow_scope(
+            accessor,
+            index,
+            paths,
+            pattern,
+            fixed_string=fl.bool("F"),
             recursive=recursive,
-            on_default_branch=(accessor.ref == accessor.default_branch),
-        ) and is_repo_root(key) and file_count > SCOPE_WARN)
-        if use_search:
-            narrowed = await narrow_paths(accessor.config, accessor.owner,
-                                          accessor.repo, pattern, paths)
-            if narrowed:
-                resolved = narrowed
-                file_count = len(narrowed)
-            else:
-                resolved = await resolve_glob(accessor, paths, index)
-        else:
-            resolved = await resolve_glob(accessor, paths, index)
+        )
         if file_count > SCOPE_ERROR:
             msg = f"grep: {file_count} files in scope, narrow the path\n"
             return b"", IOResult(exit_code=1, stderr=msg.encode())
+        if used_search:
+            short = files_only_shortcircuit(fl, pattern, resolved, paths[0])
+            if short is not None:
+                return short
 
     return await generic_grep(
         resolved,

--- a/python/mirage/commands/builtin/github/narrow.py
+++ b/python/mirage/commands/builtin/github/narrow.py
@@ -1,0 +1,127 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import Callable
+
+from mirage.accessor.github import GitHubAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.constants import PatternType
+from mirage.commands.builtin.grep_helper import classify_pattern, search_query
+from mirage.commands.builtin.utils.output import format_records
+from mirage.commands.spec.types import FlagView
+from mirage.core.github.constants import SCOPE_WARN
+from mirage.core.github.glob import resolve_glob
+from mirage.core.github.scope import (count_scope_files, scope_relative_key,
+                                      should_use_search)
+from mirage.core.github.search import narrow_paths
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+from mirage.utils.path import rebase_display
+
+
+async def narrow_scope(
+    accessor: GitHubAccessor,
+    index: IndexCacheStore,
+    paths: list[PathSpec],
+    pattern: str | None,
+    *,
+    fixed_string: bool,
+    recursive: bool,
+) -> tuple[list[PathSpec], int, bool]:
+    """Resolve grep/rg scope paths, narrowing via GitHub code search.
+
+    Narrows any recursive scope (repo root or subdirectory) on the default
+    branch when a literal can be pushed down to code search and the scope is
+    larger than ``SCOPE_WARN``; otherwise expands the scope by glob. Regex
+    patterns narrow on an extracted required literal and stay exact because the
+    caller still scans the regex over the narrowed files.
+
+    Args:
+        accessor (GitHubAccessor): backend handle.
+        index (IndexCacheStore): populated path/size index.
+        paths (list[PathSpec]): scope paths, possibly mount-prefixed.
+        pattern (str | None): the search pattern, or None for -f-only greps.
+        fixed_string (bool): True if -F is set.
+        recursive (bool): True if -r/-R is set.
+
+    Returns:
+        tuple[list[PathSpec], int, bool]: resolved file paths, the file count
+            in scope (narrowed count when search was used), and whether code
+            search actually narrowed the set.
+    """
+    key = scope_relative_key(paths[0])
+    file_count = count_scope_files(index._entries, key)
+    query = search_query(pattern,
+                         fixed_string) if pattern is not None else None
+    use_search = (query is not None and should_use_search(
+        recursive=recursive,
+        on_default_branch=(accessor.ref == accessor.default_branch),
+    ) and file_count > SCOPE_WARN)
+    if use_search:
+        narrowed = await narrow_paths(accessor.config, accessor.owner,
+                                      accessor.repo, query, paths)
+        if narrowed:
+            return narrowed, len(narrowed), True
+    resolved = await resolve_glob(accessor, paths, index)
+    return resolved, file_count, False
+
+
+def files_only_shortcircuit(
+    fl: FlagView,
+    pattern: str | None,
+    resolved: list[PathSpec],
+    scope: PathSpec,
+    path_predicate: Callable[[str], bool] | None = None,
+) -> tuple[ByteSource, IOResult] | None:
+    """Emit the narrowed file list for a plain literal -l without reading.
+
+    When code search has already narrowed the scope to the files containing a
+    fully literal pattern, those files are exactly the answer to ``-l``
+    (files-with-matches), so the content fetches the generic command would do
+    can be skipped entirely. Returns None whenever the short-circuit is unsafe
+    (no -l, a non-literal pattern, or a flag that changes which lines match) so
+    the caller falls back to the generic scan. ``path_predicate`` reproduces
+    any file filtering the generic command applies (rg's hidden/--type/--glob
+    rules); files it rejects are dropped, matching the generic output.
+
+    Args:
+        fl (FlagView): spec-validated view over the raw flag kwargs.
+        pattern (str | None): the search pattern.
+        resolved (list[PathSpec]): the narrowed file paths.
+        scope (PathSpec): the original scope path, for display rebasing.
+        path_predicate (Callable[[str], bool] | None): keeps only narrowed
+            paths for which it returns True; None keeps all (grep semantics).
+
+    Returns:
+        tuple[ByteSource, IOResult] | None: the formatted file list, or None.
+    """
+    if not fl.bool("args_l") or pattern is None:
+        return None
+    if (fl.bool("i") or fl.bool("w") or fl.bool("v") or fl.bool("c")
+            or fl.bool("o")):
+        return None
+    fixed = fl.bool("F")
+    pt = classify_pattern(pattern, fixed)
+    fully_literal = fixed or pt == PatternType.EXACT or (
+        pt == PatternType.SIMPLE and "." not in pattern)
+    if not fully_literal:
+        return None
+    hits = [
+        p.original for p in resolved
+        if path_predicate is None or path_predicate(p.original)
+    ]
+    if not hits:
+        return b"", IOResult(exit_code=1)
+    displays = rebase_display(hits, scope.original, scope.display)
+    return format_records(sorted(displays)), IOResult()

--- a/python/mirage/commands/builtin/github/rg.py
+++ b/python/mirage/commands/builtin/github/rg.py
@@ -13,23 +13,22 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
+from functools import partial
 
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.constants import PatternType
 from mirage.commands.builtin.generic.rg import rg as generic_rg
-from mirage.commands.builtin.grep_helper import classify_pattern, pattern_arg
+from mirage.commands.builtin.github.narrow import (files_only_shortcircuit,
+                                                   narrow_scope)
+from mirage.commands.builtin.grep_helper import pattern_arg
+from mirage.commands.builtin.rg_helper import rg_matches_filter
 from mirage.commands.errors import UsageError
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.commands.spec.types import FlagView
-from mirage.core.github.constants import SCOPE_ERROR, SCOPE_WARN
-from mirage.core.github.glob import resolve_glob
+from mirage.core.github.constants import SCOPE_ERROR
 from mirage.core.github.read import read as github_read
 from mirage.core.github.readdir import readdir as _readdir
-from mirage.core.github.scope import (count_scope_files, is_repo_root,
-                                      scope_relative_key, should_use_search)
-from mirage.core.github.search import narrow_paths
 from mirage.core.github.stat import stat as _stat
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -52,27 +51,30 @@ async def rg(
     if paths and index is None:
         return b"", IOResult(exit_code=1)
     if paths:
-        key = scope_relative_key(paths[0])
-        file_count = count_scope_files(index._entries, key)
-        pt = classify_pattern(pattern_str, fl.bool("F"))
-        use_search = (should_use_search(
-            is_regex=(pt == PatternType.REGEX),
+        scope = paths[0]
+        paths, file_count, used_search = await narrow_scope(
+            accessor,
+            index,
+            paths,
+            pattern_str,
+            fixed_string=fl.bool("F"),
             recursive=True,
-            on_default_branch=(accessor.ref == accessor.default_branch),
-        ) and is_repo_root(key) and file_count > SCOPE_WARN)
-        if use_search:
-            narrowed = await narrow_paths(accessor.config, accessor.owner,
-                                          accessor.repo, pattern_str, paths)
-            if narrowed:
-                paths = narrowed
-                file_count = len(narrowed)
-            else:
-                paths = await resolve_glob(accessor, paths, index)
-        else:
-            paths = await resolve_glob(accessor, paths, index)
+        )
         if file_count > SCOPE_ERROR:
             msg = f"rg: {file_count} files in scope, narrow the path\n"
             return b"", IOResult(exit_code=1, stderr=msg.encode())
+        if used_search:
+            predicate = partial(rg_matches_filter,
+                                file_type=fl.str("type"),
+                                glob_pattern=fl.str("glob"),
+                                hidden=fl.bool("hidden"))
+            short = files_only_shortcircuit(fl,
+                                            pattern_str,
+                                            paths,
+                                            scope,
+                                            path_predicate=predicate)
+            if short is not None:
+                return short
 
     return await generic_rg(
         paths,

--- a/python/mirage/commands/builtin/grep_helper.py
+++ b/python/mirage/commands/builtin/grep_helper.py
@@ -63,6 +63,80 @@ def classify_pattern(
     return PatternType.REGEX
 
 
+_REGEX_BREAKERS = frozenset(".^$*+?()|{}")
+_MIN_SEARCH_LITERAL = 3
+
+
+def extract_required_literal(pattern: str) -> str | None:
+    """Longest substring every match of a regex must contain.
+
+    Returns a literal that any line matching ``pattern`` is guaranteed to
+    contain, suitable for narrowing via a literal search API before the real
+    regex is scanned locally. Conservative: returns None whenever a required
+    literal cannot be proven (top-level alternation, character classes,
+    escapes, runs shorter than ``_MIN_SEARCH_LITERAL``), so the caller falls
+    back to a full scan rather than risk a false negative.
+
+    Args:
+        pattern (str): a regular expression.
+
+    Returns:
+        str | None: the longest required literal, or None.
+    """
+    if "|" in pattern:
+        return None
+    runs: list[str] = []
+    current: list[str] = []
+    i = 0
+    n = len(pattern)
+    while i < n:
+        ch = pattern[i]
+        if ch == "\\":
+            runs.append("".join(current))
+            current = []
+            i += 2
+            continue
+        if ch == "[":
+            runs.append("".join(current))
+            current = []
+            i += 1
+            while i < n and pattern[i] != "]":
+                i += 2 if pattern[i] == "\\" else 1
+            i += 1
+            continue
+        if ch in _REGEX_BREAKERS:
+            if ch in "*?{" and current:
+                current.pop()
+            runs.append("".join(current))
+            current = []
+            if ch == "{":
+                while i < n and pattern[i] != "}":
+                    i += 1
+            i += 1
+            continue
+        current.append(ch)
+        i += 1
+    runs.append("".join(current))
+    best = max(runs, key=len, default="")
+    return best if len(best) >= _MIN_SEARCH_LITERAL else None
+
+
+def search_query(pattern: str, fixed_string: bool) -> str | None:
+    """Literal to push down to a code-search API for a grep/rg pattern.
+
+    Args:
+        pattern (str): the search pattern.
+        fixed_string (bool): True if -F is set.
+
+    Returns:
+        str | None: the pattern itself when it is literal, a required literal
+            extracted from a regex, or None when no literal can be searched.
+    """
+    if classify_pattern(pattern, fixed_string) != PatternType.REGEX:
+        return pattern
+    return extract_required_literal(pattern)
+
+
 def pattern_arg(texts: Sequence[str], flags: FlagView) -> str | None:
     """Resolve the pattern-list argument from -e values or the positional.
 

--- a/python/mirage/core/github/scope.py
+++ b/python/mirage/core/github/scope.py
@@ -68,16 +68,16 @@ def count_scope_files(entries: dict[str, IndexEntry], key: str) -> int:
 
 
 def should_use_search(
-    is_regex: bool,
     recursive: bool,
     on_default_branch: bool,
 ) -> bool:
     """Whether grep/rg should narrow paths via GitHub code search.
 
-    Search is appropriate for non-regex patterns running recursively on the
-    default branch (code search only indexes the default branch).
+    Search only helps recursive scans on the default branch (code search only
+    indexes the default branch). Whether a usable literal exists, and whether
+    the scope is large enough to bother, is decided by the caller.
     """
-    return not is_regex and recursive and on_default_branch
+    return recursive and on_default_branch
 
 
 async def estimate_scope(tree: dict[str, TreeEntry], directory: str,

--- a/python/mirage/core/github/search.py
+++ b/python/mirage/core/github/search.py
@@ -85,7 +85,10 @@ async def narrow_paths(
                 "github code search failed (%s); "
                 "falling back to per-file scan", exc)
             continue
-        narrowed.extend(r.path for r in results)
+        scope_prefix = path_filter + "/" if path_filter else ""
+        narrowed.extend(
+            r.path for r in results
+            if r.path == path_filter or r.path.startswith(scope_prefix))
     return [
         PathSpec(original=mount_prefix + "/" + n.lstrip("/"),
                  directory="",

--- a/python/tests/commands/builtin/github/test_grep_search.py
+++ b/python/tests/commands/builtin/github/test_grep_search.py
@@ -17,10 +17,12 @@ from unittest.mock import AsyncMock
 import pytest
 
 from mirage.commands.builtin.github.grep import grep
+from mirage.commands.builtin.github.narrow import narrow_scope
 from mirage.types import PathSpec
 from tests.fixtures.github_mock import MOCK_BLOBS
 
 _GLOBALS = grep.__wrapped__.__globals__
+_NGLOBALS = narrow_scope.__globals__
 
 
 @pytest.fixture(autouse=True)
@@ -54,20 +56,44 @@ async def test_grep_root_large_tree_uses_search(mock_github_api, github_env,
                  resolved=True),
     ]
     spy = AsyncMock(return_value=narrowed)
-    monkeypatch.setitem(_GLOBALS, "SCOPE_WARN", 1)
-    monkeypatch.setitem(_GLOBALS, "narrow_paths", spy)
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
     await grep(accessor, [_root()], "import", r=True, index=index)
     spy.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_grep_subdir_skips_search(mock_github_api, github_env,
-                                        monkeypatch):
+async def test_grep_subdir_uses_search(mock_github_api, github_env,
+                                       monkeypatch):
     accessor, index = github_env
     spy = AsyncMock(return_value=[])
-    monkeypatch.setitem(_GLOBALS, "SCOPE_WARN", 1)
-    monkeypatch.setitem(_GLOBALS, "narrow_paths", spy)
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
     await grep(accessor, [_subdir()], "import", r=True, index=index)
+    spy.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_grep_regex_with_literal_uses_search(mock_github_api, github_env,
+                                                   monkeypatch):
+    accessor, index = github_env
+    spy = AsyncMock(return_value=[])
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
+    await grep(accessor, [_root()], "import.*os", r=True, index=index)
+    spy.assert_awaited_once()
+    assert spy.await_args.args[3] == "import"
+
+
+@pytest.mark.asyncio
+async def test_grep_regex_without_literal_skips_search(mock_github_api,
+                                                       github_env,
+                                                       monkeypatch):
+    accessor, index = github_env
+    spy = AsyncMock(return_value=[])
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
+    await grep(accessor, [_root()], "import|export", r=True, index=index)
     spy.assert_not_awaited()
 
 
@@ -76,7 +102,7 @@ async def test_grep_small_tree_skips_search(mock_github_api, github_env,
                                             monkeypatch):
     accessor, index = github_env
     spy = AsyncMock(return_value=[])
-    monkeypatch.setitem(_GLOBALS, "narrow_paths", spy)
+    monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
     await grep(accessor, [_root()], "import", r=True, index=index)
     spy.assert_not_awaited()
 

--- a/python/tests/commands/builtin/github/test_narrow.py
+++ b/python/tests/commands/builtin/github/test_narrow.py
@@ -1,0 +1,189 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.commands.builtin.github.grep import grep
+from mirage.commands.builtin.github.narrow import narrow_scope
+from mirage.commands.builtin.github.rg import rg
+from mirage.io.stream import materialize
+from mirage.types import PathSpec
+from tests.fixtures.github_mock import MOCK_BLOBS
+
+_NGLOBALS = narrow_scope.__globals__
+
+
+@pytest.fixture
+def counting_read(monkeypatch):
+    reads: list[str] = []
+
+    async def _read_bytes(config, owner, repo, sha):
+        reads.append(sha)
+        return MOCK_BLOBS.get(sha, b"")
+
+    monkeypatch.setattr("mirage.core.github.read.read_bytes", _read_bytes)
+    return reads
+
+
+def _root() -> PathSpec:
+    return PathSpec(original="/", directory="/", prefix="", resolved=False)
+
+
+def _subdir() -> PathSpec:
+    return PathSpec(original="/src",
+                    directory="/src",
+                    prefix="",
+                    resolved=False)
+
+
+@pytest.mark.asyncio
+async def test_subdir_narrows_and_fetches_fewer(mock_github_api, github_env,
+                                                counting_read, monkeypatch):
+    accessor, index = github_env
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    await grep(accessor, [_subdir()], "import", r=True, index=index)
+    # /src holds 7 files; code search narrows to the import-matching subset.
+    assert 0 < len(counting_read) < 7
+
+
+@pytest.mark.asyncio
+async def test_regex_narrows_via_extracted_literal(mock_github_api, github_env,
+                                                   counting_read, monkeypatch):
+    accessor, index = github_env
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    await grep(accessor, [_root()], "import.*os", r=True, index=index)
+    # "import" is the required literal; only files containing it are fetched.
+    assert 0 < len(counting_read) < len(MOCK_BLOBS)
+
+
+@pytest.mark.asyncio
+async def test_files_only_shortcircuit_reads_nothing(mock_github_api,
+                                                     github_env, counting_read,
+                                                     monkeypatch):
+    accessor, index = github_env
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    stdout, io = await grep(accessor, [_root()],
+                            "import",
+                            r=True,
+                            args_l=True,
+                            index=index)
+    body = (await materialize(stdout)).decode()
+    assert len(counting_read) == 0
+    assert io.exit_code == 0
+    assert "src/main.py" in body
+
+
+@pytest.mark.asyncio
+async def test_files_only_shortcircuit_matches_generic(mock_github_api,
+                                                       github_env,
+                                                       monkeypatch):
+    accessor, index = github_env
+
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 10_000)
+    out_generic, _ = await grep(accessor, [_root()],
+                                "import",
+                                r=True,
+                                args_l=True,
+                                index=index)
+    text_generic = (await materialize(out_generic)).decode()
+
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    out_short, _ = await grep(accessor, [_root()],
+                              "import",
+                              r=True,
+                              args_l=True,
+                              index=index)
+    text_short = (await materialize(out_short)).decode()
+
+    assert text_short == text_generic
+    assert text_short
+
+
+@pytest.mark.asyncio
+async def test_rg_files_only_shortcircuit_reads_nothing(
+        mock_github_api, github_env, counting_read, monkeypatch):
+    accessor, index = github_env
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    stdout, io = await rg(accessor, [_root()],
+                          "import",
+                          args_l=True,
+                          index=index)
+    body = (await materialize(stdout)).decode()
+    assert len(counting_read) == 0
+    assert io.exit_code == 0
+    assert "src/main.py" in body
+
+
+@pytest.mark.asyncio
+async def test_rg_files_only_shortcircuit_matches_generic(
+        mock_github_api, github_env, monkeypatch):
+    accessor, index = github_env
+
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 10_000)
+    out_generic, _ = await rg(accessor, [_root()],
+                              "import",
+                              args_l=True,
+                              index=index)
+    text_generic = (await materialize(out_generic)).decode()
+
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    out_short, _ = await rg(accessor, [_root()],
+                            "import",
+                            args_l=True,
+                            index=index)
+    text_short = (await materialize(out_short)).decode()
+
+    assert text_short == text_generic
+    assert text_short
+
+
+@pytest.mark.asyncio
+async def test_rg_files_only_shortcircuit_respects_glob(
+        mock_github_api, github_env, monkeypatch):
+    accessor, index = github_env
+
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 10_000)
+    out_generic, _ = await rg(accessor, [_root()],
+                              "import",
+                              args_l=True,
+                              glob="main*.py",
+                              index=index)
+    text_generic = (await materialize(out_generic)).decode()
+
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    out_short, _ = await rg(accessor, [_root()],
+                            "import",
+                            args_l=True,
+                            glob="main*.py",
+                            index=index)
+    text_short = (await materialize(out_short)).decode()
+
+    assert text_short == text_generic
+    assert "main.py" in text_short
+    assert "utils.py" not in text_short
+
+
+@pytest.mark.asyncio
+async def test_rg_shortcircuit_no_match_exit_1(mock_github_api, github_env,
+                                               monkeypatch):
+    accessor, index = github_env
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    stdout, io = await rg(accessor, [_root()],
+                          "import",
+                          args_l=True,
+                          glob="*.nomatch",
+                          index=index)
+    body = (await materialize(stdout)).decode()
+    assert io.exit_code == 1
+    assert body == ""

--- a/python/tests/commands/builtin/github/test_rg_search.py
+++ b/python/tests/commands/builtin/github/test_rg_search.py
@@ -16,12 +16,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from mirage.commands.builtin.github.narrow import narrow_scope
 from mirage.commands.builtin.github.rg import rg
 from mirage.io.stream import materialize
 from mirage.types import PathSpec
 from tests.fixtures.github_mock import MOCK_BLOBS
 
 _GLOBALS = rg.__wrapped__.__globals__
+_NGLOBALS = narrow_scope.__globals__
 
 
 @pytest.fixture(autouse=True)
@@ -59,8 +61,8 @@ async def test_rg_root_large_tree_uses_search(mock_github_api, github_env,
                  resolved=True),
     ]
     spy = AsyncMock(return_value=narrowed)
-    monkeypatch.setitem(_GLOBALS, "SCOPE_WARN", 1)
-    monkeypatch.setitem(_GLOBALS, "narrow_paths", spy)
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
     stdout, io = await rg(accessor, [_root()], "import", c=True, index=index)
     spy.assert_awaited_once()
     text = (await materialize(stdout)).decode()
@@ -70,23 +72,35 @@ async def test_rg_root_large_tree_uses_search(mock_github_api, github_env,
 
 
 @pytest.mark.asyncio
-async def test_rg_subdir_skips_search(mock_github_api, github_env,
-                                      monkeypatch):
+async def test_rg_subdir_uses_search(mock_github_api, github_env, monkeypatch):
     accessor, index = github_env
     spy = AsyncMock(return_value=[])
-    monkeypatch.setitem(_GLOBALS, "SCOPE_WARN", 1)
-    monkeypatch.setitem(_GLOBALS, "narrow_paths", spy)
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
     await rg(accessor, [_subdir()], "import", index=index)
-    spy.assert_not_awaited()
+    spy.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_rg_regex_skips_search(mock_github_api, github_env, monkeypatch):
+async def test_rg_regex_with_literal_uses_search(mock_github_api, github_env,
+                                                 monkeypatch):
     accessor, index = github_env
     spy = AsyncMock(return_value=[])
-    monkeypatch.setitem(_GLOBALS, "SCOPE_WARN", 1)
-    monkeypatch.setitem(_GLOBALS, "narrow_paths", spy)
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
     await rg(accessor, [_root()], "imp.*rt", index=index)
+    spy.assert_awaited_once()
+    assert spy.await_args.args[3] == "imp"
+
+
+@pytest.mark.asyncio
+async def test_rg_regex_without_literal_skips_search(mock_github_api,
+                                                     github_env, monkeypatch):
+    accessor, index = github_env
+    spy = AsyncMock(return_value=[])
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
+    await rg(accessor, [_root()], "imp|exp", index=index)
     spy.assert_not_awaited()
 
 
@@ -95,7 +109,7 @@ async def test_rg_small_tree_skips_search(mock_github_api, github_env,
                                           monkeypatch):
     accessor, index = github_env
     spy = AsyncMock(return_value=[])
-    monkeypatch.setitem(_GLOBALS, "narrow_paths", spy)
+    monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
     await rg(accessor, [_root()], "import", index=index)
     spy.assert_not_awaited()
 

--- a/python/tests/commands/builtin/test_grep_helper.py
+++ b/python/tests/commands/builtin/test_grep_helper.py
@@ -12,10 +12,16 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import re
+
+import pytest
+
 from mirage.commands.builtin.constants import PatternType
 from mirage.commands.builtin.grep_helper import (NEVER_MATCH, classify_pattern,
                                                  compile_pattern,
-                                                 merge_pattern_list)
+                                                 extract_required_literal,
+                                                 merge_pattern_list,
+                                                 search_query)
 
 
 def test_single_pattern_keeps_regex_semantics():
@@ -95,3 +101,43 @@ def test_never_match_pattern_matches_nothing():
     pat = compile_pattern(NEVER_MATCH)
     assert not pat.search("")
     assert not pat.search("anything")
+
+
+@pytest.mark.parametrize("pattern,expected", [
+    ("import.*os", "import"),
+    ("imp.*rt", "imp"),
+    ("^import", "import"),
+    ("colou?r", "colo"),
+    ("[Ee]rror", "rror"),
+    (r"\d+error", "error"),
+    ("config$", "config"),
+    ("a*b", None),
+    ("ab", None),
+    ("foo|bar", None),
+    ("(ab)?cdef", "cdef"),
+])
+def test_extract_required_literal(pattern, expected):
+    assert extract_required_literal(pattern) == expected
+
+
+def test_extract_literal_is_required_substring():
+    for pattern in ("import.*os", "colou?r", "[Ee]rror", r"\d+error"):
+        literal = extract_required_literal(pattern)
+        assert literal is not None
+        for sample in ("import sys, os", "color", "colour", "Error here",
+                       "an error", "x42error"):
+            if re.search(pattern, sample):
+                assert literal in sample
+
+
+def test_search_query_literal_returns_pattern():
+    assert search_query("import", False) == "import"
+    assert search_query("foo", True) == "foo"
+
+
+def test_search_query_regex_extracts_literal():
+    assert search_query("import.*os", False) == "import"
+
+
+def test_search_query_regex_no_literal_is_none():
+    assert search_query("foo|bar", False) is None


### PR DESCRIPTION
Fixes the slow `grep -rln` / `rg -l` on the GitHub backend reported in #404 (60s timeout vs 2s on disk).

## Root cause

The code-search pushdown that avoids fetching every file only fired for **literal patterns at the repo root**. Two common cases silently fell back to reading every file:

- **Subdirectory scope** (`grep -rln x /repo/docs/`) skipped search entirely.
- **Regex patterns** skipped search entirely.

(The original "empty index on cold start" theory was wrong: the tree index is populated eagerly at construction, so the gate was the scope/regex restriction, not the index.)

## Changes

- **Subdir narrowing.** Dropped the repo-root-only gate; any recursive scope on the default branch narrows via `/search/code`, with the scope passed as the `path:` filter and results post-filtered to the scope prefix.
- **Regex narrowing.** New `extract_required_literal` pulls the longest substring every match must contain (`import.*os` -> `import`, `[Ee]rror` -> `rror`); search narrows on it and the real regex is scanned locally, so results stay exact. Falls back to a full scan when no literal can be proven required (alternation, char-class-only, < 3 chars).
- **`-l` short-circuit.** For a plain literal `-l`, the narrowed set already is the answer, so the file list is emitted without reading any content. rg applies its hidden/`--type`/`--glob` filter to that set (reusing `rg_matches_filter`); grep has no file filter so it lists all narrowed files.
- **Shared helper.** `narrow_scope` + `files_only_shortcircuit` in `github/narrow.py`, used by both `grep` and `rg`.
- Exit codes match GNU/ripgrep and the generic commands (match -> 0, no match -> 1).

## Measured (mirage-internal, github example)

- `grep -rln BaseResource /python/mirage/`: ~0.7s (short-circuit, 0 content reads)
- `rg -l GitHubAccessor /python/mirage/`: 9.9s -> ~0.9s
- `rg -l --glob '*.py'` / `--type py`: filter correctly applied to the narrowed set

## Tests

- `extract_required_literal` / `search_query` table + required-substring property.
- Fetch-counting: subdir and regex narrow and read fewer files.
- `-l` short-circuit: zero reads, output and exit code byte-identical to the un-narrowed generic; rg `--glob` parity (`main*.py` keeps only `main.py`) and no-match -> exit 1.

## Follow-up

TypeScript parity (`grep.ts`/`rg.ts`/`search.ts`/`scope.ts`) is not in this PR.