### PR TITLE
Provision trust fixes plus an s3 cost-model example

### DIFF
--- a/examples/python/s3/s3.py
+++ b/examples/python/s3/s3.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import copy as _copy
+import dataclasses
 import json
 import os
 import tempfile
@@ -60,6 +61,41 @@ def ops_summary() -> str:
     cache = ops.cache_bytes
     return (f"{len(ops.records)} ops, "
             f"{net} net, {cache} cache")
+
+
+S3_GET_PER_1K_USD = 0.0004
+S3_EGRESS_PER_GB_USD = 0.09
+
+
+def _price_wrap(original):
+    """Wrap a registered estimator so its bytes/ops become dollars."""
+
+    async def priced(accessor, paths, *texts, **kwargs):
+        result = await original(accessor, paths, *texts, **kwargs)
+        egress = result.network_read_high * S3_EGRESS_PER_GB_USD / 1e9
+        requests = result.read_ops * S3_GET_PER_1K_USD / 1000
+        result.estimated_cost_usd = egress + requests
+        return result
+
+    return priced
+
+
+def price_cat_reads(workspace: Workspace, mount_path: str) -> None:
+    """Attach an S3 price model to cat on one mount.
+
+    The shared estimator already computes bytes and request counts;
+    re-registering cat with a wrapped estimator converts them into
+    estimated_cost_usd, which the planner then combines across pipes,
+    branches, and loops like any other field (all-or-nothing: a stage
+    without a cost drops the total).
+    """
+    mount = workspace._registry.mount_for(mount_path)
+    cmd = mount.resolve_command("cat", None)
+    if cmd is not None and cmd.provision_fn is not None:
+        priced = dataclasses.replace(cmd,
+                                     provision_fn=_price_wrap(
+                                         cmd.provision_fn))
+        mount.register(priced)
 
 
 async def main():
@@ -216,6 +252,25 @@ async def main():
     print("\n--- plan after cache: grep mirage ... ---")
     print(f"  network_read: {dr.network_read}, cache_read: {dr.cache_read}")
     print(f"  cache_hits: {dr.cache_hits}, read_ops: {dr.read_ops}")
+
+    # ── cost model: attach dollars to the byte estimates ──
+    print("\n=== PROVISION COST MODEL ===\n")
+    price_cat_reads(ws, "/s3/data")
+    dr = await ws.execute("cat /s3/data/example.jsonl", provision=True)
+    print("--- priced plan: cat /s3/data/example.jsonl ---")
+    print(f"  network_read: {dr.network_read}, read_ops: {dr.read_ops}")
+    print(f"  estimated_cost_usd: {dr.estimated_cost_usd:.10f}")
+
+    dr = await ws.execute(
+        "for i in 1 2 3; do cat /s3/data/example.jsonl; done", provision=True)
+    print("--- priced plan: for-loop x3 ---")
+    print(f"  network_read: {dr.network_read}, "
+          f"estimated_cost_usd: {dr.estimated_cost_usd:.10f}")
+
+    dr = await ws.execute("cat /s3/data/example.jsonl | wc -l", provision=True)
+    print("--- priced plan: cat | wc (wc has no cost model) ---")
+    print(f"  estimated_cost_usd: {dr.estimated_cost_usd} "
+          "(all-or-nothing: an unpriced stage drops the total)")
 
     print("\n=== ACTUAL EXECUTION ===\n")
 

--- a/examples/python/s3/s3.py
+++ b/examples/python/s3/s3.py
@@ -14,7 +14,6 @@
 
 import asyncio
 import copy as _copy
-import dataclasses
 import json
 import os
 import tempfile
@@ -23,6 +22,7 @@ import uuid
 from dotenv import load_dotenv
 
 from mirage import MountMode, Workspace
+from mirage.commands.config import command
 from mirage.resource.ram import RAMResource
 from mirage.resource.s3 import S3Config, S3Resource
 from mirage.workspace.snapshot import ContentDriftError
@@ -80,22 +80,28 @@ def _price_wrap(original):
     return priced
 
 
+_BUILTIN_CAT = ws.mount("/s3/").resolve_command("cat", None)
+
+
+@command("cat",
+         resource="s3",
+         spec=_BUILTIN_CAT.spec,
+         provision=_price_wrap(_BUILTIN_CAT.provision_fn))
+async def priced_cat(accessor, paths, *texts, **kwargs):
+    return await _BUILTIN_CAT.fn(accessor, paths, *texts, **kwargs)
+
+
 def price_cat_reads(workspace: Workspace, mount_path: str) -> None:
     """Attach an S3 price model to cat on one mount.
 
-    The shared estimator already computes bytes and request counts;
-    re-registering cat with a wrapped estimator converts them into
+    The builtin estimator already computes bytes and request counts;
+    the @command decorator registers a cat that keeps the builtin
+    execution fn but carries a wrapped estimator converting them into
     estimated_cost_usd, which the planner then combines across pipes,
     branches, and loops like any other field (all-or-nothing: a stage
     without a cost drops the total).
     """
-    mount = workspace._registry.mount_for(mount_path)
-    cmd = mount.resolve_command("cat", None)
-    if cmd is not None and cmd.provision_fn is not None:
-        priced = dataclasses.replace(cmd,
-                                     provision_fn=_price_wrap(
-                                         cmd.provision_fn))
-        mount.register(priced)
+    workspace.mount(mount_path).register_fns([priced_cat])
 
 
 async def main():

--- a/integ/cases.py
+++ b/integ/cases.py
@@ -419,6 +419,10 @@ CASES: list[tuple[str, str]] = [
     ("sed_hold_accum", "sed -n 'H;${x;p}' /data/a.txt"),
     ("sed_escaped_delim", r"echo 'a/b' | sed 's/a\/b/c/'"),
     ("sed_no_final_nl", "sed 's/no/NO/' /data/no_nl.txt"),
+    # a case arm runs every statement up to its ;; terminator
+    ("case_multi_arm", "case x in x) echo one; echo two;; esac"),
+    ("case_multi_arm_default",
+     "case y in x) echo one;; *) echo fall; echo through;; esac"),
 
     # ----- tr advanced -----
     ("tr_squeeze", "echo aaabbbccc | tr -s a-z"),
@@ -965,7 +969,8 @@ PROVISION_CASES: list[tuple[str, str]] = [
     ("prov_jq_jsonl", 'jq ".id" /data/data.jsonl'),
     # ----- honest degradation -----
     ("prov_missing", "cat /data/missing.txt"),
-    ("prov_unprovisioned", "sed s/a/b/ /data/a.txt"),
+    ("prov_sed", "sed s/a/b/ /data/a.txt"),
+    ("prov_sed_inplace", "sed -i s/a/b/ /data/a.txt"),
     ("prov_write", "tee /data/prov_out.txt"),
     # ----- combinators -----
     ("prov_pipe", "cat /data/a.txt | head -c 4"),

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -356,6 +356,9 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
   ['sed_hold_accum', "sed -n 'H;${x;p}' /data/a.txt"],
   ['sed_escaped_delim', "echo 'a/b' | sed 's/a\\/b/c/'"],
   ['sed_no_final_nl', "sed 's/no/NO/' /data/no_nl.txt"],
+  // a case arm runs every statement up to its ;; terminator
+  ['case_multi_arm', 'case x in x) echo one; echo two;; esac'],
+  ['case_multi_arm_default', 'case y in x) echo one;; *) echo fall; echo through;; esac'],
 
   ["tr_squeeze", "echo aaabbbccc | tr -s a-z"],
   ["tr_complement", "cat /data/a.txt | tr -c 'a-z\\n' '*'"],
@@ -836,7 +839,8 @@ export const PROVISION_CASES: ReadonlyArray<readonly [string, string]> = [
   ["prov_jq_jsonl", 'jq ".id" /data/data.jsonl'],
   // ----- honest degradation -----
   ["prov_missing", "cat /data/missing.txt"],
-  ["prov_unprovisioned", "sed s/a/b/ /data/a.txt"],
+  ["prov_sed", "sed s/a/b/ /data/a.txt"],
+  ["prov_sed_inplace", "sed -i s/a/b/ /data/a.txt"],
   ["prov_write", "tee /data/prov_out.txt"],
   // ----- combinators -----
   ["prov_pipe", "cat /data/a.txt | head -c 4"],

--- a/integ/s3.py
+++ b/integ/s3.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import dataclasses
 import logging
 from collections import Counter
 from datetime import datetime, timezone
@@ -342,6 +343,30 @@ async def _run_coherence(endpoint: str) -> None:
     await _run(ws, "coherence:after_rmr_ls", "ls /s3/coh")
 
 
+S3_GET_PER_1K_USD = 0.0004
+S3_EGRESS_PER_GB_USD = 0.09
+
+
+def _price_wrap(original):
+
+    async def priced(accessor, paths, *texts, **kwargs):
+        result = await original(accessor, paths, *texts, **kwargs)
+        egress = result.network_read_high * S3_EGRESS_PER_GB_USD / 1e9
+        requests = result.read_ops * S3_GET_PER_1K_USD / 1000
+        result.estimated_cost_usd = egress + requests
+        return result
+
+    return priced
+
+
+def _price_cat(ws: Workspace, mount_path: str) -> None:
+    mount = ws._registry.mount_for(mount_path)
+    cmd = mount.resolve_command("cat", None)
+    assert cmd is not None and cmd.provision_fn is not None
+    mount.register(
+        dataclasses.replace(cmd, provision_fn=_price_wrap(cmd.provision_fn)))
+
+
 async def main() -> None:
     logging.getLogger("werkzeug").setLevel(logging.ERROR)
     server = ThreadedMotoServer(ip_address="127.0.0.1", port=0, verbose=False)
@@ -415,6 +440,27 @@ async def main() -> None:
             mode=MountMode.WRITE)
         await run_provision_cache_cases(ws_write, "/s3")
         await run_cache_verify_cases(ws_write, "/s3", "/gcs")
+        # user cost model: wrap cat's registered estimator so bytes and
+        # request counts become estimated_cost_usd, combined by the
+        # planner like any other field
+        _price_cat(ws_write, "/s3/data")
+        await ws_write.cache.clear()
+        result = await ws_write.execute("cat /s3/data/example.jsonl",
+                                        provision=True)
+        print("=== prov_cost_cat ===")
+        print(f"net={result.network_read} ops={result.read_ops} "
+              f"cost={result.estimated_cost_usd:.10f} "
+              f"precision={result.precision.value}")
+        result = await ws_write.execute(
+            "for i in 1 2; do cat /s3/data/example.jsonl; done",
+            provision=True)
+        print("=== prov_cost_for ===")
+        print(f"net={result.network_read} "
+              f"cost={result.estimated_cost_usd:.10f}")
+        result = await ws_write.execute("cat /s3/data/example.jsonl | wc -l",
+                                        provision=True)
+        print("=== prov_cost_unpriced_stage ===")
+        print(f"cost={result.estimated_cost_usd}")
         await _run_consistency(endpoint)
         await _run_coherence(endpoint)
     finally:

--- a/integ/s3.py
+++ b/integ/s3.py
@@ -13,7 +13,6 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
-import dataclasses
 import logging
 from collections import Counter
 from datetime import datetime, timezone
@@ -29,6 +28,10 @@ from moto.server import ThreadedMotoServer
 from mirage import MountMode, Workspace
 from mirage.accessor.s3 import S3Accessor
 from mirage.commands import safeguard as _safeguard
+from mirage.commands.builtin.generic_bind import make_file_read_provision
+from mirage.commands.config import command
+from mirage.commands.spec import SPECS
+from mirage.core.s3.stat import stat as _s3_stat
 from mirage.resource.gcs import GCSConfig, GCSResource
 from mirage.resource.minio import MinIOConfig, MinIOResource
 from mirage.resource.s3 import S3Config, S3Resource
@@ -359,12 +362,23 @@ def _price_wrap(original):
     return priced
 
 
+_PRICED_CAT_BASE: dict = {}
+
+
+@command("cat",
+         resource="s3",
+         spec=SPECS["cat"],
+         provision=_price_wrap(make_file_read_provision(_s3_stat)))
+async def _priced_cat(accessor, paths, *texts, **kwargs):
+    return await _PRICED_CAT_BASE["fn"](accessor, paths, *texts, **kwargs)
+
+
 def _price_cat(ws: Workspace, mount_path: str) -> None:
-    mount = ws._registry.mount_for(mount_path)
-    cmd = mount.resolve_command("cat", None)
-    assert cmd is not None and cmd.provision_fn is not None
-    mount.register(
-        dataclasses.replace(cmd, provision_fn=_price_wrap(cmd.provision_fn)))
+    mount = ws.mount(mount_path)
+    base = mount.resolve_command("cat", None)
+    assert base is not None and base.provision_fn is not None
+    _PRICED_CAT_BASE["fn"] = base.fn
+    mount.register_fns([_priced_cat])
 
 
 async def main() -> None:

--- a/integ/s3.ts
+++ b/integ/s3.ts
@@ -26,6 +26,8 @@ import {
   S3Resource,
   SeaweedFSResource,
   Workspace,
+  RegisteredCommand,
+  ProvisionResult,
 } from "@struktoai/mirage-node";
 import { ConsistencyPolicy } from "@struktoai/mirage-core";
 import { runCacheVerifyCases, runNotFound, runProvisionCacheCases } from "./cases.ts";
@@ -391,6 +393,39 @@ async function runCoherence(): Promise<void> {
   }
 }
 
+const S3_GET_PER_1K_USD = 0.0004;
+const S3_EGRESS_PER_GB_USD = 0.09;
+
+function priceCat(ws: Workspace, mountPath: string): void {
+  const mount = ws.registry.mountFor(mountPath);
+  if (mount === null) throw new Error(`no mount for ${mountPath}`);
+  const cmd = mount.resolveCommand("cat", null);
+  if (cmd === null || cmd.provisionFn === null) throw new Error("cat has no estimator");
+  const original = cmd.provisionFn;
+  const priced: typeof original = async (accessor, paths, texts, opts) => {
+    const result = (await original(accessor, paths, texts, opts)) as ProvisionResult;
+    const egress = (result.networkReadHigh * S3_EGRESS_PER_GB_USD) / 1e9;
+    const requests = (result.readOps * S3_GET_PER_1K_USD) / 1000;
+    result.estimatedCostUsd = egress + requests;
+    return result;
+  };
+  mount.register(
+    new RegisteredCommand({
+      name: cmd.name,
+      spec: cmd.spec,
+      resource: cmd.resource,
+      filetype: cmd.filetype,
+      fn: cmd.fn,
+      provisionFn: priced,
+      aggregate: cmd.aggregate,
+      src: cmd.src,
+      dst: cmd.dst,
+      write: cmd.write,
+      safeguard: cmd.safeguard,
+    }),
+  );
+}
+
 async function main(): Promise<void> {
   await seed();
   const ws = buildWorkspace();
@@ -469,6 +504,27 @@ async function main(): Promise<void> {
     try {
       await runProvisionCacheCases(wsWrite, "/s3");
       await runCacheVerifyCases(wsWrite, "/s3", "/gcs");
+      // user cost model: wrap cat's registered estimator so bytes and
+      // request counts become estimatedCostUsd, combined by the
+      // planner like any other field
+      priceCat(wsWrite, "/s3/data");
+      await wsWrite.cache.clear();
+      let priced = await wsWrite.execute("cat /s3/data/example.jsonl", { provision: true });
+      process.stdout.write("=== prov_cost_cat ===\n");
+      process.stdout.write(
+        `net=${priced.networkRead} ops=${String(priced.readOps)} ` +
+          `cost=${(priced.estimatedCostUsd ?? 0).toFixed(10)} precision=${priced.precision}\n`,
+      );
+      priced = await wsWrite.execute("for i in 1 2; do cat /s3/data/example.jsonl; done", {
+        provision: true,
+      });
+      process.stdout.write("=== prov_cost_for ===\n");
+      process.stdout.write(
+        `net=${priced.networkRead} cost=${(priced.estimatedCostUsd ?? 0).toFixed(10)}\n`,
+      );
+      priced = await wsWrite.execute("cat /s3/data/example.jsonl | wc -l", { provision: true });
+      process.stdout.write("=== prov_cost_unpriced_stage ===\n");
+      process.stdout.write(`cost=${String(priced.estimatedCostUsd)}\n`);
     } finally {
       await wsWrite.close();
     }

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -1162,6 +1162,12 @@ c
 === sed_no_final_nl ===
 NO trailing newline
 \ No newline at end of output
+=== case_multi_arm ===
+one
+two
+=== case_multi_arm_default ===
+fall
+through
 === tr_squeeze ===
 abc
 === tr_complement ===
@@ -1881,8 +1887,8 @@ disptree/d
 disptree/d/y.txt
 disptree/x.txt
 === history_last_two ===
-489  (cd /data && ls -R disptree)
-490  (cd /data && find disptree)
+491  (cd /data && ls -R disptree)
+492  (cd /data && find disptree)
 === bash_history_tail ===
 (cd /data && ls -R disptree)
 (cd /data && find disptree)
@@ -2327,8 +2333,10 @@ net=29 write=0 cache=0 ops=1 hits=0 precision=exact
 net=27 write=0 cache=0 ops=1 hits=0 precision=exact
 === prov_missing ===
 net=0 write=0 cache=0 ops=1 hits=0 precision=unknown
-=== prov_unprovisioned ===
-net=0 write=0 cache=0 ops=0 hits=0 precision=unknown
+=== prov_sed ===
+net=24 write=0 cache=0 ops=1 hits=0 precision=exact
+=== prov_sed_inplace ===
+net=24 write=0 cache=0 ops=1 hits=0 precision=unknown
 === prov_write ===
 net=0 write=0 cache=0 ops=0 hits=0 precision=unknown
 === prov_pipe ===
@@ -2392,7 +2400,7 @@ net=48 write=0 cache=0 ops=2 hits=0 precision=unknown
 === prov_for_nested ===
 net=24 write=0 cache=0 ops=4 hits=0 precision=exact
 === prov_cmdsub ===
-net=24 write=0 cache=0 ops=1 hits=0 precision=exact
+net=0 write=0 cache=0 ops=0 hits=0 precision=unknown
 === prov_deep_mix ===
 net=60 write=0 cache=0 ops=4 hits=0 precision=unknown
 === prov_env_prefix ===

--- a/integ/truth_dify.txt
+++ b/integ/truth_dify.txt
@@ -107,7 +107,7 @@ stat: /knowledge/__nf_missing__.txt: No such file or directory
 exit=1
 grep: /knowledge/__nf_missing__.txt: No such file or directory
 === prov_probe_cat ===
-net=0 write=0 cache=0 ops=0 hits=0 precision=unknown
+net=0 write=0 cache=190 ops=1 hits=1 precision=exact
 === prov_probe_grep ===
 net=0 write=0 cache=190 ops=1 hits=1 precision=exact
 === prov_probe_ls ===

--- a/integ/truth_s3.txt
+++ b/integ/truth_s3.txt
@@ -685,6 +685,12 @@ bytes=0
 net=0 write=0 cache=13 ops=1 hits=1 precision=exact
 === cachev_xmount_cp_warm_source ===
 bytes=13
+=== prov_cost_cat ===
+net=10414430 ops=1 cost=0.0009376987 precision=exact
+=== prov_cost_for ===
+net=20828860 cost=0.0018753974
+=== prov_cost_unpriced_stage ===
+cost=None
 === consistency:always:first ===
 v1
 === consistency:always:second ===

--- a/integ/truth_s3_ts.txt
+++ b/integ/truth_s3_ts.txt
@@ -565,6 +565,12 @@ bytes=0
 net=0 write=0 cache=13 ops=1 hits=1 precision=exact
 === cachev_xmount_cp_warm_source ===
 bytes=0
+=== prov_cost_cat ===
+net=10414430 ops=1 cost=0.0009376987 precision=exact
+=== prov_cost_for ===
+net=20828860 cost=0.0018753974
+=== prov_cost_unpriced_stage ===
+cost=null
 === consistency:always:first ===
 v1
 === consistency:always:second ===

--- a/python/mirage/commands/builtin/chroma/sed.py
+++ b/python/mirage/commands/builtin/chroma/sed.py
@@ -17,8 +17,10 @@ from functools import partial
 from mirage.commands.builtin.generic.sed_command import make_sed
 from mirage.core.chroma.glob import resolve_glob
 from mirage.core.chroma.read import read_bytes
+from mirage.core.chroma.stat import stat as _stat
 
 sed = make_sed(
+    stat_fn=_stat,
     resource="chroma",
     glob_fn=resolve_glob,
     make_read=lambda accessor, index, paths: partial(read_bytes, index=index),

--- a/python/mirage/commands/builtin/databricks_volume/sed.py
+++ b/python/mirage/commands/builtin/databricks_volume/sed.py
@@ -16,8 +16,10 @@ from mirage.commands.builtin.databricks_volume._helpers import (
     path_prefix, read_bytes_with_index)
 from mirage.commands.builtin.generic.sed_command import make_sed
 from mirage.core.databricks_volume.glob import resolve_glob
+from mirage.core.databricks_volume.stat import stat as _stat
 
 sed = make_sed(
+    stat_fn=_stat,
     resource="databricks_volume",
     glob_fn=resolve_glob,
     make_read=lambda accessor, index, paths: read_bytes_with_index(

--- a/python/mirage/commands/builtin/dify/cat.py
+++ b/python/mirage/commands/builtin/dify/cat.py
@@ -1,8 +1,11 @@
 from mirage.commands.builtin.generic.cat import cat as generic_cat
 from mirage.commands.builtin.generic_bind import CommandIO
+from mirage.commands.builtin.generic_bind.provision import \
+    make_file_read_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.dify.glob import resolve_glob
+from mirage.core.dify.stat import stat as dify_stat
 from mirage.io.cachable_iterator import CachableAsyncIterator
 from mirage.io.stream import async_chain
 from mirage.io.types import ByteSource, IOResult
@@ -17,7 +20,10 @@ def make_cat(ops: CommandIO):
             ``read_stream`` already serve cached bytes when warm.
     """
 
-    @command("cat", resource="dify", spec=SPECS["cat"])
+    @command("cat",
+             resource="dify",
+             spec=SPECS["cat"],
+             provision=make_file_read_provision(dify_stat))
     async def cat(
         accessor,
         paths: list[PathSpec],

--- a/python/mirage/commands/builtin/dify/sed.py
+++ b/python/mirage/commands/builtin/dify/sed.py
@@ -17,8 +17,10 @@ from functools import partial
 from mirage.commands.builtin.generic.sed_command import make_sed
 from mirage.core.dify.glob import resolve_glob
 from mirage.core.dify.read import read_bytes
+from mirage.core.dify.stat import stat as _stat
 
 sed = make_sed(
+    stat_fn=_stat,
     resource="dify",
     glob_fn=resolve_glob,
     make_read=lambda accessor, index, paths: partial(read_bytes, index=index),

--- a/python/mirage/commands/builtin/disk/sed.py
+++ b/python/mirage/commands/builtin/disk/sed.py
@@ -15,9 +15,11 @@
 from mirage.commands.builtin.generic.sed_command import make_sed
 from mirage.core.disk.glob import resolve_glob
 from mirage.core.disk.read import read_bytes
+from mirage.core.disk.stat import stat as _stat
 from mirage.core.disk.write import write_bytes
 
 sed = make_sed(
+    stat_fn=_stat,
     resource="disk",
     glob_fn=resolve_glob,
     glob_when=lambda accessor, index: accessor.root is not None,

--- a/python/mirage/commands/builtin/gdrive/sed.py
+++ b/python/mirage/commands/builtin/gdrive/sed.py
@@ -17,8 +17,10 @@ from functools import partial
 from mirage.commands.builtin.generic.sed_command import make_sed
 from mirage.core.gdrive.glob import resolve_glob
 from mirage.core.gdrive.read import read as gdrive_read
+from mirage.core.gdrive.stat import stat as _stat
 
 sed = make_sed(
+    stat_fn=_stat,
     resource="gdrive",
     glob_fn=resolve_glob,
     make_read=lambda accessor, index, paths: partial(gdrive_read, index=index),

--- a/python/mirage/commands/builtin/generic/sed_command.py
+++ b/python/mirage/commands/builtin/generic/sed_command.py
@@ -25,6 +25,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.sed import sed as generic_sed
+from mirage.commands.builtin.generic_bind.provision import make_sed_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.io.types import ByteSource, IOResult
@@ -100,9 +101,14 @@ def make_sed(
     glob_when: GlobWhen | None = None,
     write_bytes: Callable[..., Awaitable[None]] | None = None,
     inplace_error: tuple[type[Exception], str] | None = None,
+    stat_fn: Callable | None = None,
 ) -> Callable:
 
-    @command("sed", resource=resource, spec=SPECS["sed"])
+    @command(
+        "sed",
+        resource=resource,
+        spec=SPECS["sed"],
+        provision=make_sed_provision(stat_fn) if stat_fn is not None else None)
     async def sed(
         accessor: object,
         paths: list[PathSpec],

--- a/python/mirage/commands/builtin/generic_bind/__init__.py
+++ b/python/mirage/commands/builtin/generic_bind/__init__.py
@@ -19,8 +19,8 @@ from mirage.commands.builtin.generic_bind.factory import (
 from mirage.commands.builtin.generic_bind.provision import (
     default_provision, make_copy_provision, make_file_read_provision,
     make_head_tail_provision, make_jq_provision, make_search_provision,
-    make_transform_provision, metadata_provision, pure_provision,
-    write_metadata_provision)
+    make_sed_provision, make_transform_provision, metadata_provision,
+    pure_provision, write_metadata_provision)
 
 __all__ = [
     "CommandIO",
@@ -32,6 +32,7 @@ __all__ = [
     "make_jq_provision",
     "make_resolve_glob",
     "make_search_provision",
+    "make_sed_provision",
     "make_transform_provision",
     "metadata_provision",
     "pure_provision",

--- a/python/mirage/commands/builtin/generic_bind/provision.py
+++ b/python/mirage/commands/builtin/generic_bind/provision.py
@@ -206,6 +206,28 @@ def make_jq_provision(stat: Callable) -> Callable:
     return jq_provision
 
 
+def make_sed_provision(stat: Callable) -> Callable:
+    """Provision for sed: operands are read fully; -i writes back, so
+    the output keeps the read total as a floor with UNKNOWN."""
+    base = make_file_read_provision(stat)
+
+    async def sed_provision(
+        accessor: Accessor,
+        paths: list[PathSpec],
+        *_args: str,
+        command: str = "",
+        i: bool = False,
+        index: IndexCacheStore | None = None,
+        **kwargs,
+    ) -> ProvisionResult:
+        result = await base(accessor, paths, command=command, index=index)
+        if i:
+            result.precision = Precision.UNKNOWN
+        return result
+
+    return sed_provision
+
+
 def make_search_provision(stat: Callable) -> Callable:
     """Provision for grep/rg/jq: render pattern then delegate to file_read."""
     base = make_file_read_provision(stat)

--- a/python/mirage/commands/builtin/github/sed.py
+++ b/python/mirage/commands/builtin/github/sed.py
@@ -17,8 +17,10 @@ from functools import partial
 from mirage.commands.builtin.generic.sed_command import make_sed
 from mirage.core.github.glob import resolve_glob
 from mirage.core.github.read import read as github_read
+from mirage.core.github.stat import stat as _stat
 
 sed = make_sed(
+    stat_fn=_stat,
     resource="github",
     glob_fn=resolve_glob,
     glob_when=lambda accessor, index: index is not None,

--- a/python/mirage/commands/builtin/hf_buckets/sed.py
+++ b/python/mirage/commands/builtin/hf_buckets/sed.py
@@ -16,9 +16,11 @@ from mirage.accessor._hf import HF_RESOURCES
 from mirage.commands.builtin.generic.sed_command import make_sed
 from mirage.core.hf_buckets.glob import resolve_glob
 from mirage.core.hf_buckets.read import read_bytes
+from mirage.core.hf_buckets.stat import stat as _stat
 from mirage.core.hf_buckets.write import write_bytes
 
 sed = make_sed(
+    stat_fn=_stat,
     resource=HF_RESOURCES,
     glob_fn=resolve_glob,
     make_read=lambda accessor, index, paths: read_bytes,

--- a/python/mirage/commands/builtin/nextcloud/sed.py
+++ b/python/mirage/commands/builtin/nextcloud/sed.py
@@ -15,9 +15,11 @@
 from mirage.commands.builtin.generic.sed_command import make_sed
 from mirage.core.nextcloud.glob import resolve_glob
 from mirage.core.nextcloud.read import read_bytes
+from mirage.core.nextcloud.stat import stat as _stat
 from mirage.core.nextcloud.write import write_bytes
 
 sed = make_sed(
+    stat_fn=_stat,
     resource="nextcloud",
     glob_fn=resolve_glob,
     make_read=lambda accessor, index, paths: read_bytes,

--- a/python/mirage/commands/builtin/onedrive/sed.py
+++ b/python/mirage/commands/builtin/onedrive/sed.py
@@ -15,9 +15,11 @@
 from mirage.commands.builtin.generic.sed_command import make_sed
 from mirage.core.onedrive.glob import resolve_glob
 from mirage.core.onedrive.read import read_bytes
+from mirage.core.onedrive.stat import stat as _stat
 from mirage.core.onedrive.write import write_bytes
 
 sed = make_sed(
+    stat_fn=_stat,
     resource="onedrive",
     glob_fn=resolve_glob,
     make_read=lambda accessor, index, paths: read_bytes,

--- a/python/mirage/commands/builtin/ram/sed.py
+++ b/python/mirage/commands/builtin/ram/sed.py
@@ -15,9 +15,11 @@
 from mirage.commands.builtin.generic.sed_command import make_sed
 from mirage.core.ram.glob import resolve_glob
 from mirage.core.ram.read import read_bytes
+from mirage.core.ram.stat import stat as _stat
 from mirage.core.ram.write import write_bytes
 
 sed = make_sed(
+    stat_fn=_stat,
     resource="ram",
     glob_fn=resolve_glob,
     glob_when=lambda accessor, index: accessor.store is not None,

--- a/python/mirage/commands/builtin/redis/sed.py
+++ b/python/mirage/commands/builtin/redis/sed.py
@@ -15,9 +15,11 @@
 from mirage.commands.builtin.generic.sed_command import make_sed
 from mirage.core.redis.glob import resolve_glob
 from mirage.core.redis.read import read_bytes
+from mirage.core.redis.stat import stat as _stat
 from mirage.core.redis.write import write_bytes
 
 sed = make_sed(
+    stat_fn=_stat,
     resource="redis",
     glob_fn=resolve_glob,
     glob_when=lambda accessor, index: accessor.store is not None,

--- a/python/mirage/commands/builtin/s3/sed.py
+++ b/python/mirage/commands/builtin/s3/sed.py
@@ -15,9 +15,11 @@
 from mirage.commands.builtin.generic.sed_command import make_sed
 from mirage.core.s3.glob import resolve_glob
 from mirage.core.s3.read import read_bytes
+from mirage.core.s3.stat import stat as _stat
 from mirage.core.s3.write import write_bytes
 
 sed = make_sed(
+    stat_fn=_stat,
     resource="s3",
     glob_fn=resolve_glob,
     make_read=lambda accessor, index, paths: read_bytes,

--- a/python/mirage/commands/builtin/sharepoint/sed.py
+++ b/python/mirage/commands/builtin/sharepoint/sed.py
@@ -15,9 +15,11 @@
 from mirage.commands.builtin.generic.sed_command import make_sed
 from mirage.core.sharepoint.glob import resolve_glob
 from mirage.core.sharepoint.read import read_bytes
+from mirage.core.sharepoint.stat import stat as _stat
 from mirage.core.sharepoint.write import write_bytes
 
 sed = make_sed(
+    stat_fn=_stat,
     resource="sharepoint",
     glob_fn=resolve_glob,
     make_read=lambda accessor, index, paths: read_bytes,

--- a/python/mirage/commands/builtin/ssh/sed.py
+++ b/python/mirage/commands/builtin/ssh/sed.py
@@ -15,9 +15,11 @@
 from mirage.commands.builtin.generic.sed_command import make_sed
 from mirage.core.ssh.glob import resolve_glob
 from mirage.core.ssh.read import read_bytes
+from mirage.core.ssh.stat import stat as _stat
 from mirage.core.ssh.write import write_bytes
 
 sed = make_sed(
+    stat_fn=_stat,
     resource="ssh",
     glob_fn=resolve_glob,
     glob_when=lambda accessor, index: accessor.root is not None,

--- a/python/mirage/provision/types.py
+++ b/python/mirage/provision/types.py
@@ -90,12 +90,15 @@ class ProvisionResult(BaseModel):
             command (str | None): Command label for the scaled result.
 
         Returns:
-            ProvisionResult: New result with byte and op counters scaled;
-            precision is carried over and estimated_cost_usd is dropped.
+            ProvisionResult: New result with byte, op, and cost fields
+            scaled; precision is carried over.
         """
         fields = {f: getattr(self, f) * n for f in COMBINE_FIELDS}
+        cost = (self.estimated_cost_usd *
+                n if self.estimated_cost_usd is not None else None)
         return ProvisionResult(command=command,
                                precision=self.precision,
+                               estimated_cost_usd=cost,
                                **fields)
 
 

--- a/python/mirage/shell/helpers.py
+++ b/python/mirage/shell/helpers.py
@@ -327,22 +327,23 @@ def get_case_word(node: tree_sitter.Node) -> tree_sitter.Node:
 
 def get_case_items(
     node: tree_sitter.Node,
-) -> list[tuple[str, tree_sitter.Node | None]]:  # noqa: E125,E501
-    """Get (pattern, body) pairs from case."""
-    items: list[tuple[list[str], tree_sitter.Node | None]] = []
+) -> list[tuple[list[str], list[tree_sitter.Node]]]:  # noqa: E125,E501
+    """Get (patterns, body_statements) pairs from case.
+
+    An arm's body is every statement up to its ;; terminator, so
+    multi-statement arms (x) cmd1; cmd2;;) keep all commands.
+    """
+    items: list[tuple[list[str], list[tree_sitter.Node]]] = []
     for c in node.named_children:
         if c.type == NT.CASE_ITEM:
             patterns = []
-            body = None
+            body: list[tree_sitter.Node] = []
             for child in c.children:
-                if child.type in (NT.EXTGLOB_PATTERN, NT.WORD,
-                                  NT.CONCATENATION, NT.STRING):
+                if not body and child.type in (NT.EXTGLOB_PATTERN, NT.WORD,
+                                               NT.CONCATENATION, NT.STRING):
                     patterns.append(get_text(child))
-                elif child.is_named and child.type not in (
-                        NT.EXTGLOB_PATTERN, NT.WORD, NT.CONCATENATION,
-                        NT.STRING) and child.type != "|":
-                    body = child
-                    break
+                elif child.is_named and child.type != "|":
+                    body.append(child)
             if not patterns:
                 patterns = [get_text(c.named_children[0])]
             items.append((patterns, body))

--- a/python/mirage/workspace/executor/control.py
+++ b/python/mirage/workspace/executor/control.py
@@ -285,16 +285,27 @@ async def handle_until(
 async def handle_case(
     execute_node: Callable,
     word: str,
-    items: list[tuple[list[str], tree_sitter.Node | None]],
+    items: list[tuple[list[str], list[tree_sitter.Node]]],
     session: Session,
     stdin: ByteSource | None = None,
     call_stack: CallStack | None = None,
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
     for patterns, body in items:
         if any(fnmatch.fnmatch(word, p.strip()) for p in patterns):
-            if body is not None:
-                return await execute_node(body, session, stdin, call_stack)
-            return None, IOResult(), ExecutionNode(command="case", exit_code=0)
+            all_stdout: list[ByteSource] = []
+            merged_io = IOResult()
+            last_exec = ExecutionNode(command="case", exit_code=0)
+            for stmt in body:
+                stdout, io, last_exec = await execute_node(
+                    stmt, session, stdin, call_stack)
+                stdin = None
+                if stdout is not None:
+                    all_stdout.append(stdout)
+                merged_io = await merged_io.merge(io)
+            if len(all_stdout) == 1:
+                return all_stdout[0], merged_io, last_exec
+            combined = async_chain(*all_stdout) if all_stdout else None
+            return combined, merged_io, last_exec
     return None, IOResult(), ExecutionNode(command="case", exit_code=0)
 
 

--- a/python/mirage/workspace/node/provision_node.py
+++ b/python/mirage/workspace/node/provision_node.py
@@ -203,8 +203,11 @@ async def provision_node(
         items = get_case_items(node)
         children = []
         for _, body in items:
-            if body is not None:
-                children.append(await recurse(body, session))
+            if not body:
+                continue
+            stmts = [await recurse(stmt, session) for stmt in body]
+            children.append(stmts[0] if len(stmts) ==
+                            1 else rollup_list(";", stmts))
         if children:
             return rollup_list("||", children)
         return ProvisionResult(precision=Precision.EXACT)

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -614,6 +614,16 @@ class Workspace:
         except KeyError:
             return None
 
+    async def _plan_eval_stub(self, cmd: str, **opts: Any) -> IOResult:
+        """Inert evaluator for provision walks.
+
+        A dry run must never execute: a command substitution with side
+        effects ($(tee ...)) would otherwise run while "estimating".
+        Substitutions expand to empty, so affected words degrade the
+        plan to honest UNKNOWN instead of resolving via execution.
+        """
+        return IOResult()
+
     async def _exec_recursion(self, cancel: asyncio.Event | None, cmd: str,
                               **opts: Any) -> Any:
         # The executor's internal eval ($(), source, eval, xargs, ...):
@@ -707,7 +717,7 @@ class Workspace:
                                 if prov_resolved is not None else None)
                 return await run_with_timeout(
                     provision_node(self._registry, self.dispatch,
-                                   exec_recursion, self._namespace, ast,
+                                   self._plan_eval_stub, self._namespace, ast,
                                    effective_session), prov_timeout, prov_name)
             io, _ = await run_command_tree(
                 self.dispatch,

--- a/python/tests/provision/test_provision_types.py
+++ b/python/tests/provision/test_provision_types.py
@@ -36,3 +36,15 @@ def test_precision_values():
     assert Precision.EXACT == "exact"
     assert Precision.RANGE == "range"
     assert Precision.UNKNOWN == "unknown"
+
+
+def test_scaled_multiplies_cost():
+    result = ProvisionResult(network_read_low=10,
+                             network_read_high=10,
+                             read_ops=1,
+                             estimated_cost_usd=0.5)
+    tripled = result.scaled(3)
+    assert tripled.network_read_low == 30
+    assert tripled.estimated_cost_usd == 1.5
+    free = ProvisionResult(network_read_low=10, network_read_high=10)
+    assert free.scaled(3).estimated_cost_usd is None

--- a/python/tests/shell/test_helpers.py
+++ b/python/tests/shell/test_helpers.py
@@ -213,8 +213,14 @@ def test_get_if_multiple_elif():
 def test_get_case_empty_body():
     items = get_case_items(_first("case x in a) ;; b) echo b;; esac"))
     assert len(items) == 2
-    assert items[0][1] is None
-    assert items[1][1] is not None
+    assert items[0][1] == []
+    assert len(items[1][1]) == 1
+
+
+def test_get_case_multi_statement_body():
+    items = get_case_items(_first("case x in a) echo 1; echo 2;; esac"))
+    assert len(items) == 1
+    assert len(items[0][1]) == 2
 
 
 def test_get_redirect_stderr():

--- a/python/tests/workspace/provision/test_node_coverage.py
+++ b/python/tests/workspace/provision/test_node_coverage.py
@@ -116,3 +116,31 @@ async def test_provision_follows_symlinks_and_spans_mounts():
     result = await ws.execute("cat /data2/b.txt /data/a.txt", provision=True)
     assert result.network_read == "30"
     await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_provision_is_dry_and_case_arms_run_fully():
+    ws = Workspace({"/data": RAMResource()}, mode=MountMode.WRITE)
+    await ws.execute("tee /data/a.txt > /dev/null", stdin=b"x" * 24)
+    # a dry run must not execute command substitutions
+    result = await ws.execute(
+        "cat $(tee /data/leak.txt > /dev/null; echo /data/a.txt)",
+        provision=True)
+    assert result.precision.value == "unknown"
+    listing = await (await ws.execute("ls /data")).stdout_str()
+    assert "leak.txt" not in listing
+    # a case arm runs every statement up to its ;; terminator
+    out = await (
+        await
+        ws.execute("case x in x) echo one; echo two;; esac")).stdout_str()
+    assert out == "one\ntwo\n"
+    result = await ws.execute(
+        "case x in x) cat /data/a.txt; cat /data/a.txt;; esac", provision=True)
+    assert result.network_read == "48"
+    # sed reads its operands; -i degrades to a floor
+    result = await ws.execute("sed s/x/y/ /data/a.txt", provision=True)
+    assert result.network_read == "24"
+    assert result.precision.value == "exact"
+    result = await ws.execute("sed -i s/x/y/ /data/a.txt", provision=True)
+    assert result.precision.value == "unknown"
+    await ws.close()

--- a/typescript/packages/browser/src/commands/builtin/opfs/sed.ts
+++ b/typescript/packages/browser/src/commands/builtin/opfs/sed.ts
@@ -15,9 +15,11 @@
 import { ResourceName, makeSed } from '@struktoai/mirage-core'
 import type { OPFSAccessor } from '../../../accessor/opfs.ts'
 import { stream as opfsStream } from '../../../core/opfs/stream.ts'
+import { stat as opfsProvStat } from '../../../core/opfs/stat.ts'
 import { writeBytes as opfsWrite } from '../../../core/opfs/write.ts'
 
 export const OPFS_SED = makeSed<OPFSAccessor>({
+  stat: (a, p) => opfsProvStat(a, p),
   resource: ResourceName.OPFS,
   stream: (a, p) => opfsStream(a, p),
   write: (a, p, d) => opfsWrite(a, p, d),

--- a/typescript/packages/core/src/commands/builtin/box/sed.ts
+++ b/typescript/packages/core/src/commands/builtin/box/sed.ts
@@ -15,10 +15,12 @@
 import type { BoxAccessor } from '../../../accessor/box.ts'
 import { resolveGlob } from '../../../core/box/glob.ts'
 import { stream as boxStream } from '../../../core/box/read.ts'
+import { stat as boxStat } from '../../../core/box/stat.ts'
 import { ResourceName } from '../../../types.ts'
 import { makeSed } from '../generic/sed_command.ts'
 
 export const BOX_SED = makeSed<BoxAccessor>({
+  stat: (a, p) => boxStat(a, p),
   resource: ResourceName.BOX,
   stream: (a, p, opts) => boxStream(a, p, opts.index ?? undefined),
   glob: (a, paths, opts) => resolveGlob(a, paths, opts.index ?? undefined),

--- a/typescript/packages/core/src/commands/builtin/chroma/sed.ts
+++ b/typescript/packages/core/src/commands/builtin/chroma/sed.ts
@@ -14,11 +14,13 @@
 
 import type { ChromaAccessor } from '../../../accessor/chroma.ts'
 import { resolveGlob } from '../../../core/chroma/glob.ts'
+import { stat as chromaProvStat } from '../../../core/chroma/stat.ts'
 import { readStream } from '../../../core/chroma/read.ts'
 import { ResourceName } from '../../../types.ts'
 import { makeSed } from '../generic/sed_command.ts'
 
 export const CHROMA_SED = makeSed<ChromaAccessor>({
+  stat: (a, p) => chromaProvStat(a, p),
   resource: ResourceName.CHROMA,
   stream: (a, p, opts) => readStream(a, p, opts.index ?? undefined),
   glob: (a, paths, opts) => resolveGlob(a, paths, opts.index ?? undefined),

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/sed.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/sed.ts
@@ -14,12 +14,14 @@
 
 import type { DatabricksVolumeAccessor } from '../../../accessor/databricks_volume.ts'
 import { resolveGlob } from '../../../core/databricks_volume/glob.ts'
+import { stat as databricksProvStat } from '../../../core/databricks_volume/stat.ts'
 import { readStream as dbxStream } from '../../../core/databricks_volume/stream.ts'
 import { writeBytes as dbxWrite } from '../../../core/databricks_volume/write.ts'
 import { ResourceName } from '../../../types.ts'
 import { makeSed } from '../generic/sed_command.ts'
 
 export const DATABRICKS_VOLUME_SED = makeSed<DatabricksVolumeAccessor>({
+  stat: (a, p) => databricksProvStat(a, p),
   resource: ResourceName.DATABRICKS_VOLUME,
   stream: (a, p) => dbxStream(a, p),
   write: (a, p, d) => dbxWrite(a, p, d),

--- a/typescript/packages/core/src/commands/builtin/dropbox/sed.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/sed.ts
@@ -14,11 +14,13 @@
 
 import type { DropboxAccessor } from '../../../accessor/dropbox.ts'
 import { resolveGlob } from '../../../core/dropbox/glob.ts'
+import { stat as dropboxProvStat } from '../../../core/dropbox/stat.ts'
 import { stream as dropboxStream } from '../../../core/dropbox/read.ts'
 import { ResourceName } from '../../../types.ts'
 import { makeSed } from '../generic/sed_command.ts'
 
 export const DROPBOX_SED = makeSed<DropboxAccessor>({
+  stat: (a, p) => dropboxProvStat(a, p),
   resource: ResourceName.DROPBOX,
   stream: (a, p, opts) => dropboxStream(a, p, opts.index ?? undefined),
   glob: (a, paths, opts) => resolveGlob(a, paths, opts.index ?? undefined),

--- a/typescript/packages/core/src/commands/builtin/gdrive/sed.ts
+++ b/typescript/packages/core/src/commands/builtin/gdrive/sed.ts
@@ -14,11 +14,13 @@
 
 import type { GDriveAccessor } from '../../../accessor/gdrive.ts'
 import { resolveGlob } from '../../../core/gdrive/glob.ts'
+import { stat as gdriveProvStat } from '../../../core/gdrive/stat.ts'
 import { stream as gdriveStream } from '../../../core/gdrive/read.ts'
 import { ResourceName } from '../../../types.ts'
 import { makeSed } from '../generic/sed_command.ts'
 
 export const GDRIVE_SED = makeSed<GDriveAccessor>({
+  stat: (a, p) => gdriveProvStat(a, p),
   resource: ResourceName.GDRIVE,
   stream: (a, p, opts) => gdriveStream(a, p, opts.index ?? undefined),
   glob: (a, paths, opts) => resolveGlob(a, paths, opts.index ?? undefined),

--- a/typescript/packages/core/src/commands/builtin/generic/sed_command.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/sed_command.ts
@@ -19,6 +19,8 @@ import { PathSpec, type ResourceName } from '../../../types.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { resolvePath } from '../../spec/parser.ts'
+import type { StatOp } from '../generic_bind/adapter.ts'
+import { makeSedProvision } from '../generic_bind/provision.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { sedGeneric } from './sed.ts'
 
@@ -60,14 +62,17 @@ export interface SedBackend<A extends Accessor> {
   glob?: (accessor: A, paths: PathSpec[], opts: CommandOpts) => Promise<PathSpec[]>
   /** Human-readable mount name used in the read-only `-i` rejection message. */
   readOnlyMount?: string
+  /** Backend stat for the provision estimator. Omit to plan as unknown. */
+  stat?: StatOp<A>
 }
 
 export function makeSed<A extends Accessor>(backend: SedBackend<A>) {
-  const { resource, stream, write, glob, readOnlyMount } = backend
+  const { resource, stream, write, glob, readOnlyMount, stat } = backend
   return command<A>({
     name: 'sed',
     resource,
     spec: specOf('sed'),
+    provision: stat !== undefined ? makeSedProvision(stat) : null,
     fn: async (
       accessor: A,
       paths: PathSpec[],

--- a/typescript/packages/core/src/commands/builtin/generic_bind/index.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/index.ts
@@ -27,6 +27,7 @@ export {
   makeHeadTailProvision,
   makeJqProvision,
   makeSearchProvision,
+  makeSedProvision,
   makeTransformProvision,
   metadataProvision,
   pureProvision,

--- a/typescript/packages/core/src/commands/builtin/generic_bind/provision.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/provision.ts
@@ -263,6 +263,19 @@ export function pureProvision(
   )
 }
 
+/**
+ * Provision for sed: operands are read fully; -i writes back, so the
+ * output keeps the read total as a floor with UNKNOWN.
+ */
+export function makeSedProvision<A extends Accessor>(stat: StatOp<A>): ProvisionFn<A> {
+  const base = makeFileReadProvision(stat)
+  return async (accessor: A, paths: PathSpec[], texts: string[], opts: CommandOpts) => {
+    const result = (await base(accessor, paths, texts, opts)) as ProvisionResult
+    if (opts.flags.i === true) result.precision = Precision.UNKNOWN
+    return result
+  }
+}
+
 /** Provision for grep/rg: render the pattern then delegate to file_read. */
 export function makeSearchProvision<A extends Accessor>(stat: StatOp<A>): ProvisionFn<A> {
   const base = makeFileReadProvision(stat)

--- a/typescript/packages/core/src/commands/builtin/github/sed.ts
+++ b/typescript/packages/core/src/commands/builtin/github/sed.ts
@@ -14,11 +14,13 @@
 
 import type { GitHubAccessor } from '../../../accessor/github.ts'
 import { resolveGlob } from '../../../core/github/glob.ts'
+import { stat as githubProvStat } from '../../../core/github/stat.ts'
 import { stream as githubStream } from '../../../core/github/read.ts'
 import { ResourceName } from '../../../types.ts'
 import { makeSed } from '../generic/sed_command.ts'
 
 export const GITHUB_SED = makeSed<GitHubAccessor>({
+  stat: (a, p) => githubProvStat(a, p),
   resource: ResourceName.GITHUB,
   stream: (a, p, opts) => githubStream(a, p, opts.index ?? undefined),
   glob: (a, paths, opts) => resolveGlob(a, paths, opts.index ?? undefined),

--- a/typescript/packages/core/src/commands/builtin/ram/sed.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/sed.ts
@@ -14,11 +14,13 @@
 
 import type { RAMAccessor } from '../../../accessor/ram.ts'
 import { stream as ramStream } from '../../../core/ram/stream.ts'
+import { stat as ramProvStat } from '../../../core/ram/stat.ts'
 import { writeBytes as ramWrite } from '../../../core/ram/write.ts'
 import { ResourceName } from '../../../types.ts'
 import { makeSed } from '../generic/sed_command.ts'
 
 export const RAM_SED = makeSed<RAMAccessor>({
+  stat: (a, p) => ramProvStat(a, p),
   resource: ResourceName.RAM,
   stream: (a, p) => ramStream(a, p),
   write: (a, p, d) => ramWrite(a, p, d),

--- a/typescript/packages/core/src/commands/builtin/s3/sed.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/sed.ts
@@ -14,12 +14,14 @@
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
 import { resolveGlob } from '../../../core/s3/glob.ts'
+import { stat as s3ProvStat } from '../../../core/s3/stat.ts'
 import { stream as s3Stream } from '../../../core/s3/stream.ts'
 import { write as s3Write } from '../../../core/s3/write.ts'
 import { ResourceName } from '../../../types.ts'
 import { makeSed } from '../generic/sed_command.ts'
 
 export const S3_SED = makeSed<S3Accessor>({
+  stat: (a, p) => s3ProvStat(a, p),
   resource: ResourceName.S3,
   stream: (a, p) => s3Stream(a, p),
   write: (a, p, d) => s3Write(a, p, d),

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -167,6 +167,7 @@ export {
   makeJqProvision,
   makeResolveGlob,
   makeSearchProvision,
+  makeSedProvision,
   makeTransformProvision,
   metadataProvision,
   pureProvision,

--- a/typescript/packages/core/src/provision/types.test.ts
+++ b/typescript/packages/core/src/provision/types.test.ts
@@ -41,3 +41,19 @@ describe('Precision enum', () => {
     expect(Precision.UNKNOWN).toBe('unknown')
   })
 })
+
+describe('scaled cost', () => {
+  it('multiplies estimatedCostUsd and keeps null costs null', () => {
+    const priced = new ProvisionResult({
+      networkReadLow: 10,
+      networkReadHigh: 10,
+      readOps: 1,
+      estimatedCostUsd: 0.5,
+    })
+    const tripled = priced.scaled(3)
+    expect(tripled.networkReadLow).toBe(30)
+    expect(tripled.estimatedCostUsd).toBe(1.5)
+    const free = new ProvisionResult({ networkReadLow: 10, networkReadHigh: 10 })
+    expect(free.scaled(3).estimatedCostUsd).toBeNull()
+  })
+})

--- a/typescript/packages/core/src/provision/types.ts
+++ b/typescript/packages/core/src/provision/types.ts
@@ -93,11 +93,12 @@ export class ProvisionResult {
 
   /**
    * Multiply every combinable field by an iteration count (for-loops).
-   * Precision is carried over and estimatedCostUsd is dropped.
+   * Precision is carried over; estimatedCostUsd scales with the count.
    */
   scaled(n: number, command: string | null = null): ProvisionResult {
     const init: ProvisionResultInit = { command, precision: this.precision }
     for (const f of COMBINE_FIELDS) init[f] = this[f] * n
+    if (this.estimatedCostUsd !== null) init.estimatedCostUsd = this.estimatedCostUsd * n
     return new ProvisionResult(init)
   }
 }

--- a/typescript/packages/core/src/shell/helpers.ts
+++ b/typescript/packages/core/src/shell/helpers.ts
@@ -272,23 +272,28 @@ export function getCaseWord(node: TSNodeLike): TSNodeLike {
   return first
 }
 
-export function getCaseItems(node: TSNodeLike): [string[], TSNodeLike | null][] {
-  const items: [string[], TSNodeLike | null][] = []
+/**
+ * Get (patterns, bodyStatements) pairs from case. An arm's body is
+ * every statement up to its ;; terminator, so multi-statement arms
+ * (x) cmd1; cmd2;;) keep all commands.
+ */
+export function getCaseItems(node: TSNodeLike): [string[], TSNodeLike[]][] {
+  const items: [string[], TSNodeLike[]][] = []
   for (const c of node.namedChildren) {
     if (c.type !== NT.CASE_ITEM) continue
     const patterns: string[] = []
-    let body: TSNodeLike | null = null
+    const body: TSNodeLike[] = []
     for (const child of c.children) {
       if (
-        child.type === NT.EXTGLOB_PATTERN ||
-        child.type === NT.WORD ||
-        child.type === NT.CONCATENATION ||
-        child.type === NT.STRING
+        body.length === 0 &&
+        (child.type === NT.EXTGLOB_PATTERN ||
+          child.type === NT.WORD ||
+          child.type === NT.CONCATENATION ||
+          child.type === NT.STRING)
       ) {
         patterns.push(getText(child))
       } else if (child.isNamed === true && child.type !== '|') {
-        body = child
-        break
+        body.push(child)
       }
     }
     if (patterns.length === 0) {

--- a/typescript/packages/core/src/workspace/executor/control.test.ts
+++ b/typescript/packages/core/src/workspace/executor/control.test.ts
@@ -208,10 +208,10 @@ describe('handleCase', () => {
       which = n.text
       return Promise.resolve([null, new IOResult(), new ExecutionNode()])
     }
-    const items: [string[], TSNodeLike | null][] = [
-      [['a*'], node('A')],
-      [['b*'], node('B')],
-      [['*'], node('catchall')],
+    const items: [string[], TSNodeLike[]][] = [
+      [['a*'], [node('A')]],
+      [['b*'], [node('B')]],
+      [['*'], [node('catchall')]],
     ]
     await handleCase(execute, 'banana', items, new Session({ sessionId: 'test' }))
     expect(which).toBe('B')
@@ -223,9 +223,9 @@ describe('handleCase', () => {
       which = n.text
       return Promise.resolve([null, new IOResult(), new ExecutionNode()])
     }
-    const items: [string[], TSNodeLike | null][] = [
-      [['a*'], node('A')],
-      [['*'], node('catchall')],
+    const items: [string[], TSNodeLike[]][] = [
+      [['a*'], [node('A')]],
+      [['*'], [node('catchall')]],
     ]
     await handleCase(execute, 'xyz', items, new Session({ sessionId: 'test' }))
     expect(which).toBe('catchall')

--- a/typescript/packages/core/src/workspace/executor/control.ts
+++ b/typescript/packages/core/src/workspace/executor/control.ts
@@ -290,15 +290,28 @@ export function handleUntil(
 export async function handleCase(
   executeNode: ExecuteNodeFn,
   word: string,
-  items: readonly [readonly string[], TSNodeLike | null][],
+  items: readonly [readonly string[], readonly TSNodeLike[]][],
   session: Session,
   stdin: ByteSource | null = null,
   callStack: CallStack | null = null,
 ): Promise<Result> {
   for (const [patterns, body] of items) {
     if (patterns.some((p) => fnmatch(word, p.trim()))) {
-      if (body !== null) return executeNode(body, session, stdin, callStack)
-      return [null, new IOResult(), new ExecutionNode({ command: 'case', exitCode: 0 })]
+      const allStdout: ByteSource[] = []
+      let mergedIo = new IOResult()
+      let lastExec = new ExecutionNode({ command: 'case', exitCode: 0 })
+      let stageStdin = stdin
+      for (const stmt of body) {
+        const [stdout, io, execNode] = await executeNode(stmt, session, stageStdin, callStack)
+        stageStdin = null
+        lastExec = execNode
+        if (stdout !== null) allStdout.push(stdout)
+        mergedIo = await mergedIo.merge(io)
+      }
+      const first = allStdout[0]
+      if (allStdout.length === 1 && first !== undefined) return [first, mergedIo, lastExec]
+      const combined = allStdout.length > 0 ? asyncChain(...allStdout) : null
+      return [combined, mergedIo, lastExec]
     }
   }
   return [null, new IOResult(), new ExecutionNode({ command: 'case', exitCode: 0 })]

--- a/typescript/packages/core/src/workspace/node/provision_node.ts
+++ b/typescript/packages/core/src/workspace/node/provision_node.ts
@@ -230,7 +230,11 @@ export async function provisionNode(
     const items = getCaseItems(node)
     const children: ProvisionResult[] = []
     for (const [, body] of items) {
-      if (body !== null) children.push(await recurse(body, session))
+      if (body.length === 0) continue
+      const stmts: ProvisionResult[] = []
+      for (const stmt of body) stmts.push(await recurse(stmt, session))
+      const first = stmts[0]
+      children.push(stmts.length === 1 && first !== undefined ? first : rollupList(';', stmts))
     }
     if (children.length > 0) return rollupList('||', children)
     return new ProvisionResult({ precision: Precision.EXACT })

--- a/typescript/packages/core/src/workspace/provision/node_coverage.test.ts
+++ b/typescript/packages/core/src/workspace/provision/node_coverage.test.ts
@@ -159,4 +159,35 @@ describe('planner covers every statement kind', () => {
       await ws.close()
     }
   })
+
+  it('is dry, runs case arms fully, and prices sed reads', async () => {
+    const ws = buildWorkspace()
+    try {
+      await ws.execute('tee /data/a.txt > /dev/null', { stdin: ENC.encode('x'.repeat(24)) })
+      // a dry run must not execute command substitutions
+      let result = await ws.execute('cat $(tee /data/leak.txt > /dev/null; echo /data/a.txt)', {
+        provision: true,
+      })
+      expect(result.precision).toBe('unknown')
+      const listing = new TextDecoder().decode((await ws.execute('ls /data')).stdout)
+      expect(listing).not.toContain('leak.txt')
+      // a case arm runs every statement up to its ;; terminator
+      const out = new TextDecoder().decode(
+        (await ws.execute('case x in x) echo one; echo two;; esac')).stdout,
+      )
+      expect(out).toBe('one\ntwo\n')
+      result = await ws.execute('case x in x) cat /data/a.txt; cat /data/a.txt;; esac', {
+        provision: true,
+      })
+      expect(result.networkRead).toBe('48')
+      // sed reads its operands; -i degrades to a floor
+      result = await ws.execute('sed s/x/y/ /data/a.txt', { provision: true })
+      expect(result.networkRead).toBe('24')
+      expect(result.precision).toBe('exact')
+      result = await ws.execute('sed -i s/x/y/ /data/a.txt', { provision: true })
+      expect(result.precision).toBe('unknown')
+    } finally {
+      await ws.close()
+    }
+  })
 })

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -691,14 +691,11 @@ export class Workspace {
     const root = parser.parse(command)
     const rootNode = root as unknown as TSNodeLike
     const session = this.sessionManager.get(this.sessionManager.defaultId)
-    const executeFn: ExecuteFn = async (cmd) => {
-      const res = await this.execute(cmd)
-      return new IOResult({
-        stdout: res.stdout,
-        stderr: res.stderr,
-        exitCode: res.exitCode,
-      })
-    }
+    // A dry run must never execute: a command substitution with side
+    // effects ($(tee ...)) would otherwise run while "estimating".
+    // Substitutions expand to empty, so affected words degrade the
+    // plan to honest UNKNOWN instead of resolving via execution.
+    const executeFn: ExecuteFn = () => Promise.resolve(new IOResult())
     const provName = command.trim().split(/\s+/)[0] ?? ''
     const provResolved = provName !== '' ? resolveSafeguard(provName) : null
     const provTimeout = provResolved !== null ? provResolved.timeoutSeconds : null

--- a/typescript/packages/node/src/commands/builtin/disk/sed.ts
+++ b/typescript/packages/node/src/commands/builtin/disk/sed.ts
@@ -15,9 +15,11 @@
 import { ResourceName, makeSed } from '@struktoai/mirage-core'
 import type { DiskAccessor } from '../../../accessor/disk.ts'
 import { stream as diskStream } from '../../../core/disk/stream.ts'
+import { stat as diskProvStat } from '../../../core/disk/stat.ts'
 import { writeBytes as diskWrite } from '../../../core/disk/write.ts'
 
 export const DISK_SED = makeSed<DiskAccessor>({
+  stat: (a, p) => diskProvStat(a, p),
   resource: ResourceName.DISK,
   stream: (a, p) => diskStream(a, p),
   write: (a, p, d) => diskWrite(a, p, d),

--- a/typescript/packages/node/src/commands/builtin/hf/sed.ts
+++ b/typescript/packages/node/src/commands/builtin/hf/sed.ts
@@ -16,9 +16,11 @@ import { makeSed } from '@struktoai/mirage-core'
 import type { HfAccessor } from '../../../accessor/hf.ts'
 import { HF_RESOURCES } from '../../../accessor/hf.ts'
 import { stream as hfStream } from '../../../core/hf/stream.ts'
+import { stat as hfProvStat } from '../../../core/hf/stat.ts'
 import { write as hfWrite } from '../../../core/hf/write.ts'
 
 export const HF_SED = makeSed<HfAccessor>({
+  stat: (a, p) => hfProvStat(a, p),
   resource: [...HF_RESOURCES],
   stream: (a, p) => hfStream(a, p),
   write: (a, p, d) => hfWrite(a, p, d),

--- a/typescript/packages/node/src/commands/builtin/redis/sed.ts
+++ b/typescript/packages/node/src/commands/builtin/redis/sed.ts
@@ -15,9 +15,11 @@
 import { ResourceName, makeSed } from '@struktoai/mirage-core'
 import type { RedisAccessor } from '../../../accessor/redis.ts'
 import { stream as redisStream } from '../../../core/redis/stream.ts'
+import { stat as redisProvStat } from '../../../core/redis/stat.ts'
 import { writeBytes as redisWrite } from '../../../core/redis/write.ts'
 
 export const REDIS_SED = makeSed<RedisAccessor>({
+  stat: (a, p) => redisProvStat(a, p),
   resource: ResourceName.REDIS,
   stream: (a, p) => redisStream(a, p),
   write: (a, p, d) => redisWrite(a, p, d),

--- a/typescript/packages/node/src/commands/builtin/ssh/sed.ts
+++ b/typescript/packages/node/src/commands/builtin/ssh/sed.ts
@@ -15,9 +15,11 @@
 import { ResourceName, makeSed } from '@struktoai/mirage-core'
 import type { SSHAccessor } from '../../../accessor/ssh.ts'
 import { stream as sshStream } from '../../../core/ssh/stream.ts'
+import { stat as sshProvStat } from '../../../core/ssh/stat.ts'
 import { writeBytes as sshWrite } from '../../../core/ssh/write.ts'
 
 export const SSH_SED = makeSed<SSHAccessor>({
+  stat: (a, p) => sshProvStat(a, p),
   resource: ResourceName.SSH,
   stream: (a, p) => sshStream(a, p),
   write: (a, p, d) => sshWrite(a, p, d),


### PR DESCRIPTION
Phase A (trust) plus the Phase B worked example.

## Trust fixes

- **Multi-statement case arms ran only their first statement.** `get_case_items` now returns the arm's full statement list; the executor runs every statement (stdout chained, stdin to the first) and the planner sums them per arm. Both languages, plus `case_multi_arm` integ cases.
- **Provision executed command substitutions.** The plan walk now receives an inert evaluator, so `$(...)` never runs during a dry plan; affected words degrade the plan to an honest unknown. Pinned by a test that asserts no file leaks from `$(tee ...)` during provision, and the `prov_cmdsub` integ case.
- **sed was unprovisioned everywhere.** New `make_sed_provision` (file-read estimate; `-i` floors to unknown) wired through `make_sed` in 14 py and 12 TS backends. `prov_sed` / `prov_sed_inplace` integ cases.
- **`scaled(n)` dropped `estimated_cost_usd`.** Loop costs now scale (visible in the integ: the for-loop pin is exactly 2x the single cat).
- **dify cat** gets a file-read estimator.

## Cost-model example (Phase B)

`examples/python/s3/s3.py` shows how a user turns byte estimates into dollars: resolve the mount's `cat`, wrap its `provision_fn` to price GET requests + egress, and `mount.register` the replacement. Deterministic integ pins in `integ/s3.py` and `integ/s3.ts` (`prov_cost_cat`, `prov_cost_for` at 2x, `prov_cost_unpriced_stage` staying None under all-or-nothing).

## Verification

Full py suite, TS core/node/browser suites, all 11 shared-truth runners byte-identical, s3 suites against moto (py) and MinIO (TS), pre-commit clean.