### PR TITLE
awk: repeatable -v, -f frees the program operand

### DIFF
--- a/integ/cases.py
+++ b/integ/cases.py
@@ -337,6 +337,11 @@ CASES: list[tuple[str, str]] = [
     ("awk_fs_comma", 'awk -F , \'{print $2}\' /data/csv.csv'),
     ("awk_ofs", 'awk -F , \'BEGIN{OFS=":"} {print $1, $2}\' /data/csv.csv'),
     ("awk_range", "awk 'NR>=2 && NR<=4' /data/a.txt"),
+    ("awk_v_repeat",
+     "awk -v a=va1 -v b=vb2 '{print a, b}' /data/one_byte.txt"),
+    ("awk_v_equals", "awk -v x=eq=val '{print x}' /data/one_byte.txt"),
+    ("awk_f_program", "echo '{print $3, $1}' | tee /data/prog.awk > /dev/null"
+     " && awk -f /data/prog.awk /data/fields.txt && rm /data/prog.awk"),
 
     # ----- sed advanced -----
     ("sed_d_first", "sed 1d /data/a.txt"),

--- a/integ/cases.ts
+++ b/integ/cases.ts
@@ -269,6 +269,13 @@ export const CASES: ReadonlyArray<readonly [string, string]> = [
   ["awk_fs_comma", "awk -F , '{print $2}' /data/csv.csv"],
   ["awk_ofs", "awk -F , 'BEGIN{OFS=\":\"} {print $1, $2}' /data/csv.csv"],
   ["awk_range", "awk 'NR>=2 && NR<=4' /data/a.txt"],
+  ["awk_v_repeat", "awk -v a=va1 -v b=vb2 '{print a, b}' /data/one_byte.txt"],
+  ["awk_v_equals", "awk -v x=eq=val '{print x}' /data/one_byte.txt"],
+  [
+    "awk_f_program",
+    "echo '{print $3, $1}' | tee /data/prog.awk > /dev/null" +
+      " && awk -f /data/prog.awk /data/fields.txt && rm /data/prog.awk",
+  ],
 
   ["sed_d_first", "sed 1d /data/a.txt"],
   ["sed_d_last", "sed '$d' /data/a.txt"],

--- a/integ/truth.txt
+++ b/integ/truth.txt
@@ -922,6 +922,14 @@ bob 25
 world
 foo
 bar
+=== awk_v_repeat ===
+va1 vb2
+=== awk_v_equals ===
+eq=val
+=== awk_f_program ===
+engineer alice
+designer bob
+manager carol
 === sed_d_first ===
 world
 foo

--- a/python/mirage/commands/builtin/generic/awk.py
+++ b/python/mirage/commands/builtin/generic/awk.py
@@ -273,7 +273,7 @@ async def awk(
     accessor: object = None,
     stdin: AsyncIterator[bytes] | bytes | None = None,
     field_separator: str | None = None,
-    variable_assignment: str | None = None,
+    variable_assignment: str | list[str] | None = None,
     program_file: PathSpec | None = None,
     index: IndexCacheStore | None = None,
 ) -> tuple[ByteSource | None, IOResult]:
@@ -296,9 +296,12 @@ async def awk(
 
     fs = field_separator if field_separator else " "
     variables: dict[str, str] = {}
-    if variable_assignment and "=" in variable_assignment:
-        key, val = variable_assignment.split("=", 1)
-        variables[key] = val
+    assignments = ([variable_assignment] if isinstance(
+        variable_assignment, str) else variable_assignment or [])
+    for assignment in assignments:
+        if "=" in assignment:
+            key, val = assignment.split("=", 1)
+            variables[key] = val
 
     cache: list[str] = []
     if data_paths:

--- a/python/mirage/commands/builtin/generic_bind/builders/awk.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/awk.py
@@ -32,7 +32,7 @@ async def awk(
     *texts: str,
     stdin: AsyncIterator[bytes] | bytes | None = None,
     F: str | None = None,
-    v: str | None = None,
+    v: str | list[str] | None = None,
     f: PathSpec | None = None,
     index: IndexCacheStore | None = None,
     **kwargs,

--- a/python/mirage/commands/spec/builtin_specs/search.py
+++ b/python/mirage/commands/spec/builtin_specs/search.py
@@ -124,10 +124,10 @@ SPECS: dict[str, CommandSpec] = {
     CommandSpec(
         options=(
             Option(short="-F", value_kind=OperandKind.TEXT),
-            Option(short="-v", value_kind=OperandKind.TEXT),
+            Option(short="-v", value_kind=OperandKind.TEXT, repeatable=True),
             Option(short="-f", value_kind=OperandKind.PATH),
         ),
-        positional=(Operand(kind=OperandKind.TEXT), ),
+        positional=(Operand(kind=OperandKind.TEXT, provided_by=("-f", )), ),
         rest=Operand(kind=OperandKind.PATH),
     ),
     'strings':

--- a/python/tests/commands/spec/test_parser.py
+++ b/python/tests/commands/spec/test_parser.py
@@ -217,3 +217,20 @@ def test_long_equals_and_separate_repeatable_accumulate():
     parsed = parse_command(spec, ["--tag=a", "--tag", "b", "/x"], "/")
     assert parsed.flags["--tag"] == ["a", "b"]
     assert parsed.paths() == ["/x"]
+
+
+def test_awk_repeated_dash_v_accumulates():
+    parsed = parse_command(
+        SPECS["awk"],
+        ["-v", "a=1", "-v", "b=2", "{print a, b}", "/data/x.txt"], "/")
+    assert parsed.flags["-v"] == ["a=1", "b=2"]
+    assert parsed.texts() == ["{print a, b}"]
+    assert parsed.paths() == ["/data/x.txt"]
+
+
+def test_awk_dash_f_frees_positional_slot_for_paths():
+    parsed = parse_command(SPECS["awk"],
+                           ["-f", "/prog.awk", "/data/a.txt", "/data/b.txt"],
+                           "/")
+    assert parsed.texts() == []
+    assert parsed.paths() == ["/data/a.txt", "/data/b.txt"]

--- a/typescript/packages/core/src/commands/builtin/generic/awk.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/awk.ts
@@ -63,9 +63,12 @@ export async function awkGeneric(
   }
   const fs = typeof opts.flags.F === 'string' ? opts.flags.F : ' '
   const variables: Record<string, string> = {}
-  if (typeof opts.flags.v === 'string' && opts.flags.v.includes('=')) {
-    const [key, val] = opts.flags.v.split('=', 2)
-    if (key !== undefined && val !== undefined) variables[key] = val
+  const rawV = opts.flags.v
+  const assignments = Array.isArray(rawV) ? rawV : typeof rawV === 'string' ? [rawV] : []
+  for (const assignment of assignments) {
+    if (typeof assignment !== 'string') continue
+    const eq = assignment.indexOf('=')
+    if (eq > 0) variables[assignment.slice(0, eq)] = assignment.slice(eq + 1)
   }
   const cache: string[] = []
   let source: AsyncIterable<Uint8Array>

--- a/typescript/packages/core/src/commands/spec/builtins.ts
+++ b/typescript/packages/core/src/commands/spec/builtins.ts
@@ -408,10 +408,10 @@ export const BUILTIN_SPECS: Readonly<Record<string, CommandSpec>> = Object.freez
   awk: new CommandSpec({
     options: [
       new Option({ short: '-F', valueKind: OperandKind.TEXT }),
-      new Option({ short: '-v', valueKind: OperandKind.TEXT }),
+      new Option({ short: '-v', valueKind: OperandKind.TEXT, repeatable: true }),
       new Option({ short: '-f', valueKind: OperandKind.PATH }),
     ],
-    positional: [new Operand({ kind: OperandKind.TEXT })],
+    positional: [new Operand({ kind: OperandKind.TEXT, providedBy: ['-f'] })],
     rest: new Operand({ kind: OperandKind.PATH }),
   }),
   paste: new CommandSpec({

--- a/typescript/packages/core/src/commands/spec/parser.test.ts
+++ b/typescript/packages/core/src/commands/spec/parser.test.ts
@@ -426,3 +426,22 @@ describe('parseToKwargs', () => {
     expect(parseToKwargs(parsed)).toEqual({ args_1: true })
   })
 })
+
+describe('parseCommand — awk spec', () => {
+  it('accumulates repeated -v assignments', () => {
+    const p = parseCommand(
+      specOf('awk'),
+      ['-v', 'a=1', '-v', 'b=2', '{print a, b}', '/data/x.txt'],
+      '/',
+    )
+    expect(p.flags['-v']).toEqual(['a=1', 'b=2'])
+    expect(p.texts()).toEqual(['{print a, b}'])
+    expect(p.paths()).toEqual(['/data/x.txt'])
+  })
+
+  it('frees the program slot when -f is present', () => {
+    const p = parseCommand(specOf('awk'), ['-f', '/prog.awk', '/data/a.txt', '/data/b.txt'], '/')
+    expect(p.texts()).toEqual([])
+    expect(p.paths()).toEqual(['/data/a.txt', '/data/b.txt'])
+  })
+})


### PR DESCRIPTION
First slice of the generic-awk improvement plan (docs/plan/2026-07-10-awk-generic-improvements.md).

## Changes

- Spec (both langs): `-v` is repeatable and accumulates; the program operand is `provided_by`/`providedBy` `-f`, so `awk -f prog.awk a.txt b.txt` classifies data files as paths instead of leaking the first one into texts.
- Generics: minimal shim so `-v` accepts the new list shape end to end (single and repeated). Fixes the TS bug where `-v x=a=b` truncated the value to `a`.
- Integ: 3 new shared cases (`awk_v_repeat`, `awk_v_equals`, `awk_f_program`) plus truth entries.

## Testing

- New parser tests both langs (py spec suite green, TS 49/49).
- Shared-truth integ verified locally with exact diff on 7 runners: py disk/ram/redis, ts disk/ram/opfs/redis.
- Full py pytest green except the known live-jina 401 flake (`test_curl_jina_returns_markdown`, external auth, unrelated). TS core suite 3609 passed.

Follow-ups (Tasks 2-3 of the plan): GNU default FS, multi-file NR (#451), UsageError exit 2, and the generic rewrite to the frozen flag-struct convention.