### PR TITLE
fix(databricks): avoid redundant cat stat

### DIFF
--- a/python/mirage/commands/builtin/databricks_volume/__init__.py
+++ b/python/mirage/commands/builtin/databricks_volume/__init__.py
@@ -41,6 +41,7 @@ _DATABRICKS_CMD_OPS = CommandIO(
     stat=_stat,
     is_mounted=lambda a: True,
     local=False,
+    cat_preflight_stat=False,
     write=_write,
     exists=_exists,
     mkdir=_mkdir,

--- a/python/mirage/commands/builtin/generic_bind/adapter.py
+++ b/python/mirage/commands/builtin/generic_bind/adapter.py
@@ -126,6 +126,7 @@ class CommandIO:
     find: Callable | None = None
     du_total: Callable | None = None
     du_all: Callable | None = None
+    cat_preflight_stat: bool = True
 
     @property
     def resolve_glob(self) -> Callable:

--- a/python/mirage/commands/builtin/generic_bind/builders/cat.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/cat.py
@@ -43,7 +43,7 @@ async def cat(
                 await ops.stat(accessor, p, index)
         if len(paths) == 1:
             p = paths[0]
-            if not ops.local:
+            if not ops.local and ops.cat_preflight_stat:
                 await ops.stat(accessor, p, index)
             cachable = CachableAsyncIterator(
                 ops.read_stream(accessor, p, index))

--- a/python/mirage/core/databricks_volume/_helpers.py
+++ b/python/mirage/core/databricks_volume/_helpers.py
@@ -12,7 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
+from typing import NoReturn
+
+from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
+from mirage.core.databricks_volume.errors import is_not_found
 from mirage.types import PathSpec
+from mirage.utils.errors import enoent
 from mirage.utils.key_prefix import mount_key, mount_prefix_of
 
 
@@ -37,3 +43,18 @@ def parent_path(path: PathSpec | str) -> PathSpec:
         original = parent_relative
     return PathSpec.from_str_path(original or "/",
                                   mount_key(original or "/", prefix))
+
+
+async def raise_not_found_or_directory(
+    accessor: DatabricksVolumeAccessor,
+    remote_path: str,
+    path: PathSpec,
+) -> NoReturn:
+    try:
+        await asyncio.to_thread(accessor.files.get_directory_metadata,
+                                remote_path)
+    except Exception as exc:
+        if is_not_found(exc):
+            raise enoent(path) from exc
+        raise
+    raise IsADirectoryError(path.virtual)

--- a/python/mirage/core/databricks_volume/stream.py
+++ b/python/mirage/core/databricks_volume/stream.py
@@ -18,12 +18,12 @@ from typing import BinaryIO
 
 from mirage.accessor.databricks_volume import DatabricksVolumeAccessor
 from mirage.cache.index import IndexCacheStore
+from mirage.core.databricks_volume._helpers import raise_not_found_or_directory
 from mirage.core.databricks_volume.errors import is_not_found
 from mirage.core.databricks_volume.path import backend_path
 from mirage.core.databricks_volume.read import read_bytes
 from mirage.observe.context import record_stream
 from mirage.types import PathSpec
-from mirage.utils.errors import enoent
 
 
 def _download_contents(response) -> BinaryIO:
@@ -73,7 +73,7 @@ async def read_stream(
             yield chunk
     except Exception as exc:
         if is_not_found(exc):
-            raise enoent(path) from exc
+            await raise_not_found_or_directory(accessor, remote_path, path)
         raise
     finally:
         if contents is not None:

--- a/python/tests/commands/builtin/databricks_volume/test_cat.py
+++ b/python/tests/commands/builtin/databricks_volume/test_cat.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from unittest.mock import Mock
+
 import pytest
 
 
@@ -21,6 +23,44 @@ async def test_cat_single_file(databricks_text_workspace):
 
     assert io.exit_code == 0
     assert io.stdout == b"beta\nalpha\nalpha\n"
+
+
+@pytest.mark.asyncio
+async def test_cat_single_file_does_not_fetch_metadata(
+    databricks_text_workspace,
+    databricks_text_files,
+    monkeypatch,
+):
+    get_metadata = Mock(wraps=databricks_text_files.get_metadata)
+    get_directory_metadata = Mock(
+        wraps=databricks_text_files.get_directory_metadata)
+    download = Mock(wraps=databricks_text_files.download)
+    monkeypatch.setattr(databricks_text_files, "get_metadata", get_metadata)
+    monkeypatch.setattr(databricks_text_files, "get_directory_metadata",
+                        get_directory_metadata)
+    monkeypatch.setattr(databricks_text_files, "download", download)
+
+    io = await databricks_text_workspace.execute("cat /dbx/words.txt")
+
+    assert io.exit_code == 0
+    assert io.stdout == b"beta\nalpha\nalpha\n"
+    get_metadata.assert_not_called()
+    get_directory_metadata.assert_not_called()
+    download.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cat_directory_reports_is_directory(
+    databricks_text_workspace,
+    databricks_text_files,
+):
+    root = "/Volumes/main/default/agent_files/root"
+    databricks_text_files.create_directory(f"{root}/sub")
+
+    io = await databricks_text_workspace.execute("cat /dbx/sub")
+
+    assert io.exit_code == 1
+    assert io.stderr == b"cat: /dbx/sub: Is a directory\n"
 
 
 @pytest.mark.asyncio

--- a/typescript/packages/core/src/commands/builtin/databricks_volume/ops.ts
+++ b/typescript/packages/core/src/commands/builtin/databricks_volume/ops.ts
@@ -35,6 +35,7 @@ export const DATABRICKS_VOLUME_CMD_OPS: CommandIO<DatabricksVolumeAccessor> = {
   stat: dbxStat,
   isMounted: () => true,
   local: false,
+  catPreflightStat: false,
   write: dbxWrite,
   exists: dbxExists,
   mkdir: (accessor, path, parents) => dbxMkdir(accessor, path, undefined, parents === true),

--- a/typescript/packages/core/src/commands/builtin/generic/cat.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cat.test.ts
@@ -51,6 +51,16 @@ function statFn(p: PathSpec): Promise<FileStat> {
 }
 
 describe('catGeneric multi-file streaming', () => {
+  it('does not stat before streaming', async () => {
+    const pulled: string[] = []
+    const result = await catGeneric([spec('/a.txt')], [], opts(), null, (p) =>
+      fileStream(p.virtual, pulled),
+    )
+    const [stdout] = result ?? [null]
+    expect(DEC.decode(await materialize(stdout))).toBe('a1\na2\na3\n')
+    expect(pulled).toEqual(['/a.txt'])
+  })
+
   it('records one reads entry per file, not the joined stream', async () => {
     const pulled: string[] = []
     const result = await catGeneric([spec('/a.txt'), spec('/b.txt')], [], opts(), statFn, (p) =>

--- a/typescript/packages/core/src/commands/builtin/generic/cat.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cat.ts
@@ -70,12 +70,14 @@ export async function catGeneric(
   paths: PathSpec[],
   texts: string[],
   opts: CommandOpts,
-  stat: Stat,
+  stat: Stat | null,
   stream: Stream,
 ): Promise<CommandFnResult> {
   const nFlag = opts.flags.n === true
   if (paths.length > 0) {
-    for (const p of paths) await stat(p)
+    if (stat !== null) {
+      for (const p of paths) await stat(p)
+    }
     const reads: Record<string, ByteSource> = {}
     const cacheKeys: string[] = []
     const outputs: AsyncIterable<Uint8Array>[] = []

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
@@ -114,6 +114,7 @@ export interface CommandIO<A extends Accessor = Accessor> {
   stat: StatOp<A>
   isMounted: (accessor: A) => boolean
   local?: boolean
+  catPreflightStat?: boolean
   maxGlobMatches?: number
   write?: WriteOp<A>
   exists?: ExistsOp<A>

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/cat.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/cat.ts
@@ -27,7 +27,9 @@ export const CAT_BUILDER: Builder = {
       resolved,
       texts,
       opts,
-      (p) => ops.stat(accessor, p, idx),
+      ops.local === true || ops.catPreflightStat !== false
+        ? (p) => ops.stat(accessor, p, idx)
+        : null,
       (p) => ops.readStream(accessor, p, idx),
     )
   },

--- a/typescript/packages/core/src/core/databricks_volume/_helpers.ts
+++ b/typescript/packages/core/src/core/databricks_volume/_helpers.ts
@@ -12,9 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.ts'
 import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
 import { PathSpec } from '../../types.ts'
 import { rstripSlash } from '../../utils/slash.ts'
+import { dbxFetch } from './_client.ts'
+import { isADirectoryError, isNotFound, notFoundError } from './errors.ts'
 
 export function ensurePathSpec(path: PathSpec | string): PathSpec {
   if (path instanceof PathSpec) return path
@@ -36,4 +39,18 @@ export function parentPath(path: PathSpec | string): PathSpec {
   }
   const full = virtual !== '' ? virtual : '/'
   return PathSpec.fromStrPath(full, mountKey(full, prefix))
+}
+
+export async function throwNotFoundOrDirectory(
+  accessor: DatabricksVolumeAccessor,
+  remotePath: string,
+  path: PathSpec,
+): Promise<never> {
+  try {
+    await dbxFetch(accessor, 'HEAD', 'directories', remotePath)
+  } catch (exc) {
+    if (isNotFound(exc)) throw notFoundError(path.virtual)
+    throw exc
+  }
+  throw isADirectoryError(path.virtual)
 }

--- a/typescript/packages/core/src/core/databricks_volume/stream.test.ts
+++ b/typescript/packages/core/src/core/databricks_volume/stream.test.ts
@@ -54,11 +54,30 @@ describe('readStream', () => {
   })
 
   it('raises ENOENT for missing files', async () => {
-    const { fetch } = routedFetch(() => notFoundResponse())
+    const { fetch, calls } = routedFetch(() => notFoundResponse())
     vi.stubGlobal('fetch', fetch)
     const err = (await collect(readStream(makeAccessor(), spec('/volume/gone.bin'))).catch(
       (e: unknown) => e,
     )) as Error & { code?: string }
     expect(err.code).toBe('ENOENT')
+    expect(calls.map((call) => call.url)).toEqual([
+      'https://dbc.example.com/api/2.0/fs/files/Volumes/main/default/agent_files/root/gone.bin',
+      'https://dbc.example.com/api/2.0/fs/directories/Volumes/main/default/agent_files/root/gone.bin',
+    ])
+  })
+
+  it('raises EISDIR when a failed file download resolves as a directory', async () => {
+    const { fetch, calls } = routedFetch((call) =>
+      call.url.includes('/directories/') ? new Response(null, { status: 200 }) : notFoundResponse(),
+    )
+    vi.stubGlobal('fetch', fetch)
+    const err = (await collect(readStream(makeAccessor(), spec('/volume/folder'))).catch(
+      (e: unknown) => e,
+    )) as Error & { code?: string }
+    expect(err.code).toBe('EISDIR')
+    expect(calls.map((call) => call.url)).toEqual([
+      'https://dbc.example.com/api/2.0/fs/files/Volumes/main/default/agent_files/root/folder',
+      'https://dbc.example.com/api/2.0/fs/directories/Volumes/main/default/agent_files/root/folder',
+    ])
   })
 })

--- a/typescript/packages/core/src/core/databricks_volume/stream.ts
+++ b/typescript/packages/core/src/core/databricks_volume/stream.ts
@@ -16,7 +16,8 @@ import type { DatabricksVolumeAccessor } from '../../accessor/databricks_volume.
 import { recordStream } from '../../observe/context.ts'
 import { ResourceName, type PathSpec } from '../../types.ts'
 import { dbxFetch } from './_client.ts'
-import { isNotFound, notFoundError } from './errors.ts'
+import { throwNotFoundOrDirectory } from './_helpers.ts'
+import { isNotFound } from './errors.ts'
 import { backendPath } from './path.ts'
 import { readBytes } from './read.ts'
 
@@ -42,7 +43,7 @@ export async function* readStream(
       headers: { Accept: 'application/octet-stream' },
     })
   } catch (exc) {
-    if (isNotFound(exc)) throw notFoundError(path.virtual)
+    if (isNotFound(exc)) await throwNotFoundOrDirectory(accessor, remotePath, path)
     throw exc
   }
   const body = r.body


### PR DESCRIPTION
## Summary

- let command backends opt out of `cat`'s metadata preflight and disable it for Databricks Volumes in Python and TypeScript
- make a successful explicit-path `cat` use one file download instead of metadata plus download
- after a failed file download, probe the directory endpoint so directories report `Is a directory` while missing paths remain `No such file or directory`
- add regression coverage for request counts and error semantics

## Behavior

Before, `cat /dbx/file.txt` fetched metadata whose result was discarded, then downloaded the file. Removing that call alone would retain the existing incorrect directory error because the Databricks Files API returns 404 when a directory is downloaded.

After this change, successful file reads take the single-download fast path. Only a failed file download performs the directory probe needed to distinguish a directory from a missing path. Other backends keep their existing `cat` preflight behavior.

## Verification

- Python Databricks `cat`, generic command, and stream tests
- TypeScript generic `cat`, generic-bind, and Databricks stream tests
