### PR TITLE
refactor(paths): consolidate mount-prefix stripping onto PathSpec.key (py+ts)

### DIFF
--- a/python/mirage/core/discord/read.py
+++ b/python/mirage/core/discord/read.py
@@ -45,15 +45,8 @@ async def read(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original if isinstance(path, PathSpec) else path
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     parts = key.split("/")
 
     # <guild>/channels/<ch>/<date>/chat.jsonl

--- a/python/mirage/core/discord/stat.py
+++ b/python/mirage/core/discord/stat.py
@@ -54,15 +54,8 @@ async def stat(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
 
     if not key:
         return FileStat(name="/", type=FileType.DIRECTORY)

--- a/python/mirage/core/disk/read.py
+++ b/python/mirage/core/disk/read.py
@@ -35,14 +35,9 @@ async def read_bytes(accessor: DiskAccessor,
                      index: IndexCacheStore = None) -> bytes:
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
+    virtual = path.original
     if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    virtual = path
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+        path = path.strip_prefix
     root = accessor.root
     start_ms = int(time.monotonic() * 1000)
     p = _resolve(root, path)

--- a/python/mirage/core/disk/stat.py
+++ b/python/mirage/core/disk/stat.py
@@ -36,14 +36,9 @@ async def stat(accessor: DiskAccessor,
                index: IndexCacheStore = None) -> FileStat:
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
+    virtual = path.original
     if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    virtual = path
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+        path = path.strip_prefix
     root = accessor.root
     p = _resolve(root, path)
     if not await aio_path.exists(p):

--- a/python/mirage/core/disk/stream.py
+++ b/python/mirage/core/disk/stream.py
@@ -36,14 +36,9 @@ async def read_stream(accessor: DiskAccessor,
                       chunk_size: int = 8192) -> AsyncIterator[bytes]:
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
+    virtual = path.original
     if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    virtual = path
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+        path = path.strip_prefix
     root = accessor.root
     rec = record_stream("read", path, "disk")
     p = _resolve(root, path)

--- a/python/mirage/core/email/read.py
+++ b/python/mirage/core/email/read.py
@@ -30,15 +30,8 @@ async def read(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     if index is None:
         raise enoent(virtual)
     virtual_key = prefix + "/" + key if prefix else "/" + key

--- a/python/mirage/core/email/readdir.py
+++ b/python/mirage/core/email/readdir.py
@@ -57,13 +57,8 @@ async def readdir(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.directory if path.pattern else path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+    prefix = path.prefix
+    path = (path.dir if path.pattern else path).strip_prefix
     key = path.strip("/")
     virtual_key = prefix + "/" + key if key else prefix or "/"
     parts = key.split("/") if key else []

--- a/python/mirage/core/email/stat.py
+++ b/python/mirage/core/email/stat.py
@@ -36,15 +36,8 @@ async def stat(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     if not key:
         return FileStat(name="/", type=FileType.DIRECTORY)
     if index is None:

--- a/python/mirage/core/gdocs/read.py
+++ b/python/mirage/core/gdocs/read.py
@@ -37,15 +37,8 @@ async def read(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     if index is None:
         raise enoent(virtual)
     virtual_key = prefix + "/" + key if prefix else "/" + key

--- a/python/mirage/core/gdocs/stat.py
+++ b/python/mirage/core/gdocs/stat.py
@@ -29,15 +29,8 @@ async def stat(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     if key in VIRTUAL_DIRS:
         name = key if key else "/"
         return FileStat(name=name, type=FileType.DIRECTORY)

--- a/python/mirage/core/gdrive/read.py
+++ b/python/mirage/core/gdrive/read.py
@@ -42,15 +42,8 @@ async def read(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     if index is None:
         raise enoent(virtual)
     virtual_key = prefix + "/" + key if prefix else "/" + key

--- a/python/mirage/core/gdrive/readdir.py
+++ b/python/mirage/core/gdrive/readdir.py
@@ -49,13 +49,8 @@ async def readdir(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.directory if path.pattern else path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+    prefix = path.prefix
+    path = (path.dir if path.pattern else path).strip_prefix
     key = path.strip("/")
     virtual_key = prefix + "/" + key if key else prefix or "/"
 

--- a/python/mirage/core/gdrive/stat.py
+++ b/python/mirage/core/gdrive/stat.py
@@ -29,15 +29,8 @@ async def stat(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     if not key:
         return FileStat(name="/", type=FileType.DIRECTORY)
     if index is None:

--- a/python/mirage/core/github/read.py
+++ b/python/mirage/core/github/read.py
@@ -43,13 +43,8 @@ async def read(
         path = PathSpec(original=path, directory=path)
     virtual = path.original
     if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
+        path = path.strip_prefix
 
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
     key = "/" + path.strip("/")
     if index is None:
         raise enoent(virtual)

--- a/python/mirage/core/github_ci/read.py
+++ b/python/mirage/core/github_ci/read.py
@@ -33,14 +33,8 @@ async def read(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     parts = key.split("/")
 
     # /workflows/<name>_<id>.json

--- a/python/mirage/core/github_ci/readdir.py
+++ b/python/mirage/core/github_ci/readdir.py
@@ -35,13 +35,8 @@ async def readdir(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.directory if path.pattern else path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+    prefix = path.prefix
+    path = (path.dir if path.pattern else path).strip_prefix
     key = path.strip("/")
     virtual_key = prefix + "/" + key if key else prefix or "/"
 

--- a/python/mirage/core/github_ci/stat.py
+++ b/python/mirage/core/github_ci/stat.py
@@ -53,14 +53,8 @@ async def stat(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
 
     if not key:
         return FileStat(name="/", type=FileType.DIRECTORY)

--- a/python/mirage/core/gmail/read.py
+++ b/python/mirage/core/gmail/read.py
@@ -31,15 +31,8 @@ async def read(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     if index is None:
         raise enoent(virtual)
     virtual_key = prefix + "/" + key if prefix else "/" + key

--- a/python/mirage/core/gmail/readdir.py
+++ b/python/mirage/core/gmail/readdir.py
@@ -141,13 +141,8 @@ async def readdir(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.directory if path.pattern else path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+    prefix = path.prefix
+    path = (path.dir if path.pattern else path).strip_prefix
     key = path.strip("/")
     virtual_key = prefix + "/" + key if key else prefix or "/"
     parts = key.split("/") if key else []

--- a/python/mirage/core/gmail/stat.py
+++ b/python/mirage/core/gmail/stat.py
@@ -36,15 +36,8 @@ async def stat(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     if not key:
         return FileStat(name="/", type=FileType.DIRECTORY)
     if index is None:

--- a/python/mirage/core/gsheets/read.py
+++ b/python/mirage/core/gsheets/read.py
@@ -84,15 +84,8 @@ async def read(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     if index is None:
         raise enoent(virtual)
     virtual_key = prefix + "/" + key if prefix else "/" + key

--- a/python/mirage/core/gsheets/stat.py
+++ b/python/mirage/core/gsheets/stat.py
@@ -29,15 +29,8 @@ async def stat(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     if key in VIRTUAL_DIRS:
         name = key if key else "/"
         return FileStat(name=name, type=FileType.DIRECTORY)

--- a/python/mirage/core/gslides/read.py
+++ b/python/mirage/core/gslides/read.py
@@ -39,15 +39,8 @@ async def read(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     if index is None:
         raise enoent(virtual)
     virtual_key = prefix + "/" + key if prefix else "/" + key

--- a/python/mirage/core/gslides/stat.py
+++ b/python/mirage/core/gslides/stat.py
@@ -29,15 +29,8 @@ async def stat(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     if key in VIRTUAL_DIRS:
         name = key if key else "/"
         return FileStat(name=name, type=FileType.DIRECTORY)

--- a/python/mirage/core/langfuse/read.py
+++ b/python/mirage/core/langfuse/read.py
@@ -53,15 +53,8 @@ async def read(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    path.prefix
+    key = path.key
 
     if any(p.startswith(".") for p in key.split("/")):
         raise enoent(virtual)

--- a/python/mirage/core/langfuse/readdir.py
+++ b/python/mirage/core/langfuse/readdir.py
@@ -39,13 +39,8 @@ async def readdir(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.directory if path.pattern else path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+    prefix = path.prefix
+    path = (path.dir if path.pattern else path).strip_prefix
     key = path.strip("/")
 
     if key and any(p.startswith(".") for p in key.split("/")):

--- a/python/mirage/core/langfuse/stat.py
+++ b/python/mirage/core/langfuse/stat.py
@@ -36,15 +36,8 @@ async def stat(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    path.prefix
+    key = path.key
 
     if not key:
         return FileStat(name="/", type=FileType.DIRECTORY)

--- a/python/mirage/core/linear/read.py
+++ b/python/mirage/core/linear/read.py
@@ -127,11 +127,6 @@ async def read(
         path = PathSpec(original=path, directory=path)
     virtual = path.original
     if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
+        path = path.strip_prefix
 
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
     return await read_bytes(accessor.config, path, virtual)

--- a/python/mirage/core/linear/readdir.py
+++ b/python/mirage/core/linear/readdir.py
@@ -34,13 +34,8 @@ async def readdir(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.directory if path.pattern else path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+    prefix = path.prefix
+    path = (path.dir if path.pattern else path).strip_prefix
     key = path.strip("/")
     idx_key = "/" + key if key else "/"
 

--- a/python/mirage/core/linear/stat.py
+++ b/python/mirage/core/linear/stat.py
@@ -50,15 +50,8 @@ async def stat(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     idx_key = "/" + key if key else "/"
 
     if key in VIRTUAL_DIRS:

--- a/python/mirage/core/notion/read.py
+++ b/python/mirage/core/notion/read.py
@@ -38,12 +38,7 @@ async def read(
         path = PathSpec(original=path, directory=path)
     virtual = path.original
     if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+        path = path.strip_prefix
 
     key = path.strip("/")
     parts = key.split("/")

--- a/python/mirage/core/notion/readdir.py
+++ b/python/mirage/core/notion/readdir.py
@@ -31,13 +31,8 @@ async def readdir(
 ) -> list[str]:
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.directory if path.pattern else path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+    prefix = path.prefix
+    path = (path.dir if path.pattern else path).strip_prefix
     key = path.strip("/")
     idx_key = "/" + key if key else "/"
 

--- a/python/mirage/core/notion/stat.py
+++ b/python/mirage/core/notion/stat.py
@@ -30,12 +30,7 @@ async def stat(
         path = PathSpec(original=path, directory=path)
     virtual = path.original
     if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+        path = path.strip_prefix
 
     key = path.strip("/")
 

--- a/python/mirage/core/ram/read.py
+++ b/python/mirage/core/ram/read.py
@@ -43,15 +43,8 @@ async def read(accessor: RAMAccessor,
                index: IndexCacheStore = None) -> bytes:
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
-    virtual = path.original if isinstance(path, PathSpec) else path
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+    virtual = path.original
     try:
-        return await read_bytes(accessor, path)
+        return await read_bytes(accessor, path.strip_prefix)
     except FileNotFoundError as exc:
         raise enoent(virtual) from exc

--- a/python/mirage/core/ram/stat.py
+++ b/python/mirage/core/ram/stat.py
@@ -27,12 +27,7 @@ async def stat(accessor: RAMAccessor,
         path = PathSpec(original=path, directory=path)
     virtual = path.original if isinstance(path, PathSpec) else path
     if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+        path = path.strip_prefix
     store = accessor.store
     p = norm(path)
     if p in store.dirs:

--- a/python/mirage/core/redis/read.py
+++ b/python/mirage/core/redis/read.py
@@ -47,12 +47,7 @@ async def read(
         path = PathSpec(original=path, directory=path)
     virtual = path.original if isinstance(path, PathSpec) else path
     if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+        path = path.strip_prefix
     try:
         return await read_bytes(accessor, path)
     except FileNotFoundError as exc:

--- a/python/mirage/core/redis/stat.py
+++ b/python/mirage/core/redis/stat.py
@@ -29,12 +29,7 @@ async def stat(
         path = PathSpec(original=path, directory=path)
     virtual = path.original
     if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+        path = path.strip_prefix
     store = accessor.store
     p = norm(path)
     if await store.has_dir(p):

--- a/python/mirage/core/s3/read.py
+++ b/python/mirage/core/s3/read.py
@@ -57,14 +57,8 @@ async def read_bytes(accessor: S3Accessor,
     """
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
-    virtual = path.original if isinstance(path, PathSpec) else path
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+    virtual = path.original
+    path = path.strip_prefix
     config = accessor.config
     key = _key(path, config)
     kwargs = {"Bucket": config.bucket, "Key": key}

--- a/python/mirage/core/s3/stream.py
+++ b/python/mirage/core/s3/stream.py
@@ -47,14 +47,8 @@ async def read_stream(
     """
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
-    virtual = path.original if isinstance(path, PathSpec) else path
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+    virtual = path.original
+    path = path.strip_prefix
     pinned_revision = revision_for(virtual)
     config = accessor.config
     rec = record_stream("read", path, "s3")

--- a/python/mirage/core/ssh/read.py
+++ b/python/mirage/core/ssh/read.py
@@ -33,12 +33,7 @@ async def read_bytes(accessor: SSHAccessor,
         path = PathSpec(original=path, directory=path)
     virtual = path.original
     if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+        path = path.strip_prefix
     config = accessor.config
     sftp = await accessor.sftp()
     start_ms = int(time.monotonic() * 1000)

--- a/python/mirage/core/ssh/stat.py
+++ b/python/mirage/core/ssh/stat.py
@@ -30,12 +30,7 @@ async def stat(accessor: SSHAccessor,
         path = PathSpec(original=path, directory=path)
     virtual = path.original
     if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+        path = path.strip_prefix
     config = accessor.config
     sftp = await accessor.sftp()
     try:

--- a/python/mirage/core/trello/read.py
+++ b/python/mirage/core/trello/read.py
@@ -110,11 +110,6 @@ async def read(
         path = PathSpec(original=path, directory=path)
     virtual = path.original
     if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
+        path = path.strip_prefix
 
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
     return await read_bytes(accessor.config, path, virtual)

--- a/python/mirage/core/trello/readdir.py
+++ b/python/mirage/core/trello/readdir.py
@@ -34,13 +34,8 @@ async def readdir(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.directory if path.pattern else path.original
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
+    prefix = path.prefix
+    path = (path.dir if path.pattern else path).strip_prefix
     key = path.strip("/")
     idx_key = "/" + key if key else "/"
 

--- a/python/mirage/core/trello/stat.py
+++ b/python/mirage/core/trello/stat.py
@@ -54,15 +54,8 @@ async def stat(
     if isinstance(path, str):
         path = PathSpec(original=path, directory=path)
     virtual = path.original
-    if isinstance(path, PathSpec):
-        prefix = path.prefix
-        path = path.original
-
-    if prefix and path.startswith(prefix):
-        rest = path[len(prefix):]
-        if prefix.endswith("/") or rest == "" or rest.startswith("/"):
-            path = rest or "/"
-    key = path.strip("/")
+    prefix = path.prefix
+    key = path.key
     idx_key = "/" + key if key else "/"
 
     if key in VIRTUAL_DIRS:

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -15,7 +15,7 @@
 import pytest
 from pydantic import ValidationError
 
-from mirage.types import Aggr, CommandSafeguard, FileStat, OnExceed
+from mirage.types import Aggr, CommandSafeguard, FileStat, OnExceed, PathSpec
 
 
 def test_filestat_defaults():
@@ -85,3 +85,33 @@ def test_every_field_declares_an_aggr_rule():
         assert any(
             isinstance(m, Aggr)
             for m in field.metadata), (f"field {name!r} has no Aggr rule")
+
+
+def test_pathspec_strip_prefix_and_key():
+    p = PathSpec(original="/data/sub/x.txt",
+                 directory="/data/sub",
+                 prefix="/data")
+    assert p.strip_prefix == "/sub/x.txt"
+    assert p.key == "sub/x.txt"
+
+
+def test_pathspec_prefix_respects_path_boundary():
+    # `/data` must not be stripped from a sibling like `/database` that only
+    # shares it as a string prefix, not a path prefix.
+    p = PathSpec(original="/database/x.txt",
+                 directory="/database",
+                 prefix="/data")
+    assert p.strip_prefix == "/database/x.txt"
+    assert p.key == "database/x.txt"
+
+
+def test_pathspec_key_at_mount_root():
+    p = PathSpec(original="/data", directory="/data", prefix="/data")
+    assert p.strip_prefix == "/"
+    assert p.key == ""
+
+
+def test_pathspec_key_without_prefix():
+    p = PathSpec(original="/x.txt", directory="/")
+    assert p.strip_prefix == "/x.txt"
+    assert p.key == "x.txt"

--- a/typescript/packages/core/src/core/box/readdir.ts
+++ b/typescript/packages/core/src/core/box/readdir.ts
@@ -17,7 +17,7 @@ import { IndexEntry } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
 import { listFolderItems, type BoxItem } from './api.ts'
-import { rstripSlash, stripSlash } from '../../utils/slash.ts'
+import { rstripSlash } from '../../utils/slash.ts'
 
 const ROOT_FOLDER_ID = '0'
 
@@ -62,10 +62,7 @@ export async function readdir(
   index?: IndexCacheStore,
 ): Promise<string[]> {
   const prefix = path.prefix
-  const raw = path.pattern !== null ? path.directory : path.original
-  let p = raw
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = (path.pattern !== null ? path.dir : path).key
   const virtualKey = key !== '' ? `${prefix}/${key}` : prefix !== '' ? prefix : '/'
 
   if (index !== undefined) {

--- a/typescript/packages/core/src/core/box/stat.ts
+++ b/typescript/packages/core/src/core/box/stat.ts
@@ -16,7 +16,6 @@ import type { BoxAccessor } from '../../accessor/box.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { readdir as coreReaddir } from './readdir.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 function guessType(name: string): FileType {
@@ -48,9 +47,7 @@ export async function stat(
 ): Promise<FileStat> {
   void accessor
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
   if (key === '') return new FileStat({ name: '/', type: FileType.DIRECTORY })
 
   if (index === undefined) throw enoent(path.original)

--- a/typescript/packages/core/src/core/dropbox/readdir.ts
+++ b/typescript/packages/core/src/core/dropbox/readdir.ts
@@ -17,7 +17,6 @@ import { IndexEntry } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import type { PathSpec } from '../../types.ts'
 import { listFolder, type DropboxEntry } from './api.ts'
-import { stripSlash } from '../../utils/slash.ts'
 
 function resourceTypeFor(entry: DropboxEntry): string {
   if (entry['.tag'] === 'folder') return 'dropbox/folder'
@@ -35,10 +34,7 @@ export async function readdir(
   index?: IndexCacheStore,
 ): Promise<string[]> {
   const prefix = path.prefix
-  const raw = path.pattern !== null ? path.directory : path.original
-  let p = raw
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = (path.pattern !== null ? path.dir : path).key
   const virtualKey = key !== '' ? `${prefix}/${key}` : prefix !== '' ? prefix : '/'
 
   if (index !== undefined) {

--- a/typescript/packages/core/src/core/dropbox/stat.ts
+++ b/typescript/packages/core/src/core/dropbox/stat.ts
@@ -16,7 +16,6 @@ import type { DropboxAccessor } from '../../accessor/dropbox.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { readdir as coreReaddir } from './readdir.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 function guessType(name: string): FileType {
@@ -45,9 +44,7 @@ export async function stat(
 ): Promise<FileStat> {
   void accessor
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
   if (key === '') return new FileStat({ name: '/', type: FileType.DIRECTORY })
 
   if (index === undefined) throw enoent(path.original)

--- a/typescript/packages/core/src/core/gdocs/read.ts
+++ b/typescript/packages/core/src/core/gdocs/read.ts
@@ -17,7 +17,7 @@ import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
 import { DOCS_API_BASE, type TokenManager, googleGet } from '../google/_client.ts'
 import { readdir } from './readdir.ts'
-import { rstripSlash, stripSlash } from '../../utils/slash.ts'
+import { rstripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 const ENC = new TextEncoder()
@@ -40,9 +40,7 @@ export async function read(
   index?: IndexCacheStore,
 ): Promise<Uint8Array> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
   if (index === undefined) throw enoent(path.original)
   const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`
   let result = await index.get(virtualKey)

--- a/typescript/packages/core/src/core/gdocs/stat.ts
+++ b/typescript/packages/core/src/core/gdocs/stat.ts
@@ -16,7 +16,6 @@ import type { GDocsAccessor } from '../../accessor/gdocs.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { readdir as coreReaddir } from './readdir.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 const VIRTUAL_DIRS = new Set(['', 'owned', 'shared'])
@@ -27,9 +26,7 @@ export async function stat(
   index?: IndexCacheStore,
 ): Promise<FileStat> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
 
   if (VIRTUAL_DIRS.has(key)) {
     const name = key !== '' ? key : '/'

--- a/typescript/packages/core/src/core/gdocs/unlink.ts
+++ b/typescript/packages/core/src/core/gdocs/unlink.ts
@@ -16,7 +16,6 @@ import { invalidateAfterUnlink } from '../../cache/context.ts'
 import type { GDocsAccessor } from '../../accessor/gdocs.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { deleteFile } from '../google/drive.ts'
 import { readdir as coreReaddir } from './readdir.ts'
 import { enoent } from '../../utils/errors.ts'
@@ -35,9 +34,7 @@ export async function unlink(
   index?: IndexCacheStore,
 ): Promise<void> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
   if (VIRTUAL_DIRS.has(key)) throw eisdir(path.original)
   if (index === undefined) throw enoent(path.original)
   const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`

--- a/typescript/packages/core/src/core/gdrive/read.ts
+++ b/typescript/packages/core/src/core/gdrive/read.ts
@@ -21,7 +21,7 @@ import { readSpreadsheet } from '../gsheets/read.ts'
 import { readPresentation } from '../gslides/read.ts'
 import type { TokenManager } from '../google/_client.ts'
 import { DIRECTORY_RESOURCE_TYPES, readdir } from './readdir.ts'
-import { rstripSlash, stripSlash } from '../../utils/slash.ts'
+import { rstripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 function eisdir(p: string): Error {
@@ -40,9 +40,7 @@ export async function read(
   index?: IndexCacheStore,
 ): Promise<Uint8Array> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
   if (index === undefined) throw enoent(path.original)
   const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`
   let result = await index.get(virtualKey)

--- a/typescript/packages/core/src/core/gdrive/readdir.ts
+++ b/typescript/packages/core/src/core/gdrive/readdir.ts
@@ -17,7 +17,7 @@ import { IndexEntry } from '../../cache/index/config.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
 import { MIME_TO_EXT, listFiles, listSharedDrives } from '../google/drive.ts'
-import { rstripSlash, stripSlash } from '../../utils/slash.ts'
+import { rstripSlash } from '../../utils/slash.ts'
 
 export const DIRECTORY_RESOURCE_TYPES: ReadonlySet<string> = new Set([
   'gdrive/folder',
@@ -60,10 +60,7 @@ export async function readdir(
   index?: IndexCacheStore,
 ): Promise<string[]> {
   const prefix = path.prefix
-  const raw = path.pattern !== null ? path.directory : path.original
-  let p = raw
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = (path.pattern !== null ? path.dir : path).key
   const virtualKey = key !== '' ? `${prefix}/${key}` : prefix !== '' ? prefix : '/'
 
   if (index !== undefined) {

--- a/typescript/packages/core/src/core/gdrive/stat.ts
+++ b/typescript/packages/core/src/core/gdrive/stat.ts
@@ -16,7 +16,6 @@ import type { GDriveAccessor } from '../../accessor/gdrive.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { DIRECTORY_RESOURCE_TYPES, readdir as coreReaddir } from './readdir.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 function guessType(name: string): FileType {
@@ -51,9 +50,7 @@ export async function stat(
 ): Promise<FileStat> {
   void accessor
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
   if (key === '') return new FileStat({ name: '/', type: FileType.DIRECTORY })
 
   if (index === undefined) throw enoent(path.original)

--- a/typescript/packages/core/src/core/gmail/read.ts
+++ b/typescript/packages/core/src/core/gmail/read.ts
@@ -17,7 +17,6 @@ import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
 import { getAttachment, getMessageProcessed } from './messages.ts'
 import { readdir } from './readdir.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { gnuDirname } from '../../utils/path.ts'
 import { enoent } from '../../utils/errors.ts'
 
@@ -35,9 +34,7 @@ export async function read(
   index?: IndexCacheStore,
 ): Promise<Uint8Array> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
   if (index === undefined) throw enoent(path.original)
   const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`
   let result = await index.get(virtualKey)

--- a/typescript/packages/core/src/core/gmail/readdir.ts
+++ b/typescript/packages/core/src/core/gmail/readdir.ts
@@ -20,7 +20,6 @@ import { listLabels } from './labels.ts'
 import type { GmailMessageRaw } from './messages.ts'
 import { extractAttachments, extractHeader, getMessageRaw, listMessages } from './messages.ts'
 import { GoogleFileSuffix } from '../google/drive.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 export function isDirName(child: string): boolean {
@@ -65,10 +64,7 @@ export async function readdir(
   index?: IndexCacheStore,
 ): Promise<string[]> {
   const prefix = path.prefix
-  const raw = path.pattern !== null ? path.directory : path.original
-  let p = raw
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = (path.pattern !== null ? path.dir : path).key
   const virtualKey = key !== '' ? `${prefix}/${key}` : prefix !== '' ? prefix : '/'
   const parts = key === '' ? [] : key.split('/')
   const depth = parts.length

--- a/typescript/packages/core/src/core/gmail/stat.ts
+++ b/typescript/packages/core/src/core/gmail/stat.ts
@@ -17,7 +17,6 @@ import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { readdir as coreReaddir } from './readdir.ts'
 import { listLabels } from './labels.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 function guessType(name: string): FileType {
@@ -42,9 +41,7 @@ export async function stat(
   index?: IndexCacheStore,
 ): Promise<FileStat> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
   if (key === '') return new FileStat({ name: '/', type: FileType.DIRECTORY })
 
   if (index === undefined) throw enoent(path.original)

--- a/typescript/packages/core/src/core/gsheets/read.ts
+++ b/typescript/packages/core/src/core/gsheets/read.ts
@@ -17,7 +17,7 @@ import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
 import { SHEETS_API_BASE, type TokenManager, googleGet } from '../google/_client.ts'
 import { readdir } from './readdir.ts'
-import { rstripSlash, stripSlash } from '../../utils/slash.ts'
+import { rstripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 const ENC = new TextEncoder()
@@ -60,9 +60,7 @@ export async function read(
   index?: IndexCacheStore,
 ): Promise<Uint8Array> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
   if (index === undefined) throw enoent(path.original)
   const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`
   let result = await index.get(virtualKey)

--- a/typescript/packages/core/src/core/gsheets/stat.ts
+++ b/typescript/packages/core/src/core/gsheets/stat.ts
@@ -16,7 +16,6 @@ import type { GSheetsAccessor } from '../../accessor/gsheets.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { readdir as coreReaddir } from './readdir.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 const VIRTUAL_DIRS = new Set(['', 'owned', 'shared'])
@@ -27,9 +26,7 @@ export async function stat(
   index?: IndexCacheStore,
 ): Promise<FileStat> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
 
   if (VIRTUAL_DIRS.has(key)) {
     const name = key !== '' ? key : '/'

--- a/typescript/packages/core/src/core/gsheets/unlink.ts
+++ b/typescript/packages/core/src/core/gsheets/unlink.ts
@@ -16,7 +16,6 @@ import { invalidateAfterUnlink } from '../../cache/context.ts'
 import type { GSheetsAccessor } from '../../accessor/gsheets.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { deleteFile } from '../google/drive.ts'
 import { readdir as coreReaddir } from './readdir.ts'
 import { enoent } from '../../utils/errors.ts'
@@ -35,9 +34,7 @@ export async function unlink(
   index?: IndexCacheStore,
 ): Promise<void> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
   if (VIRTUAL_DIRS.has(key)) throw eisdir(path.original)
   if (index === undefined) throw enoent(path.original)
   const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`

--- a/typescript/packages/core/src/core/gslides/read.ts
+++ b/typescript/packages/core/src/core/gslides/read.ts
@@ -17,7 +17,7 @@ import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
 import { SLIDES_API_BASE, type TokenManager, googleGet } from '../google/_client.ts'
 import { readdir } from './readdir.ts'
-import { rstripSlash, stripSlash } from '../../utils/slash.ts'
+import { rstripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 const ENC = new TextEncoder()
@@ -43,9 +43,7 @@ export async function read(
   index?: IndexCacheStore,
 ): Promise<Uint8Array> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
   if (index === undefined) throw enoent(path.original)
   const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`
   let result = await index.get(virtualKey)

--- a/typescript/packages/core/src/core/gslides/stat.ts
+++ b/typescript/packages/core/src/core/gslides/stat.ts
@@ -16,7 +16,6 @@ import type { GSlidesAccessor } from '../../accessor/gslides.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { readdir as coreReaddir } from './readdir.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 const VIRTUAL_DIRS = new Set(['', 'owned', 'shared'])
@@ -27,9 +26,7 @@ export async function stat(
   index?: IndexCacheStore,
 ): Promise<FileStat> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
 
   if (VIRTUAL_DIRS.has(key)) {
     const name = key !== '' ? key : '/'

--- a/typescript/packages/core/src/core/gslides/unlink.ts
+++ b/typescript/packages/core/src/core/gslides/unlink.ts
@@ -16,7 +16,6 @@ import { invalidateAfterUnlink } from '../../cache/context.ts'
 import type { GSlidesAccessor } from '../../accessor/gslides.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { PathSpec } from '../../types.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { deleteFile } from '../google/drive.ts'
 import { readdir as coreReaddir } from './readdir.ts'
 import { enoent } from '../../utils/errors.ts'
@@ -35,9 +34,7 @@ export async function unlink(
   index?: IndexCacheStore,
 ): Promise<void> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
   if (VIRTUAL_DIRS.has(key)) throw eisdir(path.original)
   if (index === undefined) throw enoent(path.original)
   const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`

--- a/typescript/packages/core/src/core/langfuse/read.ts
+++ b/typescript/packages/core/src/core/langfuse/read.ts
@@ -16,7 +16,6 @@ import type { LangfuseAccessor } from '../../accessor/langfuse.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import type { PathSpec } from '../../types.ts'
 import { fetchDatasetItems, fetchDatasetRuns, fetchPrompt, fetchTrace } from './_client.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 const ENC = new TextEncoder()
@@ -36,12 +35,7 @@ export async function read(
   path: PathSpec,
   _index?: IndexCacheStore,
 ): Promise<Uint8Array> {
-  const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) {
-    p = p.slice(prefix.length) || '/'
-  }
-  const key = stripSlash(p)
+  const key = path.key
   if (key === '') throw enoent(path)
   const parts = key.split('/')
   for (const part of parts) {

--- a/typescript/packages/core/src/core/langfuse/stat.ts
+++ b/typescript/packages/core/src/core/langfuse/stat.ts
@@ -15,7 +15,6 @@
 import type { LangfuseAccessor } from '../../accessor/langfuse.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, type PathSpec } from '../../types.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 const TOP_LEVEL_DIRS = new Set(['traces', 'sessions', 'prompts', 'datasets'])
@@ -26,12 +25,7 @@ export async function stat(
   _index?: IndexCacheStore,
 ): Promise<FileStat> {
   void accessor
-  const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) {
-    p = p.slice(prefix.length) || '/'
-  }
-  const key = stripSlash(p)
+  const key = path.key
 
   if (key === '') {
     return Promise.resolve(new FileStat({ name: '/', type: FileType.DIRECTORY }))

--- a/typescript/packages/core/src/core/linear/stat.ts
+++ b/typescript/packages/core/src/core/linear/stat.ts
@@ -16,7 +16,6 @@ import type { LinearAccessor } from '../../accessor/linear.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { readdir as coreReaddir } from './readdir.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 const VIRTUAL_DIRS = new Set(['', 'teams'])
@@ -60,11 +59,7 @@ export async function stat(
   index?: IndexCacheStore,
 ): Promise<FileStat> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) {
-    p = p.slice(prefix.length) || '/'
-  }
-  const key = stripSlash(p)
+  const key = path.key
   const virtualKey = makeVirtualKey(prefix, key)
 
   if (VIRTUAL_DIRS.has(key)) {

--- a/typescript/packages/core/src/core/notion/read.ts
+++ b/typescript/packages/core/src/core/notion/read.ts
@@ -18,7 +18,6 @@ import type { NotionTransport } from './_client.ts'
 import { normalizeDatabase, normalizePage, toJsonBytes } from './normalize.ts'
 import { getBlockTree, getDatabase, getPage } from './pages.ts'
 import { parseSegment } from './pathing.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 export interface NotionReadAccessor {
@@ -31,12 +30,7 @@ export async function read(
   _index?: IndexCacheStore,
 ): Promise<Uint8Array> {
   void _index
-  const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) {
-    p = p.slice(prefix.length) || '/'
-  }
-  const key = stripSlash(p)
+  const key = path.key
   if (key === '') throw enoent(path.original)
   const parts = key.split('/')
   const last = parts[parts.length - 1] ?? ''

--- a/typescript/packages/core/src/core/notion/stat.ts
+++ b/typescript/packages/core/src/core/notion/stat.ts
@@ -17,7 +17,6 @@ import { FileStat, FileType, type PathSpec } from '../../types.ts'
 import type { NotionTransport } from './_client.ts'
 import { getDatabase } from './pages.ts'
 import { parseSegment } from './pathing.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 export interface NotionStatAccessor {
@@ -34,12 +33,7 @@ export async function stat(
   path: PathSpec,
   index?: IndexCacheStore,
 ): Promise<FileStat> {
-  const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) {
-    p = p.slice(prefix.length) || '/'
-  }
-  const key = stripSlash(p)
+  const key = path.key
 
   if (key === '' || key === 'pages' || key === 'databases') {
     return new FileStat({ name: key !== '' ? key : '/', type: FileType.DIRECTORY })

--- a/typescript/packages/core/src/core/trello/stat.ts
+++ b/typescript/packages/core/src/core/trello/stat.ts
@@ -16,7 +16,6 @@ import type { TrelloAccessor } from '../../accessor/trello.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import { FileStat, FileType, PathSpec } from '../../types.ts'
 import { readdir as coreReaddir } from './readdir.ts'
-import { stripSlash } from '../../utils/slash.ts'
 import { enoent } from '../../utils/errors.ts'
 
 const VIRTUAL_DIRS = new Set(['', 'workspaces'])
@@ -60,11 +59,7 @@ export async function stat(
   index?: IndexCacheStore,
 ): Promise<FileStat> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) {
-    p = p.slice(prefix.length) || '/'
-  }
-  const key = stripSlash(p)
+  const key = path.key
   const virtualKey = makeVirtualKey(prefix, key)
 
   if (VIRTUAL_DIRS.has(key)) {

--- a/typescript/packages/core/src/types.test.ts
+++ b/typescript/packages/core/src/types.test.ts
@@ -280,3 +280,31 @@ describe('PathSpec immutability', () => {
     expect(Object.isFrozen(p)).toBe(true)
   })
 })
+
+describe('PathSpec.stripPrefix / key', () => {
+  it('strips the mount prefix at a path boundary', () => {
+    const p = new PathSpec({ original: '/data/sub/x.txt', directory: '/data/sub', prefix: '/data' })
+    expect(p.stripPrefix).toBe('/sub/x.txt')
+    expect(p.key).toBe('sub/x.txt')
+  })
+
+  it('does not strip a sibling that only shares the prefix as a string', () => {
+    // `/data` must not be stripped from `/database`, which shares it as a
+    // string prefix but not a path prefix.
+    const p = new PathSpec({ original: '/database/x.txt', directory: '/database', prefix: '/data' })
+    expect(p.stripPrefix).toBe('/database/x.txt')
+    expect(p.key).toBe('database/x.txt')
+  })
+
+  it('reduces to "/" and empty key at the mount root', () => {
+    const p = new PathSpec({ original: '/data', directory: '/data', prefix: '/data' })
+    expect(p.stripPrefix).toBe('/')
+    expect(p.key).toBe('')
+  })
+
+  it('is identity without a prefix', () => {
+    const p = new PathSpec({ original: '/x.txt', directory: '/' })
+    expect(p.stripPrefix).toBe('/x.txt')
+    expect(p.key).toBe('x.txt')
+  })
+})

--- a/typescript/packages/node/src/core/email/read.ts
+++ b/typescript/packages/node/src/core/email/read.ts
@@ -37,9 +37,7 @@ export async function read(
   index?: IndexCacheStore,
 ): Promise<Uint8Array> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
   if (index === undefined) throw enoent(path.original)
   const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`
   const result = await index.get(virtualKey)

--- a/typescript/packages/node/src/core/email/readdir.ts
+++ b/typescript/packages/node/src/core/email/readdir.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { IndexCacheStore, PathSpec } from '@struktoai/mirage-core'
-import { IndexEntry, PathSpec as PathSpecCtor, stripSlash } from '@struktoai/mirage-core'
+import { IndexEntry, PathSpec as PathSpecCtor } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../accessor/email.ts'
 import { fetchHeaders, listMessageUids } from './_client.ts'
 import { listFolders } from './folders.ts'
@@ -57,10 +57,7 @@ export async function readdir(
   index?: IndexCacheStore,
 ): Promise<string[]> {
   const prefix = path.prefix
-  const raw = path.pattern !== null ? path.directory : path.original
-  let p = raw
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = (path.pattern !== null ? path.dir : path).key
   const virtualKey = key !== '' ? `${prefix}/${key}` : prefix !== '' ? prefix : '/'
   const parts = key === '' ? [] : key.split('/')
   const depth = parts.length

--- a/typescript/packages/node/src/core/email/stat.ts
+++ b/typescript/packages/node/src/core/email/stat.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { IndexCacheStore, PathSpec } from '@struktoai/mirage-core'
-import { FileStat, FileType, stripSlash } from '@struktoai/mirage-core'
+import { FileStat, FileType } from '@struktoai/mirage-core'
 import type { EmailAccessor } from '../../accessor/email.ts'
 import { listFolders } from './folders.ts'
 
@@ -45,9 +45,7 @@ export async function stat(
   index?: IndexCacheStore,
 ): Promise<FileStat> {
   const prefix = path.prefix
-  let p = path.original
-  if (prefix !== '' && p.startsWith(prefix)) p = p.slice(prefix.length) || '/'
-  const key = stripSlash(p)
+  const key = path.key
   if (key === '') return new FileStat({ name: '/', type: FileType.DIRECTORY })
 
   if (index === undefined) throw enoent(path.original)


### PR DESCRIPTION
## What

Backends hand-rolled the mount-prefix strip inline , an 11-line ritual that re-implements logic already living on `PathSpec` (`strip_prefix` / `.key` / `dir.key`). This replaces every clean instance with the property.

Groundwork for routing reads through the namespace (follow-on-read): "the path" needs to be one unambiguous virtual string, not a prefix-stamped struct each backend un-stamps differently.

## Scope

- **Python: 44** backend `read`/`stat`/`stream`/`readdir` files.
- **TypeScript: 28** backend files (same families + `box`/`dropbox`).
- Net **~-300 LOC** of source.
- `virtual_key` reconstruction is left untouched where a backend reuses `prefix` (preserves index-key normalization, incl. the root trailing-slash case).

Three provably-equivalent transforms: inline strip -> `path.strip_prefix` / `key = path.key`; readdir -> `(path.dir if path.pattern else path).key`.

## Fixes two bugs

- **`PathSpec` leak**: a `PathSpec` was left where a stripped `str` was expected, so `record(...)` hit `'PathSpec' object has no attribute 'startswith'` on a prefixed s3 read. Reassign `path = path.strip_prefix`.
- **TS boundary guard**: the TS hand-roll omitted the `rest.startsWith('/')` guard, so `/database` mis-stripped under a `/data` prefix (`base/x` instead of `database/x`). `.key`/`.stripPrefix` restores the guarded result and aligns TS with Python.

## Tests

Adds `PathSpec.stripPrefix`/`key` unit tests in **both** languages (boundary strip, sibling-prefix guard, mount-root, no-prefix) , the property had no prior unit coverage.

Verified: Python full suite green; TS core 3483 + node 1558 green; integ ram/disk byte-identical py/ts.

## Deferred

Bespoke-shape backends (s3 ternary, `github`/`discord`/`postgres` variants) are left for the follow-up that retires the `PathSpec.prefix` field, which rewrites those sites anyway.