### PR TITLE
Cross-mount du/md5/file fan-out; cp populates the read cache

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -926,8 +926,11 @@ CROSS_MOUNT_CASES: list[tuple[str, str]] = [
      " && cat /data2/xm_moved.txt && ls /data2"),
     ("xm_grep_multi", "grep -c s /data/a.txt /data2/xm.txt"),
     ("xm_wc_multi", "wc -l /data/a.txt /data2/xm.txt"),
-    # du/md5/file reject multi-mount operands explicitly; pin the error
-    ("xm_du_multi_rejected", "du /data/b.txt /data2/xm.txt 2>&1"),
+    # du/md5/file fan out per mount and aggregate like the other readers
+    ("xm_du_multi", "du /data/b.txt /data2/xm.txt"),
+    ("xm_du_multi_total", "du -c /data/b.txt /data2/xm.txt"),
+    ("xm_md5_multi", "md5 /data/b.txt /data2/xm.txt"),
+    ("xm_file_multi", "file /data/a.txt /data2/xm.txt"),
     ("xm_find", "find /data2 -type f | sort"),
     ("xm_pipe", "cat /data2/xm.txt | tr a-z A-Z"),
     ("xm_ln_over", "ln -s /data/a.txt /data2/xm_link.txt"
@@ -1029,8 +1032,9 @@ PROVISION_CASES: list[tuple[str, str]] = [
     ("prov_xmount_concat", "cat /data/a.txt /data2/xm.txt"),
     ("prov_xmount_grep", "grep s /data/a.txt /data2/xm.txt"),
     ("prov_xmount_pipe", "cat /data/a.txt /data2/xm.txt | wc -c"),
-    # md5 rejects cross-mount operands, so its plan is honest unknown
-    ("prov_xmount_rejected", "md5 /data/a.txt /data2/xm.txt"),
+    # md5 fans out per mount, so its plan sums per-mount estimates
+    ("prov_xmount_md5", "md5 /data/a.txt /data2/xm.txt"),
+    ("prov_xmount_du", "du /data/a.txt /data2/xm.txt"),
     # ----- glob + recursive expansion (readdir/index-driven) -----
     ("prov_glob", "cat /data/rgm/d1/*.txt"),
     ("prov_glob_unmatched", "cat /data/rgm/d1/*.nope"),
@@ -1122,6 +1126,13 @@ async def run_cache_verify_cases(ws,
         print("=== cachev_xmount_cp_warm_source ===")
         print(f"bytes="
               f"{await _backend_bytes(ws, f'cp {target} {m2}/cachev_cp.txt')}")
+        await ws.cache.clear()
+        print("=== cachev_xmount_cp_cold_populates ===")
+        print(
+            f"bytes="
+            f"{await _backend_bytes(ws, f'cp {target} {m2}/cachev_cp2.txt')}")
+        print("=== cachev_cat_after_cp ===")
+        print(f"bytes={await _backend_bytes(ws, f'cat {target}')}")
     await ws.execute(f"rm {link} {target}")
 
 

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -798,8 +798,11 @@ export const CROSS_MOUNT_CASES: ReadonlyArray<readonly [string, string]> = [
   ["xm_mv_over", "mv /data/xm_back.txt /data2/xm_moved.txt && cat /data2/xm_moved.txt && ls /data2"],
   ["xm_grep_multi", "grep -c s /data/a.txt /data2/xm.txt"],
   ["xm_wc_multi", "wc -l /data/a.txt /data2/xm.txt"],
-  // du/md5/file reject multi-mount operands explicitly; pin the error
-  ["xm_du_multi_rejected", "du /data/b.txt /data2/xm.txt 2>&1"],
+  // du/md5/file fan out per mount and aggregate like the other readers
+  ["xm_du_multi", "du /data/b.txt /data2/xm.txt"],
+  ["xm_du_multi_total", "du -c /data/b.txt /data2/xm.txt"],
+  ["xm_md5_multi", "md5 /data/b.txt /data2/xm.txt"],
+  ["xm_file_multi", "file /data/a.txt /data2/xm.txt"],
   ["xm_find", "find /data2 -type f | sort"],
   ["xm_pipe", "cat /data2/xm.txt | tr a-z A-Z"],
   ["xm_ln_over", "ln -s /data/a.txt /data2/xm_link.txt && cat /data2/xm_link.txt"],
@@ -893,8 +896,9 @@ export const PROVISION_CASES: ReadonlyArray<readonly [string, string]> = [
   ["prov_xmount_concat", "cat /data/a.txt /data2/xm.txt"],
   ["prov_xmount_grep", "grep s /data/a.txt /data2/xm.txt"],
   ["prov_xmount_pipe", "cat /data/a.txt /data2/xm.txt | wc -c"],
-  // md5 rejects cross-mount operands, so its plan is honest unknown
-  ["prov_xmount_rejected", "md5 /data/a.txt /data2/xm.txt"],
+  // md5 fans out per mount, so its plan sums per-mount estimates
+  ["prov_xmount_md5", "md5 /data/a.txt /data2/xm.txt"],
+  ["prov_xmount_du", "du /data/a.txt /data2/xm.txt"],
   // ----- glob + recursive expansion (readdir/index-driven) -----
   ["prov_glob", "cat /data/rgm/d1/*.txt"],
   ["prov_glob_unmatched", "cat /data/rgm/d1/*.nope"],
@@ -1112,6 +1116,13 @@ export async function runCacheVerifyCases(
     process.stdout.write(
       `bytes=${String(await backendBytes(ws, `cp ${target} ${m2}/cachev_cp.txt`))}\n`,
     );
+    await ws.cache.clear();
+    process.stdout.write("=== cachev_xmount_cp_cold_populates ===\n");
+    process.stdout.write(
+      `bytes=${String(await backendBytes(ws, `cp ${target} ${m2}/cachev_cp2.txt`))}\n`,
+    );
+    process.stdout.write("=== cachev_cat_after_cp ===\n");
+    process.stdout.write(`bytes=${String(await backendBytes(ws, `cat ${target}`))}\n`);
   }
   await ws.execute(`rm ${link} ${target}`);
 }

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -2274,8 +2274,19 @@ xm_moved.txt
 5 /data/a.txt
 1 /data2/xm.txt
 6 total
-=== xm_du_multi_rejected ===
-du: paths span multiple mounts (/data/, /data2/), cross-mount not supported
+=== xm_du_multi ===
+6	/data/b.txt
+6	/data2/xm.txt
+=== xm_du_multi_total ===
+6	/data/b.txt
+6	/data2/xm.txt
+12	total
+=== xm_md5_multi ===
+c0710d6b4f15dfa88f600b0e6b624077  /data/b.txt
+8aef595260cf440c67da223d5a9b3e74  /data2/xm.txt
+=== xm_file_multi ===
+/data/a.txt: text
+/data2/xm.txt: text
 === xm_find ===
 /data2/xm.txt
 /data2/xm_copy.txt
@@ -2429,8 +2440,10 @@ net=30 write=0 cache=0 ops=2 hits=0 precision=exact
 net=30 write=0 cache=0 ops=2 hits=0 precision=exact
 === prov_xmount_pipe ===
 net=30 write=0 cache=0 ops=2 hits=0 precision=exact
-=== prov_xmount_rejected ===
-net=0 write=0 cache=0 ops=0 hits=0 precision=unknown
+=== prov_xmount_md5 ===
+net=30 write=0 cache=0 ops=2 hits=0 precision=exact
+=== prov_xmount_du ===
+net=0 write=0 cache=0 ops=2 hits=0 precision=exact
 === prov_glob ===
 net=24 write=0 cache=0 ops=1 hits=0 precision=exact
 === prov_glob_unmatched ===

--- a/integ/truth_s3.txt
+++ b/integ/truth_s3.txt
@@ -685,6 +685,10 @@ bytes=0
 net=0 write=0 cache=13 ops=1 hits=1 precision=exact
 === cachev_xmount_cp_warm_source ===
 bytes=13
+=== cachev_xmount_cp_cold_populates ===
+bytes=26
+=== cachev_cat_after_cp ===
+bytes=0
 === prov_cost_cat ===
 net=10414430 ops=1 cost=0.0009376987 precision=exact
 === prov_cost_for ===

--- a/integ/truth_s3_ts.txt
+++ b/integ/truth_s3_ts.txt
@@ -565,6 +565,10 @@ bytes=0
 net=0 write=0 cache=13 ops=1 hits=1 precision=exact
 === cachev_xmount_cp_warm_source ===
 bytes=0
+=== cachev_xmount_cp_cold_populates ===
+bytes=13
+=== cachev_cat_after_cp ===
+bytes=0
 === prov_cost_cat ===
 net=10414430 ops=1 cost=0.0009376987 precision=exact
 === prov_cost_for ===

--- a/python/mirage/commands/builtin/generic/cp.py
+++ b/python/mirage/commands/builtin/generic/cp.py
@@ -105,6 +105,7 @@ async def cp(
     *sources, dst = paths
     dst_is_dir = await is_directory(stat, dst, index)
     writes: dict[str, bytes] = {}
+    reads: dict[str, bytes] = {}
     lines: list[str] = []
     errors: list[str] = []
     for src, target in copy_targets(sources, dst, dst_is_dir):
@@ -140,7 +141,9 @@ async def cp(
                         continue
                     if n and await path_exists(stat, entry_dst):
                         continue
-                    await write(entry_dst, data=await read_bytes(entry))
+                    data = await read_bytes(entry)
+                    await write(entry_dst, data=data)
+                    reads[entry] = data
                     writes[entry_dst] = b""
                     if v:
                         lines.append(f"'{entry}' -> '{entry_dst}'")
@@ -168,7 +171,9 @@ async def cp(
             continue
         if copy is None:
             # write takes bytes, not a stream: the file is materialized here.
-            await write(target, data=await read_bytes(src))
+            data = await read_bytes(src)
+            await write(target, data=data)
+            reads[src.virtual] = data
         else:
             await copy(src, target)
         writes[target.mount_path] = b""
@@ -176,8 +181,12 @@ async def cp(
             lines.append(f"'{src.virtual}' -> '{target.virtual}'")
     output = "\n".join(lines) + "\n" if lines else None
     stderr = ("\n".join(errors) + "\n").encode() if errors else None
+    # Sources that streamed through the client are recorded as reads so
+    # apply_io can populate the file cache: a cp is also a full read.
     return output.encode() if output else None, IOResult(
         writes=writes,
+        reads=dict(reads),
+        cache=list(reads),
         stderr=stderr,
         exit_code=1 if errors else 0,
     )

--- a/python/mirage/commands/builtin/generic/crossmount/aggregate.py
+++ b/python/mirage/commands/builtin/generic/crossmount/aggregate.py
@@ -1,0 +1,88 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import functools
+from typing import Callable
+
+from mirage.commands.builtin.generic.crossmount.primitives import (CrossResult,
+                                                                   relay)
+from mirage.commands.builtin.generic.du import du_multi
+from mirage.commands.builtin.generic.file import file_cmd
+from mirage.commands.builtin.generic.md5 import md5 as generic_md5
+from mirage.commands.spec import SPECS
+from mirage.commands.spec.types import FlagView
+from mirage.io import IOResult
+from mirage.types import FileType, PathSpec
+
+
+async def _du_walk(dispatch: Callable, path: PathSpec) -> int:
+    """Total bytes under one operand via relayed stat/readdir.
+
+    Mirrors the factory du builder's walk fallback for backends without
+    a native du op, so cross-mount totals match single-mount ones.
+    """
+    try:
+        s = await relay(dispatch, "stat", None, path)
+    except (FileNotFoundError, ValueError):
+        return 0
+    if s.type != FileType.DIRECTORY:
+        return s.size or 0
+    try:
+        children = await relay(dispatch, "readdir", None, path)
+    except (FileNotFoundError, ValueError):
+        return 0
+    total = 0
+    for child in children:
+        total += await _du_walk(dispatch, PathSpec.from_str_path(child))
+    return total
+
+
+async def run_aggregate(cmd_name: str, scopes: list[PathSpec],
+                        flag_kwargs: dict, dispatch: Callable) -> CrossResult:
+    """Run a per-operand aggregating command whose operands span mounts.
+
+    Pure wiring: every operand is stat'd or read via ``dispatch``-relayed
+    primitives on its owning mount, and the shared generic (du/md5/file)
+    formats the output, so it matches the single-mount commands line for
+    line. du totals come from the same walk the factory builder uses for
+    backends without a native du op; ``-a``/``--max-depth`` degrade to one
+    line per operand there, and do the same here.
+
+    Args:
+        cmd_name (str): One of du, md5, file.
+        scopes (list[PathSpec]): Resolved operands spanning mounts.
+        flag_kwargs (dict): Flags parsed against the shared command spec.
+        dispatch (Callable): Workspace operation dispatcher.
+    """
+    p = functools.partial
+    if cmd_name == "du":
+        fl = FlagView(flag_kwargs, spec=SPECS["du"])
+        max_depth = fl.str("max_depth")
+        out = await du_multi(
+            scopes,
+            compute_total=p(_du_walk, dispatch),
+            h=fl.bool("h"),
+            s=fl.bool("s"),
+            a=fl.bool("a"),
+            max_depth=int(max_depth) if max_depth is not None else None,
+            c=fl.bool("c"))
+        return out, IOResult()
+    if cmd_name == "md5":
+        return await generic_md5(scopes, read_bytes=p(relay, dispatch, "read"))
+    fl = FlagView(flag_kwargs, spec=SPECS["file"])
+    return await file_cmd(scopes,
+                          read_bytes=p(relay, dispatch, "read"),
+                          stat_fn=p(relay, dispatch, "stat"),
+                          b=fl.bool("b"),
+                          i=fl.bool("i"))

--- a/python/mirage/commands/builtin/generic/crossmount/detect.py
+++ b/python/mirage/commands/builtin/generic/crossmount/detect.py
@@ -17,10 +17,12 @@ from mirage.types import PathSpec
 TRANSFER_COMMANDS = frozenset({"cp", "mv"})
 COMPARE_COMMANDS = frozenset({"diff", "cmp"})
 READ_COMMANDS = frozenset({"cat", "head", "tail", "wc", "grep", "rg"})
+AGGREGATE_COMMANDS = frozenset({"du", "file", "md5"})
 
 
 def is_cross_mount(cmd_name: str, scopes: list[PathSpec], registry) -> bool:
-    allowed = TRANSFER_COMMANDS | COMPARE_COMMANDS | READ_COMMANDS
+    allowed = (TRANSFER_COMMANDS | COMPARE_COMMANDS | READ_COMMANDS
+               | AGGREGATE_COMMANDS)
     if cmd_name not in allowed or len(scopes) < 2:
         return False
     mounts = set()

--- a/python/mirage/commands/builtin/generic/crossmount/route.py
+++ b/python/mirage/commands/builtin/generic/crossmount/route.py
@@ -14,9 +14,10 @@
 
 from typing import Callable
 
+from mirage.commands.builtin.generic.crossmount.aggregate import run_aggregate
 from mirage.commands.builtin.generic.crossmount.compare import run_compare
 from mirage.commands.builtin.generic.crossmount.detect import (
-    COMPARE_COMMANDS, READ_COMMANDS, TRANSFER_COMMANDS)
+    AGGREGATE_COMMANDS, COMPARE_COMMANDS, READ_COMMANDS, TRANSFER_COMMANDS)
 from mirage.commands.builtin.generic.crossmount.primitives import CrossResult
 from mirage.commands.builtin.generic.crossmount.read import run_read
 from mirage.commands.builtin.generic.crossmount.transfer import run_transfer
@@ -55,6 +56,8 @@ async def handle_cross_mount(
         if cmd_name in READ_COMMANDS:
             return await run_read(cmd_name, scopes, text_args, flag_kwargs,
                                   dispatch)
+        if cmd_name in AGGREGATE_COMMANDS:
+            return await run_aggregate(cmd_name, scopes, flag_kwargs, dispatch)
     except (FileNotFoundError, NotADirectoryError, IsADirectoryError,
             PermissionError) as exc:
         return None, IOResult(exit_code=1,

--- a/python/tests/commands/builtin/generic/test_cp.py
+++ b/python/tests/commands/builtin/generic/test_cp.py
@@ -178,3 +178,34 @@ async def test_recursive_into_nested_subtree_refused():
     assert io.exit_code == 1
     assert b"into itself" in io.stderr
     assert set(files) == {"/d/a.txt"}
+
+
+@pytest.mark.asyncio
+async def test_primitive_copy_records_source_reads():
+    files = {"/a.txt": b"AAA"}
+    stat, _, _ = _make_backend(files, set())
+
+    async def read_bytes(p) -> bytes:
+        return files[_key(p)]
+
+    async def write(p, data: bytes) -> None:
+        files[_key(p)] = data
+
+    _, io = await cp([_spec("/a.txt"), _spec("/copy.txt")],
+                     stat=stat,
+                     read_bytes=read_bytes,
+                     write=write,
+                     recursive=False,
+                     n=False,
+                     v=False)
+    assert files["/copy.txt"] == b"AAA"
+    assert io.reads == {"/a.txt": b"AAA"}
+    assert io.cache == ["/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_native_copy_records_no_reads():
+    files = {"/a.txt": b"AAA"}
+    _, io = await _run(files, set(), ["/a.txt", "/copy.txt"])
+    assert io.reads == {}
+    assert io.cache == []

--- a/python/tests/commands/native/test_cross_mount.py
+++ b/python/tests/commands/native/test_cross_mount.py
@@ -226,27 +226,34 @@ def test_pipe_cross(cross):
     assert "hello" in result
 
 
-def test_cross_resource_no_aggregate_raises(cross):
+def test_cross_resource_md5_fans_out(cross):
     cross.create_file(1, "a.txt", b"hello\n")
     cross.create_file(2, "b.txt", b"world\n")
-    assert cross.exit("md5 /m1/a.txt /m2/b.txt") != 0
+    single = cross.run("md5 /m1/a.txt") + cross.run("md5 /m2/b.txt")
+    assert cross.run("md5 /m1/a.txt /m2/b.txt") == single
 
 
-def test_cross_resource_no_aggregate_error_message(cross):
+def test_cross_resource_du_fans_out(cross):
+    cross.create_file(1, "a.txt", b"hello\n")
+    cross.create_file(2, "b.txt", b"world!!\n")
+    out = cross.run("du -c /m1/a.txt /m2/b.txt")
+    assert "6\t/m1/a.txt" in out
+    assert "8\t/m2/b.txt" in out
+    assert "14\ttotal" in out
+
+
+def test_cross_resource_file_fans_out(cross):
     cross.create_file(1, "a.txt", b"hello\n")
     cross.create_file(2, "b.txt", b"world\n")
-
-    async def _inner():
-        io = await cross.ws.execute("md5 /m1/a.txt /m2/b.txt")
-        return await io.stderr_str()
-
-    stderr = asyncio.run(_inner())
-    assert "/m1" in stderr or "/m2" in stderr
+    out = cross.run("file /m1/a.txt /m2/b.txt")
+    assert "/m1/a.txt:" in out
+    assert "/m2/b.txt:" in out
 
 
-def test_plan_cross_resource_no_aggregate(cross):
+def test_plan_cross_resource_aggregate_sums(cross):
     cross.create_file(1, "a.txt", b"hello\n")
     cross.create_file(2, "b.txt", b"world\n")
     result = asyncio.run(
         cross.ws.execute("md5 /m1/a.txt /m2/b.txt", provision=True))
-    assert result.precision == Precision.UNKNOWN
+    assert result.precision == Precision.EXACT
+    assert result.network_read == "12"

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/aggregate.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/aggregate.ts
@@ -1,0 +1,83 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { IOResult } from '../../../../io/types.ts'
+import { FileType, PathSpec } from '../../../../types.ts'
+import { duMulti } from '../du.ts'
+import { fileGeneric } from '../file.ts'
+import { md5Generic } from '../md5.ts'
+import {
+  type CrossResult,
+  type DispatchFn,
+  crossOpts,
+  readBytesOp,
+  readdirOp,
+  statOp,
+  streamOp,
+} from './primitives.ts'
+
+// Total bytes under one operand via relayed stat/readdir. Mirrors the
+// factory du builder's walk fallback for backends without a native du
+// op, so cross-mount totals match single-mount ones.
+async function duWalk(dispatch: DispatchFn, path: PathSpec): Promise<number> {
+  const stat = statOp(dispatch)
+  let s
+  try {
+    s = await stat(path)
+  } catch {
+    return 0
+  }
+  if (s.type !== FileType.DIRECTORY) return s.size ?? 0
+  let children: string[]
+  try {
+    children = await readdirOp(dispatch)(path)
+  } catch {
+    return 0
+  }
+  let total = 0
+  for (const child of children) {
+    total += await duWalk(dispatch, PathSpec.fromStrPath(child))
+  }
+  return total
+}
+
+/**
+ * Run a per-operand aggregating command whose operands span mounts.
+ * Pure wiring: every operand is stat'd or read via `dispatch`-relayed
+ * primitives on its owning mount, and the shared generic (du/md5/file)
+ * formats the output, so it matches the single-mount commands line for
+ * line. du totals come from the same walk the factory builder uses for
+ * backends without a native du op; -a/-s/--max-depth collapse to one
+ * line per operand there, and do the same here.
+ */
+export async function runAggregate(
+  cmdName: string,
+  scopes: PathSpec[],
+  flagKwargs: Record<string, string | boolean | string[]>,
+  dispatch: DispatchFn,
+): Promise<CrossResult> {
+  const opts = crossOpts(flagKwargs)
+  if (cmdName === 'du') {
+    return (await duMulti(scopes, opts, (p) => duWalk(dispatch, p))) ?? [null, new IOResult()]
+  }
+  if (cmdName === 'md5') {
+    return (await md5Generic(scopes, opts, streamOp(dispatch))) ?? [null, new IOResult()]
+  }
+  return (
+    (await fileGeneric(scopes, opts, statOp(dispatch), readBytesOp(dispatch))) ?? [
+      null,
+      new IOResult(),
+    ]
+  )
+}

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/detect.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/detect.ts
@@ -17,6 +17,7 @@ import type { PathSpec } from '../../../../types.ts'
 
 export const TRANSFER_COMMANDS: ReadonlySet<string> = new Set(['cp', 'mv'])
 export const COMPARE_COMMANDS: ReadonlySet<string> = new Set(['diff', 'cmp'])
+export const AGGREGATE_COMMANDS: ReadonlySet<string> = new Set(['du', 'file', 'md5'])
 export const READ_COMMANDS: ReadonlySet<string> = new Set([
   'cat',
   'head',
@@ -32,7 +33,10 @@ export function isCrossMount(
   registry: MountRegistry,
 ): boolean {
   const allowed =
-    TRANSFER_COMMANDS.has(cmdName) || COMPARE_COMMANDS.has(cmdName) || READ_COMMANDS.has(cmdName)
+    TRANSFER_COMMANDS.has(cmdName) ||
+    COMPARE_COMMANDS.has(cmdName) ||
+    READ_COMMANDS.has(cmdName) ||
+    AGGREGATE_COMMANDS.has(cmdName)
   if (!allowed || scopes.length < 2) return false
   const mounts = new Set<string>()
   for (const s of scopes) {

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/route.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/route.ts
@@ -14,8 +14,9 @@
 
 import { IOResult } from '../../../../io/types.ts'
 import type { PathSpec } from '../../../../types.ts'
+import { runAggregate } from './aggregate.ts'
 import { runCompare } from './compare.ts'
-import { COMPARE_COMMANDS, READ_COMMANDS, TRANSFER_COMMANDS } from './detect.ts'
+import { AGGREGATE_COMMANDS, COMPARE_COMMANDS, READ_COMMANDS, TRANSFER_COMMANDS } from './detect.ts'
 import { type CrossResult, type DispatchFn } from './primitives.ts'
 import { runRead } from './read.ts'
 import { runTransfer } from './transfer.ts'
@@ -41,6 +42,9 @@ export async function handleCrossMount(
     }
     if (READ_COMMANDS.has(cmdName)) {
       return await runRead(cmdName, scopes, textArgs, flagKwargs, dispatch)
+    }
+    if (AGGREGATE_COMMANDS.has(cmdName)) {
+      return await runAggregate(cmdName, scopes, flagKwargs, dispatch)
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/transfer.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/transfer.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { IOResult } from '../../../../io/types.ts'
 import type { FindOptions } from '../../../../resource/base.ts'
 import type { PathSpec } from '../../../../types.ts'
 import { cpGeneric, cpWalk } from '../cp.ts'
@@ -50,14 +51,22 @@ export async function runTransfer(
 
   if (cmdName === 'cp') {
     const recursive = flagKwargs.r === true || flagKwargs.R === true || flagKwargs.a === true
+    // Sources stream through the client here, so record them as reads:
+    // apply_io then populates the file cache (a cp is also a full read).
+    const reads: Record<string, Uint8Array> = {}
+    const recordingRead = async (p: PathSpec): Promise<Uint8Array> => {
+      const data = await readBytes(p)
+      reads[p.virtual] = data
+      return data
+    }
     const copy = async (src: PathSpec, target: PathSpec): Promise<void> => {
-      await write(target, await readBytes(src))
+      await write(target, await recordingRead(src))
     }
     const find = async (src: PathSpec, _options: FindOptions): Promise<string[]> => {
       const tree = await cpWalk(readdir, stat, src)
       return tree.filter((e) => !e.isDir).map((e) => e.path)
     }
-    const [out, io] = await cpGeneric(
+    const result = await cpGeneric(
       flat,
       copy,
       find,
@@ -68,8 +77,11 @@ export async function runTransfer(
       undefined,
       undefined,
       undefined,
-      { readBytes, write, mkdir, readdir },
+      { readBytes: recordingRead, write, mkdir, readdir },
     )
+    const [out, io] = result ?? [null, new IOResult()]
+    io.reads = { ...io.reads, ...reads }
+    io.cache = [...io.cache, ...Object.keys(reads)]
     return [out, io]
   }
 

--- a/typescript/packages/node/src/commands/native_cross_mount.test.ts
+++ b/typescript/packages/node/src/commands/native_cross_mount.test.ts
@@ -135,24 +135,40 @@ describe.each(CROSS_MOUNT_PAIRS)('native cross mount (%s -> %s)', (p1, p2) => {
     }
   })
 
-  it('no-aggregate cross fails', async () => {
+  it('md5 fans out across mounts', async () => {
     const env = makeCrossEnv([p1, p2])
     try {
       env.createFile(1, 'a.txt', ENC.encode('hello\n'))
       env.createFile(2, 'b.txt', ENC.encode('world\n'))
-      expect(await env.exit('md5 /m1/a.txt /m2/b.txt')).not.toBe(0)
+      const single = (await env.run('md5 /m1/a.txt')) + (await env.run('md5 /m2/b.txt'))
+      expect(await env.run('md5 /m1/a.txt /m2/b.txt')).toBe(single)
     } finally {
       await env.cleanup()
     }
   })
 
-  it('no-aggregate cross error message', async () => {
+  it('du fans out across mounts', async () => {
+    const env = makeCrossEnv([p1, p2])
+    try {
+      env.createFile(1, 'a.txt', ENC.encode('hello\n'))
+      env.createFile(2, 'b.txt', ENC.encode('world!!\n'))
+      const out = await env.run('du -c /m1/a.txt /m2/b.txt')
+      expect(out).toContain('6\t/m1/a.txt')
+      expect(out).toContain('8\t/m2/b.txt')
+      expect(out).toContain('14\ttotal')
+    } finally {
+      await env.cleanup()
+    }
+  })
+
+  it('file fans out across mounts', async () => {
     const env = makeCrossEnv([p1, p2])
     try {
       env.createFile(1, 'a.txt', ENC.encode('hello\n'))
       env.createFile(2, 'b.txt', ENC.encode('world\n'))
-      const stderr = await env.stderr('md5 /m1/a.txt /m2/b.txt')
-      expect(stderr.includes('/m1') || stderr.includes('/m2')).toBe(true)
+      const out = await env.run('file /m1/a.txt /m2/b.txt')
+      expect(out).toContain('/m1/a.txt:')
+      expect(out).toContain('/m2/b.txt:')
     } finally {
       await env.cleanup()
     }


### PR DESCRIPTION
Last slice of the provision accuracy backlog (Phase D), following #440.

## du/md5/file fan out per mount (D2)

These three commands rejected operands spanning mounts (`du /data/a.txt /data2/b.txt` errored with "cross-mount not supported"). They now route through the same cross-mount machinery as cat/grep/cp: a new `run_aggregate` relays each operand's stat/read/readdir to its owning mount through the workspace dispatcher, and the shared generic (du/md5/file) formats the output, so lines match the single-mount commands exactly. du totals use the same stat/readdir walk the factory builder already uses for backends without a native du op, and `-a`/`--max-depth` collapse to one line per operand there, same as that fallback.

Because the planner shares `is_cross_mount`, their provision plans flipped automatically from honest-unknown to summed per-mount estimates: `md5 /data/a.txt /data2/xm.txt` now plans exact byte totals (the old `xm_du_multi_rejected` and `prov_xmount_rejected` pins are replaced by real-output pins: `xm_du_multi`, `xm_du_multi_total`, `xm_md5_multi`, `xm_file_multi`, `prov_xmount_md5`, `prov_xmount_du`).

## cp populates the read cache (D3)

cp read sources through the cache but never filled it, so a plan made right after a copy still priced a network read that would not happen. Client-streamed source bytes are now recorded as reads in cp's IOResult (py in the generic, TS in the cross-mount transfer wiring, its only primitive-mode path), so `apply_io` populates the file cache. Native server-side copies record nothing, correctly: no bytes pass through the client. Pinned on both s3 suites: `cachev_xmount_cp_cold_populates` (cold copy pays the read) then `cachev_cat_after_cp` reports `bytes=0`.

## Verification

Full py suite green; TS core 3553 / node 1562 / browser 165; truth.txt regenerated (only the six replaced/added cross-mount pins changed) and byte-identical on py ram/disk/redis/ssh/s3_cases/onedrive_cases and TS ram/disk/redis/ssh; s3 bespoke suites (moto + MinIO) pin the new cache-populate lines; pre-commit clean with post-format re-verification.