### PR TITLE
chore(kb): dify/chroma wrapper and stat fixes

### DIFF
--- a/python/mirage/commands/builtin/chroma/find.py
+++ b/python/mirage/commands/builtin/chroma/find.py
@@ -69,7 +69,7 @@ async def find(
     iname: str | None = None,
     path: str | None = None,
     mindepth: str | None = None,
-    index: IndexCacheStore = None,
+    index: IndexCacheStore | None = None,
     cwd: PathSpec | None = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:

--- a/python/mirage/commands/builtin/chroma/search.py
+++ b/python/mirage/commands/builtin/chroma/search.py
@@ -1,3 +1,4 @@
+from mirage.cache.index import IndexCacheStore
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.chroma import search as search_core
@@ -17,10 +18,7 @@ def default_paths(paths: list[PathSpec],
 
 
 def is_mount_root(path: PathSpec) -> bool:
-    root = mount_prefix_of(path.virtual,
-                           path.resource_path).rstrip("/") if mount_prefix_of(
-                               path.virtual, path.resource_path) else "/"
-    root = root or "/"
+    root = mount_prefix_of(path.virtual, path.resource_path).rstrip("/") or "/"
     value = path.virtual.rstrip("/") or "/"
     return value == "/" or value == root
 
@@ -31,15 +29,14 @@ async def search(
     paths: list[PathSpec],
     *texts: str,
     top_k: str | int = 10,
+    index: IndexCacheStore | None = None,
+    cwd: PathSpec | None = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     if not texts:
         raise ValueError("search: query is required")
     query = texts[0]
-    index = _extra.get("index")
-    cwd = _extra.get("cwd")
-    target_paths = default_paths(paths,
-                                 cwd if isinstance(cwd, PathSpec) else None)
+    target_paths = default_paths(paths, cwd)
     mount_prefix = mount_prefix_of(
         target_paths[0].virtual,
         target_paths[0].resource_path) if target_paths else ""

--- a/python/mirage/commands/builtin/dify/cat.py
+++ b/python/mirage/commands/builtin/dify/cat.py
@@ -1,3 +1,4 @@
+from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.cat import cat as generic_cat
 from mirage.commands.builtin.generic_bind import CommandIO
 from mirage.commands.builtin.generic_bind.provision import \
@@ -29,9 +30,9 @@ def make_cat(ops: CommandIO):
         paths: list[PathSpec],
         *texts: str,
         n: bool = False,
+        index: IndexCacheStore | None = None,
         **_extra: object,
     ) -> tuple[ByteSource | None, IOResult]:
-        index = _extra.get("index")
         paths = await resolve_glob(accessor, paths, index)
         # dify is a remote (cacheable) backend. Single file: stream via a
         # cachable returned AS stdout so the tee fills the cache as the

--- a/python/mirage/commands/builtin/dify/find.py
+++ b/python/mirage/commands/builtin/dify/find.py
@@ -69,7 +69,7 @@ async def find(
     iname: str | None = None,
     path: str | None = None,
     mindepth: str | None = None,
-    index: IndexCacheStore = None,
+    index: IndexCacheStore | None = None,
     cwd: PathSpec | None = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:

--- a/python/mirage/commands/builtin/dify/search.py
+++ b/python/mirage/commands/builtin/dify/search.py
@@ -1,3 +1,4 @@
+from mirage.cache.index import IndexCacheStore
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.dify import search as search_core
@@ -17,10 +18,7 @@ def default_paths(paths: list[PathSpec],
 
 
 def is_mount_root(path: PathSpec) -> bool:
-    root = mount_prefix_of(path.virtual,
-                           path.resource_path).rstrip("/") if mount_prefix_of(
-                               path.virtual, path.resource_path) else "/"
-    root = root or "/"
+    root = mount_prefix_of(path.virtual, path.resource_path).rstrip("/") or "/"
     value = path.virtual.rstrip("/") or "/"
     return value == "/" or value == root
 
@@ -33,15 +31,14 @@ async def search(
     method: str = "semantic",
     top_k: str | int = 10,
     threshold: str | float = 0.0,
+    index: IndexCacheStore | None = None,
+    cwd: PathSpec | None = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     if not texts:
         raise ValueError("search: query is required")
     query = texts[0]
-    index = _extra.get("index")
-    cwd = _extra.get("cwd")
-    target_paths = default_paths(paths,
-                                 cwd if isinstance(cwd, PathSpec) else None)
+    target_paths = default_paths(paths, cwd)
     mount_prefix = mount_prefix_of(
         target_paths[0].virtual,
         target_paths[0].resource_path) if target_paths else ""

--- a/python/mirage/core/dify/read.py
+++ b/python/mirage/core/dify/read.py
@@ -1,5 +1,6 @@
 import errno
 from collections.abc import AsyncIterator
+from typing import Any
 
 from mirage.cache.index import IndexCacheStore
 from mirage.core.dify._client import get_document_segments, iter_segment_pages
@@ -31,11 +32,11 @@ async def read_stream(accessor, path: PathSpec,
             yield segment_text(segment).encode()
 
 
-def segments_to_bytes(segments: list[dict]) -> bytes:
+def segments_to_bytes(segments: list[dict[str, Any]]) -> bytes:
     return "\n".join(segment_text(segment) for segment in segments).encode()
 
 
-def segment_text(segment: dict) -> str:
+def segment_text(segment: dict[str, Any]) -> str:
     value = segment.get("content")
     if value is None:
         return ""

--- a/python/mirage/core/dify/search.py
+++ b/python/mirage/core/dify/search.py
@@ -4,6 +4,7 @@ from typing import Any
 from mirage.cache.index import IndexCacheStore, IndexEntry
 from mirage.core.dify._client import dify_post
 from mirage.core.dify.path import resolve_path
+from mirage.core.dify.read import segment_text
 from mirage.core.dify.tree import normalize_slug
 from mirage.core.dify.walk import walk
 from mirage.types import PathSpec
@@ -156,7 +157,7 @@ def records_to_bytes(
         header = format_record_header(record, slug_metadata_name, mount_prefix)
         if header is None:
             continue
-        content = segment_content(segment)
+        content = segment_text(segment)
         contents.append(f"{header}\n{content}")
     if not contents:
         return b""
@@ -221,12 +222,3 @@ def document_path(
     if name is None:
         return None
     return str(name)
-
-
-def segment_content(segment: dict[str, Any]) -> str:
-    content = segment.get("content")
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-    return str(content)

--- a/python/mirage/core/dify/stat.py
+++ b/python/mirage/core/dify/stat.py
@@ -38,6 +38,8 @@ async def stat(accessor, path: PathSpec, index: IndexCacheStore) -> FileStat:
             type=FileType.DIRECTORY,
             extra={"children_count": 0},
         )
+    if resolved.entry is None:
+        raise enoent(path)
     detail = await get_document_detail(accessor.config, resolved.entry.id)
     size = extract_document_size(detail)
     if size is None:

--- a/python/mirage/core/dify/tree.py
+++ b/python/mirage/core/dify/tree.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from mirage.cache.index import IndexCacheStore, IndexEntry
-from mirage.core.dify._client import is_visible_document, list_all_documents
+from mirage.core.dify._client import list_all_documents
 from mirage.utils.path import gnu_basename, parent
 
 
@@ -14,9 +14,10 @@ async def ensure_tree(accessor,
     if listing.entries is not None:
         return
 
+    # list_all_documents already filters to visible documents.
     documents = await list_all_documents(accessor.config)
     dir_entries = build_dir_entries(
-        [document for document in documents if is_visible_document(document)],
+        documents,
         prefix,
         accessor.config.slug_metadata_name,
     )

--- a/python/tests/core/dify/test_tree.py
+++ b/python/tests/core/dify/test_tree.py
@@ -1,6 +1,7 @@
 import pytest
 
 from mirage.core.dify import tree
+from mirage.core.dify._client import is_visible_document
 
 from .conftest import document
 
@@ -8,7 +9,9 @@ tree_calls = {"documents": 0}
 
 
 async def list_documents_with_hidden_and_fallbacks(config):
-    return [
+    # Mirrors the list_all_documents contract: hidden documents (archived,
+    # disabled, still indexing) never leave the client.
+    documents = [
         document("doc-1", "Quickstart", slug="guides/quickstart", size=333),
         document("doc-2", "API", slug="api", size=444, archived=True),
         document("doc-3", "Draft", slug="draft", indexing_status="indexing"),
@@ -16,6 +19,7 @@ async def list_documents_with_hidden_and_fallbacks(config):
         document("doc-5", "Archived", slug="archived", archived=True),
         document("doc-6", "README.md", size=None),
     ]
+    return [doc for doc in documents if is_visible_document(doc)]
 
 
 async def counted_documents(config):


### PR DESCRIPTION
## What

Small independent fixes in the dify and chroma backends (no shared abstractions between them, per the decision to keep these two backends separate):

- **Wrapper rule:** `dify cat`/`dify search`/`chroma search` declare the dispatcher-injected `index`/`cwd` explicitly in their signatures instead of fishing them out of `**_extra` with `.get()`; both `find` wrappers annotate `index: IndexCacheStore | None`.
- **Missing guard:** dify `stat()` raises ENOENT when the resolved entry is `None`, matching `stat_light` (chroma already had the guard).
- **Dead filter:** `ensure_tree` drops the redundant `is_visible_document` re-filter — `list_all_documents` already filters. The tree test fake now honors that client contract; client-level filtering stays covered by `test_list_all_documents_paginates_and_filters`.
- **Dedupe within dify:** search reuses `read.segment_text`; the duplicate `segment_content` is deleted. `is_mount_root` computes the mount prefix once.

## Verification

- dify+chroma unit suites 107/107, full pytest green (known live jina curl flake only)
- integ: `integ/dify.py` (mock server) and `integ/chroma.py` (live ChromaDB OSS) both byte-match their truth files
- pre-commit all green