### PR TITLE
ts(cache): hide the file cache as a store, not a mount

### DIFF
--- a/integ/mongodb.ts
+++ b/integ/mongodb.ts
@@ -139,9 +139,6 @@ async function runFollow(ws: Workspace, client: MongoClient): Promise<void> {
 function setCatSafeguard(ws: Workspace, maxLines: number): void {
   const sg = new CommandSafeguard({ maxLines });
   for (const m of ws.registry.allMounts()) m.commandSafeguards.set("cat", sg);
-  if (ws.registry.defaultMount !== null) {
-    ws.registry.defaultMount.commandSafeguards.set("cat", sg);
-  }
 }
 
 async function main(): Promise<void> {

--- a/integ/postgres.ts
+++ b/integ/postgres.ts
@@ -111,9 +111,6 @@ async function run(ws: Workspace, name: string, cmd: string): Promise<void> {
 function setCatSafeguard(ws: Workspace, maxLines: number): void {
   const sg = new CommandSafeguard({ maxLines });
   for (const m of ws.registry.allMounts()) m.commandSafeguards.set("cat", sg);
-  if (ws.registry.defaultMount !== null) {
-    ws.registry.defaultMount.commandSafeguards.set("cat", sg);
-  }
 }
 
 async function main(): Promise<void> {

--- a/typescript/packages/core/src/cache/lock.test.ts
+++ b/typescript/packages/core/src/cache/lock.test.ts
@@ -1,0 +1,91 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+// Behavioral mirror of python/tests/cache/test_lock.py. Python exposes a
+// per-key asyncio lock (`_lock_for`); TS exposes a `withLock(key, fn)` runner.
+// The guarantees are the same: same key serializes, different keys run
+// concurrently, the lock releases on throw, and discard/clear are safe.
+
+import { describe, expect, it } from 'vitest'
+import { KeyLock } from './lock.ts'
+
+const tick = (ms = 10): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('KeyLock', () => {
+  it('serializes calls on the same key', async () => {
+    const lock = new KeyLock()
+    const order: string[] = []
+    const first = lock.withLock('/same', async () => {
+      order.push('first_start')
+      await tick()
+      order.push('first_end')
+    })
+    const second = lock.withLock('/same', async () => {
+      order.push('second_start')
+      await tick()
+      order.push('second_end')
+    })
+    await Promise.all([first, second])
+    expect(order).toEqual(['first_start', 'first_end', 'second_start', 'second_end'])
+  })
+
+  it('runs different keys concurrently without blocking', async () => {
+    const lock = new KeyLock()
+    const order: string[] = []
+    const a = lock.withLock('/a', async () => {
+      order.push('a_start')
+      await tick()
+      order.push('a_end')
+    })
+    const b = lock.withLock('/b', async () => {
+      order.push('b_start')
+      await tick()
+      order.push('b_end')
+    })
+    await Promise.all([a, b])
+    // Both critical sections start before either ends (they interleave).
+    expect(order.indexOf('b_start')).toBeLessThan(order.indexOf('a_end'))
+    expect(order.indexOf('a_start')).toBeLessThan(order.indexOf('b_end'))
+  })
+
+  it('returns the callback result', async () => {
+    const lock = new KeyLock()
+    expect(await lock.withLock('/k', () => Promise.resolve(42))).toBe(42)
+  })
+
+  it('releases the lock when the callback throws', async () => {
+    const lock = new KeyLock()
+    await expect(lock.withLock('/k', () => Promise.reject(new Error('boom')))).rejects.toThrow(
+      'boom',
+    )
+    // A subsequent call on the same key must still acquire the lock.
+    expect(await lock.withLock('/k', () => Promise.resolve('ok'))).toBe('ok')
+  })
+
+  it('discard and clear are safe (including a missing key)', async () => {
+    const lock = new KeyLock()
+    await lock.withLock('/a', () => Promise.resolve(undefined))
+    expect(() => {
+      lock.discard('/missing')
+    }).not.toThrow()
+    expect(() => {
+      lock.discard('/a')
+    }).not.toThrow()
+    expect(() => {
+      lock.clear()
+    }).not.toThrow()
+    // Still usable after clear.
+    expect(await lock.withLock('/a', () => Promise.resolve('again'))).toBe('again')
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/general/curl_persist.test.ts
+++ b/typescript/packages/core/src/commands/builtin/general/curl_persist.test.ts
@@ -90,11 +90,14 @@ describe('curl -o persists to mount', () => {
     await ws.close()
   })
 
-  it('fails when target has no mount', async () => {
+  it('fails when the target path has no parent directory', async () => {
+    // No `/nope` mount and no `/nope` dir under the root anchor, so the write
+    // routes to the empty root mount and fails because the parent is missing
+    // (the catch-all root never silently swallows an unmounted path).
     const ws = await makeWs()
     const io = await ws.execute('curl -s https://x.test/file -o /nope/foo.bin')
     expect(io.exitCode).toBe(1)
-    expect(io.stderrText).toMatch(/no mount/)
+    expect(io.stderrText).toMatch(/parent directory does not exist/)
     expect(io.stderrText).toContain('/nope/foo.bin')
     await ws.close()
   })

--- a/typescript/packages/core/src/workspace/cache_invalidation.test.ts
+++ b/typescript/packages/core/src/workspace/cache_invalidation.test.ts
@@ -1,0 +1,132 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+// Mirror of python/tests/workspace/test_cache_invalidation.py. The Python
+// suite uses moto S3 (a caching backend); TS core has no S3 in unit tests, so
+// it forces a RAM mount to cache reads, which exercises the same write-site
+// invalidation hooks (a mutation invalidates the file cache and the parent
+// listing before the next command in the pipeline runs).
+
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+import { RAMResource } from '../resource/ram/ram.ts'
+import { createShellParser } from '../shell/parse.ts'
+import { MountMode } from '../types.ts'
+import { Workspace } from './workspace.ts'
+
+const DEC = new TextDecoder()
+const require = createRequire(import.meta.url)
+const engineWasm = readFileSync(require.resolve('web-tree-sitter/web-tree-sitter.wasm'))
+const grammarWasm = readFileSync(require.resolve('tree-sitter-bash/tree-sitter-bash.wasm'))
+
+function cachingWorkspace(): Workspace {
+  const ram = new RAMResource()
+  // Force the cache on so reads are cached and write-site invalidation matters,
+  // mirroring an S3-style caching backend (local RAM does not cache by default).
+  ;(ram as unknown as { cachesReads: boolean }).cachesReads = true
+  return new Workspace(
+    { '/data': ram },
+    {
+      mode: MountMode.WRITE,
+      shellParserFactory: async () => createShellParser({ engineWasm, grammarWasm }),
+    },
+  )
+}
+
+async function exec(ws: Workspace, cmd: string): Promise<{ code: number; out: string }> {
+  const res = await ws.execute(cmd)
+  return { code: res.exitCode, out: DEC.decode(res.stdout) }
+}
+
+describe('cache invalidation at the write site', () => {
+  it('gzip roundtrip with an interleaved ls sees the recreated file', async () => {
+    const ws = cachingWorkspace()
+    try {
+      const { code, out } = await exec(
+        ws,
+        'mkdir -p /data/arch' +
+          ' && echo two | tee /data/arch/h.txt > /dev/null' +
+          ' && gzip /data/arch/h.txt' +
+          ' && ls /data/arch' +
+          ' && gunzip /data/arch/h.txt.gz' +
+          ' && cat /data/arch/h.txt',
+      )
+      expect(code).toBe(0)
+      expect(out).toContain('two')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('ls sees a file created after a prior listing cached the directory', async () => {
+    const ws = cachingWorkspace()
+    try {
+      const setup = await exec(
+        ws,
+        'mkdir -p /data/arch && echo one | tee /data/arch/a.txt > /dev/null && ls /data/arch',
+      )
+      expect(setup.code).toBe(0)
+      const { code, out } = await exec(
+        ws,
+        'echo two | tee /data/arch/b.txt > /dev/null && ls /data/arch',
+      )
+      expect(code).toBe(0)
+      expect(out).toContain('b.txt')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('ls does not show a file removed after it was listed', async () => {
+    const ws = cachingWorkspace()
+    try {
+      const setup = await exec(
+        ws,
+        'mkdir -p /data/arch && echo gone | tee /data/arch/c.txt > /dev/null && ls /data/arch',
+      )
+      expect(setup.code).toBe(0)
+      const rm = await exec(ws, 'rm /data/arch/c.txt')
+      expect(rm.code).toBe(0)
+      const { code, out } = await exec(ws, 'ls /data/arch')
+      expect(code).toBe(0)
+      expect(out).not.toContain('c.txt')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  // Mirrors python/tests/integration/test_cache_write_through.py: a cat warms
+  // the file cache, rm evicts that cached entry (not just the listing), so a
+  // re-cat fails instead of serving the stale cached bytes.
+  it('rm after cat evicts the file cache so a re-read fails', async () => {
+    const ws = cachingWorkspace()
+    try {
+      const setup = await exec(
+        ws,
+        'mkdir -p /data/arch && echo hi | tee /data/arch/f.txt > /dev/null',
+      )
+      expect(setup.code).toBe(0)
+      const first = await exec(ws, 'cat /data/arch/f.txt')
+      expect(first.code).toBe(0)
+      expect(first.out).toContain('hi')
+      const rm = await exec(ws, 'rm /data/arch/f.txt')
+      expect(rm.code).toBe(0)
+      const reread = await exec(ws, 'cat /data/arch/f.txt')
+      expect(reread.code).not.toBe(0)
+    } finally {
+      await ws.close()
+    }
+  })
+})

--- a/typescript/packages/core/src/workspace/cache_mount.test.ts
+++ b/typescript/packages/core/src/workspace/cache_mount.test.ts
@@ -12,147 +12,78 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import { describe, expect, it } from 'vitest'
-import { command } from '../commands/config.ts'
-import { specOf } from '../commands/spec/builtins.ts'
-import { IOResult } from '../io/types.ts'
-import type { RegisteredOp } from '../ops/registry.ts'
+import { cachesReads } from '../resource/base.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
-import { MountMode, ResourceName, type PathSpec } from '../types.ts'
-import { MountEntry } from './mount/mount.ts'
+import { createShellParser } from '../shell/parse.ts'
+import { ConsistencyPolicy, MountMode, PathSpec } from '../types.ts'
 import { Workspace } from './workspace.ts'
 
 const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+const require = createRequire(import.meta.url)
+const engineWasm = readFileSync(require.resolve('web-tree-sitter/web-tree-sitter.wasm'))
+const grammarWasm = readFileSync(require.resolve('tree-sitter-bash/tree-sitter-bash.wasm'))
 
-const echopath = command({
-  name: 'echopath',
-  resource: ResourceName.RAM,
-  spec: specOf('cat'),
-  fn: (_accessor, paths: readonly PathSpec[]) => {
-    const first = paths[0]
-    if (first === undefined) {
-      return [
-        null,
-        new IOResult({ exitCode: 1, stderr: ENC.encode('echopath: missing operand\n') }),
-      ]
+describe('cache is a hidden store, not a mount', () => {
+  it('is decoupled from the root mount', async () => {
+    // The file cache is reached via `registry.fileCache`, not the root mount's
+    // resource. When no `/` is mounted the root is an ordinary empty RAM mount
+    // at `/` (a normal entry in allMounts) and never holds the cache.
+    const ws = new Workspace({ '/data/': new RAMResource() }, { mode: MountMode.WRITE })
+    try {
+      expect(ws.registry.fileCache).toBe(ws.cache)
+      const root = ws.registry.rootMount
+      expect(root).not.toBeNull()
+      expect(root?.resource).not.toBe(ws.cache)
+      expect(cachesReads(root?.resource ?? new RAMResource())).toBe(false)
+      expect(root?.prefix).toBe('/')
+      expect(ws.registry.allMounts()).toContain(root)
+    } finally {
+      await ws.close()
     }
-    return [ENC.encode(`echopath:${first.original}`), new IOResult()]
-  },
-})
-
-const helloOp: RegisteredOp = {
-  name: 'hello_op',
-  resource: ResourceName.RAM,
-  filetype: null,
-  fn: (_accessor, path) => `hello:${path.original}`,
-  write: false,
-}
-
-function mkWs(): Workspace {
-  return new Workspace({ '/data/': new RAMResource() }, { mode: MountMode.WRITE })
-}
-
-describe('Workspace.cacheMount accessor', () => {
-  it('returns a Mount that is the registry default mount', () => {
-    const ws = mkWs()
-    expect(ws.cacheMount).toBeInstanceOf(MountEntry)
-    expect(ws.cacheMount).toBe(ws.registry.defaultMount)
-    expect(ws.cacheMount.prefix).toBe('/_default/')
   })
 
-  it('cacheMount.resource is the workspace cache', () => {
-    const ws = mkWs()
-    expect(ws.cacheMount.resource).toBe(ws.cache)
+  it('reuses a user-provided / mount as the root anchor (no synthetic root)', async () => {
+    const userRoot = new RAMResource()
+    const ws = new Workspace({ '/': userRoot }, { mode: MountMode.WRITE })
+    try {
+      expect(ws.registry.rootMount?.resource).toBe(userRoot)
+      expect(ws.registry.fileCache).toBe(ws.cache)
+    } finally {
+      await ws.close()
+    }
   })
 })
 
-describe('Workspace.cacheMount.registerFns', () => {
-  it('accepts a RAM-typed command', () => {
-    const ws = mkWs()
-    ws.cacheMount.registerFns(echopath)
-    const cmd = ws.cacheMount.resolveCommand('echopath')
-    expect(cmd).not.toBeNull()
-    expect(cmd?.name).toBe('echopath')
-  })
-
-  it('accepts a RAM-typed op', () => {
-    const ws = mkWs()
-    ws.cacheMount.registerFns([helloOp])
-    const registered = ws.cacheMount.registeredOps()
-    expect(registered.hello_op).toBeDefined()
-  })
-
-  it('rejects a command whose resource kind mismatches the cache', () => {
-    const ws = mkWs()
-    const diskOnly = command({
-      name: 'disk_only',
-      resource: ResourceName.DISK,
-      spec: specOf('cat'),
-      fn: () => [null, new IOResult()],
-    })
-    expect(() => {
-      ws.cacheMount.registerFns(diskOnly)
-    }).toThrow(/'disk'/)
-  })
-
-  it('multi-resource command filters to matching resource', () => {
-    const ws = mkWs()
-    const multi = command({
-      name: 'multi',
-      resource: [ResourceName.RAM, ResourceName.S3],
-      spec: specOf('cat'),
-      fn: () => [null, new IOResult()],
-    })
-    ws.cacheMount.registerFns(multi)
-    const cmd = ws.cacheMount.resolveCommand('multi')
-    expect(cmd).not.toBeNull()
-    expect(cmd?.resource).toBe(ResourceName.RAM)
-  })
-
-  it('multi-resource command with no matching resource throws', () => {
-    const ws = mkWs()
-    const noneMatch = command({
-      name: 'noneMatch',
-      resource: [ResourceName.S3, ResourceName.DISK],
-      spec: specOf('cat'),
-      fn: () => [null, new IOResult()],
-    })
-    expect(() => {
-      ws.cacheMount.registerFns(noneMatch)
-    }).toThrow(/'disk'.*'s3'/)
-  })
-
-  it('multi-resource op filters to matching resource', () => {
-    const ws = mkWs()
-    const fn = (_acc: unknown, p: PathSpec): string => `multi:${p.original}`
-    const multiOps: RegisteredOp[] = [
-      { name: 'multi_op', resource: ResourceName.RAM, filetype: null, fn, write: false },
-      { name: 'multi_op', resource: ResourceName.S3, filetype: null, fn, write: false },
-    ]
-    ws.cacheMount.registerFns(multiOps)
-    expect(ws.cacheMount.registeredOps().multi_op).toBeDefined()
-  })
-
-  it('multi-resource op with no matching resource throws', () => {
-    const ws = mkWs()
-    const fn = (_acc: unknown, p: PathSpec): string => p.original
-    const noneMatchOps: RegisteredOp[] = [
-      { name: 'none_op', resource: ResourceName.S3, filetype: null, fn, write: false },
-      { name: 'none_op', resource: ResourceName.DISK, filetype: null, fn, write: false },
-    ]
-    expect(() => {
-      ws.cacheMount.registerFns(noneMatchOps)
-    }).toThrow(/'disk'.*'s3'/)
-  })
-})
-
-describe('setDefaultMount ops symmetry', () => {
-  it('auto-registers resource.ops() on the cache mount, mirroring mount()', () => {
-    const ws = mkWs()
-    const cacheOps = ws.cacheMount.registeredOps()
-    const resourceOpNames = new Set((ws.cacheMount.resource.ops?.() ?? []).map((o) => o.name))
-    for (const name of resourceOpNames) {
-      expect(cacheOps[name]).toBeDefined()
+describe('warm read serves from the hidden store, command stays on its mount', () => {
+  it('serves a cached operand under LAZY after out-of-band mutation', async () => {
+    const ram = new RAMResource()
+    // Force the cache on a local backend so the read is cached and, under LAZY,
+    // never revalidated. A subsequent out-of-band mutation must NOT be seen:
+    // the warm read serves the cached bytes from the hidden store while the
+    // command stays on its real mount.
+    ;(ram as unknown as { cachesReads: boolean }).cachesReads = true
+    const ws = new Workspace(
+      { '/r': ram },
+      {
+        mode: MountMode.WRITE,
+        consistency: ConsistencyPolicy.LAZY,
+        shellParserFactory: async () => createShellParser({ engineWasm, grammarWasm }),
+      },
+    )
+    try {
+      await ram.writeFile(PathSpec.fromStrPath('/a.txt'), ENC.encode('v1\n'))
+      const first = DEC.decode((await ws.execute('cat /r/a.txt')).stdout)
+      expect(first).toContain('v1')
+      await ram.writeFile(PathSpec.fromStrPath('/a.txt'), ENC.encode('v2\n'))
+      const second = DEC.decode((await ws.execute('cat /r/a.txt')).stdout)
+      expect(second).toContain('v1')
+      expect(second).not.toContain('v2')
+    } finally {
+      await ws.close()
     }
   })
 })

--- a/typescript/packages/core/src/workspace/command_safeguard.test.ts
+++ b/typescript/packages/core/src/workspace/command_safeguard.test.ts
@@ -44,9 +44,6 @@ function buildWs(nLines: number): Workspace {
 
 function overrideSafeguard(ws: Workspace, name: string, sg: CommandSafeguard): void {
   for (const m of ws.registry.allMounts()) m.commandSafeguards.set(name, sg)
-  if (ws.registry.defaultMount !== null) {
-    ws.registry.defaultMount.commandSafeguards.set(name, sg)
-  }
 }
 
 async function runCmd(

--- a/typescript/packages/core/src/workspace/default_mount_cache_dedup.test.ts
+++ b/typescript/packages/core/src/workspace/default_mount_cache_dedup.test.ts
@@ -54,7 +54,7 @@ describe('default mount cache dedup', () => {
 
       expect(sizeSecond).toBe(sizeFirst)
       expect(keysSecond).toEqual(keysFirst)
-      expect(keysSecond.every((k) => !k.startsWith('/_default/'))).toBe(true)
+      expect(keysSecond.every((k) => k.startsWith('/r/'))).toBe(true)
     } finally {
       await ws.close()
     }

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -304,7 +304,7 @@ export async function handleCommand(
       }
     }
     const prefix = rstripSlash(mount.prefix)
-    if (prefix !== '' && mount !== registry.defaultMount) {
+    if (prefix !== '') {
       io.reads = prefixKeys(io.reads, prefix)
       io.writes = prefixKeys(io.writes, prefix)
       io.cache = io.cache.map((p) => prefix + p)

--- a/typescript/packages/core/src/workspace/mount/registry.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.ts
@@ -23,13 +23,6 @@ import { rstripSlash, stripSlash } from '../../utils/slash.ts'
 
 export const DEV_PREFIX = '/dev/'
 
-function isFileCache(resource: Resource): resource is Resource & FileCache {
-  const r = resource as Partial<FileCache>
-  return (
-    typeof r.allCached === 'function' && typeof r.get === 'function' && typeof r.set === 'function'
-  )
-}
-
 export interface OpsMountInfo {
   prefix: string
   resourceType: string
@@ -38,25 +31,25 @@ export interface OpsMountInfo {
 
 export class MountRegistry {
   private readonly mountList: MountEntry[]
-  private defaultMountRef: MountEntry | null = null
+  private rootRef: MountEntry | null = null
   private consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY
   private readonly defaultMode: MountMode
-  private fileCache: FileCache | null = null
+  private cacheStore: FileCache | null = null
 
   /**
    * Attach the workspace file cache and build per-mount CacheManagers.
    * Called once by Workspace after the cache store exists; mounts
-   * added later get their manager in `mount()` / `setDefaultMount()`.
+   * added later get their manager in `mount()`. The cache is a hidden
+   * store, never a mount.
    */
   attachFileCache(cache: FileCache | null): void {
-    this.fileCache = cache
+    this.cacheStore = cache
     for (const m of this.mountList) this.attachManager(m)
-    if (this.defaultMountRef !== null) this.attachManager(this.defaultMountRef)
   }
 
   private attachManager(m: MountEntry): void {
     m.cacheManager = new CacheManager(
-      this.fileCache,
+      this.cacheStore,
       m.resource.index ?? null,
       m.prefix,
       cachesReads(m.resource),
@@ -90,6 +83,7 @@ export class MountRegistry {
     }
     mounts.sort((a, b) => b.prefix.length - a.prefix.length)
     this.mountList = mounts
+    this.rootRef = mounts.find((m) => m.prefix === '/') ?? null
   }
 
   setConsistency(consistency: ConsistencyPolicy): void {
@@ -136,9 +130,10 @@ export class MountRegistry {
         else m.registerOp(op)
       }
     }
-    if (this.fileCache !== null) this.attachManager(m)
+    if (this.cacheStore !== null) this.attachManager(m)
     this.mountList.push(m)
     this.mountList.sort((a, b) => b.prefix.length - a.prefix.length)
+    if (norm === '/') this.rootRef = m
     return m
   }
 
@@ -160,6 +155,7 @@ export class MountRegistry {
     if (removed === undefined) {
       throw new Error(`no mount at prefix: ${norm}`)
     }
+    if (removed === this.rootRef) this.rootRef = null
     return removed
   }
 
@@ -247,22 +243,12 @@ export class MountRegistry {
     return [...groups.entries()]
   }
 
-  setDefaultMount(resource: Resource): MountEntry {
-    const mount = new MountEntry({ prefix: '/_default/', resource, mode: MountMode.WRITE })
-    const ops = resource.ops?.()
-    if (ops !== undefined) {
-      for (const op of ops) {
-        if (op.resource === null) mount.registerGeneralOp(op)
-        else mount.registerOp(op)
-      }
-    }
-    if (this.fileCache !== null) this.attachManager(mount)
-    this.defaultMountRef = mount
-    return mount
+  get rootMount(): MountEntry | null {
+    return this.rootRef
   }
 
-  get defaultMount(): MountEntry | null {
-    return this.defaultMountRef
+  get fileCache(): FileCache | null {
+    return this.cacheStore
   }
 
   resolve(path: string): [Resource, PathSpec, MountMode] {
@@ -305,9 +291,9 @@ export class MountRegistry {
   }
 
   mountForCommand(cmdName: string): MountEntry | null {
-    if (this.defaultMountRef !== null) {
-      const cmd = this.defaultMountRef.resolveCommand(cmdName)
-      if (cmd !== null) return this.defaultMountRef
+    if (this.rootRef !== null) {
+      const cmd = this.rootRef.resolveCommand(cmdName)
+      if (cmd !== null) return this.rootRef
     }
     for (const m of this.mountList) {
       if (m.prefix === DEV_PREFIX) continue
@@ -329,21 +315,19 @@ export class MountRegistry {
       mount = this.mountForCommand(cmdName)
     }
     if (mount === null) return null
-    const defaultMount = this.defaultMountRef
     // Warm reads are served in place by withReadCache, so a read-only command
     // stays on its real mount. The cache is a hidden store (not a mount);
     // under ALWAYS we evict stale entries from it here so the read-through
     // serves fresh bytes.
     const baseCmd = mount.resolveCommand(cmdName)
     if (
-      defaultMount !== null &&
+      this.cacheStore !== null &&
       pathScopes.length > 0 &&
-      isFileCache(defaultMount.resource) &&
       cachesReads(mount.resource) &&
       baseCmd?.write !== true &&
       this.consistency === ConsistencyPolicy.ALWAYS
     ) {
-      await this.evictStale(mount, defaultMount.resource, pathScopes)
+      await this.evictStale(mount, this.cacheStore, pathScopes)
     }
     return mount
   }

--- a/typescript/packages/core/src/workspace/provision/command.ts
+++ b/typescript/packages/core/src/workspace/provision/command.ts
@@ -125,10 +125,7 @@ export async function handleCommandProvision(
     result.command = cmdStr
   }
 
-  const defaultMount = registry.defaultMount
-  const cache =
-    defaultMount !== null ? (defaultMount.resource as unknown as FileCache | null) : null
-  const hits = await checkCacheHits(cache, scopedParts)
+  const hits = await checkCacheHits(registry.fileCache, scopedParts)
   if (hits > 0) {
     result.cacheHits = hits
     result.cacheReadLow = result.networkReadLow

--- a/typescript/packages/core/src/workspace/session/session.test.ts
+++ b/typescript/packages/core/src/workspace/session/session.test.ts
@@ -67,7 +67,7 @@ describe('Session.fork', () => {
       sessionId: 'orig',
       cwd: '/disk',
       env: { FOO: 'bar' },
-      allowedMounts: new Set(['/s3', '/dev', '/_default']),
+      allowedMounts: new Set(['/s3', '/dev', '/']),
       shellOptions: { errexit: true },
       readonlyVars: new Set(['HOME']),
       arrays: { ARGV: ['a', 'b'] },

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -166,14 +166,16 @@ describe('Workspace.execute AbortSignal', () => {
 })
 
 describe('Workspace.unmount', () => {
-  it('removes a mount from mounts() and rejects subsequent dispatch', async () => {
+  it('removes a mount from mounts(); the path falls through to the root anchor', async () => {
     const a = new RAMResource()
     const b = new RAMResource()
     const ws = new Workspace({ '/a': a, '/b': b }, { mode: MountMode.WRITE })
     expect(ws.mounts().some((m) => m.prefix === '/a/')).toBe(true)
     await ws.unmount('/a')
     expect(ws.mounts().some((m) => m.prefix === '/a/')).toBe(false)
-    await expect(ws.resolve('/a/x')).rejects.toThrow(/no mount/i)
+    // With /a gone the path no longer routes to a's resource; it falls through
+    // to the empty root anchor (prefix '/'), not back to /a.
+    expect(ws.registry.mountFor('/a/x')?.prefix).toBe('/')
     await ws.close()
   })
 
@@ -196,9 +198,9 @@ describe('Workspace.unmount', () => {
     await ws.close()
   })
 
-  it('throws on cache root, history view, /dev/, and unknown prefix', async () => {
+  it('throws on root, history view, /dev/, and unknown prefix', async () => {
     const ws = new Workspace({ '/data': new RAMResource() })
-    await expect(ws.unmount('/')).rejects.toThrow(/cache root/i)
+    await expect(ws.unmount('/')).rejects.toThrow(/root/i)
     await expect(ws.unmount('/.bash_history')).rejects.toThrow(/history view/i)
     await expect(ws.unmount('/dev')).rejects.toThrow(/reserved/i)
     await expect(ws.unmount('/missing')).rejects.toThrow(/no mount/i)
@@ -217,19 +219,21 @@ describe('Workspace.unmount', () => {
 })
 
 describe('Workspace mount fallback', () => {
-  it('falls back to the default cache mount, not the observer', async () => {
+  it('falls back to the root mount, not the observer', async () => {
     const ws = new Workspace({ '/': new RAMResource() }, { mode: MountMode.WRITE })
     const m = ws.registry.mountForCommand('mkdir')
     expect(m).not.toBeNull()
-    expect(m?.prefix).toBe('/_default/')
+    expect(m?.prefix).toBe('/')
     await ws.close()
   })
 
-  it('skips the history view mount even when no default cache provides the command', async () => {
+  it('skips the history view mount even when no user root provides the command', async () => {
     const ws = new Workspace({ '/r': new RAMResource() }, { mode: MountMode.READ })
-    // The default cache is RAM-backed and writable, so it will satisfy `mkdir`.
-    // The point: even with the read-only history view in the registry, fallback is /_default/, never /.bash_history/.
+    // No `/` was mounted, so the workspace adds a plain empty RAM root anchor
+    // at `/`, which satisfies `mkdir`. The point: even with the read-only
+    // history view in the registry, fallback is the root, never /.bash_history/.
     const m = ws.registry.mountForCommand('mkdir')
+    expect(m?.prefix).toBe('/')
     expect(m?.prefix).not.toBe('/.bash_history/')
     await ws.close()
   })

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -16,6 +16,7 @@ import { NOOPAccessor } from '../accessor/base.ts'
 import type { FileCache } from '../cache/file/mixin.ts'
 import type { IndexConfig } from '../cache/index/config.ts'
 import { RAMFileCacheStore } from '../cache/file/ram.ts'
+import { RAMResource } from '../resource/ram/ram.ts'
 import type { ByteSource } from '../io/types.ts'
 import { IOResult, materialize } from '../io/types.ts'
 import { runWithRecording, runWithRevisions } from '../observe/context.ts'
@@ -190,6 +191,9 @@ export class Workspace {
   private readonly workspaceId: string = `ws-${String(Date.now())}-${Math.random().toString(36).slice(2, 10)}`
   private readonly closers: (() => Promise<void>)[] = []
   private readonly pythonRuntime: PyodideRuntime
+  // True when the workspace auto-added an empty `/` anchor (no user `/` mount).
+  // The anchor is internal and is not forwarded into the Pyodide filesystem.
+  private syntheticRootAnchor = false
   // Drift check state populated by Workspace.load. Empty during normal
   // runs. Drained on first dispatch/execute after load (see
   // {@link runPendingDriftCheck}).
@@ -233,7 +237,15 @@ export class Workspace {
       (p) => this.resolve(p),
       consistency,
     )
-    const defaultMount = this.registry.setDefaultMount(this.cache)
+    // The file cache is a hidden store (attached above), never a mount. Arg-less
+    // commands and root listing resolve against a neutral root anchor: reuse the
+    // user's `/` mount if they gave one, else add a plain empty RAM mount at `/`.
+    // A synthetic anchor is mirage-internal and must NOT be forwarded to Pyodide,
+    // whose own `/` filesystem (holding the Python stdlib) would be hijacked.
+    if (this.registry.rootMount === null) {
+      this.registry.mount('/', new RAMResource(), options.mode ?? MountMode.READ)
+      this.syntheticRootAnchor = true
+    }
     for (const resource of [...this.registry.allMounts().map((m) => m.resource), this.cache]) {
       const resourceOps = resource.ops?.()
       if (resourceOps === undefined) continue
@@ -241,7 +253,7 @@ export class Workspace {
         this.opsRegistry.register(op)
       }
     }
-    for (const mount of [...this.registry.allMounts(), defaultMount]) {
+    for (const mount of this.registry.allMounts()) {
       const cmds = mount.resource.commands?.()
       if (cmds !== undefined) {
         for (const cmd of cmds) {
@@ -266,6 +278,7 @@ export class Workspace {
     this.fs = new WorkspaceFS((path) => this.resolve(path), this.opsRegistry)
     for (const m of this.registry.allMounts()) {
       if (m.prefix === HISTORY_PREFIX || m.prefix === HISTORY_PREFIX + '/') continue
+      if (this.syntheticRootAnchor && m.prefix === '/') continue
       void this.forwardAddMountToPython(m.prefix)
     }
   }
@@ -356,15 +369,15 @@ export class Workspace {
   /**
    * Mount prefixes a session is always allowed to touch.
    *
-   * The cache mount (where text-processing commands like `wc` without a
+   * The root mount (where text-processing commands like `wc` without a
    * path argument resolve), the device mount, and the history view are
    * infrastructure: they hold no user credentials, and rejecting them
    * would break common shell idioms or the history builtin.
    */
   private infrastructureMountPrefixes(): Set<string> {
     const prefixes = new Set<string>(['/dev', HISTORY_PREFIX])
-    const def = this.registry.defaultMount
-    if (def !== null) prefixes.add('/' + stripSlash(def.prefix))
+    const root = this.registry.rootMount
+    if (root !== null) prefixes.add('/' + stripSlash(root.prefix))
     return prefixes
   }
 
@@ -429,8 +442,8 @@ export class Workspace {
     if (this.closed) throw new Error('Workspace is closed')
     const stripped = stripSlash(prefix)
     const norm = stripped ? `/${stripped}/` : '/'
-    if (norm === '/' || norm === '/_default/') {
-      throw new Error(`cannot unmount cache root: ${prefix}`)
+    if (norm === '/') {
+      throw new Error(`cannot unmount root: ${prefix}`)
     }
     if (norm === '/dev/') {
       throw new Error(`cannot unmount reserved prefix: /dev/`)
@@ -458,10 +471,14 @@ export class Workspace {
     }
   }
 
-  get cacheMount(): MountEntry {
-    const m = this.registry.defaultMount
-    if (m === null) throw new Error('cache mount is initialized in constructor')
-    return m
+  /**
+   * True when the `/` mount is an empty anchor the workspace added itself
+   * (no user `/` mount). Consumers that distinguish "genuinely mounted" from
+   * "merely caught by the root anchor" (e.g. the node fs monkey-patch) check
+   * this before treating a root-matched path as backed by a real mount.
+   */
+  get syntheticRoot(): boolean {
+    return this.syntheticRootAnchor
   }
 
   get maxDrainBytes(): number | null {

--- a/typescript/packages/core/src/workspace/workspace_observe.test.ts
+++ b/typescript/packages/core/src/workspace/workspace_observe.test.ts
@@ -106,13 +106,14 @@ describe('Workspace observer wiring', () => {
     await ws.close()
   })
 
-  it('does not mount the observer store (only /data, /dev, /.bash_history)', async () => {
+  it('does not mount the observer store (only root, /data, /dev, /.bash_history)', async () => {
     const ws = buildWorkspace()
     await ws.execute('echo hi > /data/f.txt')
     const result = await ws.execute('ls /.sessions')
     expect(result.exitCode).not.toBe(0)
     const prefixes = new Set(ws.registry.allMounts().map((m) => m.prefix))
-    expect(prefixes).toEqual(new Set(['/data/', '/dev/', '/.bash_history/']))
+    // No `/` was mounted, so the workspace adds an empty root anchor at `/`.
+    expect(prefixes).toEqual(new Set(['/', '/data/', '/dev/', '/.bash_history/']))
     await ws.close()
   })
 })

--- a/typescript/packages/node/src/fs_monkey.ts
+++ b/typescript/packages/node/src/fs_monkey.ts
@@ -30,7 +30,13 @@ type FsLike = Record<string, unknown>
 
 function mountedPath(ws: Workspace, p: string): boolean {
   try {
-    return ws.registry.mountFor(p) !== null
+    const m = ws.registry.mountFor(p)
+    if (m === null) return false
+    // The synthetic root anchor is an empty internal mount that matches every
+    // path; it does not back real files, so paths caught only by it fall
+    // through to the native fs. A user-provided `/` mount is honored.
+    if (ws.syntheticRoot && m === ws.registry.rootMount) return false
+    return true
   } catch {
     return false
   }

--- a/typescript/packages/server/src/summary.test.ts
+++ b/typescript/packages/server/src/summary.test.ts
@@ -25,7 +25,9 @@ describe('summary', () => {
     const brief = makeBrief(entry)
     expect(brief.id).toBe('ws-x')
     expect(brief.mode).toBe('write')
-    expect(brief.mountCount).toBe(1)
+    // /data/ plus the empty root anchor the workspace adds at / (no user /
+    // mount). /dev and the history view are auto-prefixes and filtered out.
+    expect(brief.mountCount).toBe(2)
   })
 
   it('makeDetail emits mounts + sessions', async () => {
@@ -33,8 +35,9 @@ describe('summary', () => {
     const ws = new Workspace({ '/data/': new RAMResource() }, { mode: MountMode.WRITE })
     const entry = r.add(ws, 'ws-y')
     const detail = await makeDetail(entry)
-    expect(detail.mounts).toHaveLength(1)
-    expect(detail.mounts[0]?.prefix).toBe('/data/')
-    expect(detail.mounts[0]?.resource).toBe('ram')
+    // /data/ plus the empty root anchor at / (no user / mount was given).
+    expect(detail.mounts.map((m) => m.prefix).sort()).toEqual(['/', '/data/'])
+    const dataMount = detail.mounts.find((m) => m.prefix === '/data/')
+    expect(dataMount?.resource).toBe('ram')
   })
 })


### PR DESCRIPTION
## What

Mirror Python's cache-as-store architecture into TypeScript (Python PR #401 + the virtual-root follow-up that TS never received).

Before, the TS file cache was both the resource of the `/_default/` mount **and** a hidden store. This decouples them:

- The cache is now **only a hidden store**, reached via `registry.fileCache`.
- Arg-less commands and root listing resolve against a neutral **root anchor**: the user's `/` mount if they gave one, otherwise an auto-added empty RAM mount at `/`.
- Removed `setDefaultMount`, the `defaultMount` getter, the `/_default/` namespace, the `isFileCache` redirect guard, and the `cacheMount` accessor.
- `mountForCommand` now prefers the root mount; ALWAYS-consistency eviction reads the hidden store directly. This matches `python/mirage/workspace/mount/registry.py` and `workspace.py` line-for-line.

### One intentional TS-only detail
The synthetic root anchor is **not** forwarded into the Pyodide filesystem (it would hijack Pyodide's own `/` holding the Python stdlib). A user-provided `/` mount still is. Python has no Pyodide bridge, so there is no counterpart.

## Why
This was the last unmirrored caching gap between the two implementations (read-through #378 and write-site invalidation #329 were already mirrored). It also unblocks future copy-on-write `ws.fork()` work, which needs the cache split from the mount.

## Cache test parity (also in this PR)
Mirrored the Python cache tests that had no TS counterpart:
- `cache_invalidation.test.ts` — write-site invalidation (gzip-interleaved-ls, ls-sees-new, ls-hides-removed) + cat→rm→re-cat-fails eviction. Mirrors `test_cache_invalidation.py` + `test_cache_write_through.py`.
- `lock.test.ts` — mirrors `test_lock.py` (behavior-adapted to the TS `withLock` API).
- Rewrote `cache_mount.test.ts` to assert the cache/root decoupling, mirroring the new `test_cache_mount.py`.

## Verification
- Behavior-transparent: **core (3402), node (1557), browser (165)** vitest suites green.
- Offline integ matches truth: `ram`, `disk`, `s3_cases`, `cross_commands` (shared `truth.txt`) and `s3.ts` native warm-serve (`truth_s3_ts.txt`, all 20 `bytes=0 served_from_cache=true` cases) on clean buckets.
- pre-commit clean.

## Not included
Caching integ for `onedrive`/`dify`/`nextcloud` is Python-only because those **backends do not exist in TS**; porting them is a separate effort, not a caching change.