### PR TITLE
rg multi-pattern pushdown on postgres/email; GNU error shape for unsupported path-bound commands

### DIFF
--- a/integ/postgres.py
+++ b/integ/postgres.py
@@ -59,6 +59,8 @@ CASES: list[tuple[str, str]] = [
     ("grep_ada", f"grep ada {MOUNT}/public/tables/books/rows.jsonl"),
     ("grep_e_multi",
      f"grep -n -e ada -e ben {MOUNT}/public/tables/books/rows.jsonl"),
+    ("rg_e_multi",
+     f"rg -n -e ada -e ben {MOUNT}/public/tables/books/rows.jsonl"),
     ("grep_schema_scope", f"grep ada {MOUNT}/public/tables/"),
     ("rg_schema_scope", f"rg ben {MOUNT}/public/"),
     ("find_rows", f"find {MOUNT}/public/ -name rows.jsonl"),

--- a/integ/postgres.ts
+++ b/integ/postgres.ts
@@ -59,6 +59,7 @@ const CASES: ReadonlyArray<readonly [string, string]> = [
   ["grep_c_title", `grep -c title ${MOUNT}/public/tables/books/rows.jsonl`],
   ["grep_ada", `grep ada ${MOUNT}/public/tables/books/rows.jsonl`],
   ["grep_e_multi", `grep -n -e ada -e ben ${MOUNT}/public/tables/books/rows.jsonl`],
+  ["rg_e_multi", `rg -n -e ada -e ben ${MOUNT}/public/tables/books/rows.jsonl`],
   ["grep_schema_scope", `grep ada ${MOUNT}/public/tables/`],
   ["rg_schema_scope", `rg ben ${MOUNT}/public/`],
   ["find_rows", `find ${MOUNT}/public/ -name rows.jsonl`],

--- a/integ/truth_postgres.txt
+++ b/integ/truth_postgres.txt
@@ -73,6 +73,11 @@ output truncated at safeguard limit (2 lines)
 2:{"id":2,"title":"beta","author":"ben","year":2021
 4:{"id":4,"title":"delta","author":"ada","year":2023
 5:{"id":5,"title":"epsilon","author":"ben","year":2024
+=== rg_e_multi ===
+1:{"id":1,"title":"alpha","author":"ada","year":2020
+2:{"id":2,"title":"beta","author":"ben","year":2021
+4:{"id":4,"title":"delta","author":"ada","year":2023
+5:{"id":5,"title":"epsilon","author":"ben","year":2024
 === nf_cat ===
 exit=1
 cat: /pg/__nf_missing__.txt: No such file or directory

--- a/python/mirage/commands/builtin/email/rg.py
+++ b/python/mirage/commands/builtin/email/rg.py
@@ -27,6 +27,7 @@ from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.commands.spec.types import FlagView
 from mirage.core.email._client import fetch_message
+from mirage.core.email.glob import resolve_glob
 from mirage.core.email.read import read as email_read
 from mirage.core.email.readdir import readdir as _readdir
 from mirage.core.email.scope import extract_folder
@@ -62,7 +63,9 @@ async def rg(
     max_count = fl.int("m")
     pat = compile_pattern(pattern_str, i, F, w)
 
-    if paths:
+    # IMAP text search takes one pattern; a newline-joined multi -e set
+    # must fall through to the generic so each pattern matches (#347).
+    if paths and "\n" not in pattern_str:
         folder = extract_folder(paths)
         if not folder:
             return b"", IOResult(exit_code=1)
@@ -112,8 +115,9 @@ async def rg(
             return b"", IOResult(exit_code=1)
         return format_records(all_results), IOResult()
 
+    resolved = await resolve_glob(accessor, paths, index) if paths else []
     return await generic_rg(
-        [],
+        resolved,
         texts,
         flags,
         readdir=_readdir,

--- a/python/mirage/commands/builtin/postgres/rg.py
+++ b/python/mirage/commands/builtin/postgres/rg.py
@@ -53,7 +53,9 @@ async def rg(
     config = accessor.config
     limit = config.default_search_limit
 
-    if paths:
+    # Native search takes one pattern; a newline-joined multi -e set
+    # must fall through to the generic so each pattern matches (#347).
+    if paths and "\n" not in pattern_str:
         scope = detect_scope(paths[0])
 
         if scope.level == "root":
@@ -88,10 +90,10 @@ async def rg(
             all_lines = format_grep_results(results)
             return format_records(all_lines), IOResult()
 
-        paths = await resolve_glob(accessor, paths, index=index)
-
+    resolved = await resolve_glob(accessor, paths,
+                                  index=index) if paths else []
     return await generic_rg(
-        paths,
+        resolved,
         texts,
         flags,
         readdir=_readdir,

--- a/python/mirage/workspace/mount/registry.py
+++ b/python/mirage/workspace/mount/registry.py
@@ -25,12 +25,18 @@ DEV_PREFIX = "/dev/"
 
 
 class MountCommandUnsupported(Exception):
-    """Raised when a path-bound command is unsupported by its backend."""
+    """Raised when a path-bound command is unsupported by its backend.
 
-    def __init__(self, cmd_name: str, backend: str) -> None:
+    Rendered in the GNU shape ``<cmd>: <operand>: <reason>`` with the
+    EOPNOTSUPP strerror, naming the offending path like coreutils does;
+    the backend name stays on the exception for programmatic use (#394).
+    """
+
+    def __init__(self, cmd_name: str, backend: str, operand: str) -> None:
         self.cmd_name = cmd_name
         self.backend = backend
-        super().__init__(f"{cmd_name}: not supported on the {backend} backend")
+        self.operand = operand
+        super().__init__(f"{cmd_name}: {operand}: Operation not supported")
 
 
 class MountRegistry:
@@ -264,7 +270,8 @@ class MountRegistry:
 
         if mount is not None and mount.resolve_command(cmd_name) is None:
             if path_scopes:
-                raise MountCommandUnsupported(cmd_name, mount.resource.name)
+                raise MountCommandUnsupported(cmd_name, mount.resource.name,
+                                              path_scopes[0].raw_path)
             mount = self.mount_for_command(cmd_name)
         elif mount is None:
             mount = self.mount_for_command(cmd_name)

--- a/python/tests/commands/builtin/email/test_rg.py
+++ b/python/tests/commands/builtin/email/test_rg.py
@@ -1,0 +1,90 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mirage.io.types import IOResult
+from mirage.types import PathSpec
+from mirage.utils.key_prefix import mount_key
+
+sys.modules.setdefault(
+    "aioimaplib",
+    SimpleNamespace(IMAP4=object, IMAP4_SSL=object),
+)
+sys.modules.setdefault(
+    "aiosmtplib",
+    SimpleNamespace(SMTP=object, send=AsyncMock()),
+)
+
+rg = importlib.import_module("mirage.commands.builtin.email.rg").rg
+
+
+def _path(s: str = "/email/INBOX") -> PathSpec:
+    return PathSpec(resource_path=mount_key(s, "/email"),
+                    virtual=s,
+                    directory=s)
+
+
+@pytest.mark.asyncio
+async def test_rg_multi_pattern_skips_imap_search():
+    # A newline-joined multi -e set must bypass the IMAP text search and
+    # still resolve globs before the generic runs (#347).
+    accessor = SimpleNamespace(config=SimpleNamespace(max_messages=10))
+    seen: dict[str, object] = {}
+
+    async def fake_resolve(_accessor, paths, index=None):
+        seen["resolved"] = [p.virtual for p in paths]
+        return paths
+
+    async def fake_generic(paths, _texts, _flags, **_kwargs):
+        seen["generic"] = [p.virtual for p in paths]
+        return b"", IOResult()
+
+    with patch(
+            "mirage.commands.builtin.email.rg.search_messages",
+            new=AsyncMock(side_effect=AssertionError("imap search ran")),
+    ), patch(
+            "mirage.commands.builtin.email.rg.resolve_glob",
+            new=fake_resolve,
+    ), patch(
+            "mirage.commands.builtin.email.rg.generic_rg",
+            new=fake_generic,
+    ):
+        _, io = await rg(accessor, [_path()], e=["ada", "ben"])
+
+    assert io.exit_code == 0
+    assert seen["resolved"] == ["/email/INBOX"]
+    assert seen["generic"] == ["/email/INBOX"]
+
+
+@pytest.mark.asyncio
+async def test_rg_single_pattern_uses_imap_search():
+    accessor = SimpleNamespace(config=SimpleNamespace(max_messages=10))
+    search = AsyncMock(return_value=[])
+    with patch(
+            "mirage.commands.builtin.email.rg.search_messages",
+            new=search,
+    ), patch(
+            "mirage.commands.builtin.email.rg.resolve_glob",
+            new=AsyncMock(side_effect=AssertionError("glob ran")),
+    ):
+        _, io = await rg(accessor, [_path()], "ada")
+
+    assert io.exit_code == 1
+    search.assert_awaited_once()

--- a/python/tests/commands/builtin/postgres/test_rg.py
+++ b/python/tests/commands/builtin/postgres/test_rg.py
@@ -1,0 +1,80 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mirage.accessor.postgres import PostgresAccessor
+from mirage.commands.builtin.postgres.rg import rg
+from mirage.io.types import IOResult
+from mirage.resource.postgres.config import PostgresConfig
+from mirage.types import PathSpec
+
+
+@pytest.fixture
+def accessor():
+    return PostgresAccessor(config=PostgresConfig(
+        dsn="postgres://u:p@localhost:5432/db"))
+
+
+def _path(s: str = "/public/tables/books/rows.jsonl") -> PathSpec:
+    return PathSpec(virtual=s, directory=s, resource_path=s.strip("/"))
+
+
+@pytest.mark.asyncio
+async def test_rg_multi_pattern_skips_native_search(accessor):
+    # A newline-joined multi -e set must bypass the native pushdown and
+    # still resolve globs before the generic runs (#347).
+    seen: dict[str, object] = {}
+
+    async def fake_resolve(_accessor, paths, index=None):
+        seen["resolved"] = [p.virtual for p in paths]
+        return paths
+
+    async def fake_generic(paths, _texts, _flags, **_kwargs):
+        seen["generic"] = [p.virtual for p in paths]
+        return b"", IOResult()
+
+    with patch(
+            "mirage.commands.builtin.postgres.rg.search_entity",
+            new=AsyncMock(side_effect=AssertionError("native search ran")),
+    ), patch(
+            "mirage.commands.builtin.postgres.rg.resolve_glob",
+            new=fake_resolve,
+    ), patch(
+            "mirage.commands.builtin.postgres.rg.generic_rg",
+            new=fake_generic,
+    ):
+        _, io = await rg(accessor, [_path()], e=["ada", "ben"])
+
+    assert io.exit_code == 0
+    assert seen["resolved"] == ["/public/tables/books/rows.jsonl"]
+    assert seen["generic"] == ["/public/tables/books/rows.jsonl"]
+
+
+@pytest.mark.asyncio
+async def test_rg_single_pattern_uses_native_search(accessor):
+    search = AsyncMock(return_value=[])
+    with patch(
+            "mirage.commands.builtin.postgres.rg.search_entity",
+            new=search,
+    ), patch(
+            "mirage.commands.builtin.postgres.rg.resolve_glob",
+            new=AsyncMock(side_effect=AssertionError("glob ran")),
+    ):
+        _, io = await rg(accessor, [_path()], "ada")
+
+    assert io.exit_code == 1
+    search.assert_awaited_once()

--- a/python/tests/workspace/mount/test_registry.py
+++ b/python/tests/workspace/mount/test_registry.py
@@ -377,7 +377,7 @@ async def test_resolve_mount_rejects_path_bound_unsupported_command():
                      resolved=True)
     with pytest.raises(
             MountCommandUnsupported,
-            match="fallback-only: not supported on the limited backend"):
+            match="fallback-only: /limited/file.txt: Operation not supported"):
         await reg.resolve_mount("fallback-only", [scope], "/limited")
 
 

--- a/typescript/packages/core/src/workspace/mount/registry.test.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.test.ts
@@ -341,7 +341,7 @@ describe('MountRegistry.resolveMount: path-bound dispatch', () => {
       MountCommandUnsupported,
     )
     await expect(reg.resolveMount('fallback-only', [path], '/limited')).rejects.toThrow(
-      'fallback-only: not supported on the limited backend',
+      'fallback-only: /limited/file.txt: Operation not supported',
     )
   })
 

--- a/typescript/packages/core/src/workspace/mount/registry.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.ts
@@ -24,15 +24,21 @@ import { rstripSlash, stripSlash } from '../../utils/slash.ts'
 
 export const DEV_PREFIX = '/dev/'
 
+// Raised when a path-bound command is unsupported by its backend.
+// Rendered in the GNU shape `<cmd>: <operand>: <reason>` with the
+// EOPNOTSUPP strerror, naming the offending path like coreutils does;
+// the backend name stays on the error for programmatic use (#394).
 export class MountCommandUnsupported extends Error {
   readonly cmdName: string
   readonly backend: string
+  readonly operand: string
 
-  constructor(cmdName: string, backend: string) {
-    super(`${cmdName}: not supported on the ${backend} backend`)
+  constructor(cmdName: string, backend: string, operand: string) {
+    super(`${cmdName}: ${operand}: Operation not supported`)
     this.name = 'MountCommandUnsupported'
     this.cmdName = cmdName
     this.backend = backend
+    this.operand = operand
   }
 }
 
@@ -332,7 +338,7 @@ export class MountRegistry {
     const mountPath = pathScopes.length > 0 ? (pathScopes[0]?.virtual ?? cwd) : cwd
     let mount = this.mountFor(mountPath)
     if (mount !== null && mount.resolveCommand(cmdName) == null && pathScopes.length > 0) {
-      throw new MountCommandUnsupported(cmdName, mount.resource.kind)
+      throw new MountCommandUnsupported(cmdName, mount.resource.kind, pathScopes[0]?.rawPath ?? cwd)
     }
     if (mount?.resolveCommand(cmdName) == null) {
       mount = this.mountForCommand(cmdName)


### PR DESCRIPTION
Two small GNU-correctness fixes.

## rg multi-pattern pushdown (closes #347)

`rg -e a -e b <path>` joined the patterns with a newline and handed the literal to the native search, returning empty results. mongodb/discord/slack/gmail/langfuse were already guarded; this adds the same guard to the two remaining backends:

- **postgres**: all four scope levels (root/schema/kind/entity) pushed the joined pattern to `search_*`. The pushdown now requires a single pattern, and glob resolution is hoisted out of the pushdown block (mongodb shape) so `rg -e a -e b *.jsonl` still resolves.
- **email**: `search_messages(text=...)` got the joined pattern. Same guard, and the fallback now resolves globs before the generic instead of passing `[]`.

Unit tests assert the two properties the issue called out: native search is skipped AND resolve_glob still runs for multi-pattern; single-pattern still uses the pushdown. Shared postgres integ gains `rg_e_multi` (verified against live postgres:16 in both languages; TS postgres has no pushdown and its generic already handles multi `-e`).

## GNU shape for MountCommandUnsupported (closes #394)

`sed /gmail/foo.eml` on a backend without sed printed `sed: not supported on the gmail backend`: no operand, non-errno reason. It now prints the coreutils shape with the as-typed operand:

```
sed: /gmail/foo.eml: Operation not supported
```

(EOPNOTSUPP strerror, exit 1 unchanged.) The backend name stays on the exception for programmatic use. Applied in both languages; registry tests updated.

## Verification

- py: `tests/commands/builtin/{postgres,email}/test_rg.py`, `tests/workspace` green
- ts: registry tests, workspace suite (1265) green, typecheck clean
- postgres integ (py + ts) green against live postgres:16 including the new `rg_e_multi` case
- pre-commit clean