### PR TITLE
fix(cache): background-drain streamed reads into the Redis file cache

### DIFF
--- a/python/mirage/cache/file/redis.py
+++ b/python/mirage/cache/file/redis.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
 from collections.abc import Iterable
 
 from mirage.cache.file.mixin import FileCacheMixin
@@ -29,11 +30,16 @@ class RedisFileCacheStore(RedisResource, FileCacheMixin):
         max_drain_bytes: int | None = None,
     ) -> None:
         super().__init__(url=url, key_prefix=key_prefix)
+        # Advisory only: unlike the RAM store there is no client-side
+        # LRU, so nothing evicts on overflow. Cap memory on the Redis
+        # server instead (maxmemory + maxmemory-policy allkeys-lru) to
+        # approximate the RAM store's eviction behavior.
         self._cache_limit: int = parse_limit(cache_limit)
         self._cache_client = self._store._client
         self._data_prefix = f"{key_prefix}data:"
         self._meta_prefix = f"{key_prefix}meta:"
         self.max_drain_bytes: int | None = max_drain_bytes
+        self._drain_tasks: dict[str, asyncio.Task] = {}
 
     async def get(self, key: str) -> bytes | None:
         return await self._cache_client.get(f"{self._data_prefix}{key}")
@@ -72,6 +78,9 @@ class RedisFileCacheStore(RedisResource, FileCacheMixin):
         return True
 
     async def remove(self, key: str) -> None:
+        task = self._drain_tasks.pop(key, None)
+        if task:
+            task.cancel()
         pipe = self._cache_client.pipeline()
         pipe.delete(f"{self._data_prefix}{key}")
         pipe.delete(f"{self._meta_prefix}{key}")
@@ -90,6 +99,9 @@ class RedisFileCacheStore(RedisResource, FileCacheMixin):
         return fp == remote_fingerprint
 
     async def clear(self) -> None:
+        for task in self._drain_tasks.values():
+            task.cancel()
+        self._drain_tasks.clear()
         for pattern in (
                 f"{self._data_prefix}*",
                 f"{self._meta_prefix}*",

--- a/python/tests/cache/file/test_redis_cache.py
+++ b/python/tests/cache/file/test_redis_cache.py
@@ -12,12 +12,16 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
 import os
 
 import pytest
 import pytest_asyncio
 
+from mirage.cache.file import io as cache_io
 from mirage.cache.file.redis import RedisFileCacheStore
+from mirage.io import CachableAsyncIterator, IOResult
+from mirage.observe.record import OpRecord
 
 REDIS_URL = os.environ.get("REDIS_URL", "")
 pytestmark = pytest.mark.skipif(not REDIS_URL, reason="REDIS_URL not set")
@@ -123,3 +127,50 @@ async def test_key_prefix_isolation():
     await c2.clear()
     await c1._store.close()
     await c2._store.close()
+
+
+@pytest.mark.asyncio
+async def test_apply_io_drains_stream_into_cache(cache):
+    """An unexhausted stream must background-drain into the Redis cache
+    like the RAM store does, carrying the record fingerprint."""
+
+    async def _gen():
+        yield b"drained"
+
+    stream = CachableAsyncIterator(_gen())
+    io = IOResult(reads={"/file.txt": stream}, cache=["/file.txt"])
+    records = [
+        OpRecord(op="read",
+                 path="/file.txt",
+                 source="s3",
+                 bytes=0,
+                 timestamp=0,
+                 duration_ms=0,
+                 fingerprint="etag-9")
+    ]
+    await cache_io.apply_io(cache, io, records=records)
+    tasks = list(cache._drain_tasks.values())
+    assert tasks, "drain task must be registered"
+    await asyncio.gather(*tasks)
+    assert await cache.get("/file.txt") == b"drained"
+    assert await cache.is_fresh("/file.txt", "etag-9") is True
+
+
+@pytest.mark.asyncio
+async def test_remove_cancels_pending_drain(cache):
+    started = asyncio.Event()
+
+    async def _gen():
+        started.set()
+        await asyncio.sleep(1)
+        yield b"slow"
+
+    stream = CachableAsyncIterator(_gen())
+    io = IOResult(reads={"/slow.txt": stream}, cache=["/slow.txt"])
+    await cache_io.apply_io(cache, io)
+    assert "/slow.txt" in cache._drain_tasks
+    await started.wait()
+    await cache.remove("/slow.txt")
+    assert "/slow.txt" not in cache._drain_tasks
+    await asyncio.sleep(0.05)
+    assert await cache.get("/slow.txt") is None

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -371,6 +371,7 @@ export { type FileCache } from './cache/file/mixin.ts'
 export { CacheEntry, type CacheEntryInit } from './cache/file/entry.ts'
 export { defaultFingerprint, parseLimit } from './cache/file/utils.ts'
 export { RAMFileCacheStore } from './cache/file/ram.ts'
+export { applyIo, readFingerprint } from './cache/file/io.ts'
 export {
   LookupStatus,
   type IndexConfig,

--- a/typescript/packages/node/src/cache/redis/file.test.ts
+++ b/typescript/packages/node/src/cache/redis/file.test.ts
@@ -12,7 +12,13 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { defaultFingerprint } from '@struktoai/mirage-core'
+import {
+  CachableAsyncIterator,
+  IOResult,
+  OpRecord,
+  applyIo,
+  defaultFingerprint,
+} from '@struktoai/mirage-core'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { RedisFileCacheStore } from './file.ts'
 
@@ -98,5 +104,52 @@ describe.skipIf(skip)('RedisFileCacheStore', () => {
     await cache.clear()
     expect(await cache.exists('a')).toBe(false)
     expect(await cache.exists('b')).toBe(false)
+  })
+
+  it('background-drains an unexhausted stream, carrying the record fingerprint', async () => {
+    async function* gen(): AsyncGenerator<Uint8Array> {
+      await Promise.resolve()
+      yield new TextEncoder().encode('drained')
+    }
+    const stream = new CachableAsyncIterator(gen())
+    const io = new IOResult({ reads: { '/file.txt': stream }, cache: ['/file.txt'] })
+    const records = [
+      new OpRecord({
+        op: 'read',
+        path: '/file.txt',
+        source: 's3',
+        bytes: 0,
+        timestamp: 0,
+        durationMs: 0,
+        fingerprint: 'etag-9',
+      }),
+    ]
+    await applyIo(cache, io, undefined, records)
+    expect(cache.drainTasks.has('/file.txt')).toBe(true)
+    await Promise.all([...cache.drainTasks.values()])
+    expect(new TextDecoder().decode((await cache.get('/file.txt')) ?? undefined)).toBe('drained')
+    expect(await cache.isFresh('/file.txt', 'etag-9')).toBe(true)
+  })
+
+  it('remove aborts a pending drain fill', async () => {
+    let started!: () => void
+    const gate = new Promise<void>((r) => {
+      started = r
+    })
+    async function* gen(): AsyncGenerator<Uint8Array> {
+      started()
+      await new Promise((r) => setTimeout(r, 200))
+      yield new TextEncoder().encode('slow')
+    }
+    const stream = new CachableAsyncIterator(gen())
+    const io = new IOResult({ reads: { '/slow.txt': stream }, cache: ['/slow.txt'] })
+    await applyIo(cache, io)
+    const task = cache.drainTasks.get('/slow.txt')
+    expect(task).toBeDefined()
+    await gate
+    await cache.remove('/slow.txt')
+    expect(cache.drainTasks.has('/slow.txt')).toBe(false)
+    await task
+    expect(await cache.get('/slow.txt')).toBeNull()
   })
 })

--- a/typescript/packages/node/src/cache/redis/file.ts
+++ b/typescript/packages/node/src/cache/redis/file.ts
@@ -27,10 +27,15 @@ export interface RedisFileCacheOptions extends RedisResourceOptions {
 }
 
 export class RedisFileCacheStore extends RedisResource implements FileCache {
+  // Advisory only: unlike the RAM store there is no client-side LRU, so
+  // nothing evicts on overflow. Cap memory on the Redis server instead
+  // (maxmemory + maxmemory-policy allkeys-lru) to approximate the RAM
+  // store's eviction behavior.
   private readonly limit: number
   private readonly dataPrefix: string
   private readonly metaPrefix: string
   maxDrainBytes: number | null
+  readonly drainTasks = new Map<string, Promise<void>>()
 
   constructor(options: RedisFileCacheOptions = {}) {
     super({
@@ -102,6 +107,10 @@ export class RedisFileCacheStore extends RedisResource implements FileCache {
   }
 
   async remove(key: string): Promise<void> {
+    // Promises cannot be cancelled: dropping the map entry makes the
+    // pending backgroundDrain skip its cache fill, mirroring the RAM
+    // store's task cancel.
+    this.drainTasks.delete(key)
     const c = await this.cacheClient()
     const pipe = c.multi()
     pipe.del(`${this.dataPrefix}${key}`)
@@ -123,6 +132,7 @@ export class RedisFileCacheStore extends RedisResource implements FileCache {
   }
 
   async clear(): Promise<void> {
+    this.drainTasks.clear()
     const c = await this.cacheClient()
     for (const pattern of [`${this.dataPrefix}*`, `${this.metaPrefix}*`]) {
       const batch: string[] = []


### PR DESCRIPTION
## Problem

`apply_io` only starts a background drain when the cache store has a drain-task registry, and only the RAM store had one. With a Redis file cache:

- streamed cold reads (a plain `cat` on a remote file) never populated the cache, so warm hit rates were systematically lower than RAM for the same workload;
- `Workspace.close()` crashed with `AttributeError` because it touches `self._cache._drain_tasks` unconditionally.

## Fix (Python + TS mirror)

- `RedisFileCacheStore` owns the same drain registry as the RAM store (py `_drain_tasks` dict, ts `drainTasks` map), so `apply_io` background-drains unexhausted streams into Redis, carrying the record fingerprint.
- `remove()` cancels the pending drain for that key; `clear()` cancels all (TS: dropping the map entry makes the pending drain skip its fill, promises not being cancellable).
- `cache_limit` gets a comment stating it is advisory on Redis: no client-side LRU, cap memory on the server with `maxmemory` + `maxmemory-policy allkeys-lru` to approximate the RAM store.
- Exported `applyIo`/`readFingerprint` from the TS core index (matches Python's importable `cache_io`), used by the node-package tests.

Not included: the `add()` EXISTS-then-SET race, which this change makes more reachable; filed as #438.

## Tests

- py `test_redis_cache.py`: unexhausted stream drains into Redis with the record fingerprint; `remove()` cancels a pending drain.
- ts node `file.test.ts`: same two cases. Both verified red against the unmodified store.

Verified: full py suite green except the known jina live-network flake; TS core and node suites green with REDIS_URL; pre-commit green.