### PR TITLE
fix(cache): thread backend fingerprints into apply_io so ALWAYS mode stops evicting non-MD5 backends

### DIFF
--- a/python/mirage/cache/file/io.py
+++ b/python/mirage/cache/file/io.py
@@ -18,14 +18,54 @@ from typing import Callable
 
 from mirage.cache.file.mixin import FileCacheMixin
 from mirage.io import CachableAsyncIterator, IOResult
+from mirage.observe.record import OpRecord
 
 logger = logging.getLogger(__name__)
+
+
+def read_fingerprint(records: list[OpRecord] | None, path: str) -> str | None:
+    """Latest backend fingerprint recorded for a read of ``path``.
+
+    Backends stamp read records with the content identifier they
+    returned (S3 ETag, OneDrive cTag, Postgres sha256). Threading it
+    into the cache entry lets ALWAYS-mode ``is_fresh`` compare like
+    with like; the MD5-of-content default only matches simple-PUT S3
+    objects.
+
+    Args:
+        records (list[OpRecord] | None): Op records emitted by the
+            command that produced the IOResult being applied.
+        path (str): Virtual path used as the cache key.
+    """
+    if records is None:
+        return None
+    for rec in reversed(records):
+        if rec.op == "read" and rec.path == path and rec.fingerprint:
+            return rec.fingerprint
+    return None
+
+
+async def _set_cached(
+    cache: FileCacheMixin,
+    path: str,
+    data: bytes,
+    records: list[OpRecord] | None,
+) -> None:
+    fingerprint = read_fingerprint(records, path)
+    if fingerprint is None and await cache.get(path) == data:
+        # Warm read: the bytes were served from this cache, so there is
+        # no backend read record. Re-setting would replace the backend
+        # fingerprint stamped on the cold read with the MD5 default and
+        # force ALWAYS mode to evict and refetch on every read.
+        return
+    await cache.set(path, data, fingerprint=fingerprint)
 
 
 async def apply_io(
     cache: FileCacheMixin,
     io: IOResult,
     is_cacheable: Callable[[str], bool] | None = None,
+    records: list[OpRecord] | None = None,
 ) -> None:
     cache_set = set(io.cache)
     max_bytes = getattr(cache, "max_drain_bytes", None)
@@ -38,16 +78,18 @@ async def apply_io(
         if data is None:
             continue
         if isinstance(data, bytes):
-            await cache.set(path, data)
+            await _set_cached(cache, path, data, records)
         elif isinstance(data, CachableAsyncIterator):
             if data.exhausted:
-                await cache.set(path, b"".join(data.buffered_chunks))
+                await _set_cached(cache, path, b"".join(data.buffered_chunks),
+                                  records)
             else:
                 if (hasattr(cache, "_drain_tasks")
                         and path not in cache._drain_tasks
                         and not await cache.exists(path)):
                     task = asyncio.create_task(
-                        _background_drain(cache, path, data, max_bytes))
+                        _background_drain(cache, path, data, max_bytes,
+                                          records))
                     cache._drain_tasks[path] = task
                     task.add_done_callback(
                         lambda t, p=path: cache._drain_tasks.pop(p, None))
@@ -64,6 +106,7 @@ async def _background_drain(
     path: str,
     it: CachableAsyncIterator,
     max_bytes: int | None = None,
+    records: list[OpRecord] | None = None,
 ) -> None:
     """Drain an unconsumed stream and write to cache.
 
@@ -71,15 +114,21 @@ async def _background_drain(
     shutdown. If max_bytes is set and the drain exceeds it without
     exhausting the source, the partial buffer is discarded and the path
     is not cached (next read will fetch fresh from the resource).
+    The fingerprint is looked up after the drain: streaming backends
+    stamp their read record lazily, once the GET response arrives.
     """
     try:
         if max_bytes is None:
             materialized = await it.drain()
-            await cache.add(path, materialized)
+            await cache.add(path,
+                            materialized,
+                            fingerprint=read_fingerprint(records, path))
             return
         materialized, fully_drained = await it.drain_bounded(max_bytes)
         if fully_drained:
-            await cache.add(path, materialized)
+            await cache.add(path,
+                            materialized,
+                            fingerprint=read_fingerprint(records, path))
         else:
             logger.info(
                 "cache drain budget exceeded for %s "

--- a/python/mirage/workspace/dispatcher.py
+++ b/python/mirage/workspace/dispatcher.py
@@ -17,6 +17,7 @@ from typing import Any
 from mirage.cache.file import io as cache_io
 from mirage.cache.manager import CacheManager
 from mirage.io import IOResult
+from mirage.observe.record import OpRecord
 from mirage.types import ConsistencyPolicy, FileStat, PathSpec
 from mirage.workspace.mount import MountEntry
 from mirage.workspace.mount.namespace import Namespace
@@ -101,8 +102,13 @@ class Dispatcher:
         raw, _ = await self.dispatch("readdir", scope)
         return raw
 
-    async def apply_io(self, io: IOResult) -> None:
-        await cache_io.apply_io(self._cache, io, self.is_cacheable_path)
+    async def apply_io(self,
+                       io: IOResult,
+                       records: list[OpRecord] | None = None) -> None:
+        await cache_io.apply_io(self._cache,
+                                io,
+                                self.is_cacheable_path,
+                                records=records)
 
     def is_cacheable_path(self, path: str) -> bool:
         try:

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -35,6 +35,7 @@ except ImportError:
 from mirage.io import IOResult
 from mirage.observe.context import RecordingScope
 from mirage.observe.observer import Observer
+from mirage.observe.record import OpRecord
 from mirage.observe.store import ObserverStore
 from mirage.ops import Ops
 from mirage.ops.open import make_open
@@ -602,8 +603,10 @@ class Workspace:
 
     # ── execution ────────────────────────────────────────────────────────────
 
-    async def apply_io(self, io: IOResult) -> None:
-        await self._dispatcher.apply_io(io)
+    async def apply_io(self,
+                       io: IOResult,
+                       records: list[OpRecord] | None = None) -> None:
+        await self._dispatcher.apply_io(io, records=records)
 
     async def _invalidate_after_write_by_path(self, path: str) -> None:
         await self._dispatcher.invalidate_after_write_by_path(path)
@@ -722,7 +725,7 @@ class Workspace:
                 cancel,
             )
             session.last_exit_code = io.exit_code
-            await self.apply_io(io)
+            await self.apply_io(io, records=scope.records)
             return io
         except CommandTimeoutError as exc:
             logger.debug("command %r timed out after %ss", exc.command,

--- a/python/tests/cache/file/test_io.py
+++ b/python/tests/cache/file/test_io.py
@@ -19,6 +19,17 @@ import pytest
 from mirage.cache.file import io as cache_io
 from mirage.cache.file.ram import RAMFileCacheStore
 from mirage.io import CachableAsyncIterator, IOResult
+from mirage.observe.record import OpRecord
+
+
+def _read_record(path: str, fingerprint: str | None) -> OpRecord:
+    return OpRecord(op="read",
+                    path=path,
+                    source="s3",
+                    bytes=0,
+                    timestamp=0,
+                    duration_ms=0,
+                    fingerprint=fingerprint)
 
 
 @pytest.fixture
@@ -76,6 +87,78 @@ async def test_apply_io_multiple_paths(cache):
     await cache_io.apply_io(cache, io)
     assert await cache.get("/a.txt") == b"aaa"
     assert await cache.get("/b.txt") == b"bbb"
+
+
+# ── backend fingerprint threading ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apply_io_sets_backend_fingerprint_from_records(cache):
+    """A read record with a backend fingerprint (ETag, cTag, sha256)
+    stamps the cache entry, so ALWAYS-mode is_fresh can match it."""
+    io = IOResult(reads={"/s3/f.txt": b"hello"}, cache=["/s3/f.txt"])
+    records = [_read_record("/s3/f.txt", "etag-multipart-2")]
+    await cache_io.apply_io(cache, io, records=records)
+    assert await cache.get("/s3/f.txt") == b"hello"
+    assert await cache.is_fresh("/s3/f.txt", "etag-multipart-2")
+
+
+@pytest.mark.asyncio
+async def test_apply_io_exhausted_stream_uses_record_fingerprint(cache):
+    """An exhausted stream read carries its record fingerprint too."""
+    stream = _make_stream(b"hello")
+    assert await stream.drain() == b"hello"
+    io = IOResult(reads={"/s3/f.txt": stream}, cache=["/s3/f.txt"])
+    records = [_read_record("/s3/f.txt", "etag-multipart-2")]
+    await cache_io.apply_io(cache, io, records=records)
+    assert await cache.is_fresh("/s3/f.txt", "etag-multipart-2")
+
+
+@pytest.mark.asyncio
+async def test_apply_io_warm_reapply_preserves_fingerprint(cache):
+    """A warm read re-applies cache-served bytes with no backend read
+    record; the entry's backend fingerprint must survive, not be
+    replaced by the MD5-of-content default."""
+    cold = IOResult(reads={"/s3/f.txt": b"hello"}, cache=["/s3/f.txt"])
+    await cache_io.apply_io(cache,
+                            cold,
+                            records=[_read_record("/s3/f.txt", "etag-3")])
+    warm = IOResult(reads={"/s3/f.txt": b"hello"}, cache=["/s3/f.txt"])
+    await cache_io.apply_io(cache, warm, records=[])
+    assert await cache.is_fresh("/s3/f.txt", "etag-3")
+
+
+@pytest.mark.asyncio
+async def test_apply_io_changed_data_without_record_resets_entry(cache):
+    """New bytes with no backend fingerprint still replace the entry."""
+    cold = IOResult(reads={"/s3/f.txt": b"old"}, cache=["/s3/f.txt"])
+    await cache_io.apply_io(cache,
+                            cold,
+                            records=[_read_record("/s3/f.txt", "etag-3")])
+    fresh = IOResult(writes={"/s3/f.txt": b"new"}, cache=["/s3/f.txt"])
+    await cache_io.apply_io(cache, fresh, records=[])
+    assert await cache.get("/s3/f.txt") == b"new"
+    assert not await cache.is_fresh("/s3/f.txt", "etag-3")
+
+
+@pytest.mark.asyncio
+async def test_apply_io_drain_uses_fingerprint_recorded_during_drain():
+    """Streaming backends set the record fingerprint lazily when the GET
+    response arrives, i.e. during the background drain. The drained
+    entry must pick it up."""
+    cache = RAMFileCacheStore()
+    records: list[OpRecord] = []
+
+    async def _gen():
+        records.append(_read_record("/s3/f.txt", "etag-multipart-2"))
+        yield b"hello"
+
+    stream = CachableAsyncIterator(_gen())
+    io = IOResult(reads={"/s3/f.txt": stream}, cache=["/s3/f.txt"])
+    await cache_io.apply_io(cache, io, records=records)
+    await asyncio.sleep(0.05)
+    assert await cache.get("/s3/f.txt") == b"hello"
+    assert await cache.is_fresh("/s3/f.txt", "etag-multipart-2")
 
 
 # ── cache invalidation ──────────────────────────────────────────────────

--- a/python/tests/integration/s3_mock.py
+++ b/python/tests/integration/s3_mock.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import hashlib
+from collections import Counter
 from contextlib import ExitStack
 from datetime import datetime, timezone
 from unittest.mock import patch
@@ -127,10 +128,18 @@ class MultiBucketS3Client:
 
     def __init__(self,
                  buckets: dict[str, dict[str, bytes]],
-                 versioned: set[str] | None = None) -> None:
+                 versioned: set[str] | None = None,
+                 etag_suffix: str = "") -> None:
         self.buckets = buckets
         self.versioned = versioned or set()
         self._versions: dict[tuple[str, str], list[tuple[str, bytes]]] = {}
+        # Non-empty simulates multipart-upload ETags ("<md5>-2"), which are
+        # NOT the MD5 of the content.
+        self.etag_suffix = etag_suffix
+        self.calls: Counter[str] = Counter()
+
+    def _etag(self, data: bytes) -> str:
+        return hashlib.md5(data).hexdigest() + self.etag_suffix
 
     def _objects(self, bucket: str) -> dict[str, bytes]:
         if bucket not in self.buckets:
@@ -154,6 +163,7 @@ class MultiBucketS3Client:
                          Key: str,
                          Range: str | None = None,
                          VersionId: str | None = None) -> dict:
+        self.calls["get_object"] += 1
         vid_for_resp = self._track(Bucket, Key)
         if VersionId is not None:
             history = self._versions.get((Bucket, Key), [])
@@ -168,7 +178,7 @@ class MultiBucketS3Client:
             if Key not in objects:
                 raise _mock_s3_error("NoSuchKey")
             data = objects[Key]
-        etag = hashlib.md5(data).hexdigest()
+        etag = self._etag(data)
         if Range is not None:
             data = _slice_range(data, Range)
         resp: dict = {"Body": _AsyncMockBody(data), "ETag": f'"{etag}"'}
@@ -177,11 +187,12 @@ class MultiBucketS3Client:
         return resp
 
     async def head_object(self, Bucket: str, Key: str) -> dict:
+        self.calls["head_object"] += 1
         objects = self._objects(Bucket)
         if Key not in objects:
             raise _mock_s3_error("NoSuchKey")
         data = objects[Key]
-        etag = hashlib.md5(data).hexdigest()
+        etag = self._etag(data)
         vid = self._track(Bucket, Key)
         resp: dict = {
             "ContentLength": len(data),
@@ -238,18 +249,24 @@ class MultiBucketSession:
 
     def __init__(self,
                  buckets: dict[str, dict[str, bytes]],
-                 versioned: set[str] | None = None) -> None:
-        self._client = MultiBucketS3Client(buckets, versioned=versioned)
+                 versioned: set[str] | None = None,
+                 etag_suffix: str = "") -> None:
+        self._client = MultiBucketS3Client(buckets,
+                                           versioned=versioned,
+                                           etag_suffix=etag_suffix)
 
     def client(self, **kwargs):
         return self._client
 
 
-def patch_s3_multi(buckets: dict[str, dict[str, bytes]],
-                   versioned: set[str] | None = None) -> ExitStack:
-    session = MultiBucketSession(buckets, versioned=versioned)
+def patch_s3_session(session: MultiBucketSession) -> ExitStack:
     stack = ExitStack()
     for mod in _CORE_MODULES:
         stack.enter_context(patch(f"{mod}.async_session",
                                   return_value=session))
     return stack
+
+
+def patch_s3_multi(buckets: dict[str, dict[str, bytes]],
+                   versioned: set[str] | None = None) -> ExitStack:
+    return patch_s3_session(MultiBucketSession(buckets, versioned=versioned))

--- a/python/tests/workspace/test_fingerprint_spike.py
+++ b/python/tests/workspace/test_fingerprint_spike.py
@@ -17,8 +17,10 @@ import time
 
 from mirage.resource.disk import DiskResource
 from mirage.resource.ram import RAMResource
+from mirage.resource.s3 import S3Config, S3Resource
 from mirage.types import ConsistencyPolicy, MountMode
 from mirage.workspace import Workspace
+from tests.integration.s3_mock import MultiBucketSession, patch_s3_session
 
 
 def test_disk_always_refetches_after_external_mutation(tmp_path):
@@ -73,6 +75,43 @@ def test_disk_lazy_keeps_stale_cache_after_external_mutation(tmp_path):
     assert first == b"v1"
     assert second in (b"v1", b"v2"), (
         "LAZY allowed to serve cached bytes; this test just confirms no crash")
+
+
+def test_s3_always_warm_read_serves_cache_for_non_md5_fingerprint():
+    """Multipart-style ETags are not the MD5 of the content. The cold
+    read must stamp the cache entry with the backend ETag so a warm read
+    under ALWAYS passes the freshness check and serves from cache
+    instead of evicting and refetching on every read."""
+    store = {"data.txt": b"name,age\nalice,30\n"}
+    session = MultiBucketSession({"test-bucket": store}, etag_suffix="-2")
+    client = session._client
+    with patch_s3_session(session):
+        config = S3Config(
+            bucket="test-bucket",
+            region="us-east-1",
+            aws_access_key_id="fake",
+            aws_secret_access_key="fake",
+        )
+        ws = Workspace(
+            {"/s3": (S3Resource(config), MountMode.WRITE)},
+            mode=MountMode.WRITE,
+            consistency=ConsistencyPolicy.ALWAYS,
+        )
+
+        async def run() -> tuple[bytes, bytes]:
+            io1 = await ws.execute("cat /s3/data.txt | wc -c")
+            first = await io1.materialize_stdout()
+            io2 = await ws.execute("cat /s3/data.txt | wc -c")
+            second = await io2.materialize_stdout()
+            return first, second
+
+        first, second = asyncio.run(run())
+    assert first == second == b"18\n"
+    assert client.calls["head_object"] >= 1, (
+        "ALWAYS must consult the remote fingerprint on the warm read")
+    assert client.calls["get_object"] == 1, (
+        "warm read with an unchanged remote fingerprint must serve from "
+        "cache; a second get_object means the entry was evicted")
 
 
 def test_ram_falls_back_to_lazy_when_fingerprint_absent():

--- a/python/tests/workspace/test_io_key_prefix.py
+++ b/python/tests/workspace/test_io_key_prefix.py
@@ -64,9 +64,9 @@ def _capture_io(ws: Workspace) -> list:
     captured: list = []
     orig = ws._dispatcher.apply_io
 
-    async def recording(result):
+    async def recording(result, records=None):
         captured.append(result)
-        return await orig(result)
+        return await orig(result, records=records)
 
     ws._dispatcher.apply_io = recording
     return captured

--- a/typescript/packages/core/src/cache/file/io.test.ts
+++ b/typescript/packages/core/src/cache/file/io.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it } from 'vitest'
 
 import { CachableAsyncIterator } from '../../io/cachable_iterator.ts'
 import { IOResult } from '../../io/types.ts'
+import { OpRecord } from '../../observe/record.ts'
 import { applyIo } from './io.ts'
 import { RAMFileCacheStore } from './ram.ts'
 
@@ -83,6 +84,87 @@ describe('cache population via applyIo', () => {
     await applyIo(cache, io)
     expect(DEC.decode((await cache.get('/a.txt')) ?? undefined)).toBe('aaa')
     expect(DEC.decode((await cache.get('/b.txt')) ?? undefined)).toBe('bbb')
+  })
+})
+
+function readRecord(path: string, fingerprint: string | null): OpRecord {
+  return new OpRecord({
+    op: 'read',
+    path,
+    source: 's3',
+    bytes: 0,
+    timestamp: 0,
+    durationMs: 0,
+    fingerprint,
+  })
+}
+
+describe('backend fingerprint threading', () => {
+  it('stamps the cache entry with the record fingerprint', async () => {
+    const cache = new RAMFileCacheStore()
+    const io = new IOResult({
+      reads: { '/s3/f.txt': ENC.encode('hello') },
+      cache: ['/s3/f.txt'],
+    })
+    await applyIo(cache, io, undefined, [readRecord('/s3/f.txt', 'etag-multipart-2')])
+    expect(DEC.decode((await cache.get('/s3/f.txt')) ?? undefined)).toBe('hello')
+    expect(await cache.isFresh('/s3/f.txt', 'etag-multipart-2')).toBe(true)
+  })
+
+  it('uses the record fingerprint for an exhausted stream', async () => {
+    const cache = new RAMFileCacheStore()
+    const stream = makeStream('hello')
+    expect(DEC.decode(await stream.drain())).toBe('hello')
+    const io = new IOResult({ reads: { '/s3/f.txt': stream }, cache: ['/s3/f.txt'] })
+    await applyIo(cache, io, undefined, [readRecord('/s3/f.txt', 'etag-multipart-2')])
+    expect(await cache.isFresh('/s3/f.txt', 'etag-multipart-2')).toBe(true)
+  })
+
+  it('preserves the entry fingerprint on a warm re-apply', async () => {
+    const cache = new RAMFileCacheStore()
+    const cold = new IOResult({
+      reads: { '/s3/f.txt': ENC.encode('hello') },
+      cache: ['/s3/f.txt'],
+    })
+    await applyIo(cache, cold, undefined, [readRecord('/s3/f.txt', 'etag-3')])
+    const warm = new IOResult({
+      reads: { '/s3/f.txt': ENC.encode('hello') },
+      cache: ['/s3/f.txt'],
+    })
+    await applyIo(cache, warm, undefined, [])
+    expect(await cache.isFresh('/s3/f.txt', 'etag-3')).toBe(true)
+  })
+
+  it('replaces the entry when data changed without a record', async () => {
+    const cache = new RAMFileCacheStore()
+    const cold = new IOResult({
+      reads: { '/s3/f.txt': ENC.encode('old') },
+      cache: ['/s3/f.txt'],
+    })
+    await applyIo(cache, cold, undefined, [readRecord('/s3/f.txt', 'etag-3')])
+    const fresh = new IOResult({
+      writes: { '/s3/f.txt': ENC.encode('new') },
+      cache: ['/s3/f.txt'],
+    })
+    await applyIo(cache, fresh, undefined, [])
+    expect(DEC.decode((await cache.get('/s3/f.txt')) ?? undefined)).toBe('new')
+    expect(await cache.isFresh('/s3/f.txt', 'etag-3')).toBe(false)
+  })
+
+  it('picks up a fingerprint recorded during the background drain', async () => {
+    const cache = new RAMFileCacheStore()
+    const records: OpRecord[] = []
+    async function* gen(): AsyncGenerator<Uint8Array> {
+      await Promise.resolve()
+      records.push(readRecord('/s3/f.txt', 'etag-multipart-2'))
+      yield ENC.encode('hello')
+    }
+    const stream = new CachableAsyncIterator(gen())
+    const io = new IOResult({ reads: { '/s3/f.txt': stream }, cache: ['/s3/f.txt'] })
+    await applyIo(cache, io, undefined, records)
+    await sleep(50)
+    expect(DEC.decode((await cache.get('/s3/f.txt')) ?? undefined)).toBe('hello')
+    expect(await cache.isFresh('/s3/f.txt', 'etag-multipart-2')).toBe(true)
   })
 })
 

--- a/typescript/packages/core/src/cache/file/io.ts
+++ b/typescript/packages/core/src/cache/file/io.ts
@@ -14,12 +14,61 @@
 
 import { CachableAsyncIterator, concat } from '../../io/cachable_iterator.ts'
 import { materialize, type IOResult } from '../../io/types.ts'
+import type { OpRecord } from '../../observe/record.ts'
 import type { FileCache } from './mixin.ts'
+
+/**
+ * Latest backend fingerprint recorded for a read of `path`.
+ *
+ * Backends stamp read records with the content identifier they returned
+ * (S3 ETag, OneDrive cTag, Postgres sha256). Threading it into the cache
+ * entry lets ALWAYS-mode `isFresh` compare like with like; the
+ * MD5-of-content default only matches simple-PUT S3 objects.
+ */
+export function readFingerprint(
+  records: readonly OpRecord[] | undefined,
+  path: string,
+): string | null {
+  if (records === undefined) return null
+  for (let i = records.length - 1; i >= 0; i--) {
+    const rec = records[i]
+    if (rec?.op === 'read' && rec.path === path && rec.fingerprint) {
+      return rec.fingerprint
+    }
+  }
+  return null
+}
+
+function bytesEqual(a: Uint8Array | null, b: Uint8Array): boolean {
+  if (a?.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+async function setCached(
+  cache: FileCache,
+  path: string,
+  data: Uint8Array,
+  records: readonly OpRecord[] | undefined,
+): Promise<void> {
+  const fingerprint = readFingerprint(records, path)
+  if (fingerprint === null && bytesEqual(await cache.get(path), data)) {
+    // Warm read: the bytes were served from this cache, so there is no
+    // backend read record. Re-setting would replace the backend
+    // fingerprint stamped on the cold read with the MD5 default and
+    // force ALWAYS mode to evict and refetch on every read.
+    return
+  }
+  await cache.set(path, data, { fingerprint })
+}
 
 export async function applyIo(
   cache: FileCache,
   io: IOResult,
   isCacheable?: (path: string) => boolean,
+  records?: readonly OpRecord[],
 ): Promise<void> {
   const cacheSet = new Set(io.cache)
   const maxBytes = cache.maxDrainBytes
@@ -28,14 +77,14 @@ export async function applyIo(
     const source = io.reads[path] ?? io.writes[path]
     if (source === undefined) continue
     if (source instanceof Uint8Array) {
-      await cache.set(path, source)
+      await setCached(cache, path, source, records)
     } else if (source instanceof CachableAsyncIterator) {
       if (source.exhausted) {
-        await cache.set(path, concat(source.bufferedChunks))
+        await setCached(cache, path, concat(source.bufferedChunks), records)
       } else {
         const tasks = cache.drainTasks
         if (tasks !== undefined && !tasks.has(path) && !(await cache.exists(path))) {
-          const task = backgroundDrain(cache, tasks, path, source, maxBytes)
+          const task = backgroundDrain(cache, tasks, path, source, maxBytes, records)
           tasks.set(path, task)
           void task.finally(() => {
             if (tasks.get(path) === task) tasks.delete(path)
@@ -44,7 +93,7 @@ export async function applyIo(
       }
     } else {
       const data = await materialize(source)
-      await cache.set(path, data)
+      await setCached(cache, path, data, records)
     }
   }
   for (const path of Object.keys(io.writes)) {
@@ -56,13 +105,16 @@ export async function applyIo(
 
 // Drains an unconsumed stream and fills the cache, mirroring the Python
 // _background_drain. Promises cannot be cancelled, so remove()/clear()
-// delete the map entry and the result is discarded here instead.
+// delete the map entry and the result is discarded here instead. The
+// fingerprint is looked up after the drain: streaming backends stamp
+// their read record lazily, once the GET response arrives.
 async function backgroundDrain(
   cache: FileCache,
   tasks: Map<string, Promise<void>>,
   path: string,
   it: CachableAsyncIterator,
   maxBytes: number | null,
+  records?: readonly OpRecord[],
 ): Promise<void> {
   try {
     let materialized: Uint8Array
@@ -73,7 +125,9 @@ async function backgroundDrain(
       if (!fullyDrained) return
       materialized = data
     }
-    if (tasks.has(path)) await cache.add(path, materialized)
+    if (tasks.has(path)) {
+      await cache.add(path, materialized, { fingerprint: readFingerprint(records, path) })
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     console.warn(`background drain failed for ${path}: ${msg}`)

--- a/typescript/packages/core/src/workspace/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher.ts
@@ -17,6 +17,7 @@ import { applyIo } from '../cache/file/io.ts'
 import type { FileCache } from '../cache/file/mixin.ts'
 import { IOResult } from '../io/types.ts'
 import { runWithRevisions } from '../observe/context.ts'
+import type { OpRecord } from '../observe/record.ts'
 import type { OpsRegistry } from '../ops/registry.ts'
 import { type OpKwargs } from '../ops/registry.ts'
 import { cachesReads, type Resource } from '../resource/base.ts'
@@ -139,7 +140,7 @@ export class Dispatcher {
     return cachesReads(mount.resource)
   }
 
-  async applyIo(io: IOResult): Promise<void> {
-    await applyIo(this.cache, io, this.isCacheablePath)
+  async applyIo(io: IOResult, records?: readonly OpRecord[]): Promise<void> {
+    await applyIo(this.cache, io, this.isCacheablePath, records)
   }
 }

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -831,7 +831,7 @@ export class Workspace {
     targetSession.lastExitCode = io.exitCode
     let stdoutBytes: Uint8Array
     try {
-      await this.dispatcher.applyIo(io)
+      await this.dispatcher.applyIo(io, opRecords)
       stdoutBytes = materialized === null ? new Uint8Array() : await materialize(materialized)
     } catch (err) {
       // Lazy reads can fail while draining (e.g. head/tail that open the

--- a/typescript/packages/node/src/workspace/io_key_prefix.test.ts
+++ b/typescript/packages/node/src/workspace/io_key_prefix.test.ts
@@ -13,17 +13,18 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { MountMode, RAMResource, type IOResult } from '@struktoai/mirage-core'
+import { MountMode, RAMResource, type IOResult, type OpRecord } from '@struktoai/mirage-core'
 import { Workspace } from '../workspace.ts'
+
+type ApplyIoFn = (io: IOResult, records?: readonly OpRecord[]) => Promise<void>
 
 function captureIo(ws: Workspace): IOResult[] {
   const captured: IOResult[] = []
-  const dispatcher = (ws as unknown as { dispatcher: { applyIo: (io: IOResult) => Promise<void> } })
-    .dispatcher
+  const dispatcher = (ws as unknown as { dispatcher: { applyIo: ApplyIoFn } }).dispatcher
   const orig = dispatcher.applyIo.bind(dispatcher)
-  dispatcher.applyIo = async (io: IOResult) => {
+  dispatcher.applyIo = async (io: IOResult, records?: readonly OpRecord[]) => {
     captured.push(io)
-    return orig(io)
+    return orig(io, records)
   }
   return captured
 }


### PR DESCRIPTION
## Problem

`apply_io` filled the file cache with `cache.set(path, data)` and dropped the backend fingerprint already captured in the read records (`rec.fingerprint` from s3 stream, onedrive read, postgres stat, ...). The RAM/Redis stores then defaulted the entry fingerprint to MD5(content).

Under `ConsistencyPolicy.ALWAYS`, `is_fresh` compares the cached fingerprint to the remote stat fingerprint. That only matches for simple-PUT S3 objects whose ETag is the content MD5. For OneDrive (cTag), gdrive (remote_time), Postgres (sha256), and multipart S3 uploads, the comparison always failed, so ALWAYS mode evicted and refetched on every warm read: correct bytes, but the cache was useless.

## Fix (Python + TS mirror)

- `apply_io`/`applyIo` accept the command's op records; each cache fill looks up the latest read record for the path and passes its backend fingerprint to `cache.set`.
- The background drain looks the fingerprint up after the drain completes, since streaming backends stamp the record lazily when the GET response arrives.
- A warm re-apply with no backend read record and unchanged bytes is skipped, so it cannot replace the cold-read fingerprint with the MD5 default (which would reintroduce the eviction loop one read later).
- `Workspace.execute` threads `scope.records`/`opRecords` through `Dispatcher.apply_io`.

## Tests

- End-to-end (py): a warm read under ALWAYS against an S3 mock returning multipart-style (non-MD5) ETags consults `head_object` but issues no second `get_object`.
- Unit (py + ts): record fingerprint stamps the entry; exhausted-stream and background-drain paths pick it up (including a fingerprint recorded mid-drain); warm re-apply preserves the entry; changed data without a record still resets it.
- Shared S3 mock gains `etag_suffix`, per-method call counters, and `patch_s3_session`.

Known gap: no TS end-to-end ALWAYS test (needs a fake backend whose ops record fingerprints; TS core tests fake caching with RAM, which records none). The TS mechanism is covered by the applyIo unit tests and the wiring mirrors Python.

Verified: full py suite green except the known jina live-network flake; TS core 3546 and node 1557 tests green; pre-commit green.