### PR TITLE
chore: second cleanup round

### DIFF
--- a/python/mirage/cache/file/mixin.py
+++ b/python/mirage/cache/file/mixin.py
@@ -82,5 +82,10 @@ class FileCacheMixin:
         raise NotImplementedError
 
     @property
+    def cache_entries(self) -> int:
+        """Number of cached entries; 0 for stores that don't track them."""
+        return 0
+
+    @property
     def cache_limit(self) -> int:
         raise NotImplementedError

--- a/python/mirage/cache/file/mixin.py
+++ b/python/mirage/cache/file/mixin.py
@@ -78,13 +78,14 @@ class FileCacheMixin:
             await self.set(key, data, fingerprint=fingerprint, ttl=ttl)
 
     @property
-    def cache_size(self) -> int:
+    def cache_size(self) -> int | None:
+        """Cached bytes; None for stores that don't track them."""
         raise NotImplementedError
 
     @property
-    def cache_entries(self) -> int:
-        """Number of cached entries; 0 for stores that don't track them."""
-        return 0
+    def cache_entries(self) -> int | None:
+        """Number of cached entries; None for stores that don't track them."""
+        return None
 
     @property
     def cache_limit(self) -> int:

--- a/python/mirage/cache/file/ram.py
+++ b/python/mirage/cache/file/ram.py
@@ -160,5 +160,9 @@ class RAMFileCacheStore(RAMResource, FileCacheMixin, KeyLockMixin):
         return self._cache_size
 
     @property
+    def cache_entries(self) -> int:
+        return len(self._entries)
+
+    @property
     def cache_limit(self) -> int:
         return self._cache_limit

--- a/python/mirage/cache/file/redis.py
+++ b/python/mirage/cache/file/redis.py
@@ -109,8 +109,9 @@ class RedisFileCacheStore(RedisResource, FileCacheMixin):
         pass
 
     @property
-    def cache_size(self) -> int:
-        return 0
+    def cache_size(self) -> int | None:
+        # Size lives in the redis server and is not tracked client-side.
+        return None
 
     @property
     def cache_limit(self) -> int:

--- a/python/mirage/cli/workspace.py
+++ b/python/mirage/cli/workspace.py
@@ -97,7 +97,9 @@ def _format_workspace_detail(detail: dict[str, Any]) -> str:
         lines.append("Internals:")
         for key in ("cache_bytes", "cache_entries", "history_length",
                     "in_flight_jobs"):
-            lines.append(f"  {key:<16} {internals[key]}")
+            value = internals[key]
+            shown = "n/a (not tracked)" if value is None else value
+            lines.append(f"  {key:<16} {shown}")
     return "\n".join(lines)
 
 

--- a/python/mirage/commands/builtin/generic/grep.py
+++ b/python/mirage/commands/builtin/generic/grep.py
@@ -82,7 +82,6 @@ async def grep(
     read_stream: Callable[..., AsyncIterator[bytes]] | None,
     accessor: object = None,
     stdin: AsyncIterator[bytes] | bytes | None = None,
-    show_filename: bool = False,
     index: IndexCacheStore | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
     """Run grep-style fallback search over backend paths or stdin.
@@ -106,8 +105,6 @@ async def grep(
         accessor (object): Backend accessor passed through wrapper helpers.
         stdin (AsyncIterator[bytes] | bytes | None): Input used when paths is
             empty.
-        show_filename (bool): Force filename prefixes on a single path,
-            for callers that pre-expanded a multi-file scope.
         index (IndexCacheStore | None): Optional cache index for wrapped
             backend calls.
 
@@ -225,7 +222,7 @@ async def grep(
         pat = compile_pattern(pattern, f.ignore_case, f.fixed_string,
                               f.whole_word)
 
-        if len(paths) > 1 or show_filename:
+        if len(paths) > 1:
             all_results = []
             multi_warnings: list[str] = []
             for p in paths:

--- a/python/mirage/commands/builtin/utils/wrap.py
+++ b/python/mirage/commands/builtin/utils/wrap.py
@@ -65,13 +65,3 @@ async def stream_from_bytes(
     prefix: str = "",
 ) -> AsyncIterator[bytes]:
     yield await read_fn(accessor, to_pathspec(path, prefix), index)
-
-
-def call_read_stream(
-    read_fn: Callable,
-    accessor: Any,
-    path: Any,
-    index: Any = None,
-    prefix: str = "",
-):
-    return read_fn(accessor, to_pathspec(path, prefix), index)

--- a/python/mirage/resource/redis/store.py
+++ b/python/mirage/resource/redis/store.py
@@ -96,10 +96,6 @@ class RedisStore:
         length = await self._client.strlen(self._fk(path))
         return length
 
-    async def get_range(self, path: str, start: int, end: int) -> bytes:
-        data = await self._client.getrange(self._fk(path), start, end)
-        return data
-
     async def has_dir(self, path: str) -> bool:
         return bool(await self._client.sismember(self._dk(), path))
 

--- a/python/mirage/server/jobs.py
+++ b/python/mirage/server/jobs.py
@@ -80,13 +80,6 @@ class JobTable:
             j for j in self._jobs.values() if j.workspace_id == workspace_id
         ]
 
-    def remove_for_workspace(self, workspace_id: str) -> None:
-        ids = [
-            j.id for j in self._jobs.values() if j.workspace_id == workspace_id
-        ]
-        for jid in ids:
-            self._jobs.pop(jid, None)
-
     def submit(self, workspace_id: str, command: str,
                schedule: Callable[[Awaitable], concurrent.futures.Future],
                coro_factory: Callable[[], Awaitable]) -> JobEntry:

--- a/python/mirage/server/schemas/workspaces.py
+++ b/python/mirage/server/schemas/workspaces.py
@@ -21,8 +21,8 @@ from mirage.server.schemas.common import MountSummary, SessionSummary
 
 
 class WorkspaceInternals(BaseModel):
-    cache_bytes: int
-    cache_entries: int
+    cache_bytes: int | None
+    cache_entries: int | None
     history_length: int
     in_flight_jobs: int
 

--- a/python/mirage/server/summary.py
+++ b/python/mirage/server/summary.py
@@ -40,12 +40,11 @@ def _user_mounts(ws: Workspace):
 
 
 async def _build_internals(ws: Workspace) -> WorkspaceInternals:
-    cache = ws._cache
-    cache_bytes = sum(len(v) for v in cache._store.files.values())
+    cache = ws.cache
     history_len = len(await ws.history())
     return WorkspaceInternals(
-        cache_bytes=cache_bytes,
-        cache_entries=len(cache._entries),
+        cache_bytes=cache.cache_size,
+        cache_entries=cache.cache_entries,
         history_length=history_len,
         in_flight_jobs=len(ws.job_table.list_jobs()),
     )

--- a/python/tests/resource/redis/test_redis_store.py
+++ b/python/tests/resource/redis/test_redis_store.py
@@ -85,13 +85,6 @@ async def test_file_len(store):
 
 
 @pytest.mark.asyncio
-async def test_get_range(store):
-    await store.set_file("/a.txt", b"hello world")
-    result = await store.get_range("/a.txt", 0, 4)
-    assert result == b"hello"
-
-
-@pytest.mark.asyncio
 async def test_has_dir(store):
     assert await store.has_dir("/") is True
     assert await store.has_dir("/sub") is False

--- a/python/tests/server/test_workspaces_router.py
+++ b/python/tests/server/test_workspaces_router.py
@@ -143,9 +143,10 @@ async def test_get_verbose_internals_with_redis_cache():
         internals = r.json()["internals"]
         assert internals is not None
         # Redis cache does not track size or entries; the summary must
-        # still build instead of reaching into RAM-store internals.
-        assert internals["cache_bytes"] == 0
-        assert internals["cache_entries"] == 0
+        # report them as untracked instead of reaching into RAM-store
+        # internals or conflating "not tracked" with an empty cache.
+        assert internals["cache_bytes"] is None
+        assert internals["cache_entries"] is None
 
         await client.delete(f"/v1/workspaces/{wid}")
 

--- a/python/tests/server/test_workspaces_router.py
+++ b/python/tests/server/test_workspaces_router.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import os
 import time
 
 import pytest
@@ -108,6 +109,45 @@ async def test_get_verbose_includes_internals():
         assert internals is not None
         assert "cache_bytes" in internals
         assert "cache_entries" in internals
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not os.environ.get("REDIS_URL"),
+                    reason="REDIS_URL not set")
+async def test_get_verbose_internals_with_redis_cache():
+    body = {
+        "config": {
+            "mounts": {
+                "/": {
+                    "resource": "ram",
+                    "mode": "WRITE"
+                }
+            },
+            "cache": {
+                "type": "redis",
+                "url": os.environ["REDIS_URL"],
+                "key_prefix": "test:summary:",
+            },
+        },
+    }
+    app, _ = _make_app_with_short_grace(grace=10.0)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport,
+                           base_url="http://test") as client:
+        r = await client.post("/v1/workspaces", json=body)
+        assert r.status_code == 201, r.text
+        wid = r.json()["id"]
+
+        r = await client.get(f"/v1/workspaces/{wid}?verbose=true")
+        assert r.status_code == 200, r.text
+        internals = r.json()["internals"]
+        assert internals is not None
+        # Redis cache does not track size or entries; the summary must
+        # still build instead of reaching into RAM-store internals.
+        assert internals["cache_bytes"] == 0
+        assert internals["cache_entries"] == 0
+
+        await client.delete(f"/v1/workspaces/{wid}")
 
 
 @pytest.mark.asyncio

--- a/typescript/packages/cli/src/workspace.ts
+++ b/typescript/packages/cli/src/workspace.ts
@@ -63,8 +63,8 @@ interface SessionSummary {
 }
 
 interface Internals {
-  cacheBytes: number
-  cacheEntries: number
+  cacheBytes: number | null
+  cacheEntries: number | null
   historyLength: number
   inFlightJobs: number
 }
@@ -113,7 +113,8 @@ function formatWorkspaceDetail(d: WorkspaceDetail): string {
   if (d.internals != null) {
     lines.push('', 'Internals:')
     for (const k of ['cacheBytes', 'cacheEntries', 'historyLength', 'inFlightJobs'] as const) {
-      lines.push(`  ${k.padEnd(16)} ${String(d.internals[k])}`)
+      const value = d.internals[k]
+      lines.push(`  ${k.padEnd(16)} ${value === null ? 'n/a (not tracked)' : String(value)}`)
     }
   }
   return lines.join('\n')

--- a/typescript/packages/core/src/cache/file/mixin.ts
+++ b/typescript/packages/core/src/cache/file/mixin.ts
@@ -32,7 +32,10 @@ export interface FileCache {
   clear(): Promise<void>
   allCached(keys: readonly string[]): Promise<boolean>
   multiGet(keys: readonly string[]): Promise<(Uint8Array | null)[]>
-  readonly cacheSize: number
+  // Cached bytes / entry count; null (or absent) for stores that don't
+  // track them client-side (e.g. redis owns its own keyspace).
+  readonly cacheSize: number | null
+  readonly cacheEntries?: number | null
   readonly cacheLimit: number
   maxDrainBytes: number | null
   // Present only on stores that support background drains (mirrors the

--- a/typescript/packages/core/src/cache/file/ram.ts
+++ b/typescript/packages/core/src/cache/file/ram.ts
@@ -39,6 +39,10 @@ export class RAMFileCacheStore extends RAMResource implements FileCache {
     return this.size
   }
 
+  get cacheEntries(): number {
+    return this.entries.size
+  }
+
   get cacheLimit(): number {
     return this.limit
   }

--- a/typescript/packages/core/src/commands/builtin/generic/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/grep.ts
@@ -112,7 +112,6 @@ export async function grepGeneric(
   stat: Stat,
   readdir: Readdir,
   stream: Stream,
-  showFilename = false,
 ): Promise<CommandFnResult> {
   stream = cacheAwareStream(stream)
   const resolution = await resolvePatternFromFlags(
@@ -222,7 +221,7 @@ export async function grepGeneric(
       ]
     }
 
-    if (paths.length > 1 || showFilename) {
+    if (paths.length > 1) {
       const allResults: string[] = []
       const multiWarnings: string[] = []
       for (const p of paths) {

--- a/typescript/packages/node/src/cache/redis/file.ts
+++ b/typescript/packages/node/src/cache/redis/file.ts
@@ -43,7 +43,9 @@ export class RedisFileCacheStore extends RedisResource implements FileCache {
     this.maxDrainBytes = options.maxDrainBytes ?? null
   }
 
-  readonly cacheSize = 0
+  // Size lives in the redis server and is not tracked client-side.
+  readonly cacheSize: number | null = null
+  readonly cacheEntries: number | null = null
 
   get cacheLimit(): number {
     return this.limit

--- a/typescript/packages/node/src/resource/redis/store.test.ts
+++ b/typescript/packages/node/src/resource/redis/store.test.ts
@@ -80,11 +80,6 @@ describe.skipIf(skip)('RedisStore', () => {
     expect(await store.fileLen('/x')).toBe(5)
   })
 
-  it('getRange slices bytes', async () => {
-    await store.setFile('/x', new Uint8Array([10, 20, 30, 40, 50]))
-    expect(await store.getRange('/x', 1, 3)).toEqual(new Uint8Array([20, 30, 40]))
-  })
-
   it('addDir / hasDir / removeDir / listDirs', async () => {
     await store.addDir('/')
     await store.addDir('/foo')

--- a/typescript/packages/node/src/resource/redis/store.ts
+++ b/typescript/packages/node/src/resource/redis/store.ts
@@ -115,22 +115,6 @@ export class RedisStore {
     return c.strLen(this.fk(path))
   }
 
-  async getRange(path: string, start: number, end: number): Promise<Uint8Array> {
-    const c = await this.client()
-    const typed = c as unknown as {
-      withTypeMapping: (m: Record<number, unknown>) => {
-        getRange: (k: string, s: number, e: number) => Promise<Buffer>
-      }
-    }
-    const mod = (await import('redis')) as unknown as {
-      RESP_TYPES: { readonly BLOB_STRING: number }
-    }
-    const blob = mod.RESP_TYPES.BLOB_STRING
-    const mapping: Record<number, unknown> = { [blob]: Buffer }
-    const raw = await typed.withTypeMapping(mapping).getRange(this.fk(path), start, end)
-    return new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength)
-  }
-
   async hasDir(path: string): Promise<boolean> {
     const c = await this.client()
     return (await c.sIsMember(this.dk(), path)) === 1

--- a/typescript/packages/server/src/schemas.ts
+++ b/typescript/packages/server/src/schemas.ts
@@ -33,8 +33,8 @@ export interface SessionSummary {
 }
 
 export interface WorkspaceInternals {
-  cacheBytes: number
-  cacheEntries: number
+  cacheBytes: number | null
+  cacheEntries: number | null
   historyLength: number
   inFlightJobs: number
 }

--- a/typescript/packages/server/src/summary.ts
+++ b/typescript/packages/server/src/summary.ts
@@ -45,10 +45,10 @@ function describeResource(resource: Resource): string {
 }
 
 async function buildInternals(ws: Workspace): Promise<WorkspaceInternals> {
-  const cache = ws.cache as typeof ws.cache & { snapshotEntries?: () => unknown[] }
+  const cache = ws.cache
   return {
     cacheBytes: cache.cacheSize,
-    cacheEntries: cache.snapshotEntries?.().length ?? 0,
+    cacheEntries: cache.cacheEntries ?? null,
     historyLength: (await ws.history()).length,
     inFlightJobs: ws.jobTable.listJobs().length,
   }


### PR DESCRIPTION
Small cleanups following up on #423.

- Remove dead helpers orphaned by the last sweep: `call_read_stream` (py), `remove_for_workspace` (py server jobs), and the test-only `get_range`/`getRange` on the redis stores (both languages).
- Remove the never-passed `show_filename`/`showFilename` parameter from the generic grep in both languages.
- `server/summary.py` now uses the cache store's `cache_size`/`cache_entries` properties instead of reaching into RAM-store internals; the old code crashed on a redis-backed cache (`AttributeError: 'RedisStore' object has no attribute 'files'`).
- Cache stats that a store does not track are now reported as `null` instead of `0`, in both languages (store properties, server schemas, CLI shows `n/a (not tracked)`). A redis-backed cache previously looked identical to an empty cache in `workspace get -v`.
- Regression test: `test_get_verbose_internals_with_redis_cache` creates a workspace with a redis cache block and asserts the verbose summary builds with untracked (`null`) stats; verified it reproduces the AttributeError on the pre-fix code. Runs in CI (pytest job has REDIS_URL), skips locally without redis.

Verified: full python suite, all TS package suites, ram integ both languages, pre-commit.