### PR TITLE
refactor(shell): one NodeKind classification for both walkers; close planner drift; cost redirects

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -905,6 +905,36 @@ SLEEP_CASES: list[tuple[str, str, float]] = [
     ("sleep_one", "sleep 1", 1.0),
 ]
 
+# Cross-mount coverage: every runner mounts a second resource of its own
+# backend at /data2, so reads, writes, links, and provision spanning two
+# mounts behave identically on every backend. Seeds happen inside the
+# section (tee), so the /data listings earlier in the battery stay
+# untouched.
+CROSS_MOUNT_CASES: list[tuple[str, str]] = [
+    ("xm_seed", "echo cross | tee /data2/xm.txt"),
+    ("xm_ls", "ls /data2"),
+    ("xm_cat_concat", "cat /data/a.txt /data2/xm.txt"),
+    ("xm_cp_over", "cp /data/a.txt /data2/xm_copy.txt"
+     " && cat /data2/xm_copy.txt"),
+    ("xm_cp_back", "cp /data2/xm.txt /data/xm_back.txt"
+     " && cat /data/xm_back.txt"),
+    ("xm_mv_over", "mv /data/xm_back.txt /data2/xm_moved.txt"
+     " && cat /data2/xm_moved.txt && ls /data2"),
+    ("xm_grep_multi", "grep -c s /data/a.txt /data2/xm.txt"),
+    ("xm_wc_multi", "wc -l /data/a.txt /data2/xm.txt"),
+    # du/md5/file reject multi-mount operands explicitly; pin the error
+    ("xm_du_multi_rejected", "du /data/b.txt /data2/xm.txt 2>&1"),
+    ("xm_find", "find /data2 -type f | sort"),
+    ("xm_pipe", "cat /data2/xm.txt | tr a-z A-Z"),
+    ("xm_ln_over", "ln -s /data/a.txt /data2/xm_link.txt"
+     " && cat /data2/xm_link.txt"),
+    ("xm_ln_readlink", "readlink /data2/xm_link.txt"),
+    ("xm_ln_back", "ln -s /data2/xm.txt /data/xm_rlink.txt"
+     " && cat /data/xm_rlink.txt"),
+    ("xm_link_grep", "grep -c cross /data/xm_rlink.txt"),
+    ("xm_cd_across", "(cd /data2 && cat xm.txt && cd /data && ls b.txt)"),
+]
+
 # Provision (dry-run cost estimates) must print identical numbers on every
 # backend: sizes come from seeded files, and the file cache is cleared first
 # so read-caching backends (s3, onedrive, nextcloud) report the same cold
@@ -988,6 +1018,14 @@ PROVISION_CASES: list[tuple[str, str]] = [
     ("prov_until", "until false; do cat /data/a.txt; done"),
     ("prov_redirect_in", "wc -l < /data/a.txt"),
     ("prov_redirect_devnull", "cat /data/a.txt > /dev/null"),
+    # ----- namespace links and cross-mount commands -----
+    ("prov_symlink", "cat /data2/xm_link.txt"),
+    ("prov_symlink_grep", "grep x /data/xm_rlink.txt"),
+    ("prov_xmount_concat", "cat /data/a.txt /data2/xm.txt"),
+    ("prov_xmount_grep", "grep s /data/a.txt /data2/xm.txt"),
+    ("prov_xmount_pipe", "cat /data/a.txt /data2/xm.txt | wc -c"),
+    # md5 rejects cross-mount operands, so its plan is honest unknown
+    ("prov_xmount_rejected", "md5 /data/a.txt /data2/xm.txt"),
 ]
 
 
@@ -1016,6 +1054,60 @@ async def run_provision_probe(ws, file_path: str) -> None:
         result = await ws.execute(cmd, provision=True)
         print(f"=== {name} ===")
         print(provision_line(result))
+
+
+async def _backend_bytes(ws, cmd: str) -> int:
+    before = sum(rec.bytes for rec in ws.ops.records)
+    result = await ws.execute(cmd)
+    await result.stdout_str()
+    return sum(rec.bytes for rec in ws.ops.records) - before
+
+
+async def run_cache_verify_cases(ws,
+                                 mount: str = "/data",
+                                 mount2: str | None = None) -> None:
+    """Byte-accounted cache verification for read-caching backends.
+
+    A second read of the same file pulls zero backend bytes, whether it
+    goes through the file's own path or a symlink (the link and its
+    target share one cache entry), and provision reports the hit. With
+    a second mount, the same holds for a cross-mount link, and the
+    cross-mount cp is pinned as-is (it does not read through the
+    cache today).
+    """
+    m = mount.rstrip("/")
+    target = f"{m}/cachev.txt"
+    link = f"{m}/cachev_link.txt"
+    await ws.execute(f"tee {target} > /dev/null", stdin=b"cache verify\n")
+    await ws.execute(f"ln -s {target} {link}")
+    await ws.cache.clear()
+    print("=== cachev_link_cold ===")
+    print(f"bytes={await _backend_bytes(ws, f'cat {link}')}")
+    print("=== cachev_link_warm ===")
+    print(f"bytes={await _backend_bytes(ws, f'cat {link}')}")
+    print("=== cachev_target_shares_entry ===")
+    print(f"bytes={await _backend_bytes(ws, f'cat {target}')}")
+    print("=== cachev_warm_grep ===")
+    print(f"bytes={await _backend_bytes(ws, f'grep cache {target}')}")
+    print("=== cachev_prov_link ===")
+    result = await ws.execute(f"cat {link}", provision=True)
+    print(provision_line(result))
+    if mount2 is not None:
+        m2 = mount2.rstrip("/")
+        xlink = f"{m2}/cachev_xlink.txt"
+        await ws.execute(f"ln -s {target} {xlink}")
+        await ws.cache.clear()
+        print("=== cachev_xmount_cold ===")
+        print(f"bytes={await _backend_bytes(ws, f'cat {xlink}')}")
+        print("=== cachev_xmount_warm ===")
+        print(f"bytes={await _backend_bytes(ws, f'cat {xlink}')}")
+        print("=== cachev_xmount_prov ===")
+        result = await ws.execute(f"cat {xlink}", provision=True)
+        print(provision_line(result))
+        print("=== cachev_xmount_cp_warm_source ===")
+        print(f"bytes="
+              f"{await _backend_bytes(ws, f'cp {target} {m2}/cachev_cp.txt')}")
+    await ws.execute(f"rm {link} {target}")
 
 
 async def run_provision_cache_cases(ws, mount: str = "/data") -> None:
@@ -1110,6 +1202,12 @@ async def run_cases(ws) -> None:
         else:
             print(f"{name} FAIL exit={result.exit_code} "
                   f"elapsed={elapsed:.3f}")
+
+    for name, cmd in CROSS_MOUNT_CASES:
+        result = await ws.execute(cmd)
+        out = await result.stdout_str()
+        print(f"=== {name} ===")
+        _emit_body(out)
 
     await run_provision_cases(ws)
 

--- a/integ/cases.py
+++ b/integ/cases.py
@@ -978,6 +978,16 @@ PROVISION_CASES: list[tuple[str, str]] = [
     ("prov_cmdsub", "cat $(echo /data/a.txt)"),
     ("prov_deep_mix",
      "for i in 1 2; do cat /data/a.txt | wc -l && cat /data/b.txt; done"),
+    # ----- planner/executor drift fixes (env prefix, functions, eval,
+    # select/until, redirect costing) -----
+    ("prov_env_prefix", "FOO=1 cat /data/a.txt"),
+    ("prov_func_call", "pfn() { cat /data/b.txt; }; pfn; pfn"),
+    ("prov_func_recursive", "prec() { prec; }; prec"),
+    ("prov_eval", "eval 'cat /data/a.txt'"),
+    ("prov_select", "select x in a b; do cat /data/a.txt; done"),
+    ("prov_until", "until false; do cat /data/a.txt; done"),
+    ("prov_redirect_in", "wc -l < /data/a.txt"),
+    ("prov_redirect_devnull", "cat /data/a.txt > /dev/null"),
 ]
 
 

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -781,6 +781,31 @@ export const SLEEP_CASES: ReadonlyArray<readonly [string, string, number]> = [
   ["sleep_one", "sleep 1", 1],
 ];
 
+// Cross-mount coverage: every runner mounts a second resource of its own
+// backend at /data2, so reads, writes, links, and provision spanning two
+// mounts behave identically on every backend. Seeds happen inside the
+// section (tee), so the /data listings earlier in the battery stay
+// untouched.
+export const CROSS_MOUNT_CASES: ReadonlyArray<readonly [string, string]> = [
+  ["xm_seed", "echo cross | tee /data2/xm.txt"],
+  ["xm_ls", "ls /data2"],
+  ["xm_cat_concat", "cat /data/a.txt /data2/xm.txt"],
+  ["xm_cp_over", "cp /data/a.txt /data2/xm_copy.txt && cat /data2/xm_copy.txt"],
+  ["xm_cp_back", "cp /data2/xm.txt /data/xm_back.txt && cat /data/xm_back.txt"],
+  ["xm_mv_over", "mv /data/xm_back.txt /data2/xm_moved.txt && cat /data2/xm_moved.txt && ls /data2"],
+  ["xm_grep_multi", "grep -c s /data/a.txt /data2/xm.txt"],
+  ["xm_wc_multi", "wc -l /data/a.txt /data2/xm.txt"],
+  // du/md5/file reject multi-mount operands explicitly; pin the error
+  ["xm_du_multi_rejected", "du /data/b.txt /data2/xm.txt 2>&1"],
+  ["xm_find", "find /data2 -type f | sort"],
+  ["xm_pipe", "cat /data2/xm.txt | tr a-z A-Z"],
+  ["xm_ln_over", "ln -s /data/a.txt /data2/xm_link.txt && cat /data2/xm_link.txt"],
+  ["xm_ln_readlink", "readlink /data2/xm_link.txt"],
+  ["xm_ln_back", "ln -s /data2/xm.txt /data/xm_rlink.txt && cat /data/xm_rlink.txt"],
+  ["xm_link_grep", "grep -c cross /data/xm_rlink.txt"],
+  ["xm_cd_across", "(cd /data2 && cat xm.txt && cd /data && ls b.txt)"],
+];
+
 // Provision (dry-run cost estimates) must print identical numbers on every
 // backend: sizes come from seeded files, and the file cache is cleared first
 // so read-caching backends (s3, onedrive, nextcloud) report the same cold
@@ -858,6 +883,14 @@ export const PROVISION_CASES: ReadonlyArray<readonly [string, string]> = [
   ["prov_until", "until false; do cat /data/a.txt; done"],
   ["prov_redirect_in", "wc -l < /data/a.txt"],
   ["prov_redirect_devnull", "cat /data/a.txt > /dev/null"],
+  // ----- namespace links and cross-mount commands -----
+  ["prov_symlink", "cat /data2/xm_link.txt"],
+  ["prov_symlink_grep", "grep x /data/xm_rlink.txt"],
+  ["prov_xmount_concat", "cat /data/a.txt /data2/xm.txt"],
+  ["prov_xmount_grep", "grep s /data/a.txt /data2/xm.txt"],
+  ["prov_xmount_pipe", "cat /data/a.txt /data2/xm.txt | wc -c"],
+  // md5 rejects cross-mount operands, so its plan is honest unknown
+  ["prov_xmount_rejected", "md5 /data/a.txt /data2/xm.txt"],
 ];
 
 // Not-found errors must always show the full virtual path the user typed
@@ -971,6 +1004,13 @@ export async function runCases(ws: Workspace): Promise<void> {
     }
   }
 
+  for (const [name, cmd] of CROSS_MOUNT_CASES) {
+    const result = await ws.execute(cmd);
+    const out = new TextDecoder().decode(result.stdout);
+    process.stdout.write(`=== ${name} ===\n`);
+    emitBody(out);
+  }
+
   await runProvisionCases(ws);
 }
 
@@ -1006,6 +1046,60 @@ export async function runProvisionProbe(ws: Workspace, filePath: string): Promis
     process.stdout.write(`=== ${name} ===\n`);
     process.stdout.write(provisionLine(result) + "\n");
   }
+}
+
+async function backendBytes(ws: Workspace, cmd: string): Promise<number> {
+  const before = ws.records.reduce((sum, r) => sum + r.bytes, 0);
+  await ws.execute(cmd);
+  return ws.records.reduce((sum, r) => sum + r.bytes, 0) - before;
+}
+
+// Byte-accounted cache verification for read-caching backends. A second
+// read of the same file pulls zero backend bytes, whether it goes through
+// the file's own path or a symlink (the link and its target share one
+// cache entry), and provision reports the hit. With a second mount, the
+// same holds for a cross-mount link, and the cross-mount cp is pinned
+// as-is (it does not read through the cache today).
+export async function runCacheVerifyCases(
+  ws: Workspace,
+  mount = "/data",
+  mount2: string | null = null,
+): Promise<void> {
+  const m = mount.replace(/\/+$/, "");
+  const target = `${m}/cachev.txt`;
+  const link = `${m}/cachev_link.txt`;
+  await ws.execute(`tee ${target} > /dev/null`, { stdin: ENC.encode("cache verify\n") });
+  await ws.execute(`ln -s ${target} ${link}`);
+  await ws.cache.clear();
+  process.stdout.write("=== cachev_link_cold ===\n");
+  process.stdout.write(`bytes=${String(await backendBytes(ws, `cat ${link}`))}\n`);
+  process.stdout.write("=== cachev_link_warm ===\n");
+  process.stdout.write(`bytes=${String(await backendBytes(ws, `cat ${link}`))}\n`);
+  process.stdout.write("=== cachev_target_shares_entry ===\n");
+  process.stdout.write(`bytes=${String(await backendBytes(ws, `cat ${target}`))}\n`);
+  process.stdout.write("=== cachev_warm_grep ===\n");
+  process.stdout.write(`bytes=${String(await backendBytes(ws, `grep cache ${target}`))}\n`);
+  process.stdout.write("=== cachev_prov_link ===\n");
+  let result = await ws.execute(`cat ${link}`, { provision: true });
+  process.stdout.write(provisionLine(result) + "\n");
+  if (mount2 !== null) {
+    const m2 = mount2.replace(/\/+$/, "");
+    const xlink = `${m2}/cachev_xlink.txt`;
+    await ws.execute(`ln -s ${target} ${xlink}`);
+    await ws.cache.clear();
+    process.stdout.write("=== cachev_xmount_cold ===\n");
+    process.stdout.write(`bytes=${String(await backendBytes(ws, `cat ${xlink}`))}\n`);
+    process.stdout.write("=== cachev_xmount_warm ===\n");
+    process.stdout.write(`bytes=${String(await backendBytes(ws, `cat ${xlink}`))}\n`);
+    process.stdout.write("=== cachev_xmount_prov ===\n");
+    result = await ws.execute(`cat ${xlink}`, { provision: true });
+    process.stdout.write(provisionLine(result) + "\n");
+    process.stdout.write("=== cachev_xmount_cp_warm_source ===\n");
+    process.stdout.write(
+      `bytes=${String(await backendBytes(ws, `cp ${target} ${m2}/cachev_cp.txt`))}\n`,
+    );
+  }
+  await ws.execute(`rm ${link} ${target}`);
 }
 
 // Cache-hit flipping for read-caching backends (cachesReads=true). Once a

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -848,6 +848,16 @@ export const PROVISION_CASES: ReadonlyArray<readonly [string, string]> = [
   ["prov_for_nested", "for i in 1 2; do for j in 1 2; do cat /data/b.txt; done; done"],
   ["prov_cmdsub", "cat $(echo /data/a.txt)"],
   ["prov_deep_mix", "for i in 1 2; do cat /data/a.txt | wc -l && cat /data/b.txt; done"],
+  // ----- planner/executor drift fixes (env prefix, functions, eval,
+  // select/until, redirect costing) -----
+  ["prov_env_prefix", "FOO=1 cat /data/a.txt"],
+  ["prov_func_call", "pfn() { cat /data/b.txt; }; pfn; pfn"],
+  ["prov_func_recursive", "prec() { prec; }; prec"],
+  ["prov_eval", "eval 'cat /data/a.txt'"],
+  ["prov_select", "select x in a b; do cat /data/a.txt; done"],
+  ["prov_until", "until false; do cat /data/a.txt; done"],
+  ["prov_redirect_in", "wc -l < /data/a.txt"],
+  ["prov_redirect_devnull", "cat /data/a.txt > /dev/null"],
 ];
 
 // Not-found errors must always show the full virtual path the user typed

--- a/integ/disk.py
+++ b/integ/disk.py
@@ -29,15 +29,21 @@ from mirage.resource.disk import DiskResource  # noqa: E402
 
 async def main() -> None:
     tmp = tempfile.mkdtemp(prefix="mirage-integ-disk-")
+    tmp2 = tempfile.mkdtemp(prefix="mirage-integ-disk2-")
     obs_root = tempfile.mkdtemp(prefix="mirage-integ-observer-")
     try:
-        ws = Workspace({"/data": DiskResource(root=tmp)},
-                       mode=MountMode.WRITE,
-                       observe=DiskObserverStore(obs_root))
+        ws = Workspace(
+            {
+                "/data": DiskResource(root=tmp),
+                "/data2": DiskResource(root=tmp2)
+            },
+            mode=MountMode.WRITE,
+            observe=DiskObserverStore(obs_root))
         await run_cases(ws)
         await assert_real_mtime(ws)
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
+        shutil.rmtree(tmp2, ignore_errors=True)
         shutil.rmtree(obs_root, ignore_errors=True)
 
 

--- a/integ/disk.ts
+++ b/integ/disk.ts
@@ -20,9 +20,10 @@ import { assertRealMtime, runCases } from './cases.ts'
 
 async function main(): Promise<void> {
   const root = mkdtempSync(join(tmpdir(), 'mirage-integ-disk-'))
+  const root2 = mkdtempSync(join(tmpdir(), 'mirage-integ-disk2-'))
   const obsRoot = mkdtempSync(join(tmpdir(), 'mirage-integ-observer-'))
   const ws = new Workspace(
-    { '/data': new DiskResource({ root }) },
+    { '/data': new DiskResource({ root }), '/data2': new DiskResource({ root: root2 }) },
     { mode: MountMode.WRITE, observe: new DiskObserverStore(obsRoot) },
   )
   try {
@@ -31,6 +32,7 @@ async function main(): Promise<void> {
   } finally {
     await ws.close()
     rmSync(root, { recursive: true, force: true })
+    rmSync(root2, { recursive: true, force: true })
     rmSync(obsRoot, { recursive: true, force: true })
   }
 }

--- a/integ/nextcloud_cases.py
+++ b/integ/nextcloud_cases.py
@@ -36,6 +36,7 @@ PASSWORD = os.environ.get("NEXTCLOUD_PASSWORD", "admin123")
 # empty folder rather than the account root, which holds Nextcloud's default
 # skeleton files.
 SUBDIR = "integ-cases"
+SUBDIR2 = "integ-cases-xm"
 
 
 async def main() -> None:
@@ -44,10 +45,19 @@ async def main() -> None:
     boot = Workspace({"/root": root}, mode=MountMode.WRITE)
     await boot.execute(f"rm -rf /root/{SUBDIR}")
     await boot.execute(f"mkdir -p /root/{SUBDIR}")
+    await boot.execute(f"rm -rf /root/{SUBDIR2}")
+    await boot.execute(f"mkdir -p /root/{SUBDIR2}")
     cases_url = URL.rstrip("/") + f"/{SUBDIR}/"
+    cases_url2 = URL.rstrip("/") + f"/{SUBDIR2}/"
     resource = NextcloudResource(
         NextcloudConfig(url=cases_url, username=USERNAME, password=PASSWORD))
-    ws = Workspace({"/data": resource}, mode=MountMode.WRITE)
+    resource2 = NextcloudResource(
+        NextcloudConfig(url=cases_url2, username=USERNAME, password=PASSWORD))
+    ws = Workspace({
+        "/data": resource,
+        "/data2": resource2
+    },
+                   mode=MountMode.WRITE)
     await run_cases(ws)
 
 

--- a/integ/onedrive.py
+++ b/integ/onedrive.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from cases import run_cache_verify_cases  # noqa: E402
 from cases import run_not_found, run_provision_cache_cases  # noqa: E402
 from onedrive_server import start_fake_graph  # noqa: E402
 
@@ -258,6 +259,7 @@ async def main() -> None:
             },
             mode=MountMode.WRITE)
         await run_provision_cache_cases(ws_write, MOUNT)
+        await run_cache_verify_cases(ws_write, MOUNT)
         await _run_consistency(state)
     finally:
         await runner.cleanup()

--- a/integ/onedrive_cases.py
+++ b/integ/onedrive_cases.py
@@ -30,7 +30,13 @@ async def main() -> None:
     _state, _server, runner = await start_fake_graph()
     try:
         resource = OneDriveResource(OneDriveConfig(access_token="integ-token"))
-        ws = Workspace({"/data": resource}, mode=MountMode.WRITE)
+        resource2 = OneDriveResource(
+            OneDriveConfig(access_token="integ-token", key_prefix="xm2"))
+        ws = Workspace({
+            "/data": resource,
+            "/data2": resource2
+        },
+                       mode=MountMode.WRITE)
         await run_cases(ws)
     finally:
         await runner.cleanup()

--- a/integ/opfs.ts
+++ b/integ/opfs.ts
@@ -18,7 +18,10 @@ import { runCases } from './cases.ts'
 
 async function main(): Promise<void> {
   const restoreNav = installFakeNavigator(() => makeMockRoot())
-  const ws = new Workspace({ '/data': new OPFSResource() }, { mode: MountMode.WRITE })
+  const ws = new Workspace(
+    { '/data': new OPFSResource(), '/data2': new OPFSResource({ root: 'xm2' }) },
+    { mode: MountMode.WRITE },
+  )
   try {
     await runCases(ws as unknown as Parameters<typeof runCases>[0])
   } finally {

--- a/integ/ram.py
+++ b/integ/ram.py
@@ -25,7 +25,11 @@ from mirage.resource.ram import RAMResource  # noqa: E402
 
 
 async def main() -> None:
-    ws = Workspace({"/data": RAMResource()}, mode=MountMode.WRITE)
+    ws = Workspace({
+        "/data": RAMResource(),
+        "/data2": RAMResource()
+    },
+                   mode=MountMode.WRITE)
     await run_cases(ws)
     await assert_real_mtime(ws)
 

--- a/integ/ram.ts
+++ b/integ/ram.ts
@@ -16,7 +16,10 @@ import { MountMode, RAMResource, Workspace } from '@struktoai/mirage-node'
 import { assertRealMtime, runCases } from './cases.ts'
 
 async function main(): Promise<void> {
-  const ws = new Workspace({ '/data': new RAMResource() }, { mode: MountMode.WRITE })
+  const ws = new Workspace(
+    { '/data': new RAMResource(), '/data2': new RAMResource() },
+    { mode: MountMode.WRITE },
+  )
   try {
     await runCases(ws)
     await assertRealMtime(ws)

--- a/integ/redis.py
+++ b/integ/redis.py
@@ -37,9 +37,16 @@ async def main() -> None:
     run_id = uuid.uuid4().hex[:8]
     prefix = f"mirage-integ-{run_id}/"
     resource = RedisResource(url=REDIS_URL, key_prefix=prefix)
+    resource2 = RedisResource(url=REDIS_URL,
+                              key_prefix=f"mirage-integ-xm-{run_id}/")
     observe = RedisObserverStore(url=REDIS_URL,
                                  key_prefix=f"mirage-integ-observer-{run_id}:")
-    ws = Workspace({"/data": resource}, mode=MountMode.WRITE, observe=observe)
+    ws = Workspace({
+        "/data": resource,
+        "/data2": resource2
+    },
+                   mode=MountMode.WRITE,
+                   observe=observe)
     await run_cases(ws)
     await assert_real_mtime(ws)
     await observe.clear()

--- a/integ/redis.ts
+++ b/integ/redis.ts
@@ -19,8 +19,12 @@ async function main(): Promise<void> {
   const url = process.env.REDIS_URL ?? 'redis://localhost:6379/0'
   const runId = `${String(process.pid)}-${String(Date.now())}`
   const resource = new RedisResource({ url, keyPrefix: `mirage-integ-${runId}` })
+  const resource2 = new RedisResource({ url, keyPrefix: `mirage-integ-xm-${runId}` })
   const observe = new RedisObserverStore({ url, keyPrefix: `mirage-integ-observer-${runId}:` })
-  const ws = new Workspace({ '/data': resource }, { mode: MountMode.WRITE, observe })
+  const ws = new Workspace(
+    { '/data': resource, '/data2': resource2 },
+    { mode: MountMode.WRITE, observe },
+  )
   try {
     await runCases(ws)
     await assertRealMtime(ws)

--- a/integ/s3.py
+++ b/integ/s3.py
@@ -21,7 +21,8 @@ from pathlib import Path
 import aiobotocore.client
 import boto3
 import moto.s3.models as _s3_models
-from cases import run_not_found, run_provision_cache_cases
+from cases import (run_cache_verify_cases, run_not_found,
+                   run_provision_cache_cases)
 from moto.server import ThreadedMotoServer
 
 from mirage import MountMode, Workspace
@@ -390,6 +391,14 @@ async def main() -> None:
         await run_not_found(ws, MOUNTS[0])
         # The suite workspace is read-only; the cache-flip probe seeds its
         # own files, so it gets a write-mode mount on the same bucket.
+        gcs_write = GCSResource(
+            GCSConfig(bucket=GCS_BUCKET,
+                      endpoint_url=endpoint,
+                      access_key_id="testing",
+                      secret_access_key="testing"))
+        gcs_write.config = gcs_write.config.model_copy(
+            update={"path_style": True})
+        gcs_write.accessor = S3Accessor(gcs_write.config)
         ws_write = Workspace(
             {
                 "/s3":
@@ -399,10 +408,13 @@ async def main() -> None:
                              endpoint_url=endpoint,
                              aws_access_key_id="testing",
                              aws_secret_access_key="testing",
-                             path_style=True))
+                             path_style=True)),
+                "/gcs":
+                gcs_write,
             },
             mode=MountMode.WRITE)
         await run_provision_cache_cases(ws_write, "/s3")
+        await run_cache_verify_cases(ws_write, "/s3", "/gcs")
         await _run_consistency(endpoint)
         await _run_coherence(endpoint)
     finally:

--- a/integ/s3.ts
+++ b/integ/s3.ts
@@ -28,7 +28,7 @@ import {
   Workspace,
 } from "@struktoai/mirage-node";
 import { ConsistencyPolicy } from "@struktoai/mirage-core";
-import { runNotFound, runProvisionCacheCases } from "./cases.ts";
+import { runCacheVerifyCases, runNotFound, runProvisionCacheCases } from "./cases.ts";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -456,11 +456,19 @@ async function main(): Promise<void> {
           secretAccessKey: SECRET,
           forcePathStyle: true,
         }),
+        "/gcs": new GCSResource({
+          bucket: GCS_BUCKET,
+          endpoint: ENDPOINT,
+          accessKeyId: ACCESS,
+          secretAccessKey: SECRET,
+          forcePathStyle: true,
+        }),
       },
       { mode: MountMode.WRITE },
     );
     try {
       await runProvisionCacheCases(wsWrite, "/s3");
+      await runCacheVerifyCases(wsWrite, "/s3", "/gcs");
     } finally {
       await wsWrite.close();
     }

--- a/integ/s3_cases.py
+++ b/integ/s3_cases.py
@@ -28,6 +28,7 @@ from mirage import MountMode, Workspace  # noqa: E402
 from mirage.resource.s3 import S3Config, S3Resource  # noqa: E402
 
 BUCKET = "mirage-integ-s3-cases"
+BUCKET2 = "mirage-integ-s3-cases-xm"
 CREDS = dict(aws_access_key_id="testing",
              aws_secret_access_key="testing",
              region_name="us-east-1")
@@ -40,8 +41,9 @@ async def main() -> None:
     host, port = server.get_host_and_port()
     endpoint = f"http://{host}:{port}"
     try:
-        boto3.client("s3", endpoint_url=endpoint,
-                     **CREDS).create_bucket(Bucket=BUCKET)
+        client = boto3.client("s3", endpoint_url=endpoint, **CREDS)
+        client.create_bucket(Bucket=BUCKET)
+        client.create_bucket(Bucket=BUCKET2)
         s3 = S3Resource(
             S3Config(bucket=BUCKET,
                      region="us-east-1",
@@ -49,7 +51,14 @@ async def main() -> None:
                      aws_access_key_id="testing",
                      aws_secret_access_key="testing",
                      path_style=True))
-        ws = Workspace({"/data": s3}, mode=MountMode.WRITE)
+        s3b = S3Resource(
+            S3Config(bucket=BUCKET2,
+                     region="us-east-1",
+                     endpoint_url=endpoint,
+                     aws_access_key_id="testing",
+                     aws_secret_access_key="testing",
+                     path_style=True))
+        ws = Workspace({"/data": s3, "/data2": s3b}, mode=MountMode.WRITE)
         await run_cases(ws)
     finally:
         server.stop()

--- a/integ/s3_cases.ts
+++ b/integ/s3_cases.ts
@@ -24,16 +24,20 @@ async function main(): Promise<void> {
   const region = process.env.S3_REGION ?? 'us-east-1'
   const accessKeyId = process.env.AWS_ACCESS_KEY_ID
   const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY
-  const keyPrefix = `mirage-integ-${String(process.pid)}-${String(Date.now())}/`
-  const resource = new S3Resource({
+  const runId = `${String(process.pid)}-${String(Date.now())}`
+  const common = {
     bucket,
     region,
-    keyPrefix,
     ...(endpoint !== undefined && endpoint !== '' ? { endpoint, forcePathStyle: true } : {}),
     ...(accessKeyId !== undefined && accessKeyId !== '' ? { accessKeyId } : {}),
     ...(secretAccessKey !== undefined && secretAccessKey !== '' ? { secretAccessKey } : {}),
-  })
-  const ws = new Workspace({ '/data': resource }, { mode: MountMode.WRITE })
+  }
+  const resource = new S3Resource({ ...common, keyPrefix: `mirage-integ-${runId}/` })
+  const resource2 = new S3Resource({ ...common, keyPrefix: `mirage-integ-xm-${runId}/` })
+  const ws = new Workspace(
+    { '/data': resource, '/data2': resource2 },
+    { mode: MountMode.WRITE },
+  )
   try {
     await runCases(ws)
   } finally {

--- a/integ/ssh.py
+++ b/integ/ssh.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import os
 import shutil
 import sys
 import tempfile
@@ -53,9 +54,25 @@ async def main() -> None:
     )
     try:
         port = server.get_port()
+        # Sibling subroots: /data must not see /data2's directory in
+        # its own listings, so neither mount roots at the chroot root.
+        os.makedirs(os.path.join(ROOT_DIR, "xm1"), exist_ok=True)
+        os.makedirs(os.path.join(ROOT_DIR, "xm2"), exist_ok=True)
         resource = SSHResource(
-            SSHConfig(host="127.0.0.1", port=port, username="integ", root="/"))
-        ws = Workspace({"/data": resource}, mode=MountMode.WRITE)
+            SSHConfig(host="127.0.0.1",
+                      port=port,
+                      username="integ",
+                      root="/xm1"))
+        resource2 = SSHResource(
+            SSHConfig(host="127.0.0.1",
+                      port=port,
+                      username="integ",
+                      root="/xm2"))
+        ws = Workspace({
+            "/data": resource,
+            "/data2": resource2
+        },
+                       mode=MountMode.WRITE)
         await run_cases(ws)
         await assert_real_mtime(ws)
         await resource.accessor.close()

--- a/integ/ssh.ts
+++ b/integ/ssh.ts
@@ -291,14 +291,28 @@ function startMockServer(root: string): Promise<{ server: Server; port: number }
 async function main(): Promise<void> {
   const root = fs.mkdtempSync(join(tmpdir(), "mirage-integ-ssh-"));
   const { server, port } = await startMockServer(root);
+  // Sibling subroots: /data must not see /data2's directory in its
+  // own listings, so neither mount roots at the chroot root.
+  fs.mkdirSync(join(root, "xm1"), { recursive: true });
+  fs.mkdirSync(join(root, "xm2"), { recursive: true });
   const resource = new SSHResource({
     host: "127.0.0.1",
     port,
     username: "integ",
     password: "integ",
-    root: "/",
+    root: "/xm1",
   });
-  const ws = new Workspace({ "/data": resource }, { mode: MountMode.WRITE });
+  const resource2 = new SSHResource({
+    host: "127.0.0.1",
+    port,
+    username: "integ",
+    password: "integ",
+    root: "/xm2",
+  });
+  const ws = new Workspace(
+    { "/data": resource, "/data2": resource2 },
+    { mode: MountMode.WRITE },
+  );
   try {
     await runCases(ws);
     await assertRealMtime(ws);

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -2237,6 +2237,60 @@ sleep_zero ok
 sleep_fraction ok
 === sleep_one ===
 sleep_one ok
+=== xm_seed ===
+cross
+=== xm_ls ===
+xm.txt
+=== xm_cat_concat ===
+hello
+world
+foo
+bar
+baz
+cross
+=== xm_cp_over ===
+hello
+world
+foo
+bar
+baz
+=== xm_cp_back ===
+cross
+=== xm_mv_over ===
+cross
+xm.txt
+xm_copy.txt
+xm_moved.txt
+=== xm_grep_multi ===
+/data/a.txt:0
+/data2/xm.txt:1
+=== xm_wc_multi ===
+5 /data/a.txt
+1 /data2/xm.txt
+6 total
+=== xm_du_multi_rejected ===
+du: paths span multiple mounts (/data/, /data2/), cross-mount not supported
+=== xm_find ===
+/data2/xm.txt
+/data2/xm_copy.txt
+/data2/xm_moved.txt
+=== xm_pipe ===
+CROSS
+=== xm_ln_over ===
+hello
+world
+foo
+bar
+baz
+=== xm_ln_readlink ===
+/data/a.txt
+=== xm_ln_back ===
+cross
+=== xm_link_grep ===
+1
+=== xm_cd_across ===
+cross
+b.txt
 === prov_cat ===
 net=24 write=0 cache=0 ops=1 hits=0 precision=exact
 === prov_cat_multi ===
@@ -2357,3 +2411,15 @@ net=24 write=0 cache=0 ops=1 hits=0 precision=unknown
 net=24 write=0 cache=0 ops=1 hits=0 precision=unknown
 === prov_redirect_devnull ===
 net=24 write=0 cache=0 ops=1 hits=0 precision=exact
+=== prov_symlink ===
+net=24 write=0 cache=0 ops=1 hits=0 precision=exact
+=== prov_symlink_grep ===
+net=6 write=0 cache=0 ops=1 hits=0 precision=exact
+=== prov_xmount_concat ===
+net=30 write=0 cache=0 ops=2 hits=0 precision=exact
+=== prov_xmount_grep ===
+net=30 write=0 cache=0 ops=2 hits=0 precision=exact
+=== prov_xmount_pipe ===
+net=30 write=0 cache=0 ops=2 hits=0 precision=unknown
+=== prov_xmount_rejected ===
+net=0 write=0 cache=0 ops=0 hits=0 precision=unknown

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -2330,7 +2330,7 @@ net=30 write=0 cache=0 ops=2 hits=0 precision=exact
 === prov_negate ===
 net=24 write=0 cache=0 ops=1 hits=0 precision=exact
 === prov_redirect_out ===
-net=24 write=0 cache=0 ops=1 hits=0 precision=exact
+net=24 write=0-24 cache=0 ops=1 hits=0 precision=range
 === prov_or_unknown_branch ===
 net=0-24 write=0 cache=0 ops=0 hits=0 precision=unknown
 === prov_for_pipe ===
@@ -2341,3 +2341,19 @@ net=24 write=0 cache=0 ops=4 hits=0 precision=exact
 net=24 write=0 cache=0 ops=1 hits=0 precision=exact
 === prov_deep_mix ===
 net=60 write=0 cache=0 ops=4 hits=0 precision=unknown
+=== prov_env_prefix ===
+net=24 write=0 cache=0 ops=1 hits=0 precision=exact
+=== prov_func_call ===
+net=12 write=0 cache=0 ops=2 hits=0 precision=exact
+=== prov_func_recursive ===
+net=0 write=0 cache=0 ops=0 hits=0 precision=unknown
+=== prov_eval ===
+net=0 write=0 cache=0 ops=0 hits=0 precision=unknown
+=== prov_select ===
+net=24 write=0 cache=0 ops=1 hits=0 precision=unknown
+=== prov_until ===
+net=24 write=0 cache=0 ops=1 hits=0 precision=unknown
+=== prov_redirect_in ===
+net=24 write=0 cache=0 ops=1 hits=0 precision=unknown
+=== prov_redirect_devnull ===
+net=24 write=0 cache=0 ops=1 hits=0 precision=exact

--- a/integ/truth_onedrive.txt
+++ b/integ/truth_onedrive.txt
@@ -185,6 +185,16 @@ net=0 write=0 cache=17 ops=1 hits=1 precision=exact
 net=0 write=0 cache=29 ops=2 hits=1 precision=exact
 === prov_cache_cleared ===
 net=17 write=0 cache=0 ops=1 hits=0 precision=exact
+=== cachev_link_cold ===
+bytes=13
+=== cachev_link_warm ===
+bytes=0
+=== cachev_target_shares_entry ===
+bytes=0
+=== cachev_warm_grep ===
+bytes=0
+=== cachev_prov_link ===
+net=0 write=0 cache=13 ops=1 hits=1 precision=exact
 === consistency:always:first ===
 v1
 === consistency:always:second ===

--- a/integ/truth_s3.txt
+++ b/integ/truth_s3.txt
@@ -667,6 +667,24 @@ net=0 write=0 cache=17 ops=1 hits=1 precision=exact
 net=0 write=0 cache=29 ops=2 hits=1 precision=exact
 === prov_cache_cleared ===
 net=17 write=0 cache=0 ops=1 hits=0 precision=exact
+=== cachev_link_cold ===
+bytes=13
+=== cachev_link_warm ===
+bytes=0
+=== cachev_target_shares_entry ===
+bytes=0
+=== cachev_warm_grep ===
+bytes=0
+=== cachev_prov_link ===
+net=0 write=0 cache=13 ops=1 hits=1 precision=exact
+=== cachev_xmount_cold ===
+bytes=13
+=== cachev_xmount_warm ===
+bytes=0
+=== cachev_xmount_prov ===
+net=0 write=0 cache=13 ops=1 hits=1 precision=exact
+=== cachev_xmount_cp_warm_source ===
+bytes=13
 === consistency:always:first ===
 v1
 === consistency:always:second ===

--- a/integ/truth_s3_ts.txt
+++ b/integ/truth_s3_ts.txt
@@ -547,6 +547,24 @@ net=0 write=0 cache=17 ops=1 hits=1 precision=exact
 net=0 write=0 cache=29 ops=2 hits=1 precision=exact
 === prov_cache_cleared ===
 net=17 write=0 cache=0 ops=1 hits=0 precision=exact
+=== cachev_link_cold ===
+bytes=13
+=== cachev_link_warm ===
+bytes=0
+=== cachev_target_shares_entry ===
+bytes=0
+=== cachev_warm_grep ===
+bytes=0
+=== cachev_prov_link ===
+net=0 write=0 cache=13 ops=1 hits=1 precision=exact
+=== cachev_xmount_cold ===
+bytes=13
+=== cachev_xmount_warm ===
+bytes=0
+=== cachev_xmount_prov ===
+net=0 write=0 cache=13 ops=1 hits=1 precision=exact
+=== cachev_xmount_cp_warm_source ===
+bytes=0
 === consistency:always:first ===
 v1
 === consistency:always:second ===

--- a/python/mirage/shell/helpers.py
+++ b/python/mirage/shell/helpers.py
@@ -47,6 +47,28 @@ def get_parts(node: tree_sitter.Node) -> list[tree_sitter.Node]:
     return [c for c in node.named_children if c.type not in _SKIP]
 
 
+def split_env_prefix(
+    parts: list[tree_sitter.Node],
+) -> tuple[list[tree_sitter.Node], list[tree_sitter.Node]]:
+    """Split FOO=1 BAR=2 cmd parts into (assignments, remaining).
+
+    The single structural rule for env-prefixed commands, shared by the
+    executor (which expands and applies the assignments) and the
+    provision planner (which only needs the command parts).
+    """
+    assignments: list[tree_sitter.Node] = []
+    remaining: list[tree_sitter.Node] = []
+    saw_command_name = False
+    for p in parts:
+        if not saw_command_name and p.type == NT.VARIABLE_ASSIGNMENT:
+            assignments.append(p)
+            continue
+        if p.type == NT.COMMAND_NAME:
+            saw_command_name = True
+        remaining.append(p)
+    return assignments, remaining
+
+
 def get_pipeline_commands(
     node: tree_sitter.Node,
 ) -> tuple[list[tree_sitter.Node], list[bool]]:  # noqa: E125,E501

--- a/python/mirage/shell/node_kind.py
+++ b/python/mirage/shell/node_kind.py
@@ -1,0 +1,96 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from enum import StrEnum
+from typing import Any
+
+from mirage.shell.types import NodeType as NT
+
+
+class NodeKind(StrEnum):
+    """Statement kinds both tree walkers dispatch on.
+
+    The executor and the provision planner walk the same tree-sitter
+    AST. This enum is the single classification both use, so a
+    construct cannot be supported by one walker and silently
+    unclassified by the other: `node_kind` owns every tree-sitter
+    node-type check, including the lookahead that distinguishes
+    `select` from `for` and `until` from `while`.
+    """
+    COMMENT = "comment"
+    PROGRAM = "program"
+    COMMAND = "command"
+    PIPELINE = "pipeline"
+    LIST = "list"
+    REDIRECT = "redirect"
+    SUBSHELL = "subshell"
+    COMPOUND = "compound"
+    IF = "if"
+    FOR = "for"
+    SELECT = "select"
+    WHILE = "while"
+    UNTIL = "until"
+    CASE = "case"
+    FUNCTION_DEF = "function_def"
+    DECLARATION = "declaration"
+    UNSET = "unset"
+    TEST = "test"
+    NEGATED = "negated"
+    VAR_ASSIGN = "var_assign"
+    UNSUPPORTED = "unsupported"
+
+
+_SIMPLE_KINDS = {
+    NT.COMMENT: NodeKind.COMMENT,
+    NT.PROGRAM: NodeKind.PROGRAM,
+    NT.COMMAND: NodeKind.COMMAND,
+    NT.PIPELINE: NodeKind.PIPELINE,
+    NT.LIST: NodeKind.LIST,
+    NT.REDIRECTED_STATEMENT: NodeKind.REDIRECT,
+    NT.SUBSHELL: NodeKind.SUBSHELL,
+    NT.COMPOUND_STATEMENT: NodeKind.COMPOUND,
+    NT.IF_STATEMENT: NodeKind.IF,
+    NT.CASE_STATEMENT: NodeKind.CASE,
+    NT.FUNCTION_DEFINITION: NodeKind.FUNCTION_DEF,
+    NT.DECLARATION_COMMAND: NodeKind.DECLARATION,
+    NT.UNSET_COMMAND: NodeKind.UNSET,
+    NT.TEST_COMMAND: NodeKind.TEST,
+    NT.NEGATED_COMMAND: NodeKind.NEGATED,
+    NT.VARIABLE_ASSIGNMENT: NodeKind.VAR_ASSIGN,
+}
+
+
+def node_kind(node: Any) -> NodeKind:
+    """Classify a tree-sitter node into the shared statement kind.
+
+    Args:
+        node (Any): tree-sitter node.
+
+    Returns:
+        NodeKind: statement kind, or UNSUPPORTED for node types
+        neither walker implements (c-style for, arithmetic, ...).
+    """
+    ntype = node.type
+    simple = _SIMPLE_KINDS.get(ntype)
+    if simple is not None:
+        return simple
+    if ntype == NT.FOR_STATEMENT:
+        if node.children and node.children[0].type == NT.SELECT:
+            return NodeKind.SELECT
+        return NodeKind.FOR
+    if ntype == NT.WHILE_STATEMENT:
+        if node.children and node.children[0].type == NT.UNTIL:
+            return NodeKind.UNTIL
+        return NodeKind.WHILE
+    return NodeKind.UNSUPPORTED

--- a/python/mirage/workspace/expand/__init__.py
+++ b/python/mirage/workspace/expand/__init__.py
@@ -15,6 +15,7 @@
 from mirage.workspace.expand.classify import classify_parts, classify_word
 from mirage.workspace.expand.node import expand_node
 from mirage.workspace.expand.parts import expand_and_classify, expand_parts
+from mirage.workspace.expand.redirects import expand_redirects
 
 __all__ = [
     "classify_parts",
@@ -22,4 +23,5 @@ __all__ = [
     "expand_and_classify",
     "expand_node",
     "expand_parts",
+    "expand_redirects",
 ]

--- a/python/mirage/workspace/expand/redirects.py
+++ b/python/mirage/workspace/expand/redirects.py
@@ -1,0 +1,91 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from typing import Any, Callable
+
+from mirage.shell.call_stack import CallStack
+from mirage.shell.types import Redirect, RedirectKind
+from mirage.workspace.expand.classify import classify_word
+from mirage.workspace.expand.node import expand_node
+from mirage.workspace.mount import MountRegistry
+from mirage.workspace.session import Session
+
+
+async def expand_redirects(
+    redirects: list[Redirect],
+    session: Session,
+    execute_fn: Callable,
+    registry: MountRegistry,
+    call_stack: CallStack | None = None,
+) -> tuple[list[Redirect], Any]:
+    """Expand redirect targets: heredoc vars, target words, pipelines.
+
+    The single expansion path for redirected statements, shared by the
+    executor (which then applies the redirects) and the provision
+    planner (which only costs them). Heredoc/herestring bodies get
+    session variables substituted; file targets are expanded and
+    classified into PathSpec or plain text; the first attached
+    pipeline is detached and returned separately.
+
+    Args:
+        redirects (list[Redirect]): parsed redirects from get_redirects.
+        session (Session): shell session state.
+        execute_fn (Callable): recursive execute (for expansions).
+        registry (MountRegistry): mount registry for classification.
+        call_stack (CallStack | None): shell call stack for expansion.
+
+    Returns:
+        (expanded, pipe_node): expanded redirects and the detached
+        pipeline node (or None).
+    """
+    expanded: list[Redirect] = []
+    for r in redirects:
+        if r.kind in (RedirectKind.HEREDOC, RedirectKind.HERESTRING):
+            body = r.target
+            if isinstance(body, str) and r.expand_vars:
+                for var, val in session.env.items():
+                    body = body.replace("$" + var, val)
+            expanded.append(
+                Redirect(fd=r.fd,
+                         target=body,
+                         target_node=r.target_node,
+                         kind=r.kind,
+                         append=r.append,
+                         pipeline=r.pipeline,
+                         expand_vars=r.expand_vars))
+            continue
+        if isinstance(r.target, int):
+            expanded.append(r)
+            continue
+        target_node = r.target_node
+        if target_node is not None:
+            target_str = await expand_node(target_node, session, execute_fn,
+                                           call_stack)
+            target_scope = classify_word(target_str, registry, session.cwd)
+        else:
+            target_scope = r.target
+        expanded.append(
+            Redirect(fd=r.fd,
+                     target=target_scope,
+                     target_node=r.target_node,
+                     kind=r.kind,
+                     append=r.append,
+                     pipeline=r.pipeline))
+    pipe_node = None
+    for r in expanded:
+        if r.pipeline is not None:
+            pipe_node = r.pipeline
+            r.pipeline = None
+            break
+    return expanded, pipe_node

--- a/python/mirage/workspace/node/command_dispatch.py
+++ b/python/mirage/workspace/node/command_dispatch.py
@@ -34,7 +34,7 @@ from mirage.workspace.types import ExecutionNode
 
 from mirage.shell.helpers import (  # isort: skip
     ProcessSubDirection, get_command_name, get_parts,
-    get_process_sub_direction, get_text)
+    get_process_sub_direction, get_text, split_env_prefix)
 from mirage.workspace.executor.builtins import (  # isort: skip
     NO_FOLLOW_COMMANDS, follow_paths, handle_bash, handle_cd, handle_echo,
     handle_eval, handle_export, handle_history, handle_ln, handle_local,
@@ -110,30 +110,21 @@ async def execute_command(
 ) -> tuple[Any, IOResult, ExecutionNode]:
     """Dispatch a command node by name."""
     name = get_command_name(node)
-    parts = get_parts(node)
+    assignment_nodes, parts = split_env_prefix(get_parts(node))
 
     prefix_assignments: list[tuple[str, str]] = []
-    non_prefix_parts = []
-    saw_command_name = False
-    for p in parts:
-        if not saw_command_name and p.type == NT.VARIABLE_ASSIGNMENT:
-            atext = get_text(p)
-            if "=" in atext:
-                key, _, raw_val = atext.partition("=")
-                val_nodes = [
-                    c for c in p.named_children if c.type != NT.VARIABLE_NAME
-                ]
-                if val_nodes:
-                    v = await expand_node(val_nodes[0], session, execute_fn,
-                                          call_stack)
-                else:
-                    v = raw_val
-                prefix_assignments.append((key, v))
+    for p in assignment_nodes:
+        atext = get_text(p)
+        if "=" not in atext:
             continue
-        if p.type == NT.COMMAND_NAME:
-            saw_command_name = True
-        non_prefix_parts.append(p)
-    parts = non_prefix_parts
+        key, _, raw_val = atext.partition("=")
+        val_nodes = [c for c in p.named_children if c.type != NT.VARIABLE_NAME]
+        if val_nodes:
+            v = await expand_node(val_nodes[0], session, execute_fn,
+                                  call_stack)
+        else:
+            v = raw_val
+        prefix_assignments.append((key, v))
 
     for k, _ in prefix_assignments:
         if k in session.readonly_vars:

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -20,9 +20,9 @@ from mirage.io import IOResult
 from mirage.io.stream import async_chain
 from mirage.shell.call_stack import CallStack
 from mirage.shell.job_table import JobTable
+from mirage.shell.node_kind import NodeKind, node_kind
 from mirage.shell.types import ERREXIT_EXEMPT_TYPES
 from mirage.shell.types import NodeType as NT
-from mirage.shell.types import Redirect, RedirectKind
 from mirage.workspace.abort import MirageAbortError
 from mirage.workspace.executor.control import (handle_case, handle_for,
                                                handle_if, handle_select,
@@ -30,8 +30,8 @@ from mirage.workspace.executor.control import (handle_case, handle_for,
 from mirage.workspace.executor.pipes import (handle_connection, handle_pipe,
                                              handle_subshell)
 from mirage.workspace.executor.redirect import handle_redirect
-from mirage.workspace.expand import (classify_word, expand_and_classify,
-                                     expand_node)
+from mirage.workspace.expand import (expand_and_classify, expand_node,
+                                     expand_redirects)
 from mirage.workspace.mount import MountRegistry
 from mirage.workspace.mount.namespace import Namespace
 from mirage.workspace.node.command_dispatch import execute_command
@@ -91,18 +91,18 @@ async def execute_node(
                       agent_id,
                       cancel=cancel)
 
-    ntype = node.type
+    kind = node_kind(node)
 
-    if ntype == NT.COMMENT:
+    if kind == NodeKind.COMMENT:
         return None, IOResult(), ExecutionNode(command="", exit_code=0)
 
     # ── program (root / semicolons) ─────────────
-    if ntype == NT.PROGRAM:
+    if kind == NodeKind.PROGRAM:
         return await execute_program(recurse, node, session, stdin, cs,
                                      job_table, agent_id)
 
     # ── command ─────────────────────────────────
-    if ntype == NT.COMMAND:
+    if kind == NodeKind.COMMAND:
         return await execute_command(recurse,
                                      dispatch,
                                      registry,
@@ -116,59 +116,22 @@ async def execute_node(
                                      cancel=cancel)
 
     # ── pipeline ────────────────────────────────
-    if ntype == NT.PIPELINE:
+    if kind == NodeKind.PIPELINE:
         commands, stderr_flags = get_pipeline_commands(node)
         return await handle_pipe(recurse, commands, stderr_flags, session,
                                  stdin, cs)
 
     # ── list (&&, ||) ───────────────────────────
-    if ntype == NT.LIST:
+    if kind == NodeKind.LIST:
         left, op, right = get_list_parts(node)
         return await handle_connection(recurse, left, op, right, session,
                                        stdin, cs)
 
     # ── redirected statement ────────────────────
-    if ntype == NT.REDIRECTED_STATEMENT:
+    if kind == NodeKind.REDIRECT:
         command, redirects = get_redirects(node)
-        expanded_redirects = []
-        for r in redirects:
-            if r.kind in (RedirectKind.HEREDOC, RedirectKind.HERESTRING):
-                body = r.target
-                if isinstance(body, str) and r.expand_vars:
-                    for var, val in session.env.items():
-                        body = body.replace("$" + var, val)
-                expanded_redirects.append(
-                    Redirect(fd=r.fd,
-                             target=body,
-                             target_node=r.target_node,
-                             kind=r.kind,
-                             append=r.append,
-                             pipeline=r.pipeline,
-                             expand_vars=r.expand_vars))
-                continue
-            if isinstance(r.target, int):
-                expanded_redirects.append(r)
-                continue
-            target_node = r.target_node
-            if target_node is not None:
-                target_str = await expand_node(target_node, session,
-                                               execute_fn, cs)
-                target_scope = classify_word(target_str, registry, session.cwd)
-            else:
-                target_scope = r.target
-            expanded_redirects.append(
-                Redirect(fd=r.fd,
-                         target=target_scope,
-                         target_node=r.target_node,
-                         kind=r.kind,
-                         append=r.append,
-                         pipeline=r.pipeline))
-        pipe_node = None
-        for r in expanded_redirects:
-            if r.pipeline is not None:
-                pipe_node = r.pipeline
-                r.pipeline = None
-                break
+        expanded_redirects, pipe_node = await expand_redirects(
+            redirects, session, execute_fn, registry, cs)
         stdout, io, exec_node = await handle_redirect(recurse, dispatch,
                                                       command,
                                                       expanded_redirects,
@@ -181,12 +144,12 @@ async def execute_node(
         return stdout, io, exec_node
 
     # ── subshell ────────────────────────────────
-    if ntype == NT.SUBSHELL:
+    if kind == NodeKind.SUBSHELL:
         body = get_subshell_body(node)
         return await handle_subshell(recurse, body, session, stdin, cs)
 
     # ── compound statement ({ ... }) ───────────
-    if ntype == NT.COMPOUND_STATEMENT:
+    if kind == NodeKind.COMPOUND:
         all_stdout: list = []
         merged_io = IOResult()
         last_exec = ExecutionNode(command="{}", exit_code=0)
@@ -207,40 +170,40 @@ async def execute_node(
         return combined, merged_io, last_exec
 
     # ── if ──────────────────────────────────────
-    if ntype == NT.IF_STATEMENT:
+    if kind == NodeKind.IF:
         branches, else_body = get_if_branches(node)
         return await handle_if(recurse, branches, else_body, session, stdin,
                                cs)
 
     # ── for / select ────────────────────────────
-    if ntype == NT.FOR_STATEMENT:
+    if kind in (NodeKind.FOR, NodeKind.SELECT):
         var, values, body = get_for_parts(node)
         classified = await expand_and_classify(values, session, execute_fn,
                                                registry, session.cwd, cs)
         classified = await resolve_globs(classified, registry)
-        if node.children[0].type == NT.SELECT:
+        if kind == NodeKind.SELECT:
             return await handle_select(recurse, var, classified, body, session,
                                        stdin, cs)
         return await handle_for(recurse, var, classified, body, session, stdin,
                                 cs)
 
     # ── while / until ───────────────────────────
-    if ntype == NT.WHILE_STATEMENT:
+    if kind in (NodeKind.WHILE, NodeKind.UNTIL):
         condition, body = get_while_parts(node)
-        if node.children[0].type == NT.UNTIL:
+        if kind == NodeKind.UNTIL:
             return await handle_until(recurse, condition, body, session, stdin,
                                       cs)
         return await handle_while(recurse, condition, body, session, stdin, cs)
 
     # ── case ────────────────────────────────────
-    if ntype == NT.CASE_STATEMENT:
+    if kind == NodeKind.CASE:
         word_node = get_case_word(node)
         word = await expand_node(word_node, session, execute_fn, cs)
         items = get_case_items(node)
         return await handle_case(recurse, word, items, session, stdin, cs)
 
     # ── function definition ─────────────────────
-    if ntype == NT.FUNCTION_DEFINITION:
+    if kind == NodeKind.FUNCTION_DEF:
         name = get_function_name(node)
         body = get_function_body(node)
         session.functions[name] = body
@@ -248,7 +211,7 @@ async def execute_node(
                                                exit_code=0)
 
     # ── declaration (export/local/declare/readonly) ──
-    if ntype == NT.DECLARATION_COMMAND:
+    if kind == NodeKind.DECLARATION:
         keyword = get_declaration_keyword(node)
         assignments = []
         flag_chars: set[str] = set()
@@ -284,18 +247,18 @@ async def execute_node(
         return await handle_export(assignments, session)
 
     # ── unset ───────────────────────────────────
-    if ntype == NT.UNSET_COMMAND:
+    if kind == NodeKind.UNSET:
         names = get_unset_names(node)
         return await handle_unset(names, session)
 
     # ── test ([ ] or [[ ]]) ─────────────────────
-    if ntype == NT.TEST_COMMAND:
+    if kind == NodeKind.TEST:
         expanded = await expand_test_expr(node, session, execute_fn, cs,
                                           registry)
         return await handle_test(dispatch, expanded, session)
 
     # ── negated command ─────────────────────────
-    if ntype == NT.NEGATED_COMMAND:
+    if kind == NodeKind.NEGATED:
         inner = get_negated_command(node)
         stdout, io, exec_node = await recurse(inner, session, stdin, cs)
         io = IOResult(
@@ -309,7 +272,7 @@ async def execute_node(
         return stdout, io, exec_node
 
     # ── variable assignment at top level ────────
-    if ntype == NT.VARIABLE_ASSIGNMENT:
+    if kind == NodeKind.VAR_ASSIGN:
         text = get_text(node)
         if "=" in text:
             key, _, val = text.partition("=")
@@ -337,4 +300,4 @@ async def execute_node(
             session.arrays.pop(key, None)
         return None, IOResult(), ExecutionNode(command=text, exit_code=0)
 
-    raise TypeError(f"unsupported tree-sitter node type: {ntype}")
+    raise TypeError(f"unsupported tree-sitter node type: {node.type}")

--- a/python/mirage/workspace/node/provision_node.py
+++ b/python/mirage/workspace/node/provision_node.py
@@ -12,39 +12,44 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from dataclasses import dataclass, field
 from functools import partial
 from typing import Any, Callable
 
 from mirage.provision import Precision, ProvisionResult
-from mirage.shell.helpers import (get_case_items, get_command_name,
-                                  get_for_parts, get_if_branches,
-                                  get_list_parts, get_negated_command,
-                                  get_parts, get_pipeline_commands,
-                                  get_redirect_parts, get_subshell_body,
-                                  get_text, get_while_parts)
+from mirage.shell.node_kind import NodeKind, node_kind
 from mirage.shell.types import NodeType as NT
+from mirage.shell.types import RedirectKind
 from mirage.shell.types import ShellBuiltin as SB
+from mirage.types import PathSpec
 from mirage.workspace.expand import (classify_parts, expand_and_classify,
-                                     expand_parts)
+                                     expand_parts, expand_redirects)
 from mirage.workspace.mount import MountRegistry
 from mirage.workspace.provision.builtins import handle_builtin_provision
 from mirage.workspace.provision.command import handle_command_provision
 from mirage.workspace.provision.control import (handle_for_provision,
+                                                handle_function_provision,
                                                 handle_if_provision,
                                                 handle_while_provision)
 from mirage.workspace.provision.pipes import (handle_connection_provision,
                                               handle_pipe_provision)
 from mirage.workspace.provision.redirect import handle_redirect_provision
-from mirage.workspace.provision.rollup import rollup_list
+from mirage.workspace.provision.rollup import rollup_list, rollup_pipe
 from mirage.workspace.session import Session
 
+from mirage.shell.helpers import (  # isort: skip
+    get_case_items, get_command_name, get_for_parts, get_function_body,
+    get_function_name, get_if_branches, get_list_parts, get_negated_command,
+    get_parts, get_pipeline_commands, get_redirects, get_subshell_body,
+    get_text, get_while_parts, split_env_prefix)
+
+# eval / source execute their payload, so they are NOT free builtins:
+# leaving them out lets them fall through to command resolution, which
+# honestly reports UNKNOWN instead of a zero-cost EXACT.
 _BUILTIN_NAMES = frozenset({
     SB.CD,
     SB.TRUE,
     SB.FALSE,
-    SB.SOURCE,
-    SB.DOT,
-    SB.EVAL,
     SB.EXPORT,
     SB.UNSET,
     SB.LOCAL,
@@ -70,57 +75,58 @@ _BUILTIN_NAMES = frozenset({
 })
 
 
+@dataclass
+class PlanScope:
+    """Walk-local planner state.
+
+    Function definitions seen during this plan are recorded here (not
+    on the session: planning must not mutate shell state), and
+    `planning` guards recursive functions from looping the planner.
+    """
+    functions: dict[str, list] = field(default_factory=dict)
+    planning: set[str] = field(default_factory=set)
+
+
 async def provision_node(
     registry: MountRegistry,
     dispatch: Callable,
     execute_fn: Callable,
     node: Any,
     session: Session,
+    scope: PlanScope | None = None,
 ) -> ProvisionResult:
     """Walk tree-sitter AST and estimate execution cost.
 
+    Dispatches on the same NodeKind classification as the executor
+    (`mirage.shell.classify`), so every construct the executor runs
+    has a planner branch; kinds neither walker supports fall through
+    to an honest UNKNOWN.
+
     Args:
         registry (MountRegistry): mount registry for path resolution.
-        dispatch (Callable): VFS op dispatcher.
-        execute_fn (Callable): workspace.execute for $(cmd) expansion.
-        node (Any): tree-sitter node.
+        dispatch (Callable): VFS op dispatcher (op, path, **kw).
+        execute_fn (Callable): recursive execute (for expansions).
+        node (Any): tree-sitter node to plan.
         session (Session): shell session state.
+        scope (PlanScope | None): walk-local planner state; created at
+            the root and threaded through recursion.
     """
-    recurse = partial(provision_node, registry, dispatch, execute_fn)
-    ntype = node.type
+    plan_scope = scope if scope is not None else PlanScope()
+    recurse = partial(provision_node,
+                      registry,
+                      dispatch,
+                      execute_fn,
+                      scope=plan_scope)
+    kind = node_kind(node)
 
-    if ntype == "program":
-        children = []
-        for child in node.named_children:
-            children.append(await recurse(child, session))
-        if not children:
-            return ProvisionResult(precision=Precision.EXACT)
-        return rollup_list(";", children)
+    if kind == NodeKind.COMMENT:
+        return ProvisionResult(precision=Precision.EXACT)
 
-    if ntype == NT.COMMAND:
-        name = get_command_name(node)
-        if name in _BUILTIN_NAMES:
-            return await handle_builtin_provision()
-        parts = get_parts(node)
-        expanded = await expand_parts(parts, session, execute_fn)
-        classified = classify_parts(expanded, registry, session.cwd)
-        return await handle_command_provision(registry, classified, session)
-
-    if ntype == NT.PIPELINE:
-        commands, _ = get_pipeline_commands(node)
-        return await handle_pipe_provision(recurse, commands, session)
-
-    if ntype == NT.LIST:
-        left, op, right = get_list_parts(node)
-        return await handle_connection_provision(recurse, left, op, right,
-                                                 session)
-
-    if ntype == NT.REDIRECTED_STATEMENT:
-        command, _, _, _ = get_redirect_parts(node)
-        return await handle_redirect_provision(recurse, command, session)
-
-    if ntype == NT.SUBSHELL:
-        body = get_subshell_body(node)
+    if kind in (NodeKind.PROGRAM, NodeKind.SUBSHELL, NodeKind.COMPOUND):
+        if kind == NodeKind.SUBSHELL:
+            body = get_subshell_body(node)
+        else:
+            body = [c for c in node.named_children if c.type != NT.COMMENT]
         children = []
         for child in body:
             children.append(await recurse(child, session))
@@ -128,22 +134,68 @@ async def provision_node(
             return ProvisionResult(precision=Precision.EXACT)
         return rollup_list(";", children)
 
-    if ntype == NT.IF_STATEMENT:
+    if kind == NodeKind.COMMAND:
+        name = get_command_name(node)
+        func_body = plan_scope.functions.get(name)
+        if func_body is None:
+            func_body = session.functions.get(name)
+        if func_body is not None:
+            return await handle_function_provision(recurse, name, func_body,
+                                                   plan_scope.planning,
+                                                   session)
+        if name in _BUILTIN_NAMES:
+            return await handle_builtin_provision()
+        _, parts = split_env_prefix(get_parts(node))
+        if not parts:
+            return ProvisionResult(precision=Precision.EXACT)
+        expanded = await expand_parts(parts, session, execute_fn)
+        classified = classify_parts(expanded, registry, session.cwd)
+        return await handle_command_provision(registry, classified, session)
+
+    if kind == NodeKind.PIPELINE:
+        commands, _ = get_pipeline_commands(node)
+        return await handle_pipe_provision(recurse, commands, session)
+
+    if kind == NodeKind.LIST:
+        left, op, right = get_list_parts(node)
+        return await handle_connection_provision(recurse, left, op, right,
+                                                 session)
+
+    if kind == NodeKind.REDIRECT:
+        command, redirects = get_redirects(node)
+        expanded, pipe_node = await expand_redirects(redirects, session,
+                                                     execute_fn, registry)
+        targets = [(r.kind, r.target) for r in expanded
+                   if r.kind in (RedirectKind.STDIN, RedirectKind.STDOUT)
+                   and isinstance(r.target, PathSpec)
+                   and not r.target.virtual.startswith("/dev/")]
+        result = await handle_redirect_provision(recurse, registry, command,
+                                                 targets, session)
+        if pipe_node is not None:
+            return rollup_pipe([result, await recurse(pipe_node, session)])
+        return result
+
+    if kind == NodeKind.IF:
         branches, else_body = get_if_branches(node)
         return await handle_if_provision(recurse, branches, else_body, session)
 
-    if ntype == NT.FOR_STATEMENT:
+    if kind == NodeKind.FOR:
         _, values, body = get_for_parts(node)
         classified = await expand_and_classify(values, session, execute_fn,
                                                registry, session.cwd)
         n = len(classified) or 1
         return await handle_for_provision(recurse, body, n, session)
 
-    if ntype == NT.WHILE_STATEMENT:
+    if kind == NodeKind.SELECT:
+        # select re-prompts until break: unbounded like while.
+        _, _, body = get_for_parts(node)
+        return await handle_while_provision(recurse, body, session)
+
+    if kind in (NodeKind.WHILE, NodeKind.UNTIL):
         _, body = get_while_parts(node)
         return await handle_while_provision(recurse, body, session)
 
-    if ntype == NT.CASE_STATEMENT:
+    if kind == NodeKind.CASE:
         items = get_case_items(node)
         children = []
         for _, body in items:
@@ -153,31 +205,19 @@ async def provision_node(
             return rollup_list("||", children)
         return ProvisionResult(precision=Precision.EXACT)
 
-    if ntype == NT.FUNCTION_DEFINITION:
+    if kind == NodeKind.FUNCTION_DEF:
+        name = get_function_name(node)
+        body = get_function_body(node)
+        if name and body is not None:
+            plan_scope.functions[name] = body
         return await handle_builtin_provision()
 
-    if ntype == NT.DECLARATION_COMMAND:
+    if kind in (NodeKind.DECLARATION, NodeKind.UNSET, NodeKind.TEST,
+                NodeKind.VAR_ASSIGN):
         return await handle_builtin_provision()
 
-    if ntype == NT.UNSET_COMMAND:
-        return await handle_builtin_provision()
-
-    if ntype == NT.TEST_COMMAND:
-        return await handle_builtin_provision()
-
-    if ntype == NT.NEGATED_COMMAND:
+    if kind == NodeKind.NEGATED:
         inner = get_negated_command(node)
         return await recurse(inner, session)
-
-    if ntype == NT.VARIABLE_ASSIGNMENT:
-        return await handle_builtin_provision()
-
-    if ntype == NT.COMPOUND_STATEMENT:
-        children = []
-        for child in node.named_children:
-            children.append(await recurse(child, session))
-        if not children:
-            return ProvisionResult(precision=Precision.EXACT)
-        return rollup_list(";", children)
 
     return ProvisionResult(command=get_text(node), precision=Precision.UNKNOWN)

--- a/python/mirage/workspace/node/provision_node.py
+++ b/python/mirage/workspace/node/provision_node.py
@@ -25,6 +25,7 @@ from mirage.types import PathSpec
 from mirage.workspace.expand import (classify_parts, expand_and_classify,
                                      expand_parts, expand_redirects)
 from mirage.workspace.mount import MountRegistry
+from mirage.workspace.mount.namespace import Namespace
 from mirage.workspace.provision.builtins import handle_builtin_provision
 from mirage.workspace.provision.command import handle_command_provision
 from mirage.workspace.provision.control import (handle_for_provision,
@@ -91,6 +92,7 @@ async def provision_node(
     registry: MountRegistry,
     dispatch: Callable,
     execute_fn: Callable,
+    namespace: Namespace | None,
     node: Any,
     session: Session,
     scope: PlanScope | None = None,
@@ -116,6 +118,7 @@ async def provision_node(
                       registry,
                       dispatch,
                       execute_fn,
+                      namespace,
                       scope=plan_scope)
     kind = node_kind(node)
 
@@ -150,7 +153,8 @@ async def provision_node(
             return ProvisionResult(precision=Precision.EXACT)
         expanded = await expand_parts(parts, session, execute_fn)
         classified = classify_parts(expanded, registry, session.cwd)
-        return await handle_command_provision(registry, classified, session)
+        return await handle_command_provision(registry, classified, session,
+                                              namespace)
 
     if kind == NodeKind.PIPELINE:
         commands, _ = get_pipeline_commands(node)
@@ -170,7 +174,7 @@ async def provision_node(
                    and isinstance(r.target, PathSpec)
                    and not r.target.virtual.startswith("/dev/")]
         result = await handle_redirect_provision(recurse, registry, command,
-                                                 targets, session)
+                                                 targets, session, namespace)
         if pipe_node is not None:
             return rollup_pipe([result, await recurse(pipe_node, session)])
         return result

--- a/python/mirage/workspace/provision/command.py
+++ b/python/mirage/workspace/provision/command.py
@@ -15,12 +15,14 @@
 import dataclasses
 
 from mirage.cache.file.mixin import FileCacheMixin
+from mirage.commands.builtin.generic.crossmount import is_cross_mount
 from mirage.commands.resolve import get_extension
 from mirage.commands.spec import parse_command, parse_to_kwargs
-from mirage.provision import Precision, ProvisionResult
+from mirage.provision import Precision, ProvisionResult, combine_sum
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 from mirage.workspace.mount import MountRegistry
+from mirage.workspace.mount.namespace import Namespace
 from mirage.workspace.session import Session
 
 
@@ -38,18 +40,90 @@ async def _check_cache_hits(
     return hits
 
 
+def _mount_groups(registry: MountRegistry,
+                  parts: list[str | PathSpec]) -> list[list[PathSpec]]:
+    """Group path args by their own mount, in first-appearance order.
+
+    Args that resolve to no mount (glob patterns, expression operands)
+    ride with the first group: they scoped to the primary mount before
+    and must not fabricate a cross-mount split.
+    """
+    groups: list[list[PathSpec]] = []
+    seen: dict[str, int] = {}
+    unresolved: list[PathSpec] = []
+    for p in parts[1:]:
+        if not isinstance(p, PathSpec):
+            continue
+        if p.pattern:
+            # Globs are not expanded during planning; a pattern operand
+            # (find -name, ls *.txt) must not fabricate a mount group.
+            unresolved.append(p)
+            continue
+        try:
+            prefix = registry.mount_for(p.virtual).prefix
+        except ValueError:
+            unresolved.append(p)
+            continue
+        idx = seen.get(prefix)
+        if idx is None:
+            seen[prefix] = len(groups)
+            groups.append([p])
+        else:
+            groups[idx].append(p)
+    if unresolved:
+        if groups:
+            groups[0].extend(unresolved)
+        else:
+            groups.append(unresolved)
+    return groups
+
+
 async def handle_command_provision(
     registry: MountRegistry,
     parts: list[str | PathSpec],
     session: Session,
+    namespace: Namespace | None = None,
 ) -> ProvisionResult:
-    """Estimate cost of a simple command."""
+    """Estimate cost of a simple command.
+
+    Paths are namespace-followed first (a symlinked read costs its
+    target, and the cache-hit check sees the entry the executor would
+    actually serve), then grouped by mount: a command spanning mounts
+    is estimated per mount against each mount's own backend and the
+    results summed, instead of statting foreign paths against the
+    first path's backend.
+    """
     if not parts:
         return ProvisionResult(precision=Precision.EXACT)
+
+    if namespace is not None:
+        for i, p in enumerate(parts):
+            if isinstance(p, PathSpec):
+                followed = namespace.follow(p.virtual)
+                if followed != p.virtual:
+                    parts[i] = PathSpec.from_str_path(followed)
 
     cmd_name = str(parts[0])
     cmd_str = " ".join(p.virtual if isinstance(p, PathSpec) else p
                        for p in parts)
+
+    groups = _mount_groups(registry, parts)
+    if len(groups) > 1:
+        path_parts = [p for p in parts[1:] if isinstance(p, PathSpec)]
+        if not is_cross_mount(cmd_name, path_parts, registry):
+            # The executor rejects this command across mounts, so an
+            # aggregated byte estimate would cost a run that errors.
+            return ProvisionResult(command=cmd_str,
+                                   precision=Precision.UNKNOWN)
+        texts = [p for p in parts[1:] if not isinstance(p, PathSpec)]
+        children = []
+        for group in groups:
+            sub: list[str | PathSpec] = [cmd_name, *texts, *group]
+            children.append(await
+                            handle_command_provision(registry, sub, session))
+        combined = combine_sum(";", children)
+        combined.command = cmd_str
+        return combined
 
     first_scope = None
     for p in parts[1:]:

--- a/python/mirage/workspace/provision/control.py
+++ b/python/mirage/workspace/provision/control.py
@@ -32,6 +32,37 @@ async def _plan_body(provision_node_fn, body: list,
     return rollup_list(";", children)
 
 
+async def handle_function_provision(
+    provision_node_fn,
+    name: str,
+    body: list,
+    planning: set[str],
+    session: Session,
+) -> ProvisionResult:
+    """Plan a shell function call: the body's cost.
+
+    Recursive functions would loop the planner, so a function already
+    being planned reports UNKNOWN instead of recursing again.
+
+    Args:
+        provision_node_fn: recursive planner.
+        name (str): function name.
+        body (list): function body statement nodes.
+        planning (set[str]): names currently being planned (guard).
+        session (Session): shell session state.
+    """
+    if name in planning:
+        return ProvisionResult(command=name, precision=Precision.UNKNOWN)
+    planning.add(name)
+    try:
+        result = await _plan_body(provision_node_fn, body, session)
+    finally:
+        planning.discard(name)
+    if not result.command:
+        result.command = name
+    return result
+
+
 async def handle_if_provision(
     provision_node_fn,
     branches: list[tuple[Any, Any]],

--- a/python/mirage/workspace/provision/redirect.py
+++ b/python/mirage/workspace/provision/redirect.py
@@ -14,14 +14,57 @@
 
 from typing import Any
 
-from mirage.provision import ProvisionResult
+from mirage.provision import Precision, ProvisionResult
+from mirage.shell.types import RedirectKind
+from mirage.types import PathSpec
+from mirage.workspace.mount import MountRegistry
+from mirage.workspace.provision.command import handle_command_provision
+from mirage.workspace.provision.rollup import rollup_list
 from mirage.workspace.session import Session
 
 
 async def handle_redirect_provision(
     provision_node_fn,
+    registry: MountRegistry,
     command: Any,
+    targets: list[tuple[RedirectKind, PathSpec]],
     session: Session,
 ) -> ProvisionResult:
-    """Plan a redirect: plan the command, add write cost."""
-    return await provision_node_fn(command, session)
+    """Plan a redirect: the inner command plus the redirect I/O.
+
+    A `< file` source is read fully, so it is planned as a cat of the
+    source (exact when the size resolves). A `>`/`>>` target writes
+    the inner command's stdout, whose size is only knowable when the
+    inner read total is: the write is bracketed 0..inner read high as
+    a RANGE, or UNKNOWN when the inner plan has no usable ceiling.
+    stderr redirects, fd duplications, /dev targets, and heredocs are
+    filtered out by the caller and cost nothing.
+
+    Args:
+        provision_node_fn: recursive planner.
+        registry (MountRegistry): mount registry for the source read.
+        command (Any): the redirected command node.
+        targets (list[tuple[RedirectKind, PathSpec]]): resolved
+            stdin/stdout redirect targets on mounts.
+        session (Session): shell session state.
+    """
+    inner = await provision_node_fn(command, session)
+    if not targets:
+        return inner
+    children = [inner]
+    for kind, target in targets:
+        if kind == RedirectKind.STDIN:
+            children.append(await
+                            handle_command_provision(registry, ["cat", target],
+                                                     session))
+            continue
+        if inner.network_read_high > 0:
+            children.append(
+                ProvisionResult(
+                    network_write_low=0,
+                    network_write_high=inner.network_read_high,
+                    precision=Precision.RANGE,
+                ))
+        else:
+            children.append(ProvisionResult(precision=Precision.UNKNOWN))
+    return rollup_list(";", children)

--- a/python/mirage/workspace/provision/redirect.py
+++ b/python/mirage/workspace/provision/redirect.py
@@ -18,6 +18,7 @@ from mirage.provision import Precision, ProvisionResult
 from mirage.shell.types import RedirectKind
 from mirage.types import PathSpec
 from mirage.workspace.mount import MountRegistry
+from mirage.workspace.mount.namespace import Namespace
 from mirage.workspace.provision.command import handle_command_provision
 from mirage.workspace.provision.rollup import rollup_list
 from mirage.workspace.session import Session
@@ -29,6 +30,7 @@ async def handle_redirect_provision(
     command: Any,
     targets: list[tuple[RedirectKind, PathSpec]],
     session: Session,
+    namespace: Namespace | None = None,
 ) -> ProvisionResult:
     """Plan a redirect: the inner command plus the redirect I/O.
 
@@ -56,7 +58,7 @@ async def handle_redirect_provision(
         if kind == RedirectKind.STDIN:
             children.append(await
                             handle_command_provision(registry, ["cat", target],
-                                                     session))
+                                                     session, namespace))
             continue
         if inner.network_read_high > 0:
             children.append(

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -707,8 +707,8 @@ class Workspace:
                                 if prov_resolved is not None else None)
                 return await run_with_timeout(
                     provision_node(self._registry, self.dispatch,
-                                   exec_recursion, ast, effective_session),
-                    prov_timeout, prov_name)
+                                   exec_recursion, self._namespace, ast,
+                                   effective_session), prov_timeout, prov_name)
             io, _ = await run_command_tree(
                 self.dispatch,
                 self._registry,

--- a/python/tests/shell/test_node_kind.py
+++ b/python/tests/shell/test_node_kind.py
@@ -1,0 +1,74 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.shell.node_kind import NodeKind, node_kind
+from mirage.shell.parse import parse
+
+# One snippet per statement kind. The map must cover the full enum
+# (asserted below), so adding a NodeKind without deciding how it
+# classifies fails here before it can drift between the walkers.
+SNIPPETS = {
+    NodeKind.COMMENT: "# a comment",
+    NodeKind.PROGRAM: "true",
+    NodeKind.COMMAND: "cat /data/a.txt",
+    NodeKind.PIPELINE: "cat /data/a.txt | wc -l",
+    NodeKind.LIST: "true && false",
+    NodeKind.REDIRECT: "cat /data/a.txt > /data/b.txt",
+    NodeKind.SUBSHELL: "(true)",
+    NodeKind.COMPOUND: "{ true; }",
+    NodeKind.IF: "if true; then false; fi",
+    NodeKind.FOR: "for i in 1 2; do true; done",
+    NodeKind.SELECT: "select x in a b; do true; done",
+    NodeKind.WHILE: "while true; do false; done",
+    NodeKind.UNTIL: "until false; do true; done",
+    NodeKind.CASE: "case x in x) true;; esac",
+    NodeKind.FUNCTION_DEF: "f() { true; }",
+    NodeKind.DECLARATION: "export FOO=1",
+    NodeKind.UNSET: "unset FOO",
+    NodeKind.TEST: "[[ -n x ]]",
+    NodeKind.NEGATED: "! true",
+    NodeKind.VAR_ASSIGN: "FOO=1",
+    NodeKind.UNSUPPORTED: "for ((i=0;i<2;i++)); do true; done",
+}
+
+
+def _first_statement(snippet: str):
+    root = parse(snippet)
+    assert root.type == "program"
+    return root.named_children[0]
+
+
+def test_snippets_cover_the_full_enum():
+    assert set(SNIPPETS) == set(NodeKind)
+
+
+@pytest.mark.parametrize("kind", list(NodeKind))
+def test_node_kind_classifies(kind):
+    node = _first_statement(SNIPPETS[kind])
+    if kind == NodeKind.PROGRAM:
+        node = parse(SNIPPETS[kind])
+    assert node_kind(node) == kind
+
+
+def test_select_and_until_disambiguate():
+    assert node_kind(_first_statement("select x in a; do true; done")) \
+        == NodeKind.SELECT
+    assert node_kind(_first_statement("for i in a; do true; done")) \
+        == NodeKind.FOR
+    assert node_kind(_first_statement("until false; do true; done")) \
+        == NodeKind.UNTIL
+    assert node_kind(_first_statement("while true; do false; done")) \
+        == NodeKind.WHILE

--- a/python/tests/workspace/provision/test_node_coverage.py
+++ b/python/tests/workspace/provision/test_node_coverage.py
@@ -94,3 +94,25 @@ async def test_function_call_and_env_prefix_plan():
     assert result.network_write == "0"
     assert result.precision.value == "exact"
     await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_provision_follows_symlinks_and_spans_mounts():
+    ws = Workspace({
+        "/data": RAMResource(),
+        "/data2": RAMResource()
+    },
+                   mode=MountMode.WRITE)
+    await ws.execute("tee /data/a.txt > /dev/null", stdin=b"x" * 24)
+    await ws.execute("tee /data2/b.txt > /dev/null", stdin=b"y" * 6)
+    await ws.execute("ln -s /data/a.txt /data2/lnk.txt")
+    result = await ws.execute("cat /data2/lnk.txt", provision=True)
+    assert result.network_read == "24"
+    assert result.precision.value == "exact"
+    result = await ws.execute("cat /data/a.txt /data2/b.txt", provision=True)
+    assert result.network_read == "30"
+    assert result.read_ops == 2
+    assert result.precision.value == "exact"
+    result = await ws.execute("cat /data2/b.txt /data/a.txt", provision=True)
+    assert result.network_read == "30"
+    await ws.close()

--- a/python/tests/workspace/provision/test_node_coverage.py
+++ b/python/tests/workspace/provision/test_node_coverage.py
@@ -1,0 +1,96 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, Workspace
+from mirage.resource.ram import RAMResource
+from mirage.shell.node_kind import NodeKind
+
+# Drift guard: every statement kind the executor supports must have a
+# pinned provision expectation here. The map must cover the full enum
+# (asserted below), so adding a NodeKind forces deciding what the
+# planner reports for it; a construct can no longer be supported by
+# the executor and silently mis-planned.
+#
+# The seeded file is 24 bytes. Expectations are
+# (snippet, network_read, network_write, precision).
+PLANS = {
+    NodeKind.COMMENT: ("# a comment", "0", "0", "exact"),
+    NodeKind.PROGRAM: ("cat /data/a.txt; cat /data/a.txt", "48", "0", "exact"),
+    NodeKind.COMMAND: ("cat /data/a.txt", "24", "0", "exact"),
+    NodeKind.PIPELINE: ("cat /data/a.txt | wc -l", "24", "0", "unknown"),
+    NodeKind.LIST: ("cat /data/a.txt && cat /data/a.txt", "48", "0", "exact"),
+    NodeKind.REDIRECT:
+    ("cat /data/a.txt > /data/out.txt", "24", "0-24", "range"),
+    NodeKind.SUBSHELL: ("(cat /data/a.txt)", "24", "0", "exact"),
+    NodeKind.COMPOUND: ("{ cat /data/a.txt; }", "24", "0", "exact"),
+    NodeKind.IF: ("if true; then cat /data/a.txt; fi", "0-24", "0", "range"),
+    NodeKind.FOR:
+    ("for i in 1 2; do cat /data/a.txt; done", "48", "0", "exact"),
+    NodeKind.SELECT:
+    ("select x in a b; do cat /data/a.txt; done", "24", "0", "unknown"),
+    NodeKind.WHILE:
+    ("while true; do cat /data/a.txt; done", "24", "0", "unknown"),
+    NodeKind.UNTIL: ("until false; do cat /data/a.txt; done", "24", "0",
+                     "unknown"),
+    NodeKind.CASE: ("case x in x) cat /data/a.txt;; esac", "24", "0", "range"),
+    NodeKind.FUNCTION_DEF: ("f() { cat /data/a.txt; }", "0", "0", "exact"),
+    NodeKind.DECLARATION: ("export FOO=1", "0", "0", "exact"),
+    NodeKind.UNSET: ("unset FOO", "0", "0", "exact"),
+    NodeKind.TEST: ("[[ -n x ]]", "0", "0", "exact"),
+    NodeKind.NEGATED: ("! grep zzz /data/a.txt", "24", "0", "exact"),
+    NodeKind.VAR_ASSIGN: ("FOO=1", "0", "0", "exact"),
+    NodeKind.UNSUPPORTED: ("for ((i=0;i<2;i++)); do true; done", "0", "0",
+                           "unknown"),
+}
+
+
+def test_plans_cover_the_full_enum():
+    assert set(PLANS) == set(NodeKind)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", list(NodeKind))
+async def test_every_kind_plans(kind):
+    snippet, net, write, precision = PLANS[kind]
+    ws = Workspace({"/data": RAMResource()}, mode=MountMode.WRITE)
+    await ws.execute("tee /data/a.txt > /dev/null", stdin=b"x" * 24)
+    result = await ws.execute(snippet, provision=True)
+    assert result.network_read == net, kind
+    assert result.network_write == write, kind
+    assert result.precision.value == precision, kind
+    await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_function_call_and_env_prefix_plan():
+    ws = Workspace({"/data": RAMResource()}, mode=MountMode.WRITE)
+    await ws.execute("tee /data/a.txt > /dev/null", stdin=b"x" * 24)
+    result = await ws.execute("f() { cat /data/a.txt; }; f", provision=True)
+    assert result.network_read == "24"
+    assert result.precision.value == "exact"
+    result = await ws.execute("f() { f; }; f", provision=True)
+    assert result.precision.value == "unknown"
+    result = await ws.execute("FOO=1 cat /data/a.txt", provision=True)
+    assert result.network_read == "24"
+    assert result.precision.value == "exact"
+    result = await ws.execute("eval 'cat /data/a.txt'", provision=True)
+    assert result.precision.value == "unknown"
+    result = await ws.execute("wc -l < /data/a.txt", provision=True)
+    assert result.network_read == "24"
+    result = await ws.execute("cat /data/a.txt > /dev/null", provision=True)
+    assert result.network_write == "0"
+    assert result.precision.value == "exact"
+    await ws.close()

--- a/typescript/packages/core/src/shell/helpers.ts
+++ b/typescript/packages/core/src/shell/helpers.ts
@@ -32,6 +32,28 @@ export function getParts(node: TSNodeLike): TSNodeLike[] {
   return node.namedChildren.filter((c) => !SKIP_PARTS.has(c.type))
 }
 
+/**
+ * Split FOO=1 BAR=2 cmd parts into [assignments, remaining].
+ *
+ * The single structural rule for env-prefixed commands, shared by the
+ * executor (which expands and applies the assignments) and the
+ * provision planner (which only needs the command parts).
+ */
+export function splitEnvPrefix(parts: TSNodeLike[]): [TSNodeLike[], TSNodeLike[]] {
+  const assignments: TSNodeLike[] = []
+  const remaining: TSNodeLike[] = []
+  let sawCommandName = false
+  for (const p of parts) {
+    if (!sawCommandName && p.type === NT.VARIABLE_ASSIGNMENT) {
+      assignments.push(p)
+      continue
+    }
+    if (p.type === NT.COMMAND_NAME) sawCommandName = true
+    remaining.push(p)
+  }
+  return [assignments, remaining]
+}
+
 export function getPipelineCommands(node: TSNodeLike): [TSNodeLike[], boolean[]] {
   const commands: TSNodeLike[] = []
   const stderrFlags: boolean[] = []

--- a/typescript/packages/core/src/shell/node_kind.test.ts
+++ b/typescript/packages/core/src/shell/node_kind.test.ts
@@ -1,0 +1,85 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { NodeKind, nodeKind } from './node_kind.ts'
+import { createShellParser, type ShellParser } from './parse.ts'
+
+const require = createRequire(import.meta.url)
+const engineWasm = readFileSync(require.resolve('web-tree-sitter/web-tree-sitter.wasm'))
+const grammarWasm = readFileSync(require.resolve('tree-sitter-bash/tree-sitter-bash.wasm'))
+
+let parser: ShellParser
+
+beforeAll(async () => {
+  parser = await createShellParser({ engineWasm, grammarWasm })
+})
+
+// One snippet per statement kind. The map must cover the full enum
+// (asserted below), so adding a NodeKind without deciding how it
+// classifies fails here before it can drift between the walkers.
+const SNIPPETS: Record<NodeKind, string> = {
+  [NodeKind.COMMENT]: '# a comment',
+  [NodeKind.PROGRAM]: 'true',
+  [NodeKind.COMMAND]: 'cat /data/a.txt',
+  [NodeKind.PIPELINE]: 'cat /data/a.txt | wc -l',
+  [NodeKind.LIST]: 'true && false',
+  [NodeKind.REDIRECT]: 'cat /data/a.txt > /data/b.txt',
+  [NodeKind.SUBSHELL]: '(true)',
+  [NodeKind.COMPOUND]: '{ true; }',
+  [NodeKind.IF]: 'if true; then false; fi',
+  [NodeKind.FOR]: 'for i in 1 2; do true; done',
+  [NodeKind.SELECT]: 'select x in a b; do true; done',
+  [NodeKind.WHILE]: 'while true; do false; done',
+  [NodeKind.UNTIL]: 'until false; do true; done',
+  [NodeKind.CASE]: 'case x in x) true;; esac',
+  [NodeKind.FUNCTION_DEF]: 'f() { true; }',
+  [NodeKind.DECLARATION]: 'export FOO=1',
+  [NodeKind.UNSET]: 'unset FOO',
+  [NodeKind.TEST]: '[[ -n x ]]',
+  [NodeKind.NEGATED]: '! true',
+  [NodeKind.VAR_ASSIGN]: 'FOO=1',
+  [NodeKind.UNSUPPORTED]: 'for ((i=0;i<2;i++)); do true; done',
+}
+
+function firstStatement(snippet: string) {
+  const root = parser.parse(snippet)
+  expect(root.type).toBe('program')
+  const first = root.namedChildren[0]
+  if (first === undefined) throw new Error('empty program')
+  return first
+}
+
+describe('nodeKind', () => {
+  it('snippets cover the full enum', () => {
+    expect(new Set(Object.keys(SNIPPETS))).toEqual(new Set(Object.values(NodeKind)))
+  })
+
+  for (const kind of Object.values(NodeKind)) {
+    it(`classifies ${kind}`, () => {
+      const node =
+        kind === NodeKind.PROGRAM ? parser.parse(SNIPPETS[kind]) : firstStatement(SNIPPETS[kind])
+      expect(nodeKind(node)).toBe(kind)
+    })
+  }
+
+  it('disambiguates select/for and until/while', () => {
+    expect(nodeKind(firstStatement('select x in a; do true; done'))).toBe(NodeKind.SELECT)
+    expect(nodeKind(firstStatement('for i in a; do true; done'))).toBe(NodeKind.FOR)
+    expect(nodeKind(firstStatement('until false; do true; done'))).toBe(NodeKind.UNTIL)
+    expect(nodeKind(firstStatement('while true; do false; done'))).toBe(NodeKind.WHILE)
+  })
+})

--- a/typescript/packages/core/src/shell/node_kind.ts
+++ b/typescript/packages/core/src/shell/node_kind.ts
@@ -1,0 +1,94 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { NodeType as NT } from './types.ts'
+
+/**
+ * Statement kinds both tree walkers dispatch on.
+ *
+ * The executor and the provision planner walk the same tree-sitter
+ * AST. This enum is the single classification both use, so a
+ * construct cannot be supported by one walker and silently
+ * unclassified by the other: `nodeKind` owns every tree-sitter
+ * node-type check, including the lookahead that distinguishes
+ * `select` from `for` and `until` from `while`.
+ */
+export const NodeKind = Object.freeze({
+  COMMENT: 'comment',
+  PROGRAM: 'program',
+  COMMAND: 'command',
+  PIPELINE: 'pipeline',
+  LIST: 'list',
+  REDIRECT: 'redirect',
+  SUBSHELL: 'subshell',
+  COMPOUND: 'compound',
+  IF: 'if',
+  FOR: 'for',
+  SELECT: 'select',
+  WHILE: 'while',
+  UNTIL: 'until',
+  CASE: 'case',
+  FUNCTION_DEF: 'function_def',
+  DECLARATION: 'declaration',
+  UNSET: 'unset',
+  TEST: 'test',
+  NEGATED: 'negated',
+  VAR_ASSIGN: 'var_assign',
+  UNSUPPORTED: 'unsupported',
+} as const)
+export type NodeKind = (typeof NodeKind)[keyof typeof NodeKind]
+
+const SIMPLE_KINDS: Readonly<Record<string, NodeKind>> = Object.freeze({
+  [NT.COMMENT]: NodeKind.COMMENT,
+  [NT.PROGRAM]: NodeKind.PROGRAM,
+  [NT.COMMAND]: NodeKind.COMMAND,
+  [NT.PIPELINE]: NodeKind.PIPELINE,
+  [NT.LIST]: NodeKind.LIST,
+  [NT.REDIRECTED_STATEMENT]: NodeKind.REDIRECT,
+  [NT.SUBSHELL]: NodeKind.SUBSHELL,
+  [NT.COMPOUND_STATEMENT]: NodeKind.COMPOUND,
+  [NT.IF_STATEMENT]: NodeKind.IF,
+  [NT.CASE_STATEMENT]: NodeKind.CASE,
+  [NT.FUNCTION_DEFINITION]: NodeKind.FUNCTION_DEF,
+  [NT.DECLARATION_COMMAND]: NodeKind.DECLARATION,
+  [NT.UNSET_COMMAND]: NodeKind.UNSET,
+  [NT.TEST_COMMAND]: NodeKind.TEST,
+  [NT.NEGATED_COMMAND]: NodeKind.NEGATED,
+  [NT.VARIABLE_ASSIGNMENT]: NodeKind.VAR_ASSIGN,
+})
+
+interface KindNodeLike {
+  type: string
+  children?: readonly { type: string }[] | { type: string }[]
+}
+
+/**
+ * Classify a tree-sitter node into the shared statement kind, or
+ * UNSUPPORTED for node types neither walker implements (c-style for,
+ * arithmetic, ...).
+ */
+export function nodeKind(node: KindNodeLike): NodeKind {
+  const ntype = node.type
+  const simple = SIMPLE_KINDS[ntype]
+  if (simple !== undefined) return simple
+  if (ntype === NT.FOR_STATEMENT) {
+    if (node.children?.[0]?.type === NT.SELECT) return NodeKind.SELECT
+    return NodeKind.FOR
+  }
+  if (ntype === NT.WHILE_STATEMENT) {
+    if (node.children?.[0]?.type === NT.UNTIL) return NodeKind.UNTIL
+    return NodeKind.WHILE
+  }
+  return NodeKind.UNSUPPORTED
+}

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -152,13 +152,18 @@ export async function handleCommand(
   }
 
   if (isCrossMount(cmdName, pathScopes, registry)) {
+    // Parse against the mount spec so flags and text operands split like
+    // the single-mount path: raw argv would hand flag tokens ("-c") to
+    // the generic as the search pattern.
     const srcMount = registry.mountFor(pathScopes[0]?.virtual ?? session.cwd)
-    const csFlags =
-      srcMount !== null ? parseFlags(parts.slice(1), srcMount, cmdName, session.cwd)[2] : {}
+    const csParsed =
+      srcMount !== null ? parseFlags(parts.slice(1), srcMount, cmdName, session.cwd) : null
+    const csFlags = csParsed !== null ? csParsed[2] : {}
+    const csTexts = csParsed !== null ? csParsed[1] : textOnly
     const [csStdout, csIo, csExec] = await handleCrossMount(
       cmdName,
       pathScopes,
-      textOnly,
+      csTexts,
       csFlags,
       dispatch,
       cmdStr,

--- a/typescript/packages/core/src/workspace/expand/redirects.ts
+++ b/typescript/packages/core/src/workspace/expand/redirects.ts
@@ -1,0 +1,96 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { CallStack } from '../../shell/call_stack.ts'
+import { Redirect, RedirectKind } from '../../shell/types.ts'
+import type { MountRegistry } from '../mount/registry.ts'
+import type { Session } from '../session/session.ts'
+import { classifyBarePath } from './classify.ts'
+import { expandNode } from './node.ts'
+import type { ExecuteFn } from './node.ts'
+import type { TSNodeLike } from './variable.ts'
+
+/**
+ * Expand redirect targets: heredoc vars, target words, pipelines.
+ *
+ * The single expansion path for redirected statements, shared by the
+ * executor (which then applies the redirects) and the provision
+ * planner (which only costs them). Heredoc/herestring bodies get
+ * session variables substituted; file targets are expanded and
+ * classified into PathSpec or plain text; the first attached pipeline
+ * is detached and returned separately.
+ */
+export async function expandRedirects(
+  redirects: readonly Redirect[],
+  session: Session,
+  executeFn: ExecuteFn,
+  registry: MountRegistry,
+  callStack: CallStack | null = null,
+): Promise<[Redirect[], TSNodeLike | null]> {
+  const expanded: Redirect[] = []
+  for (const r of redirects) {
+    if (r.kind === RedirectKind.HEREDOC || r.kind === RedirectKind.HERESTRING) {
+      let body: unknown = r.target
+      if (typeof body === 'string' && r.expandVars) {
+        let s: string = body
+        for (const [k, v] of Object.entries(session.env)) {
+          s = s.replaceAll('$' + k, v)
+        }
+        body = s
+      }
+      expanded.push(
+        new Redirect({
+          fd: r.fd,
+          target: body,
+          targetNode: r.targetNode,
+          kind: r.kind,
+          append: r.append,
+          pipeline: r.pipeline,
+          expandVars: r.expandVars,
+        }),
+      )
+      continue
+    }
+    if (typeof r.target === 'number') {
+      expanded.push(r)
+      continue
+    }
+    const targetNode = r.targetNode as TSNodeLike | null
+    let targetScope: unknown = r.target
+    if (targetNode !== null) {
+      const targetStr = await expandNode(targetNode, session, executeFn, callStack)
+      targetScope = classifyBarePath(targetStr, registry, session.cwd)
+    }
+    expanded.push(
+      new Redirect({
+        fd: r.fd,
+        target: targetScope,
+        targetNode: r.targetNode,
+        kind: r.kind,
+        append: r.append,
+        pipeline: r.pipeline,
+        expandVars: r.expandVars,
+      }),
+    )
+  }
+  let pipeNode: TSNodeLike | null = null
+  for (const r of expanded) {
+    if (r.pipeline !== null && r.pipeline !== undefined) {
+      pipeNode = r.pipeline as TSNodeLike
+      r.pipeline = null
+      break
+    }
+  }
+  return [expanded, pipeNode]
+}

--- a/typescript/packages/core/src/workspace/node/command_dispatch.ts
+++ b/typescript/packages/core/src/workspace/node/command_dispatch.ts
@@ -22,6 +22,7 @@ import {
   getParts,
   getProcessSubDirection,
   getText,
+  splitEnvPrefix,
 } from '../../shell/helpers.ts'
 import type { PyodideRuntime } from '../executor/python/runtime.ts'
 import type { JobTable } from '../../shell/job_table.ts'
@@ -146,30 +147,20 @@ export async function executeCommand(
   signal?: AbortSignal,
 ): Promise<Result> {
   const name = getCommandName(node)
-  const rawParts = getParts(node)
+  const [assignmentNodes, nonPrefixParts] = splitEnvPrefix(getParts(node))
 
   const prefixAssignments: [string, string][] = []
-  const nonPrefixParts: TSNodeLike[] = []
-  let sawCommandName = false
-  for (const p of rawParts) {
-    if (!sawCommandName && p.type === NT.VARIABLE_ASSIGNMENT) {
-      const atext = getText(p)
-      const eq = atext.indexOf('=')
-      if (eq >= 0) {
-        const key = atext.slice(0, eq)
-        const rawVal = atext.slice(eq + 1)
-        const valNodes = p.namedChildren.filter((c) => c.type !== NT.VARIABLE_NAME)
-        const firstVal = valNodes[0]
-        const v =
-          firstVal !== undefined
-            ? await expandNode(firstVal, session, executeFn, callStack)
-            : rawVal
-        prefixAssignments.push([key, v])
-      }
-      continue
-    }
-    if (p.type === NT.COMMAND_NAME) sawCommandName = true
-    nonPrefixParts.push(p)
+  for (const p of assignmentNodes) {
+    const atext = getText(p)
+    const eq = atext.indexOf('=')
+    if (eq < 0) continue
+    const key = atext.slice(0, eq)
+    const rawVal = atext.slice(eq + 1)
+    const valNodes = p.namedChildren.filter((c) => c.type !== NT.VARIABLE_NAME)
+    const firstVal = valNodes[0]
+    const v =
+      firstVal !== undefined ? await expandNode(firstVal, session, executeFn, callStack) : rawVal
+    prefixAssignments.push([key, v])
   }
 
   for (const [k] of prefixAssignments) {

--- a/typescript/packages/core/src/workspace/node/execute_node.ts
+++ b/typescript/packages/core/src/workspace/node/execute_node.ts
@@ -36,13 +36,9 @@ import {
 } from '../../shell/helpers.ts'
 import type { PyodideRuntime } from '../executor/python/runtime.ts'
 import type { JobTable } from '../../shell/job_table.ts'
-import {
-  ERREXIT_EXEMPT_TYPES,
-  NodeType as NT,
-  Redirect,
-  RedirectKind as Redirect_,
-} from '../../shell/types.ts'
-import { classifyBarePath } from '../expand/classify.ts'
+import { ERREXIT_EXEMPT_TYPES, NodeType as NT } from '../../shell/types.ts'
+import { NodeKind, nodeKind } from '../../shell/node_kind.ts'
+import { expandRedirects } from '../expand/redirects.ts'
 import { type ExecuteFn, expandNode } from '../expand/node.ts'
 import { expandAndClassify } from '../expand/parts.ts'
 import type { TSNodeLike } from '../expand/variable.ts'
@@ -105,21 +101,21 @@ export async function executeNode(
   ): Promise<Result> => executeNode(deps, n, s, i, cs)
 
   const { dispatch, registry, jobTable, executeFn, agentId } = deps
-  const ntype = node.type
+  const kind = nodeKind(node)
 
   if (deps.signal?.aborted === true) {
     throw makeAbortError()
   }
 
-  if (ntype === NT.COMMENT) {
+  if (kind === NodeKind.COMMENT) {
     return [null, new IOResult(), new ExecutionNode({ command: '', exitCode: 0 })]
   }
 
-  if (ntype === NT.PROGRAM) {
+  if (kind === NodeKind.PROGRAM) {
     return executeProgram(recurse, node, session, stdin, callStack, jobTable, agentId)
   }
 
-  if (ntype === NT.COMMAND) {
+  if (kind === NodeKind.COMMAND) {
     return executeCommand(
       recurse,
       dispatch,
@@ -138,72 +134,25 @@ export async function executeNode(
     )
   }
 
-  if (ntype === NT.PIPELINE) {
+  if (kind === NodeKind.PIPELINE) {
     const [commands, stderrFlags] = getPipelineCommands(node)
     return handlePipe(recurse, commands, stderrFlags, session, stdin, callStack)
   }
 
-  if (ntype === NT.LIST) {
+  if (kind === NodeKind.LIST) {
     const [left, op, right] = getListParts(node)
     return handleConnection(recurse, left, op, right, session, stdin, callStack)
   }
 
-  if (ntype === NT.REDIRECTED_STATEMENT) {
+  if (kind === NodeKind.REDIRECT) {
     const [command, redirects] = getRedirects(node)
-    const expandedRedirects: Redirect[] = []
-    for (const r of redirects) {
-      if (r.kind === Redirect_.HEREDOC || r.kind === Redirect_.HERESTRING) {
-        let body: unknown = r.target
-        if (typeof body === 'string' && r.expandVars) {
-          let s: string = body
-          for (const [k, v] of Object.entries(session.env)) {
-            s = s.replaceAll('$' + k, v)
-          }
-          body = s
-        }
-        expandedRedirects.push(
-          new Redirect({
-            fd: r.fd,
-            target: body,
-            targetNode: r.targetNode,
-            kind: r.kind,
-            append: r.append,
-            pipeline: r.pipeline,
-            expandVars: r.expandVars,
-          }),
-        )
-        continue
-      }
-      if (typeof r.target === 'number') {
-        expandedRedirects.push(r)
-        continue
-      }
-      const targetNode = r.targetNode as TSNodeLike | null
-      let targetScope: unknown = r.target
-      if (targetNode !== null) {
-        const targetStr = await expandNode(targetNode, session, executeFn, callStack)
-        targetScope = classifyBarePath(targetStr, registry, session.cwd)
-      }
-      expandedRedirects.push(
-        new Redirect({
-          fd: r.fd,
-          target: targetScope,
-          targetNode: r.targetNode,
-          kind: r.kind,
-          append: r.append,
-          pipeline: r.pipeline,
-          expandVars: r.expandVars,
-        }),
-      )
-    }
-    let pipeNode: TSNodeLike | null = null
-    for (const r of expandedRedirects) {
-      if (r.pipeline !== null && r.pipeline !== undefined) {
-        pipeNode = r.pipeline as TSNodeLike
-        r.pipeline = null
-        break
-      }
-    }
+    const [expandedRedirects, pipeNode] = await expandRedirects(
+      redirects,
+      session,
+      executeFn,
+      registry,
+      callStack,
+    )
     let [stdout, io, execNode] = await handleRedirect(
       recurse,
       dispatch,
@@ -222,11 +171,11 @@ export async function executeNode(
     return [stdout, io, execNode]
   }
 
-  if (ntype === NT.SUBSHELL) {
+  if (kind === NodeKind.SUBSHELL) {
     return handleSubshell(recurse, getSubshellBody(node), session, stdin, callStack)
   }
 
-  if (ntype === NT.COMPOUND_STATEMENT) {
+  if (kind === NodeKind.COMPOUND) {
     const allStdout: ByteSource[] = []
     let mergedIo = new IOResult()
     let lastExec = new ExecutionNode({ command: '{}', exitCode: 0 })
@@ -252,12 +201,12 @@ export async function executeNode(
     return [combined, mergedIo, lastExec]
   }
 
-  if (ntype === NT.IF_STATEMENT) {
+  if (kind === NodeKind.IF) {
     const [branches, elseBody] = getIfBranches(node)
     return handleIf(recurse, branches, elseBody, session, stdin, callStack)
   }
 
-  if (ntype === NT.FOR_STATEMENT) {
+  if (kind === NodeKind.FOR || kind === NodeKind.SELECT) {
     const [variable, values, body] = getForParts(node)
     const classified = await expandAndClassify(
       values,
@@ -268,35 +217,35 @@ export async function executeNode(
       callStack,
     )
     const resolved = await resolveGlobs(classified, registry)
-    if (node.children[0]?.type === NT.SELECT) {
+    if (kind === NodeKind.SELECT) {
       return handleSelect(recurse, variable, resolved, body, session, stdin, callStack)
     }
     return handleFor(recurse, variable, resolved, body, session, stdin, callStack)
   }
 
-  if (ntype === NT.WHILE_STATEMENT) {
+  if (kind === NodeKind.WHILE || kind === NodeKind.UNTIL) {
     const [condition, body] = getWhileParts(node)
-    if (node.children[0]?.type === NT.UNTIL) {
+    if (kind === NodeKind.UNTIL) {
       return handleUntil(recurse, condition, body, session, stdin, callStack)
     }
     return handleWhile(recurse, condition, body, session, stdin, callStack)
   }
 
-  if (ntype === NT.CASE_STATEMENT) {
+  if (kind === NodeKind.CASE) {
     const wordNode = getCaseWord(node)
     const word = await expandNode(wordNode, session, executeFn, callStack)
     const items = getCaseItems(node)
     return handleCase(recurse, word, items, session, stdin, callStack)
   }
 
-  if (ntype === NT.FUNCTION_DEFINITION) {
+  if (kind === NodeKind.FUNCTION_DEF) {
     const name = getFunctionName(node)
     const body = getFunctionBody(node)
     session.functions[name] = body
     return [null, new IOResult(), new ExecutionNode({ command: `function ${name}`, exitCode: 0 })]
   }
 
-  if (ntype === NT.DECLARATION_COMMAND) {
+  if (kind === NodeKind.DECLARATION) {
     const keyword = getDeclarationKeyword(node)
     const assignments: string[] = []
     const flagChars = new Set<string>()
@@ -338,16 +287,16 @@ export async function executeNode(
     return handleExport(assignments, session)
   }
 
-  if (ntype === NT.UNSET_COMMAND) {
+  if (kind === NodeKind.UNSET) {
     return handleUnset(getUnsetNames(node), session)
   }
 
-  if (ntype === NT.TEST_COMMAND) {
+  if (kind === NodeKind.TEST) {
     const expanded = await expandTestExpr(node, session, executeFn, callStack)
     return handleTest(dispatch, expanded, session)
   }
 
-  if (ntype === NT.NEGATED_COMMAND) {
+  if (kind === NodeKind.NEGATED) {
     const inner = getNegatedCommand(node)
     const [stdout, io, execNode] = await recurse(inner, session, stdin, callStack)
     const flipped = new IOResult({
@@ -361,7 +310,7 @@ export async function executeNode(
     return [stdout, flipped, execNode]
   }
 
-  if (ntype === NT.VARIABLE_ASSIGNMENT) {
+  if (kind === NodeKind.VAR_ASSIGN) {
     const text = getText(node)
     if (text.includes('=')) {
       const eq = text.indexOf('=')
@@ -397,5 +346,5 @@ export async function executeNode(
     return [null, new IOResult(), new ExecutionNode({ command: text, exitCode: 0 })]
   }
 
-  throw new TypeError(`unsupported tree-sitter node type: ${ntype}`)
+  throw new TypeError(`unsupported tree-sitter node type: ${node.type}`)
 }

--- a/typescript/packages/core/src/workspace/node/provision_node.ts
+++ b/typescript/packages/core/src/workspace/node/provision_node.ts
@@ -40,6 +40,7 @@ import type { ExecuteFn } from '../expand/node.ts'
 import { expandAndClassify, expandParts } from '../expand/parts.ts'
 import { expandRedirects } from '../expand/redirects.ts'
 import type { MountRegistry } from '../mount/registry.ts'
+import type { Namespace } from '../mount/namespace.ts'
 import { handleCommandProvision } from '../provision/command.ts'
 import {
   handleForProvision,
@@ -89,6 +90,7 @@ function handleBuiltinProvision(): ProvisionResult {
 interface ProvisionContext {
   registry: MountRegistry
   executeFn: ExecuteFn
+  namespace?: Namespace | null
 }
 
 /**
@@ -153,7 +155,7 @@ export async function provisionNode(
     if (parts.length === 0) return new ProvisionResult({ precision: Precision.EXACT })
     const expanded = await expandParts(parts, session, ctx.executeFn)
     const classified = classifyParts(expanded, ctx.registry, session.cwd)
-    return handleCommandProvision(ctx.registry, classified, session)
+    return handleCommandProvision(ctx.registry, classified, session, ctx.namespace ?? null)
   }
 
   if (kind === NodeKind.PIPELINE) {
@@ -187,6 +189,7 @@ export async function provisionNode(
       command,
       targets,
       session,
+      ctx.namespace ?? null,
     )
     if (pipeNode !== null) {
       return rollupPipe([result, await recurse(pipeNode, session)])

--- a/typescript/packages/core/src/workspace/node/provision_node.ts
+++ b/typescript/packages/core/src/workspace/node/provision_node.ts
@@ -16,6 +16,8 @@ import {
   getCaseItems,
   getCommandName,
   getForParts,
+  getFunctionBody,
+  getFunctionName,
   getIfBranches,
   getListParts,
   getNegatedCommand,
@@ -25,18 +27,23 @@ import {
   getSubshellBody,
   getText,
   getWhileParts,
+  splitEnvPrefix,
 } from '../../shell/helpers.ts'
-import { NodeType as NT, ShellBuiltin as SB } from '../../shell/types.ts'
+import { NodeKind, nodeKind } from '../../shell/node_kind.ts'
+import { NodeType as NT, RedirectKind, ShellBuiltin as SB } from '../../shell/types.ts'
 import { Precision, ProvisionResult } from '../../provision/types.ts'
-import { rollupList } from '../../provision/rollup.ts'
+import { rollupList, rollupPipe } from '../../provision/rollup.ts'
+import { PathSpec } from '../../types.ts'
 import type { TSNodeLike } from '../expand/variable.ts'
 import { classifyParts } from '../expand/classify.ts'
-import { expandAndClassify, expandParts } from '../expand/parts.ts'
 import type { ExecuteFn } from '../expand/node.ts'
+import { expandAndClassify, expandParts } from '../expand/parts.ts'
+import { expandRedirects } from '../expand/redirects.ts'
 import type { MountRegistry } from '../mount/registry.ts'
 import { handleCommandProvision } from '../provision/command.ts'
 import {
   handleForProvision,
+  handleFunctionProvision,
   handleIfProvision,
   handleWhileProvision,
 } from '../provision/control.ts'
@@ -44,13 +51,13 @@ import { handleConnectionProvision, handlePipeProvision } from '../provision/pip
 import { handleRedirectProvision } from '../provision/redirect.ts'
 import type { Session } from '../session/session.ts'
 
+// eval / source execute their payload, so they are NOT free builtins:
+// leaving them out lets them fall through to command resolution, which
+// honestly reports UNKNOWN instead of a zero-cost EXACT.
 const BUILTIN_NAMES: ReadonlySet<string> = new Set([
   SB.CD,
   SB.TRUE,
   SB.FALSE,
-  SB.SOURCE,
-  SB.DOT,
-  SB.EVAL,
   SB.EXPORT,
   SB.UNSET,
   SB.LOCAL,
@@ -84,81 +91,115 @@ interface ProvisionContext {
   executeFn: ExecuteFn
 }
 
+/**
+ * Walk-local planner state. Function definitions seen during this
+ * plan are recorded here (not on the session: planning must not
+ * mutate shell state), and `planning` guards recursive functions
+ * from looping the planner.
+ */
+interface PlanScope {
+  functions: Map<string, TSNodeLike[]>
+  planning: Set<string>
+}
+
+/**
+ * Walk tree-sitter AST and estimate execution cost.
+ *
+ * Dispatches on the same NodeKind classification as the executor
+ * (`shell/node_kind.ts`), so every construct the executor runs has a
+ * planner branch; kinds neither walker supports fall through to an
+ * honest UNKNOWN.
+ */
 export async function provisionNode(
   ctx: ProvisionContext,
   node: TSNodeLike | null | undefined,
   session: Session,
+  scope?: PlanScope,
 ): Promise<ProvisionResult> {
-  const recurse = (n: TSNodeLike, s: Session): Promise<ProvisionResult> => provisionNode(ctx, n, s)
+  const planScope: PlanScope = scope ?? { functions: new Map(), planning: new Set() }
+  const recurse = (n: TSNodeLike, s: Session): Promise<ProvisionResult> =>
+    provisionNode(ctx, n, s, planScope)
+  const recurseUnknown = (n: unknown, s: Session): Promise<ProvisionResult> =>
+    recurse(n as TSNodeLike, s)
   if (node === null || node === undefined) {
     return new ProvisionResult({ precision: Precision.EXACT })
   }
-  const ntype = node.type
+  const kind = nodeKind(node)
 
-  if (ntype === NT.PROGRAM) {
-    const children: ProvisionResult[] = []
-    for (const c of node.namedChildren) children.push(await recurse(c, session))
-    if (children.length === 0) return new ProvisionResult({ precision: Precision.EXACT })
-    return rollupList(';', children)
+  if (kind === NodeKind.COMMENT) {
+    return new ProvisionResult({ precision: Precision.EXACT })
   }
 
-  if (ntype === NT.COMMAND) {
-    const name = getCommandName(node)
-    if (BUILTIN_NAMES.has(name)) return handleBuiltinProvision()
-    const parts = getParts(node)
-    const expanded = await expandParts(parts, session, ctx.executeFn)
-    const classified = classifyParts(expanded, ctx.registry, session.cwd)
-    return handleCommandProvision(ctx.registry, classified, session)
-  }
-
-  if (ntype === NT.PIPELINE) {
-    const [commands] = getPipelineCommands(node)
-    return handlePipeProvision(
-      (n: unknown, s: Session) => recurse(n as TSNodeLike, s),
-      commands,
-      session,
-    )
-  }
-
-  if (ntype === NT.LIST) {
-    const [left, op, right] = getListParts(node)
-    return handleConnectionProvision(
-      (n: unknown, s: Session) => recurse(n as TSNodeLike, s),
-      left,
-      op ?? '&&',
-      right,
-      session,
-    )
-  }
-
-  if (ntype === NT.REDIRECTED_STATEMENT) {
-    const [command] = getRedirects(node)
-    return handleRedirectProvision(
-      (n: unknown, s: Session) => recurse(n as TSNodeLike, s),
-      command,
-      session,
-    )
-  }
-
-  if (ntype === NT.SUBSHELL) {
-    const body = getSubshellBody(node)
+  if (kind === NodeKind.PROGRAM || kind === NodeKind.SUBSHELL || kind === NodeKind.COMPOUND) {
+    const body =
+      kind === NodeKind.SUBSHELL
+        ? getSubshellBody(node)
+        : node.namedChildren.filter((c) => c.type !== NT.COMMENT)
     const children: ProvisionResult[] = []
     for (const c of body) children.push(await recurse(c, session))
     if (children.length === 0) return new ProvisionResult({ precision: Precision.EXACT })
     return rollupList(';', children)
   }
 
-  if (ntype === NT.IF_STATEMENT) {
-    const [branches, elseBody] = getIfBranches(node)
-    return handleIfProvision(
-      (n: unknown, s: Session) => recurse(n as TSNodeLike, s),
-      branches,
-      elseBody,
-      session,
-    )
+  if (kind === NodeKind.COMMAND) {
+    const name = getCommandName(node)
+    const funcBody =
+      planScope.functions.get(name) ?? (session.functions[name] as TSNodeLike[] | undefined)
+    if (funcBody !== undefined) {
+      return handleFunctionProvision(recurseUnknown, name, funcBody, planScope.planning, session)
+    }
+    if (BUILTIN_NAMES.has(name)) return handleBuiltinProvision()
+    const [, parts] = splitEnvPrefix(getParts(node))
+    if (parts.length === 0) return new ProvisionResult({ precision: Precision.EXACT })
+    const expanded = await expandParts(parts, session, ctx.executeFn)
+    const classified = classifyParts(expanded, ctx.registry, session.cwd)
+    return handleCommandProvision(ctx.registry, classified, session)
   }
 
-  if (ntype === NT.FOR_STATEMENT) {
+  if (kind === NodeKind.PIPELINE) {
+    const [commands] = getPipelineCommands(node)
+    return handlePipeProvision(recurseUnknown, commands, session)
+  }
+
+  if (kind === NodeKind.LIST) {
+    const [left, op, right] = getListParts(node)
+    return handleConnectionProvision(recurseUnknown, left, op ?? '&&', right, session)
+  }
+
+  if (kind === NodeKind.REDIRECT) {
+    const [command, redirects] = getRedirects(node)
+    const [expanded, pipeNode] = await expandRedirects(
+      redirects,
+      session,
+      ctx.executeFn,
+      ctx.registry,
+    )
+    const targets: [RedirectKind, PathSpec][] = []
+    for (const r of expanded) {
+      if (r.kind !== RedirectKind.STDIN && r.kind !== RedirectKind.STDOUT) continue
+      if (!(r.target instanceof PathSpec)) continue
+      if (r.target.virtual.startsWith('/dev/')) continue
+      targets.push([r.kind, r.target])
+    }
+    const result = await handleRedirectProvision(
+      recurseUnknown,
+      ctx.registry,
+      command,
+      targets,
+      session,
+    )
+    if (pipeNode !== null) {
+      return rollupPipe([result, await recurse(pipeNode, session)])
+    }
+    return result
+  }
+
+  if (kind === NodeKind.IF) {
+    const [branches, elseBody] = getIfBranches(node)
+    return handleIfProvision(recurseUnknown, branches, elseBody, session)
+  }
+
+  if (kind === NodeKind.FOR) {
     const [, values, body] = getForParts(node)
     const classified = await expandAndClassify(
       values,
@@ -168,24 +209,21 @@ export async function provisionNode(
       session.cwd,
     )
     const n = classified.length || 1
-    return handleForProvision(
-      (nn: unknown, s: Session) => recurse(nn as TSNodeLike, s),
-      body,
-      n,
-      session,
-    )
+    return handleForProvision(recurseUnknown, body, n, session)
   }
 
-  if (ntype === NT.WHILE_STATEMENT) {
+  if (kind === NodeKind.SELECT) {
+    // select re-prompts until break: unbounded like while.
+    const [, , body] = getForParts(node)
+    return handleWhileProvision(recurseUnknown, body, session)
+  }
+
+  if (kind === NodeKind.WHILE || kind === NodeKind.UNTIL) {
     const [, body] = getWhileParts(node)
-    return handleWhileProvision(
-      (n: unknown, s: Session) => recurse(n as TSNodeLike, s),
-      body,
-      session,
-    )
+    return handleWhileProvision(recurseUnknown, body, session)
   }
 
-  if (ntype === NT.CASE_STATEMENT) {
+  if (kind === NodeKind.CASE) {
     const items = getCaseItems(node)
     const children: ProvisionResult[] = []
     for (const [, body] of items) {
@@ -195,26 +233,25 @@ export async function provisionNode(
     return new ProvisionResult({ precision: Precision.EXACT })
   }
 
+  if (kind === NodeKind.FUNCTION_DEF) {
+    const name = getFunctionName(node)
+    const body = getFunctionBody(node)
+    if (name !== '' && body !== null) planScope.functions.set(name, body)
+    return handleBuiltinProvision()
+  }
+
   if (
-    ntype === NT.FUNCTION_DEFINITION ||
-    ntype === NT.DECLARATION_COMMAND ||
-    ntype === NT.UNSET_COMMAND ||
-    ntype === NT.TEST_COMMAND ||
-    ntype === NT.VARIABLE_ASSIGNMENT
+    kind === NodeKind.DECLARATION ||
+    kind === NodeKind.UNSET ||
+    kind === NodeKind.TEST ||
+    kind === NodeKind.VAR_ASSIGN
   ) {
     return handleBuiltinProvision()
   }
 
-  if (ntype === NT.NEGATED_COMMAND) {
+  if (kind === NodeKind.NEGATED) {
     const inner = getNegatedCommand(node)
     return recurse(inner, session)
-  }
-
-  if (ntype === NT.COMPOUND_STATEMENT) {
-    const children: ProvisionResult[] = []
-    for (const c of node.namedChildren) children.push(await recurse(c, session))
-    if (children.length === 0) return new ProvisionResult({ precision: Precision.EXACT })
-    return rollupList(';', children)
   }
 
   return new ProvisionResult({ command: getText(node), precision: Precision.UNKNOWN })

--- a/typescript/packages/core/src/workspace/provision/command.ts
+++ b/typescript/packages/core/src/workspace/provision/command.ts
@@ -12,14 +12,16 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { isCrossMount } from '../../commands/builtin/generic/crossmount/index.ts'
 import { mountKey } from '../../utils/key_prefix.ts'
 import type { FileCache } from '../../cache/file/mixin.ts'
 import type { IndexCacheStore } from '../../cache/index/index.ts'
 import { parseCommand, parseToKwargs } from '../../commands/spec/parser.ts'
 import { getExtension } from '../../commands/resolve.ts'
-import { Precision, ProvisionResult } from '../../provision/types.ts'
+import { Precision, ProvisionResult, combineSum } from '../../provision/types.ts'
 import { PathSpec } from '../../types.ts'
 import type { MountRegistry } from '../mount/registry.ts'
+import type { Namespace } from '../mount/namespace.ts'
 import type { Session } from '../session/session.ts'
 import type { Accessor } from '../../accessor/base.ts'
 import type { Resource } from '../../resource/base.ts'
@@ -39,20 +41,100 @@ async function checkCacheHits(
   return hits
 }
 
+/**
+ * Group path args by their own mount, in first-appearance order. Args
+ * that resolve to no mount (glob patterns, expression operands) ride
+ * with the first group: they scoped to the primary mount before and
+ * must not fabricate a cross-mount split.
+ */
+function mountGroups(registry: MountRegistry, parts: readonly (string | PathSpec)[]): PathSpec[][] {
+  const groups: PathSpec[][] = []
+  const seen = new Map<string, number>()
+  const unresolved: PathSpec[] = []
+  for (let i = 1; i < parts.length; i++) {
+    const p = parts[i]
+    if (!(p instanceof PathSpec)) continue
+    if (p.pattern !== null && p.pattern !== '') {
+      // Globs are not expanded during planning; a pattern operand
+      // (find -name, ls *.txt) must not fabricate a mount group.
+      unresolved.push(p)
+      continue
+    }
+    const mount = registry.mountFor(p.virtual)
+    if (mount === null) {
+      unresolved.push(p)
+      continue
+    }
+    const idx = seen.get(mount.prefix)
+    if (idx === undefined) {
+      seen.set(mount.prefix, groups.length)
+      groups.push([p])
+    } else {
+      groups[idx]?.push(p)
+    }
+  }
+  if (unresolved.length > 0) {
+    const first = groups[0]
+    if (first !== undefined) first.push(...unresolved)
+    else groups.push(unresolved)
+  }
+  return groups
+}
+
+/**
+ * Estimate cost of a simple command.
+ *
+ * Paths are namespace-followed first (a symlinked read costs its
+ * target, and the cache-hit check sees the entry the executor would
+ * actually serve), then grouped by mount: a command spanning mounts
+ * is estimated per mount against each mount's own backend and the
+ * results summed, instead of statting foreign paths against the
+ * first path's backend.
+ */
 export async function handleCommandProvision(
   registry: MountRegistry,
   parts: readonly (string | PathSpec)[],
   session: Session,
+  namespace: Namespace | null = null,
 ): Promise<ProvisionResult> {
   if (parts.length === 0) return new ProvisionResult({ precision: Precision.EXACT })
   const head = parts[0]
   if (head === undefined) return new ProvisionResult({ precision: Precision.EXACT })
+
+  let followedParts: (string | PathSpec)[] = [...parts]
+  if (namespace !== null) {
+    followedParts = followedParts.map((p) => {
+      if (!(p instanceof PathSpec)) return p
+      const followed = namespace.follow(p.virtual)
+      return followed !== p.virtual ? PathSpec.fromStrPath(followed) : p
+    })
+  }
   const cmdName = typeof head === 'string' ? head : head.virtual
-  const cmdStr = parts.map((p) => (typeof p === 'string' ? p : p.virtual)).join(' ')
+  const cmdStr = followedParts.map((p) => (typeof p === 'string' ? p : p.virtual)).join(' ')
+
+  const groups = mountGroups(registry, followedParts)
+  if (groups.length > 1) {
+    const pathParts = followedParts.slice(1).filter((p): p is PathSpec => p instanceof PathSpec)
+    if (!isCrossMount(cmdName, pathParts, registry)) {
+      // The executor rejects this command across mounts, so an
+      // aggregated byte estimate would cost a run that errors.
+      return new ProvisionResult({ command: cmdStr, precision: Precision.UNKNOWN })
+    }
+    const texts = followedParts.slice(1).filter((p): p is string => typeof p === 'string')
+    const children: ProvisionResult[] = []
+    for (const group of groups) {
+      const sub: (string | PathSpec)[] = [cmdName, ...texts, ...group]
+      children.push(await handleCommandProvision(registry, sub, session))
+    }
+    const combined = combineSum(';', children)
+    combined.command = cmdStr
+    return combined
+  }
+  const parts2 = followedParts
 
   let firstScope: PathSpec | null = null
-  for (let i = 1; i < parts.length; i++) {
-    const p = parts[i]
+  for (let i = 1; i < parts2.length; i++) {
+    const p = parts2[i]
     if (p instanceof PathSpec) {
       firstScope = p
       break
@@ -74,10 +156,10 @@ export async function handleCommandProvision(
   }
 
   const mountPrefix = rstripSlash(mount.prefix)
-  const scopedParts: (string | PathSpec)[] = [parts[0] ?? '']
+  const scopedParts: (string | PathSpec)[] = [parts2[0] ?? '']
   const resourceScopes: PathSpec[] = []
-  for (let i = 1; i < parts.length; i++) {
-    const p = parts[i]
+  for (let i = 1; i < parts2.length; i++) {
+    const p = parts2[i]
     if (p instanceof PathSpec) {
       const scoped = new PathSpec({
         virtual: p.virtual,

--- a/typescript/packages/core/src/workspace/provision/control.ts
+++ b/typescript/packages/core/src/workspace/provision/control.ts
@@ -34,6 +34,32 @@ async function planBody(
 }
 
 /**
+ * Plan a shell function call: the body's cost. Recursive functions
+ * would loop the planner, so a function already being planned reports
+ * UNKNOWN instead of recursing again.
+ */
+export async function handleFunctionProvision(
+  provisionNode: ProvisionNodeFn,
+  name: string,
+  body: readonly unknown[],
+  planning: Set<string>,
+  session: Session,
+): Promise<ProvisionResult> {
+  if (planning.has(name)) {
+    return new ProvisionResult({ command: name, precision: Precision.UNKNOWN })
+  }
+  planning.add(name)
+  let result: ProvisionResult
+  try {
+    result = await planBody(provisionNode, body, session)
+  } finally {
+    planning.delete(name)
+  }
+  if (result.command === null || result.command === '') result.command = name
+  return result
+}
+
+/**
  * Plan an if: branches bracket as alternatives. Taking branch i
  * evaluates conditions 1..i plus body i, so each alternative sums its
  * condition ladder with its body. The else (or, without one, the

--- a/typescript/packages/core/src/workspace/provision/node_coverage.test.ts
+++ b/typescript/packages/core/src/workspace/provision/node_coverage.test.ts
@@ -112,4 +112,51 @@ describe('planner covers every statement kind', () => {
       await ws.close()
     }
   })
+
+  it('follows symlinks and spans mounts', async () => {
+    const ws = new Workspace(
+      { '/data': new RAMResource(), '/data2': new RAMResource() },
+      {
+        mode: MountMode.WRITE,
+        shellParserFactory: async () => createShellParser({ engineWasm, grammarWasm }),
+      },
+    )
+    try {
+      await ws.execute('tee /data/a.txt > /dev/null', { stdin: ENC.encode('x'.repeat(24)) })
+      await ws.execute('tee /data2/b.txt > /dev/null', { stdin: ENC.encode('y'.repeat(6)) })
+      await ws.execute('ln -s /data/a.txt /data2/lnk.txt')
+      let result = await ws.execute('cat /data2/lnk.txt', { provision: true })
+      expect(result.networkRead).toBe('24')
+      expect(result.precision).toBe('exact')
+      result = await ws.execute('cat /data/a.txt /data2/b.txt', { provision: true })
+      expect(result.networkRead).toBe('30')
+      expect(result.readOps).toBe(2)
+      expect(result.precision).toBe('exact')
+      result = await ws.execute('cat /data2/b.txt /data/a.txt', { provision: true })
+      expect(result.networkRead).toBe('30')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('cross-mount grep keeps parsed flags and pattern', async () => {
+    const ws = new Workspace(
+      { '/data': new RAMResource(), '/data2': new RAMResource() },
+      {
+        mode: MountMode.WRITE,
+        shellParserFactory: async () => createShellParser({ engineWasm, grammarWasm }),
+      },
+    )
+    try {
+      await ws.execute('tee /data/a.txt > /dev/null', { stdin: ENC.encode('sun\nmoon\n') })
+      await ws.execute('tee /data2/b.txt > /dev/null', { stdin: ENC.encode('cross\n') })
+      const count = await ws.execute('grep -c s /data/a.txt /data2/b.txt')
+      expect(new TextDecoder().decode(count.stdout)).toBe('/data/a.txt:1\n/data2/b.txt:1\n')
+      expect(count.exitCode).toBe(0)
+      const numbered = await ws.execute('grep -n cross /data/a.txt /data2/b.txt')
+      expect(new TextDecoder().decode(numbered.stdout)).toBe('/data2/b.txt:1:cross\n')
+    } finally {
+      await ws.close()
+    }
+  })
 })

--- a/typescript/packages/core/src/workspace/provision/node_coverage.test.ts
+++ b/typescript/packages/core/src/workspace/provision/node_coverage.test.ts
@@ -1,0 +1,115 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+import { RAMResource } from '../../resource/ram/ram.ts'
+import { NodeKind } from '../../shell/node_kind.ts'
+import { createShellParser } from '../../shell/parse.ts'
+import { MountMode } from '../../types.ts'
+import { Workspace } from '../workspace.ts'
+
+const ENC = new TextEncoder()
+const require = createRequire(import.meta.url)
+const engineWasm = readFileSync(require.resolve('web-tree-sitter/web-tree-sitter.wasm'))
+const grammarWasm = readFileSync(require.resolve('tree-sitter-bash/tree-sitter-bash.wasm'))
+
+// Drift guard: every statement kind the executor supports must have a
+// pinned provision expectation here. The map must cover the full enum
+// (asserted below), so adding a NodeKind forces deciding what the
+// planner reports for it; a construct can no longer be supported by
+// the executor and silently mis-planned.
+//
+// The seeded file is 24 bytes. Expectations are
+// [snippet, networkRead, networkWrite, precision].
+const PLANS: Record<NodeKind, [string, string, string, string]> = {
+  [NodeKind.COMMENT]: ['# a comment', '0', '0', 'exact'],
+  [NodeKind.PROGRAM]: ['cat /data/a.txt; cat /data/a.txt', '48', '0', 'exact'],
+  [NodeKind.COMMAND]: ['cat /data/a.txt', '24', '0', 'exact'],
+  [NodeKind.PIPELINE]: ['cat /data/a.txt | wc -l', '24', '0', 'unknown'],
+  [NodeKind.LIST]: ['cat /data/a.txt && cat /data/a.txt', '48', '0', 'exact'],
+  [NodeKind.REDIRECT]: ['cat /data/a.txt > /data/out.txt', '24', '0-24', 'range'],
+  [NodeKind.SUBSHELL]: ['(cat /data/a.txt)', '24', '0', 'exact'],
+  [NodeKind.COMPOUND]: ['{ cat /data/a.txt; }', '24', '0', 'exact'],
+  [NodeKind.IF]: ['if true; then cat /data/a.txt; fi', '0-24', '0', 'range'],
+  [NodeKind.FOR]: ['for i in 1 2; do cat /data/a.txt; done', '48', '0', 'exact'],
+  [NodeKind.SELECT]: ['select x in a b; do cat /data/a.txt; done', '24', '0', 'unknown'],
+  [NodeKind.WHILE]: ['while true; do cat /data/a.txt; done', '24', '0', 'unknown'],
+  [NodeKind.UNTIL]: ['until false; do cat /data/a.txt; done', '24', '0', 'unknown'],
+  [NodeKind.CASE]: ['case x in x) cat /data/a.txt;; esac', '24', '0', 'range'],
+  [NodeKind.FUNCTION_DEF]: ['f() { cat /data/a.txt; }', '0', '0', 'exact'],
+  [NodeKind.DECLARATION]: ['export FOO=1', '0', '0', 'exact'],
+  [NodeKind.UNSET]: ['unset FOO', '0', '0', 'exact'],
+  [NodeKind.TEST]: ['[[ -n x ]]', '0', '0', 'exact'],
+  [NodeKind.NEGATED]: ['! grep zzz /data/a.txt', '24', '0', 'exact'],
+  [NodeKind.VAR_ASSIGN]: ['FOO=1', '0', '0', 'exact'],
+  [NodeKind.UNSUPPORTED]: ['for ((i=0;i<2;i++)); do true; done', '0', '0', 'unknown'],
+}
+
+function buildWorkspace(): Workspace {
+  return new Workspace(
+    { '/data': new RAMResource() },
+    {
+      mode: MountMode.WRITE,
+      shellParserFactory: async () => createShellParser({ engineWasm, grammarWasm }),
+    },
+  )
+}
+
+describe('planner covers every statement kind', () => {
+  it('plans cover the full enum', () => {
+    expect(new Set(Object.keys(PLANS))).toEqual(new Set(Object.values(NodeKind)))
+  })
+
+  for (const kind of Object.values(NodeKind)) {
+    it(`plans ${kind}`, async () => {
+      const [snippet, net, write, precision] = PLANS[kind]
+      const ws = buildWorkspace()
+      try {
+        await ws.execute('tee /data/a.txt > /dev/null', { stdin: ENC.encode('x'.repeat(24)) })
+        const result = await ws.execute(snippet, { provision: true })
+        expect(result.networkRead, kind).toBe(net)
+        expect(result.networkWrite, kind).toBe(write)
+        expect(result.precision, kind).toBe(precision)
+      } finally {
+        await ws.close()
+      }
+    })
+  }
+
+  it('plans function calls, env prefixes, eval, and redirect reads', async () => {
+    const ws = buildWorkspace()
+    try {
+      await ws.execute('tee /data/a.txt > /dev/null', { stdin: ENC.encode('x'.repeat(24)) })
+      let result = await ws.execute('f() { cat /data/a.txt; }; f', { provision: true })
+      expect(result.networkRead).toBe('24')
+      expect(result.precision).toBe('exact')
+      result = await ws.execute('f() { f; }; f', { provision: true })
+      expect(result.precision).toBe('unknown')
+      result = await ws.execute('FOO=1 cat /data/a.txt', { provision: true })
+      expect(result.networkRead).toBe('24')
+      expect(result.precision).toBe('exact')
+      result = await ws.execute("eval 'cat /data/a.txt'", { provision: true })
+      expect(result.precision).toBe('unknown')
+      result = await ws.execute('wc -l < /data/a.txt', { provision: true })
+      expect(result.networkRead).toBe('24')
+      result = await ws.execute('cat /data/a.txt > /dev/null', { provision: true })
+      expect(result.networkWrite).toBe('0')
+      expect(result.precision).toBe('exact')
+    } finally {
+      await ws.close()
+    }
+  })
+})

--- a/typescript/packages/core/src/workspace/provision/redirect.ts
+++ b/typescript/packages/core/src/workspace/provision/redirect.ts
@@ -12,14 +12,52 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { ProvisionResult } from '../../provision/types.ts'
+import { rollupList } from '../../provision/rollup.ts'
+import { Precision, ProvisionResult } from '../../provision/types.ts'
+import { RedirectKind } from '../../shell/types.ts'
+import type { PathSpec } from '../../types.ts'
+import type { MountRegistry } from '../mount/registry.ts'
+import { handleCommandProvision } from './command.ts'
 import type { Session } from '../session/session.ts'
 import type { ProvisionNodeFn } from './pipes.ts'
 
+/**
+ * Plan a redirect: the inner command plus the redirect I/O.
+ *
+ * A `< file` source is read fully, so it is planned as a cat of the
+ * source (exact when the size resolves). A `>`/`>>` target writes the
+ * inner command's stdout, whose size is only knowable when the inner
+ * read total is: the write is bracketed 0..inner read high as a
+ * RANGE, or UNKNOWN when the inner plan has no usable ceiling. stderr
+ * redirects, fd duplications, /dev targets, and heredocs are filtered
+ * out by the caller and cost nothing.
+ */
 export async function handleRedirectProvision(
   provisionNode: ProvisionNodeFn,
+  registry: MountRegistry,
   command: unknown,
+  targets: readonly [RedirectKind, PathSpec][],
   session: Session,
 ): Promise<ProvisionResult> {
-  return provisionNode(command, session)
+  const inner = await provisionNode(command, session)
+  if (targets.length === 0) return inner
+  const children: ProvisionResult[] = [inner]
+  for (const [kind, target] of targets) {
+    if (kind === RedirectKind.STDIN) {
+      children.push(await handleCommandProvision(registry, ['cat', target], session))
+      continue
+    }
+    if (inner.networkReadHigh > 0) {
+      children.push(
+        new ProvisionResult({
+          networkWriteLow: 0,
+          networkWriteHigh: inner.networkReadHigh,
+          precision: Precision.RANGE,
+        }),
+      )
+    } else {
+      children.push(new ProvisionResult({ precision: Precision.UNKNOWN }))
+    }
+  }
+  return rollupList(';', children)
 }

--- a/typescript/packages/core/src/workspace/provision/redirect.ts
+++ b/typescript/packages/core/src/workspace/provision/redirect.ts
@@ -17,6 +17,7 @@ import { Precision, ProvisionResult } from '../../provision/types.ts'
 import { RedirectKind } from '../../shell/types.ts'
 import type { PathSpec } from '../../types.ts'
 import type { MountRegistry } from '../mount/registry.ts'
+import type { Namespace } from '../mount/namespace.ts'
 import { handleCommandProvision } from './command.ts'
 import type { Session } from '../session/session.ts'
 import type { ProvisionNodeFn } from './pipes.ts'
@@ -38,13 +39,14 @@ export async function handleRedirectProvision(
   command: unknown,
   targets: readonly [RedirectKind, PathSpec][],
   session: Session,
+  namespace: Namespace | null = null,
 ): Promise<ProvisionResult> {
   const inner = await provisionNode(command, session)
   if (targets.length === 0) return inner
   const children: ProvisionResult[] = [inner]
   for (const [kind, target] of targets) {
     if (kind === RedirectKind.STDIN) {
-      children.push(await handleCommandProvision(registry, ['cat', target], session))
+      children.push(await handleCommandProvision(registry, ['cat', target], session, namespace))
       continue
     }
     if (inner.networkReadHigh > 0) {

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -703,7 +703,11 @@ export class Workspace {
     const provResolved = provName !== '' ? resolveSafeguard(provName) : null
     const provTimeout = provResolved !== null ? provResolved.timeoutSeconds : null
     return runWithTimeout(
-      provisionNode({ registry: this.registry, executeFn }, rootNode, session),
+      provisionNode(
+        { registry: this.registry, executeFn, namespace: this.namespace },
+        rootNode,
+        session,
+      ),
       provTimeout,
       provName !== '' ? provName : '?',
     )


### PR DESCRIPTION
Follow-up to #428. The executor and the provision planner each walked the tree-sitter AST with their own hand-maintained `if node.type == ...` ladder, and the planner copy drifted: `if` crashed the planner until #428, `select` was costed as a bounded `for` (a confident wrong number), `FOO=1 cmd` and shell function calls fell to `unknown`, and `eval` was claimed free. This PR makes that drift structural instead of accidental, and closes #429 while inside the redirect handler.

**One classification, both walkers (Tier 2).** `shell/node_kind` (py + TS) owns every tree-sitter node-type check, including the lookahead that splits `select` from `for` and `until` from `while`. `execute_node` and `provision_node` both dispatch on `NodeKind`; node types neither supports classify as `UNSUPPORTED` for both (executor raises, planner reports honest `unknown`). Two more previously-duplicated decompositions now live in one place: redirect expansion (heredoc var substitution, target word expansion/classification, attached-pipeline detachment) moves from an inline executor block to `workspace/expand/redirects`, and the `FOO=1` prefix split moves to `shell/helpers.split_env_prefix`, both consumed by executor and planner.

**Planner drift fixes (Tier 1).**
- `FOO=1 cat a.txt` plans the command (was `unknown, 0`).
- Shell function calls plan the body: definitions seen during the plan land in a walk-local scope (planning never mutates the session), previously-executed definitions come from `session.functions`, and a recursion guard turns `f() { f; }; f` into `unknown` instead of a hang.
- `eval`/`source` leave the free-builtin set: they execute their payload, so `exact 0` was a lie; they now report `unknown`.
- `select` plans like `while` (unbounded, body floor) instead of a bounded `for`.
- `until` gets an explicit branch; comments are free.

**Redirect costing (closes #429).** `cmd < file` plans a full read of the source (`wc -l < a.txt` -> `net=24` floor, was `0`). `>`/`>>` to a mount bracket the write `0..inner-read-high` as a range (`cat a.txt > out.txt` -> `net=24 write=0-24 range`), degrading to `unknown` when the inner plan has no usable ceiling (`echo hi > f`). stderr redirects, fd duplications, `/dev` targets, and heredocs stay free.

**Drift guard.** A snippet-per-`NodeKind` table test in both languages pins the planner output for every statement kind and asserts the table covers the full enum, so adding a construct to the executor forces deciding what the planner reports for it (`tests/shell/test_node_kind.py`, `tests/workspace/provision/test_node_coverage.py`, TS twins).

**Coverage.** The shared battery gains 8 provision cases (env prefix, function call and recursion, eval, select, until, redirect-in, `/dev/null`), and `prov_redirect_out` now expects the write envelope. Every other line of the 2300-line shared truth is unchanged across all 11 runner/language combinations, which pins the executor refactor as behavior-identical.

Tests: full python suite, TS core/node/browser suites, and the integ matrix pass locally; pre-commit clean.


---

**Second commit: cross-mount and cache coverage on every backend.**

Every shared-truth runner mounts a second resource of its own backend at `/data2` (second bucket / tmpdir / SSH subroot / key prefix / OPFS root), and the battery gains a cross-mount section (concat, cp, mv, links, readlink, grep, find, pipes, cd across mounts; `du`'s explicit multi-mount rejection pinned) plus provision pins for symlinked and mount-spanning commands. `run_cache_verify_cases` (s3+gcs, onedrive) proves with backend byte accounting that a second `cat` of a cached file pulls **zero** bytes, directly or through a symlink (the link and its target share one cache entry, cross-mount links included), and that provision reports the hit.

Three bugs the new coverage caught, fixed in both languages:

- **Planner never followed symlinks**: provisioning a link statted the link path on the backend (`unknown`) and the cache-hit check missed the target's cache entry. `handle_command_provision` now namespace-follows like the dispatcher.
- **Cross-mount provision estimated everything against the first path's mount**: `cat /s3/x /gcs/y` reported unknown floors. Paths now group by their own mount and per-mount estimates sum (`30 exact`, order-independent), gated on `is_cross_mount` so commands the executor rejects across mounts (`md5`, `du`, `file`) still report honest `unknown`; glob operands ride with the primary group.
- **TS cross-mount executor passed raw argv as text args**: `grep -c pat a b` searched for the literal pattern `"-c"` (every count 0, exit 1) and `grep -n` lost all matches. The cross-mount path now parses against the mount spec like python.
