### PR TITLE
feat(ts): js sandbox reads and writes workspace mounts

### DIFF
--- a/docs/typescript/runtime/javascript.mdx
+++ b/docs/typescript/runtime/javascript.mdx
@@ -9,7 +9,7 @@ two names for the same command family. One runtime ships today:
 
 | Runtime | Engine | Filesystem | Default |
 | --- | --- | --- | --- |
-| `quickjs` | [quickjs-emscripten](https://github.com/justjake/quickjs-emscripten), quickjs compiled to WebAssembly (browser + Node) | None: no host filesystem, no mounts, no network | Yes |
+| `quickjs` | [quickjs-emscripten](https://github.com/justjake/quickjs-emscripten), quickjs compiled to WebAssembly (browser + Node) | Workspace mounts only, bridged through Mirage; no host filesystem, no network | Yes |
 
 ## What it is for
 
@@ -33,9 +33,10 @@ Three input forms, mirroring `python3`:
   run, so a mounted script executes.
 - **stdin** with no `-e` or file runs the piped text as the program.
 
-`scriptArgs` holds the arguments after the code or script, and
-`std.in.readAsString()` reads piped stdin. These match the Python
-`quickjs` runtime, so a script behaves the same in both languages.
+`scriptArgs` holds the arguments after the code or script,
+`std.in.readAsString()` reads piped stdin, and `std.open`/`os.readdir`
+reach workspace mounts (see [Isolation](#isolation)). These match the
+Python `quickjs` runtime, so a script behaves the same in both languages.
 
 ## Modules
 
@@ -50,16 +51,17 @@ js -m -e "const x = await Promise.resolve(41); console.log(x + 1)"
 ## Isolation
 
 The engine runs under WebAssembly capability isolation: it sees only what
-the run passes it. Host files, mounts, and the network are all invisible,
-and file I/O inside the code cannot reach workspace mounts. The `node`/`js`
-command still resolves a script *file* through the workspace before running
-it, so `node /data/script.mjs` works, but reading another mount path inside
-the code does not.
+the run passes it. Host files and the network are invisible.
 
-Known gap: the Python `quickjs` runtime bridges the sandbox's file I/O
-into the workspace mounts (it intercepts the engine's WASI filesystem
-imports); quickjs-emscripten exposes no equivalent seam, so TypeScript
-sandbox code cannot reach mounts yet.
+Workspace mounts are visible with no setup: `std.open('/data/f.txt', 'r')`
+reads the mount and `os.readdir('/data')` lists it, bridged through the
+workspace dispatch so the code sees exactly what `cat` sees, with the same
+cache and write modes. Writes are visible to every command once the file is
+closed, and a read-only mount (or a session narrowed to read) fails the
+open, so `std.open` returns `null` instead of writing. The engine runs on
+quickjs-emscripten's asyncify build, which lets `std.open` suspend the run
+while a mount read or write awaits the dispatch, matching the Python
+`quickjs` runtime's live file I/O.
 
 This is capability isolation, not a resource sandbox: the sandboxed code
 cannot reach your files or the network, but CPU and memory are bounded only

--- a/integ/cli_runtime.sh
+++ b/integ/cli_runtime.sh
@@ -150,9 +150,9 @@ YML
 # Wasm sandbox mount access (Python daemon only: the py wasi/quickjs
 # runtimes intercept the guest's filesystem imports and bridge them
 # through the workspace dispatch, so sandboxed python3/js code reads AND
-# writes virtual mounts with no FUSE and no host directory. TS quickjs
-# is quickjs-emscripten (no mount bridge), a documented gap, hence no
-# ts probe.
+# writes virtual mounts with no FUSE and no host directory. The TS
+# daemon runs the same js probe on quickjs-emscripten (see
+# sandbox_probe_ts), which bridges std.open/os.readdir to the dispatch.
 sandbox_probe() {
   local cli="$1"
   local yaml="/tmp/cli-runtime-sbx.yaml"
@@ -176,6 +176,29 @@ YML
   $cli execute -w sbx -c "python3 -c \"import os; os.mkdir('/data/sub'); open('/data/sub/n.txt','w').write('nested'); os.rename('/data/sub/n.txt','/data/sub/m.txt')\"" </dev/null >/dev/null
   echo "sbx_py3_dirops=$($cli execute -w sbx -c 'cat /data/sub/m.txt' </dev/null | grep -o nested | head -1)"
   $cli workspace delete sbx >/dev/null 2>&1 </dev/null || true
+  rm -f "$yaml"
+}
+
+# TS js mount access on quickjs-emscripten (bundled, no wasm download).
+# The default runtimes (js quickjs, python pyodide) both bridge mounts;
+# this probes the js side, the newly-closed parity gap.
+sandbox_probe_ts() {
+  local cli="$1"
+  local yaml="/tmp/cli-runtime-sbx-ts.yaml"
+  cat > "$yaml" <<YML
+mode: EXEC
+mounts:
+  /data:
+    resource: ram
+YML
+  $cli workspace delete sbxts >/dev/null 2>&1 </dev/null || true
+  $cli workspace create "$yaml" --id sbxts >/dev/null </dev/null
+  $cli execute -w sbxts -c 'echo sandbox-sees-me > /data/probe.txt' </dev/null >/dev/null
+  echo "sbx_js_read=$($cli execute -w sbxts -c "js -e \"const f = std.open('/data/probe.txt', 'r'); console.log(f.readAsString().trim())\"" </dev/null | grep -o sandbox-sees-me | head -1)"
+  $cli execute -w sbxts -c "js -e \"const w = std.open('/data/from-js.txt', 'w'); w.puts('js-wrote-this'); w.close()\"" </dev/null >/dev/null
+  echo "sbx_js_write=$($cli execute -w sbxts -c 'cat /data/from-js.txt' </dev/null | grep -o js-wrote-this | head -1)"
+  echo "sbx_js_readdir=$($cli execute -w sbxts -c "js -e \"const [n] = os.readdir('/data'); console.log(n.includes('probe.txt') ? 'listed' : 'no')\"" </dev/null | grep -o listed | head -1)"
+  $cli workspace delete sbxts >/dev/null 2>&1 </dev/null || true
   rm -f "$yaml"
 }
 
@@ -203,6 +226,16 @@ fi
 echo
 echo "===== typescript cli ====="
 probe "$TS_CLI" ts 9440 pyodide monty local | tee /tmp/cli-runtime-ts.txt
+
+echo
+echo "===== js sandbox mount access (typescript daemon) ====="
+export MIRAGE_HOME
+MIRAGE_HOME="$(mktemp -d /tmp/cli-runtime-sbxts-home.XXXXXX)"
+"$TS_CLI" config set port 9441 >/dev/null </dev/null
+"$TS_CLI" config set url "http://127.0.0.1:9441" >/dev/null </dev/null
+sandbox_probe_ts "$TS_CLI" | tee -a /tmp/cli-runtime-ts.txt
+"$TS_CLI" daemon stop >/dev/null 2>&1 </dev/null || true
+sleep 1
 
 echo
 echo "===== expected values ====="
@@ -241,6 +274,9 @@ expect /tmp/cli-runtime-ts.txt "sg_exec" "exit124"
 expect /tmp/cli-runtime-ts.txt "sg_msg" "python3: timed out after"
 expect /tmp/cli-runtime-ts.txt "wasip_msg" "unknown pyodide runtime option"
 expect /tmp/cli-runtime-ts.txt "js_out" "42"
+expect /tmp/cli-runtime-ts.txt "sbx_js_read" "sandbox-sees-me"
+expect /tmp/cli-runtime-ts.txt "sbx_js_write" "js-wrote-this"
+expect /tmp/cli-runtime-ts.txt "sbx_js_readdir" "listed"
 
 py_invalid="$(grep -F 'invalid_create=' /tmp/cli-runtime-py.txt | head -1 | cut -d= -f2-)"
 ts_invalid="$(grep -F 'invalid_create=' /tmp/cli-runtime-ts.txt | head -1 | cut -d= -f2-)"

--- a/integ/cli_runtime.sh
+++ b/integ/cli_runtime.sh
@@ -231,10 +231,11 @@ echo
 echo "===== js sandbox mount access (typescript daemon) ====="
 export MIRAGE_HOME
 MIRAGE_HOME="$(mktemp -d /tmp/cli-runtime-sbxts-home.XXXXXX)"
-"$TS_CLI" config set port 9441 >/dev/null </dev/null
-"$TS_CLI" config set url "http://127.0.0.1:9441" >/dev/null </dev/null
+# $TS_CLI is multi-word ("node .../mirage.js") so it must expand unquoted.
+$TS_CLI config set port 9441 >/dev/null </dev/null
+$TS_CLI config set url "http://127.0.0.1:9441" >/dev/null </dev/null
 sandbox_probe_ts "$TS_CLI" | tee -a /tmp/cli-runtime-ts.txt
-"$TS_CLI" daemon stop >/dev/null 2>&1 </dev/null || true
+$TS_CLI daemon stop >/dev/null 2>&1 </dev/null || true
 sleep 1
 
 echo

--- a/typescript/packages/core/src/workspace/executor/js/interface.ts
+++ b/typescript/packages/core/src/workspace/executor/js/interface.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { BridgeDispatchFn } from '../python/mirage_bridge.ts'
 import type { JsRunArgs, JsRunResult } from './types.ts'
 
 export const QUICKJS_RUNTIME = 'quickjs'
@@ -22,11 +23,25 @@ export const JS_RUNTIMES = [QUICKJS_RUNTIME] as const
 export const DEFAULT_JS_RUNTIME = JS_RUNTIMES[0]
 
 /**
+ * Construction options a JavaScript runtime accepts.
+ *
+ * `workspaceBridge` and `listMounts` wire the engine's `std.open` /
+ * `os.readdir` to the workspace dispatch, so guest file I/O reaches the
+ * mounts (the same bridge the sandboxed Python runtimes take). Omit them
+ * for an engine with no filesystem.
+ */
+export interface JsRuntimeOptions {
+  workspaceBridge?: BridgeDispatchFn
+  listMounts?: () => string[]
+}
+
+/**
  * A JavaScript engine the workspace can execute `node`/`js` code on.
  *
  * Implementations own their engine lifecycle (lazy boot, reuse across
- * runs, teardown in `close`). Like the sandboxed Python runtimes, the
- * engine sees only what the run passes it, not workspace mounts.
+ * runs, teardown in `close`). With a workspace bridge the engine sees
+ * the workspace mounts through `std.open`/`os.readdir`; without one it
+ * sees an empty filesystem.
  */
 export interface JsRuntime {
   readonly name: string

--- a/typescript/packages/core/src/workspace/executor/js/mirage_fs.ts
+++ b/typescript/packages/core/src/workspace/executor/js/mirage_fs.ts
@@ -1,0 +1,244 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { MirageBridge } from '../python/mirage_bridge.ts'
+import type { QuickJSAsyncContext, QuickJSHandle } from 'quickjs-emscripten'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder('utf-8', { fatal: false })
+
+// quickjs-ng os.readdir errno for a path that is not a directory / not
+// found; the guest reads it as the second tuple element.
+const ENOENT = 2
+
+interface GuestFile {
+  path: string
+  buf: Uint8Array
+  pos: number
+  dirty: boolean
+  writable: boolean
+}
+
+// The `std.open`/`os.readdir` surface that qjs-wasi exposes natively,
+// synthesized here over the workspace bridge so quickjs-emscripten
+// matches it. Whole-file buffering mirrors the Python `WasiFs`: open
+// fetches the bytes (or starts empty), the byte-level calls touch the
+// in-memory buffer, and close flushes a dirty buffer back through
+// dispatch. Only open, close, and readdir cross the async bridge, so
+// they are asyncified host functions (the guest suspends until the
+// dispatch resolves); the byte-level calls are synchronous.
+//
+// The JS bootstrap that wires these host functions into `std`/`os`.
+// Appended after the main quickjs bootstrap, which defines `std`.
+export const MIRAGE_FS_BOOTSTRAP = `
+std.open = (path, mode) => {
+  const fd = __mirage_open(String(path), String(mode === undefined ? 'r' : mode));
+  if (fd < 0) return null;
+  return {
+    readAsString: (max) => __mirage_read(fd, max === undefined ? -1 : (max | 0)),
+    read: () => __mirage_read(fd, -1),
+    getline: () => __mirage_getline(fd),
+    puts: (s) => { __mirage_write(fd, String(s)); },
+    write: (s) => { __mirage_write(fd, String(s)); return String(s).length; },
+    seek: (offset, whence) => { __mirage_seek(fd, offset | 0, whence === undefined ? 0 : (whence | 0)); return 0; },
+    tell: () => __mirage_tell(fd),
+    eof: () => __mirage_eof(fd),
+    flush: () => {},
+    close: () => { __mirage_close(fd); return 0; },
+  };
+};
+globalThis.os = globalThis.os || {};
+os.readdir = (path) => __mirage_readdir(String(path));
+`
+
+function isWritable(mode: string): boolean {
+  return /[wax+]/.test(mode)
+}
+
+function writeAt(file: GuestFile, bytes: Uint8Array): void {
+  const end = file.pos + bytes.length
+  if (end > file.buf.length) {
+    const grown = new Uint8Array(end)
+    grown.set(file.buf)
+    file.buf = grown
+  }
+  file.buf.set(bytes, file.pos)
+  file.pos = end
+  file.dirty = true
+}
+
+/**
+ * Install the `std.open`/`os.readdir` host functions on an asyncified
+ * quickjs context, backed by the workspace bridge. A null bridge (no
+ * workspace mounts wired) still installs the surface, but every open
+ * and readdir fails cleanly — `std.open` returns null and `os.readdir`
+ * reports ENOENT — so guest code sees an empty filesystem rather than a
+ * missing global.
+ *
+ * @param ctx - the asyncified quickjs context
+ * @param bridge - the workspace bridge, or null when no mounts are wired
+ */
+export function installMirageFs(ctx: QuickJSAsyncContext, bridge: MirageBridge | null): void {
+  const table = new Map<number, GuestFile>()
+  let nextFd = 1
+
+  const underMount = (path: string): boolean => {
+    if (bridge === null) return false
+    return bridge.prefixes().some((p) => path === p.slice(0, -1) || path.startsWith(p))
+  }
+
+  const defineAsync = (
+    name: string,
+    fn: (...args: QuickJSHandle[]) => Promise<QuickJSHandle>,
+  ): void => {
+    const handle = ctx.newAsyncifiedFunction(name, fn)
+    ctx.setProp(ctx.global, name, handle)
+    handle.dispose()
+  }
+
+  const defineSync = (name: string, fn: (...args: QuickJSHandle[]) => QuickJSHandle): void => {
+    const handle = ctx.newFunction(name, fn)
+    ctx.setProp(ctx.global, name, handle)
+    handle.dispose()
+  }
+
+  defineAsync('__mirage_open', async (pathH, modeH) => {
+    const path = ctx.getString(pathH)
+    const mode = ctx.getString(modeH)
+    if (bridge === null || !underMount(path)) return ctx.newNumber(-1)
+    const truncate = mode.includes('w')
+    const append = mode.includes('a')
+    const writable = isWritable(mode)
+    let buf: Uint8Array = new Uint8Array()
+    let existed = false
+    if (!truncate) {
+      try {
+        buf = await bridge.fetch(path)
+        existed = true
+      } catch {
+        if (!writable) return ctx.newNumber(-1)
+      }
+    }
+    // Truncate or create writes through the bridge at open, mirroring
+    // the Python runtime: this enforces write modes (a read-only mount
+    // or a read-narrowed session throws here, so the guest gets null)
+    // and establishes the file before the buffered writes.
+    if (truncate || (writable && !existed)) {
+      try {
+        await bridge.flush(path, buf)
+      } catch {
+        return ctx.newNumber(-1)
+      }
+    }
+    const fd = nextFd++
+    table.set(fd, {
+      path,
+      buf,
+      pos: append ? buf.length : 0,
+      dirty: false,
+      writable,
+    })
+    return ctx.newNumber(fd)
+  })
+
+  defineAsync('__mirage_close', async (fdH) => {
+    const file = table.get(ctx.getNumber(fdH))
+    if (file === undefined) return ctx.undefined
+    table.delete(ctx.getNumber(fdH))
+    if (file.dirty && file.writable && bridge !== null) {
+      await bridge.flush(file.path, file.buf)
+    }
+    return ctx.undefined
+  })
+
+  defineAsync('__mirage_readdir', async (pathH) => {
+    const path = ctx.getString(pathH)
+    const names: string[] = []
+    let errno = 0
+    if (bridge === null || !underMount(path)) {
+      errno = ENOENT
+    } else {
+      try {
+        const prefix = path.endsWith('/') ? path : path + '/'
+        for (const entry of await bridge.list(prefix)) {
+          const rel = entry.path.replace(/\/$/, '').slice(prefix.length)
+          if (rel.length > 0 && !rel.includes('/')) names.push(rel)
+        }
+        names.sort()
+      } catch {
+        errno = ENOENT
+      }
+    }
+    const namesArr = ctx.newArray()
+    names.forEach((name, i) => {
+      const s = ctx.newString(name)
+      ctx.setProp(namesArr, i, s)
+      s.dispose()
+    })
+    const tuple = ctx.newArray()
+    ctx.setProp(tuple, 0, namesArr)
+    namesArr.dispose()
+    const errH = ctx.newNumber(errno)
+    ctx.setProp(tuple, 1, errH)
+    errH.dispose()
+    return tuple
+  })
+
+  defineSync('__mirage_read', (fdH, maxH) => {
+    const file = table.get(ctx.getNumber(fdH))
+    if (file === undefined) return ctx.newString('')
+    const max = ctx.getNumber(maxH)
+    const end = max < 0 ? file.buf.length : Math.min(file.buf.length, file.pos + max)
+    const slice = file.buf.subarray(file.pos, end)
+    file.pos = end
+    return ctx.newString(DEC.decode(slice))
+  })
+
+  defineSync('__mirage_getline', (fdH) => {
+    const file = table.get(ctx.getNumber(fdH))
+    if (file === undefined || file.pos >= file.buf.length) return ctx.null
+    let end = file.pos
+    while (end < file.buf.length && file.buf[end] !== 0x0a) end++
+    const line = file.buf.subarray(file.pos, end)
+    file.pos = end < file.buf.length ? end + 1 : end
+    return ctx.newString(DEC.decode(line))
+  })
+
+  defineSync('__mirage_write', (fdH, textH) => {
+    const file = table.get(ctx.getNumber(fdH))
+    if (file?.writable) writeAt(file, ENC.encode(ctx.getString(textH)))
+    return ctx.undefined
+  })
+
+  defineSync('__mirage_seek', (fdH, offsetH, whenceH) => {
+    const file = table.get(ctx.getNumber(fdH))
+    if (file === undefined) return ctx.undefined
+    const offset = ctx.getNumber(offsetH)
+    const whence = ctx.getNumber(whenceH)
+    const base = whence === 1 ? file.pos : whence === 2 ? file.buf.length : 0
+    file.pos = Math.max(0, base + offset)
+    return ctx.undefined
+  })
+
+  defineSync('__mirage_tell', (fdH) => {
+    const file = table.get(ctx.getNumber(fdH))
+    return ctx.newNumber(file === undefined ? -1 : file.pos)
+  })
+
+  defineSync('__mirage_eof', (fdH) => {
+    const file = table.get(ctx.getNumber(fdH))
+    const atEof = file === undefined || file.pos >= file.buf.length
+    return atEof ? ctx.true : ctx.false
+  })
+}

--- a/typescript/packages/core/src/workspace/executor/js/quickjs.ts
+++ b/typescript/packages/core/src/workspace/executor/js/quickjs.ts
@@ -12,16 +12,22 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { QUICKJS_RUNTIME, type JsRuntime } from './interface.ts'
+import {
+  createMirageBridge,
+  type BridgeDispatchFn,
+  type MirageBridge,
+} from '../python/mirage_bridge.ts'
+import { QUICKJS_RUNTIME, type JsRuntime, type JsRuntimeOptions } from './interface.ts'
+import { installMirageFs, MIRAGE_FS_BOOTSTRAP } from './mirage_fs.ts'
 import { QuickJsUnavailableError, type JsRunArgs, type JsRunResult } from './types.ts'
 import type {
-  QuickJSContext,
+  QuickJSAsyncContext,
+  QuickJSAsyncRuntime,
+  QuickJSAsyncWASMModule,
   QuickJSHandle,
-  QuickJSRuntime,
-  QuickJSWASMModule,
 } from 'quickjs-emscripten'
 
-type GetQuickJS = () => Promise<QuickJSWASMModule>
+type NewAsyncModule = () => Promise<QuickJSAsyncWASMModule>
 
 const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
@@ -32,7 +38,8 @@ const STACK_SIZE = 1024 * 1024
 // Assembles the std/console/scriptArgs surface from injected primitives.
 // Kept identical to the quickjs-ng `--std` globals the Python runtime
 // exposes, so a script runs the same on both: `std.in.readAsString()`,
-// `std.exit()`, `console.log`, `scriptArgs`.
+// `std.exit()`, `console.log`, `scriptArgs`. `std.open`/`os.readdir` are
+// added afterward by MIRAGE_FS_BOOTSTRAP when a workspace bridge is wired.
 const BOOTSTRAP = `
 const __fmt = (v) =>
   typeof v === 'string' ? v
@@ -56,15 +63,25 @@ globalThis.std = {
 
 // quickjs-emscripten bundles its own wasm, so the `home` option the
 // config accepts (for parity with the Python quickjs runtime, which
-// locates qjs-wasi.wasm) has nothing to locate here and is ignored.
+// locates qjs-wasi.wasm) has nothing to locate here and is ignored. The
+// asyncify variant is used so `std.open`/`os.readdir` can suspend the
+// guest while a workspace-mount read or write awaits the dispatch,
+// matching the Python runtime's live file I/O.
 export class QuickJsRuntime implements JsRuntime {
   readonly name = QUICKJS_RUNTIME
-  private getQuickJS: GetQuickJS | null = null
+  private newAsyncModule: NewAsyncModule | null = null
+  private readonly workspaceBridge: BridgeDispatchFn | null
+  private readonly listMounts: () => string[]
+
+  constructor(options: JsRuntimeOptions = {}) {
+    this.workspaceBridge = options.workspaceBridge ?? null
+    this.listMounts = options.listMounts ?? ((): string[] => [])
+  }
 
   async run(args: JsRunArgs): Promise<JsRunResult> {
-    const getQuickJS = await this.loadModule()
-    const QuickJS = await getQuickJS()
-    const runtime = QuickJS.newRuntime()
+    const newAsyncModule = await this.loadModule()
+    const QuickJS = await newAsyncModule()
+    const runtime: QuickJSAsyncRuntime = QuickJS.newRuntime()
     runtime.setMemoryLimit(MEMORY_LIMIT)
     runtime.setMaxStackSize(STACK_SIZE)
     const ctx = runtime.newContext()
@@ -73,14 +90,20 @@ export class QuickJsRuntime implements JsRuntime {
     const exit = { code: 0, called: false }
     try {
       this.installGlobals(ctx, args, out, err, exit)
-      const boot = ctx.evalCode(BOOTSTRAP, 'mirage:bootstrap')
+      const bridge: MirageBridge | null =
+        this.workspaceBridge !== null
+          ? createMirageBridge(this.workspaceBridge, this.listMounts)
+          : null
+      installMirageFs(ctx, bridge)
+
+      const boot = ctx.evalCode(BOOTSTRAP + MIRAGE_FS_BOOTSTRAP, 'mirage:bootstrap')
       if (boot.error) {
         boot.error.dispose()
         throw new Error('quickjs bootstrap failed')
       }
       boot.value.dispose()
 
-      const result = ctx.evalCode(args.code, args.module ? 'input.mjs' : 'input.js', {
+      const result = await ctx.evalCodeAsync(args.code, args.module ? 'input.mjs' : 'input.js', {
         type: args.module ? 'module' : 'global',
       })
       let exitCode = 0
@@ -114,7 +137,7 @@ export class QuickJsRuntime implements JsRuntime {
   }
 
   private installGlobals(
-    ctx: QuickJSContext,
+    ctx: QuickJSAsyncContext,
     args: JsRunArgs,
     out: string[],
     err: string[],
@@ -155,7 +178,11 @@ export class QuickJsRuntime implements JsRuntime {
     setGlobal('__mirage_env', env)
   }
 
-  private drainJobs(runtime: QuickJSRuntime, ctx: QuickJSContext, err: string[]): number | null {
+  private drainJobs(
+    runtime: QuickJSAsyncRuntime,
+    ctx: QuickJSAsyncContext,
+    err: string[],
+  ): number | null {
     for (;;) {
       const jobs = runtime.executePendingJobs()
       if (jobs.error) {
@@ -167,7 +194,7 @@ export class QuickJsRuntime implements JsRuntime {
     }
   }
 
-  private formatError(ctx: QuickJSContext, handle: QuickJSHandle): string {
+  private formatError(ctx: QuickJSAsyncContext, handle: QuickJSHandle): string {
     const readStr = (key: string): string | undefined => {
       const p = ctx.getProp(handle, key)
       const value: unknown = ctx.dump(p)
@@ -179,17 +206,19 @@ export class QuickJsRuntime implements JsRuntime {
     return `${name}: ${message}`
   }
 
-  private async loadModule(): Promise<GetQuickJS> {
-    if (this.getQuickJS !== null) return this.getQuickJS
+  private async loadModule(): Promise<NewAsyncModule> {
+    if (this.newAsyncModule !== null) return this.newAsyncModule
     try {
-      const mod = (await import('quickjs-emscripten')) as unknown as { getQuickJS: GetQuickJS }
-      this.getQuickJS = mod.getQuickJS
+      const mod = (await import('quickjs-emscripten')) as unknown as {
+        newQuickJSAsyncWASMModule: NewAsyncModule
+      }
+      this.newAsyncModule = mod.newQuickJSAsyncWASMModule
     } catch (err) {
       throw new QuickJsUnavailableError(
         "the quickjs runtime requires the 'quickjs-emscripten' package — install it to run `node`/`js`",
         { cause: err },
       )
     }
-    return this.getQuickJS
+    return this.newAsyncModule
   }
 }

--- a/typescript/packages/core/src/workspace/executor/js/select.ts
+++ b/typescript/packages/core/src/workspace/executor/js/select.ts
@@ -12,7 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { DEFAULT_JS_RUNTIME, QUICKJS_RUNTIME, type JsRuntime } from './interface.ts'
+import {
+  DEFAULT_JS_RUNTIME,
+  QUICKJS_RUNTIME,
+  type JsRuntime,
+  type JsRuntimeOptions,
+} from './interface.ts'
 import { QuickJsRuntime } from './quickjs.ts'
 import { resolveRuntimeOptions, type RuntimeOptions } from '../runtime_options.ts'
 
@@ -20,11 +25,14 @@ import { resolveRuntimeOptions, type RuntimeOptions } from '../runtime_options.t
  * Build the JavaScript runtime for a workspace.
  *
  * @param name - runtime name; undefined means the default (quickjs)
+ * @param options - workspace bridge + mount list, wiring the engine's
+ *   `std.open`/`os.readdir` to the workspace dispatch
  * @param runtimeOptions - per-runtime option blocks; the selected
  *   runtime consumes its own block. Other blocks are ignored.
  */
 export function selectJsRuntime(
   name: string | undefined,
+  options: JsRuntimeOptions = {},
   runtimeOptions?: RuntimeOptions,
 ): JsRuntime {
   const resolved = name ?? DEFAULT_JS_RUNTIME
@@ -32,7 +40,7 @@ export function selectJsRuntime(
     // Validates the quickjs block's keys; `home` is ignored here since
     // quickjs-emscripten bundles its own wasm.
     resolveRuntimeOptions(resolved, runtimeOptions)
-    return new QuickJsRuntime()
+    return new QuickJsRuntime(options)
   }
   throw new Error(`unknown js runtime: ${resolved} (expected 'quickjs')`)
 }

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -276,12 +276,19 @@ export class Workspace {
       {
         ...userPython,
         workspaceBridge: this.buildWorkspaceBridge(),
-        listMounts: () => this.pythonVisibleMounts(),
+        listMounts: () => this.sandboxVisibleMounts(),
       },
       options.runtimeOptions,
     )
     this.closers.push(() => this.pythonRuntime.close())
-    this.jsRuntime = selectJsRuntime(options.jsRuntime, options.runtimeOptions)
+    this.jsRuntime = selectJsRuntime(
+      options.jsRuntime,
+      {
+        workspaceBridge: this.buildWorkspaceBridge(),
+        listMounts: () => this.sandboxVisibleMounts(),
+      },
+      options.runtimeOptions,
+    )
     this.closers.push(() => this.jsRuntime.close())
     this.observer = new Observer(options.observe)
     this.registry.mount(HISTORY_PREFIX, new HistoryViewResource(this.observer), MountMode.READ)
@@ -350,11 +357,12 @@ export class Workspace {
   }
 
   /**
-   * Mount prefixes the Python runtime may see. Excludes the history view
-   * and a synthetic `/` anchor: Pyodide's own `/` filesystem holds the
-   * Python stdlib and must not be hijacked by an internal anchor.
+   * Mount prefixes the sandboxed runtimes (python3 and node/js) may see.
+   * Excludes the history view and a synthetic `/` anchor: Pyodide's own
+   * `/` filesystem holds the Python stdlib and must not be hijacked by an
+   * internal anchor.
    */
-  private pythonVisibleMounts(): string[] {
+  private sandboxVisibleMounts(): string[] {
     const prefixes: string[] = []
     for (const m of this.registry.allMounts()) {
       if (m.prefix === HISTORY_PREFIX || m.prefix === HISTORY_PREFIX + '/') continue
@@ -381,6 +389,15 @@ export class Workspace {
           if (bytes === undefined) throw new Error('WRITE op requires bytes')
           const buf =
             bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes as ArrayLike<number>)
+          // Enforce the mount's mode, narrowed by the current session,
+          // the same way the command dispatch does. The bridge is the
+          // sole write path for the sandboxed runtimes, so a read-only
+          // mount (or a session narrowed to read) denies their writes.
+          const [, , mode] = await this.resolve(path)
+          const capPrefix = this.registry.mountFor(path)?.prefix ?? '/'
+          if (effectiveMountMode(capPrefix, mode) === MountMode.READ) {
+            throw new Error(`mount at '${path}' is read-only`)
+          }
           await this.fs.writeFile(path, buf)
           return undefined
         }

--- a/typescript/packages/core/src/workspace/workspace_js_mount.test.ts
+++ b/typescript/packages/core/src/workspace/workspace_js_mount.test.ts
@@ -1,0 +1,94 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { makeWorkspace, stdoutStr } from './fixtures/workspace_fixture.ts'
+
+// The quickjs runtime's `std.open`/`os.readdir` bridge to the workspace
+// dispatch, so sandboxed JS reaches mounts the same way python3 does.
+describe('node/js: workspace mount access', () => {
+  it('std.open reads a file the shell wrote', async () => {
+    const { ws } = await makeWorkspace()
+    await ws.execute('echo hello-from-shell > /ram/in.txt')
+    const io = await ws.execute(
+      "js -e \"const f = std.open('/ram/in.txt', 'r'); console.log(f.readAsString().trim().toUpperCase()); f.close()\"",
+    )
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe('HELLO-FROM-SHELL\n')
+    await ws.close()
+  }, 60_000)
+
+  it('std.open writes a file cat can read back', async () => {
+    const { ws } = await makeWorkspace()
+    const io = await ws.execute(
+      "js -e \"const f = std.open('/ram/out.txt', 'w'); f.puts('js-wrote-this'); f.close()\"",
+    )
+    expect(io.exitCode).toBe(0)
+    const back = await ws.execute('cat /ram/out.txt')
+    expect(stdoutStr(back)).toBe('js-wrote-this')
+    await ws.close()
+  }, 60_000)
+
+  it('os.readdir lists files written into a fresh subdir', async () => {
+    const { ws } = await makeWorkspace()
+    await ws.execute('mkdir /ram/dir')
+    await ws.execute('echo a > /ram/dir/a.txt')
+    await ws.execute('echo b > /ram/dir/b.txt')
+    const io = await ws.execute(
+      "js -e \"const [names] = os.readdir('/ram/dir'); console.log(names.filter((n) => !n.startsWith('.')).sort().join(','))\"",
+    )
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe('a.txt,b.txt\n')
+    await ws.close()
+  }, 60_000)
+
+  it('a host path outside any mount is invisible (std.open returns null)', async () => {
+    const { ws } = await makeWorkspace()
+    const io = await ws.execute("js -e \"console.log(std.open('/etc/passwd', 'r') === null)\"")
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe('true\n')
+    await ws.close()
+  }, 60_000)
+
+  it('a session narrowed to read denies writes (std.open returns null)', async () => {
+    const { ws } = await makeWorkspace()
+    await ws.execute('echo seeded > /ram/seed.txt')
+    ws.createSession('narrow', { mounts: { '/ram': 'read' } })
+    const io = await ws.execute(
+      "js -e \"const f = std.open('/ram/blocked.txt', 'w'); console.log(f === null ? 'denied' : 'WROTE')\"",
+      { sessionId: 'narrow' },
+    )
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe('denied\n')
+    const check = await ws.execute('cat /ram/blocked.txt', { sessionId: 'narrow' })
+    expect(check.exitCode).not.toBe(0)
+    // The narrowed session still reads.
+    const read = await ws.execute(
+      "js -e \"const f = std.open('/ram/seed.txt', 'r'); console.log(f.readAsString().trim()); f.close()\"",
+      { sessionId: 'narrow' },
+    )
+    expect(stdoutStr(read)).toBe('seeded\n')
+    await ws.close()
+  }, 60_000)
+
+  it('reads its own writes after close within a run (whole-file buffering)', async () => {
+    const { ws } = await makeWorkspace()
+    const io = await ws.execute(
+      "js -e \"const w = std.open('/ram/live.txt', 'w'); w.puts('v1'); w.close(); const r = std.open('/ram/live.txt', 'r'); console.log(r.readAsString()); r.close()\"",
+    )
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe('v1\n')
+    await ws.close()
+  }, 60_000)
+})


### PR DESCRIPTION
Closes the TS side of the sandbox mount-access gap: sandboxed `js` code can now read and write workspace mounts through `std.open` / `os.readdir`, matching the Python runtimes (#508).

- Switch the quickjs runtime to the asyncify variant of quickjs-emscripten; `std.open`/`os.readdir` are asyncified host functions that suspend the guest while the workspace dispatch resolves.
- New `executor/js/mirage_fs.ts`: fd table with whole-file buffering (fetch at open, flush at close), mirroring the Python `WasiFs`. Byte-level ops (read/getline/write/seek/tell/eof) are synchronous over the buffer.
- Open-time mode enforcement: truncate/create flush through the bridge at `open`, so a read-only mount or read-narrowed session returns `null` instead of failing at close.
- `buildWorkspaceBridge` WRITE now checks `effectiveMountMode`, closing a mode-enforcement gap shared by quickjs, pyodide, and monty.
- Tests: 6-case suite (read, write, readdir, host path invisible, session narrowing, read-own-writes); integ `cli_runtime.sh` gains a TS sandbox probe; docs gap note removed.

Follow-up (not here): route the bridge through the cache-aware dispatch so sandbox reads/writes get cache read-through and invalidation on caching backends.