### PR TITLE
chore(py): clear 10 more modules from mypy baseline (None-guards + type fixes)

### DIFF
--- a/python/mirage/commands/builtin/discord/head.py
+++ b/python/mirage/commands/builtin/discord/head.py
@@ -79,6 +79,7 @@ async def head(
                     "limit": lines
                 },
             )
+            assert isinstance(msgs, list)
             msgs.sort(key=lambda m: int(m["id"]))
             jsonl = "\n".join(
                 json.dumps(m, ensure_ascii=False, separators=(",", ":"))

--- a/python/mirage/commands/builtin/generic/awk.py
+++ b/python/mirage/commands/builtin/generic/awk.py
@@ -144,7 +144,7 @@ def _split_fields(line: str, fs: str | None) -> list[str]:
 def _build_field_map(line: str, fs: str | None, nr: int,
                      variables: Mapping[str, str]) -> dict[str, str]:
     fields = _split_fields(line, fs)
-    field_map = {
+    field_map: dict[str, str] = {
         AwkBuiltin.REC: line,
         AwkBuiltin.NR: str(nr),
         AwkBuiltin.NF: str(len(fields)),

--- a/python/mirage/commands/builtin/generic/du.py
+++ b/python/mirage/commands/builtin/generic/du.py
@@ -29,7 +29,7 @@ async def _du_one(
     h: bool,
     max_depth: int | None,
 ) -> tuple[str, int]:
-    label = path.raw_path
+    label = path.raw_path or path.virtual
 
     if s:
         total = await compute_total(path)
@@ -100,11 +100,13 @@ async def _du_block(
 ) -> tuple[list[str], int]:
     if s or compute_all is None:
         total = await compute_total(p0)
-        return [_format_size(total, h) + "\t" + p0.raw_path], total
+        return [_format_size(total, h) + "\t" + (p0.raw_path or p0.virtual)
+                ], total
     all_entries = await compute_all(p0)
     if not all_entries:
         total = await compute_total(p0)
-        return [_format_size(total, h) + "\t" + p0.raw_path], total
+        return [_format_size(total, h) + "\t" + (p0.raw_path or p0.virtual)
+                ], total
     if not a:
         all_entries = [(p, sz) for p, sz in all_entries if p == p0.virtual]
     if max_depth is not None:
@@ -112,7 +114,8 @@ async def _du_block(
                        if _depth(p, p0.virtual) <= max_depth]
     if not all_entries:
         total = await compute_total(p0)
-        return [_format_size(total, h) + "\t" + p0.raw_path], total
+        return [_format_size(total, h) + "\t" + (p0.raw_path or p0.virtual)
+                ], total
     lines = [_format_size(sz, h) + "\t" + p for p, sz in all_entries]
     return lines, sum(sz for _, sz in all_entries)
 

--- a/python/mirage/commands/builtin/generic/jq.py
+++ b/python/mirage/commands/builtin/generic/jq.py
@@ -12,6 +12,8 @@ async def _read_stdin_bytes(
         stdin: AsyncIterator[bytes] | bytes | None) -> bytes:
     if isinstance(stdin, bytes):
         return stdin
+    if stdin is None:
+        return b""
     raw = b""
     async for chunk in stdin:
         raw += chunk

--- a/python/mirage/commands/spec/parser.py
+++ b/python/mirage/commands/spec/parser.py
@@ -249,7 +249,11 @@ def parse_command(
                                         and mixed[2] is None):
                 # A declared value flag (alone or ending a cluster) with no
                 # argument left on the line. GNU reports the flag character.
-                needy = tok[1:] if tok in value_flags else mixed[1][1:]
+                if tok in value_flags:
+                    needy = tok[1:]
+                else:
+                    assert mixed is not None
+                    needy = mixed[1][1:]
                 needs_value_options.append(needy)
             else:
                 # GNU reports the first offending character, not the token.

--- a/python/mirage/context/session_context.py
+++ b/python/mirage/context/session_context.py
@@ -82,7 +82,8 @@ def assert_mount_allowed(mount_prefix: str) -> None:
     if _session_mode(mount_prefix) is not None:
         return
     sess = _current_session.get()
-    raise PermissionError(f"session {sess.session_id!r} not allowed to "
+    sid = sess.session_id if sess is not None else "<none>"
+    raise PermissionError(f"session {sid!r} not allowed to "
                           f"access mount {_norm_prefix(mount_prefix)!r}")
 
 

--- a/python/mirage/core/chroma/read.py
+++ b/python/mirage/core/chroma/read.py
@@ -13,6 +13,7 @@ async def read_bytes(accessor,
     resolved = await resolve_path(accessor, path, index)
     if resolved.is_dir:
         raise IsADirectoryError(errno.EISDIR, "Is a directory", path.virtual)
+    assert resolved.entry is not None
     text = await fetch_page_chunks(accessor, resolved.entry.extra["slug"])
     return text.encode()
 
@@ -24,6 +25,7 @@ async def read_stream(
     resolved = await resolve_path(accessor, path, index)
     if resolved.is_dir:
         raise IsADirectoryError(errno.EISDIR, "Is a directory", path.virtual)
+    assert resolved.entry is not None
     first = True
     async for chunk in iter_page_chunks(accessor,
                                         resolved.entry.extra["slug"]):

--- a/python/mirage/core/dify/read.py
+++ b/python/mirage/core/dify/read.py
@@ -14,6 +14,7 @@ async def read_bytes(accessor,
     resolved = await resolve_path(accessor, path, index)
     if resolved.is_dir:
         raise IsADirectoryError(errno.EISDIR, "Is a directory", path.virtual)
+    assert resolved.entry is not None
     segments = await get_document_segments(accessor.config, resolved.entry.id)
     return segments_to_bytes(segments)
 
@@ -25,6 +26,7 @@ async def read_stream(
     resolved = await resolve_path(accessor, path, index)
     if resolved.is_dir:
         raise IsADirectoryError(errno.EISDIR, "Is a directory", path.virtual)
+    assert resolved.entry is not None
     first = True
     async for page in iter_segment_pages(accessor.config, resolved.entry.id):
         for segment in page:

--- a/python/mirage/shell/helpers.py
+++ b/python/mirage/shell/helpers.py
@@ -27,7 +27,7 @@ class ProcessSubDirection(StrEnum):
 
 def get_text(node: tree_sitter.Node) -> str:
     """Get the text content of a node."""
-    return node.text.decode()
+    return (node.text or b"").decode()
 
 
 def get_command_name(node: tree_sitter.Node) -> str:

--- a/python/mirage/workspace/expand/node.py
+++ b/python/mirage/workspace/expand/node.py
@@ -20,6 +20,7 @@ import tree_sitter
 from mirage.shell.arith import evaluate_arith
 from mirage.shell.call_stack import CallStack
 from mirage.shell.errors import ArithError
+from mirage.shell.helpers import get_text
 from mirage.shell.types import NodeType as NT
 from mirage.utils.path import expand_tilde
 from mirage.workspace.expand.constants import ARITH_DELIMITERS, ARITH_OPERATORS
@@ -61,15 +62,15 @@ async def expand_arith(
             parts.append(await expand_arith(child, session, execute_fn,
                                             call_stack))
         elif child.type in ARITH_OPERATORS:
-            parts.append(child.text.decode())
+            parts.append(get_text(child))
         elif child.type == NT.NUMBER:
-            parts.append(child.text.decode())
+            parts.append(get_text(child))
         elif child.type in (NT.SIMPLE_EXPANSION, NT.EXPANSION,
                             NT.COMMAND_SUBSTITUTION):
             parts.append(await expand_node(child, session, execute_fn,
                                            call_stack))
         elif child.type == NT.VARIABLE_NAME:
-            parts.append(child.text.decode())
+            parts.append(get_text(child))
         else:
             parts.append(await expand_node(child, session, execute_fn,
                                            call_stack))
@@ -86,11 +87,11 @@ async def expand_node(
     ntype = ts_node.type
 
     if ntype == NT.WORD:
-        word = _unescape_unquoted(ts_node.text.decode())
+        word = _unescape_unquoted(get_text(ts_node))
         return expand_tilde(word, home_dir(session))
 
     if ntype == NT.NUMBER:
-        return ts_node.text.decode()
+        return get_text(ts_node)
 
     if ntype == NT.COMMAND_NAME:
         # The name is a word like any other: $CMD, "quoted", $(sub) all
@@ -98,10 +99,10 @@ async def expand_node(
         # through to its own expansion rule.
         for child in ts_node.named_children:
             return await expand_node(child, session, execute_fn, call_stack)
-        return ts_node.text.decode()
+        return get_text(ts_node)
 
     if ntype == NT.SIMPLE_EXPANSION:
-        raw = ts_node.text.decode()
+        raw = get_text(ts_node)
         dollar = raw.rfind("$")
         prefix = raw[:dollar]
         var = raw[dollar + 1:]
@@ -119,7 +120,7 @@ async def expand_node(
         ]
         if not inner_cmds:
             return ""
-        inner = inner_cmds[0].text.decode()
+        inner = get_text(inner_cmds[0])
         io = await execute_fn(inner, session_id=session.session_id)
         return (await io.stdout_str()).rstrip("\n")
 
@@ -128,7 +129,7 @@ async def expand_node(
         try:
             value, updates = evaluate_arith(expr, session.env)
         except ArithError:
-            return ts_node.text.decode()
+            return get_text(ts_node)
         session.env.update(updates)
         return str(value)
 
@@ -156,7 +157,7 @@ async def expand_node(
     if ntype == NT.STRING_CONTENT:
         # Bash double-quote escapes: \$, \`, \", \\, \<newline>.
         # Everything else preserves the backslash literally.
-        text = ts_node.text.decode()
+        text = get_text(ts_node)
         text = text.replace("\\\\", "\x00")
         text = text.replace('\\"', '"')
         text = text.replace("\\$", "$")
@@ -166,11 +167,11 @@ async def expand_node(
         return text
 
     if ntype == NT.RAW_STRING:
-        raw = ts_node.text.decode()
+        raw = get_text(ts_node)
         return raw[1:-1]
 
     if ntype == NT.VARIABLE_ASSIGNMENT:
-        raw = ts_node.text.decode()
+        raw = get_text(ts_node)
         if "=" in raw:
             key, _, val_part = raw.partition("=")
             val_nodes = [
@@ -183,4 +184,4 @@ async def expand_node(
             return f"{key}={val_part}"
         return raw
 
-    return ts_node.text.decode()
+    return get_text(ts_node)

--- a/python/mirage/workspace/expand/parts.py
+++ b/python/mirage/workspace/expand/parts.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 import tree_sitter
 
 from mirage.shell.call_stack import CallStack
+from mirage.shell.helpers import get_text
 from mirage.shell.types import NodeType as NT
 from mirage.types import PathSpec
 from mirage.workspace.expand.classify import classify_word
@@ -27,7 +28,7 @@ from mirage.workspace.session import Session
 
 def _has_at_expansion(node: tree_sitter.Node) -> bool:
     for child in node.children:
-        if (child.type == NT.SIMPLE_EXPANSION and child.text.decode() == "$@"):
+        if (child.type == NT.SIMPLE_EXPANSION and get_text(child) == "$@"):
             return True
     return False
 
@@ -47,9 +48,9 @@ def _array_at_name(child: tree_sitter.Node) -> str | None:
     var_name = None
     for sc in sub.named_children:
         if sc.type == NT.VARIABLE_NAME:
-            var_name = sc.text.decode()
+            var_name = get_text(sc)
         else:
-            idx_text = sc.text.decode()
+            idx_text = get_text(sc)
     if var_name and idx_text == "@":
         return var_name
     return None

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -247,6 +247,7 @@ warn_redundant_casts = true
 
 
 
+
 # Ratchet baseline: modules with pre-existing mypy errors. Shrink this
 # list, never grow it: when a module is cleaned, delete its entry so
 # regressions in it fail CI. New modules must not be added here.
@@ -267,11 +268,9 @@ module = [
     "mirage.cache.index.redis",
     "mirage.commands",
     "mirage.commands.builtin.discord.grep",
-    "mirage.commands.builtin.discord.head",
     "mirage.commands.builtin.email.email_triage",
     "mirage.commands.builtin.general.bc",
     "mirage.commands.builtin.general.wget",
-    "mirage.commands.builtin.generic.awk",
     "mirage.commands.builtin.generic.base64_cmd",
     "mirage.commands.builtin.generic.cmp",
     "mirage.commands.builtin.generic.column",
@@ -281,14 +280,12 @@ module = [
     "mirage.commands.builtin.generic.crossmount.relay.mv",
     "mirage.commands.builtin.generic.csplit",
     "mirage.commands.builtin.generic.diff",
-    "mirage.commands.builtin.generic.du",
     "mirage.commands.builtin.generic.find",
     "mirage.commands.builtin.generic.grep",
     "mirage.commands.builtin.generic.gunzip",
     "mirage.commands.builtin.generic.gzip",
     "mirage.commands.builtin.generic.iconv",
     "mirage.commands.builtin.generic.join",
-    "mirage.commands.builtin.generic.jq",
     "mirage.commands.builtin.generic.look",
     "mirage.commands.builtin.generic.ls",
     "mirage.commands.builtin.generic.mv",
@@ -389,11 +386,7 @@ module = [
     "mirage.commands.builtin.utils.copy",
     "mirage.commands.builtin.utils.safeguard",
     "mirage.commands.config",
-    "mirage.commands.spec.parser",
-    "mirage.context.session_context",
-    "mirage.core.chroma.read",
     "mirage.core.databricks_volume.readdir",
-    "mirage.core.dify.read",
     "mirage.core.discord.readdir",
     "mirage.core.disk.append",
     "mirage.core.disk.copy",
@@ -572,8 +565,6 @@ module = [
     "mirage.workspace.executor.pipes",
     "mirage.workspace.executor.redirect",
     "mirage.workspace.expand.globs",
-    "mirage.workspace.expand.node",
-    "mirage.workspace.expand.parts",
     "mirage.workspace.mount.mount",
     "mirage.workspace.mount.registry",
     "mirage.workspace.node.command_dispatch",


### PR DESCRIPTION
Continues the incremental mypy-baseline shrink (after #500/#501/#506). Baseline **333 → 323 modules**, all fixes test-verified.

Genuine per-module typing fixes (no mechanical sweep):
- **dify/chroma read**: assert `entry` non-None after the `is_dir` guard — `resolve_path` only returns `is_dir=False` with a real entry, an invariant mypy can't see across fields.
- **jq**: guard `None` stdin; **discord/head**: narrow `msgs` to `list` before `.sort`.
- **session_context**: None-safe session id in the PermissionError message.
- **du**: `label`/`raw_path` fall back to `path.virtual` (`raw_path` is `str | None`).
- **expand/node, expand/parts**: route tree-sitter `node.text` through a now-None-safe `get_text()` instead of `.text.decode()`.
- **awk**: `field_map` typed `dict[str, str]`; **spec/parser**: assert `mixed` non-None in the needy branch.

mypy green, pre-commit green, full pytest green.

Deliberately left baselined: the `PathSpec | str` readdir union-attrs (slack/discord/sharepoint) are the load-bearing str-tolerance zone (the class that broke 402 tests when removed mechanically); the `bytes | AsyncIterator` narrowing cluster (safeguard/agents/discord-grep) is a separate careful follow-up.