### PR TITLE
Fix py/ts stat divergences (slack/discord/gdrive); remove verified dead code

### DIFF
--- a/python/mirage/commands/builtin/rg_helper.py
+++ b/python/mirage/commands/builtin/rg_helper.py
@@ -14,16 +14,12 @@
 
 import fnmatch
 import posixpath
-import re
 
 from mirage.commands.builtin.grep_helper import (BINARY_EXTENSIONS,
                                                  compile_pattern,
-                                                 get_extension,
-                                                 grep_count_has_matches,
-                                                 grep_lines)
+                                                 get_extension)
 from mirage.commands.builtin.utils.types import (_AsyncReadBytes,
-                                                 _AsyncReaddir, _AsyncStat,
-                                                 _ReadBytes)
+                                                 _AsyncReaddir, _AsyncStat)
 from mirage.types import FileType
 
 TYPE_EXTENSIONS: dict[str, list[str]] = {
@@ -67,86 +63,6 @@ def rg_matches_filter(
             basename, glob_pattern):
         return False
     return True
-
-
-def rg_search_file(
-    read_bytes: _ReadBytes,
-    entry: str,
-    compiled: re.Pattern[str],
-    invert: bool,
-    line_numbers: bool,
-    count_only: bool,
-    files_only: bool,
-    only_matching: bool,
-    max_count: int | None,
-    context_before: int,
-    context_after: int,
-    prefix_path: bool,
-    warnings: list[str] | None = None,
-) -> list[str]:
-    try:
-        data = read_bytes(entry).decode(errors="replace").splitlines()
-    except Exception as exc:
-        if warnings is not None:
-            warnings.append(f"rg: {entry}: {exc}")
-        return []
-
-    if context_before == 0 and context_after == 0:
-        lines = grep_lines(
-            entry,
-            data,
-            compiled,
-            invert,
-            line_numbers,
-            count_only,
-            files_only,
-            only_matching,
-            max_count,
-        )
-        if count_only and not grep_count_has_matches(lines):
-            return []
-        if prefix_path and not count_only and not files_only:
-            return [f"{entry}:{ln}" for ln in lines]
-        return lines
-
-    results: list[str] = []
-    match_indices: set[int] = set()
-    count = 0
-    for idx, line in enumerate(data):
-        m = compiled.search(line)
-        matched = bool(m) != invert
-        if matched:
-            count += 1
-            match_indices.add(idx)
-            if max_count is not None and count >= max_count:
-                break
-
-    if count_only:
-        return [str(count)] if count > 0 else []
-    if files_only:
-        return [entry] if count > 0 else []
-
-    output_indices: set[int] = set()
-    for idx in sorted(match_indices):
-        for j in range(max(0, idx - context_before),
-                       min(len(data), idx + context_after + 1)):
-            output_indices.add(j)
-
-    prev_idx = -2
-    pfx = f"{entry}:" if prefix_path else ""
-    for idx in sorted(output_indices):
-        if prev_idx >= 0 and idx > prev_idx + 1:
-            results.append("--")
-        line = data[idx]
-        lineno = idx + 1
-        is_match = idx in match_indices
-        sep = ":" if is_match else "-"
-        if line_numbers:
-            results.append(f"{pfx}{lineno}{sep}{line}")
-        else:
-            results.append(f"{pfx}{line}")
-        prev_idx = idx
-    return results
 
 
 async def rg_folder(

--- a/python/mirage/core/discord/stat.py
+++ b/python/mirage/core/discord/stat.py
@@ -125,16 +125,18 @@ async def stat(
         return FileStat(name=parts[3], type=FileType.DIRECTORY)
 
     # <guild>/channels/<ch>/<date>/chat.jsonl
-    if (len(parts) == 5 and parts[1] == "channels"
+    if (len(parts) == 5 and parts[1] == "channels" and _DATE_RE.match(parts[3])
             and parts[4] == "chat.jsonl"):
         return FileStat(name="chat.jsonl", type=FileType.TEXT)
 
     # <guild>/channels/<ch>/<date>/files
-    if (len(parts) == 5 and parts[1] == "channels" and parts[4] == "files"):
+    if (len(parts) == 5 and parts[1] == "channels" and _DATE_RE.match(parts[3])
+            and parts[4] == "files"):
         return FileStat(name="files", type=FileType.DIRECTORY)
 
     # <guild>/channels/<ch>/<date>/files/<blob>
-    if (len(parts) == 6 and parts[1] == "channels" and parts[4] == "files"):
+    if (len(parts) == 6 and parts[1] == "channels" and _DATE_RE.match(parts[3])
+            and parts[4] == "files"):
         if index is None:
             raise enoent(virtual)
         lookup = await index.get(virtual_key)

--- a/python/mirage/core/gdrive/stat.py
+++ b/python/mirage/core/gdrive/stat.py
@@ -68,7 +68,7 @@ async def stat(
             extra={"file_id": result.entry.id},
         )
     return FileStat(
-        name=result.entry.vfs_name,
+        name=result.entry.vfs_name or result.entry.name,
         size=result.entry.size,
         type=guess_type(result.entry.vfs_name),
         modified=result.entry.remote_time,

--- a/python/mirage/core/github/scope.py
+++ b/python/mirage/core/github/scope.py
@@ -12,10 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import fnmatch
-
 from mirage.cache.index import IndexEntry
-from mirage.core.github.tree_entry import TreeEntry
 from mirage.types import PathSpec
 
 
@@ -78,19 +75,3 @@ def should_use_search(
     the scope is large enough to bother, is decided by the caller.
     """
     return recursive and on_default_branch
-
-
-async def estimate_scope(tree: dict[str, TreeEntry], directory: str,
-                         pattern: str) -> tuple[int, int]:
-    key = directory
-    prefix = key + "/" if key else ""
-    file_count = 0
-    total_bytes = 0
-    for p, entry in tree.items():
-        if not p.startswith(prefix):
-            continue
-        remainder = p[len(prefix):]
-        if entry.type == "blob" and fnmatch.fnmatch(remainder, pattern):
-            file_count += 1
-            total_bytes += entry.size or 0
-    return file_count, total_bytes

--- a/python/mirage/core/slack/stat.py
+++ b/python/mirage/core/slack/stat.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import re
+
 from mirage.accessor.slack import SlackAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.core.slack.readdir import readdir as _readdir
@@ -21,6 +23,7 @@ from mirage.utils.errors import enoent
 from mirage.utils.filetype import filetype_from_mimetype
 
 VIRTUAL_DIRS = {"", "channels", "dms", "users"}
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 def _slack_modified(remote_time: str) -> str | None:
@@ -107,19 +110,20 @@ async def stat(
             extra={"user_id": lookup.entry.id},
         )
 
-    if len(parts) == 3 and parts[0] in ("channels", "dms"):
+    if (len(parts) == 3 and parts[0] in ("channels", "dms")
+            and _DATE_RE.match(parts[2])):
         return FileStat(name=parts[2], type=FileType.DIRECTORY)
 
     if (len(parts) == 4 and parts[0] in ("channels", "dms")
-            and parts[3] == "chat.jsonl"):
+            and _DATE_RE.match(parts[2]) and parts[3] == "chat.jsonl"):
         return FileStat(name="chat.jsonl", type=FileType.TEXT)
 
     if (len(parts) == 4 and parts[0] in ("channels", "dms")
-            and parts[3] == "files"):
+            and _DATE_RE.match(parts[2]) and parts[3] == "files"):
         return FileStat(name="files", type=FileType.DIRECTORY)
 
     if (len(parts) == 5 and parts[0] in ("channels", "dms")
-            and parts[3] == "files"):
+            and _DATE_RE.match(parts[2]) and parts[3] == "files"):
         if index is None:
             raise enoent(virtual)
         lookup = await index.get(virtual_key)

--- a/python/mirage/core/ssh/_client.py
+++ b/python/mirage/core/ssh/_client.py
@@ -60,9 +60,3 @@ def _connect_kwargs(config) -> dict:
 
 async def connect(config) -> asyncssh.SSHClientConnection:
     return await asyncssh.connect(**_connect_kwargs(config))
-
-
-async def sftp_session(config):
-    conn = await connect(config)
-    sftp = await conn.start_sftp_client()
-    return conn, sftp

--- a/python/tests/commands/builtin/slack/test_grep_pushdown.py
+++ b/python/tests/commands/builtin/slack/test_grep_pushdown.py
@@ -75,13 +75,18 @@ async def test_grep_falls_back_when_native_search_raises():
                  pattern="*.jsonl",
                  prefix="/slack"),
     ]
+    resolved = [
+        PathSpec(original="/slack/channels/general__C1/2026-04-10/chat.jsonl",
+                 directory="/slack/channels/general__C1/2026-04-10/",
+                 prefix="/slack"),
+    ]
     with patch(
             "mirage.commands.builtin.slack.grep.search_messages",
             new=AsyncMock(
                 side_effect=RuntimeError("missing search:read scope")),
     ), patch(
             "mirage.commands.builtin.slack.grep.resolve_glob",
-            new=AsyncMock(return_value=paths),
+            new=AsyncMock(return_value=resolved),
     ), patch(
             "mirage.commands.builtin.slack.grep.slack_read",
             new=AsyncMock(return_value=b""),

--- a/python/tests/core/discord/test_stat.py
+++ b/python/tests/core/discord/test_stat.py
@@ -130,6 +130,20 @@ async def test_stat_files_dir(accessor, index):
 
 
 @pytest.mark.asyncio
+async def test_stat_non_date_chat_jsonl_not_found(accessor, index):
+    path = "/My Server/channels/general/notadate/chat.jsonl"
+    with pytest.raises(FileNotFoundError):
+        await stat(accessor, PathSpec(original=path, directory=path), index)
+
+
+@pytest.mark.asyncio
+async def test_stat_non_date_files_dir_not_found(accessor, index):
+    path = "/My Server/channels/general/notadate/files"
+    with pytest.raises(FileNotFoundError):
+        await stat(accessor, PathSpec(original=path, directory=path), index)
+
+
+@pytest.mark.asyncio
 async def test_stat_not_found(accessor, index):
     with pytest.raises(FileNotFoundError):
         await stat(

--- a/python/tests/core/github/test_scope.py
+++ b/python/tests/core/github/test_scope.py
@@ -16,54 +16,9 @@ from types import SimpleNamespace
 
 import pytest
 
-from mirage.core.github.scope import (count_scope_files, estimate_scope,
-                                      is_repo_root, scope_relative_key)
-from mirage.core.github.tree_entry import TreeEntry
+from mirage.core.github.scope import (count_scope_files, is_repo_root,
+                                      scope_relative_key)
 from mirage.types import PathSpec
-
-
-@pytest.fixture
-def tree():
-    return {
-        "src":
-        TreeEntry(path="src", type="tree", sha="aaa", size=None),
-        "src/main.py":
-        TreeEntry(path="src/main.py", type="blob", sha="bbb", size=120),
-        "src/utils.py":
-        TreeEntry(path="src/utils.py", type="blob", sha="ccc", size=80),
-        "src/data.json":
-        TreeEntry(path="src/data.json", type="blob", sha="ddd", size=500),
-        "README.md":
-        TreeEntry(path="README.md", type="blob", sha="eee", size=50),
-    }
-
-
-@pytest.mark.asyncio
-async def test_estimate_scope_all_files(tree):
-    count, total = await estimate_scope(tree, "", "*")
-    assert count == 4
-    assert total == 750
-
-
-@pytest.mark.asyncio
-async def test_estimate_scope_pattern_filter(tree):
-    count, total = await estimate_scope(tree, "src", "*.py")
-    assert count == 2
-    assert total == 200
-
-
-@pytest.mark.asyncio
-async def test_estimate_scope_specific_match(tree):
-    count, total = await estimate_scope(tree, "src", "data.json")
-    assert count == 1
-    assert total == 500
-
-
-@pytest.mark.asyncio
-async def test_estimate_scope_empty_directory(tree):
-    count, total = await estimate_scope(tree, "nonexistent", "*")
-    assert count == 0
-    assert total == 0
 
 
 @pytest.fixture

--- a/python/tests/core/slack/test_stat.py
+++ b/python/tests/core/slack/test_stat.py
@@ -132,6 +132,15 @@ async def test_stat_date_dir(accessor, index):
 
 
 @pytest.mark.asyncio
+async def test_stat_non_date_dir_not_found(accessor, index):
+    with pytest.raises(FileNotFoundError):
+        await stat(accessor,
+                   PathSpec(original="/channels/general__C001/notadate",
+                            directory="/channels/general__C001/notadate"),
+                   index=index)
+
+
+@pytest.mark.asyncio
 async def test_stat_chat_jsonl(accessor, index):
     s = await stat(
         accessor,

--- a/typescript/packages/core/src/cache/read_through.ts
+++ b/typescript/packages/core/src/cache/read_through.ts
@@ -30,7 +30,6 @@ type OpBytes<A extends Accessor> = (
 ) => Promise<Uint8Array>
 
 type PathStream = (path: PathSpec) => AsyncIterable<Uint8Array>
-type PathBytes = (path: PathSpec) => Promise<Uint8Array>
 
 async function* serveStream(
   manager: CacheInvalidator | null,
@@ -85,11 +84,6 @@ export function cacheAwareReadBytes<A extends Accessor>(raw: OpBytes<A>): OpByte
  */
 export function cacheAwareStream(raw: PathStream): PathStream {
   return (path) => serveStream(activeCacheManager(), path, () => raw(path))
-}
-
-/** Wrap a path-keyed bytes reader for warm read-through (capture at call). */
-export function cacheAwareBytes(raw: PathBytes): PathBytes {
-  return (path) => serveBytes(activeCacheManager(), path, () => raw(path))
 }
 
 /**

--- a/typescript/packages/core/src/core/github/scope.ts
+++ b/typescript/packages/core/src/core/github/scope.ts
@@ -12,7 +12,6 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { fnmatch } from '../../utils/fnmatch.ts'
 import { stripSlash } from '../../utils/slash.ts'
 import type { PathSpec } from '../../types.ts'
 import type { TreeEntry } from './tree_entry.ts'
@@ -52,24 +51,4 @@ export function shouldUseSearch(recursive: boolean, onDefaultBranch: boolean): b
   // indexes the default branch). Whether a usable literal exists, and whether
   // the scope is large enough to bother, is decided by the caller.
   return recursive && onDefaultBranch
-}
-
-export function estimateScope(
-  tree: Record<string, TreeEntry>,
-  directory: string,
-  pattern: string,
-): { fileCount: number; totalBytes: number } {
-  const key = directory
-  const prefix = key !== '' ? `${key}/` : ''
-  let fileCount = 0
-  let totalBytes = 0
-  for (const [p, entry] of Object.entries(tree)) {
-    if (!p.startsWith(prefix)) continue
-    const remainder = p.slice(prefix.length)
-    if (entry.type === 'blob' && fnmatch(remainder, pattern)) {
-      fileCount += 1
-      totalBytes += entry.size ?? 0
-    }
-  }
-  return { fileCount, totalBytes }
 }


### PR DESCRIPTION
Third py/ts divergence + dead-code audit round. Each finding was verified against source before acting (the candidate lists had false positives).

## Divergence fixes (Python -> match TypeScript / GNU)
- **slack `stat`**: validate the date component on `channels`/`dms` 3/4/5-part paths. Python returned a phantom `DIRECTORY` for any non-date name (e.g. `stat /slack/channels/general/notadate`); TypeScript already guards with `DATE_RE`. Added a test; also corrected one grep-pushdown unit test whose mock fed `resolve_glob` an impossible glob-literal path that only passed because of the old bug (real `resolve_glob` expands or drops globs, so the path never reaches stat in production).
- **discord `stat`**: add the same date guard to the `chat.jsonl` / `files` / `<blob>` sub-branches (only the top-level date was validated). Added 2 tests.
- **gdrive `stat`**: `name = vfs_name or name` fallback, matching TypeScript.

## Dead code removed (verified zero production and test references)
- Python: `rg_search_file`, `sftp_session`, `estimate_scope` (plus its 4 dedicated tests).
- TypeScript: `estimateScope` (github), `cacheAwareBytes` (plus the orphaned `PathBytes` type and `fnmatch` import).

## Investigated and deliberately kept
- Server router functions (`@router.post` handlers, not dead).
- Shell AST helpers (`get_redirect_target_node`, etc.) - tested.
- databricks `find_files` / `is_dir_name` / `read_stream_with_index` - entangled with `test_call_counts` and a conftest that patches `_read_stream`.
- `scope_warning` / `getThreadJsonl` / `writeValues` / `fetchSheetNames` / `getHerestringContent` - symmetric on both languages (tested or public barrel exports on the TS side); removing one side would create a divergence.
- `statLight` (chroma) - dead in TS but used in Python; an entangled perf gap, not clean dead code.
- `VIRTUAL_ROOTS` - exported via py `__all__`.
- gmail attachment naming / filetype - verified byte-identical (false positives).

## Verification
- Affected Python tests green; full `tests/commands/builtin` green.
- TS core builds (including DTS) + 3449 tests pass.
- pre-commit fully green.