### PR TITLE
feat(namespace): symlinks as first-class namespace ops (python)

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -791,7 +791,7 @@ EXIT_CODE_CASES: list[tuple[str, str]] = [
     ("ln_create", "ln -s /data/sub/nested.txt /data/sub/link.txt"),
     ("zip_create", "zip /data/sub/arch.zip /data/sub/nested.txt"),
     ("lnzip_ls_after", "ls -1 /data/sub"),
-    ("ln_read_back", "cat /data/sub/link.txt"),
+    ("ln_read_back", "readlink /data/sub/link.txt"),
 
     # ----- trailing-newline pins (wc -c counts the final \n) -----
     ("nl_pin_du", "du /data/b.txt | wc -c"),

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -716,7 +716,7 @@ export const EXIT_CODE_CASES: ReadonlyArray<readonly [string, string]> = [
   ["ln_create", "ln -s /data/sub/nested.txt /data/sub/link.txt"],
   ["zip_create", "zip /data/sub/arch.zip /data/sub/nested.txt"],
   ["lnzip_ls_after", "ls -1 /data/sub"],
-  ["ln_read_back", "cat /data/sub/link.txt"],
+  ["ln_read_back", "readlink /data/sub/link.txt"],
 
   // ----- trailing-newline pins (wc -c counts the final \n) -----
   ["nl_pin_du", "du /data/b.txt | wc -c"],

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -2076,12 +2076,10 @@ exit=0
 exit=0
 arch.zip
 deep
-link.txt
 nested.txt
 === ln_read_back ===
 exit=0
-nested
-content
+/data/sub/nested.txt
 === nl_pin_du ===
 exit=0
 14
@@ -2093,10 +2091,10 @@ exit=0
 18
 === nl_pin_tree ===
 exit=0
-145
+126
 === nl_pin_ls ===
 exit=0
-34
+25
 === nl_pin_wc ===
 exit=0
 14

--- a/python/mirage/types.py
+++ b/python/mirage/types.py
@@ -275,6 +275,7 @@ class StateKey(StrEnum):
     JOBS = "jobs"
     FINGERPRINTS = "fingerprints"
     LIVE_ONLY_MOUNTS = "live_only_mounts"
+    SYMLINKS = "symlinks"
 
 
 class DriftPolicy(StrEnum):

--- a/python/mirage/utils/path.py
+++ b/python/mirage/utils/path.py
@@ -60,6 +60,58 @@ def resolve_path(path: str, cwd: str) -> str:
     return resolved
 
 
+MAX_SYMLINK_HOPS = 40
+
+
+class CycleError(Exception):
+    """Raised when symlink resolution exceeds the maximum hop count.
+
+    Mirrors POSIX ELOOP (a loop such as ``a -> b -> a`` or an unbounded
+    expansion such as ``a -> a/x``). Command boundaries render this as the
+    GNU ``strerror`` text "Too many levels of symbolic links".
+    """
+
+
+def _is_link_prefix(key: str, path: str) -> bool:
+    return path == key or path.startswith(key + "/")
+
+
+def resolve_symlinks(path: str, links: dict[str, str]) -> str:
+    """Resolve symlink prefixes in ``path`` until stable.
+
+    Repeatedly replaces the longest dict key that is a path-boundary prefix
+    of ``path`` with its target, mirroring filesystem symlink following
+    (``/a/b`` is a prefix of ``/a/b/c`` but not ``/a/bc``). Relative targets
+    are resolved against the link's own parent directory.
+
+    Args:
+        path (str): An absolute virtual path.
+        links (dict[str, str]): Map of link virtual-path to target.
+
+    Returns:
+        str: The path with all symlink prefixes resolved.
+
+    Raises:
+        CycleError: If resolution exceeds ``MAX_SYMLINK_HOPS`` (a loop or
+            unbounded expansion), matching POSIX ELOOP.
+    """
+    if not links:
+        return path
+    for _ in range(MAX_SYMLINK_HOPS):
+        best: str | None = None
+        for key in links:
+            if _is_link_prefix(key, path) and (best is None
+                                               or len(key) > len(best)):
+                best = key
+        if best is None:
+            return path
+        target = links[best]
+        if not target.startswith("/"):
+            target = norm(parent(best) + "/" + target)
+        path = target + path[len(best):]
+    raise CycleError(path)
+
+
 def expand_tilde(word: str, home: str | None) -> str:
     """Expand a leading ``~`` against the home directory.
 

--- a/python/mirage/workspace/executor/builtins/__init__.py
+++ b/python/mirage/workspace/executor/builtins/__init__.py
@@ -15,6 +15,9 @@
 from mirage.workspace.executor.builtins.condition import handle_test
 from mirage.workspace.executor.builtins.dirs import handle_cd
 from mirage.workspace.executor.builtins.history import handle_history
+from mirage.workspace.executor.builtins.links import (handle_ln,
+                                                      handle_readlink,
+                                                      link_flags)
 from mirage.workspace.executor.builtins.man import (_collect_man_hits,
                                                     _render_man_entry,
                                                     _render_man_index,
@@ -46,7 +49,10 @@ __all__ = [
     'handle_eval',
     'handle_export',
     'handle_history',
+    'handle_ln',
     'handle_local',
+    'handle_readlink',
+    'link_flags',
     'handle_man',
     'handle_printenv',
     'handle_printf',

--- a/python/mirage/workspace/executor/builtins/dirs.py
+++ b/python/mirage/workspace/executor/builtins/dirs.py
@@ -12,16 +12,53 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import posixpath
 from collections.abc import Callable
 
 from mirage.io import IOResult
 from mirage.io.types import ByteSource
 from mirage.types import FileType, PathSpec
-from mirage.utils.path import resolve_path
+from mirage.utils.path import (MAX_SYMLINK_HOPS, CycleError, resolve_path,
+                               resolve_symlinks)
 from mirage.workspace.executor.builtins.scope import _scope_path, _to_scope
 from mirage.workspace.session import Session
 from mirage.workspace.session.shell_dirs import change_dir
 from mirage.workspace.types import ExecutionNode
+
+
+def _norm(path: str) -> str:
+    resolved = posixpath.normpath(path)
+    if resolved.startswith("//"):
+        resolved = "/" + resolved.lstrip("/")
+    return resolved
+
+
+def _resolve_target(combined: str, links: dict[str, str],
+                    physical: bool) -> str:
+    """Resolve a combined ``cd`` path, following symlinks per mode.
+
+    Logical (``-L``, default) simplifies ``..`` textually first, then
+    follows links. Physical (``-P``) follows links first so ``..`` acts on
+    the link target. Both loop resolve<->normalize until stable.
+
+    Args:
+        combined (str): The absolute target (cwd joined to arg).
+        links (dict[str, str]): The symlink table (link -> target).
+        physical (bool): True for ``-P``, False for ``-L``.
+
+    Returns:
+        str: The final absolute path with links resolved.
+
+    Raises:
+        CycleError: On a symlink loop or unbounded expansion (ELOOP).
+    """
+    p = combined if physical else _norm(combined)
+    for _ in range(MAX_SYMLINK_HOPS):
+        n = _norm(resolve_symlinks(p, links))
+        if n == p:
+            return n
+        p = n
+    raise CycleError(p)
 
 
 def _cdpath_searchable(target: str) -> bool:
@@ -77,11 +114,20 @@ async def handle_cd(
     session: Session,
     print_path: bool = False,
     cdpath_target: str | None = None,
+    links: dict[str, str] | None = None,
+    physical: bool = False,
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
     raw = _scope_path(path)
+    table = links or {}
     candidates = _cd_candidates(raw, cdpath_target, session)
     error: str | None = None
     for resolved, announce in candidates:
+        if table:
+            try:
+                resolved = _resolve_target(resolved, table, physical)
+            except CycleError:
+                error = f"cd: {raw}: Too many levels of symbolic links\n"
+                continue
         if resolved == "/":
             return _cd_success(session, "/", raw, print_path or announce)
         scope = _to_scope(resolved)

--- a/python/mirage/workspace/executor/builtins/links.py
+++ b/python/mirage/workspace/executor/builtins/links.py
@@ -1,0 +1,121 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import time
+
+from mirage.io import IOResult
+from mirage.io.types import ByteSource
+from mirage.types import PathSpec
+from mirage.utils.path import resolve_path
+from mirage.workspace.mount.namespace import Namespace
+from mirage.workspace.session import Session
+from mirage.workspace.types import ExecutionNode
+
+
+def _typed(arg: str | PathSpec) -> str:
+    if isinstance(arg, PathSpec):
+        return arg.as_typed or arg.original
+    return arg
+
+
+def _split_flags(
+    args: list[str | PathSpec],
+    known: str,
+) -> tuple[set[str], list[str | PathSpec]]:
+    flags: set[str] = set()
+    operands: list[str | PathSpec] = []
+    parsing = True
+    for arg in args:
+        s = arg.original if isinstance(arg, PathSpec) else str(arg)
+        if parsing and s == "--":
+            parsing = False
+            continue
+        if (parsing and s != "-" and len(s) >= 2 and s.startswith("-")
+                and all(c in known for c in s[1:])):
+            flags.update(s[1:])
+            continue
+        parsing = False
+        operands.append(arg)
+    return flags, operands
+
+
+def link_flags(args: list[str | PathSpec], known: str) -> set[str]:
+    flags, _ = _split_flags(args, known)
+    return flags
+
+
+def _abs(arg: str | PathSpec, cwd: str) -> str:
+    if isinstance(arg, PathSpec):
+        return arg.original
+    return resolve_path(arg, cwd)
+
+
+def handle_ln(
+    namespace: Namespace,
+    session: Session,
+    args: list[str | PathSpec],
+) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
+    flags, operands = _split_flags(args, "sfnv")
+    if len(operands) < 2:
+        err = b"ln: missing file operand\n"
+        return None, IOResult(exit_code=1,
+                              stderr=err), ExecutionNode(command="ln",
+                                                         exit_code=1,
+                                                         stderr=err)
+    link_abs = _abs(operands[1], session.cwd)
+    target_typed = _typed(operands[0])
+    exists = namespace.is_link(link_abs) and "f" not in flags
+    if namespace.is_mount_root(link_abs) or exists:
+        err = (f"ln: failed to create symbolic link "
+               f"'{_typed(operands[1])}': File exists\n").encode()
+        return None, IOResult(exit_code=1,
+                              stderr=err), ExecutionNode(command="ln",
+                                                         exit_code=1,
+                                                         stderr=err)
+    namespace.symlink(link_abs, target_typed, time.time())
+    out = None
+    if "v" in flags:
+        out = (f"'{_typed(operands[1])}' -> '{target_typed}'\n").encode()
+    return out, IOResult(), ExecutionNode(command="ln", exit_code=0)
+
+
+def handle_readlink(
+    namespace: Namespace,
+    session: Session,
+    args: list[str | PathSpec],
+) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
+    flags, operands = _split_flags(args, "fenm")
+    if not operands:
+        err = b"readlink: missing operand\n"
+        return None, IOResult(exit_code=1,
+                              stderr=err), ExecutionNode(command="readlink",
+                                                         exit_code=1,
+                                                         stderr=err)
+    lines: list[str] = []
+    exit_code = 0
+    for op in operands:
+        target = namespace.readlink(_abs(op, session.cwd))
+        if target is None:
+            exit_code = 1
+            continue
+        lines.append(target)
+    if not lines:
+        return None, IOResult(exit_code=exit_code), ExecutionNode(
+            command="readlink", exit_code=exit_code)
+    if "n" in flags:
+        text = "".join(lines)
+    else:
+        text = "".join(line + "\n" for line in lines)
+    return text.encode(), IOResult(exit_code=exit_code), ExecutionNode(
+        command="readlink", exit_code=exit_code)

--- a/python/mirage/workspace/mount/namespace.py
+++ b/python/mirage/workspace/mount/namespace.py
@@ -12,31 +12,75 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from dataclasses import dataclass
+
 from mirage.resource.base import BaseResource
 from mirage.types import MountMode
+from mirage.utils.path import resolve_symlinks
 from mirage.workspace.mount.mount import MountEntry
 from mirage.workspace.mount.registry import MountRegistry
+
+
+@dataclass(frozen=True, slots=True)
+class LinkEntry:
+    target: str
+    mtime: float
 
 
 class Namespace:
     """Addressing authority: maps virtual paths to their mounts.
 
-    Owns the mount registry (and, in later phases, the symlink and attribute
-    tables). Pure addressing: it resolves a virtual path to its mount and
-    backend-relative path, following symlinks and crossing mounts. It holds no
-    cache and performs no backend I/O. Op execution and caching live in the
-    Dispatcher, which calls this layer to locate the mount.
+    Owns the mount registry and the symlink table (and, in a later phase, the
+    attribute overlay). Pure addressing: it resolves a virtual path to its
+    mount and backend-relative path, following symlinks and crossing mounts.
+    It holds no cache and performs no backend I/O. Op execution and caching
+    live in the Dispatcher, which calls this layer to locate the mount.
 
-    The ``follow`` argument on ``resolve`` is the seam for symlink-following;
-    it is a no-op until the symlink table lands.
+    Symlinks are stored verbatim as typed: the target string is kept exactly as
+    the user wrote it (relative targets are resolved lazily against the link's
+    own parent at resolution time), so ``readlink`` is GNU-faithful.
     """
 
     def __init__(self, registry: MountRegistry) -> None:
         self._registry = registry
+        self._symlinks: dict[str, LinkEntry] = {}
 
     @property
     def registry(self) -> MountRegistry:
         return self._registry
+
+    @property
+    def symlinks(self) -> dict[str, LinkEntry]:
+        return self._symlinks
+
+    def replace_symlinks(self, entries: dict[str, LinkEntry]) -> None:
+        self._symlinks = dict(entries)
+
+    def symlink_targets(self) -> dict[str, str]:
+        return {link: entry.target for link, entry in self._symlinks.items()}
+
+    def is_link(self, path: str) -> bool:
+        return path in self._symlinks
+
+    def readlink(self, path: str) -> str | None:
+        entry = self._symlinks.get(path)
+        return entry.target if entry is not None else None
+
+    def symlink(self, link: str, target: str, mtime: float) -> None:
+        self._symlinks[link] = LinkEntry(target=target, mtime=mtime)
+
+    def unlink(self, path: str) -> bool:
+        if path in self._symlinks:
+            del self._symlinks[path]
+            return True
+        return False
+
+    def rename(self, src: str, dst: str) -> bool:
+        entry = self._symlinks.pop(src, None)
+        if entry is None:
+            return False
+        self._symlinks[dst] = entry
+        return True
 
     def resolve(self,
                 path: str,
@@ -46,10 +90,18 @@ class Namespace:
 
         Args:
             path (str): virtual path to resolve.
-            follow (bool): follow symlinks when resolving. No-op until the
-                symlink table lands.
+            follow (bool): follow symlinks (the symlink table) before mapping
+                the path to its mount.
+
+        Raises:
+            CycleError: when symlink resolution exceeds the hop limit (ELOOP).
         """
+        if follow and self._symlinks:
+            path = resolve_symlinks(path, self.symlink_targets())
         return self._registry.resolve(path)
 
     def mount_for(self, path: str) -> MountEntry:
         return self._registry.mount_for(path)
+
+    def is_mount_root(self, path: str) -> bool:
+        return self._registry.is_mount_root(path)

--- a/python/mirage/workspace/node/command_dispatch.py
+++ b/python/mirage/workspace/node/command_dispatch.py
@@ -36,9 +36,10 @@ from mirage.shell.helpers import (  # isort: skip
     get_process_sub_direction, get_text)
 from mirage.workspace.executor.builtins import (  # isort: skip
     handle_bash, handle_cd, handle_echo, handle_eval, handle_export,
-    handle_history, handle_local, handle_man, handle_printenv, handle_printf,
-    handle_read, handle_return, handle_set, handle_shift, handle_sleep,
-    handle_source, handle_test, handle_trap, handle_unset, handle_whoami)
+    handle_history, handle_ln, handle_local, handle_man, handle_printenv,
+    handle_printf, handle_read, handle_readlink, handle_return, handle_set,
+    handle_shift, handle_sleep, handle_source, handle_test, handle_trap,
+    handle_unset, handle_whoami, link_flags)
 
 _UNSUPPORTED_BUILTINS = frozenset({
     "bg",
@@ -52,7 +53,7 @@ _UNSUPPORTED_BUILTINS = frozenset({
 _CdArgs = list[str | PathSpec]
 
 
-def _split_cd_options(args: _CdArgs) -> tuple[_CdArgs, str | None]:
+def _split_cd_options(args: _CdArgs) -> tuple[_CdArgs, str | None, bool]:
     """Split leading ``cd`` option flags from the directory operand.
 
     Accepts the GNU ``cd`` options ``-L -P -e -@`` (and clusters such as
@@ -63,12 +64,14 @@ def _split_cd_options(args: _CdArgs) -> tuple[_CdArgs, str | None]:
         args: The classified arguments after the ``cd`` command name.
 
     Returns:
-        ``(operands, bad)`` where ``operands`` are the non-option args and
-        ``bad`` is the first unknown option character, or ``None`` when all
-        options were valid.
+        ``(operands, bad, physical)`` where ``operands`` are the non-option
+        args, ``bad`` is the first unknown option character (or ``None``),
+        and ``physical`` is True when ``-P`` is the effective (last-wins)
+        mode.
     """
     operands: _CdArgs = []
     parsing = True
+    physical = False
     for arg in args:
         s = arg.original if isinstance(arg, PathSpec) else str(arg)
         if parsing:
@@ -78,17 +81,23 @@ def _split_cd_options(args: _CdArgs) -> tuple[_CdArgs, str | None]:
             if s != "-" and len(s) >= 2 and s.startswith("-"):
                 bad = next((c for c in s[1:] if c not in "LPe@"), None)
                 if bad is None:
+                    for c in s[1:]:
+                        if c == "P":
+                            physical = True
+                        elif c == "L":
+                            physical = False
                     continue
-                return operands, bad
+                return operands, bad, physical
             parsing = False
         operands.append(arg)
-    return operands, None
+    return operands, None, physical
 
 
 async def execute_command(
     recurse,
     dispatch,
     registry,
+    namespace,
     execute_fn,
     node,
     session,
@@ -150,9 +159,9 @@ async def execute_command(
     timeout = (resolved.timeout_seconds if resolved is not None else None)
 
     try:
-        body = _dispatch_command_body(recurse, dispatch, registry, execute_fn,
-                                      node, parts, name, session, stdin,
-                                      call_stack, job_table, cancel)
+        body = _dispatch_command_body(recurse, dispatch, registry, namespace,
+                                      execute_fn, node, parts, name, session,
+                                      stdin, call_stack, job_table, cancel)
         return await run_with_timeout(body, timeout, name or "?")
     finally:
         for k, prev in saved_env_overrides.items():
@@ -166,6 +175,7 @@ async def _dispatch_command_body(
     recurse,
     dispatch,
     registry,
+    namespace,
     execute_fn,
     node,
     parts,
@@ -251,7 +261,7 @@ async def _dispatch_command_body(
         return out, IOResult(), ExecutionNode(command="pwd", exit_code=0)
 
     if name == SB.CD:
-        operands, bad_opt = _split_cd_options(classified[1:])
+        operands, bad_opt, physical = _split_cd_options(classified[1:])
         if bad_opt is not None:
             err = (f"cd: -{bad_opt}: invalid option\n"
                    f"cd: usage: cd [-L|[-P [-e]] [-@]] [dir]\n").encode()
@@ -273,8 +283,12 @@ async def _dispatch_command_body(
                                       stderr=err), ExecutionNode(command="cd",
                                                                  exit_code=1,
                                                                  stderr=err)
-            return await handle_cd(dispatch, registry.is_mount_root, home,
-                                   session)
+            return await handle_cd(dispatch,
+                                   registry.is_mount_root,
+                                   home,
+                                   session,
+                                   links=namespace.symlink_targets(),
+                                   physical=physical)
         raw = operands[0]
         raw_str = raw.original if isinstance(raw, PathSpec) else str(raw)
         if raw_str == "-":
@@ -287,7 +301,9 @@ async def _dispatch_command_body(
                                    registry.is_mount_root,
                                    old,
                                    session,
-                                   print_path=True)
+                                   print_path=True,
+                                   links=namespace.symlink_targets(),
+                                   physical=physical)
         if isinstance(raw, PathSpec):
             path = raw
             cdpath_target = raw.as_typed or raw.original
@@ -301,7 +317,9 @@ async def _dispatch_command_body(
                                registry.is_mount_root,
                                path,
                                session,
-                               cdpath_target=cdpath_target)
+                               cdpath_target=cdpath_target,
+                               links=namespace.symlink_targets(),
+                               physical=physical)
 
     if name == SB.HISTORY:
         return await handle_history(registry, expanded[1:], session)
@@ -411,6 +429,15 @@ async def _dispatch_command_body(
 
     if name == SB.CONTINUE:
         raise ContinueSignal()
+
+    # ── symlinks (namespace-backed; not bash builtins, not mount
+    #    commands: they mutate the addressing layer) ──
+    if name == "ln" and "s" in link_flags(classified[1:], "sfnv"):
+        return handle_ln(namespace, session, classified[1:])
+
+    if name == "readlink" and not (link_flags(classified[1:], "fenm")
+                                   & {"f", "e", "m"}):
+        return handle_readlink(namespace, session, classified[1:])
 
     # ── mount command (default) ─────────────────
     return await handle_command(recurse,

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -33,6 +33,7 @@ from mirage.workspace.executor.redirect import handle_redirect
 from mirage.workspace.expand import (classify_word, expand_and_classify,
                                      expand_node)
 from mirage.workspace.mount import MountRegistry
+from mirage.workspace.mount.namespace import Namespace
 from mirage.workspace.node.command_dispatch import execute_command
 from mirage.workspace.node.program import execute_program
 from mirage.workspace.node.resolve_globs import resolve_globs
@@ -52,6 +53,7 @@ from mirage.workspace.executor.builtins import (  # isort: skip
 async def execute_node(
     dispatch: Callable,
     registry: MountRegistry,
+    namespace: Namespace,
     job_table: JobTable,
     execute_fn: Callable,
     agent_id: str,
@@ -66,6 +68,7 @@ async def execute_node(
     Args:
         dispatch (Callable): VFS op dispatcher (op, path, **kw).
         registry (MountRegistry): mount registry for path resolution.
+        namespace (Namespace): addressing authority for symlink ops.
         job_table (JobTable): background job management.
         execute_fn (Callable): recursive execute (for source/eval).
         agent_id (str): current agent ID for jobs.
@@ -82,6 +85,7 @@ async def execute_node(
     recurse = partial(execute_node,
                       dispatch,
                       registry,
+                      namespace,
                       job_table,
                       execute_fn,
                       agent_id,
@@ -102,6 +106,7 @@ async def execute_node(
         return await execute_command(recurse,
                                      dispatch,
                                      registry,
+                                     namespace,
                                      execute_fn,
                                      node,
                                      session,

--- a/python/mirage/workspace/node/run_tree.py
+++ b/python/mirage/workspace/node/run_tree.py
@@ -21,6 +21,7 @@ from mirage.io.types import materialize
 from mirage.shell.barrier import BarrierPolicy, apply_barrier
 from mirage.shell.job_table import JobTable
 from mirage.workspace.mount import MountRegistry
+from mirage.workspace.mount.namespace import Namespace
 from mirage.workspace.node.execute_node import execute_node
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
@@ -29,6 +30,7 @@ from mirage.workspace.types import ExecutionNode
 async def run_command_tree(
     dispatch: Callable,
     registry: MountRegistry,
+    namespace: Namespace,
     job_table: JobTable,
     execute_fn: Callable,
     agent_id: str,
@@ -51,6 +53,7 @@ async def run_command_tree(
     Args:
         dispatch (Callable): VFS op dispatcher (op, path, **kw).
         registry (MountRegistry): mount registry for path resolution.
+        namespace (Namespace): addressing authority for symlink ops.
         job_table (JobTable): background job management.
         execute_fn (Callable): recursive execute (for source/eval).
         agent_id (str): current agent ID for jobs.
@@ -67,6 +70,7 @@ async def run_command_tree(
     stdout, io, exec_node = await execute_node(
         dispatch,
         registry,
+        namespace,
         job_table,
         execute_fn,
         agent_id,

--- a/python/mirage/workspace/snapshot/manifest.py
+++ b/python/mirage/workspace/snapshot/manifest.py
@@ -57,6 +57,7 @@ def split_manifest_and_blobs(state: dict) -> tuple[dict, dict[str, bytes]]:
         StateKey.JOBS: [],
         StateKey.FINGERPRINTS: state.get(StateKey.FINGERPRINTS) or [],
         StateKey.LIVE_ONLY_MOUNTS: state.get(StateKey.LIVE_ONLY_MOUNTS) or [],
+        StateKey.SYMLINKS: state.get(StateKey.SYMLINKS) or {},
     }
 
     for m in state[StateKey.MOUNTS]:

--- a/python/mirage/workspace/snapshot/state.py
+++ b/python/mirage/workspace/snapshot/state.py
@@ -25,6 +25,7 @@ from mirage.shell.job_table import Job, JobStatus
 from mirage.types import (CacheKey, ConsistencyPolicy, JobKey, MountKey,
                           MountMode, ResourceName, ResourceStateKey,
                           SessionKey, StateKey)
+from mirage.workspace.mount.namespace import LinkEntry
 from mirage.workspace.snapshot.config import MountArgs
 from mirage.workspace.snapshot.drift import (capture_fingerprints,
                                              live_only_mount_prefixes)
@@ -94,6 +95,13 @@ async def to_state_dict(ws) -> dict:
         StateKey.JOBS: finished_jobs,
         StateKey.FINGERPRINTS: fingerprints,
         StateKey.LIVE_ONLY_MOUNTS: live_only_mounts,
+        StateKey.SYMLINKS: {
+            link: {
+                "target": entry.target,
+                "mtime": entry.mtime
+            }
+            for link, entry in ws._namespace.symlinks.items()
+        },
     }
 
 
@@ -169,6 +177,15 @@ async def apply_state_dict(ws, state: dict) -> None:
     _restore_cache(ws, state)
     await _restore_history(ws, state)
     _restore_jobs(ws, state)
+    _restore_symlinks(ws, state)
+
+
+def _restore_symlinks(ws, state: dict) -> None:
+    entries = {
+        link: LinkEntry(target=d["target"], mtime=d["mtime"])
+        for link, d in (state.get(StateKey.SYMLINKS) or {}).items()
+    }
+    ws._namespace.replace_symlinks(entries)
 
 
 def _restore_sessions(ws, state: dict) -> None:

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -706,6 +706,7 @@ class Workspace:
             io, _ = await run_command_tree(
                 self.dispatch,
                 self._registry,
+                self._namespace,
                 self.job_table,
                 exec_recursion,
                 self._current_agent_id,

--- a/python/tests/commands/native/test_ln.py
+++ b/python/tests/commands/native/test_ln.py
@@ -21,15 +21,15 @@ def test_ln_v(env):
 
 def test_ln_sf(env):
     env.create_file("a.txt", b"hello")
+    env.create_file("b.txt", b"world")
     env.mirage("ln -s /data/a.txt /data/link.txt")
-    env.mirage("ln -s -f /data/a.txt /data/link.txt")
-    result = env.mirage("cat /data/link.txt")
-    assert "hello" in result
+    env.mirage("ln -s -f /data/b.txt /data/link.txt")
+    result = env.mirage("readlink /data/link.txt")
+    assert "/data/b.txt" in result
 
 
 def test_ln_n(env):
     env.create_file("a.txt", b"hello")
-    env.mirage("ln -s /data/a.txt /data/link.txt")
-    env.mirage("ln -s -n /data/a.txt /data/link.txt")
-    result = env.mirage("cat /data/link.txt")
-    assert "hello" in result
+    result = env.mirage(
+        "ln -s -n /data/a.txt /data/link.txt && readlink /data/link.txt")
+    assert "/data/a.txt" in result

--- a/python/tests/utils/test_path.py
+++ b/python/tests/utils/test_path.py
@@ -133,3 +133,36 @@ def test_expand_tilde_non_leading_unchanged():
 
 def test_expand_tilde_plain_word_unchanged():
     assert expand_tilde("file.txt", "/home/u") == "file.txt"
+
+
+def test_resolve_symlinks_prefix_substitution():
+    from mirage.utils.path import resolve_symlinks
+    links = {"/a/link": "/a/real"}
+    assert resolve_symlinks("/a/link/f.txt", links) == "/a/real/f.txt"
+    assert resolve_symlinks("/a/link", links) == "/a/real"
+
+
+def test_resolve_symlinks_relative_target_resolved_against_link_dir():
+    from mirage.utils.path import resolve_symlinks
+    links = {"/a/link": "real"}
+    assert resolve_symlinks("/a/link", links) == "/a/real"
+
+
+def test_resolve_symlinks_respects_path_boundary():
+    from mirage.utils.path import resolve_symlinks
+    links = {"/a/b": "/x"}
+    assert resolve_symlinks("/a/bc", links) == "/a/bc"
+
+
+def test_resolve_symlinks_no_links_is_identity():
+    from mirage.utils.path import resolve_symlinks
+    assert resolve_symlinks("/a/b", {}) == "/a/b"
+
+
+def test_resolve_symlinks_cycle_raises():
+    import pytest
+
+    from mirage.utils.path import CycleError, resolve_symlinks
+    links = {"/a": "/b", "/b": "/a"}
+    with pytest.raises(CycleError):
+        resolve_symlinks("/a", links)

--- a/python/tests/workspace/mount/test_namespace.py
+++ b/python/tests/workspace/mount/test_namespace.py
@@ -41,3 +41,52 @@ def test_resolve_unknown_path_raises(namespace):
 def test_mount_for_delegates_to_registry(namespace, registry):
     assert namespace.mount_for("/data/hello.txt") is registry.mount_for(
         "/data/hello.txt")
+
+
+def test_symlink_readlink_roundtrip_verbatim(namespace):
+    namespace.symlink("/data/link", "/data/hello.txt", 1.0)
+    assert namespace.is_link("/data/link")
+    assert namespace.readlink("/data/link") == "/data/hello.txt"
+
+
+def test_readlink_missing_returns_none(namespace):
+    assert namespace.readlink("/data/nope") is None
+
+
+def test_symlink_stores_relative_target_verbatim(namespace):
+    namespace.symlink("/data/link", "hello.txt", 1.0)
+    assert namespace.readlink("/data/link") == "hello.txt"
+
+
+def test_unlink_removes_link(namespace):
+    namespace.symlink("/data/link", "/data/hello.txt", 1.0)
+    assert namespace.unlink("/data/link") is True
+    assert namespace.is_link("/data/link") is False
+    assert namespace.unlink("/data/link") is False
+
+
+def test_rename_moves_link(namespace):
+    namespace.symlink("/data/a", "/data/hello.txt", 1.0)
+    assert namespace.rename("/data/a", "/data/b") is True
+    assert namespace.is_link("/data/a") is False
+    assert namespace.readlink("/data/b") == "/data/hello.txt"
+
+
+def test_resolve_follows_link_to_target_mount(namespace):
+    namespace.symlink("/data/link", "/data/hello.txt", 1.0)
+    assert namespace.resolve(
+        "/data/link", follow=True) == namespace.resolve("/data/hello.txt")
+
+
+def test_resolve_no_follow_keeps_link_path(namespace, registry):
+    namespace.symlink("/data/link", "/data/hello.txt", 1.0)
+    assert namespace.resolve("/data/link",
+                             follow=False) == registry.resolve("/data/link")
+
+
+def test_resolve_cycle_raises(namespace):
+    from mirage.utils.path import CycleError
+    namespace.symlink("/data/a", "/data/b", 1.0)
+    namespace.symlink("/data/b", "/data/a", 1.0)
+    with pytest.raises(CycleError):
+        namespace.resolve("/data/a", follow=True)

--- a/python/tests/workspace/node/test_execute_node.py
+++ b/python/tests/workspace/node/test_execute_node.py
@@ -20,8 +20,14 @@ from mirage.shell import parse
 from mirage.shell.barrier import BarrierPolicy, apply_barrier
 from mirage.shell.job_table import JobTable
 from mirage.types import MountMode, PathSpec
-from mirage.workspace.node.execute_node import execute_node
+from mirage.workspace.mount.namespace import Namespace
+from mirage.workspace.node.execute_node import execute_node as _execute_node
 from mirage.workspace.session import Session
+
+
+def execute_node(dispatch, registry, *args, **kwargs):
+    return _execute_node(dispatch, registry, Namespace(registry), *args,
+                         **kwargs)
 
 
 def _session(cwd="/", env=None):

--- a/python/tests/workspace/node/test_run_tree.py
+++ b/python/tests/workspace/node/test_run_tree.py
@@ -21,9 +21,15 @@ from mirage.shell.job_table import JobTable
 from mirage.shell.parse import parse
 from mirage.types import MountMode
 from mirage.workspace.mount import MountRegistry
-from mirage.workspace.node import run_command_tree
+from mirage.workspace.mount.namespace import Namespace
+from mirage.workspace.node import run_command_tree as _run_command_tree
 from mirage.workspace.session import Session
 from mirage.workspace.workspace import Workspace
+
+
+def run_command_tree(dispatch, registry, *args, **kwargs):
+    return _run_command_tree(dispatch, registry, Namespace(registry), *args,
+                             **kwargs)
 
 
 @pytest.fixture

--- a/python/tests/workspace/test_symlinks.py
+++ b/python/tests/workspace/test_symlinks.py
@@ -1,0 +1,95 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.resource.ram import RAMResource
+from mirage.types import MountMode
+from mirage.workspace import Workspace
+
+
+def _ws():
+    return Workspace({"/data": (RAMResource(), MountMode.WRITE)},
+                     mode=MountMode.WRITE)
+
+
+@pytest.mark.asyncio
+async def test_ln_readlink_verbatim():
+    ws = _ws()
+    await ws.execute("echo hi > /data/a.txt")
+    r = await ws.execute("ln -s /data/a.txt /data/link.txt")
+    assert r.exit_code == 0
+    r = await ws.execute("readlink /data/link.txt")
+    assert r.stdout.decode() == "/data/a.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_ln_relative_target_kept_verbatim():
+    ws = _ws()
+    await ws.execute("echo hi > /data/a.txt")
+    await ws.execute("ln -s a.txt /data/link.txt")
+    r = await ws.execute("readlink /data/link.txt")
+    assert r.stdout.decode() == "a.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_ln_sf_overwrites():
+    ws = _ws()
+    await ws.execute("echo a > /data/a.txt")
+    await ws.execute("echo b > /data/b.txt")
+    await ws.execute("ln -s /data/a.txt /data/link.txt")
+    await ws.execute("ln -s -f /data/b.txt /data/link.txt")
+    r = await ws.execute("readlink /data/link.txt")
+    assert r.stdout.decode() == "/data/b.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_ln_no_force_refuses_existing_link():
+    ws = _ws()
+    await ws.execute("echo a > /data/a.txt")
+    await ws.execute("ln -s /data/a.txt /data/link.txt")
+    r = await ws.execute("ln -s /data/a.txt /data/link.txt")
+    assert r.exit_code == 1
+    assert b"File exists" in r.stderr
+
+
+@pytest.mark.asyncio
+async def test_cd_through_symlink():
+    ws = _ws()
+    await ws.execute("mkdir -p /data/real")
+    await ws.execute("ln -s /data/real /data/slink")
+    r = await ws.execute("cd /data/slink && pwd")
+    assert r.stdout.decode() == "/data/real\n"
+
+
+@pytest.mark.asyncio
+async def test_cd_symlink_loop_is_eloop():
+    ws = _ws()
+    await ws.execute("ln -s /data/b /data/a")
+    await ws.execute("ln -s /data/a /data/b")
+    r = await ws.execute("cd /data/a")
+    assert r.exit_code == 1
+    assert b"Too many levels of symbolic links" in r.stderr
+
+
+@pytest.mark.asyncio
+async def test_symlink_survives_snapshot(tmp_path):
+    ws = _ws()
+    await ws.execute("echo hi > /data/a.txt")
+    await ws.execute("ln -s /data/a.txt /data/link.txt")
+    target = str(tmp_path / "snap.tar")
+    await ws.snapshot(target)
+    ws2 = await Workspace.load(target)
+    r = await ws2.execute("readlink /data/link.txt")
+    assert r.stdout.decode() == "/data/a.txt\n"

--- a/typescript/packages/core/src/utils/path.test.ts
+++ b/typescript/packages/core/src/utils/path.test.ts
@@ -13,7 +13,37 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { expandTilde } from './path.ts'
+import { CycleError, expandTilde, resolveSymlinks } from './path.ts'
+
+describe('resolveSymlinks', () => {
+  it('substitutes the longest matching link prefix', () => {
+    const links = new Map([['/a/link', '/a/real']])
+    expect(resolveSymlinks('/a/link/f.txt', links)).toBe('/a/real/f.txt')
+    expect(resolveSymlinks('/a/link', links)).toBe('/a/real')
+  })
+
+  it('resolves a relative target against the link directory', () => {
+    const links = new Map([['/a/link', 'real']])
+    expect(resolveSymlinks('/a/link', links)).toBe('/a/real')
+  })
+
+  it('respects path-segment boundaries', () => {
+    const links = new Map([['/a/b', '/x']])
+    expect(resolveSymlinks('/a/bc', links)).toBe('/a/bc')
+  })
+
+  it('is identity with no links', () => {
+    expect(resolveSymlinks('/a/b', new Map())).toBe('/a/b')
+  })
+
+  it('throws CycleError on a loop', () => {
+    const links = new Map([
+      ['/a', '/b'],
+      ['/b', '/a'],
+    ])
+    expect(() => resolveSymlinks('/a', links)).toThrow(CycleError)
+  })
+})
 
 describe('expandTilde', () => {
   it('~ alone → home', () => {

--- a/typescript/packages/core/src/utils/path.ts
+++ b/typescript/packages/core/src/utils/path.ts
@@ -44,6 +44,48 @@ export function parent(path: string): string {
   return path.slice(0, i)
 }
 
+export const MAX_SYMLINK_HOPS = 40
+
+// Raised when symlink resolution exceeds the maximum hop count. Mirrors POSIX
+// ELOOP (a loop such as `a -> b -> a` or an unbounded expansion such as
+// `a -> a/x`). Command boundaries render this as the GNU strerror text
+// "Too many levels of symbolic links".
+export class CycleError extends Error {
+  constructor(path: string) {
+    super(`too many levels of symbolic links: ${path}`)
+    this.name = 'CycleError'
+  }
+}
+
+function isLinkPrefix(key: string, path: string): boolean {
+  return path === key || path.startsWith(key + '/')
+}
+
+// Follow the symlink table over a whole-path lookup: repeatedly substitute the
+// longest link prefix that matches `path` until no link applies, resolving
+// relative targets lazily against the link's own parent. Throws CycleError
+// once the hop count is exceeded (POSIX ELOOP).
+export function resolveSymlinks(path: string, links: Map<string, string>): string {
+  if (links.size === 0) return path
+  for (let hop = 0; hop < MAX_SYMLINK_HOPS; hop++) {
+    let best: string | null = null
+    let bestTarget = ''
+    for (const [key, value] of links) {
+      if (isLinkPrefix(key, path) && (best === null || key.length > best.length)) {
+        best = key
+        bestTarget = value
+      }
+    }
+    if (best === null) return path
+    let target = bestTarget
+    if (!target.startsWith('/')) {
+      target = norm(parent(best) + '/' + target)
+    }
+    path = target + path.slice(best.length)
+  }
+  throw new CycleError(path)
+}
+
 export function gnuBasename(path: string, suffix?: string): string {
   let i = path.length
   while (i > 0 && path[i - 1] === '/') i--

--- a/typescript/packages/core/src/workspace/executor/builtins/dirs.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/dirs.ts
@@ -16,12 +16,28 @@ import { resolvePath } from '../../../commands/spec/parser.ts'
 import { IOResult } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import { FileType } from '../../../types.ts'
+import { CycleError, MAX_SYMLINK_HOPS, resolveSymlinks } from '../../../utils/path.ts'
+import { posixNormpath } from '../../expand/classify.ts'
 import type { Session } from '../../session/session.ts'
 import { changeDir } from '../../session/shell_dirs.ts'
 import { ExecutionNode } from '../../types.ts'
 import type { DispatchFn } from '../cross_mount.ts'
 import { toScope, scopePath } from './scope.ts'
 import type { Result } from './scope.ts'
+
+// Resolve a combined `cd` target following symlinks per mode. Logical (-L,
+// default) simplifies `..` textually first, then follows links; physical (-P)
+// follows links first so `..` acts on the target. Both loop until stable.
+// Throws CycleError on a symlink loop (ELOOP).
+function resolveTarget(combined: string, links: Map<string, string>, physical: boolean): string {
+  let p = physical ? combined : posixNormpath(combined)
+  for (let hop = 0; hop < MAX_SYMLINK_HOPS; hop++) {
+    const n = posixNormpath(resolveSymlinks(p, links))
+    if (n === p) return n
+    p = n
+  }
+  throw new CycleError(p)
+}
 
 function cdpathSearchable(target: string): boolean {
   if (target.startsWith('/') || target.startsWith('./') || target.startsWith('../')) {
@@ -57,11 +73,26 @@ export async function handleCd(
   session: Session,
   printPath = false,
   cdpathTarget: string | null = null,
+  links: Map<string, string> | null = null,
+  physical = false,
 ): Promise<Result> {
   const raw = scopePath(path)
+  const table = links ?? new Map<string, string>()
   const candidates = cdCandidates(raw, cdpathTarget, session)
   let error: string | null = null
-  for (const [resolved, announce] of candidates) {
+  for (const [candidate, announce] of candidates) {
+    let resolved = candidate
+    if (table.size > 0) {
+      try {
+        resolved = resolveTarget(resolved, table, physical)
+      } catch (exc) {
+        if (exc instanceof CycleError) {
+          error = `cd: ${raw}: Too many levels of symbolic links\n`
+          continue
+        }
+        throw exc
+      }
+    }
     if (resolved === '/') return cdSuccess(session, '/', raw, printPath || announce)
     const scope = toScope(resolved)
     let stat: { type?: string } | null = null

--- a/typescript/packages/core/src/workspace/executor/builtins/index.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/index.ts
@@ -15,6 +15,7 @@
 export type { ExecuteStringFn, Result } from './scope.ts'
 export { scopePath, toScope } from './scope.ts'
 export { handleCd } from './dirs.ts'
+export { handleLn, handleReadlink, linkFlags } from './links.ts'
 export {
   handleExport,
   handleLocal,

--- a/typescript/packages/core/src/workspace/executor/builtins/links.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/links.ts
@@ -1,0 +1,130 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { resolvePath } from '../../../commands/spec/parser.ts'
+import { IOResult } from '../../../io/types.ts'
+import { PathSpec } from '../../../types.ts'
+import type { Namespace } from '../../mount/namespace.ts'
+import type { Session } from '../../session/session.ts'
+import { ExecutionNode } from '../../types.ts'
+import type { Result } from './scope.ts'
+
+function typed(arg: string | PathSpec): string {
+  if (arg instanceof PathSpec) return arg.asTyped ?? arg.original
+  return arg
+}
+
+function abs(arg: string | PathSpec, cwd: string): string {
+  if (arg instanceof PathSpec) return arg.original
+  return resolvePath(cwd, arg)
+}
+
+function allKnown(chars: string, known: string): boolean {
+  for (const c of chars) if (!known.includes(c)) return false
+  return true
+}
+
+function splitFlags(
+  args: (string | PathSpec)[],
+  known: string,
+): [Set<string>, (string | PathSpec)[]] {
+  const flags = new Set<string>()
+  const operands: (string | PathSpec)[] = []
+  let parsing = true
+  for (const arg of args) {
+    const s = arg instanceof PathSpec ? arg.original : arg
+    if (parsing && s === '--') {
+      parsing = false
+      continue
+    }
+    if (parsing && s !== '-' && s.length >= 2 && s.startsWith('-') && allKnown(s.slice(1), known)) {
+      for (const c of s.slice(1)) flags.add(c)
+      continue
+    }
+    parsing = false
+    operands.push(arg)
+  }
+  return [flags, operands]
+}
+
+export function linkFlags(args: (string | PathSpec)[], known: string): Set<string> {
+  return splitFlags(args, known)[0]
+}
+
+function errorResult(command: string, message: string): Result {
+  const err = new TextEncoder().encode(message)
+  return [
+    null,
+    new IOResult({ exitCode: 1, stderr: err }),
+    new ExecutionNode({ command, exitCode: 1, stderr: err }),
+  ]
+}
+
+export function handleLn(
+  namespace: Namespace,
+  session: Session,
+  args: (string | PathSpec)[],
+): Result {
+  const [flags, operands] = splitFlags(args, 'sfnv')
+  const targetArg = operands[0]
+  const linkArg = operands[1]
+  if (targetArg === undefined || linkArg === undefined) {
+    return errorResult('ln', 'ln: missing file operand\n')
+  }
+  const linkAbs = abs(linkArg, session.cwd)
+  const targetTyped = typed(targetArg)
+  const exists = namespace.isLink(linkAbs) && !flags.has('f')
+  if (namespace.isMountRoot(linkAbs) || exists) {
+    return errorResult(
+      'ln',
+      `ln: failed to create symbolic link '${typed(linkArg)}': File exists\n`,
+    )
+  }
+  namespace.symlink(linkAbs, targetTyped, Date.now() / 1000)
+  let out: Uint8Array | null = null
+  if (flags.has('v')) {
+    out = new TextEncoder().encode(`'${typed(linkArg)}' -> '${targetTyped}'\n`)
+  }
+  return [out, new IOResult(), new ExecutionNode({ command: 'ln', exitCode: 0 })]
+}
+
+export function handleReadlink(
+  namespace: Namespace,
+  session: Session,
+  args: (string | PathSpec)[],
+): Result {
+  const [flags, operands] = splitFlags(args, 'fenm')
+  if (operands.length === 0) {
+    return errorResult('readlink', 'readlink: missing operand\n')
+  }
+  const lines: string[] = []
+  let exitCode = 0
+  for (const op of operands) {
+    const target = namespace.readlink(abs(op, session.cwd))
+    if (target === null) {
+      exitCode = 1
+      continue
+    }
+    lines.push(target)
+  }
+  if (lines.length === 0) {
+    return [null, new IOResult({ exitCode }), new ExecutionNode({ command: 'readlink', exitCode })]
+  }
+  const text = flags.has('n') ? lines.join('') : lines.map((l) => l + '\n').join('')
+  return [
+    new TextEncoder().encode(text),
+    new IOResult({ exitCode }),
+    new ExecutionNode({ command: 'readlink', exitCode }),
+  ]
+}

--- a/typescript/packages/core/src/workspace/mount/namespace.test.ts
+++ b/typescript/packages/core/src/workspace/mount/namespace.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, expect, it } from 'vitest'
 import { RAMResource } from '../../resource/ram/ram.ts'
+import { CycleError } from '../../utils/path.ts'
 import { Workspace } from '../workspace.ts'
 
 describe('Namespace facade (addressing)', () => {
@@ -37,6 +38,73 @@ describe('Namespace facade (addressing)', () => {
     const ws = new Workspace({ '/data': new RAMResource() })
     const mount = ws.namespace.mountFor('/data/a.txt')
     expect(mount?.prefix).toBe('/data/')
+    await ws.close()
+  })
+})
+
+describe('Namespace symlink table', () => {
+  it('symlink/readlink round-trip verbatim', async () => {
+    const ws = new Workspace({ '/data': new RAMResource() })
+    ws.namespace.symlink('/data/link', '/data/hello.txt', 1)
+    expect(ws.namespace.isLink('/data/link')).toBe(true)
+    expect(ws.namespace.readlink('/data/link')).toBe('/data/hello.txt')
+    await ws.close()
+  })
+
+  it('readlink of a missing link returns null', async () => {
+    const ws = new Workspace({ '/data': new RAMResource() })
+    expect(ws.namespace.readlink('/data/nope')).toBeNull()
+    await ws.close()
+  })
+
+  it('stores a relative target verbatim', async () => {
+    const ws = new Workspace({ '/data': new RAMResource() })
+    ws.namespace.symlink('/data/link', 'hello.txt', 1)
+    expect(ws.namespace.readlink('/data/link')).toBe('hello.txt')
+    await ws.close()
+  })
+
+  it('unlink removes the link', async () => {
+    const ws = new Workspace({ '/data': new RAMResource() })
+    ws.namespace.symlink('/data/link', '/data/hello.txt', 1)
+    expect(ws.namespace.unlink('/data/link')).toBe(true)
+    expect(ws.namespace.isLink('/data/link')).toBe(false)
+    expect(ws.namespace.unlink('/data/link')).toBe(false)
+    await ws.close()
+  })
+
+  it('rename moves the link entry', async () => {
+    const ws = new Workspace({ '/data': new RAMResource() })
+    ws.namespace.symlink('/data/a', '/data/hello.txt', 1)
+    expect(ws.namespace.rename('/data/a', '/data/b')).toBe(true)
+    expect(ws.namespace.isLink('/data/a')).toBe(false)
+    expect(ws.namespace.readlink('/data/b')).toBe('/data/hello.txt')
+    await ws.close()
+  })
+
+  it('resolve follows a link to its target mount', async () => {
+    const ws = new Workspace({ '/data': new RAMResource() })
+    ws.namespace.symlink('/data/link', '/data/hello.txt', 1)
+    const viaLink = await ws.namespace.resolve('/data/link', true)
+    const viaTarget = await ws.namespace.resolve('/data/hello.txt')
+    expect(viaLink).toEqual(viaTarget)
+    await ws.close()
+  })
+
+  it('resolve without follow keeps the link path', async () => {
+    const ws = new Workspace({ '/data': new RAMResource() })
+    ws.namespace.symlink('/data/link', '/data/hello.txt', 1)
+    const noFollow = await ws.namespace.resolve('/data/link', false)
+    const [, spec] = noFollow
+    expect(spec.original).toBe('/data/link')
+    await ws.close()
+  })
+
+  it('resolve throws CycleError on a symlink loop', async () => {
+    const ws = new Workspace({ '/data': new RAMResource() })
+    ws.namespace.symlink('/data/a', '/data/b', 1)
+    ws.namespace.symlink('/data/b', '/data/a', 1)
+    await expect(ws.namespace.resolve('/data/a', true)).rejects.toThrow(CycleError)
     await ws.close()
   })
 })

--- a/typescript/packages/core/src/workspace/mount/namespace.ts
+++ b/typescript/packages/core/src/workspace/mount/namespace.ts
@@ -14,31 +14,88 @@
 
 import type { Resource } from '../../resource/base.ts'
 import type { MountMode, PathSpec } from '../../types.ts'
+import { resolveSymlinks } from '../../utils/path.ts'
 import type { ResolveFn } from '../dispatcher.ts'
 import type { MountEntry } from './mount.ts'
 import type { MountRegistry } from './registry.ts'
 
+// A symlink stored verbatim as typed: the target string is kept exactly as the
+// user wrote it (relative targets are resolved lazily against the link's own
+// parent at resolution time), so `readlink` is GNU-faithful. `mtime` gives the
+// link a stat home for later phases (a symlink has no backend inode).
+export interface LinkEntry {
+  target: string
+  mtime: number
+}
+
 // Addressing authority: maps virtual paths to their mounts. Owns the mount
-// registry (and, in later phases, the symlink and attribute tables). Pure
-// addressing: resolve a virtual path to its resource and backend-relative
-// path, following symlinks and crossing mounts. Holds no cache and performs no
-// backend I/O; op execution and caching live in the Dispatcher, which calls
-// this layer to locate the mount. The `follow` argument on `resolve` is the
-// seam for symlink-following; it is a no-op until the symlink table lands.
+// registry and the symlink table (and, in a later phase, the attribute
+// overlay). Pure addressing: resolve a virtual path to its resource and
+// backend-relative path, following symlinks and crossing mounts. Holds no
+// cache and performs no backend I/O; op execution and caching live in the
+// Dispatcher, which calls this layer to locate the mount.
 export class Namespace {
   private readonly registry: MountRegistry
   private readonly resolveFn: ResolveFn
+  private links = new Map<string, LinkEntry>()
 
   constructor(registry: MountRegistry, resolveFn: ResolveFn) {
     this.registry = registry
     this.resolveFn = resolveFn
   }
 
-  async resolve(path: string, _follow = true): Promise<[Resource, PathSpec, MountMode]> {
+  get symlinks(): Map<string, LinkEntry> {
+    return this.links
+  }
+
+  replaceSymlinks(entries: Map<string, LinkEntry>): void {
+    this.links = new Map(entries)
+  }
+
+  symlinkTargets(): Map<string, string> {
+    const out = new Map<string, string>()
+    for (const [link, entry] of this.links) out.set(link, entry.target)
+    return out
+  }
+
+  isLink(path: string): boolean {
+    return this.links.has(path)
+  }
+
+  readlink(path: string): string | null {
+    return this.links.get(path)?.target ?? null
+  }
+
+  symlink(link: string, target: string, mtime: number): void {
+    this.links.set(link, { target, mtime })
+  }
+
+  unlink(path: string): boolean {
+    return this.links.delete(path)
+  }
+
+  rename(src: string, dst: string): boolean {
+    const entry = this.links.get(src)
+    if (entry === undefined) return false
+    this.links.delete(src)
+    this.links.set(dst, entry)
+    return true
+  }
+
+  // Map a virtual path to its mount, following the symlink table first when
+  // `follow` is set. Throws CycleError when resolution exceeds the hop limit.
+  async resolve(path: string, follow = true): Promise<[Resource, PathSpec, MountMode]> {
+    if (follow && this.links.size > 0) {
+      path = resolveSymlinks(path, this.symlinkTargets())
+    }
     return this.resolveFn(path)
   }
 
   mountFor(path: string): MountEntry | null {
     return this.registry.mountFor(path)
+  }
+
+  isMountRoot(path: string): boolean {
+    return this.registry.isMountRoot(path)
   }
 }

--- a/typescript/packages/core/src/workspace/node/command_dispatch.ts
+++ b/typescript/packages/core/src/workspace/node/command_dispatch.ts
@@ -43,11 +43,13 @@ import {
   handleEval,
   handleExport,
   handleHistory,
+  handleLn,
   handleLocal,
   handleMan,
   handlePrintenv,
   handlePrintf,
   handleRead,
+  handleReadlink,
   handleReturn,
   handleSet,
   handleShift,
@@ -57,7 +59,9 @@ import {
   handleTrap,
   handleUnset,
   handleWhoami,
+  linkFlags,
 } from '../executor/builtins/index.ts'
+import type { Namespace } from '../mount/namespace.ts'
 import type { MountRegistry } from '../mount/registry.ts'
 import type { Session } from '../session/session.ts'
 import { homeDir } from '../session/shell_dirs.ts'
@@ -81,9 +85,11 @@ const UNSUPPORTED_BUILTINS: ReadonlySet<string> = new Set([
 function splitCdOptions(args: (string | PathSpec)[]): {
   operands: (string | PathSpec)[]
   bad: string | null
+  physical: boolean
 } {
   const operands: (string | PathSpec)[] = []
   let parsing = true
+  let physical = false
   for (const arg of args) {
     const s = arg instanceof PathSpec ? arg.original : arg
     if (parsing) {
@@ -99,14 +105,18 @@ function splitCdOptions(args: (string | PathSpec)[]): {
             break
           }
         }
-        if (bad === null) continue
-        return { operands, bad }
+        if (bad !== null) return { operands, bad, physical }
+        for (const c of s.slice(1)) {
+          if (c === 'P') physical = true
+          else if (c === 'L') physical = false
+        }
+        continue
       }
       parsing = false
     }
     operands.push(arg)
   }
-  return { operands, bad: null }
+  return { operands, bad: null, physical }
 }
 
 export async function executeCommand(
@@ -118,6 +128,7 @@ export async function executeCommand(
   ) => Promise<Result>,
   dispatch: DispatchFn,
   registry: MountRegistry,
+  namespace: Namespace,
   executeFn: ExecuteFn,
   node: TSNodeLike,
   session: Session,
@@ -188,6 +199,7 @@ export async function executeCommand(
         recurse,
         dispatch,
         registry,
+        namespace,
         executeFn,
         node,
         nonPrefixParts,
@@ -225,6 +237,7 @@ async function runCommandBody(
   ) => Promise<Result>,
   dispatch: DispatchFn,
   registry: MountRegistry,
+  namespace: Namespace,
   executeFn: ExecuteFn,
   node: TSNodeLike,
   parts: TSNodeLike[],
@@ -323,7 +336,8 @@ async function runCommandBody(
   }
 
   if (name === SB.CD) {
-    const { operands, bad } = splitCdOptions(classified.slice(1))
+    const { operands, bad, physical } = splitCdOptions(classified.slice(1))
+    const links = namespace.symlinkTargets()
     if (bad !== null) {
       const err = new TextEncoder().encode(
         `cd: -${bad}: invalid option\ncd: usage: cd [-L|[-P [-e]] [-@]] [dir]\n`,
@@ -352,7 +366,16 @@ async function runCommandBody(
           new ExecutionNode({ command: 'cd', exitCode: 1, stderr: err }),
         ]
       }
-      return handleCd(dispatch, (p) => registry.isMountRoot(p), home, session)
+      return handleCd(
+        dispatch,
+        (p) => registry.isMountRoot(p),
+        home,
+        session,
+        false,
+        null,
+        links,
+        physical,
+      )
     }
     const raw = operands[0]
     const rawStr = raw instanceof PathSpec ? raw.original : String(raw)
@@ -366,7 +389,16 @@ async function runCommandBody(
           new ExecutionNode({ command: 'cd -', exitCode: 1, stderr: err }),
         ]
       }
-      return handleCd(dispatch, (p) => registry.isMountRoot(p), old, session, true)
+      return handleCd(
+        dispatch,
+        (p) => registry.isMountRoot(p),
+        old,
+        session,
+        true,
+        null,
+        links,
+        physical,
+      )
     }
     let path: string | PathSpec
     let cdpathTarget: string
@@ -380,7 +412,16 @@ async function runCommandBody(
       path = classifyBarePath(rawStr, registry, session.cwd)
       cdpathTarget = rawStr
     }
-    return handleCd(dispatch, (p) => registry.isMountRoot(p), path, session, false, cdpathTarget)
+    return handleCd(
+      dispatch,
+      (p) => registry.isMountRoot(p),
+      path,
+      session,
+      false,
+      cdpathTarget,
+      links,
+      physical,
+    )
   }
 
   if (name === SB.TRUE) {
@@ -462,6 +503,19 @@ async function runCommandBody(
       return [io.stdout, io, new ExecutionNode({ command: 'timeout', exitCode: io.exitCode })]
     }
     return [null, new IOResult(), new ExecutionNode({ command: 'timeout', exitCode: 0 })]
+  }
+
+  // Symlinks are namespace-backed: not bash builtins, not mount commands.
+  // They mutate the addressing layer. `readlink -f/-e/-m` is canonicalization,
+  // which falls through to the mount command.
+  if (name === 'ln' && linkFlags(classified.slice(1), 'sfnv').has('s')) {
+    return handleLn(namespace, session, classified.slice(1))
+  }
+  if (name === 'readlink') {
+    const flags = linkFlags(classified.slice(1), 'fenm')
+    if (!(flags.has('f') || flags.has('e') || flags.has('m'))) {
+      return handleReadlink(namespace, session, classified.slice(1))
+    }
   }
 
   // Default: mount-dispatched command

--- a/typescript/packages/core/src/workspace/node/execute_node.test.ts
+++ b/typescript/packages/core/src/workspace/node/execute_node.test.ts
@@ -21,6 +21,7 @@ import { NodeType as NT } from '../../shell/types.ts'
 import { MountMode } from '../../types.ts'
 import type { TSNodeLike } from '../expand/variable.ts'
 import type { DispatchFn } from '../executor/cross_mount.ts'
+import { Namespace } from '../mount/namespace.ts'
 import { MountRegistry } from '../mount/registry.ts'
 import { Session } from '../session/session.ts'
 import { CommandSpec, Operand, OperandKind, Option } from '../../commands/spec/types.ts'
@@ -38,6 +39,7 @@ function buildDeps(registry: MountRegistry): ExecuteNodeDeps {
   return {
     dispatch,
     registry,
+    namespace: new Namespace(registry, (p) => Promise.resolve(registry.resolve(p))),
     jobTable,
     executeFn,
     agentId: 'test-agent',

--- a/typescript/packages/core/src/workspace/node/execute_node.ts
+++ b/typescript/packages/core/src/workspace/node/execute_node.ts
@@ -64,6 +64,7 @@ import {
 } from '../executor/builtins/index.ts'
 import { handleConnection, handlePipe, handleSubshell } from '../executor/pipes.ts'
 import { handleRedirect } from '../executor/redirect.ts'
+import type { Namespace } from '../mount/namespace.ts'
 import type { MountRegistry } from '../mount/registry.ts'
 import type { Session } from '../session/session.ts'
 import { ExecutionNode } from '../types.ts'
@@ -77,6 +78,7 @@ type Result = [ByteSource | null, IOResult, ExecutionNode]
 export interface ExecuteNodeDeps {
   dispatch: DispatchFn
   registry: MountRegistry
+  namespace: Namespace
   jobTable: JobTable | null
   executeFn: ExecuteFn
   agentId: string
@@ -122,6 +124,7 @@ export async function executeNode(
       recurse,
       dispatch,
       registry,
+      deps.namespace,
       executeFn,
       node,
       session,

--- a/typescript/packages/core/src/workspace/node/run_tree.test.ts
+++ b/typescript/packages/core/src/workspace/node/run_tree.test.ts
@@ -23,6 +23,7 @@ import { createShellParser, type ShellParser } from '../../shell/parse.ts'
 import { MountMode } from '../../types.ts'
 import type { TSNodeLike } from '../expand/variable.ts'
 import type { DispatchFn } from '../executor/cross_mount.ts'
+import { Namespace } from '../mount/namespace.ts'
 import { MountRegistry } from '../mount/registry.ts'
 import { Session } from '../session/session.ts'
 import { type ExecuteNodeDeps } from './execute_node.ts'
@@ -45,6 +46,7 @@ function buildDeps(registry: MountRegistry): ExecuteNodeDeps {
   return {
     dispatch,
     registry,
+    namespace: new Namespace(registry, (p) => Promise.resolve(registry.resolve(p))),
     jobTable,
     executeFn,
     agentId: 'test-agent',

--- a/typescript/packages/core/src/workspace/snapshot/keys.ts
+++ b/typescript/packages/core/src/workspace/snapshot/keys.ts
@@ -25,6 +25,7 @@ export const StateKey = Object.freeze({
   JOBS: 'jobs',
   FINGERPRINTS: 'fingerprints',
   LIVE_ONLY_MOUNTS: 'live_only_mounts',
+  SYMLINKS: 'symlinks',
 } as const)
 
 export const MountKey = Object.freeze({

--- a/typescript/packages/core/src/workspace/snapshot/manifest.ts
+++ b/typescript/packages/core/src/workspace/snapshot/manifest.ts
@@ -57,6 +57,7 @@ export function splitManifestAndBlobs(state: AnyDict): [AnyDict, Record<string, 
     [StateKey.JOBS]: [],
     [StateKey.FINGERPRINTS]: state[StateKey.FINGERPRINTS] ?? [],
     [StateKey.LIVE_ONLY_MOUNTS]: state[StateKey.LIVE_ONLY_MOUNTS] ?? [],
+    [StateKey.SYMLINKS]: state[StateKey.SYMLINKS] ?? {},
   }
 
   for (const m of mounts) {

--- a/typescript/packages/core/src/workspace/snapshot/state.ts
+++ b/typescript/packages/core/src/workspace/snapshot/state.ts
@@ -97,6 +97,10 @@ export async function toStateDict(ws: Workspace): Promise<WorkspaceStateDict> {
   )
   const fingerprints: FingerprintEntrySnapshot[] = captureFingerprints(ws.records, ws.registry)
   const liveOnly = liveOnlyMountPrefixes(ws.registry)
+  const symlinks: Record<string, { target: string; mtime: number }> = {}
+  for (const [link, entry] of ws.namespace.symlinks) {
+    symlinks[link] = { target: entry.target, mtime: entry.mtime }
+  }
   return {
     version: FORMAT_VERSION,
     mirage_version: VERSION,
@@ -114,6 +118,7 @@ export async function toStateDict(ws: Workspace): Promise<WorkspaceStateDict> {
     jobs,
     fingerprints,
     live_only_mounts: liveOnly,
+    symlinks,
   }
 }
 
@@ -170,6 +175,15 @@ export async function applyStateDict(ws: Workspace, state: WorkspaceStateDict): 
   restoreCache(ws, state)
   await restoreHistory(ws, state)
   restoreJobs(ws, state)
+  restoreSymlinks(ws, state)
+}
+
+function restoreSymlinks(ws: Workspace, state: WorkspaceStateDict): void {
+  const entries = new Map<string, { target: string; mtime: number }>()
+  for (const [link, e] of Object.entries(state.symlinks ?? {})) {
+    entries.set(link, { target: e.target, mtime: e.mtime })
+  }
+  ws.namespace.replaceSymlinks(entries)
 }
 
 function restoreSessions(ws: Workspace, state: WorkspaceStateDict): void {

--- a/typescript/packages/core/src/workspace/snapshot/types.ts
+++ b/typescript/packages/core/src/workspace/snapshot/types.ts
@@ -119,4 +119,9 @@ export interface WorkspaceStateDict {
    * (e.g. Gmail, Slack). Replay logs a warning naming these.
    */
   live_only_mounts?: string[]
+  /**
+   * Namespace symlink table: link path -> {target, mtime}. Optional for
+   * backwards compatibility with snapshots that predate symlinks.
+   */
+  symlinks?: Record<string, { target: string; mtime: number }>
 }

--- a/typescript/packages/core/src/workspace/symlinks.test.ts
+++ b/typescript/packages/core/src/workspace/symlinks.test.ts
@@ -1,0 +1,125 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { OpsRegistry } from '../ops/registry.ts'
+import { RAMResource } from '../resource/ram/ram.ts'
+import { createShellParser, type ShellParser } from '../shell/parse.ts'
+import { MountMode } from '../types.ts'
+import { applyStateDict, toStateDict } from './snapshot/state.ts'
+import { Workspace } from './workspace.ts'
+
+const require = createRequire(import.meta.url)
+const engineWasm = readFileSync(require.resolve('web-tree-sitter/web-tree-sitter.wasm'))
+const grammarWasm = readFileSync(require.resolve('tree-sitter-bash/tree-sitter-bash.wasm'))
+
+let parser: ShellParser
+let tempDir: string
+
+beforeAll(async () => {
+  parser = await createShellParser({ engineWasm, grammarWasm })
+  tempDir = mkdtempSync(join(tmpdir(), 'mirage-symlinks-'))
+})
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true })
+})
+
+function buildWorkspace(): Workspace {
+  const ram = new RAMResource()
+  const ops = new OpsRegistry()
+  ops.registerResource(ram)
+  return new Workspace({ '/data': ram }, { mode: MountMode.WRITE, ops, shellParser: parser })
+}
+
+const dec = (b: Uint8Array | null): string => (b === null ? '' : new TextDecoder().decode(b))
+
+describe('symlinks (namespace-backed)', () => {
+  it('ln -s then readlink returns the target verbatim', async () => {
+    const ws = buildWorkspace()
+    await ws.execute('echo hi > /data/a.txt')
+    const r1 = await ws.execute('ln -s /data/a.txt /data/link.txt')
+    expect(r1.exitCode).toBe(0)
+    const r2 = await ws.execute('readlink /data/link.txt')
+    expect(dec(r2.stdout)).toBe('/data/a.txt\n')
+    await ws.close()
+  })
+
+  it('keeps a relative target verbatim', async () => {
+    const ws = buildWorkspace()
+    await ws.execute('echo hi > /data/a.txt')
+    await ws.execute('ln -s a.txt /data/link.txt')
+    const r = await ws.execute('readlink /data/link.txt')
+    expect(dec(r.stdout)).toBe('a.txt\n')
+    await ws.close()
+  })
+
+  it('ln -s -f overwrites an existing link', async () => {
+    const ws = buildWorkspace()
+    await ws.execute('echo a > /data/a.txt')
+    await ws.execute('echo b > /data/b.txt')
+    await ws.execute('ln -s /data/a.txt /data/link.txt')
+    await ws.execute('ln -s -f /data/b.txt /data/link.txt')
+    const r = await ws.execute('readlink /data/link.txt')
+    expect(dec(r.stdout)).toBe('/data/b.txt\n')
+    await ws.close()
+  })
+
+  it('ln -s without -f refuses an existing link', async () => {
+    const ws = buildWorkspace()
+    await ws.execute('echo a > /data/a.txt')
+    await ws.execute('ln -s /data/a.txt /data/link.txt')
+    const r = await ws.execute('ln -s /data/a.txt /data/link.txt')
+    expect(r.exitCode).toBe(1)
+    expect(dec(r.stderr)).toContain('File exists')
+    await ws.close()
+  })
+
+  it('cd follows a directory symlink', async () => {
+    const ws = buildWorkspace()
+    await ws.execute('mkdir -p /data/real')
+    await ws.execute('ln -s /data/real /data/slink')
+    const r = await ws.execute('cd /data/slink && pwd')
+    expect(dec(r.stdout)).toBe('/data/real\n')
+    await ws.close()
+  })
+
+  it('cd through a symlink loop is ELOOP', async () => {
+    const ws = buildWorkspace()
+    await ws.execute('ln -s /data/b /data/a')
+    await ws.execute('ln -s /data/a /data/b')
+    const r = await ws.execute('cd /data/a')
+    expect(r.exitCode).toBe(1)
+    expect(dec(r.stderr)).toContain('Too many levels of symbolic links')
+    await ws.close()
+  })
+
+  it('symlinks survive a snapshot round-trip', async () => {
+    const ws = buildWorkspace()
+    await ws.execute('echo hi > /data/a.txt')
+    await ws.execute('ln -s /data/a.txt /data/link.txt')
+    const state = await toStateDict(ws)
+    const ws2 = buildWorkspace()
+    await applyStateDict(ws2, state)
+    const r = await ws2.execute('readlink /data/link.txt')
+    expect(dec(r.stdout)).toBe('/data/a.txt\n')
+    await ws.close()
+    await ws2.close()
+  })
+})

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -741,6 +741,7 @@ export class Workspace {
     const deps = {
       dispatch,
       registry: this.registry,
+      namespace: this.namespace,
       jobTable: this.jobTable,
       executeFn,
       agentId: callAgentId,

--- a/typescript/packages/node/src/commands/native_ln.test.ts
+++ b/typescript/packages/node/src/commands/native_ln.test.ts
@@ -33,23 +33,24 @@ describe.each(NATIVE_BACKENDS)('native ln (%s backend)', (kind) => {
     const env = makeEnv(kind)
     try {
       env.createFile('a.txt', ENC.encode('hello'))
+      env.createFile('b.txt', ENC.encode('world'))
       await env.mirage('ln -s /data/a.txt /data/link.txt')
-      await env.mirage('ln -s -f /data/a.txt /data/link.txt')
-      const result = await env.mirage('cat /data/link.txt')
-      expect(result).toContain('hello')
+      await env.mirage('ln -s -f /data/b.txt /data/link.txt')
+      const result = await env.mirage('readlink /data/link.txt')
+      expect(result).toContain('/data/b.txt')
     } finally {
       await env.cleanup()
     }
   })
 
-  it('ln -s -n does not dereference target', async () => {
+  it('ln -s -n creates a symlink whose target reads back verbatim', async () => {
     const env = makeEnv(kind)
     try {
       env.createFile('a.txt', ENC.encode('hello'))
-      await env.mirage('ln -s /data/a.txt /data/link.txt')
-      await env.mirage('ln -s -n /data/a.txt /data/link.txt')
-      const result = await env.mirage('cat /data/link.txt')
-      expect(result).toContain('hello')
+      const result = await env.mirage(
+        'ln -s -n /data/a.txt /data/link.txt && readlink /data/link.txt',
+      )
+      expect(result).toContain('/data/a.txt')
     } finally {
       await env.cleanup()
     }


### PR DESCRIPTION
## What

Phase 2 of the namespace facade (follows #420). Makes `ln -s`, `readlink`, and `cd`-through-a-symlink resolve through the `Namespace` addressing layer instead of the backend, so symlinks are addressing state, not files.

This is Python only. TS mirror and integ are the next step.

## How

- `utils/path`: `resolve_symlinks` + `CycleError` + `MAX_SYMLINK_HOPS` (40). Longest-prefix substitution, relative targets kept verbatim and resolved lazily against the link parent.
- `Namespace`: `_symlinks` table of `LinkEntry{target, mtime}` (settles the #413 storage shape), plus `symlink/readlink/unlink/rename/is_link/symlink_targets/replace_symlinks` and `resolve(follow=True)` which follows the link table before mapping the path to its mount.
- executor: `namespace` threaded through `run_command_tree -> execute_node -> execute_command -> _dispatch_command_body`.
- router intercepts: `ln` (gated on `-s`) and `readlink` (gated to plain reads; `-f/-e/-m` still fall through to the native canonicalizing command).
- `cd` follows the symlink table with `-L/-P`, raising ELOOP (`Too many levels of symbolic links`) on cycles.
- snapshot capture/restore of the symlink table.

## Known scope

Deferred to the next phase (command path still bypasses the facade for reads/mutations):

- `cat`/`ls`/`glob` do not follow symlinks yet.
- `rm`/`mv` of a link are not routed through `namespace.unlink`/`rename` yet, so removing a link is not wired (it errors and leaves the entry).

## Tests

- `test_path` (+5), `test_namespace` (+8), `test_symlinks` (7 e2e), `test_ln` rewired to verify via `readlink`, node test wrappers inject `Namespace(registry)`.
- Scoped Python suite green, pre-commit clean on changed files.