### PR TITLE
fix(shell): relative words follow bash semantics

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -635,6 +635,14 @@ CASES: list[tuple[str, str]] = [
     ("glob_relative_for", "for f in sub/*.txt; do echo $f; done"),
     ("glob_relative_func",
      "f() { echo $1 $#; }; f sub/*.txt && cd / && rm -r /data/g12"),
+    ("redirect_after_cd", "mkdir -p /data/g13 && cd /data/g13"
+     " && echo hi > CDOUT && cat /data/g13/CDOUT"),
+    ("redirect_list_last_only",
+     "echo one && echo two > captured && cat captured"),
+    ("redirect_chain",
+     "echo a > chain && echo b >> chain && cat chain && wc -l < chain"),
+    ("redirect_group",
+     "{ echo g1; echo g2; } > gout && cat gout && cd / && rm -r /data/g13"),
 
     # ----- cp / mv multi-source into a directory (last; these mutate) -----
     ("cp_multi_into_dir", "cp /data/a.txt /data/b.txt /data/sub"),

--- a/integ/cases.py
+++ b/integ/cases.py
@@ -624,6 +624,17 @@ CASES: list[tuple[str, str]] = [
     ("redirect_relative_write", "echo one > sub/LOG"),
     ("redirect_relative_append", "echo two >> sub/LOG && cat sub/LOG"),
     ("redirect_stdin_relative", "wc -l < sub/LOG && cd / && rm -r /data/g11"),
+    ("relword_prep", "mkdir -p /data/g12/sub && cd /data/g12"
+     " && printf 'y\n' | tee plain.txt > /dev/null"
+     " && printf 'x\n' | tee sub/a.txt > /dev/null"
+     " && printf 'x\n' | tee sub/b.txt > /dev/null"),
+    ("test_relative_paths",
+     "test -f plain.txt && echo yes-f && test -d sub && echo yes-d"
+     " && test -f missing.txt || echo no-f"),
+    ("glob_relative_display", "echo sub/*.txt && echo *.nope"),
+    ("glob_relative_for", "for f in sub/*.txt; do echo $f; done"),
+    ("glob_relative_func",
+     "f() { echo $1 $#; }; f sub/*.txt && cd / && rm -r /data/g12"),
 
     # ----- cp / mv multi-source into a directory (last; these mutate) -----
     ("cp_multi_into_dir", "cp /data/a.txt /data/b.txt /data/sub"),

--- a/integ/cases.py
+++ b/integ/cases.py
@@ -643,6 +643,17 @@ CASES: list[tuple[str, str]] = [
      "echo a > chain && echo b >> chain && cat chain && wc -l < chain"),
     ("redirect_group",
      "{ echo g1; echo g2; } > gout && cat gout && cd / && rm -r /data/g13"),
+    ("relspell_prep", "mkdir -p /data/g14/sub && cd /data/g14"
+     " && printf 'hello\n' | tee sub/a.txt > /dev/null"
+     " && printf 'hello\n' | tee sub/b.txt > /dev/null"),
+    ("relspell_walk_grep", "grep -r hello sub"),
+    ("relspell_walk_find", "find sub -name '*.txt'"),
+    ("relspell_error_cat", "cat sub/missing.txt 2>&1"),
+    ("relspell_error_grep", "grep hello sub/missing.txt 2>&1"),
+    ("relspell_glob_dot", "echo ./sub/*.txt"),
+    ("relspell_du_slash", "du -s sub/"),
+    ("relspell_labels", "wc -l sub/a.txt && head -v sub/a.txt"
+     " && cd / && rm -r /data/g14"),
 
     # ----- cp / mv multi-source into a directory (last; these mutate) -----
     ("cp_multi_into_dir", "cp /data/a.txt /data/b.txt /data/sub"),

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -565,6 +565,19 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
   ["redirect_list_last_only", "echo one && echo two > captured && cat captured"],
   ["redirect_chain", "echo a > chain && echo b >> chain && cat chain && wc -l < chain"],
   ["redirect_group", "{ echo g1; echo g2; } > gout && cat gout && cd / && rm -r /data/g13"],
+  [
+    "relspell_prep",
+    "mkdir -p /data/g14/sub && cd /data/g14" +
+      " && printf 'hello\n' | tee sub/a.txt > /dev/null" +
+      " && printf 'hello\n' | tee sub/b.txt > /dev/null",
+  ],
+  ["relspell_walk_grep", "grep -r hello sub"],
+  ["relspell_walk_find", "find sub -name '*.txt'"],
+  ["relspell_error_cat", "cat sub/missing.txt 2>&1"],
+  ["relspell_error_grep", "grep hello sub/missing.txt 2>&1"],
+  ["relspell_glob_dot", "echo ./sub/*.txt"],
+  ["relspell_du_slash", "du -s sub/"],
+  ["relspell_labels", "wc -l sub/a.txt && head -v sub/a.txt && cd / && rm -r /data/g14"],
 
   // ----- cp / mv multi-source into a directory (last; these mutate) -----
   ["cp_multi_into_dir", "cp /data/a.txt /data/b.txt /data/sub"],

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -558,6 +558,13 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
   ["glob_relative_display", "echo sub/*.txt && echo *.nope"],
   ["glob_relative_for", "for f in sub/*.txt; do echo $f; done"],
   ["glob_relative_func", "f() { echo $1 $#; }; f sub/*.txt && cd / && rm -r /data/g12"],
+  [
+    "redirect_after_cd",
+    "mkdir -p /data/g13 && cd /data/g13 && echo hi > CDOUT && cat /data/g13/CDOUT",
+  ],
+  ["redirect_list_last_only", "echo one && echo two > captured && cat captured"],
+  ["redirect_chain", "echo a > chain && echo b >> chain && cat chain && wc -l < chain"],
+  ["redirect_group", "{ echo g1; echo g2; } > gout && cat gout && cd / && rm -r /data/g13"],
 
   // ----- cp / mv multi-source into a directory (last; these mutate) -----
   ["cp_multi_into_dir", "cp /data/a.txt /data/b.txt /data/sub"],

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -545,6 +545,19 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
   ["redirect_relative_write", "echo one > sub/LOG"],
   ["redirect_relative_append", "echo two >> sub/LOG && cat sub/LOG"],
   ["redirect_stdin_relative", "wc -l < sub/LOG && cd / && rm -r /data/g11"],
+  [
+    "relword_prep",
+    "mkdir -p /data/g12/sub && cd /data/g12 && printf 'y\n' | tee plain.txt > /dev/null" +
+      " && printf 'x\n' | tee sub/a.txt > /dev/null && printf 'x\n' | tee sub/b.txt > /dev/null",
+  ],
+  [
+    "test_relative_paths",
+    "test -f plain.txt && echo yes-f && test -d sub && echo yes-d" +
+      " && test -f missing.txt || echo no-f",
+  ],
+  ["glob_relative_display", "echo sub/*.txt && echo *.nope"],
+  ["glob_relative_for", "for f in sub/*.txt; do echo $f; done"],
+  ["glob_relative_func", "f() { echo $1 $#; }; f sub/*.txt && cd / && rm -r /data/g12"],
 
   // ----- cp / mv multi-source into a directory (last; these mutate) -----
   ["cp_multi_into_dir", "cp /data/a.txt /data/b.txt /data/sub"],

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -1743,6 +1743,20 @@ one
 two
 === redirect_stdin_relative ===
 2
+=== relword_prep ===
+
+=== test_relative_paths ===
+yes-f
+yes-d
+no-f
+=== glob_relative_display ===
+sub/a.txt sub/b.txt
+*.nope
+=== glob_relative_for ===
+sub/a.txt
+sub/b.txt
+=== glob_relative_func ===
+sub/a.txt 2
 === cp_multi_into_dir ===
 
 === cp_multi_verify_a ===

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -1769,6 +1769,26 @@ b
 === redirect_group ===
 g1
 g2
+=== relspell_prep ===
+
+=== relspell_walk_grep ===
+sub/a.txt:hello
+sub/b.txt:hello
+=== relspell_walk_find ===
+sub/a.txt
+sub/b.txt
+=== relspell_error_cat ===
+cat: sub/missing.txt: No such file or directory
+=== relspell_error_grep ===
+grep: sub/missing.txt: No such file or directory
+=== relspell_glob_dot ===
+./sub/a.txt ./sub/b.txt
+=== relspell_du_slash ===
+12	sub/
+=== relspell_labels ===
+1 sub/a.txt
+==> sub/a.txt <==
+hello
 === cp_multi_into_dir ===
 
 === cp_multi_verify_a ===

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -1757,6 +1757,18 @@ sub/a.txt
 sub/b.txt
 === glob_relative_func ===
 sub/a.txt 2
+=== redirect_after_cd ===
+hi
+=== redirect_list_last_only ===
+one
+two
+=== redirect_chain ===
+a
+b
+2
+=== redirect_group ===
+g1
+g2
 === cp_multi_into_dir ===
 
 === cp_multi_verify_a ===

--- a/python/mirage/commands/builtin/generic/du.py
+++ b/python/mirage/commands/builtin/generic/du.py
@@ -29,7 +29,7 @@ async def _du_one(
     h: bool,
     max_depth: int | None,
 ) -> tuple[str, int]:
-    label = path.display
+    label = path.raw_path
 
     if s:
         total = await compute_total(path)
@@ -100,11 +100,11 @@ async def _du_block(
 ) -> tuple[list[str], int]:
     if s or compute_all is None:
         total = await compute_total(p0)
-        return [_format_size(total, h) + "\t" + p0.display], total
+        return [_format_size(total, h) + "\t" + p0.raw_path], total
     all_entries = await compute_all(p0)
     if not all_entries:
         total = await compute_total(p0)
-        return [_format_size(total, h) + "\t" + p0.display], total
+        return [_format_size(total, h) + "\t" + p0.raw_path], total
     if not a:
         all_entries = [(p, sz) for p, sz in all_entries if p == p0.virtual]
     if max_depth is not None:
@@ -112,7 +112,7 @@ async def _du_block(
                        if _depth(p, p0.virtual) <= max_depth]
     if not all_entries:
         total = await compute_total(p0)
-        return [_format_size(total, h) + "\t" + p0.display], total
+        return [_format_size(total, h) + "\t" + p0.raw_path], total
     lines = [_format_size(sz, h) + "\t" + p for p, sz in all_entries]
     return lines, sum(sz for _, sz in all_entries)
 

--- a/python/mirage/commands/builtin/generic/find.py
+++ b/python/mirage/commands/builtin/generic/find.py
@@ -12,7 +12,7 @@ from mirage.commands.builtin.utils.output import format_records
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import FileStat, FileType, FindType, PathSpec
 from mirage.utils.key_prefix import mount_key, mount_prefix_of
-from mirage.utils.path import rebase_display
+from mirage.utils.path import rebase_raw
 
 
 def parse_find_args(
@@ -142,7 +142,7 @@ async def find(
         try:
             await stat(search_path)
         except (FileNotFoundError, ValueError) as exc:
-            stderr = f"find: '{search_path.display}': {exc}".encode()
+            stderr = f"find: '{search_path.raw_path}': {exc}".encode()
             return b"", IOResult(stderr=stderr, exit_code=1)
     results = await find_core(
         search_path,
@@ -168,7 +168,7 @@ async def find(
                                            stat=stat,
                                            mount_prefix=root_prefix)
     results = apply_mount_prefix(results, root_prefix)
-    results = rebase_display(results, search_path.virtual, search_path.display)
+    results = rebase_raw(results, search_path.virtual, search_path.raw_path)
     return format_records(results), IOResult()
 
 

--- a/python/mirage/commands/builtin/generic/grep.py
+++ b/python/mirage/commands/builtin/generic/grep.py
@@ -23,7 +23,7 @@ from mirage.io.stream import exit_on_empty, quiet_match
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.key_prefix import mount_prefix_of
-from mirage.utils.path import rebase_display
+from mirage.utils.path import rebase_raw
 
 
 @dataclass(frozen=True, slots=True)
@@ -166,7 +166,7 @@ async def grep(
                     warnings=warnings,
                     read_stream_fn=None,
                 )
-                results.extend(rebase_display(hits, p.virtual, p.display))
+                results.extend(rebase_raw(hits, p.virtual, p.raw_path))
             stderr = format_optional_records(warnings)
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
@@ -203,16 +203,15 @@ async def grep(
                         warnings=warnings,
                         read_stream_fn=None,
                     )
-                    all_results.extend(
-                        rebase_display(res, p.virtual, p.display))
+                    all_results.extend(rebase_raw(res, p.virtual, p.raw_path))
                 else:
                     data = split_lines(
                         (await rb(p.virtual)).decode(errors="replace"))
-                    hits = grep_lines(p.display, data, pat, f.invert,
+                    hits = grep_lines(p.raw_path, data, pat, f.invert,
                                       f.line_numbers, f.count_only,
                                       f.files_only, f.only_matching,
                                       f.max_count)
-                    label = "" if f.no_filename else f"{p.display}:"
+                    label = "" if f.no_filename else f"{p.raw_path}:"
                     if f.count_only and hits:
                         all_results.append(f"{label}{hits[0]}")
                     else:
@@ -236,17 +235,18 @@ async def grep(
                     s = await st(p.virtual)
                 except FileNotFoundError:
                     multi_warnings.append(
-                        f"grep: {p.display}: No such file or directory")
+                        f"grep: {p.raw_path}: No such file or directory")
                     continue
                 if s.type == FileType.DIRECTORY:
-                    multi_warnings.append(f"grep: {p.display}: Is a directory")
+                    multi_warnings.append(
+                        f"grep: {p.raw_path}: Is a directory")
                     continue
                 data = split_lines((await
                                     rb(p.virtual)).decode(errors="replace"))
-                hits = grep_lines(p.display, data, pat, f.invert,
+                hits = grep_lines(p.raw_path, data, pat, f.invert,
                                   f.line_numbers, f.count_only, f.files_only,
                                   f.only_matching, f.max_count)
-                label = "" if f.no_filename else f"{p.display}:"
+                label = "" if f.no_filename else f"{p.raw_path}:"
                 if f.count_only:
                     if hits:
                         all_results.append(f"{label}{hits[0]}")
@@ -264,7 +264,7 @@ async def grep(
 
         first_stat = await st(paths[0].virtual)
         if first_stat.type == FileType.DIRECTORY:
-            stderr = f"grep: {paths[0].display}: Is a directory\n".encode()
+            stderr = f"grep: {paths[0].raw_path}: Is a directory\n".encode()
             return b"", IOResult(exit_code=1, stderr=stderr)
 
         if read_stream is not None:
@@ -292,7 +292,7 @@ async def grep(
         if f.with_filename and not (f.after_context or f.before_context):
             # GNU labels context lines with `-` instead of `:`, which the
             # uniform prefix cannot reproduce, so -H skips context output.
-            out = prefix_lines(out, f"{paths[0].display}:")
+            out = prefix_lines(out, f"{paths[0].raw_path}:")
         return out, io
 
     source = _resolve_source(stdin,

--- a/python/mirage/commands/builtin/generic/head.py
+++ b/python/mirage/commands/builtin/generic/head.py
@@ -125,7 +125,7 @@ async def _head_multi(
 ) -> AsyncIterator[bytes]:
     for i, p in enumerate(paths):
         if show_headers:
-            header = f"==> {p.display} <==\n"
+            header = f"==> {p.raw_path} <==\n"
             if i > 0:
                 header = "\n" + header
             yield header.encode()

--- a/python/mirage/commands/builtin/generic/ls.py
+++ b/python/mirage/commands/builtin/generic/ls.py
@@ -59,7 +59,7 @@ async def walk(
             return [await stat(path, index)], warnings
         except (FileNotFoundError, ValueError) as exc:
             detail = fs_strerror(exc) or exc
-            warnings.append(f"ls: cannot access '{path.display}': {detail}")
+            warnings.append(f"ls: cannot access '{path.raw_path}': {detail}")
             return [], warnings
 
     try:
@@ -69,7 +69,7 @@ async def walk(
         if file_entry is not None:
             return [file_entry], warnings
         warnings.append(
-            f"ls: cannot access '{path.display}': {fs_strerror(exc) or exc}")
+            f"ls: cannot access '{path.raw_path}': {fs_strerror(exc) or exc}")
         return [], warnings
 
     if not entries:
@@ -225,7 +225,7 @@ async def ls(
             for g_idx, (dir_spec, entries) in enumerate(groups):
                 if p_idx > 0 or g_idx > 0:
                     results.append("")
-                header = rebase_one(dir_spec.virtual, p.virtual, p.display)
+                header = rebase_one(dir_spec.virtual, p.virtual, p.raw_path)
                 results.append(f"{header}:")
                 _render_group(results,
                               entries,

--- a/python/mirage/commands/builtin/generic/md5.py
+++ b/python/mirage/commands/builtin/generic/md5.py
@@ -24,7 +24,7 @@ async def md5(
     for p in paths:
         data = await read_bytes(accessor, p)
         digest = hashlib.md5(data).hexdigest()
-        outputs.append(f"{digest}  {p.display}")
+        outputs.append(f"{digest}  {p.raw_path}")
     return format_records(outputs), IOResult()
 
 

--- a/python/mirage/commands/builtin/generic/rg.py
+++ b/python/mirage/commands/builtin/generic/rg.py
@@ -25,7 +25,7 @@ from mirage.io.stream import exit_on_empty
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.key_prefix import mount_prefix_of
-from mirage.utils.path import rebase_display
+from mirage.utils.path import rebase_raw
 
 
 @dataclass(frozen=True, slots=True)
@@ -195,9 +195,9 @@ async def rg(
                     glob_pattern=f.glob_pattern,
                     hidden=f.hidden,
                     warnings=warnings_f,
-                    file_prefix=p.display if label else None,
+                    file_prefix=p.raw_path if label else None,
                 )
-                results.extend(rebase_display(hits_full, p.virtual, p.display))
+                results.extend(rebase_raw(hits_full, p.virtual, p.raw_path))
             stderr = format_optional_records(warnings_f)
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
@@ -211,17 +211,17 @@ async def rg(
             for p in paths:
                 data = split_lines((await
                                     rb(p.virtual)).decode(errors="replace"))
-                hits = grep_lines(p.display, data, pat, f.invert,
+                hits = grep_lines(p.raw_path, data, pat, f.invert,
                                   f.line_numbers, f.count_only, f.files_only,
                                   f.only_matching, f.max_count)
                 if f.count_only:
                     if grep_count_has_matches(hits):
                         all_results.append(
-                            f"{p.display}:{hits[0]}" if label else hits[0])
+                            f"{p.raw_path}:{hits[0]}" if label else hits[0])
                 elif f.files_only:
                     all_results.extend(hits)
                 elif label:
-                    all_results.extend(f"{p.display}:{r}" for r in hits)
+                    all_results.extend(f"{p.raw_path}:{r}" for r in hits)
                 else:
                     all_results.extend(hits)
             if not all_results:

--- a/python/mirage/commands/builtin/generic/sha256sum.py
+++ b/python/mirage/commands/builtin/generic/sha256sum.py
@@ -25,7 +25,7 @@ async def _sha256_multi(
         h = hashlib.sha256()
         async for chunk in read_stream(accessor, p):
             h.update(chunk)
-        yield (h.hexdigest() + "  " + p.display + "\n").encode()
+        yield (h.hexdigest() + "  " + p.raw_path + "\n").encode()
 
 
 def _resolve_check_target(filename: str, mount_prefix: str) -> str | PathSpec:

--- a/python/mirage/commands/builtin/generic/stat.py
+++ b/python/mirage/commands/builtin/generic/stat.py
@@ -50,7 +50,7 @@ async def stat(
     for p in paths:
         s = await stat_fn(accessor, p, index)
         if fmt is not None:
-            lines.append(_format_stat(fmt, s, p.display))
+            lines.append(_format_stat(fmt, s, p.raw_path))
         else:
             lines.append(f"name={s.name} size={s.size}"
                          f" modified={s.modified}"

--- a/python/mirage/commands/builtin/generic/tail.py
+++ b/python/mirage/commands/builtin/generic/tail.py
@@ -131,7 +131,7 @@ async def _tail_multi(
 ) -> AsyncIterator[bytes]:
     for i, p in enumerate(paths):
         if show_headers:
-            header = f"==> {p.display} <==\n"
+            header = f"==> {p.raw_path} <==\n"
             if i > 0:
                 header = "\n" + header
             yield header.encode()

--- a/python/mirage/commands/builtin/generic/tree.py
+++ b/python/mirage/commands/builtin/generic/tree.py
@@ -34,7 +34,7 @@ async def _walk(
     try:
         entries = sorted(await readdir(path, index))
     except (FileNotFoundError, ValueError) as exc:
-        warnings.append(f"tree: '{path.display}': {exc}")
+        warnings.append(f"tree: '{path.raw_path}': {exc}")
         return lines
 
     filtered: list[tuple[PathSpec, FileStat]] = []

--- a/python/mirage/commands/builtin/generic/wc.py
+++ b/python/mirage/commands/builtin/generic/wc.py
@@ -222,7 +222,7 @@ async def format_multi(
         if inspect.isawaitable(source):
             source = await source
         counts = await wc(source)
-        rows.append((counts, path.display))
+        rows.append((counts, path.raw_path))
         totals.merge(counts)
     if len(paths) > 1:
         rows.append((totals, "total"))

--- a/python/mirage/commands/builtin/github/narrow.py
+++ b/python/mirage/commands/builtin/github/narrow.py
@@ -27,7 +27,7 @@ from mirage.core.github.scope import (count_scope_files, scope_relative_key,
 from mirage.core.github.search import narrow_paths
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-from mirage.utils.path import rebase_display
+from mirage.utils.path import rebase_raw
 
 
 async def narrow_scope(
@@ -123,5 +123,5 @@ def files_only_shortcircuit(
     ]
     if not hits:
         return b"", IOResult(exit_code=1)
-    displays = rebase_display(hits, scope.virtual, scope.display)
-    return format_records(sorted(displays)), IOResult()
+    spelled = rebase_raw(hits, scope.virtual, scope.raw_path)
+    return format_records(sorted(spelled)), IOResult()

--- a/python/mirage/shell/helpers.py
+++ b/python/mirage/shell/helpers.py
@@ -148,17 +148,6 @@ def get_redirect_parts(
     return command, target, r.append, r.kind
 
 
-def _is_last_cmd_redirect(body: tree_sitter.Node, redirects: list) -> bool:
-    """Check if redirects belong to the last command, not the whole list.
-
-    tree-sitter-bash parses ``a || echo x > file`` as
-    ``(a || echo x) > file`` but bash treats it as
-    ``a || (echo x > file)``. Redirects never apply to an entire
-    &&/|| chain — they bind to the last simple command.
-    """
-    return body.type == NT.LIST and len(redirects) > 0
-
-
 def get_redirects(
         node: tree_sitter.Node,  # noqa: E125
 ) -> tuple[tree_sitter.Node, list[Redirect]]:

--- a/python/mirage/types.py
+++ b/python/mirage/types.py
@@ -199,14 +199,15 @@ class PathSpec:
     resolved: bool = True
     raw_path: str | None = None
 
-    @property
-    def display(self) -> str:
-        """The path as the user typed it, for rendering in output.
+    def __post_init__(self) -> None:
+        """Default ``raw_path`` to ``virtual``.
 
-        Falls back to ``virtual`` (the resolved absolute path) when no
-        raw form was recorded, e.g. for absolute arguments.
+        ``raw_path`` is the word's spelling: as typed for relative
+        words, the absolute path for everything else. It is always a
+        ``str`` after construction; pass None to take the default.
         """
-        return self.raw_path if self.raw_path is not None else self.virtual
+        if self.raw_path is None:
+            object.__setattr__(self, "raw_path", self.virtual)
 
     @property
     def mount_path(self) -> str:
@@ -253,6 +254,19 @@ class PathSpec:
             resource_path=(path.strip("/")
                            if resource_path is None else resource_path),
         )
+
+
+def word_text(word: "str | PathSpec") -> str:
+    """Shell-text form of an argv word.
+
+    Text words pass through; paths render as spelled (``raw_path``).
+    Use wherever a word re-enters string space (env values, function
+    args, the argv text view). Mount I/O keeps using ``virtual``.
+
+    Args:
+        word (str | PathSpec): text argument or path.
+    """
+    return word.raw_path if isinstance(word, PathSpec) else word
 
 
 class IndexType(str, Enum):

--- a/python/mirage/utils/path.py
+++ b/python/mirage/utils/path.py
@@ -137,8 +137,7 @@ def expand_tilde(word: str, home: str | None) -> str:
     return word
 
 
-def rebase_display(paths: list[str], original: str,
-                   display: str | None) -> list[str]:
+def rebase_raw(paths: list[str], original: str, raw: str) -> list[str]:
     """Rewrite the base of walked output paths to the as-typed form.
 
     Used by walkers like ``find``/``grep -r``: results are absolute (start
@@ -151,31 +150,32 @@ def rebase_display(paths: list[str], original: str,
 
     Example::
 
-        rebase_display(["/data/sub/x", "/data/y"], "/data", ".")
+        rebase_raw(["/data/sub/x", "/data/y"], "/data", ".")
             -> ["./sub/x", "./y"]
-        rebase_display(["/data/sub/x:hit"], "/data/sub", "sub")
+        rebase_raw(["/data/sub/x:hit"], "/data/sub", "sub")
             -> ["sub/x:hit"]
-        rebase_display(["/data/x"], "/data", "/data")   # absolute arg
-            -> ["/data/x"]                              # unchanged
+        rebase_raw(["/data/x"], "/data", "/data")   # absolute arg
+            -> ["/data/x"]                          # unchanged
 
     Args:
         paths (list[str]): Absolute result paths (or ``path:...`` lines)
             produced by walking ``original``.
         original (str): The resolved absolute start path.
-        display (str | None): The as-typed start path, or ``None``/equal to
-            leave ``paths`` unchanged (the absolute-argument case).
+        raw (str): The as-typed start path (``PathSpec.raw_path``); equal
+            to ``original`` leaves ``paths`` unchanged (the
+            absolute-argument case).
 
     Returns:
         list[str]: ``paths`` with each ``original`` base replaced by
-        ``display``.
+        ``raw``.
     """
-    if display is None or display == original:
+    if raw == original:
         return paths
-    return [rebase_one(p, original, display) for p in paths]
+    return [rebase_one(p, original, raw) for p in paths]
 
 
-def rebase_one(path: str, original: str, display: str | None) -> str:
-    """Rewrite a single path's ``original`` base to the as-typed ``display``.
+def rebase_one(path: str, original: str, raw: str) -> str:
+    """Rewrite a single path's ``original`` base to the as-typed ``raw``.
 
     Only the leading ``original`` prefix is rewritten, so any suffix after
     the path (e.g. grep's ``:line``) is preserved untouched.
@@ -186,25 +186,25 @@ def rebase_one(path: str, original: str, display: str | None) -> str:
         rebase_one("/data/sub", "/data/sub", "sub")  -> "sub"
         rebase_one("/data/x:hit", "/data", ".")      -> "./x:hit"
         rebase_one("/other/x", "/data", ".")         -> "/other/x"  # no match
-        rebase_one("/data/x", "/data", None)         -> "/data/x"   # absolute
+        rebase_one("/data/x", "/data", "/data")      -> "/data/x"   # absolute
 
     Args:
         path (str): An absolute path at or under ``original`` (optionally with
             a trailing ``:...`` suffix).
         original (str): The resolved absolute base (traversal root).
-        display (str | None): The as-typed base, or ``None``/equal to leave
-            ``path`` unchanged.
+        raw (str): The as-typed base (``PathSpec.raw_path``); equal to
+            ``original`` leaves ``path`` unchanged.
 
     Returns:
-        str: ``path`` with its ``original`` base replaced by ``display``.
+        str: ``path`` with its ``original`` base replaced by ``raw``.
     """
-    if display is None or display == original:
+    if raw == original:
         return path
     base = original.rstrip("/")
     if path == base:
-        return display
+        return raw
     if path.startswith(base + "/"):
-        return display.rstrip("/") + path[len(base):]
+        return raw.rstrip("/") + path[len(base):]
     return path
 
 

--- a/python/mirage/workspace/executor/builtins/condition.py
+++ b/python/mirage/workspace/executor/builtins/condition.py
@@ -17,17 +17,18 @@ from collections.abc import Callable
 from mirage.io import IOResult
 from mirage.io.types import ByteSource
 from mirage.types import PathSpec
+from mirage.utils.path import resolve_path
 from mirage.workspace.executor.builtins.scope import _scope_path, _to_scope
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
 
 
-async def _eval_test(dispatch: Callable, argv: list) -> bool:
+async def _eval_test(dispatch: Callable, argv: list, cwd: str) -> bool:
     if not argv:
         return False
     first = _scope_path(argv[0])
     if first == "!" and len(argv) > 1:
-        return not await _eval_test(dispatch, argv[1:])
+        return not await _eval_test(dispatch, argv[1:], cwd)
     if len(argv) == 1:
         return bool(first)
     if len(argv) == 2:
@@ -38,19 +39,26 @@ async def _eval_test(dispatch: Callable, argv: list) -> bool:
         if op == "-n":
             return _scope_path(val) != ""
         if op == "-f":
+            # A relative string operand resolves against cwd, like bash:
+            # `cd /data && test -f plain.txt` checks /data/plain.txt.
+            path = _scope_path(val)
+            if not isinstance(val, PathSpec) and not path:
+                return False
             scope = val if isinstance(val, PathSpec) else _to_scope(
-                _scope_path(val))
+                resolve_path(path, cwd))
             try:
                 await dispatch("stat", scope)
                 return True
             except (FileNotFoundError, ValueError):
                 return False
         if op == "-d":
+            path = _scope_path(val)
+            if not isinstance(val, PathSpec) and not path:
+                return False
+            if not isinstance(val, PathSpec):
+                path = resolve_path(path, cwd)
             scope = val if isinstance(val, PathSpec) else PathSpec(
-                virtual=_scope_path(val),
-                directory=_scope_path(val),
-                resource_path="",
-                resolved=False)
+                virtual=path, directory=path, resource_path="", resolved=False)
             try:
                 await dispatch("readdir", scope)
                 return True
@@ -88,7 +96,7 @@ async def handle_test(
     argv: list,
     session: Session,
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
-    result = await _eval_test(dispatch, argv)
+    result = await _eval_test(dispatch, argv, session.cwd)
     code = 0 if result else 1
     return None, IOResult(exit_code=code), ExecutionNode(command="test",
                                                          exit_code=code)

--- a/python/mirage/workspace/executor/builtins/links.py
+++ b/python/mirage/workspace/executor/builtins/links.py
@@ -12,22 +12,17 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import dataclasses
 import time
 from collections.abc import Callable
 
 from mirage.io import IOResult
 from mirage.io.types import ByteSource
-from mirage.types import FileType, PathSpec
+from mirage.types import FileType, PathSpec, word_text
 from mirage.utils.path import CycleError, resolve_path
 from mirage.workspace.mount.namespace import Namespace
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
-
-
-def _typed(arg: str | PathSpec) -> str:
-    if isinstance(arg, PathSpec):
-        return arg.raw_path or arg.virtual
-    return arg
 
 
 def _split_flags(
@@ -78,18 +73,18 @@ def handle_ln(
     # namespace links never name directories, so this is always an error
     # (an expanded multi-match glob source lands here).
     if len(operands) > 2:
-        err = (f"ln: target '{_typed(operands[-1])}' "
+        err = (f"ln: target '{word_text(operands[-1])}' "
                f"is not a directory\n").encode()
         return None, IOResult(exit_code=1,
                               stderr=err), ExecutionNode(command="ln",
                                                          exit_code=1,
                                                          stderr=err)
     link_abs = _abs(operands[1], session.cwd)
-    target_typed = _typed(operands[0])
+    target_typed = word_text(operands[0])
     exists = namespace.is_link(link_abs) and "f" not in flags
     if namespace.is_mount_root(link_abs) or exists:
         err = (f"ln: failed to create symbolic link "
-               f"'{_typed(operands[1])}': File exists\n").encode()
+               f"'{word_text(operands[1])}': File exists\n").encode()
         return None, IOResult(exit_code=1,
                               stderr=err), ExecutionNode(command="ln",
                                                          exit_code=1,
@@ -97,7 +92,7 @@ def handle_ln(
     namespace.symlink(link_abs, target_typed, time.time())
     out = None
     if "v" in flags:
-        out = (f"'{_typed(operands[1])}' -> '{target_typed}'\n").encode()
+        out = (f"'{word_text(operands[1])}' -> '{target_typed}'\n").encode()
     return out, IOResult(), ExecutionNode(command="ln", exit_code=0)
 
 
@@ -127,17 +122,16 @@ def follow_paths(
         try:
             virtual = namespace.follow(item.virtual)
         except CycleError:
-            raise CycleError(item.raw_path or item.virtual) from None
+            raise CycleError(item.raw_path) from None
         if virtual == item.virtual:
             out.append(item)
             continue
         out.append(
-            PathSpec(virtual=virtual,
-                     directory=virtual[:virtual.rfind("/") + 1] or "/",
-                     resource_path="",
-                     pattern=item.pattern,
-                     resolved=item.resolved,
-                     raw_path=item.raw_path or item.virtual))
+            dataclasses.replace(item,
+                                virtual=virtual,
+                                directory=virtual[:virtual.rfind("/") + 1]
+                                or "/",
+                                resource_path=""))
     return out
 
 

--- a/python/mirage/workspace/executor/command.py
+++ b/python/mirage/workspace/executor/command.py
@@ -389,8 +389,9 @@ async def handle_command(
     if cmd_name in session.functions:
         func_body = session.functions[cmd_name]
         cs = call_stack or CallStack()
+        # Positional args carry the word as typed ($1 stays sub/a.txt).
         text_args = [
-            p.virtual if isinstance(p, PathSpec) else p for p in parts[1:]
+            p.display if isinstance(p, PathSpec) else p for p in parts[1:]
         ]
         cs.push(text_args, function_name=cmd_name)
         saved_locals: dict[str, str | None] = {}

--- a/python/mirage/workspace/executor/command.py
+++ b/python/mirage/workspace/executor/command.py
@@ -30,7 +30,7 @@ from mirage.io.types import ByteSource
 from mirage.shell.call_stack import CallStack
 from mirage.shell.job_table import JobTable
 from mirage.shell.types import ERREXIT_EXEMPT_TYPES
-from mirage.types import PathSpec
+from mirage.types import PathSpec, word_text
 from mirage.workspace.executor.control import ReturnSignal
 from mirage.workspace.executor.fanout import (_fan_out_traversal,
                                               _should_fan_out)
@@ -48,19 +48,23 @@ from mirage.workspace.types import ExecutionNode
 _FIND_ACTION_FLAGS = frozenset({"delete", "print0", "ls"})
 
 
-async def _exec_node(cmd_str: str, io: IOResult) -> ExecutionNode:
+async def _exec_node(cmd_str: str, io: IOResult,
+                     paths: list[PathSpec]) -> ExecutionNode:
     """Build the recorded execution node, materializing any streamed stderr.
 
     Args:
         cmd_str (str): Original command text for the record.
         io (IOResult): Command result whose stderr/exit_code the node carries.
+        paths (list[PathSpec]): Classified path operands, carried so the
+            lazy-stream drain can respell filesystem errors as typed.
     """
     # The node is a recorded artifact (compared by value, serialized via a
     # sync to_dict, sometimes read twice), so the live lazy io.stderr is
     # materialized to concrete bytes here. On the cross-mount path it is bytes.
     return ExecutionNode(command=cmd_str,
                          stderr=await materialize(io.stderr),
-                         exit_code=io.exit_code)
+                         exit_code=io.exit_code,
+                         paths=paths)
 
 
 def _check_mount_root_guard_raw(
@@ -390,9 +394,7 @@ async def handle_command(
         func_body = session.functions[cmd_name]
         cs = call_stack or CallStack()
         # Positional args carry the word as typed ($1 stays sub/a.txt).
-        text_args = [
-            p.display if isinstance(p, PathSpec) else p for p in parts[1:]
-        ]
+        text_args = [word_text(p) for p in parts[1:]]
         cs.push(text_args, function_name=cmd_name)
         saved_locals: dict[str, str | None] = {}
         session._local_vars = saved_locals
@@ -492,7 +494,7 @@ async def handle_command(
         io.safeguard = (resolve_across_mounts(cmd_name, mounts)
                         if mounts else resolve_safeguard(cmd_name))
         stdout = maybe_with_timeout(stdout, io.safeguard, cmd_name)
-        return stdout, io, await _exec_node(cmd_str, io)
+        return stdout, io, await _exec_node(cmd_str, io, path_scopes)
 
     # Reject unsupported cross-mount commands
     if len(path_scopes) >= 2:
@@ -579,7 +581,7 @@ async def handle_command(
     stdout = maybe_with_timeout(stdout, io.safeguard, cmd_name)
     io.stderr = maybe_with_timeout(io.stderr, io.safeguard, cmd_name)
 
-    return stdout, io, await _exec_node(cmd_str, io)
+    return stdout, io, await _exec_node(cmd_str, io, paths)
 
 
 async def _inject_links(

--- a/python/mirage/workspace/executor/control.py
+++ b/python/mirage/workspace/executor/control.py
@@ -161,8 +161,9 @@ async def handle_for(
 
     try:
         for val in values:
-            # env stores strings only; PathSpec → .virtual
-            session.env[variable] = (val.virtual
+            # env stores strings only; PathSpec → .display, the word
+            # as typed (bash keeps `for f in sub/*.txt` matches relative)
+            session.env[variable] = (val.display
                                      if isinstance(val, PathSpec) else val)
             try:
                 stdout, io, _ = await _execute_body(execute_node, body,
@@ -330,8 +331,9 @@ async def handle_select(
 
     try:
         for val in values:
-            # env stores strings only; PathSpec → .virtual
-            session.env[variable] = (val.virtual
+            # env stores strings only; PathSpec → .display, the word
+            # as typed (bash keeps `for f in sub/*.txt` matches relative)
+            session.env[variable] = (val.display
                                      if isinstance(val, PathSpec) else val)
             try:
                 stdout, io, _ = await _execute_body(execute_node, body,

--- a/python/mirage/workspace/executor/control.py
+++ b/python/mirage/workspace/executor/control.py
@@ -24,7 +24,7 @@ from mirage.io.types import ByteSource
 from mirage.shell.barrier import BarrierPolicy, apply_barrier
 from mirage.shell.call_stack import CallStack
 from mirage.shell.types import ERREXIT_EXEMPT_TYPES
-from mirage.types import PathSpec
+from mirage.types import PathSpec, word_text
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
 
@@ -161,10 +161,9 @@ async def handle_for(
 
     try:
         for val in values:
-            # env stores strings only; PathSpec → .display, the word
-            # as typed (bash keeps `for f in sub/*.txt` matches relative)
-            session.env[variable] = (val.display
-                                     if isinstance(val, PathSpec) else val)
+            # env stores strings only; bash keeps `for f in sub/*.txt`
+            # matches relative, so the loop variable takes the typed form
+            session.env[variable] = word_text(val)
             try:
                 stdout, io, _ = await _execute_body(execute_node, body,
                                                     session, stdin, call_stack)
@@ -331,10 +330,9 @@ async def handle_select(
 
     try:
         for val in values:
-            # env stores strings only; PathSpec → .display, the word
-            # as typed (bash keeps `for f in sub/*.txt` matches relative)
-            session.env[variable] = (val.display
-                                     if isinstance(val, PathSpec) else val)
+            # env stores strings only; bash keeps `for f in sub/*.txt`
+            # matches relative, so the loop variable takes the typed form
+            session.env[variable] = word_text(val)
             try:
                 stdout, io, _ = await _execute_body(execute_node, body,
                                                     session, stdin, call_stack)

--- a/python/mirage/workspace/executor/fs_error.py
+++ b/python/mirage/workspace/executor/fs_error.py
@@ -26,7 +26,7 @@ def format_fs_error(cmd_name: str,
     exception (``exc.filename`` when set, else ``str(exc)``); backends raise
     with the resolved absolute path (``PathSpec.virtual``). When ``paths`` is
     supplied, the absolute path is rewritten to the as-typed form
-    (``PathSpec.display``) so a relative argument is reported as typed, like
+    (``PathSpec.raw_path``) so a relative argument is reported as typed, like
     GNU.
 
     Args:
@@ -39,7 +39,7 @@ def format_fs_error(cmd_name: str,
     if paths:
         for p in paths:
             if p.virtual == path:
-                path = p.display
+                path = p.raw_path
                 break
     strerror = fs_strerror(exc)
     if strerror is not None:

--- a/python/mirage/workspace/executor/redirect.py
+++ b/python/mirage/workspace/executor/redirect.py
@@ -19,7 +19,6 @@ from mirage.io.stream import materialize
 from mirage.io.types import ByteSource
 from mirage.shell.barrier import BarrierPolicy, apply_barrier
 from mirage.shell.call_stack import CallStack
-from mirage.shell.helpers import _is_last_cmd_redirect, get_list_parts
 from mirage.shell.types import Redirect, RedirectKind
 from mirage.types import PathSpec
 from mirage.workspace.executor.builtins import _to_scope
@@ -56,22 +55,6 @@ async def handle_redirect(
                 cmd_stdin = (text + "\n").encode()
             else:
                 cmd_stdin = text
-
-    if (command.type == "list" and redirects
-            and _is_last_cmd_redirect(command, redirects)):
-        left, op, right = get_list_parts(command)
-        left_stdout, left_io, left_exec = await execute_node(
-            left, session, cmd_stdin, call_stack)
-        left_bytes = await apply_barrier(left_stdout, left_io,
-                                         BarrierPolicy.VALUE)
-        session.last_exit_code = left_io.exit_code
-        run_right = (op == "||" and left_io.exit_code
-                     != 0) or (op == "&&" and left_io.exit_code == 0)
-        if run_right:
-            return await handle_redirect(execute_node, dispatch, right,
-                                         redirects, session, cmd_stdin,
-                                         call_stack)
-        return left_bytes, left_io, left_exec
 
     stdout, io, exec_node = await execute_node(command, session, cmd_stdin,
                                                call_stack)

--- a/python/mirage/workspace/expand/argv.py
+++ b/python/mirage/workspace/expand/argv.py
@@ -20,7 +20,7 @@ import tree_sitter
 
 from mirage.commands.spec.types import OperandKind
 from mirage.shell.call_stack import CallStack
-from mirage.types import PathSpec
+from mirage.types import PathSpec, word_text
 from mirage.workspace.expand.classify import classify_parts
 from mirage.workspace.expand.globs import resolve_globs
 from mirage.workspace.expand.parts import expand_parts
@@ -118,10 +118,10 @@ async def expand_argv(
         words = await resolve_globs(classified, registry)
     else:
         words = classified
-    # The text view renders words as typed (display): bash hands
+    # The text view renders words as typed (raw_path): bash hands
     # programs their words unchanged, so `echo sub/file.txt` prints the
     # relative form, not the resolved absolute path.
-    text_view = [p.display if isinstance(p, PathSpec) else p for p in words]
+    text_view = [word_text(p) for p in words]
     return Argv(name=name,
                 args=tuple(text_view[1:]),
                 operands=tuple(words[1:]))

--- a/python/mirage/workspace/expand/argv.py
+++ b/python/mirage/workspace/expand/argv.py
@@ -118,7 +118,10 @@ async def expand_argv(
         words = await resolve_globs(classified, registry)
     else:
         words = classified
-    text_view = [p.virtual if isinstance(p, PathSpec) else p for p in words]
+    # The text view renders words as typed (display): bash hands
+    # programs their words unchanged, so `echo sub/file.txt` prints the
+    # relative form, not the resolved absolute path.
+    text_view = [p.display if isinstance(p, PathSpec) else p for p in words]
     return Argv(name=name,
                 args=tuple(text_view[1:]),
                 operands=tuple(words[1:]))

--- a/python/mirage/workspace/expand/classify/__init__.py
+++ b/python/mirage/workspace/expand/classify/__init__.py
@@ -15,9 +15,11 @@
 from mirage.workspace.expand.classify.heuristic import classify_word
 from mirage.workspace.expand.classify.parts import classify_parts
 from mirage.workspace.expand.classify.path import classify_bare_path
+from mirage.workspace.expand.classify.relative import relative_spec
 
 __all__ = [
     "classify_bare_path",
     "classify_parts",
     "classify_word",
+    "relative_spec",
 ]

--- a/python/mirage/workspace/expand/classify/heuristic.py
+++ b/python/mirage/workspace/expand/classify/heuristic.py
@@ -18,6 +18,7 @@ import shlex
 
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
+from mirage.workspace.expand.classify.relative import GLOB_CHARS, relative_spec
 from mirage.workspace.mount import MountRegistry
 
 _FILENAME_CHAR = re.compile(r"[a-zA-Z0-9_./]")
@@ -56,7 +57,7 @@ def classify_word(word: str, registry: MountRegistry,
     - Relative + no glob -> plain text (never a path)
     - No mount match -> plain text
     """
-    has_glob = any(ch in word for ch in ("*", "?", "["))
+    has_glob = any(ch in word for ch in GLOB_CHARS)
 
     if word.startswith("/"):
         # Unescape backslash-escaped paths (e.g. /data/Zecheng\'s\ Server).
@@ -102,20 +103,7 @@ def classify_word(word: str, registry: MountRegistry,
     if has_glob and ("/" in word or not word.startswith(".")):
         if not _FILENAME_CHAR.search(word) or _NON_PATH_CHAR.search(word):
             return word
-        path = posixpath.normpath(cwd.rstrip("/") + "/" + word)
-        try:
-            mount = registry.mount_for(path)
-        except ValueError:
-            return word
-        last_slash = path.rfind("/")
-        return PathSpec(
-            virtual=path,
-            directory=path[:last_slash + 1],
-            resource_path=mount_key(path, mount.prefix.rstrip("/")),
-            pattern=path[last_slash + 1:],
-            resolved=False,
-            raw_path=word,
-        )
+        return relative_spec(word, registry, cwd)
 
     # Relative path (no glob): resolve against cwd if the word
     # contains "/" and looks like a subdirectory path (e.g. sub/file.txt).
@@ -127,17 +115,6 @@ def classify_word(word: str, registry: MountRegistry,
     if not has_glob and "/" in word and _RELATIVE_PATH.fullmatch(word):
         if "\\" in word:
             word = _unescape_path(word)
-        path = posixpath.normpath(cwd.rstrip("/") + "/" + word)
-        try:
-            mount = registry.mount_for(path)
-        except ValueError:
-            return word
-        return PathSpec(
-            virtual=path,
-            directory=path[:path.rfind("/") + 1],
-            resource_path=mount_key(path, mount.prefix.rstrip("/")),
-            resolved=True,
-            raw_path=word,
-        )
+        return relative_spec(word, registry, cwd)
 
     return word

--- a/python/mirage/workspace/expand/classify/path.py
+++ b/python/mirage/workspace/expand/classify/path.py
@@ -12,11 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import posixpath
-
 from mirage.types import PathSpec
-from mirage.utils.key_prefix import mount_key
 from mirage.workspace.expand.classify.heuristic import classify_word
+from mirage.workspace.expand.classify.relative import relative_spec
 from mirage.workspace.mount import MountRegistry
 
 
@@ -30,27 +28,4 @@ def classify_bare_path(word: str, registry: MountRegistry,
     classified = classify_word(word, registry, cwd)
     if not isinstance(classified, str):
         return classified
-    path = posixpath.normpath(cwd.rstrip("/") + "/" + word)
-    try:
-        mount = registry.mount_for(path)
-    except ValueError:
-        return word
-    resource_path = mount_key(path, mount.prefix.rstrip("/"))
-    has_glob = any(ch in word for ch in ("*", "?", "["))
-    if has_glob:
-        last_slash = path.rfind("/")
-        return PathSpec(
-            virtual=path,
-            directory=path[:last_slash + 1],
-            resource_path=resource_path,
-            pattern=path[last_slash + 1:],
-            resolved=False,
-            raw_path=word,
-        )
-    return PathSpec(
-        virtual=path,
-        directory=path[:path.rfind("/") + 1],
-        resource_path=resource_path,
-        resolved=True,
-        raw_path=word,
-    )
+    return relative_spec(word, registry, cwd)

--- a/python/mirage/workspace/expand/classify/relative.py
+++ b/python/mirage/workspace/expand/classify/relative.py
@@ -1,0 +1,61 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import posixpath
+
+from mirage.types import PathSpec
+from mirage.utils.key_prefix import mount_key
+from mirage.workspace.mount import MountRegistry
+
+GLOB_CHARS = ("*", "?", "[")
+
+
+def relative_spec(word: str, registry: MountRegistry,
+                  cwd: str) -> str | PathSpec:
+    """Build the PathSpec for a word typed relative to cwd.
+
+    The typed word and the cwd it was typed under are two halves of one
+    path: ``virtual`` resolves the pair to an absolute path, ``raw_path``
+    keeps the typed spelling for display. Glob chars in the word make a
+    pattern spec (unresolved); words whose resolved path has no mount
+    stay plain text.
+
+    Args:
+        word (str): the word as typed (already unescaped).
+        registry (MountRegistry): mount registry.
+        cwd (str): working directory the word was typed under.
+    """
+    path = posixpath.normpath(cwd.rstrip("/") + "/" + word)
+    try:
+        mount = registry.mount_for(path)
+    except ValueError:
+        return word
+    resource_path = mount_key(path, mount.prefix.rstrip("/"))
+    last_slash = path.rfind("/")
+    if any(ch in word for ch in GLOB_CHARS):
+        return PathSpec(
+            virtual=path,
+            directory=path[:last_slash + 1],
+            resource_path=resource_path,
+            pattern=path[last_slash + 1:],
+            resolved=False,
+            raw_path=word,
+        )
+    return PathSpec(
+        virtual=path,
+        directory=path[:last_slash + 1],
+        resource_path=resource_path,
+        resolved=True,
+        raw_path=word,
+    )

--- a/python/mirage/workspace/expand/globs.py
+++ b/python/mirage/workspace/expand/globs.py
@@ -19,6 +19,28 @@ from mirage.utils.key_prefix import mount_key
 from mirage.workspace.mount import MountRegistry
 
 
+def _match_display(item: PathSpec, match: PathSpec) -> PathSpec:
+    """Stamp a glob match with the display form the user's word implies.
+
+    Bash expands `sub/*.txt` to relative matches (`sub/a.txt`), keeping
+    the typed prefix. The glob item's raw_path records the word as
+    typed; matches rebuild it by swapping the resolved directory prefix
+    for the typed one. Absolute words (no raw_path) keep the resolved
+    virtual.
+
+    Args:
+        item (PathSpec): the glob word being resolved.
+        match (PathSpec): one resolved match.
+    """
+    if item.raw_path is None or match.raw_path is not None:
+        return match
+    if not match.virtual.startswith(item.directory):
+        return match
+    raw_dir = item.raw_path[:item.raw_path.rfind("/") + 1]
+    display = raw_dir + match.virtual[len(item.directory):]
+    return dataclasses.replace(match, raw_path=display)
+
+
 async def resolve_globs(
     classified: list[str | PathSpec],
     registry: MountRegistry,
@@ -55,12 +77,15 @@ async def resolve_globs(
                     continue
                 for p in resolved:
                     if isinstance(p, PathSpec):
-                        result.append(p)
+                        result.append(_match_display(item, p))
                     else:
                         full = prefix + p if not p.startswith(prefix) else p
                         result.append(
-                            PathSpec.from_str_path(full,
-                                                   mount_key(full, prefix)))
+                            _match_display(
+                                item,
+                                PathSpec.from_str_path(full,
+                                                       mount_key(full,
+                                                                 prefix))))
             except (ValueError, AttributeError, TypeError):
                 result.append(item)
         elif isinstance(item, PathSpec):

--- a/python/mirage/workspace/expand/globs.py
+++ b/python/mirage/workspace/expand/globs.py
@@ -19,26 +19,27 @@ from mirage.utils.key_prefix import mount_key
 from mirage.workspace.mount import MountRegistry
 
 
-def _match_display(item: PathSpec, match: PathSpec) -> PathSpec:
-    """Stamp a glob match with the display form the user's word implies.
+def _match_raw(item: PathSpec, match: PathSpec) -> PathSpec:
+    """Stamp a glob match with the spelling the user's word implies.
 
     Bash expands `sub/*.txt` to relative matches (`sub/a.txt`), keeping
     the typed prefix. The glob item's raw_path records the word as
     typed; matches rebuild it by swapping the resolved directory prefix
-    for the typed one. Absolute words (no raw_path) keep the resolved
-    virtual.
+    for the typed one. Words with no distinct spelling (absolute:
+    raw_path == virtual) keep the resolved virtual, as do matches that
+    already carry one.
 
     Args:
         item (PathSpec): the glob word being resolved.
         match (PathSpec): one resolved match.
     """
-    if item.raw_path is None or match.raw_path is not None:
+    if item.raw_path == item.virtual or match.raw_path != match.virtual:
         return match
     if not match.virtual.startswith(item.directory):
         return match
     raw_dir = item.raw_path[:item.raw_path.rfind("/") + 1]
-    display = raw_dir + match.virtual[len(item.directory):]
-    return dataclasses.replace(match, raw_path=display)
+    spelled = raw_dir + match.virtual[len(item.directory):]
+    return dataclasses.replace(match, raw_path=spelled)
 
 
 async def resolve_globs(
@@ -77,11 +78,11 @@ async def resolve_globs(
                     continue
                 for p in resolved:
                     if isinstance(p, PathSpec):
-                        result.append(_match_display(item, p))
+                        result.append(_match_raw(item, p))
                     else:
                         full = prefix + p if not p.startswith(prefix) else p
                         result.append(
-                            _match_display(
+                            _match_raw(
                                 item,
                                 PathSpec.from_str_path(full,
                                                        mount_key(full,

--- a/python/mirage/workspace/node/command_dispatch.py
+++ b/python/mirage/workspace/node/command_dispatch.py
@@ -287,7 +287,7 @@ async def _run_argv(
                                    physical=physical)
         if isinstance(raw, PathSpec):
             path = raw
-            cdpath_target = raw.raw_path or raw.virtual
+            cdpath_target = raw.raw_path
         elif raw_str.startswith("/"):
             path = raw_str
             cdpath_target = raw_str

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -50,6 +50,52 @@ from mirage.workspace.executor.builtins import (  # isort: skip
     handle_export, handle_local, handle_readonly, handle_test, handle_unset)
 
 
+async def _recurse_reassociated(
+    recurse: Callable,
+    dispatch: Callable,
+    execute_fn: Callable,
+    registry: MountRegistry,
+    redirects: list,
+    right: Any,
+    node: Any,
+    session: Session,
+    stdin: Any = None,
+    call_stack: CallStack | None = None,
+) -> tuple[Any, IOResult, ExecutionNode]:
+    """Recurse wrapper for a re-associated trailing redirect.
+
+    Executes the list's last command with the hoisted redirects,
+    expanding targets only at that point (after the left side ran, so
+    cwd changes apply); every other node recurses normally.
+
+    Args:
+        recurse (Callable): the plain execute_node recursion.
+        dispatch (Callable): VFS op dispatcher.
+        execute_fn (Callable): recursive execute (for expansions).
+        registry (MountRegistry): mount registry.
+        redirects (list): parsed redirects hoisted off the list.
+        right (Any): the list's last command node.
+        node (Any): node being executed by handle_connection.
+        session (Session): shell session state.
+        stdin (Any): input stream.
+        call_stack (CallStack | None): shell call stack.
+    """
+    if node is not right:
+        return await recurse(node, session, stdin, call_stack)
+    expanded, pipe_node = await expand_redirects(redirects, session,
+                                                 execute_fn, registry,
+                                                 call_stack)
+    stdout, io, exec_node = await handle_redirect(recurse, dispatch, right,
+                                                  expanded, session, stdin,
+                                                  call_stack)
+    if pipe_node is not None and stdout is not None:
+        stdout, io2, exec_node2 = await recurse(pipe_node, session, stdout,
+                                                call_stack)
+        io = await io.merge(io2)
+        exec_node = exec_node2
+    return stdout, io, exec_node
+
+
 async def execute_node(
     dispatch: Callable,
     registry: MountRegistry,
@@ -130,6 +176,19 @@ async def execute_node(
     # ── redirected statement ────────────────────
     if kind == NodeKind.REDIRECT:
         command, redirects = get_redirects(node)
+        if command.type == NT.LIST:
+            # tree-sitter hoists a trailing redirect over the whole
+            # &&/|| list; bash binds it to the last command:
+            #   redirected(list(L, op, R), r) == list(L, op, redirected(R, r))
+            # Re-associate and defer target expansion until R runs, so
+            # `cd /x && echo hi > f` writes under /x. Compound and
+            # subshell bodies keep the whole-body redirect (bash group
+            # semantics).
+            left, op, right = get_list_parts(command)
+            wrapped = partial(_recurse_reassociated, recurse, dispatch,
+                              execute_fn, registry, redirects, right)
+            return await handle_connection(wrapped, left, op, right, session,
+                                           stdin, cs)
         expanded_redirects, pipe_node = await expand_redirects(
             redirects, session, execute_fn, registry, cs)
         stdout, io, exec_node = await handle_redirect(recurse, dispatch,

--- a/python/mirage/workspace/node/program.py
+++ b/python/mirage/workspace/node/program.py
@@ -69,11 +69,12 @@ async def execute_program(
                 stdout = await materialize(stdout)
             except OSError as exc:
                 # Lazy reads (head/tail opening the stream mid-pipeline) can
-                # fail on the first pull; format as a GNU coreutils line with
-                # the virtual path, mirroring the eager executor chokepoint.
+                # fail on the first pull; format as a GNU coreutils line,
+                # respelling the path as typed via the operands the leaf
+                # node carries, mirroring the eager executor chokepoint.
                 cmd_name = (last_exec.command.split()[0]
                             if last_exec.command else "")
-                drain_err = format_fs_error(cmd_name, exc)
+                drain_err = format_fs_error(cmd_name, exc, last_exec.paths)
                 stdout = None
             except Exception as exc:
                 drain_err = f"{exc}\n".encode()

--- a/python/mirage/workspace/node/provision_node.py
+++ b/python/mirage/workspace/node/provision_node.py
@@ -88,6 +88,80 @@ class PlanScope:
     planning: set[str] = field(default_factory=set)
 
 
+async def _provision_redirected(
+    recurse: Callable,
+    registry: MountRegistry,
+    namespace: Namespace | None,
+    execute_fn: Callable,
+    command: Any,
+    redirects: list,
+    session: Session,
+) -> ProvisionResult:
+    """Plan one redirected command: expand targets, cost, degrade.
+
+    Args:
+        recurse (Callable): the provision recursion.
+        registry (MountRegistry): mount registry.
+        namespace (Namespace | None): addressing authority.
+        execute_fn (Callable): recursive execute (for expansions).
+        command (Any): the redirected command node.
+        redirects (list): parsed redirects.
+        session (Session): shell session state.
+    """
+    expanded, pipe_node = await expand_redirects(redirects, session,
+                                                 execute_fn, registry)
+    # A cmdsub target expands empty under provision, so its
+    # classification is garbage; the precision degrade below keeps
+    # the plan honest without costing a phantom write (mirrors TS).
+    targets = [
+        (r.kind, r.target) for r in expanded
+        if r.kind in (RedirectKind.STDIN, RedirectKind.STDOUT) and isinstance(
+            r.target, PathSpec) and not r.target.virtual.startswith("/dev/")
+        and not (r.target_node is not None
+                 and has_command_substitution(r.target_node))
+    ]
+    result = await handle_redirect_provision(recurse, registry, command,
+                                             targets, session, namespace)
+    if any(r.target_node is not None
+           and has_command_substitution(r.target_node) for r in redirects):
+        # A suppressed substitution hid the real redirect target.
+        result.precision = Precision.UNKNOWN
+    if pipe_node is not None:
+        return rollup_pipe([result, await recurse(pipe_node, session)])
+    return result
+
+
+async def _provision_reassociated(
+    recurse: Callable,
+    registry: MountRegistry,
+    namespace: Namespace | None,
+    execute_fn: Callable,
+    redirects: list,
+    right: Any,
+    node: Any,
+    session: Session,
+) -> ProvisionResult:
+    """Provision recurse wrapper for a re-associated trailing redirect.
+
+    Mirrors the executor: the list's last command carries the hoisted
+    redirects; every other node provisions normally.
+
+    Args:
+        recurse (Callable): the provision recursion.
+        registry (MountRegistry): mount registry.
+        namespace (Namespace | None): addressing authority.
+        execute_fn (Callable): recursive execute (for expansions).
+        redirects (list): parsed redirects hoisted off the list.
+        right (Any): the list's last command node.
+        node (Any): node being provisioned by the connection handler.
+        session (Session): shell session state.
+    """
+    if node is not right:
+        return await recurse(node, session)
+    return await _provision_redirected(recurse, registry, namespace,
+                                       execute_fn, right, redirects, session)
+
+
 async def provision_node(
     registry: MountRegistry,
     dispatch: Callable,
@@ -172,26 +246,17 @@ async def provision_node(
 
     if kind == NodeKind.REDIRECT:
         command, redirects = get_redirects(node)
-        expanded, pipe_node = await expand_redirects(redirects, session,
-                                                     execute_fn, registry)
-        # A cmdsub target expands empty under provision, so its
-        # classification is garbage; the precision degrade below keeps
-        # the plan honest without costing a phantom write (mirrors TS).
-        targets = [(r.kind, r.target) for r in expanded
-                   if r.kind in (RedirectKind.STDIN, RedirectKind.STDOUT)
-                   and isinstance(r.target, PathSpec)
-                   and not r.target.virtual.startswith("/dev/")
-                   and not (r.target_node is not None
-                            and has_command_substitution(r.target_node))]
-        result = await handle_redirect_provision(recurse, registry, command,
-                                                 targets, session, namespace)
-        if any(r.target_node is not None
-               and has_command_substitution(r.target_node) for r in redirects):
-            # A suppressed substitution hid the real redirect target.
-            result.precision = Precision.UNKNOWN
-        if pipe_node is not None:
-            return rollup_pipe([result, await recurse(pipe_node, session)])
-        return result
+        if command.type == NT.LIST:
+            # Mirror the executor: a trailing redirect hoisted over an
+            # &&/|| list binds to the last command.
+            left, op, right = get_list_parts(command)
+            wrapped = partial(_provision_reassociated, recurse, registry,
+                              namespace, execute_fn, redirects, right)
+            return await handle_connection_provision(wrapped, left, op, right,
+                                                     session)
+        return await _provision_redirected(recurse, registry, namespace,
+                                           execute_fn, command, redirects,
+                                           session)
 
     if kind == NodeKind.IF:
         branches, else_body = get_if_branches(node)

--- a/python/mirage/workspace/types.py
+++ b/python/mirage/workspace/types.py
@@ -15,6 +15,7 @@
 from dataclasses import asdict, dataclass, field
 
 from mirage.observe import OpRecord
+from mirage.types import PathSpec
 
 
 @dataclass
@@ -28,6 +29,9 @@ class ExecutionNode:
         exit_code (int): This node's exit code.
         children (list[ExecutionNode]): Child nodes (empty for leaf commands).
         records (list[OpRecord]): I/O operation records for this node.
+        paths (list[PathSpec]): Classified path operands of a leaf mount
+            command. Transient (not serialized): lets the lazy-stream drain
+            respell filesystem errors as typed, like the eager chokepoint.
     """
 
     command: str | None = None
@@ -36,6 +40,7 @@ class ExecutionNode:
     exit_code: int = 0
     children: list["ExecutionNode"] = field(default_factory=list)
     records: list[OpRecord] = field(default_factory=list)
+    paths: list[PathSpec] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         d: dict = {}

--- a/python/tests/shell/test_parse.py
+++ b/python/tests/shell/test_parse.py
@@ -15,9 +15,8 @@
 import tree_sitter
 
 from mirage.shell import parse
-from mirage.shell.helpers import (_is_last_cmd_redirect, get_command_name,
-                                  get_for_parts, get_if_branches,
-                                  get_list_parts, get_parts,
+from mirage.shell.helpers import (get_command_name, get_for_parts,
+                                  get_if_branches, get_list_parts, get_parts,
                                   get_pipeline_commands, get_redirect_parts,
                                   get_redirects, get_text, get_while_parts)
 from mirage.shell.types import NodeType as NT
@@ -116,13 +115,17 @@ def test_redirect_stderr():
 
 
 def test_redirect_on_list_detected():
-    """tree-sitter parses 'a || echo x > file' with > on the list."""
+    """tree-sitter parses 'a || echo x > file' with > on the list.
+
+    The executor re-associates this shape to the last command
+    (execute_node NodeKind.REDIRECT), so the parse must keep exposing
+    the list body.
+    """
     node = parse("a || echo x > /out.txt").named_children[0]
     assert node.type == NT.REDIRECTED_STATEMENT
     body, redirects = get_redirects(node)
     assert body.type == NT.LIST
     assert len(redirects) == 1
-    assert _is_last_cmd_redirect(body, redirects)
 
 
 def test_redirect_on_and_chain_detected():
@@ -130,7 +133,7 @@ def test_redirect_on_and_chain_detected():
     node = parse("a && echo x > /out.txt").named_children[0]
     body, redirects = get_redirects(node)
     assert body.type == NT.LIST
-    assert _is_last_cmd_redirect(body, redirects)
+    assert len(redirects) == 1
 
 
 def test_redirect_on_simple_command_not_list():
@@ -138,7 +141,7 @@ def test_redirect_on_simple_command_not_list():
     node = parse("echo hello > /out.txt").named_children[0]
     body, redirects = get_redirects(node)
     assert body.type == NT.COMMAND
-    assert not _is_last_cmd_redirect(body, redirects)
+    assert len(redirects) == 1
 
 
 def test_subshell():

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -15,7 +15,8 @@
 import pytest
 from pydantic import ValidationError
 
-from mirage.types import Aggr, CommandSafeguard, FileStat, OnExceed, PathSpec
+from mirage.types import (Aggr, CommandSafeguard, FileStat, OnExceed, PathSpec,
+                          word_text)
 
 
 def test_filestat_defaults():
@@ -92,19 +93,31 @@ def test_pathspec_requires_resource_path():
         PathSpec(virtual="/x.txt", directory="/")
 
 
-def test_pathspec_display_prefers_raw_path():
+def test_pathspec_raw_path_kept_when_given():
     p = PathSpec(virtual="/data/a.txt",
                  directory="/data/",
                  resource_path="a.txt",
                  raw_path="../a.txt")
-    assert p.display == "../a.txt"
+    assert p.raw_path == "../a.txt"
 
 
-def test_pathspec_display_falls_back_to_virtual():
+def test_pathspec_raw_path_defaults_to_virtual():
     p = PathSpec(virtual="/data/a.txt",
                  directory="/data/",
                  resource_path="a.txt")
-    assert p.display == "/data/a.txt"
+    assert p.raw_path == "/data/a.txt"
+
+
+def test_word_text_passes_strings_through():
+    assert word_text("plain") == "plain"
+
+
+def test_word_text_renders_paths_as_typed():
+    p = PathSpec(virtual="/data/a.txt",
+                 directory="/data/",
+                 resource_path="a.txt",
+                 raw_path="a.txt")
+    assert word_text(p) == "a.txt"
 
 
 def test_pathspec_dir_trims_resource_path():

--- a/python/tests/workspace/executor/builtins/test_condition.py
+++ b/python/tests/workspace/executor/builtins/test_condition.py
@@ -1,0 +1,85 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, RAMResource, Workspace
+
+
+async def _workspace() -> Workspace:
+    ws = Workspace({"/": RAMResource()}, mode=MountMode.WRITE)
+    await ws.execute("mkdir -p /data/sub")
+    await ws.execute("tee /data/plain.txt > /dev/null", stdin=b"y\n")
+    await ws.execute("cd /data")
+    return ws
+
+
+async def _rc(ws: Workspace, cmd: str) -> int:
+    io = await ws.execute(cmd)
+    return io.exit_code
+
+
+@pytest.mark.asyncio
+async def test_f_relative_resolves_against_cwd():
+    ws = await _workspace()
+    assert await _rc(ws, "test -f plain.txt") == 0
+
+
+@pytest.mark.asyncio
+async def test_f_relative_missing():
+    ws = await _workspace()
+    assert await _rc(ws, "test -f missing.txt") == 1
+
+
+@pytest.mark.asyncio
+async def test_f_relative_with_dotdot():
+    ws = await _workspace()
+    await ws.execute("cd /data/sub")
+    assert await _rc(ws, "test -f ../plain.txt") == 0
+
+
+@pytest.mark.asyncio
+async def test_d_relative_resolves_against_cwd():
+    ws = await _workspace()
+    assert await _rc(ws, "test -d sub") == 0
+
+
+@pytest.mark.asyncio
+async def test_d_relative_missing():
+    ws = await _workspace()
+    assert await _rc(ws, "test -d nosuch") == 1
+
+
+@pytest.mark.asyncio
+async def test_f_absolute_unchanged():
+    ws = await _workspace()
+    assert await _rc(ws, "test -f /data/plain.txt") == 0
+
+
+@pytest.mark.asyncio
+async def test_f_empty_operand_false():
+    ws = await _workspace()
+    assert await _rc(ws, 'test -f ""') == 1
+
+
+@pytest.mark.asyncio
+async def test_bracket_form_relative():
+    ws = await _workspace()
+    assert await _rc(ws, "[ -f plain.txt ]") == 0
+
+
+@pytest.mark.asyncio
+async def test_negation_relative():
+    ws = await _workspace()
+    assert await _rc(ws, "test ! -f missing.txt") == 0

--- a/python/tests/workspace/executor/test_redirect.py
+++ b/python/tests/workspace/executor/test_redirect.py
@@ -1,0 +1,103 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, RAMResource, Workspace
+
+
+async def _workspace() -> Workspace:
+    ws = Workspace({"/": RAMResource()}, mode=MountMode.WRITE)
+    await ws.execute("mkdir -p /data")
+    return ws
+
+
+async def _out(ws: Workspace, cmd: str) -> str:
+    io = await ws.execute(cmd)
+    return (io.stdout or b"").decode()
+
+
+@pytest.mark.asyncio
+async def test_redirect_target_expands_after_cd_in_list():
+    # tree-sitter hoists the trailing redirect over the && list; the
+    # target must still expand with the cwd the last command sees.
+    ws = await _workspace()
+    await ws.execute("cd /data && echo hi > OUT")
+    assert await _out(ws, "cat /data/OUT") == "hi\n"
+
+
+@pytest.mark.asyncio
+async def test_redirect_captures_only_last_command():
+    ws = await _workspace()
+    out = await _out(ws, "echo one && echo two > /data/f")
+    assert out == "one\n"
+    assert await _out(ws, "cat /data/f") == "two\n"
+
+
+@pytest.mark.asyncio
+async def test_redirect_short_circuit_and():
+    ws = await _workspace()
+    io = await ws.execute("false && echo never > /data/f3")
+    assert io.exit_code == 1
+    io = await ws.execute("test -f /data/f3")
+    assert io.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_redirect_short_circuit_or():
+    ws = await _workspace()
+    await ws.execute("false || echo fallback > /data/f4")
+    assert await _out(ws, "cat /data/f4") == "fallback\n"
+
+
+@pytest.mark.asyncio
+async def test_redirect_chain_compounds():
+    # Each redirect re-associates independently, so a multi-redirect
+    # chain executes left to right instead of hoisting.
+    ws = await _workspace()
+    out = await _out(
+        ws, "echo a > /data/c && echo b >> /data/c && cat /data/c"
+        " && wc -l < /data/c")
+    assert out == "a\nb\n2\n"
+
+
+@pytest.mark.asyncio
+async def test_redirect_group_keeps_whole_body():
+    # Compound bodies are real bash group redirects, not hoists.
+    ws = await _workspace()
+    await ws.execute("{ echo g1; echo g2; } > /data/grp")
+    assert await _out(ws, "cat /data/grp") == "g1\ng2\n"
+
+
+@pytest.mark.asyncio
+async def test_redirect_subshell_keeps_whole_body():
+    ws = await _workspace()
+    await ws.execute("(echo s1; echo s2) > /data/subq")
+    assert await _out(ws, "cat /data/subq") == "s1\ns2\n"
+
+
+@pytest.mark.asyncio
+async def test_redirect_pipeline_right_side():
+    ws = await _workspace()
+    out = await _out(
+        ws, "echo x && echo y | tr a-z A-Z > /data/up && cat /data/up")
+    assert out == "x\nY\n"
+
+
+@pytest.mark.asyncio
+async def test_stdin_redirect_binds_last_command():
+    ws = await _workspace()
+    await ws.execute("printf 'l1\\nl2\\n' | tee /data/seed > /dev/null")
+    out = await _out(ws, "echo lead && wc -l < /data/seed")
+    assert out == "lead\n2\n"

--- a/python/tests/workspace/expand/classify/test_relative.py
+++ b/python/tests/workspace/expand/classify/test_relative.py
@@ -1,0 +1,62 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.resource.ram import RAMResource
+from mirage.types import MountMode, PathSpec
+from mirage.workspace.expand.classify.relative import relative_spec
+from mirage.workspace.mount import MountRegistry
+
+
+def _registry() -> MountRegistry:
+    registry = MountRegistry()
+    registry.mount("/ram/", RAMResource(), MountMode.WRITE)
+    return registry
+
+
+def test_plain_word_resolves_and_keeps_raw():
+    result = relative_spec("sub/a.txt", _registry(), "/ram")
+    assert isinstance(result, PathSpec)
+    assert result.virtual == "/ram/sub/a.txt"
+    assert result.raw_path == "sub/a.txt"
+    assert result.resolved
+    assert result.pattern is None
+
+
+def test_glob_word_becomes_pattern():
+    result = relative_spec("sub/*.txt", _registry(), "/ram")
+    assert isinstance(result, PathSpec)
+    assert result.directory == "/ram/sub/"
+    assert result.pattern == "*.txt"
+    assert not result.resolved
+    assert result.raw_path == "sub/*.txt"
+
+
+def test_dotdot_normalizes():
+    result = relative_spec("../x.txt", _registry(), "/ram/sub")
+    assert isinstance(result, PathSpec)
+    assert result.virtual == "/ram/x.txt"
+    assert result.raw_path == "../x.txt"
+
+
+def test_unmounted_stays_text():
+    registry = MountRegistry()
+    registry.mount("/ram/", RAMResource(), MountMode.WRITE)
+    assert relative_spec("a.txt", registry, "/elsewhere") == "a.txt"
+
+
+def test_raw_path_round_trip():
+    result = relative_spec("./sub/a.txt", _registry(), "/ram")
+    assert isinstance(result, PathSpec)
+    assert result.raw_path == "./sub/a.txt"
+    assert result.virtual == "/ram/sub/a.txt"

--- a/python/tests/workspace/expand/test_globs.py
+++ b/python/tests/workspace/expand/test_globs.py
@@ -230,3 +230,68 @@ def test_scope_error_truncates_instead_of_crash():
 
     result = asyncio.run(_run())
     assert len(result) == 5
+
+
+def test_relative_glob_matches_display_as_typed():
+    matches = [
+        PathSpec(resource_path="data/sub/a.txt",
+                 virtual="/data/sub/a.txt",
+                 directory="/data/sub/",
+                 resolved=True),
+    ]
+    reg = _mock_registry(resolve_result=matches)
+    glob_ps = PathSpec(
+        resource_path="data/sub/*.txt",
+        virtual="/data/sub/*.txt",
+        directory="/data/sub/",
+        pattern="*.txt",
+        resolved=False,
+        raw_path="sub/*.txt",
+    )
+    result = _run(resolve_globs(["ls", glob_ps], reg))
+    assert isinstance(result[1], PathSpec)
+    assert result[1].raw_path == "sub/*.txt".replace("*.txt", "a.txt")
+    assert result[1].display == "sub/a.txt"
+    assert result[1].virtual == "/data/sub/a.txt"
+
+
+def test_absolute_glob_matches_keep_virtual_display():
+    matches = [
+        PathSpec(resource_path="data/a.txt",
+                 virtual="/data/a.txt",
+                 directory="/data/",
+                 resolved=True),
+    ]
+    reg = _mock_registry(resolve_result=matches)
+    glob_ps = PathSpec(
+        resource_path="data/*.txt",
+        virtual="/data/*.txt",
+        directory="/data/",
+        pattern="*.txt",
+        resolved=False,
+    )
+    result = _run(resolve_globs(["ls", glob_ps], reg))
+    assert isinstance(result[1], PathSpec)
+    assert result[1].raw_path is None
+    assert result[1].display == "/data/a.txt"
+
+
+def test_bare_relative_glob_display_has_no_dir_prefix():
+    matches = [
+        PathSpec(resource_path="data/a.txt",
+                 virtual="/data/a.txt",
+                 directory="/data/",
+                 resolved=True),
+    ]
+    reg = _mock_registry(resolve_result=matches)
+    glob_ps = PathSpec(
+        resource_path="data/*.txt",
+        virtual="/data/*.txt",
+        directory="/data/",
+        pattern="*.txt",
+        resolved=False,
+        raw_path="*.txt",
+    )
+    result = _run(resolve_globs(["ls", glob_ps], reg))
+    assert isinstance(result[1], PathSpec)
+    assert result[1].display == "a.txt"

--- a/python/tests/workspace/expand/test_globs.py
+++ b/python/tests/workspace/expand/test_globs.py
@@ -232,7 +232,7 @@ def test_scope_error_truncates_instead_of_crash():
     assert len(result) == 5
 
 
-def test_relative_glob_matches_display_as_typed():
+def test_relative_glob_matches_spelled_as_typed():
     matches = [
         PathSpec(resource_path="data/sub/a.txt",
                  virtual="/data/sub/a.txt",
@@ -250,12 +250,11 @@ def test_relative_glob_matches_display_as_typed():
     )
     result = _run(resolve_globs(["ls", glob_ps], reg))
     assert isinstance(result[1], PathSpec)
-    assert result[1].raw_path == "sub/*.txt".replace("*.txt", "a.txt")
-    assert result[1].display == "sub/a.txt"
+    assert result[1].raw_path == "sub/a.txt"
     assert result[1].virtual == "/data/sub/a.txt"
 
 
-def test_absolute_glob_matches_keep_virtual_display():
+def test_absolute_glob_matches_keep_virtual():
     matches = [
         PathSpec(resource_path="data/a.txt",
                  virtual="/data/a.txt",
@@ -272,11 +271,11 @@ def test_absolute_glob_matches_keep_virtual_display():
     )
     result = _run(resolve_globs(["ls", glob_ps], reg))
     assert isinstance(result[1], PathSpec)
-    assert result[1].raw_path is None
-    assert result[1].display == "/data/a.txt"
+    assert result[1].raw_path == result[1].virtual
+    assert result[1].raw_path == "/data/a.txt"
 
 
-def test_bare_relative_glob_display_has_no_dir_prefix():
+def test_bare_relative_glob_raw_has_no_dir_prefix():
     matches = [
         PathSpec(resource_path="data/a.txt",
                  virtual="/data/a.txt",
@@ -294,4 +293,4 @@ def test_bare_relative_glob_display_has_no_dir_prefix():
     )
     result = _run(resolve_globs(["ls", glob_ps], reg))
     assert isinstance(result[1], PathSpec)
-    assert result[1].display == "a.txt"
+    assert result[1].raw_path == "a.txt"

--- a/python/tests/workspace/node/test_program.py
+++ b/python/tests/workspace/node/test_program.py
@@ -1,0 +1,54 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage import MountMode, RAMResource, Workspace
+
+
+async def _workspace() -> Workspace:
+    ws = Workspace({"/": RAMResource()}, mode=MountMode.WRITE)
+    await ws.execute("mkdir -p /data/sub")
+    await ws.execute("echo hi > /data/sub/x.txt")
+    await ws.execute("cd /data")
+    return ws
+
+
+@pytest.mark.asyncio
+async def test_drain_error_respells_relative_operand():
+    # cat of a directory errors on the first lazy pull, past the eager
+    # chokepoint; the drain must still report the operand as typed.
+    ws = await _workspace()
+    io = await ws.execute("cat sub")
+    assert io.exit_code == 1
+    err = (io.stderr or b"").decode()
+    assert err.startswith("cat: sub: ")
+
+
+@pytest.mark.asyncio
+async def test_drain_error_keeps_absolute_operand():
+    ws = await _workspace()
+    io = await ws.execute("cat /data/sub")
+    assert io.exit_code == 1
+    err = (io.stderr or b"").decode()
+    assert err.startswith("cat: /data/sub: ")
+
+
+@pytest.mark.asyncio
+async def test_eager_error_respells_relative_operand():
+    ws = await _workspace()
+    io = await ws.execute("cat sub/missing.txt")
+    assert io.exit_code == 1
+    assert (io.stderr or b"").decode() == (
+        "cat: sub/missing.txt: No such file or directory\n")

--- a/typescript/packages/core/src/commands/builtin/generic/du.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/du.ts
@@ -61,10 +61,10 @@ export async function duGeneric(
             ? entries.filter(([p]) => depthOf(p, root.virtual) <= maxDepth)
             : entries
         for (const [p, size] of filtered) lines.push(`${fmt(size)}\t${p}`)
-        lines.push(`${fmt(total)}\t${root.display}`)
+        lines.push(`${fmt(total)}\t${root.rawPath}`)
         grand += total
       } catch {
-        lines.push(`${fmt(0)}\t${root.display}`)
+        lines.push(`${fmt(0)}\t${root.rawPath}`)
       }
     } else {
       let total = 0
@@ -73,7 +73,7 @@ export async function duGeneric(
       } catch {
         total = 0
       }
-      lines.push(`${fmt(total)}\t${root.display}`)
+      lines.push(`${fmt(total)}\t${root.rawPath}`)
       grand += total
     }
   }
@@ -115,7 +115,7 @@ export async function duMulti(
     } catch {
       total = 0
     }
-    lines.push(`${fmt(total)}\t${root.display}`)
+    lines.push(`${fmt(total)}\t${root.rawPath}`)
     grand += total
   }
   if (cumulative) {

--- a/typescript/packages/core/src/commands/builtin/generic/find.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/find.ts
@@ -19,7 +19,7 @@ import { parseFindExpression } from '../findParse.ts'
 import { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
-import { rebaseDisplay } from '../../../utils/path.ts'
+import { rebaseRaw } from '../../../utils/path.ts'
 
 const ENC = new TextEncoder()
 
@@ -193,7 +193,7 @@ export async function findGeneric(
             : rstripSlash(root.virtual) + key.slice(rootKey === '/' ? 0 : rootKey.length)
       rootMatches.push(displayPath)
     }
-    matches.push(...rebaseDisplay(rootMatches, root.virtual, root.display))
+    matches.push(...rebaseRaw(rootMatches, root.virtual, root.rawPath))
   }
   matches.sort()
   const out: ByteSource = ENC.encode(matches.length ? matches.join('\n') + '\n' : '')

--- a/typescript/packages/core/src/commands/builtin/generic/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/grep.ts
@@ -17,7 +17,7 @@ import { cacheAwareStream } from '../../../cache/read_through.ts'
 import { exitOnEmpty, quietMatch } from '../../../io/stream.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { FileType, PathSpec, type FileStat } from '../../../types.ts'
-import { rebaseDisplay } from '../../../utils/path.ts'
+import { rebaseRaw } from '../../../utils/path.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import {
   compilePattern,
@@ -164,7 +164,7 @@ export async function grepGeneric(
           filesOnlyOpts(f, recursive),
           warnings,
         )
-        for (const h of rebaseDisplay(hits, p.virtual, p.display)) results.push(h)
+        for (const h of rebaseRaw(hits, p.virtual, p.rawPath)) results.push(h)
       }
       const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n') + '\n') : undefined
       if (results.length === 0)
@@ -202,11 +202,11 @@ export async function grepGeneric(
             warnings,
             false,
           )
-          for (const r of rebaseDisplay(res, p.virtual, p.display)) allResults.push(r)
+          for (const r of rebaseRaw(res, p.virtual, p.rawPath)) allResults.push(r)
         } else {
           const data = splitLinesNoTrailing(DEC.decode(await readBytesFn(p.virtual)))
-          const hits = grepLines(p.display, data, pat, f)
-          const label = f.noFilename ? '' : `${p.display}:`
+          const hits = grepLines(p.rawPath, data, pat, f)
+          const label = f.noFilename ? '' : `${p.rawPath}:`
           if (f.countOnly) {
             if (hits.length > 0) allResults.push(`${label}${hits[0] ?? ''}`)
           } else {
@@ -236,18 +236,18 @@ export async function grepGeneric(
           s = await statFn(p.virtual)
         } catch (err) {
           if ((err as { code?: string }).code === 'ENOENT') {
-            multiWarnings.push(`grep: ${p.display}: No such file or directory`)
+            multiWarnings.push(`grep: ${p.rawPath}: No such file or directory`)
             continue
           }
           throw err
         }
         if (s.type === FileType.DIRECTORY) {
-          multiWarnings.push(`grep: ${p.display}: Is a directory`)
+          multiWarnings.push(`grep: ${p.rawPath}: Is a directory`)
           continue
         }
         const data = splitLinesNoTrailing(DEC.decode(await materialize(stream(p))))
-        const hits = grepLines(p.display, data, pat, f)
-        const label = f.noFilename ? '' : `${p.display}:`
+        const hits = grepLines(p.rawPath, data, pat, f)
+        const label = f.noFilename ? '' : `${p.rawPath}:`
         if (f.countOnly) {
           if (hits.length > 0) allResults.push(`${label}${hits[0] ?? ''}`)
         } else {
@@ -281,7 +281,7 @@ export async function grepGeneric(
         new Uint8Array(0),
         new IOResult({
           exitCode: 1,
-          stderr: ENC.encode(`grep: ${first.display}: Is a directory\n`),
+          stderr: ENC.encode(`grep: ${first.rawPath}: Is a directory\n`),
         }),
       ]
     }
@@ -296,7 +296,7 @@ export async function grepGeneric(
     if (f.withFilename && f.afterContext === 0 && f.beforeContext === 0) {
       // GNU labels context lines with `-` instead of `:`, which the uniform
       // prefix cannot reproduce, so -H skips context output.
-      out = prefixLines(out, `${first.display}:`)
+      out = prefixLines(out, `${first.rawPath}:`)
     }
     return [out, io]
   }

--- a/typescript/packages/core/src/commands/builtin/generic/head.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/head.ts
@@ -123,7 +123,7 @@ async function* headMulti(
     if (p === undefined) continue
     if (showHeaders) {
       const prefix = i > 0 ? '\n' : ''
-      yield ENC.encode(`${prefix}==> ${p.display} <==\n`)
+      yield ENC.encode(`${prefix}==> ${p.rawPath} <==\n`)
     }
     const source = stream(p)
     for await (const chunk of headStream(source, lines, bytesMode)) yield chunk

--- a/typescript/packages/core/src/commands/builtin/generic/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.ts
@@ -118,7 +118,7 @@ async function walkGrouped(
     const msg =
       gnuStrerror((err as { code?: string }).code) ??
       (err instanceof Error ? err.message : String(err))
-    warnings.push(`ls: cannot access '${dir.display}': ${msg}`)
+    warnings.push(`ls: cannot access '${dir.rawPath}': ${msg}`)
     return
   }
   const sorted = sortStats(stats, opts.sortBy, opts.reverse)
@@ -177,7 +177,7 @@ export async function lsGeneric(
         const msg =
           gnuStrerror((err as { code?: string }).code) ??
           (err instanceof Error ? err.message : String(err))
-        warnings.push(`ls: cannot access '${p.display}': ${msg}`)
+        warnings.push(`ls: cannot access '${p.rawPath}': ${msg}`)
       }
     }
     appendListing(collected, long, human, classify, lines)
@@ -206,7 +206,7 @@ export async function lsGeneric(
           const b = rstripSlash(t.virtual)
           return dirSpec.virtual === b || dirSpec.virtual.startsWith(b + '/')
         }) ?? dirSpec
-      lines.push(`${rebaseOne(dirSpec.virtual, owner.virtual, owner.display)}:`)
+      lines.push(`${rebaseOne(dirSpec.virtual, owner.virtual, owner.rawPath)}:`)
       appendListing(entries, long, human, classify, lines)
     }
     const out: ByteSource = formatRecords(lines)
@@ -229,7 +229,7 @@ export async function lsGeneric(
         const msg =
           gnuStrerror((err as { code?: string }).code) ??
           (err instanceof Error ? err.message : String(err))
-        warnings.push(`ls: cannot access '${p.display}': ${msg}`)
+        warnings.push(`ls: cannot access '${p.rawPath}': ${msg}`)
         continue
       }
     }

--- a/typescript/packages/core/src/commands/builtin/generic/md5.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/md5.ts
@@ -27,7 +27,7 @@ export async function md5Generic(
   if (paths.length > 0) {
     for (const p of paths) {
       const data = await materialize(stream(p))
-      lines.push(`${md5Hex(data)}  ${p.display}`)
+      lines.push(`${md5Hex(data)}  ${p.rawPath}`)
     }
   } else if (opts.stdin !== null) {
     const data = await materialize(opts.stdin)

--- a/typescript/packages/core/src/commands/builtin/generic/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/rg.ts
@@ -17,7 +17,7 @@ import { cacheAwareStream } from '../../../cache/read_through.ts'
 import { exitOnEmpty } from '../../../io/stream.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { FileType, PathSpec, type FileStat } from '../../../types.ts'
-import { rebaseDisplay } from '../../../utils/path.ts'
+import { rebaseRaw } from '../../../utils/path.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import {
   compilePattern,
@@ -239,9 +239,9 @@ export async function rgGeneric(
         exprText,
         fullOpts,
         warnings,
-        label ? p.display : null,
+        label ? p.rawPath : null,
       )
-      results.push(...rebaseDisplay(hitsFull, p.virtual, p.display))
+      results.push(...rebaseRaw(hitsFull, p.virtual, p.rawPath))
     }
     const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n') + '\n') : undefined
     if (results.length === 0) {
@@ -269,7 +269,7 @@ export async function rgGeneric(
       for (const p of paths) {
         const counted = await materialize(grepStream(stream(p), pat, streamOpts))
         const n = Number.parseInt(DEC.decode(counted).trim() || '0', 10)
-        if (n > 0) results.push(label ? `${p.display}:${String(n)}` : String(n))
+        if (n > 0) results.push(label ? `${p.rawPath}:${String(n)}` : String(n))
       }
       if (results.length === 0) return [new Uint8Array(0), new IOResult({ exitCode: 1 })]
       return [ENC.encode(results.join('\n') + '\n'), new IOResult()]

--- a/typescript/packages/core/src/commands/builtin/generic/sha256sum.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/sha256sum.ts
@@ -40,7 +40,7 @@ async function* sha256SingleStream(
 async function* sha256Multi(stream: Stream, paths: readonly PathSpec[]): AsyncIterable<Uint8Array> {
   for (const p of paths) {
     const digest = await hashStream(stream(p))
-    yield ENC.encode(`${digest}  ${p.display}\n`)
+    yield ENC.encode(`${digest}  ${p.rawPath}\n`)
   }
 }
 

--- a/typescript/packages/core/src/commands/builtin/generic/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/stat.ts
@@ -55,7 +55,7 @@ export async function statGeneric(
   for (const p of paths) {
     const s = await stat(p)
     if (fmt !== null) {
-      lines.push(formatStat(fmt, s, p.display))
+      lines.push(formatStat(fmt, s, p.rawPath))
     } else {
       const sizeStr = s.size === null ? 'None' : String(s.size)
       const modStr = s.modified ?? 'None'

--- a/typescript/packages/core/src/commands/builtin/generic/tail.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tail.ts
@@ -60,7 +60,7 @@ export async function tailGeneric(
       if (p === undefined) continue
       const raw = await materialize(stream(p))
       if (showHeaders) {
-        const header = i > 0 ? `\n==> ${p.display} <==\n` : `==> ${p.display} <==\n`
+        const header = i > 0 ? `\n==> ${p.rawPath} <==\n` : `==> ${p.rawPath} <==\n`
         chunks.push(ENC.encode(header))
       }
       if (bytesMode !== null) {

--- a/typescript/packages/core/src/commands/builtin/generic/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/wc.ts
@@ -96,23 +96,23 @@ export async function wcGeneric(
       const byteCount = data.byteLength
       if (LFlag) {
         const maxLen = text.split(/\r?\n/).reduce((m, l) => Math.max(m, l.length), 0)
-        rows.push({ values: [maxLen], label: p.display })
+        rows.push({ values: [maxLen], label: p.rawPath })
         totalMax = Math.max(totalMax, maxLen)
       } else if (lFlag) {
-        rows.push({ values: [lineCount], label: p.display })
+        rows.push({ values: [lineCount], label: p.rawPath })
         totalLines += lineCount
       } else if (wFlag) {
-        rows.push({ values: [wordCount], label: p.display })
+        rows.push({ values: [wordCount], label: p.rawPath })
         totalWords += wordCount
       } else if (cFlag) {
-        rows.push({ values: [byteCount], label: p.display })
+        rows.push({ values: [byteCount], label: p.rawPath })
         totalBytes += byteCount
       } else if (mFlag) {
         const charCount = text.length
-        rows.push({ values: [charCount], label: p.display })
+        rows.push({ values: [charCount], label: p.rawPath })
         totalBytes += charCount
       } else {
-        rows.push({ values: [lineCount, wordCount, byteCount], label: p.display })
+        rows.push({ values: [lineCount, wordCount, byteCount], label: p.rawPath })
         totalLines += lineCount
         totalWords += wordCount
         totalBytes += byteCount

--- a/typescript/packages/core/src/commands/builtin/github/narrow.ts
+++ b/typescript/packages/core/src/commands/builtin/github/narrow.ts
@@ -20,7 +20,7 @@ import { countScopeFiles, scopeRelativeKey, shouldUseSearch } from '../../../cor
 import { narrowPaths } from '../../../core/github/search.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
-import { rebaseDisplay } from '../../../utils/path.ts'
+import { rebaseRaw } from '../../../utils/path.ts'
 import { formatRecords } from '../utils/output.ts'
 import { classifyPattern, PatternType, searchQuery } from '../grep_helper.ts'
 
@@ -96,6 +96,6 @@ export function filesOnlyShortcircuit(
     .filter((p) => pathPredicate === undefined || pathPredicate(p.virtual))
     .map((p) => p.virtual)
   if (hits.length === 0) return [new Uint8Array(), new IOResult({ exitCode: 1 })]
-  const displays = rebaseDisplay(hits, scope.virtual, scope.display)
-  return [formatRecords([...displays].sort()), new IOResult()]
+  const spelled = rebaseRaw(hits, scope.virtual, scope.rawPath)
+  return [formatRecords([...spelled].sort()), new IOResult()]
 }

--- a/typescript/packages/core/src/types.test.ts
+++ b/typescript/packages/core/src/types.test.ts
@@ -23,6 +23,7 @@ import {
   MountMode,
   PathSpec,
   ResourceName,
+  wordText,
 } from './types.ts'
 
 describe('MountMode', () => {
@@ -330,5 +331,21 @@ describe('PathSpec.mountPath / key', () => {
     })
     expect(p.mountPath).toBe('/x.txt')
     expect(p.resourcePath).toBe('x.txt')
+  })
+})
+
+describe('wordText', () => {
+  it('passes strings through', () => {
+    expect(wordText('plain')).toBe('plain')
+  })
+
+  it('renders paths as typed', () => {
+    const p = new PathSpec({
+      resourcePath: 'a.txt',
+      virtual: '/data/a.txt',
+      directory: '/data/',
+      rawPath: 'a.txt',
+    })
+    expect(wordText(p)).toBe('a.txt')
   })
 })

--- a/typescript/packages/core/src/types.ts
+++ b/typescript/packages/core/src/types.ts
@@ -219,7 +219,7 @@ export interface PathSpecInit {
   resourcePath: string
   pattern?: string | null
   resolved?: boolean
-  rawPath?: string | null
+  rawPath?: string
 }
 
 export class PathSpec {
@@ -228,7 +228,9 @@ export class PathSpec {
   readonly resourcePath: string
   readonly pattern: string | null
   readonly resolved: boolean
-  readonly rawPath: string | null
+  // The word's spelling: as typed for relative words, the absolute path
+  // for everything else (defaults to `virtual`).
+  readonly rawPath: string
 
   constructor(init: PathSpecInit) {
     this.virtual = init.virtual
@@ -236,15 +238,8 @@ export class PathSpec {
     this.resourcePath = init.resourcePath
     this.pattern = init.pattern ?? null
     this.resolved = init.resolved ?? true
-    this.rawPath = init.rawPath ?? null
+    this.rawPath = init.rawPath ?? init.virtual
     Object.freeze(this)
-  }
-
-  // The path as the user typed it, for rendering in output. Falls back to
-  // `virtual` (the resolved absolute path) when no raw form was recorded,
-  // e.g. for absolute arguments.
-  get display(): string {
-    return this.rawPath ?? this.virtual
   }
 
   // Mount-relative path with a leading slash. Pure formatting of
@@ -285,4 +280,12 @@ export class PathSpec {
       resourcePath: resourcePath ?? stripSlash(path),
     })
   }
+}
+
+// Shell-text form of an argv word. Text words pass through; paths render
+// as spelled (`rawPath`). Use wherever a word re-enters string space (env
+// values, function args, the argv text view). Mount I/O keeps using
+// `virtual`.
+export function wordText(word: string | PathSpec): string {
+  return word instanceof PathSpec ? word.rawPath : word
 }

--- a/typescript/packages/core/src/utils/errors.ts
+++ b/typescript/packages/core/src/utils/errors.ts
@@ -21,13 +21,13 @@ export interface FsError extends Error {
   virtualPath: string
 }
 
-// Accepts a PathSpec (reads .display, the as-typed form, falling back to
-// .virtual) or a bare virtual-path string. Taking a structural shape avoids
-// importing the PathSpec class (no import cycle). .display is always virtual
-// (derived from the as-typed arg or .virtual), never a real fs path.
-function virtualOf(path: string | { virtual: string; display?: string }): string {
+// Accepts a PathSpec (reads .rawPath, the word's spelling, which defaults
+// to .virtual) or a bare virtual-path string. Taking a structural shape
+// avoids importing the PathSpec class (no import cycle). .rawPath is always
+// a virtual-space path, never a real fs path.
+function virtualOf(path: string | { virtual: string; rawPath?: string }): string {
   if (typeof path === 'string') return path
-  return path.display ?? path.virtual
+  return path.rawPath ?? path.virtual
 }
 
 function fsError(path: string | { virtual: string }, code: string): FsError {

--- a/typescript/packages/core/src/utils/path.ts
+++ b/typescript/packages/core/src/utils/path.ts
@@ -55,16 +55,19 @@ export function expandTilde(word: string, home: string | null): string {
   return word
 }
 
-export function rebaseDisplay(paths: string[], virtual: string, display: string | null): string[] {
-  if (display === null || display === virtual) return paths
-  return paths.map((p) => rebaseOne(p, virtual, display))
+// Rewrite the base of walked output paths (find/grep -r results) to the
+// as-typed form (`PathSpec.rawPath`); `raw` equal to `virtual` leaves the
+// paths unchanged (the absolute-argument case).
+export function rebaseRaw(paths: string[], virtual: string, raw: string): string[] {
+  if (raw === virtual) return paths
+  return paths.map((p) => rebaseOne(p, virtual, raw))
 }
 
-export function rebaseOne(path: string, virtual: string, display: string | null): string {
-  if (display === null || display === virtual) return path
+export function rebaseOne(path: string, virtual: string, raw: string): string {
+  if (raw === virtual) return path
   const base = rstripSlash(virtual)
-  if (path === base) return display
-  if (path.startsWith(base + '/')) return rstripSlash(display) + path.slice(base.length)
+  if (path === base) return raw
+  if (path.startsWith(base + '/')) return rstripSlash(raw) + path.slice(base.length)
   return path
 }
 

--- a/typescript/packages/core/src/workspace/executor/builtins.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins.test.ts
@@ -334,6 +334,49 @@ describe('handleTest', () => {
     const [, io] = await handleTest(dispatch, ['foo', '=', 'foo'], session)
     expect(io.exitCode).toBe(0)
   })
+
+  it('-f relative operand resolves against session.cwd', async () => {
+    const spy = vi.fn<DispatchFn>((op, scope) => {
+      const ps = scope
+      if (ps.virtual === '/data/plain.txt') {
+        return Promise.resolve<[unknown, IOResult]>([
+          new FileStat({ name: 'plain.txt' }),
+          new IOResult(),
+        ])
+      }
+      return Promise.reject(new Error(`not found: ${ps.virtual}`))
+    })
+    const s = new Session({ sessionId: 'test' })
+    s.cwd = '/data'
+    const [, io] = await handleTest(spy, ['-f', 'plain.txt'], s)
+    expect(io.exitCode).toBe(0)
+    const [, io2] = await handleTest(spy, ['-f', 'missing.txt'], s)
+    expect(io2.exitCode).toBe(1)
+  })
+
+  it('-f empty operand is false without dispatch', async () => {
+    const spy = vi.fn<DispatchFn>(() =>
+      Promise.resolve<[unknown, IOResult]>([new FileStat({ name: 'x' }), new IOResult()]),
+    )
+    const s = new Session({ sessionId: 'test' })
+    const [, io] = await handleTest(spy, ['-f', ''], s)
+    expect(io.exitCode).toBe(1)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('-d relative operand resolves against session.cwd', async () => {
+    const spy = vi.fn<DispatchFn>((op, scope) => {
+      const ps = scope
+      if (op === 'readdir' && ps.virtual === '/data/sub') {
+        return Promise.resolve<[unknown, IOResult]>([[], new IOResult()])
+      }
+      return Promise.reject(new Error(`not found: ${ps.virtual}`))
+    })
+    const s = new Session({ sessionId: 'test' })
+    s.cwd = '/data'
+    const [, io] = await handleTest(spy, ['-d', 'sub'], s)
+    expect(io.exitCode).toBe(0)
+  })
 })
 
 describe('handleShift', () => {

--- a/typescript/packages/core/src/workspace/executor/builtins/condition.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/condition.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { resolvePath } from '../../../utils/path.ts'
 import { stripSlash } from '../../../utils/slash.ts'
 import { IOResult } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
@@ -21,13 +22,17 @@ import type { DispatchFn } from '../cross_mount.ts'
 import { toScope, scopePath } from './scope.ts'
 import type { Result } from './scope.ts'
 
-async function evalTest(dispatch: DispatchFn, argv: (string | PathSpec)[]): Promise<boolean> {
+async function evalTest(
+  dispatch: DispatchFn,
+  argv: (string | PathSpec)[],
+  cwd: string,
+): Promise<boolean> {
   if (argv.length === 0) return false
   const firstArg = argv[0]
   if (firstArg === undefined) return false
   const first = scopePath(firstArg)
   if (first === '!' && argv.length > 1) {
-    return !(await evalTest(dispatch, argv.slice(1)))
+    return !(await evalTest(dispatch, argv.slice(1), cwd))
   }
   if (argv.length === 1) return Boolean(first)
   if (argv.length === 2) {
@@ -37,7 +42,10 @@ async function evalTest(dispatch: DispatchFn, argv: (string | PathSpec)[]): Prom
     if (op === '-z') return scopePath(val) === ''
     if (op === '-n') return scopePath(val) !== ''
     if (op === '-f') {
-      const scope = val instanceof PathSpec ? val : toScope(scopePath(val))
+      // A relative string operand resolves against cwd, like bash:
+      // `cd /data && test -f plain.txt` checks /data/plain.txt.
+      if (!(val instanceof PathSpec) && scopePath(val) === '') return false
+      const scope = val instanceof PathSpec ? val : toScope(resolvePath(scopePath(val), cwd))
       try {
         await dispatch('stat', scope)
         return true
@@ -46,13 +54,15 @@ async function evalTest(dispatch: DispatchFn, argv: (string | PathSpec)[]): Prom
       }
     }
     if (op === '-d') {
+      if (!(val instanceof PathSpec) && scopePath(val) === '') return false
+      const dirPath = val instanceof PathSpec ? '' : resolvePath(scopePath(val), cwd)
       const scope =
         val instanceof PathSpec
           ? val
           : new PathSpec({
-              resourcePath: stripSlash(scopePath(val)),
-              virtual: scopePath(val),
-              directory: scopePath(val),
+              resourcePath: stripSlash(dirPath),
+              virtual: dirPath,
+              directory: dirPath,
               resolved: false,
             })
       try {
@@ -89,9 +99,9 @@ async function evalTest(dispatch: DispatchFn, argv: (string | PathSpec)[]): Prom
 export async function handleTest(
   dispatch: DispatchFn,
   argv: (string | PathSpec)[],
-  _session: Session,
+  session: Session,
 ): Promise<Result> {
-  const result = await evalTest(dispatch, argv)
+  const result = await evalTest(dispatch, argv, session.cwd)
   const code = result ? 0 : 1
   return [
     null,

--- a/typescript/packages/core/src/workspace/executor/builtins/links.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/links.ts
@@ -14,7 +14,7 @@
 
 import { resolvePath } from '../../../utils/path.ts'
 import { IOResult } from '../../../io/types.ts'
-import { FileStat, FileType, PathSpec } from '../../../types.ts'
+import { FileStat, FileType, PathSpec, wordText } from '../../../types.ts'
 import { CycleError } from '../../../utils/path.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
 import type { DispatchFn } from '../cross_mount.ts'
@@ -27,11 +27,6 @@ import type { Result } from './scope.ts'
 // rm/mv mutate the link entry, ln/readlink inspect it, rmdir must not
 // descend through it. Everything else follows links before dispatch,
 // mirroring open(2).
-
-function typed(arg: string | PathSpec): string {
-  if (arg instanceof PathSpec) return arg.rawPath ?? arg.virtual
-  return arg
-}
 
 function abs(arg: string | PathSpec, cwd: string): string {
   if (arg instanceof PathSpec) return arg.virtual
@@ -95,21 +90,21 @@ export function handleLn(
   // (an expanded multi-match glob source lands here).
   if (operands.length > 2) {
     const last = operands[operands.length - 1]
-    return errorResult('ln', `ln: target '${typed(last ?? '')}' is not a directory\n`)
+    return errorResult('ln', `ln: target '${wordText(last ?? '')}' is not a directory\n`)
   }
   const linkAbs = abs(linkArg, session.cwd)
-  const targetTyped = typed(targetArg)
+  const targetTyped = wordText(targetArg)
   const exists = namespace.isLink(linkAbs) && !flags.has('f')
   if (namespace.isMountRoot(linkAbs) || exists) {
     return errorResult(
       'ln',
-      `ln: failed to create symbolic link '${typed(linkArg)}': File exists\n`,
+      `ln: failed to create symbolic link '${wordText(linkArg)}': File exists\n`,
     )
   }
   namespace.symlink(linkAbs, targetTyped, Date.now() / 1000)
   let out: Uint8Array | null = null
   if (flags.has('v')) {
-    out = new TextEncoder().encode(`'${typed(linkArg)}' -> '${targetTyped}'\n`)
+    out = new TextEncoder().encode(`'${wordText(linkArg)}' -> '${targetTyped}'\n`)
   }
   return [out, new IOResult(), new ExecutionNode({ command: 'ln', exitCode: 0 })]
 }
@@ -132,7 +127,7 @@ export function followPaths(
     try {
       virtual = namespace.follow(item.virtual)
     } catch (err) {
-      if (err instanceof CycleError) throw new CycleError(item.rawPath ?? item.virtual)
+      if (err instanceof CycleError) throw new CycleError(item.rawPath)
       throw err
     }
     if (virtual === item.virtual) {
@@ -146,7 +141,7 @@ export function followPaths(
         resourcePath: '',
         pattern: item.pattern,
         resolved: item.resolved,
-        rawPath: item.rawPath ?? item.virtual,
+        rawPath: item.rawPath,
       }),
     )
   }

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -718,7 +718,8 @@ async function executeShellFunction(
   callStack: CallStack | null,
 ): Promise<Result> {
   const cs = callStack ?? new CallStack()
-  const textArgs = restParts.map((p) => (typeof p === 'string' ? p : p.virtual))
+  // Positional args carry the word as typed ($1 stays sub/a.txt).
+  const textArgs = restParts.map((p) => (typeof p === 'string' ? p : p.display))
   cs.push(textArgs, cmdName)
   const savedLocals = new Map<string, string | null>()
   session.localVars = savedLocals

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -22,7 +22,7 @@ import { assertMountAllowed, MountNotAllowedError } from '../../runtime/session_
 import { CallStack } from '../../shell/call_stack.ts'
 import type { JobTable } from '../../shell/job_table.ts'
 import { ERREXIT_EXEMPT_TYPES } from '../../shell/types.ts'
-import { PathSpec } from '../../types.ts'
+import { PathSpec, wordText } from '../../types.ts'
 import type { MountEntry } from '../mount/mount.ts'
 import type { Namespace } from '../mount/namespace.ts'
 import { MountCommandUnsupported, type MountRegistry } from '../mount/registry.ts'
@@ -184,10 +184,10 @@ export async function runOnMount(
   } catch (err) {
     const strerror = gnuStrerror((err as { code?: string }).code)
     const vpath = errorVirtualPath(err)
-    const display = paths.find((p) => p.virtual === vpath)?.display ?? vpath
+    const spelled = paths.find((p) => p.virtual === vpath)?.rawPath ?? vpath
     const line =
       strerror !== null
-        ? `${cmdName}: ${display}: ${strerror}\n`
+        ? `${cmdName}: ${spelled}: ${strerror}\n`
         : `${cmdName}: ${err instanceof Error ? err.message : String(err)}\n`
     const errBytes = new TextEncoder().encode(line)
     return [null, new IOResult({ exitCode: 1, stderr: errBytes })]
@@ -347,6 +347,7 @@ export async function handleCommand(
     }
     csIo.safeguard =
       mounts.length > 0 ? resolveAcrossMounts(cmdName, mounts) : resolveSafeguard(cmdName)
+    csExec.paths = pathScopes
     return [maybeWithTimeout(csStdout, csIo.safeguard, cmdName), csIo, csExec]
   }
 
@@ -477,6 +478,7 @@ export async function handleCommand(
     command: cmdStr,
     stderr: stderrBytes,
     exitCode: io.exitCode,
+    paths,
   })
   return [stdout, io, exec]
 }
@@ -719,7 +721,7 @@ async function executeShellFunction(
 ): Promise<Result> {
   const cs = callStack ?? new CallStack()
   // Positional args carry the word as typed ($1 stays sub/a.txt).
-  const textArgs = restParts.map((p) => (typeof p === 'string' ? p : p.display))
+  const textArgs = restParts.map(wordText)
   cs.push(textArgs, cmdName)
   const savedLocals = new Map<string, string | null>()
   session.localVars = savedLocals

--- a/typescript/packages/core/src/workspace/executor/control.ts
+++ b/typescript/packages/core/src/workspace/executor/control.ts
@@ -165,7 +165,9 @@ export async function handleFor(
 
   try {
     for (const val of values) {
-      session.env[variable] = val instanceof PathSpec ? val.virtual : val
+      // env stores strings only; PathSpec renders as typed (bash keeps
+      // `for f in sub/*.txt` matches relative)
+      session.env[variable] = val instanceof PathSpec ? val.display : val
       try {
         const [stdout, io] = await executeBody(executeNode, body, session, stdin, callStack)
         allStdout.push(stdout)

--- a/typescript/packages/core/src/workspace/executor/control.ts
+++ b/typescript/packages/core/src/workspace/executor/control.ts
@@ -19,7 +19,8 @@ import { IOResult } from '../../io/types.ts'
 import { applyBarrier, BarrierPolicy } from '../../shell/barrier.ts'
 import type { CallStack } from '../../shell/call_stack.ts'
 import { ERREXIT_EXEMPT_TYPES } from '../../shell/types.ts'
-import { PathSpec } from '../../types.ts'
+import type { PathSpec } from '../../types.ts'
+import { wordText } from '../../types.ts'
 import type { TSNodeLike } from '../expand/variable.ts'
 import type { Session } from '../session/session.ts'
 import { ExecutionNode } from '../types.ts'
@@ -165,9 +166,9 @@ export async function handleFor(
 
   try {
     for (const val of values) {
-      // env stores strings only; PathSpec renders as typed (bash keeps
-      // `for f in sub/*.txt` matches relative)
-      session.env[variable] = val instanceof PathSpec ? val.display : val
+      // env stores strings only; bash keeps `for f in sub/*.txt`
+      // matches relative, so the loop variable takes the typed form
+      session.env[variable] = wordText(val)
       try {
         const [stdout, io] = await executeBody(executeNode, body, session, stdin, callStack)
         allStdout.push(stdout)

--- a/typescript/packages/core/src/workspace/executor/redirect.ts
+++ b/typescript/packages/core/src/workspace/executor/redirect.ts
@@ -17,8 +17,7 @@ import type { ByteSource, IOResult } from '../../io/types.ts'
 import { materialize } from '../../io/types.ts'
 import { applyBarrier, BarrierPolicy } from '../../shell/barrier.ts'
 import type { CallStack } from '../../shell/call_stack.ts'
-import { getListParts } from '../../shell/helpers.ts'
-import { NodeType as NT, type Redirect, RedirectKind } from '../../shell/types.ts'
+import { type Redirect, RedirectKind } from '../../shell/types.ts'
 import { PathSpec } from '../../types.ts'
 import type { TSNodeLike } from '../expand/variable.ts'
 import type { Session } from '../session/session.ts'
@@ -59,19 +58,6 @@ export async function handleRedirect(
         cmdStdin = text as ByteSource
       }
     }
-  }
-
-  if (command.type === NT.LIST && redirects.length > 0) {
-    const [left, op, right] = getListParts(command)
-    const [leftStdout, leftIo, leftExec] = await executeNode(left, session, cmdStdin, callStack)
-    const leftBytes = await applyBarrier(leftStdout, leftIo, BarrierPolicy.VALUE)
-    session.lastExitCode = leftIo.exitCode
-    const runRight =
-      (op === NT.OR && leftIo.exitCode !== 0) || (op === NT.AND && leftIo.exitCode === 0)
-    if (runRight) {
-      return handleRedirect(executeNode, dispatch, right, redirects, session, cmdStdin, callStack)
-    }
-    return [leftBytes, leftIo, leftExec]
   }
 
   const [stdout, io] = await executeNode(command, session, cmdStdin, callStack)

--- a/typescript/packages/core/src/workspace/expand/argv.ts
+++ b/typescript/packages/core/src/workspace/expand/argv.ts
@@ -13,7 +13,8 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { CallStack } from '../../shell/call_stack.ts'
-import { PathSpec } from '../../types.ts'
+import type { PathSpec } from '../../types.ts'
+import { wordText } from '../../types.ts'
 import type { MountRegistry } from '../mount/registry.ts'
 import { WordPolicy, route, wordPolicy } from '../route/index.ts'
 import type { Session } from '../session/session.ts'
@@ -98,9 +99,9 @@ export async function expandArgv(
   // patterns for backend pushdown; unknown names fail without
   // touching backends.
   const words = policy === WordPolicy.SHELL ? await resolveGlobs(classified, registry) : classified
-  // The text view renders words as typed (display): bash hands
+  // The text view renders words as typed (rawPath): bash hands
   // programs their words unchanged, so `echo sub/file.txt` prints the
   // relative form, not the resolved absolute path.
-  const textView = words.map((p) => (p instanceof PathSpec ? p.display : p))
+  const textView = words.map(wordText)
   return new Argv(name, textView.slice(1), words.slice(1))
 }

--- a/typescript/packages/core/src/workspace/expand/argv.ts
+++ b/typescript/packages/core/src/workspace/expand/argv.ts
@@ -98,6 +98,9 @@ export async function expandArgv(
   // patterns for backend pushdown; unknown names fail without
   // touching backends.
   const words = policy === WordPolicy.SHELL ? await resolveGlobs(classified, registry) : classified
-  const textView = words.map((p) => (p instanceof PathSpec ? p.virtual : p))
+  // The text view renders words as typed (display): bash hands
+  // programs their words unchanged, so `echo sub/file.txt` prints the
+  // relative form, not the resolved absolute path.
+  const textView = words.map((p) => (p instanceof PathSpec ? p.display : p))
   return new Argv(name, textView.slice(1), words.slice(1))
 }

--- a/typescript/packages/core/src/workspace/expand/classify/heuristic.ts
+++ b/typescript/packages/core/src/workspace/expand/classify/heuristic.ts
@@ -16,13 +16,12 @@ import { PathSpec } from '../../../types.ts'
 import type { MountRegistry } from '../../mount/registry.ts'
 import { posixNormpath } from '../../../utils/path.ts'
 import { shlexSplit } from '../../../utils/shlex.ts'
-import { rstripSlash, stripSlash } from '../../../utils/slash.ts'
+import { stripSlash } from '../../../utils/slash.ts'
+import { GLOB_CHARS, relativeSpec } from './relative.ts'
 
 const FILENAME_CHAR = /[a-zA-Z0-9_./]/
 const NON_PATH_CHAR = /[(){}=;|&<> ]/
 const RELATIVE_PATH = /^(?:\.?[a-zA-Z0-9_-]*\/)*[a-zA-Z0-9_-]+\.[a-zA-Z0-9]+$/
-
-export const GLOB_CHARS: readonly string[] = ['*', '?', '[']
 
 export function unescapePath(word: string): string {
   if (!word.includes('\\')) return word
@@ -78,32 +77,13 @@ export function classifyWord(
     if (!FILENAME_CHAR.test(word) || NON_PATH_CHAR.test(word)) {
       return word
     }
-    const path = posixNormpath(`${rstripSlash(cwd)}/${word}`)
-    const mount = registry.mountFor(path)
-    if (mount === null) return word
-    const lastSlash = path.lastIndexOf('/')
-    return new PathSpec({
-      resourcePath: stripSlash(path),
-      virtual: path,
-      directory: path.slice(0, lastSlash + 1),
-      pattern: path.slice(lastSlash + 1),
-      resolved: false,
-      rawPath: word,
-    })
+    return relativeSpec(word, registry, cwd)
   }
 
   if (!hasGlob && word.includes('/') && RELATIVE_PATH.test(word)) {
     let w = word
     if (w.includes('\\')) w = unescapePath(w)
-    const path = posixNormpath(`${rstripSlash(cwd)}/${w}`)
-    if (registry.mountFor(path) === null) return word
-    return new PathSpec({
-      resourcePath: stripSlash(path),
-      virtual: path,
-      directory: path.slice(0, path.lastIndexOf('/') + 1),
-      resolved: true,
-      rawPath: w,
-    })
+    return relativeSpec(w, registry, cwd)
   }
 
   return word

--- a/typescript/packages/core/src/workspace/expand/classify/index.ts
+++ b/typescript/packages/core/src/workspace/expand/classify/index.ts
@@ -15,3 +15,4 @@
 export { classifyWord, unescapePath } from './heuristic.ts'
 export { classifyParts } from './parts.ts'
 export { classifyBarePath } from './path.ts'
+export { relativeSpec } from './relative.ts'

--- a/typescript/packages/core/src/workspace/expand/classify/path.ts
+++ b/typescript/packages/core/src/workspace/expand/classify/path.ts
@@ -12,11 +12,10 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { PathSpec } from '../../../types.ts'
+import type { PathSpec } from '../../../types.ts'
 import type { MountRegistry } from '../../mount/registry.ts'
-import { posixNormpath } from '../../../utils/path.ts'
-import { rstripSlash, stripSlash } from '../../../utils/slash.ts'
-import { GLOB_CHARS, classifyWord } from './heuristic.ts'
+import { classifyWord } from './heuristic.ts'
+import { relativeSpec } from './relative.ts'
 
 export function classifyBarePath(
   word: string,
@@ -25,25 +24,5 @@ export function classifyBarePath(
 ): string | PathSpec {
   const classified = classifyWord(word, registry, cwd)
   if (typeof classified !== 'string') return classified
-  const path = posixNormpath(`${rstripSlash(cwd)}/${word}`)
-  if (registry.mountFor(path) === null) return word
-  const hasGlob = GLOB_CHARS.some((ch) => word.includes(ch))
-  if (hasGlob) {
-    const lastSlash = path.lastIndexOf('/')
-    return new PathSpec({
-      resourcePath: stripSlash(path),
-      virtual: path,
-      directory: path.slice(0, lastSlash + 1),
-      pattern: path.slice(lastSlash + 1),
-      resolved: false,
-      rawPath: word,
-    })
-  }
-  return new PathSpec({
-    resourcePath: stripSlash(path),
-    virtual: path,
-    directory: path.slice(0, path.lastIndexOf('/') + 1),
-    resolved: true,
-    rawPath: word,
-  })
+  return relativeSpec(word, registry, cwd)
 }

--- a/typescript/packages/core/src/workspace/expand/classify/relative.test.ts
+++ b/typescript/packages/core/src/workspace/expand/classify/relative.test.ts
@@ -1,0 +1,71 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import type { Resource } from '../../../resource/base.ts'
+import { MountMode, PathSpec } from '../../../types.ts'
+import { MountRegistry } from '../../mount/registry.ts'
+import { relativeSpec } from './relative.ts'
+
+class StubResource implements Resource {
+  readonly kind = 'stub'
+  open(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+function setup(): MountRegistry {
+  return new MountRegistry({ '/ram': new StubResource() }, MountMode.WRITE)
+}
+
+describe('relativeSpec', () => {
+  it('resolves a plain word against cwd and keeps the raw form', () => {
+    const r = relativeSpec('sub/a.txt', setup(), '/ram')
+    if (!(r instanceof PathSpec)) throw new Error('expected PathSpec')
+    expect(r.virtual).toBe('/ram/sub/a.txt')
+    expect(r.rawPath).toBe('sub/a.txt')
+    expect(r.resolved).toBe(true)
+    expect(r.pattern).toBeNull()
+  })
+
+  it('turns glob chars in the word into a pattern spec', () => {
+    const r = relativeSpec('sub/*.txt', setup(), '/ram')
+    if (!(r instanceof PathSpec)) throw new Error('expected PathSpec')
+    expect(r.directory).toBe('/ram/sub/')
+    expect(r.pattern).toBe('*.txt')
+    expect(r.resolved).toBe(false)
+    expect(r.rawPath).toBe('sub/*.txt')
+  })
+
+  it('normalizes .. against cwd', () => {
+    const r = relativeSpec('../x.txt', setup(), '/ram/sub')
+    if (!(r instanceof PathSpec)) throw new Error('expected PathSpec')
+    expect(r.virtual).toBe('/ram/x.txt')
+    expect(r.rawPath).toBe('../x.txt')
+  })
+
+  it('keeps unmounted words as plain text', () => {
+    expect(relativeSpec('a.txt', setup(), '/elsewhere')).toBe('a.txt')
+  })
+
+  it('rawPath round-trips the typed spelling', () => {
+    const r = relativeSpec('./sub/a.txt', setup(), '/ram')
+    if (!(r instanceof PathSpec)) throw new Error('expected PathSpec')
+    expect(r.rawPath).toBe('./sub/a.txt')
+    expect(r.virtual).toBe('/ram/sub/a.txt')
+  })
+})

--- a/typescript/packages/core/src/workspace/expand/classify/relative.ts
+++ b/typescript/packages/core/src/workspace/expand/classify/relative.ts
@@ -1,0 +1,56 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { PathSpec } from '../../../types.ts'
+import type { MountRegistry } from '../../mount/registry.ts'
+import { posixNormpath } from '../../../utils/path.ts'
+import { rstripSlash, stripSlash } from '../../../utils/slash.ts'
+
+export const GLOB_CHARS: readonly string[] = ['*', '?', '[']
+
+/**
+ * Build the PathSpec for a word typed relative to cwd.
+ *
+ * The typed word and the cwd it was typed under are two halves of one
+ * path: `virtual` resolves the pair to an absolute path, `rawPath`
+ * keeps the typed spelling for display. Glob chars in the word make a
+ * pattern spec (unresolved); words whose resolved path has no mount
+ * stay plain text.
+ */
+export function relativeSpec(
+  word: string,
+  registry: MountRegistry,
+  cwd: string,
+): string | PathSpec {
+  const path = posixNormpath(`${rstripSlash(cwd)}/${word}`)
+  if (registry.mountFor(path) === null) return word
+  const lastSlash = path.lastIndexOf('/')
+  if (GLOB_CHARS.some((ch) => word.includes(ch))) {
+    return new PathSpec({
+      resourcePath: stripSlash(path),
+      virtual: path,
+      directory: path.slice(0, lastSlash + 1),
+      pattern: path.slice(lastSlash + 1),
+      resolved: false,
+      rawPath: word,
+    })
+  }
+  return new PathSpec({
+    resourcePath: stripSlash(path),
+    virtual: path,
+    directory: path.slice(0, lastSlash + 1),
+    resolved: true,
+    rawPath: word,
+  })
+}

--- a/typescript/packages/core/src/workspace/expand/globs.test.ts
+++ b/typescript/packages/core/src/workspace/expand/globs.test.ts
@@ -108,3 +108,63 @@ describe('resolveGlobs', () => {
     expect((kept as PathSpec).pattern).toBe('*.nope')
   })
 })
+
+describe('matchDisplay via resolveGlobs', () => {
+  it('relative glob matches display as typed', async () => {
+    const match = new PathSpec({
+      resourcePath: 'ram/sub/a.txt',
+      virtual: '/ram/sub/a.txt',
+      directory: '/ram/sub/',
+      resolved: true,
+    })
+    const res = new GlobResource([match])
+    const reg = new MountRegistry({ '/ram': res }, MountMode.WRITE)
+    const p = new PathSpec({
+      resourcePath: 'ram/sub/*.txt',
+      virtual: '/ram/sub/*.txt',
+      directory: '/ram/sub/',
+      pattern: '*.txt',
+      resolved: false,
+      rawPath: 'sub/*.txt',
+    })
+    const out = await resolveGlobs([p], reg)
+    expect((out[0] as PathSpec).display).toBe('sub/a.txt')
+    expect((out[0] as PathSpec).virtual).toBe('/ram/sub/a.txt')
+  })
+
+  it('absolute glob matches keep the virtual display', async () => {
+    const match = new PathSpec({
+      resourcePath: 'ram/a.txt',
+      virtual: '/ram/a.txt',
+      directory: '/ram/',
+      resolved: true,
+    })
+    const res = new GlobResource([match])
+    const reg = new MountRegistry({ '/ram': res }, MountMode.WRITE)
+    const p = new PathSpec({
+      resourcePath: 'ram/*.txt',
+      virtual: '/ram/*.txt',
+      directory: '/ram/',
+      pattern: '*.txt',
+      resolved: false,
+    })
+    const out = await resolveGlobs([p], reg)
+    expect((out[0] as PathSpec).rawPath).toBeNull()
+    expect((out[0] as PathSpec).display).toBe('/ram/a.txt')
+  })
+
+  it('zero-match relative glob keeps the typed literal', async () => {
+    const res = new GlobResource([])
+    const reg = new MountRegistry({ '/ram': res }, MountMode.WRITE)
+    const p = new PathSpec({
+      resourcePath: 'ram/*.nope',
+      virtual: '/ram/*.nope',
+      directory: '/ram/',
+      pattern: '*.nope',
+      resolved: false,
+      rawPath: '*.nope',
+    })
+    const out = await resolveGlobs([p], reg)
+    expect((out[0] as PathSpec).display).toBe('*.nope')
+  })
+})

--- a/typescript/packages/core/src/workspace/expand/globs.test.ts
+++ b/typescript/packages/core/src/workspace/expand/globs.test.ts
@@ -109,8 +109,8 @@ describe('resolveGlobs', () => {
   })
 })
 
-describe('matchDisplay via resolveGlobs', () => {
-  it('relative glob matches display as typed', async () => {
+describe('matchRaw via resolveGlobs', () => {
+  it('relative glob matches spelled as typed', async () => {
     const match = new PathSpec({
       resourcePath: 'ram/sub/a.txt',
       virtual: '/ram/sub/a.txt',
@@ -128,11 +128,11 @@ describe('matchDisplay via resolveGlobs', () => {
       rawPath: 'sub/*.txt',
     })
     const out = await resolveGlobs([p], reg)
-    expect((out[0] as PathSpec).display).toBe('sub/a.txt')
+    expect((out[0] as PathSpec).rawPath).toBe('sub/a.txt')
     expect((out[0] as PathSpec).virtual).toBe('/ram/sub/a.txt')
   })
 
-  it('absolute glob matches keep the virtual display', async () => {
+  it('absolute glob matches keep the virtual path', async () => {
     const match = new PathSpec({
       resourcePath: 'ram/a.txt',
       virtual: '/ram/a.txt',
@@ -149,8 +149,8 @@ describe('matchDisplay via resolveGlobs', () => {
       resolved: false,
     })
     const out = await resolveGlobs([p], reg)
-    expect((out[0] as PathSpec).rawPath).toBeNull()
-    expect((out[0] as PathSpec).display).toBe('/ram/a.txt')
+    expect((out[0] as PathSpec).rawPath).toBe((out[0] as PathSpec).virtual)
+    expect((out[0] as PathSpec).rawPath).toBe('/ram/a.txt')
   })
 
   it('zero-match relative glob keeps the typed literal', async () => {
@@ -165,6 +165,6 @@ describe('matchDisplay via resolveGlobs', () => {
       rawPath: '*.nope',
     })
     const out = await resolveGlobs([p], reg)
-    expect((out[0] as PathSpec).display).toBe('*.nope')
+    expect((out[0] as PathSpec).rawPath).toBe('*.nope')
   })
 })

--- a/typescript/packages/core/src/workspace/expand/globs.ts
+++ b/typescript/packages/core/src/workspace/expand/globs.ts
@@ -26,6 +26,26 @@ function hasGlob(r: Resource): r is ResourceWithGlob {
   return 'glob' in r && typeof (r as { glob?: unknown }).glob === 'function'
 }
 
+// Stamp a glob match with the display form the user's word implies.
+// Bash expands `sub/*.txt` to relative matches (`sub/a.txt`), keeping
+// the typed prefix. The glob item's rawPath records the word as typed;
+// matches rebuild it by swapping the resolved directory prefix for the
+// typed one. Absolute words (no rawPath) keep the resolved virtual.
+function matchDisplay(item: PathSpec, match: PathSpec): PathSpec {
+  if (item.rawPath === null || match.rawPath !== null) return match
+  if (!match.virtual.startsWith(item.directory)) return match
+  const rawDir = item.rawPath.slice(0, item.rawPath.lastIndexOf('/') + 1)
+  const display = rawDir + match.virtual.slice(item.directory.length)
+  return new PathSpec({
+    virtual: match.virtual,
+    directory: match.directory,
+    pattern: match.pattern,
+    resolved: match.resolved,
+    resourcePath: match.resourcePath,
+    rawPath: display,
+  })
+}
+
 export async function resolveGlobs(
   classified: readonly (string | PathSpec)[],
   registry: MountRegistry,
@@ -45,6 +65,7 @@ export async function resolveGlobs(
         pattern: item.pattern,
         resolved: item.resolved,
         resourcePath: mountKey(item.virtual, prefix),
+        rawPath: item.rawPath,
       })
       try {
         const resolved = await mount.resource.glob([withPrefix], prefix)
@@ -53,7 +74,7 @@ export async function resolveGlobs(
         if (resolved.length === 0) {
           result.push(withPrefix)
         } else {
-          for (const p of resolved) result.push(p)
+          for (const p of resolved) result.push(matchDisplay(withPrefix, p))
         }
       } catch {
         result.push(withPrefix)

--- a/typescript/packages/core/src/workspace/expand/globs.ts
+++ b/typescript/packages/core/src/workspace/expand/globs.ts
@@ -26,23 +26,25 @@ function hasGlob(r: Resource): r is ResourceWithGlob {
   return 'glob' in r && typeof (r as { glob?: unknown }).glob === 'function'
 }
 
-// Stamp a glob match with the display form the user's word implies.
+// Stamp a glob match with the spelling the user's word implies.
 // Bash expands `sub/*.txt` to relative matches (`sub/a.txt`), keeping
 // the typed prefix. The glob item's rawPath records the word as typed;
 // matches rebuild it by swapping the resolved directory prefix for the
-// typed one. Absolute words (no rawPath) keep the resolved virtual.
-function matchDisplay(item: PathSpec, match: PathSpec): PathSpec {
-  if (item.rawPath === null || match.rawPath !== null) return match
+// typed one. Words with no distinct spelling (absolute: rawPath ===
+// virtual) keep the resolved virtual, as do matches that already carry
+// one.
+function matchRaw(item: PathSpec, match: PathSpec): PathSpec {
+  if (item.rawPath === item.virtual || match.rawPath !== match.virtual) return match
   if (!match.virtual.startsWith(item.directory)) return match
   const rawDir = item.rawPath.slice(0, item.rawPath.lastIndexOf('/') + 1)
-  const display = rawDir + match.virtual.slice(item.directory.length)
+  const spelled = rawDir + match.virtual.slice(item.directory.length)
   return new PathSpec({
     virtual: match.virtual,
     directory: match.directory,
     pattern: match.pattern,
     resolved: match.resolved,
     resourcePath: match.resourcePath,
-    rawPath: display,
+    rawPath: spelled,
   })
 }
 
@@ -74,7 +76,7 @@ export async function resolveGlobs(
         if (resolved.length === 0) {
           result.push(withPrefix)
         } else {
-          for (const p of resolved) result.push(matchDisplay(withPrefix, p))
+          for (const p of resolved) result.push(matchRaw(withPrefix, p))
         }
       } catch {
         result.push(withPrefix)

--- a/typescript/packages/core/src/workspace/node/command_dispatch.ts
+++ b/typescript/packages/core/src/workspace/node/command_dispatch.ts
@@ -423,7 +423,7 @@ async function runArgv(
     let cdpathTarget: string
     if (raw instanceof PathSpec) {
       path = raw
-      cdpathTarget = raw.rawPath ?? raw.virtual
+      cdpathTarget = raw.rawPath
     } else if (rawStr.startsWith('/')) {
       path = rawStr
       cdpathTarget = rawStr

--- a/typescript/packages/core/src/workspace/node/execute_node.ts
+++ b/typescript/packages/core/src/workspace/node/execute_node.ts
@@ -146,6 +146,36 @@ export async function executeNode(
 
   if (kind === NodeKind.REDIRECT) {
     const [command, redirects] = getRedirects(node)
+    if (command.type === NT.LIST) {
+      // tree-sitter hoists a trailing redirect over the whole &&/||
+      // list; bash binds it to the last command:
+      //   redirected(list(L, op, R), r) == list(L, op, redirected(R, r))
+      // Re-associate and defer target expansion until R runs, so
+      // `cd /x && echo hi > f` writes under /x. Compound and subshell
+      // bodies keep the whole-body redirect (bash group semantics).
+      const [left, op, right] = getListParts(command)
+      const wrapped: typeof recurse = async (n, sess, sin, cstack) => {
+        if (n !== right) return recurse(n, sess, sin, cstack)
+        const [expanded, pipe] = await expandRedirects(redirects, sess, executeFn, registry, cstack)
+        let [rStdout, rIo, rExec] = await handleRedirect(
+          recurse,
+          dispatch,
+          right,
+          expanded,
+          sess,
+          sin,
+          cstack,
+        )
+        if (pipe !== null && rStdout !== null) {
+          const [s2, io2, e2] = await recurse(pipe, sess, rStdout, cstack)
+          rStdout = s2
+          rIo = await rIo.merge(io2)
+          rExec = e2
+        }
+        return [rStdout, rIo, rExec]
+      }
+      return handleConnection(wrapped, left, op, right, session, stdin, callStack)
+    }
     const [expandedRedirects, pipeNode] = await expandRedirects(
       redirects,
       session,

--- a/typescript/packages/core/src/workspace/node/program.test.ts
+++ b/typescript/packages/core/src/workspace/node/program.test.ts
@@ -1,0 +1,56 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { RAMResource } from '../../resource/ram/ram.ts'
+import { MountMode } from '../../types.ts'
+import { getTestParser, stderrStr } from '../fixtures/workspace_fixture.ts'
+import { Workspace } from '../workspace.ts'
+
+async function makeWs(): Promise<Workspace> {
+  const parser = await getTestParser()
+  const ws = new Workspace(
+    { '/': new RAMResource() },
+    { mode: MountMode.WRITE, shellParser: parser },
+  )
+  await ws.execute('mkdir -p /data/sub')
+  await ws.execute('echo hi > /data/sub/x.txt')
+  await ws.execute('cd /data')
+  return ws
+}
+
+describe('drain error spelling', () => {
+  it('respells a relative operand as typed', async () => {
+    // cat of a directory errors on the first lazy pull, past the eager
+    // chokepoint; the drain must still report the operand as typed.
+    const ws = await makeWs()
+    const io = await ws.execute('cat sub')
+    expect(io.exitCode).toBe(1)
+    expect(stderrStr(io)).toMatch(/^cat: sub: /)
+  })
+
+  it('keeps an absolute operand absolute', async () => {
+    const ws = await makeWs()
+    const io = await ws.execute('cat /data/sub')
+    expect(io.exitCode).toBe(1)
+    expect(stderrStr(io)).toMatch(/^cat: \/data\/sub: /)
+  })
+
+  it('eager errors respell the relative operand', async () => {
+    const ws = await makeWs()
+    const io = await ws.execute('cat sub/missing.txt')
+    expect(io.exitCode).toBe(1)
+    expect(stderrStr(io)).toBe('cat: sub/missing.txt: No such file or directory\n')
+  })
+})

--- a/typescript/packages/core/src/workspace/node/program.ts
+++ b/typescript/packages/core/src/workspace/node/program.ts
@@ -18,6 +18,7 @@ import type { CallStack } from '../../shell/call_stack.ts'
 import type { JobTable } from '../../shell/job_table.ts'
 import { ERREXIT_EXEMPT_TYPES, NodeType as NT } from '../../shell/types.ts'
 import type { TSNodeLike } from '../expand/variable.ts'
+import { errorVirtualPath, gnuStrerror } from '../../utils/errors.ts'
 import { handleBackground } from '../executor/jobs.ts'
 import type { Session } from '../session/session.ts'
 import { ExecutionNode } from '../types.ts'
@@ -90,8 +91,19 @@ export async function executeProgram(
         stdout = await materialize(s)
       } catch (err) {
         // Lazy reads can fail on the first pull (e.g. a backend size guard);
-        // surface that as a failed statement, not a crash.
-        drainErr = err instanceof Error ? err.message : String(err)
+        // surface that as a failed statement, not a crash. Filesystem
+        // errors format as a GNU coreutils line, respelling the path as
+        // typed via the operands the leaf node carries, mirroring the
+        // eager executor chokepoint.
+        const strerror = gnuStrerror((err as { code?: string }).code)
+        if (strerror !== null) {
+          const vpath = errorVirtualPath(err)
+          const cmdName = execNode.command?.split(' ')[0] ?? ''
+          const spelled = execNode.paths.find((p) => p.virtual === vpath)?.rawPath ?? vpath
+          drainErr = `${cmdName}: ${spelled}: ${strerror}`
+        } else {
+          drainErr = err instanceof Error ? err.message : String(err)
+        }
         stdout = null
       }
       ioResult.syncExitCode()

--- a/typescript/packages/core/src/workspace/node/provision_node.ts
+++ b/typescript/packages/core/src/workspace/node/provision_node.ts
@@ -31,7 +31,12 @@ import {
   splitEnvPrefix,
 } from '../../shell/helpers.ts'
 import { NodeKind, nodeKind } from '../../shell/node_kind.ts'
-import { NodeType as NT, RedirectKind, ShellBuiltin as SB } from '../../shell/types.ts'
+import {
+  NodeType as NT,
+  type Redirect,
+  RedirectKind,
+  ShellBuiltin as SB,
+} from '../../shell/types.ts'
 import { Precision, ProvisionResult } from '../../provision/types.ts'
 import { rollupList, rollupPipe } from '../../provision/rollup.ts'
 import { PathSpec } from '../../types.ts'
@@ -103,6 +108,56 @@ interface ProvisionContext {
 interface PlanScope {
   functions: Map<string, TSNodeLike[]>
   planning: Set<string>
+}
+
+// Plan one redirected command: expand targets, cost, degrade. A cmdsub
+// target expands empty under provision, so its classification is
+// garbage; the precision degrade keeps the plan honest without costing
+// a phantom write.
+async function provisionRedirected(
+  ctx: ProvisionContext,
+  recurse: (n: TSNodeLike, s: Session) => Promise<ProvisionResult>,
+  recurseUnknown: (n: unknown, s: Session) => Promise<ProvisionResult>,
+  command: unknown,
+  redirects: Redirect[],
+  session: Session,
+): Promise<ProvisionResult> {
+  const [expanded, pipeNode] = await expandRedirects(
+    redirects,
+    session,
+    ctx.executeFn,
+    ctx.registry,
+  )
+  const targets: [RedirectKind, PathSpec][] = []
+  for (const r of expanded) {
+    if (r.kind !== RedirectKind.STDIN && r.kind !== RedirectKind.STDOUT) continue
+    if (!(r.target instanceof PathSpec)) continue
+    if (r.target.virtual.startsWith('/dev/')) continue
+    if (r.targetNode !== null && hasCommandSubstitution(r.targetNode as TSNodeLike)) {
+      continue
+    }
+    targets.push([r.kind, r.target])
+  }
+  const result = await handleRedirectProvision(
+    recurseUnknown,
+    ctx.registry,
+    command,
+    targets,
+    session,
+    ctx.namespace ?? null,
+  )
+  if (
+    redirects.some(
+      (r) => r.targetNode !== null && hasCommandSubstitution(r.targetNode as TSNodeLike),
+    )
+  ) {
+    // A suppressed substitution hid the real redirect target.
+    result.precision = Precision.UNKNOWN
+  }
+  if (pipeNode !== null) {
+    return rollupPipe([result, await recurse(pipeNode, session)])
+  }
+  return result
 }
 
 /**
@@ -182,45 +237,17 @@ export async function provisionNode(
 
   if (kind === NodeKind.REDIRECT) {
     const [command, redirects] = getRedirects(node)
-    const [expanded, pipeNode] = await expandRedirects(
-      redirects,
-      session,
-      ctx.executeFn,
-      ctx.registry,
-    )
-    const targets: [RedirectKind, PathSpec][] = []
-    for (const r of expanded) {
-      if (r.kind !== RedirectKind.STDIN && r.kind !== RedirectKind.STDOUT) continue
-      if (!(r.target instanceof PathSpec)) continue
-      if (r.target.virtual.startsWith('/dev/')) continue
-      if (r.targetNode !== null && hasCommandSubstitution(r.targetNode as TSNodeLike)) {
-        // The suppressed substitution expanded to empty, so this
-        // target classification is garbage; the degrade below keeps
-        // the plan honest without costing a phantom write.
-        continue
-      }
-      targets.push([r.kind, r.target])
+    if ((command as TSNodeLike & { type: string }).type === NT.LIST) {
+      // Mirror the executor: a trailing redirect hoisted over an
+      // &&/|| list binds to the last command.
+      const [left, op, right] = getListParts(command)
+      const wrapped = (n: unknown, s: Session): Promise<ProvisionResult> =>
+        n === right
+          ? provisionRedirected(ctx, recurse, recurseUnknown, right, redirects, s)
+          : recurseUnknown(n, s)
+      return handleConnectionProvision(wrapped, left, op ?? '&&', right, session)
     }
-    const result = await handleRedirectProvision(
-      recurseUnknown,
-      ctx.registry,
-      command,
-      targets,
-      session,
-      ctx.namespace ?? null,
-    )
-    if (
-      redirects.some(
-        (r) => r.targetNode !== null && hasCommandSubstitution(r.targetNode as TSNodeLike),
-      )
-    ) {
-      // A suppressed substitution hid the real redirect target.
-      result.precision = Precision.UNKNOWN
-    }
-    if (pipeNode !== null) {
-      return rollupPipe([result, await recurse(pipeNode, session)])
-    }
-    return result
+    return provisionRedirected(ctx, recurse, recurseUnknown, command, redirects, session)
   }
 
   if (kind === NodeKind.IF) {

--- a/typescript/packages/core/src/workspace/types.ts
+++ b/typescript/packages/core/src/workspace/types.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { OpRecord } from '../observe/record.ts'
+import type { PathSpec } from '../types.ts'
 import { DEFAULT_SESSION_ID } from '../types.ts'
 
 export interface ExecutionNodeInit {
@@ -22,6 +23,7 @@ export interface ExecutionNodeInit {
   exitCode?: number
   children?: ExecutionNode[]
   records?: OpRecord[]
+  paths?: PathSpec[]
 }
 
 export class ExecutionNode {
@@ -31,6 +33,10 @@ export class ExecutionNode {
   exitCode: number
   children: ExecutionNode[]
   records: OpRecord[]
+  // Classified path operands of a leaf mount command. Transient (not
+  // serialized): lets the lazy-stream drain respell filesystem errors as
+  // typed, like the eager chokepoint.
+  paths: PathSpec[]
 
   constructor(init: ExecutionNodeInit = {}) {
     this.command = init.command ?? null
@@ -39,6 +45,7 @@ export class ExecutionNode {
     this.exitCode = init.exitCode ?? 0
     this.children = init.children ?? []
     this.records = init.records ?? []
+    this.paths = init.paths ?? []
   }
 
   toJSON(): Record<string, unknown> {


### PR DESCRIPTION
Fixes four bash-parity bugs around relative words, trailing redirects, and error spelling, and consolidates the word-spelling model, in both langs.

## test resolves relative path operands

`cd /data && test -f plain.txt` returned 1 even when the file exists: `-f` and `-d` scoped string operands without the session cwd. Relative strings now resolve through the shared `resolve_path` before the stat or readdir probe; empty operands stay false without a backend call.

## Words render as typed

The Argv text view, for/select loop variables, and function positional args used `PathSpec.virtual`, so `echo sub/file.txt` printed the resolved absolute path where bash hands programs their words unchanged. All three now render the typed spelling, and `resolve_globs` stamps glob matches with the spelling the typed word implies: `sub/*.txt` expands to `sub/a.txt`, absolute patterns keep absolute matches, and a zero-match relative glob keeps the typed literal (the TS glob clone also dropped `rawPath`, absolutizing kept literals). Relative values re-resolve on use, so `for f in sub/*.txt; do cat $f; done` still reads the right files.

## Trailing redirect binds to the last command of a list

tree-sitter-bash hoists a trailing redirect over the whole `&&`/`||` list, so `cd /data && echo hi > BARE` expanded the target before cd ran (writing /BARE) and `a && b > f` captured both commands' output. The executor now re-associates at the redirected-statement branch: `redirected(list(L, op, R), r)` runs as `list(L, op, redirected(R, r))`, expanding the target only when R runs. Multi-redirect chains compound correctly, compound and subshell bodies keep bash's whole-body group redirect, and the provision planner mirrors the re-association. Replaces the partial list handling inside handle_redirect, which ran after eager expansion, dropped the left side's stdout, and never ran the right side of a semicolon list.

## raw_path owns word spelling; drain errors respell as typed

Follow-on from reviewing the spelling semantics (commit 5f79bdb3):

- `raw_path`/`rawPath` is now total (defaults to `virtual`) and the `display` property is deleted: one name for the word's spelling. A word's typed form and the cwd it was typed under are two halves of one fact; the new `relative_spec`/`relativeSpec` constructor owns that construction (four hand-rolled copies collapsed), `word_text`/`wordText` owns the str-or-spelling coercion, and `rebase_display` is renamed `rebase_raw` with its dead nullable parameter dropped.
- Fix: lazy-stream drain errors now respell operands as typed. `cd /data && cat sub` said `cat: /data/sub: ...` in Python, and the TS drain printed the bare message with no command prefix at all. `ExecutionNode` carries the leaf command's operands (transient, not serialized) so the drain formats like the eager chokepoint, byte-identical across languages.

Related pre-existing bugs found during review, filed separately: #457 (cat on a directory reports ENOENT on keyed backends), #458 (ls with a glob operand prints bare names). #336 (mount-command glob labels, `wc *.txt`) is not fixed here but the new `_match_raw` stamping is the groundwork its prototype described.

## Tests

- Unit: new test_condition.py, test_redirect.py, test_relative.py, test_program.py and their TS mirrors; word_text/wordText and glob spelling cases; test_parse updates.
- Integ: 22 new shared-truth cases (relative test/echo/for/function words, redirect after cd, last-command capture, multi-redirect chain, group redirect, walker label rebasing, error spelling, ./ glob, du trailing slash); truth diff is purely additive, no existing output line changed.