### PR TITLE
Fix csplit -f cwd resolution, ssh write recording, disk mkdir ordering

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -648,6 +648,8 @@ CASES: list[tuple[str, str]] = [
     ("cwd_rel_dot_cat", "(cd /data && cat ./a.txt)"),
     ("cwd_rel_subdir_cat", "(cd /data && cat sub/nested.txt)"),
     ("cwd_rel_dotdot_cat", "(cd /data/sub && cat ../a.txt)"),
+    ("cwd_rel_csplit", "(cd /data/sub && csplit -s -f cs_ nested.txt 2"
+     " && cat cs_00 cs_01 && rm cs_00 cs_01)"),
     ("cwd_echo_pwd", "(cd /data/sub && echo $PWD)"),
     ("cwd_echo_home_unset", '(echo "[$HOME]")'),
     ("cwd_cd_oldpwd", "(cd /data && cd /data/sub && echo $OLDPWD)"),

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -577,6 +577,10 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
   ['cwd_rel_dot_cat', '(cd /data && cat ./a.txt)'],
   ['cwd_rel_subdir_cat', '(cd /data && cat sub/nested.txt)'],
   ['cwd_rel_dotdot_cat', '(cd /data/sub && cat ../a.txt)'],
+  [
+    'cwd_rel_csplit',
+    '(cd /data/sub && csplit -s -f cs_ nested.txt 2 && cat cs_00 cs_01 && rm cs_00 cs_01)',
+  ],
   ['cwd_echo_pwd', '(cd /data/sub && echo $PWD)'],
   ['cwd_echo_home_unset', '(echo "[$HOME]")'],
   ['cwd_cd_oldpwd', '(cd /data && cd /data/sub && echo $OLDPWD)'],

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -1783,6 +1783,9 @@ world
 foo
 bar
 baz
+=== cwd_rel_csplit ===
+nested
+content
 === cwd_echo_pwd ===
 /data/sub
 === cwd_echo_home_unset ===
@@ -1878,8 +1881,8 @@ disptree/d
 disptree/d/y.txt
 disptree/x.txt
 === history_last_two ===
-488  (cd /data && ls -R disptree)
-489  (cd /data && find disptree)
+489  (cd /data && ls -R disptree)
+490  (cd /data && find disptree)
 === bash_history_tail ===
 (cd /data && ls -R disptree)
 (cd /data && find disptree)

--- a/python/mirage/commands/builtin/generic/csplit.py
+++ b/python/mirage/commands/builtin/generic/csplit.py
@@ -48,8 +48,6 @@ async def csplit(
 ) -> tuple[ByteSource | None, IOResult]:
     if isinstance(prefix, PathSpec):
         prefix = prefix.strip_prefix
-    if isinstance(prefix, PathSpec):
-        prefix = prefix.strip_prefix
     suffix_fmt = suffix_format if suffix_format else f"%0{digits}d"
     if paths:
         raw = await read_bytes(accessor, paths[0])

--- a/typescript/packages/core/src/commands/spec/builtins.ts
+++ b/typescript/packages/core/src/commands/spec/builtins.ts
@@ -712,7 +712,7 @@ export const BUILTIN_SPECS: Readonly<Record<string, CommandSpec>> = Object.freez
   }),
   csplit: new CommandSpec({
     options: [
-      new Option({ short: '-f', valueKind: OperandKind.TEXT }),
+      new Option({ short: '-f', valueKind: OperandKind.PATH }),
       new Option({ short: '-n', valueKind: OperandKind.TEXT }),
       new Option({ short: '-b', valueKind: OperandKind.TEXT }),
       new Option({ short: '-k' }),

--- a/typescript/packages/node/src/core/disk/mkdir.ts
+++ b/typescript/packages/node/src/core/disk/mkdir.ts
@@ -28,15 +28,14 @@ export async function mkdir(
     await invalidateAfterWrite(path)
     return
   }
-  await invalidateAfterWrite(path)
   try {
     await fsMkdir(full)
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code
-    if (code === 'EEXIST') return
     if (code === 'ENOENT') {
       throw new Error(`parent directory does not exist: ${path.stripPrefix}`)
     }
-    throw err
+    if (code !== 'EEXIST') throw err
   }
+  await invalidateAfterWrite(path)
 }

--- a/typescript/packages/node/src/core/ssh/write.test.ts
+++ b/typescript/packages/node/src/core/ssh/write.test.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { PathSpec } from '@struktoai/mirage-core'
+import { PathSpec, ResourceName, runWithRecording } from '@struktoai/mirage-core'
 import { makeFakeAccessor } from './_test_utils.ts'
 import { read } from './read.ts'
 import { writeBytes } from './write.ts'
@@ -63,5 +63,22 @@ describe('core/ssh/write', () => {
     await writeBytes(accessor, spec('/data/a.txt'), new TextEncoder().encode('rooted'))
     const out = await read(accessor, spec('/data/a.txt'))
     expect(new TextDecoder().decode(out)).toBe('rooted')
+  })
+
+  it('records the write for command history', async () => {
+    const accessor = makeFakeAccessor({
+      files: new Map(),
+      dirs: new Map([
+        ['/', {}],
+        ['/data', {}],
+      ]),
+    })
+    const [, records] = await runWithRecording(async () => {
+      await writeBytes(accessor, spec('/data/a.txt'), new TextEncoder().encode('hello'))
+    })
+    expect(records).toHaveLength(1)
+    expect(records[0]?.op).toBe('write')
+    expect(records[0]?.source).toBe(ResourceName.SSH)
+    expect(records[0]?.bytes).toBe(5)
   })
 })

--- a/typescript/packages/node/src/core/ssh/write.ts
+++ b/typescript/packages/node/src/core/ssh/write.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { invalidateAfterWrite } from '@struktoai/mirage-core'
+import { ResourceName, invalidateAfterWrite, record } from '@struktoai/mirage-core'
 import type { PathSpec } from '@struktoai/mirage-core'
 import type { SSHAccessor } from '../../accessor/ssh.ts'
 import { joinRoot, stripPrefix } from './utils.ts'
@@ -22,6 +22,7 @@ export async function writeBytes(
   p: PathSpec,
   data: Uint8Array,
 ): Promise<void> {
+  const start = performance.now()
   const sftp = await accessor.sftp()
   const virtual = stripPrefix(p)
   const remote = joinRoot(accessor.config.root ?? '/', virtual)
@@ -31,5 +32,6 @@ export async function writeBytes(
       else resolveFn()
     })
   })
+  record('write', virtual, ResourceName.SSH, data.byteLength, start)
   await invalidateAfterWrite(p)
 }


### PR DESCRIPTION
Fourth py/ts divergence audit round. Audited write/mutation ops, glob resolution, command specs, and dispatch (areas not covered in rounds 1-3). Each finding was verified against source before acting; most candidate findings were false positives.

## Divergence fixes

### csplit -f ignored cwd (TypeScript)
TS declared `csplit -f` as `TEXT`, so the output-file prefix was not cwd-resolved: `(cd /data/sub && csplit -f cs_ file)` wrote `cs_00` to the mount root (`/data/cs_00`) instead of the current directory. Python declares `-f` as `PATH` (cwd-resolved and mount-routed), matching GNU csplit (output files are created in the current directory).

Fix: declare TS `csplit -f` as `OperandKind.PATH`. The PATH-flag cwd-resolution already existed in the TS parser and TS csplit already strips the mount prefix via `opts.mountPrefix`, so the resolved value now flows correctly. Also removed a duplicate `strip_prefix` in the Python csplit generic.

### ssh writeBytes missing history recording (TypeScript)
Python ssh write and TS disk write both `record(...)` the op for command history/observability; TS ssh write did not, so SSH writes were invisible to history. Added `record('write', virtual, ResourceName.SSH, ...)` mirroring disk write.

### disk mkdir invalidation ordering (TypeScript)
The non-parents branch invalidated the cache before `mkdir`, inconsistent with its own parents branch and with Python. Aligned to invalidate after (on success / EEXIST, not on ENOENT).

## Integ
Added `cwd_rel_csplit` to the shared cases (py + ts): `(cd /data/sub && csplit -s -f cs_ nested.txt 2 && cat cs_00 cs_01 && rm cs_00 cs_01)`. It guards the csplit fix (pre-fix TS wrote to the mount root, so the cwd-relative read would fail). Verified byte-identical py/ts on ram and disk; truth regenerated. Self-cleaning so later enumeration cases are unaffected.

## Verified false positives (dismissed)
- unlink ENOENT across ram/disk/redis/ssh core: not user-facing (generic `rm` stats-first and handles ENOENT identically on both sides).
- glob trailing-slash basename: disk readdir returns no trailing-slash entries; unreachable.
- tee `-a` on missing file: TS core throws "file not found" which matches its detection; currently works.
- mkdir/write error type (FileNotFoundError vs Error): mapped to the same user-facing result at the command layer.

## Dead code
No safely-removable dead code found. vulture (py) and ts-prune (ts) candidate lists were dominated by false positives verified individually: required interface params (FUSE callbacks, `__exit__`/`__deepcopy__`), agent-framework methods called externally, an intentional generator-forcing `yield`, and cross-package public API exports. Earlier rounds already removed the grep-findable dead code.

## Verification
- TS core 3449 + node 1485 tests pass.
- Python csplit/spec/key-prefix tests pass.
- integ ram + disk byte-identical py/ts.
- pre-commit green.