### PR TITLE
Update docs to match current APIs

### DIFF
--- a/docs/home/introduction.mdx
+++ b/docs/home/introduction.mdx
@@ -29,13 +29,13 @@ mode: "frame"
     ```python
     import os
 
-    from mirage import Workspace
+    from mirage import MountMode, Workspace
     from mirage.resource.ram import RAMResource
     from mirage.resource.s3 import S3Config, S3Resource
     from mirage.resource.slack import SlackConfig, SlackResource
 
     ws = Workspace({
-        "/data": RAMResource(),
+        "/data": (RAMResource(), MountMode.WRITE),
         "/s3": S3Resource(S3Config(bucket="my-bucket")),
         "/slack": SlackResource(SlackConfig(token=os.environ["SLACK_BOT_TOKEN"])),
     })
@@ -53,14 +53,21 @@ mode: "frame"
       RAMResource,
       S3Resource,
       SlackResource,
+      MountMode,
       Workspace,
     } from '@struktoai/mirage-node'
 
-    const ws = new Workspace({
-      '/data': new RAMResource(),
-      '/s3': new S3Resource({ bucket: 'my-bucket' }),
-      '/slack': new SlackResource({ token: process.env.SLACK_BOT_TOKEN! }),
-    })
+    const ws = new Workspace(
+      {
+        '/data': new RAMResource(),
+        '/s3': new S3Resource({ bucket: 'my-bucket' }),
+        '/slack': new SlackResource({ token: process.env.SLACK_BOT_TOKEN! }),
+      },
+      {
+        mode: MountMode.READ,
+        modeOverrides: { '/data': MountMode.WRITE },
+      },
+    )
 
     // Same shell vocabulary, three different backends.
     await ws.execute('echo "hello mirage" > /data/hello.txt')
@@ -168,13 +175,17 @@ grep -r "mirage" /slack /gmail /github
 
     from mirage import MountMode, Workspace
     from mirage.agents.openai_agents import MirageSandboxClient
-    from mirage.resource.github import GitHubResource
-    from mirage.resource.linear import LinearResource
-    from mirage.resource.slack import SlackResource
+    from mirage.resource.github import GitHubConfig, GitHubResource
+    from mirage.resource.linear import LinearConfig, LinearResource
+    from mirage.resource.slack import SlackConfig, SlackResource
 
-    slack = SlackResource(...)
-    github = GitHubResource(repo="strukto-ai/mirage")
-    linear = LinearResource(...)
+    slack = SlackResource(SlackConfig(token="xoxb-..."))
+    github = GitHubResource(
+        GitHubConfig(token="github_pat_..."),
+        owner="strukto-ai",
+        repo="mirage",
+    )
+    linear = LinearResource(LinearConfig(api_key="lin_api_..."))
 
     ws = Workspace({
         "/slack": (slack, MountMode.READ),

--- a/docs/home/introduction.mdx
+++ b/docs/home/introduction.mdx
@@ -29,13 +29,13 @@ mode: "frame"
     ```python
     import os
 
-    from mirage import MountMode, Workspace
+    from mirage import Mount, MountMode, Workspace
     from mirage.resource.ram import RAMResource
     from mirage.resource.s3 import S3Config, S3Resource
     from mirage.resource.slack import SlackConfig, SlackResource
 
     ws = Workspace({
-        "/data": (RAMResource(), MountMode.WRITE),
+        "/data": Mount(RAMResource(), mode=MountMode.WRITE),
         "/s3": S3Resource(S3Config(bucket="my-bucket")),
         "/slack": SlackResource(SlackConfig(token=os.environ["SLACK_BOT_TOKEN"])),
     })
@@ -50,24 +50,19 @@ mode: "frame"
   <Tab title="TypeScript" icon="/images/typescript-logo.svg">
     ```typescript
     import {
+      Mount,
+      MountMode,
       RAMResource,
       S3Resource,
       SlackResource,
-      MountMode,
       Workspace,
     } from '@struktoai/mirage-node'
 
-    const ws = new Workspace(
-      {
-        '/data': new RAMResource(),
-        '/s3': new S3Resource({ bucket: 'my-bucket' }),
-        '/slack': new SlackResource({ token: process.env.SLACK_BOT_TOKEN! }),
-      },
-      {
-        mode: MountMode.READ,
-        modeOverrides: { '/data': MountMode.WRITE },
-      },
-    )
+    const ws = new Workspace({
+      '/data': new Mount(new RAMResource(), { mode: MountMode.WRITE }),
+      '/s3': new S3Resource({ bucket: 'my-bucket' }),
+      '/slack': new SlackResource({ token: process.env.SLACK_BOT_TOKEN! }),
+    })
 
     // Same shell vocabulary, three different backends.
     await ws.execute('echo "hello mirage" > /data/hello.txt')
@@ -173,7 +168,7 @@ grep -r "mirage" /slack /gmail /github
     from agents.run import RunConfig
     from agents.sandbox import SandboxAgent, SandboxRunConfig
 
-    from mirage import MountMode, Workspace
+    from mirage import Mount, MountMode, Workspace
     from mirage.agents.openai_agents import MirageSandboxClient
     from mirage.resource.github import GitHubConfig, GitHubResource
     from mirage.resource.linear import LinearConfig, LinearResource
@@ -188,9 +183,9 @@ grep -r "mirage" /slack /gmail /github
     linear = LinearResource(LinearConfig(api_key="lin_api_..."))
 
     ws = Workspace({
-        "/slack": (slack, MountMode.READ),
-        "/github": (github, MountMode.READ),
-        "/linear": (linear, MountMode.WRITE),
+        "/slack": slack,
+        "/github": github,
+        "/linear": Mount(linear, mode=MountMode.WRITE),
     })
 
     agent = SandboxAgent(
@@ -222,6 +217,7 @@ grep -r "mirage" /slack /gmail /github
     import {
       GitHubResource,
       LinearResource,
+      Mount,
       MountMode,
       SlackResource,
       Workspace,
@@ -237,13 +233,11 @@ grep -r "mirage" /slack /gmail /github
     })
     const linear = new LinearResource({ apiKey: process.env.LINEAR_API_KEY! })
 
-    const ws = new Workspace(
-      { '/slack': slack, '/github': github, '/linear': linear },
-      {
-        mode: MountMode.READ,
-        modeOverrides: { '/linear': MountMode.WRITE },
-      },
-    )
+    const ws = new Workspace({
+      '/slack': slack,
+      '/github': github,
+      '/linear': new Mount(linear, { mode: MountMode.WRITE }),
+    })
 
     const agent = new Agent({
       name: 'Design feedback triage',

--- a/docs/home/resource-matrix.mdx
+++ b/docs/home/resource-matrix.mdx
@@ -1,6 +1,6 @@
 ---
 title: Resource Matrix
-description: Compare Mirage resources by mount mode and setup path, organized by category.
+description: Compare Mirage resources by access, runtime, and setup path.
 icon: grid-2
 ---
 
@@ -8,7 +8,7 @@ icon: grid-2
 
 Use this page to pick the first resource to try. If you want the fastest path, start with RAM or disk. If you need real integrations, jump from the setup guide to the resource docs.
 
-The **Mount Mode** column shows which `MountMode` values the resource supports (`read`, `write`, and `exec`, the last makes a mount executable so commands can launch binaries from it; typically used with Disk or RAM). The **Docs** column shows where each resource is available, with one icon per supported runtime: <Icon icon="python" /> Python, <Icon icon="node-js" /> TypeScript (Node), and <Icon icon="globe" /> TypeScript (Browser). Click an icon to jump to that runtime's docs.
+The **Access** column separates filesystem access from API actions. `read`, `write`, and `exec` are `MountMode` values; `exec` allows commands to launch binaries from the mount and is typically used with Disk or RAM. `actions` means the resource also exposes mutating commands such as sending a message or creating an issue; run those commands on a `WRITE` mount. The **Docs** column shows where each resource is available, with one icon per supported runtime: <Icon icon="python" /> Python, <Icon icon="node-js" /> TypeScript (Node), and <Icon icon="globe" /> TypeScript (Browser). Click an icon to jump to that runtime's docs.
 
 Sections below mirror the **Setup** sidebar so you can pick a category and follow the same path through credentials → resource docs.
 
@@ -16,7 +16,7 @@ Sections below mirror the **Setup** sidebar so you can pick a category and follo
 
 No external setup, these run locally or against a connection string you already have.
 
-| Resource | Mount Mode | Docs | Notes |
+| Resource | Access | Docs | Notes |
 | --- | --- | --- | --- |
 | RAM | read, write, exec | [<Icon icon="python" />](/python/resource/ram) [<Icon icon="node-js" />](/typescript/quickstart) [<Icon icon="globe" />](/typescript/quickstart) | Best first-run option |
 | Disk | read, write, exec | [<Icon icon="python" />](/python/resource/disk) [<Icon icon="node-js" />](/typescript/setup/disk) | Local filesystem bridge |
@@ -26,7 +26,7 @@ No external setup, these run locally or against a connection string you already 
 
 ## Object Storage
 
-| Resource | Mount Mode | Setup | Docs | Notes |
+| Resource | Access | Setup | Docs | Notes |
 | --- | --- | --- | --- | --- |
 | S3 | read, write | [S3](/home/setup/s3) | [<Icon icon="python" />](/python/resource/s3) [<Icon icon="node-js" />](/typescript/setup/s3) [<Icon icon="globe" />](/typescript/setup/s3) | Common cloud object store |
 | R2 | read, write | [R2](/home/setup/r2) | [<Icon icon="python" />](/python/resource/r2) [<Icon icon="node-js" />](/typescript/setup/r2) [<Icon icon="globe" />](/typescript/setup/r2) | S3-style API |
@@ -50,17 +50,24 @@ No external setup, these run locally or against a connection string you already 
 
 ## Google Workspace
 
-| Resource | Mount Mode | Setup | Docs | Notes |
+| Resource | Access | Setup | Docs | Notes |
 | --- | --- | --- | --- | --- |
-| Gmail | read, partial write | [Google](/home/setup/google) | [<Icon icon="python" />](/python/resource/gmail) [<Icon icon="node-js" />](/typescript/setup/gmail) [<Icon icon="globe" />](/typescript/setup/gmail) | Mailbox access |
-| Drive | read, partial write | [Google](/home/setup/google) | [<Icon icon="python" />](/python/resource/gdrive) [<Icon icon="node-js" />](/typescript/setup/gdrive) [<Icon icon="globe" />](/typescript/setup/gdrive) | File tree and metadata |
-| Docs | read, partial write | [Google](/home/setup/google) | [<Icon icon="python" />](/python/resource/gdocs) [<Icon icon="node-js" />](/typescript/setup/gdocs) [<Icon icon="globe" />](/typescript/setup/gdocs) | Document content |
-| Sheets | read, partial write | [Google](/home/setup/google) | [<Icon icon="python" />](/python/resource/gsheets) [<Icon icon="node-js" />](/typescript/setup/gsheets) [<Icon icon="globe" />](/typescript/setup/gsheets) | Spreadsheet data |
-| Slides | read, partial write | [Google](/home/setup/google) | [<Icon icon="python" />](/python/resource/gslides) [<Icon icon="node-js" />](/typescript/setup/gslides) [<Icon icon="globe" />](/typescript/setup/gslides) | Presentation content |
+| Gmail | read, actions | [Google](/home/setup/google) | [<Icon icon="python" />](/python/resource/gmail) [<Icon icon="node-js" />](/typescript/setup/gmail) [<Icon icon="globe" />](/typescript/setup/gmail) | Read, send, reply, forward, and triage mail |
+| Drive | read, actions | [Google](/home/setup/google) | [<Icon icon="python" />](/python/resource/gdrive) [<Icon icon="node-js" />](/typescript/setup/gdrive) [<Icon icon="globe" />](/typescript/setup/gdrive) | File tree plus Google-native create/update commands |
+| Docs | read, actions | [Google](/home/setup/google) | [<Icon icon="python" />](/python/resource/gdocs) [<Icon icon="node-js" />](/typescript/setup/gdocs) [<Icon icon="globe" />](/typescript/setup/gdocs) | Read plus document create/update commands |
+| Sheets | read, actions | [Google](/home/setup/google) | [<Icon icon="python" />](/python/resource/gsheets) [<Icon icon="node-js" />](/typescript/setup/gsheets) [<Icon icon="globe" />](/typescript/setup/gsheets) | Read plus spreadsheet create/update commands |
+| Slides | read, actions | [Google](/home/setup/google) | [<Icon icon="python" />](/python/resource/gslides) [<Icon icon="node-js" />](/typescript/setup/gslides) [<Icon icon="globe" />](/typescript/setup/gslides) | Read plus presentation create/update commands |
+
+## Microsoft
+
+| Resource | Access | Setup | Docs | Notes |
+| --- | --- | --- | --- | --- |
+| OneDrive | read, write | [OneDrive](/home/setup/onedrive) | [<Icon icon="python" />](/python/resource/onedrive) | Files and folders through Microsoft Graph |
+| SharePoint | read, write | [SharePoint](/home/setup/sharepoint) | [<Icon icon="python" />](/python/resource/sharepoint) | Document libraries through Microsoft Graph |
 
 ## Cloud Files
 
-| Resource | Mount Mode | Setup | Docs | Notes |
+| Resource | Access | Setup | Docs | Notes |
 | --- | --- | --- | --- | --- |
 | Databricks Volume | read, write | [Databricks Volume](/home/setup/databricks) | [<Icon icon="python" />](/python/resource/databricks_volume) [<Icon icon="node-js" />](/typescript/setup/databricks_volume) | Unity Catalog volume subtree; mv/cp are non-atomic copies |
 | Dropbox | read | [Dropbox](/home/setup/dropbox) | [<Icon icon="node-js" />](/typescript/dropbox) [<Icon icon="globe" />](/typescript/dropbox) | OAuth2 + PKCE; Node and browser |
@@ -69,24 +76,24 @@ No external setup, these run locally or against a connection string you already 
 
 ## Code & DevOps
 
-| Resource | Mount Mode | Setup | Docs | Notes |
+| Resource | Access | Setup | Docs | Notes |
 | --- | --- | --- | --- | --- |
 | GitHub | read | [GitHub](/home/setup/github) | [<Icon icon="python" />](/python/resource/github) [<Icon icon="node-js" />](/typescript/setup/github) [<Icon icon="globe" />](/typescript/setup/github) | Repository browsing |
 | GitHub CI | read | [GitHub CI](/home/setup/github_ci) | [<Icon icon="python" />](/python/resource/github_ci) [<Icon icon="node-js" />](/typescript/setup/github_ci) [<Icon icon="globe" />](/typescript/setup/github_ci) | Runs, logs, artifacts |
-| Linear | read | [Linear](/home/setup/linear) | [<Icon icon="python" />](/python/resource/linear) [<Icon icon="node-js" />](/typescript/setup/linear) [<Icon icon="globe" />](/typescript/setup/linear) | Issues and projects |
+| Linear | read, actions | [Linear](/home/setup/linear) | [<Icon icon="python" />](/python/resource/linear) [<Icon icon="node-js" />](/typescript/setup/linear) [<Icon icon="globe" />](/typescript/setup/linear) | Read, create, update, comment on, and organize issues |
 | Langfuse | read | [Langfuse](/home/setup/langfuse) | [<Icon icon="python" />](/python/resource/langfuse) [<Icon icon="node-js" />](/typescript/setup/langfuse) [<Icon icon="globe" />](/typescript/setup/langfuse) | Trace exploration |
 
 ## Messaging
 
-| Resource | Mount Mode | Setup | Docs | Notes |
+| Resource | Access | Setup | Docs | Notes |
 | --- | --- | --- | --- | --- |
-| Slack | read | [Slack](/home/setup/slack) | [<Icon icon="python" />](/python/resource/slack) [<Icon icon="node-js" />](/typescript/slack) [<Icon icon="globe" />](/typescript/slack) | Channels, messages, files |
-| Discord | read | [Discord](/home/setup/discord) | [<Icon icon="python" />](/python/resource/discord) [<Icon icon="node-js" />](/typescript/discord) [<Icon icon="globe" />](/typescript/discord) | Guild and channel history |
-| Email | read, write | [Email](/home/setup/email) | [<Icon icon="python" />](/python/resource/email) [<Icon icon="node-js" />](/typescript/setup/email) | Mailbox workflows; browser blocked by raw TCP requirement |
+| Slack | read, actions | [Slack](/home/setup/slack) | [<Icon icon="python" />](/python/resource/slack) [<Icon icon="node-js" />](/typescript/slack) [<Icon icon="globe" />](/typescript/slack) | Read, post, reply, react, and search |
+| Discord | read, actions | [Discord](/home/setup/discord) | [<Icon icon="python" />](/python/resource/discord) [<Icon icon="node-js" />](/typescript/discord) [<Icon icon="globe" />](/typescript/discord) | Read history, send messages, and add reactions |
+| Email | read, actions | [Email](/home/setup/email) | [<Icon icon="python" />](/python/resource/email) [<Icon icon="node-js" />](/typescript/setup/email) | Read, send, reply, forward, and triage; browser blocked by raw TCP |
 
 ## Database
 
-| Resource | Mount Mode | Setup | Docs | Notes |
+| Resource | Access | Setup | Docs | Notes |
 | --- | --- | --- | --- | --- |
 | MongoDB | read | [MongoDB](/home/setup/mongodb) | [<Icon icon="python" />](/python/resource/mongodb) [<Icon icon="node-js" />](/typescript/setup/mongodb) [<Icon icon="globe" />](/typescript/setup/mongodb) | Collection-backed views |
 | Postgres | read | [Postgres](/home/setup/postgres) | [<Icon icon="python" />](/python/resource/postgres) [<Icon icon="node-js" />](/typescript/setup/postgres) [<Icon icon="globe" />](/typescript/setup/postgres) | SQL tables exposed as paths |
@@ -95,22 +102,22 @@ No external setup, these run locally or against a connection string you already 
 
 ## Knowledge
 
-| Resource | Mount Mode | Setup | Docs | Notes |
+| Resource | Access | Setup | Docs | Notes |
 | --- | --- | --- | --- | --- |
 | Dify | read | [Dify](/home/setup/dify) | [<Icon icon="python" />](/python/resource/dify) | Knowledge documents and retrieval search |
 | Chroma | read | [Chroma](/home/setup/chroma) | [<Icon icon="python" />](/python/resource/chroma) [<Icon icon="node-js" />](/typescript/setup/chroma) | ChromaDB collection exposed as files and vector search |
 
 ## Notes
 
-| Resource | Mount Mode | Setup | Docs | Notes |
+| Resource | Access | Setup | Docs | Notes |
 | --- | --- | --- | --- | --- |
-| Notion | read, write | [Notion](/home/setup/notion) | [<Icon icon="python" />](/python/resource/notion) [<Icon icon="node-js" />](/typescript/setup/notion) [<Icon icon="globe" />](/typescript/setup/notion) | Pages and blocks |
+| Notion | read, actions | [Notion](/home/setup/notion) | [<Icon icon="python" />](/python/resource/notion) [<Icon icon="node-js" />](/typescript/setup/notion) [<Icon icon="globe" />](/typescript/setup/notion) | Read pages; create pages, append blocks, and add comments |
 
 ## Others
 
-| Resource | Mount Mode | Setup | Docs | Notes |
+| Resource | Access | Setup | Docs | Notes |
 | --- | --- | --- | --- | --- |
-| Trello | read | [Trello](/home/setup/trello) | [<Icon icon="python" />](/python/resource/trello) [<Icon icon="node-js" />](/typescript/setup/trello) [<Icon icon="globe" />](/typescript/setup/trello) | Boards and cards |
+| Trello | read, actions | [Trello](/home/setup/trello) | [<Icon icon="python" />](/python/resource/trello) [<Icon icon="node-js" />](/typescript/setup/trello) [<Icon icon="globe" />](/typescript/setup/trello) | Read, create, update, move, label, and comment on cards |
 
 ## Agent Frameworks
 
@@ -120,7 +127,7 @@ Mirage drops into the major agent application frameworks. Each adapter exposes a
 | --- | --- | --- |
 | OpenAI Agents SDK | [<Icon icon="python" />](/python/agents/openai-agents) [<Icon icon="node-js" />](/typescript/agents/openai) [<Icon icon="globe" />](/typescript/agents/openai) | `MirageShell` and `MirageEditor` plug into `shellTool` and `applyPatchTool`. |
 | Vercel AI SDK | [<Icon icon="node-js" />](/typescript/agents/vercel) [<Icon icon="globe" />](/typescript/agents/vercel) | `mirageTools()` returns five typed tools for `generateText` / `streamText`. |
-| LangChain (deepagents) | [<Icon icon="python" />](/python/agents/langchain) [<Icon icon="node-js" />](/typescript/agents/langchain) | `LangchainWorkspace` backend for deepagents. Node only. |
+| LangChain (deepagents) | [<Icon icon="python" />](/python/agents/langchain) [<Icon icon="node-js" />](/typescript/agents/langchain) | `LangchainWorkspace` backend for Python and Node deepagents. |
 | Pi Coding Agent | [<Icon icon="node-js" />](/typescript/agents/pi) | Mirage extension for `@mariozechner/pi-coding-agent`. Node only. |
 | Mastra | [<Icon icon="node-js" />](/typescript/agents/mastra) | `mirageTools()` for Mastra `Agent` definitions. Node only. |
 | Pydantic AI | [<Icon icon="python" />](/python/agents/pydantic-ai) | For pydantic-ai and pydantic-deepagents. |

--- a/docs/home/setup/slack.mdx
+++ b/docs/home/setup/slack.mdx
@@ -28,14 +28,25 @@ description: Set up a Slack Bot Token for the Slack resource.
 1. Authorize the requested permissions
 1. Copy the **Bot User OAuth Token** (`xoxb-...`)
 
-### 4. Set Environment Variables
+### 4. Optional: Enable Workspace Search
+
+Slack's `search.messages` API does not accept bot tokens. To use `slack-search` or workspace-level search push-down:
+
+1. Add `search:read` under **User Token Scopes**.
+1. Reinstall or reauthorize the app.
+1. Copy the resulting **User OAuth Token** (`xoxp-...`).
+
+Keep using the bot token for normal reads and writes. Mirage uses the optional user token only for Slack search endpoints.
+
+### 5. Set Environment Variables
 
 ```bash
 # .env.development
 SLACK_BOT_TOKEN=xoxb-xxxx...
+SLACK_USER_TOKEN=xoxp-xxxx...  # optional, only needed for workspace search
 ```
 
-### 5. Invite the Bot
+### 6. Invite the Bot
 
 The bot must be invited to channels it needs to read:
 

--- a/docs/home/snapshot.mdx
+++ b/docs/home/snapshot.mdx
@@ -34,7 +34,7 @@ flowchart TD
 <CodeGroup>
 
 ```python Python
-# capture — async, stats every touched path on a SUPPORTS_SNAPSHOT mount
+# capture — async; serializes state plus fingerprints recorded during reads
 await ws.snapshot("run.tar")
 await ws.snapshot("run.tar.gz", compress="gz")
 
@@ -47,13 +47,28 @@ cp = await ws.copy()
 ```
 
 ```typescript TypeScript
-// TODO(snapshot-ts): API not implemented yet.
-// Tracking parity with Python's Workspace.snapshot / Workspace.load.
+import { DriftPolicy, Workspace } from '@struktoai/mirage-node'
+
+// capture to a tar file
+await ws.snapshot('run.tar')
+
+// replay with strict drift detection (default)
+const restored = await Workspace.load('run.tar')
+
+// or restore the structure while reading current remote content
+const current = await Workspace.load('run.tar', {
+  driftPolicy: DriftPolicy.OFF,
+})
+
+// in-process duplicate
+const copy = await ws.copy()
 ```
 
 </CodeGroup>
 
-Both `snapshot` and `copy` are `async` because fingerprint capture stats each touched path on a `SUPPORTS_SNAPSHOT` mount.
+TypeScript file-path snapshot I/O is available in Node. In the browser, `Workspace.load(snapshotBytes)` accepts a `Uint8Array`, and `Workspace.fromState(...)` restores a state object; writing the tar to a file or download target is the application's responsibility.
+
+Both `snapshot` and `copy` are async because they serialize workspace state and collect recorded fingerprints.
 
 ## Versioning: commit, checkout, clone
 
@@ -146,29 +161,25 @@ The cache is the optimization, the fingerprint is the verifier, and the pin is t
 
 ## Resource Support Matrix
 
-Snapshot support is **opt-in per resource** via `SUPPORTS_SNAPSHOT = True`. Resources without it surface in a load-time warning and serve current state with no drift detection.
+Remote drift detection is opt-in per resource through `SUPPORTS_SNAPSHOT` in Python and `supportsSnapshot` in TypeScript. A working adapter must also attach a fingerprint to each read record; a revision is optional and enables pinned replay.
 
-Legend: ✅ = supported · 🟡 = adapter needed (no work in flight) · 📝 = planned · ❌ = not applicable.
+Legend: ✅ = implemented · 🟡 = resource opts in, but recorded reads do not yet carry the fingerprint · ❌ = live-only · — = unavailable in that runtime.
 
-### Object Storage
+### Remote Resources
 
-| Resource | Drift detection (Py) | Revision pin (Py) | Drift detection (TS) | Revision pin (TS) | Marker | Notes |
-| --- | :---: | :---: | :---: | :---: | --- | --- |
-| S3 | ✅ | ✅ | 📝 | 📝 | `ETag` + `VersionId` | Pin requires bucket versioning. |
-| R2 | ✅ | ✅ | 📝 | 📝 | `ETag` + `VersionId` | Inherits S3 path; pin requires R2 versioning (GA 2024). |
-| GCS | ✅ | 🟡 | 📝 | 🟡 | `ETag` + `x-goog-generation` | TODO(snapshot-gcs): map generation → `ContentVersion(kind="revision")` in `core/s3/stat.py`. |
-| OCI | ✅ | 🟡 | 📝 | 🟡 | `ETag` + `versionId` header | TODO(snapshot-oci): same shape as GCS adapter. |
-| Supabase | ✅ | ❌ | 📝 | ❌ | `ETag` only | Inherits `S3Resource`. Supabase's S3-compat endpoint does not surface object `VersionId`, so drift detection works but pinning is not available. |
+| Resource family | Python | TS Node | TS Browser | Revision pin | Notes |
+| --- | :---: | :---: | :---: | :---: | --- |
+| S3 and S3-compatible object stores | ✅ | ✅ | ✅ | When `VersionId` is available | Uses `ETag`; compatible providers without object versions still get drift detection. |
+| OneDrive | ✅ | — | — | ✅ | Uses Microsoft Graph `cTag` plus the current version id. |
+| SharePoint | ✅ | — | — | ✅ | Same Microsoft Graph version flow as OneDrive. |
+| Hugging Face resources | 🟡 | 🟡 | — | ❌ | Resources opt in, but read records do not yet include the stat fingerprint. |
+| Nextcloud | 🟡 | — | — | ❌ | The resource opts in, but read records do not yet include the WebDAV ETag. |
+| GitHub and Google Drive | ❌ | ❌ | ❌ | ❌ | Current reads are live-only; revision-aware replay is not wired yet. |
+| Other remote resources | ❌ | ❌ | ❌ | ❌ | Snapshot restores their config/state, then reads current remote content. |
 
-### Files & Code
+### Local State
 
-| Resource | Drift detection (Py) | Revision pin (Py) | Drift detection (TS) | Revision pin (TS) | Marker | Notes |
-| --- | :---: | :---: | :---: | :---: | --- | --- |
-| Disk | ✅ | ❌ | 📝 | ❌ | content hash | Bytes travel inside the tar; pin not meaningful. |
-| RAM | ✅ | ❌ | 📝 | ❌ | content hash | Same as Disk. |
-| Redis | ✅ | ❌ | 📝 | ❌ | content hash | Bytes restored via `resources=` override. |
-| GitHub | 📝 | 📝 | 📝 | 📝 | commit SHA | TODO(snapshot-github): `stat → revision=sha`, read via `repos.get_contents(path, ref=sha)`. |
-| Google Drive | 📝 | 📝 | 📝 | 📝 | `md5Checksum` + `revisionId` | TODO(snapshot-gdrive): `stat → revision=revisionId`, read via `revisions().get_media`. |
+RAM, Disk, and Redis serialize their resource state into the snapshot. They do not need a remote drift check or revision pin: replay restores the captured state directly. Credentials and connection details remain redacted and may require a resource override at load time.
 
 ## Extending To A New Backend
 

--- a/docs/python/resource/new.mdx
+++ b/docs/python/resource/new.mdx
@@ -1,205 +1,134 @@
 ---
 title: Adding a New Resource
 icon: plus
-description: Step-by-step guide for implementing a new MIRAGE resource.
+description: Implement and register a Python resource using Mirage's current VFS, command, and snapshot conventions.
 ---
 
-This guide covers what you need to implement when adding a new resource
-to MIRAGE. Use the Discord or Slack resources as reference.
+A resource maps an external system to Mirage's filesystem operations and shell commands. Keep the core I/O layer independent from command parsing, and check whether the same resource or behavior should also be added to TypeScript.
+
+Use a recent resource such as Dify or Databricks Volume as the structural reference. Paths are always `PathSpec` values inside the VFS; do not pass filesystem paths as raw strings.
 
 ## File Structure
 
 ```text
-mirage/
+python/mirage/
   resource/<name>/
-    __init__.py          # lazy-loading exports
-    config.py            # Pydantic config (credentials)
-    <name>.py            # BaseResource subclass
-  accessor/<name>.py     # Accessor wrapping config
-  core/<name>/
     __init__.py
-    _client.py           # HTTP client (get/post with rate limiting)
-    readdir.py           # directory listing
-    read.py              # file reading
-    stat.py              # file metadata
-    scope.py             # scope detection
-    glob.py              # glob pattern resolution
-    ...                  # data fetching modules (history, search, post, etc.)
+    config.py
+    <name>.py
+  accessor/<name>.py
+  core/<name>/
+    read.py
+    readdir.py
+    stat.py
+    glob.py
   ops/<name>/
-    __init__.py           # exports OPS list
-    read.py               # @op wrapper
-    readdir.py            # @op wrapper
-    stat.py               # @op wrapper
+    __init__.py
+    read.py
+    readdir.py
+    stat.py
   commands/builtin/<name>/
-    __init__.py           # exports COMMANDS list
-    _plan.py              # cost estimation helpers
-    cat.py, ls.py, ...    # standard commands
-    <name>_send.py, ...   # resource-specific commands
+    __init__.py
+    <resource-specific commands>.py
 ```
 
-## Implementation Steps
+Add matching tests under `python/tests/` without creating `__init__.py` files in the test tree.
 
-### 1. Config, Accessor, ResourceName
+## 1. Config, Accessor, and Registry
 
-Create a Pydantic config model to hold credentials and an accessor
-class that wraps it.
+Define a typed Pydantic config and keep secrets in `SecretStr` fields.
 
 ```python
-# mirage/resource/<name>/config.py
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr
 
 
 class MyConfig(BaseModel):
-    token: str
+    token: SecretStr
 ```
 
+Create an `Accessor` that owns the client or transport. Add the resource name to `ResourceName`, export the config/resource from `resource/<name>/__init__.py`, and add a lazy `ResourceEntry` to `mirage/resource/registry.py`. The registry entry is required for YAML, snapshots, and the daemon to construct the resource.
+
+Keep every import at module scope. If that creates a cycle, change the dependency direction instead of adding a function-local import.
+
+## 2. Core VFS Operations
+
+Implement only the operations the backend supports. Read-only API resources usually start with:
+
+- `readdir(accessor, path, index)` returning child names.
+- `read_bytes(accessor, path, index)` returning bytes.
+- `stat(accessor, path, index)` returning `FileStat`.
+- `resolve_glob(accessor, paths, index)` returning resolved `PathSpec` values.
+
+Use explicit types:
+
 ```python
-# mirage/accessor/<name>.py
 from mirage.accessor.base import Accessor
-from mirage.resource.<name>.config import MyConfig
+from mirage.cache.index import IndexCacheStore
+from mirage.types import FileStat, PathSpec
 
 
-class MyAccessor(Accessor):
-
-    def __init__(self, config: MyConfig) -> None:
-        self.config = config
-```
-
-Add `MY_RESOURCE = "<name>"` to the `ResourceName` enum in `mirage/types.py`.
-
-### 2. HTTP Client
-
-Wrap the resource's API with rate-limit handling. All resources follow
-the same pattern: async get/post functions with retry on 429.
-
-```python
-# mirage/core/<name>/_client.py
-async def my_get(config, endpoint, params=None) -> dict: ...
-async def my_post(config, endpoint, body=None) -> dict: ...
-```
-
-### 3. Core VFS
-
-Implement the three VFS operations that map API data to a filesystem:
-
-- **`readdir.py`** -- Returns `list[str]` of child paths for a directory.
-- **`read.py`** -- Returns `bytes` content of a file.
-- **`stat.py`** -- Returns `FileStat` with name, type, and extras (e.g., IDs).
-
-All three accept `(accessor, path, index, prefix)` and use `IndexCacheStore`
-to cache name-to-ID mappings.
-
-### 4. Scope Detection and GlobScope Optimization
-
-`GlobScope` carries the raw path and pattern **before** expansion. This
-lets commands decide how to resolve paths efficiently -- skipping
-expensive glob expansion when the resource has a native API for the
-operation.
-
-**`scope.py`** parses the unexpanded path to determine the level:
-
-```python
-@dataclass
-class MyScope:
-    level: str  # "root", "category", "item", "file"
-    item_id: str | None = None
-```
-
-**How commands use scope for optimization:**
-
-```python
-# Example: grep at different scopes
-
-@command("grep", resource="my_resource", spec=SPECS["grep"])
-async def grep(accessor, paths, *texts, **_extra):
-    pattern = texts[0]
-    scope = detect_scope(paths[0], index)
-
-    if scope.level in ("category", "item"):
-        # CHEAP: use native search API (1 API call)
-        results = await search_api(accessor.config, scope.item_id, pattern)
-        return format_results(results), IOResult()
-
-    # EXPENSIVE fallback: expand glob, download each file, grep locally
-    paths = await resolve_glob(accessor, paths, index=index)
-    for p in paths:
-        data = await read(accessor, p.original, index, prefix=p.prefix)
-        # ... grep the bytes ...
-```
-
-**When to use this pattern:**
-
-| Scenario                                   | Approach                                                  |
-| ------------------------------------------ | --------------------------------------------------------- |
-| Resource has a search API (Discord, Slack) | Use scope to route to native API at directory level       |
-| Resource has no search API                 | Always fall through to file-level reads; scope is a noop  |
-| `head`/`tail` with direct message fetch    | Use scope to detect file level, fetch N messages directly |
-
-**When the resource has no search API**, keep `scope.py` as a noop for
-structural consistency. The file still parses path parts but does not
-trigger any API calls:
-
-```python
-# Noop scope -- no search API, no resource-relative paths
-def detect_scope(path: str | GlobScope) -> MyScope:
-    key = path.strip("/")
-    parts = key.split("/")
-    # Just parse path structure, no index lookups
+async def stat(
+    accessor: Accessor,
+    path: PathSpec,
+    index: IndexCacheStore | None,
+) -> FileStat:
     ...
 ```
 
-### 5. Glob Resolution
+Add write, append, create, unlink, rename, or directory operations only when the backend has matching semantics. I/O should remain async-native.
+
+## 3. Ops Layer
+
+Ops are thin typed adapters from the workspace dispatcher to core functions. Declare dispatcher-injected arguments explicitly and keep `**flags: object` opaque.
 
 ```python
-# mirage/core/<name>/glob.py
-async def resolve_glob(accessor, paths, index=None) -> list[GlobScope]:
-    # Expand patterns via readdir + fnmatch
+from mirage.accessor.base import Accessor
+from mirage.cache.index import IndexCacheStore
+from mirage.core.my_resource.read import read_bytes
+from mirage.ops.registry import op
+from mirage.types import PathSpec
+
+
+@op("read", resource="my_resource")
+async def read(
+    accessor: Accessor,
+    path: PathSpec,
+    *,
+    index: IndexCacheStore | None,
+    **flags: object,
+) -> bytes:
+    return await read_bytes(accessor, path, index)
 ```
 
-### 6. Ops Layer
+Mark mutation ops with `write=True`. Export the decorated functions as `OPS` from `ops/<name>/__init__.py`.
 
-Thin wrappers that bridge core functions to the command framework:
+## 4. Commands
 
-```python
-@op("read", resource="<name>")
-async def read(accessor, scope, **kwargs) -> bytes:
-    return await core_read(accessor, scope.original,
-                           kwargs.get("index"), prefix=scope.prefix)
-```
+Build standard commands with `CommandIO` and `make_generic_commands`; the generic command owns flag interpretation. Backend wrappers should only connect glob resolution and I/O functions.
 
-### 7. Commands
+For a resource-specific command:
 
-Copy from an existing resource (Discord/Slack), then:
+- Use the shared command spec.
+- Mark every mutation with `write=True` so `MountMode.READ` remains a real boundary.
+- Declare injected parameters such as `stdin`, `index`, and `prefix` explicitly.
+- Use `FlagView(flags, spec=...)` when the command itself must read a flag; never use `flags.get(...)`.
+- Add a provision estimator when a useful estimate is possible. Otherwise the planner reports `precision=unknown`.
 
-1. Replace accessor and core imports.
-1. Set `resource="<name>"` in decorators.
-1. Add or remove scope-based optimizations depending on API capabilities.
-1. Add resource-specific commands (send message, etc.).
+Export the final list as `COMMANDS` from `commands/builtin/<name>/__init__.py`.
 
-**Provision (dry-run estimates).** Factory-built commands
-(`make_generic_commands`) get family-default estimators for free, so
-`ws.execute(cmd, provision=True)` works without extra wiring. For
-bespoke commands, pass `provision=` to the decorator, reusing the
-shared helpers from `mirage.commands.builtin.generic_bind`:
+## 5. Resource Class
+
+Import commands and ops at module scope, then register them in the constructor:
 
 ```python
-from mirage.commands.builtin.generic_bind.provision import (
-    make_file_read_provision, metadata_provision)
-from mirage.core.<name>.stat import stat as my_stat
+from mirage.accessor.my_resource import MyAccessor
+from mirage.commands.builtin.my_resource import COMMANDS
+from mirage.ops.my_resource import OPS as MY_RESOURCE_OPS
+from mirage.resource.base import BaseResource
+from mirage.resource.my_resource.config import MyConfig
+from mirage.types import ResourceName
 
-@command("cat", resource="<name>", spec=SPECS["cat"],
-         provision=make_file_read_provision(my_stat))
-async def cat(...): ...
-```
 
-Omit `provision=` and the planner honestly reports
-`precision=unknown`. If your resource renders virtual files (a
-`chat.jsonl` built from messages), have `stat` report `size=None`
-rather than 0 so estimates degrade to floors instead of lying.
-
-### 8. Resource Class
-
-```python
 class MyResource(BaseResource):
     name: str = ResourceName.MY_RESOURCE
     caches_reads: bool = True
@@ -207,12 +136,25 @@ class MyResource(BaseResource):
     def __init__(self, config: MyConfig) -> None:
         super().__init__()
         self.config = config
-        self.accessor = MyAccessor(self.config)
-        from mirage.commands.builtin.<name> import COMMANDS
-        from mirage.ops.<name> import OPS
-
+        self.accessor = MyAccessor(config)
         for fn in COMMANDS:
             self.register(fn)
-        for fn in OPS:
+        for fn in MY_RESOURCE_OPS:
             self.register_op(fn)
 ```
+
+Set `caches_reads=True` only for stable, read-mostly content. Implement `get_state()` with credentials redacted and close any network clients in `close()`.
+
+## 6. Snapshot Support
+
+Leave `SUPPORTS_SNAPSHOT=False` unless the complete drift contract is implemented:
+
+1. `stat()` returns a stable `FileStat.fingerprint`.
+1. Every read record includes the fingerprint that produced those bytes.
+1. If the backend supports immutable revisions, reads consult `revision_for(path.virtual)` and record the resolved revision.
+
+Setting the flag without recording fingerprints does not provide drift detection.
+
+## 7. Verification
+
+Add tests for config validation, path layout, every VFS op, command behavior, read-only enforcement, state redaction, and cleanup. For major features, add or update integration coverage under `integ/` and check Python/TypeScript parity before opening the PR.

--- a/docs/python/resource/slack.mdx
+++ b/docs/python/resource/slack.mdx
@@ -16,7 +16,10 @@ import os
 from mirage import MountMode, Workspace
 from mirage.resource.slack import SlackConfig, SlackResource
 
-config = SlackConfig(token=os.environ["SLACK_BOT_TOKEN"])
+config = SlackConfig(
+    token=os.environ["SLACK_BOT_TOKEN"],
+    search_token=os.environ.get("SLACK_USER_TOKEN"),
+)
 resource = SlackResource(config=config)
 ws = Workspace({"/slack": resource}, mode=MountMode.READ)
 ```
@@ -120,7 +123,10 @@ from mirage.resource.slack import SlackConfig, SlackResource
 
 load_dotenv(".env.development")
 
-config = SlackConfig(token=os.environ["SLACK_BOT_TOKEN"])
+config = SlackConfig(
+    token=os.environ["SLACK_BOT_TOKEN"],
+    search_token=os.environ.get("SLACK_USER_TOKEN"),
+)
 resource = SlackResource(config=config)
 
 
@@ -319,6 +325,9 @@ filenames under `/slack/users/` (e.g., `alice__U04K21SEVR9.json`).
 ### `slack-search`
 
 Search messages across the workspace.
+
+This command requires `search_token`, a Slack User OAuth Token (`xoxp-...`)
+with the `search:read` scope. Bot tokens cannot call `search.messages`.
 
 ```bash
 slack-search --query "incident report"

--- a/docs/python/setup/slack.mdx
+++ b/docs/python/setup/slack.mdx
@@ -14,16 +14,21 @@ For credential setup, see the [Slack Setup](/home/setup/slack) guide.
 
 ```python
 import os
-from mirage import Workspace, MountMode
+
+from mirage import MountMode, Workspace
 from mirage.resource.slack import SlackConfig, SlackResource
 
-config = SlackConfig(token=os.environ["SLACK_BOT_TOKEN"])
+config = SlackConfig(
+    token=os.environ["SLACK_BOT_TOKEN"],
+    search_token=os.environ.get("SLACK_USER_TOKEN"),
+)
 resource = SlackResource(config=config)
 ws = Workspace({"/slack/": resource}, mode=MountMode.READ)
 ```
 
 ## Config Reference
 
-| Field   | Required | Description                             |
-| ------- | -------- | --------------------------------------- |
-| `token` | Yes      | Slack Bot User OAuth Token (`xoxb-...`) |
+| Field          | Required | Description                                                   |
+| -------------- | -------- | ------------------------------------------------------------- |
+| `token`        | Yes      | Slack Bot User OAuth Token (`xoxb-...`)                       |
+| `search_token` | No       | User OAuth Token (`xoxp-...`) with `search:read`; search only |

--- a/docs/snippets/split-card.jsx
+++ b/docs/snippets/split-card.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export const SplitCard = ({
   title,
   description,

--- a/docs/typescript/limitations.mdx
+++ b/docs/typescript/limitations.mdx
@@ -148,9 +148,16 @@ The Python FS shim (`open()` against mounted paths) flushes writes back through 
 
 See [Python FS shim](/typescript/python-fs#runtime-requirements) for the full matrix.
 
-### 5. No SSH, Postgres, MongoDB, LanceDB, Email, FUSE peers
+### 5. Some resource drivers remain Node-only
 
-These resources are only exposed by `@struktoai/mirage-node` because their drivers are Node-only. Importing them from `@struktoai/mirage-browser` is a build error. For browser apps, route those reads through your backend (or use the HTTP-driver variants where they exist, e.g. MongoDB via the bundled mongo-proxy in the examples).
+SSH, LanceDB, Email, Disk, Redis, and the Hugging Face resources are only exposed by `@struktoai/mirage-node` because their drivers need Node APIs or raw TCP. Importing them from `@struktoai/mirage-browser` is a build error.
+
+Postgres and MongoDB do have browser implementations:
+
+- Postgres uses `NeonPgDriver` over HTTP.
+- MongoDB uses `HttpMongoDriver` and an HTTP proxy such as the bundled mongo-proxy example.
+
+Those HTTP drivers still need a browser-reachable endpoint with the correct CORS policy. They are not drop-in replacements for raw Postgres or MongoDB socket connections.
 
 ---
 
@@ -169,6 +176,8 @@ These resources are only exposed by `@struktoai/mirage-node` because their drive
 | OPFS over quota | Browser | ❌ `QuotaExceededError`; check `navigator.storage.estimate()` |
 | HTTP-backed resources without CORS allow-list | Browser | ❌ blocked; use PKCE, presigned URLs, or a same-origin proxy |
 | Python `open()` writes back through mount | Browser | ✅ with JSPI (Chrome 137+); ❌ otherwise |
-| `@struktoai/mirage-node`-only resources (SSH, Postgres, MongoDB, LanceDB, Email, FUSE) | Browser | ❌ Node-only drivers |
+| Postgres through `NeonPgDriver` | Browser | ✅ over HTTP; endpoint must allow the browser origin |
+| MongoDB through `HttpMongoDriver` | Browser | ✅ through an HTTP proxy; direct MongoDB sockets are unavailable |
+| Node-only resources (SSH, LanceDB, Email, Disk, Redis, Hugging Face, FUSE) | Browser | ❌ Node APIs or raw TCP required |
 
-The first two Node limitations are runtime-level, not Mirage design decisions, and Python's equivalent behavior is strictly better there — if a workflow absolutely requires ESM-level `fs` patching or blocking reads of your own mount, consider whether the Python SDK fits better for that specific piece. Size-unknown stat is identical in both SDKs by design. The Browser limitations are by design (no kernel, no subprocess), so the workarounds there are about choosing the right runtime for the task.
+The Node limitations are runtime-level, not Mirage design decisions. Python's equivalent behavior is strictly better in each case, so if a workflow absolutely requires ESM-level `fs` patching or large API-backed FUSE reads, consider whether the Python SDK fits better for that specific piece. The Browser limitations are by design (no kernel, no subprocess), so the workarounds there are about choosing the right runtime for the task.


### PR DESCRIPTION
## Summary

- Fix Python and TypeScript quickstarts so writable examples use the correct mount modes and current resource config APIs.
- Update the resource matrix, TypeScript limitations, and snapshot support documentation to match implemented runtime behavior.
- Document Slack's optional user token for workspace search.
- Shorten and modernize the Python resource-authoring guide.
- Remove an unnecessary React import that prevented Mintlify build validation.

## Why

Several docs pages had drifted from the current codebase. Some examples used stale constructors or read-only mounts for write commands, while support tables understated browser and snapshot capabilities.

## Impact

Users get runnable examples, clearer access and runtime expectations, accurate snapshot guidance, and a more concise resource implementation guide.

## Validation

- `mintlify validate`
- Mintlify broken-link scan
- Rendered all changed routes locally with no overflow or browser console errors
- `pre-commit run --all-files`
- `cd python && uv run pytest` — 8,333 passed, 304 skipped
