### PR TITLE
docs(fuse): OS support matrix + Windows WinFsp setup page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -88,16 +88,6 @@
             "group": "Setup",
             "pages": [
               {
-                "group": "FUSE",
-                "icon": "hard-drive",
-                "pages": [
-                  "home/setup/fuse",
-                  "home/setup/macos",
-                  "home/setup/linux",
-                  "home/setup/windows"
-                ]
-              },
-              {
                 "group": "Object Storage",
                 "icon": "cloud",
                 "pages": [
@@ -204,6 +194,16 @@
                   "home/setup/trello"
                 ]
               }
+            ]
+          },
+          {
+            "group": "FUSE",
+            "icon": "hard-drive",
+            "pages": [
+              "home/setup/fuse",
+              "home/setup/macos",
+              "home/setup/linux",
+              "home/setup/windows"
             ]
           }
         ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -91,8 +91,10 @@
                 "group": "FUSE",
                 "icon": "hard-drive",
                 "pages": [
+                  "home/setup/fuse",
                   "home/setup/macos",
-                  "home/setup/linux"
+                  "home/setup/linux",
+                  "home/setup/windows"
                 ]
               },
               {

--- a/docs/home/setup/fuse.mdx
+++ b/docs/home/setup/fuse.mdx
@@ -1,0 +1,59 @@
+---
+title: Support Matrix
+icon: table
+description: Which OS and SDK combinations support MIRAGE FUSE mounts, and how well.
+---
+
+FUSE mode exposes a mount as a real OS directory so any tool (editors,
+sandbox runtimes, plain `cat`) can read it, not just MIRAGE commands. OS
+support depends on the SDK's FUSE binding: Python uses
+[mfusepy](https://github.com/mxmlnkn/mfusepy) (ctypes over libfuse), Node
+uses [@zkochan/fuse-native](https://www.npmjs.com/package/@zkochan/fuse-native)
+(a native addon), and browsers cannot mount filesystems at all.
+
+## Matrix
+
+| OS | Python | TypeScript (Node) | Notes |
+| --- | --- | --- | --- |
+| Linux | ✅ supported, CI-gated | ✅ supported, CI-gated | `fuse3`; multiple mounts per process |
+| macOS | ✅ supported | ✅ supported | macFUSE kernel extension; **one mount per process** |
+| Windows | 🧪 experimental | ❌ not supported | Python via [WinFsp](/home/setup/windows); advisory CI job passes |
+| Browser | ❌ | ❌ | no kernel; use the virtual executor instead |
+
+Per-OS install guides: [macOS](/home/setup/macos), [Linux](/home/setup/linux),
+[Windows](/home/setup/windows). SDK wiring:
+[Python FUSE setup](/python/setup/fuse),
+[TypeScript FUSE setup](/typescript/setup/fuse).
+
+## What the labels mean
+
+- **Supported, CI-gated (Linux).** The FUSE integration battery (both SDKs,
+  real kernel mounts, including size-unknown API files) runs on every change
+  and gates merges.
+- **Supported (macOS).** Same code paths, verified on real macFUSE kext
+  mounts; hosted CI runners cannot approve kernel extensions, so macOS
+  coverage is local rather than gated. Remember the one-mount-per-process
+  limit.
+- **Experimental (Windows, Python only).** The full battery passes over
+  WinFsp in an advisory CI job (not merge-gating). Windows conventions
+  (unmount at process exit, mount-level ownership, stat-opens-a-handle) are
+  documented on the [Windows page](/home/setup/windows). Write-heavy flows
+  and symlinks are not yet exercised there.
+- **Not supported (Windows, TypeScript).** `@zkochan/fuse-native` only
+  targets macOS and Linux; its legacy Windows path builds against the
+  unmaintained Dokany-based `fuse-shared-library-win32` rather than WinFsp.
+
+## Platform quirks at a glance
+
+| Quirk | Linux | macOS | Windows |
+| --- | --- | --- | --- |
+| Mounts per process | many | **one** (Python and Node) | many |
+| Unmount | `fusermount -u` / `ws.close()` | `diskutil unmount` / `ws.close()` | at process exit only |
+| Size-unknown files pre-open | stat 0 | stat 0 | stat fetches, shows real size |
+| Mountpoint directory | must exist | must exist | must **not** exist (auto-created) |
+
+The size-unknown semantics themselves (stat 0 until open, full content on
+read, real size after open) are identical across SDKs; see
+[Python](/python/setup/fuse#size-semantics-for-api-backed-files) or
+[TypeScript](/typescript/limitations#3-size-unknown-api-files-stat-as-0-bytes-until-first-open)
+for the per-tool table.

--- a/docs/home/setup/windows.mdx
+++ b/docs/home/setup/windows.mdx
@@ -1,0 +1,69 @@
+---
+title: Windows
+icon: windows
+description: Set up WinFsp on Windows for MIRAGE FUSE mounts (Python, experimental).
+---
+
+## FUSE on Windows
+
+Windows has no native FUSE. MIRAGE's Python FUSE mounts run on
+[WinFsp](https://winfsp.dev/), a maintained Windows file system driver with a
+FUSE-compatible layer. Support is **experimental**: the FUSE integration
+battery passes in CI on `windows-latest`, but Windows is not yet a fully
+supported platform. The TypeScript SDK has no Windows FUSE support at all
+(its binding only targets macOS and Linux).
+
+### Install WinFsp
+
+Requires Windows 10 (1809+) or Windows 11.
+
+<Tabs>
+  <Tab title="winget">
+    ```powershell
+    winget install -e --id WinFsp.WinFsp
+    ```
+  </Tab>
+  <Tab title="Chocolatey">
+    ```powershell
+    choco install winfsp -y
+    ```
+  </Tab>
+  <Tab title="Installer">
+    Download the MSI from the [WinFsp releases page](https://winfsp.dev/rel/)
+    and run it.
+  </Tab>
+</Tabs>
+
+No reboot or driver-signing steps are needed (unlike macFUSE on macOS).
+
+### Verify
+
+```powershell
+pip install "mirage-ai[fuse]"
+python -c "import mfusepy; print('WinFsp FUSE loaded')"
+```
+
+`mfusepy` locates `winfsp-x64.dll` through the registry; if the import
+succeeds, the driver is reachable.
+
+## Windows-specific behavior
+
+MIRAGE handles the WinFsp conventions automatically, but three behaviors
+differ from macOS/Linux and are worth knowing:
+
+- **Unmount happens at process exit.** There is no `fusermount` on Windows;
+  WinFsp releases the mount when the process serving it exits. Closing the
+  workspace does not actively unmount.
+- **Ownership is a mount-level mapping.** All files appear owned by the user
+  who mounted the filesystem (WinFsp's `uid=-1,gid=-1` mapping). Per-file
+  POSIX owners from backends are not represented.
+- **`stat` opens a handle.** Windows cannot query file attributes without
+  opening the file, so size-unknown API-backed files fetch their content on
+  the first per-file `stat` and immediately report the real size — where
+  macOS/Linux report 0 until first open. Directory listings stay cheap on
+  all platforms.
+
+Unlike macOS, multiple FUSE mounts per process work on Windows.
+
+See the [FUSE support matrix](/home/setup/fuse) for the full OS and language
+overview.

--- a/docs/python/setup/fuse.mdx
+++ b/docs/python/setup/fuse.mdx
@@ -11,10 +11,12 @@ description: Set up FUSE support for MIRAGE in Python.
 
 ## System FUSE
 
-Install the OS-level FUSE kernel extension first:
+Install the OS-level FUSE driver first (see the
+[support matrix](/home/setup/fuse) for the full OS overview):
 
 - [macOS FUSE Setup](/home/setup/macos), macFUSE + kernel extension + Apple Silicon recovery mode steps.
 - [Linux FUSE Setup](/home/setup/linux), `fuse3` install and `/etc/fuse.conf`.
+- [Windows FUSE Setup](/home/setup/windows), WinFsp install; experimental.
 
 ## Install Mirage with the FUSE Extra
 
@@ -92,10 +94,18 @@ Mirage never reports a fake size and never fetches content during `stat`:
 returning real sizes eagerly would fire one API call per file on every
 `ls -l`.
 
+<Note>
+  **Windows differs**: it cannot query attributes without opening a handle,
+  so a per-file `stat` of a size-unknown file fetches the content and shows
+  the real size immediately. Directory listings stay cheap. See
+  [Windows FUSE Setup](/home/setup/windows) for the other Windows-specific
+  behaviors (unmount at process exit, mount-level ownership).
+</Note>
+
 <Warning>
   **macOS allows only one in-process FUSE mount.** macFUSE registers a
   process-global signal source, so a second simultaneous mount in the same
   process fails with `fuse: cannot register signal source`. Multiple per-mount
-  FUSE mounts work on Linux; on macOS, enable `fuse` on a single mount per
-  workspace (or run additional mounts in separate processes).
+  FUSE mounts work on Linux and Windows; on macOS, enable `fuse` on a single
+  mount per workspace (or run additional mounts in separate processes).
 </Warning>

--- a/docs/typescript/setup/fuse.mdx
+++ b/docs/typescript/setup/fuse.mdx
@@ -11,10 +11,18 @@ description: Set up FUSE support for MIRAGE with the TypeScript SDK.
 
 ## System FUSE
 
-Install the OS-level FUSE kernel support first:
+Install the OS-level FUSE kernel support first (see the
+[support matrix](/home/setup/fuse) for the full OS overview):
 
 - [macOS FUSE Setup](/home/setup/macos), macFUSE + kernel extension + Apple Silicon recovery mode steps.
 - [Linux FUSE Setup](/home/setup/linux), `fuse3` install and `/etc/fuse.conf`.
+
+<Note>
+  **No Windows support in TypeScript.** `@zkochan/fuse-native` targets macOS
+  and Linux only; its legacy Windows path builds against the unmaintained
+  Dokany-based `fuse-shared-library-win32`, not WinFsp. Python's FUSE mounts
+  run on Windows experimentally, see [Windows FUSE Setup](/home/setup/windows).
+</Note>
 
 ## Install the Node Binding
 

--- a/python/mirage/fuse/fs.py
+++ b/python/mirage/fuse/fs.py
@@ -61,8 +61,11 @@ class MirageFS(_FUSE_OPERATIONS):
                  agent_id: str | None = None,
                  root_prefix: str = "") -> None:
         if fuse is None:
-            raise RuntimeError("FUSE support requires the 'fuse' extra: "
-                               'install "mirage-ai[fuse]"')
+            raise RuntimeError(
+                "FUSE support requires the 'fuse' extra: install "
+                '"mirage-ai[fuse]" plus the OS driver (macFUSE, fuse3, or '
+                "WinFsp). Setup and support matrix: "
+                "https://mirage.dev/home/setup/fuse")
         self._ops = ops
         self.agent_id = (agent_id or os.environ.get(_ENV_AGENT_ID)
                          or f"agent-{uuid.uuid4().hex[:8]}")


### PR DESCRIPTION
PR E, the last planned piece of the FUSE consolidation arc (#486 #488 #489 #491 #493) that is not blocked.

## What

- **`home/setup/fuse.mdx` (new):** the OS-by-SDK support matrix. Linux (both SDKs, CI-gated), macOS (both SDKs, verified on real kext mounts, one-mount-per-process), Windows (python experimental over WinFsp, advisory CI job green; TypeScript not supported, its binding only targets macOS/Linux), browser (no FUSE). Includes a platform-quirks table (mounts per process, unmount story, pre-open stat behavior, mountpoint conventions).
- **`home/setup/windows.mdx` (new):** WinFsp install (winget / choco / MSI) and the three Windows behaviors surfaced by #493: unmount at process exit, mount-level ownership mapping, and stat-opens-a-handle (size-unknown files hydrate on first per-file stat).
- Python and TS FUSE setup pages link the matrix; the TS page states the no-Windows situation explicitly; the python size-semantics section gains the Windows note.
- The python FUSE import error now names the OS drivers and points at the matrix URL (the TS optional-peer error already carried a docs link).

Docs only, plus one error-message string. Fuse unit tests pass; pre-commit clean.