### PR TITLE
Mint UUIDv7 workspace and session ids, drop reserved defaults

### DIFF
--- a/integ/history.py
+++ b/integ/history.py
@@ -80,7 +80,9 @@ EXIT_CODE_CASES: list[tuple[str, str, str]] = [
 
 
 async def main() -> None:
-    ws = Workspace({"/data": RAMResource()}, mode=MountMode.WRITE)
+    ws = Workspace({"/data": RAMResource()},
+                   mode=MountMode.WRITE,
+                   session_id="default")
     ws.create_session("s2")
 
     for name, session, cmd in CASES:

--- a/integ/session_modes.py
+++ b/integ/session_modes.py
@@ -72,6 +72,7 @@ async def main() -> None:
             "/ro": (RAMResource(), MountMode.READ),
         },
         mode=MountMode.WRITE,
+        session_id="default",
     )
     ws.create_session("reader", mounts={"/data": "read"})
     ws.create_session("writer", mounts={"/data": "write"})
@@ -85,6 +86,7 @@ async def main() -> None:
             "/data": (RAMResource(), MountMode.WRITE),
         },
         mode=MountMode.WRITE,
+        session_id="default",
     )
     ws_root.create_session("no_root", mounts={"/data": "write"})
     ws_root.create_session("root_ro", mounts={"/data": "write", "/": "read"})

--- a/integ/session_modes.ts
+++ b/integ/session_modes.ts
@@ -68,7 +68,7 @@ async function main(): Promise<void> {
       '/side': new RAMResource(),
       '/ro': [new RAMResource(), MountMode.READ] as const,
     },
-    { mode: MountMode.WRITE },
+    { mode: MountMode.WRITE, sessionId: 'default' },
   )
   try {
     ws.createSession('reader', { mounts: { '/data': MountMode.READ } })
@@ -82,7 +82,7 @@ async function main(): Promise<void> {
 
   const wsRoot = new Workspace(
     { '/': new RAMResource(), '/data': new RAMResource() },
-    { mode: MountMode.WRITE },
+    { mode: MountMode.WRITE, sessionId: 'default' },
   )
   try {
     wsRoot.createSession('no_root', { mounts: { '/data': MountMode.WRITE } })

--- a/integ/state_store.py
+++ b/integ/state_store.py
@@ -19,6 +19,7 @@ sys.path[:] = [p for p in sys.path if p not in (_INTEG_DIR, "")]
 
 import asyncio  # noqa: E402
 import os  # noqa: E402
+import uuid  # noqa: E402
 
 from mirage import MountMode, Workspace  # noqa: E402
 from mirage.resource.ram import RAMResource  # noqa: E402
@@ -71,11 +72,17 @@ async def read(prefix: str) -> None:
     probe = RedisWorkspaceStateStore(url=REDIS_URL, key_prefix=prefix)
     meta = await probe.load_meta(WORKSPACE_ID)
     check("py read: meta record found", meta is not None)
-    check("py read: default session id", meta is not None
-          and meta.get("default_session_id") == "default", f"got {meta!r}")
+    pointer = meta.get("default_session_id") if meta is not None else None
+    check("py read: default session id is uuid7",
+          isinstance(pointer, str) and uuid.UUID(pointer).version == 7,
+          f"got {meta!r}")
     await probe.close()
 
     ws, store = make_workspace(prefix)
+    await ws.ensure_sessions_loaded()
+    check("py read: adopted writer's default session",
+          ws.default_session_id == pointer,
+          f"got {ws.default_session_id!r} want {pointer!r}")
     result = await ws.execute("history")
     check("py read: history has marker", MARKER
           in result.stdout.decode(errors="replace"), f"got {result.stdout!r}")

--- a/integ/state_store.ts
+++ b/integ/state_store.ts
@@ -63,14 +63,22 @@ async function read(prefix: string): Promise<void> {
   const probe = new RedisWorkspaceStateStore({ url: REDIS_URL, keyPrefix: prefix })
   const meta = await probe.loadMeta(WORKSPACE_ID)
   check('ts read: meta record found', meta !== null)
+  const pointer = meta?.default_session_id
+  const UUID7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
   check(
-    'ts read: default session id',
-    meta?.default_session_id === 'default',
+    'ts read: default session id is uuid7',
+    typeof pointer === 'string' && UUID7_RE.test(pointer),
     `got ${JSON.stringify(meta)}`,
   )
   await probe.close()
 
   const { ws, store } = makeWorkspace(prefix)
+  await ws.ensureSessionsLoaded()
+  check(
+    "ts read: adopted writer's default session",
+    ws.defaultSessionId === pointer,
+    `got ${ws.defaultSessionId} want ${String(pointer)}`,
+  )
   const history = await ws.execute('history')
   check('ts read: history has marker', history.stdoutText.includes(MARKER), history.stdoutText)
   const target = await ws.execute('readlink /data/l.txt')

--- a/python/mirage/__init__.py
+++ b/python/mirage/__init__.py
@@ -21,8 +21,11 @@ from mirage.workspace import (ExecutionNode, Workspace, WorkspaceRunner)
 from mirage.workspace.fuse import FuseManager
 from mirage.workspace.mount.spec import Mount
 from mirage.types import ConsistencyPolicy
+from mirage.utils.ids import new_session_id, new_workspace_id, uuid7
+from mirage.version import __version__ as __version__
 
 __all__ = [
+    "__version__",
     "Workspace",
     "WorkspaceRunner",
     "RAMResource",
@@ -34,6 +37,7 @@ __all__ = [
     "Mount",
     "MountMode",
     "command",
+    "new_session_id",
+    "new_workspace_id",
+    "uuid7",
 ]
-
-__version__ = "0.0.3"

--- a/python/mirage/agents/langchain/backend.py
+++ b/python/mirage/agents/langchain/backend.py
@@ -24,7 +24,6 @@ from mirage.agents.langchain._convert import (io_to_execute_response,
                                               io_to_file_infos,
                                               io_to_grep_matches)
 from mirage.io.types import IOResult
-from mirage.types import DEFAULT_SESSION_ID
 from mirage.workspace.workspace import Workspace
 
 
@@ -40,7 +39,7 @@ class LangchainWorkspace(SandboxBackendProtocol):
         self,
         workspace: Workspace,
         sandbox_id: str = "mirage",
-        session_id: str = DEFAULT_SESSION_ID,
+        session_id: str | None = None,
     ) -> None:
         self._ws = workspace
         self._id = sandbox_id

--- a/python/mirage/agents/pydantic_ai/backend.py
+++ b/python/mirage/agents/pydantic_ai/backend.py
@@ -25,7 +25,6 @@ from mirage.agents.pydantic_ai._convert import (io_to_execute_response,
 from mirage.bridge.sync import run_async_from_sync
 from mirage.core.filetype.pdf import pages_to_images
 from mirage.io.types import IOResult
-from mirage.types import DEFAULT_SESSION_ID
 from mirage.workspace.workspace import Workspace
 
 
@@ -41,7 +40,7 @@ class PydanticAIWorkspace(SandboxProtocol):
         self,
         workspace: Workspace,
         sandbox_id: str = "mirage",
-        session_id: str = DEFAULT_SESSION_ID,
+        session_id: str | None = None,
     ) -> None:
         self._ws = workspace
         self._id = sandbox_id

--- a/python/mirage/commands/builtin/history/history.py
+++ b/python/mirage/commands/builtin/history/history.py
@@ -17,7 +17,7 @@ from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.history.render import render_history_listing
 from mirage.io.types import ByteSource, IOResult
-from mirage.types import DEFAULT_SESSION_ID, PathSpec
+from mirage.types import PathSpec
 
 
 def _out_of_range(value: str) -> IOResult:
@@ -55,7 +55,9 @@ async def history_cmd(
     (bash-verified for both -ps and -sp).
     """
     observer = accessor.observer
-    session = session_id if session_id is not None else DEFAULT_SESSION_ID
+    if session_id is None:
+        raise ValueError("history requires the caller's session id")
+    session = session_id
     if c:
         await observer.log_clear(session=session)
     if d is not None:

--- a/python/mirage/config.py
+++ b/python/mirage/config.py
@@ -265,8 +265,8 @@ class WorkspaceConfig(BaseModel):
     runtime: RuntimeBlock | None = None
     mode: MountMode = MountMode.WRITE
     consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY
-    default_session_id: str = "default"
-    default_agent_id: str = "default"
+    default_session_id: str | None = None
+    default_agent_id: str | None = None
     workspace_id: str | None = None
     cache: CacheBlock | None = None
     index: IndexBlock | None = None

--- a/python/mirage/server/registry.py
+++ b/python/mirage/server/registry.py
@@ -14,22 +14,13 @@
 
 import asyncio
 import logging
-import secrets
 import time
 from typing import Iterable
 
 from mirage import Workspace, WorkspaceRunner
+from mirage.utils.ids import new_workspace_id
 
 logger = logging.getLogger(__name__)
-
-
-def new_workspace_id() -> str:
-    """Mint a fresh workspace id of the form ``ws_<16 hex chars>``.
-
-    Returns:
-        str: opaque, URL-safe, collision-resistant id.
-    """
-    return f"ws_{secrets.token_hex(8)}"
 
 
 class WorkspaceEntry:

--- a/python/mirage/server/routers/workspaces.py
+++ b/python/mirage/server/routers/workspaces.py
@@ -20,8 +20,8 @@ from mirage import Workspace
 from mirage.resource.registry import build_resource
 from mirage.server.clone import clone_workspace_with_override
 from mirage.server.paths import PathOutsideRootError, resolve_within_root
-from mirage.server.registry import new_workspace_id
 from mirage.server.summary import make_brief, make_detail
+from mirage.utils.ids import new_workspace_id
 from mirage.workspace.snapshot.utils import norm_mount_prefix
 
 from mirage.server.schemas import (  # isort: skip

--- a/python/mirage/server/version/state_tree.py
+++ b/python/mirage/server/version/state_tree.py
@@ -144,29 +144,21 @@ def to_state(entries: dict[str, bytes], meta: dict) -> dict:
             CacheKey.SIZE: c.get(CacheKey.SIZE),
         })
     return {
-        StateKey.VERSION:
-        FORMAT_VERSION,
-        StateKey.MIRAGE_VERSION:
-        config.get(StateKey.MIRAGE_VERSION, "unknown"),
-        StateKey.MOUNTS:
-        mounts,
-        StateKey.SESSIONS:
-        meta.get("sessions", []),
-        StateKey.DEFAULT_SESSION_ID:
-        config.get(StateKey.DEFAULT_SESSION_ID, "default"),
-        StateKey.DEFAULT_AGENT_ID:
-        config.get(StateKey.DEFAULT_AGENT_ID, "default"),
-        StateKey.CURRENT_AGENT_ID:
-        config.get(StateKey.CURRENT_AGENT_ID, "default"),
+        StateKey.VERSION: FORMAT_VERSION,
+        StateKey.MIRAGE_VERSION: config.get(StateKey.MIRAGE_VERSION,
+                                            "unknown"),
+        StateKey.MOUNTS: mounts,
+        StateKey.SESSIONS: meta.get("sessions", []),
+        StateKey.DEFAULT_SESSION_ID: config.get(StateKey.DEFAULT_SESSION_ID),
+        StateKey.DEFAULT_AGENT_ID: config.get(StateKey.DEFAULT_AGENT_ID),
+        StateKey.CURRENT_AGENT_ID: config.get(StateKey.CURRENT_AGENT_ID),
         StateKey.CACHE: {
             CacheKey.LIMIT: config.get(CacheKey.LIMIT, "512MB"),
             CacheKey.MAX_DRAIN_BYTES: config.get(CacheKey.MAX_DRAIN_BYTES),
             CacheKey.ENTRIES: cache_entries,
         },
-        StateKey.HISTORY:
-        None,
+        StateKey.HISTORY: None,
         StateKey.JOBS: [],
-        StateKey.FINGERPRINTS:
-        meta.get("fingerprints", []),
+        StateKey.FINGERPRINTS: meta.get("fingerprints", []),
         StateKey.LIVE_ONLY_MOUNTS: [],
     }

--- a/python/mirage/shell/job_table.py
+++ b/python/mirage/shell/job_table.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 from mirage.io.types import IOResult
-from mirage.types import DEFAULT_SESSION_ID
 from mirage.workspace.types import ExecutionNode
 
 
@@ -42,7 +41,7 @@ class Job:
     io_result: IOResult | None = None
     created_at: float = field(default_factory=time.time)
     agent: str = "unknown"
-    session_id: str = DEFAULT_SESSION_ID
+    session_id: str = ""
 
 
 class JobTable:
@@ -57,7 +56,7 @@ class JobTable:
         task: asyncio.Task,
         cwd: str,
         agent: str = "unknown",
-        session_id: str = DEFAULT_SESSION_ID,
+        session_id: str = "",
     ) -> Job:
         job = Job(id=self._next_id,
                   command=command,

--- a/python/mirage/types.py
+++ b/python/mirage/types.py
@@ -331,11 +331,6 @@ class RuntimeType(str, Enum):
     DISK = "disk"
 
 
-DEFAULT_SESSION_ID = "default"
-DEFAULT_AGENT_ID = "default"
-DEFAULT_WORKSPACE_ID = "default"
-
-
 class StateKey(StrEnum):
     VERSION = "version"
     MIRAGE_VERSION = "mirage_version"

--- a/python/mirage/utils/ids.py
+++ b/python/mirage/utils/ids.py
@@ -1,0 +1,47 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+import uuid6
+
+
+def uuid7() -> str:
+    """Mint an RFC 9562 UUIDv7 in canonical lowercase hyphenated form.
+
+    The first 48 bits are a unix-millisecond timestamp, so ids sort by
+    creation time and stay index-friendly as database primary keys; the
+    remaining 74 bits are random. Delegates to the ``uuid6`` package
+    until ``uuid.uuid7`` lands in the stdlib (Python 3.14).
+
+    Returns:
+        str: canonical UUID string, e.g.
+            ``0198c0de-6f3a-7d21-9c4e-8b1f2a3c4d5e``.
+    """
+    return str(uuid6.uuid7())
+
+
+def new_workspace_id() -> str:
+    """Mint a fresh workspace id (UUIDv7).
+
+    Returns:
+        str: time-ordered, collision-resistant workspace id.
+    """
+    return uuid7()
+
+
+def new_session_id() -> str:
+    """Mint a fresh session id (UUIDv7).
+
+    Returns:
+        str: time-ordered, collision-resistant session id.
+    """
+    return uuid7()

--- a/python/mirage/version.py
+++ b/python/mirage/version.py
@@ -11,20 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+import importlib.metadata
 
-from dataclasses import dataclass
-
-from mirage.types import ConsistencyPolicy
-
-
-@dataclass
-class MountArgs:
-    """Constructor inputs derived from a state dict.
-
-    Workspace.load uses this to instantiate a fresh Workspace; snapshot
-    code never constructs Workspace itself.
-    """
-    mount_args: dict
-    consistency: ConsistencyPolicy
-    default_session_id: str
-    default_agent_id: str | None
+# Single source of truth: the installed distribution's metadata, i.e.
+# pyproject's version (mirrors TS version.ts reading package.json).
+# A missing distribution raises PackageNotFoundError loudly.
+__version__ = importlib.metadata.version("mirage-ai")

--- a/python/mirage/workspace/__init__.py
+++ b/python/mirage/workspace/__init__.py
@@ -12,15 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.types import DEFAULT_AGENT_ID, DEFAULT_SESSION_ID
 from mirage.workspace.runner import WorkspaceRunner
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
 from mirage.workspace.workspace import Workspace
 
 __all__ = [
-    "DEFAULT_AGENT_ID",
-    "DEFAULT_SESSION_ID",
     "ExecutionNode",
     "Session",
     "Workspace",

--- a/python/mirage/workspace/executor/builtins/vars.py
+++ b/python/mirage/workspace/executor/builtins/vars.py
@@ -97,7 +97,14 @@ async def handle_whoami(
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
     # GNU whoami reports the effective user and never consults $USER;
     # the workspace user (launch agent_id, shared via the namespace
-    # store) is the effective identity here.
+    # store) is the effective identity here. With no claimed identity
+    # it fails like GNU does for a uid with no passwd entry.
+    if namespace.user is None:
+        err = b"whoami: cannot find name for user ID\n"
+        return None, IOResult(exit_code=1,
+                              stderr=err), ExecutionNode(command="whoami",
+                                                         exit_code=1,
+                                                         stderr=err)
     out = f"{namespace.user}\n".encode()
     return out, IOResult(), ExecutionNode(command="whoami", exit_code=0)
 

--- a/python/mirage/workspace/mount/namespace/namespace.py
+++ b/python/mirage/workspace/mount/namespace/namespace.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 
 from mirage.resource.base import BaseResource
-from mirage.types import DEFAULT_AGENT_ID, MountMode, NodeMetaKey
+from mirage.types import MountMode, NodeMetaKey
 from mirage.utils.path import glob_prefix_match, resolve_symlinks
 from mirage.workspace.mount.mount import MountEntry
 from mirage.workspace.mount.namespace.ram import RAMNamespaceStore
@@ -112,17 +112,16 @@ class Namespace:
         return self._nodes
 
     @property
-    def user(self) -> str:
+    def user(self) -> str | None:
         """The workspace user (whoami identity).
 
-        Before store resolution the launch claim (or DEFAULT_AGENT_ID)
-        answers; after it, the resolved identity.
+        Before store resolution the launch claim answers; after it, the
+        resolved identity. None when no agent ever claimed the
+        workspace, mirroring a uid with no passwd entry.
         """
         if self._user is not None:
             return self._user
-        if self._claim is not None:
-            return self._claim
-        return DEFAULT_AGENT_ID
+        return self._claim
 
     async def _resolve_user(self) -> None:
         """Resolve the workspace user against the store, once.

--- a/python/mirage/workspace/session/manager.py
+++ b/python/mirage/workspace/session/manager.py
@@ -68,6 +68,31 @@ class SessionManager:
     def env(self, value: dict[str, str]) -> None:
         self._sessions[self._default_id].env = value
 
+    def adopt_default(self, session_id: str) -> None:
+        """Re-key the default session to an externally decided id.
+
+        Two callers: attach (the discovery record already names a
+        default session, so the freshly minted placeholder re-keys
+        before hydration lands the stored durable fields on it) and
+        snapshot restore (the snapshot's default identity wins). The
+        store itself is untouched; the next flush or snapshot replace
+        writes the new key.
+
+        Args:
+            session_id (str): the default session id to adopt.
+        """
+        if session_id == self._default_id:
+            return
+        if session_id in self._sessions:
+            del self._sessions[self._default_id]
+            del self._locks[self._default_id]
+        else:
+            session = self._sessions.pop(self._default_id)
+            session.session_id = session_id
+            self._sessions[session_id] = session
+            self._locks[session_id] = self._locks.pop(self._default_id)
+        self._default_id = session_id
+
     async def ensure_loaded(self) -> None:
         """Hydrate sessions from the store once.
 

--- a/python/mirage/workspace/snapshot/state.py
+++ b/python/mirage/workspace/snapshot/state.py
@@ -13,8 +13,8 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import importlib
-import importlib.metadata
 import tempfile
+import time
 
 from mirage.observe.log_entry import EVENT_CLEAR, EVENT_COMMAND, EVENT_DELETE
 from mirage.resource.history import HISTORY_PREFIX
@@ -25,19 +25,13 @@ from mirage.shell.job_table import Job, JobStatus
 from mirage.types import (CacheKey, ConsistencyPolicy, JobKey, MountKey,
                           MountMode, ResourceName, ResourceStateKey,
                           SessionKey, StateKey)
+from mirage.version import __version__
 from mirage.workspace.mount.namespace import NodeMeta
 from mirage.workspace.session.session import Session
 from mirage.workspace.snapshot.config import MountArgs
 from mirage.workspace.snapshot.drift import (capture_fingerprints,
                                              live_only_mount_prefixes)
 from mirage.workspace.snapshot.utils import FORMAT_VERSION, norm_mount_prefix
-
-
-def _mirage_version() -> str:
-    try:
-        return importlib.metadata.version("mirage-ai")
-    except importlib.metadata.PackageNotFoundError:
-        return "unknown"
 
 
 async def to_state_dict(ws) -> dict:
@@ -81,7 +75,7 @@ async def to_state_dict(ws) -> dict:
 
     return {
         StateKey.VERSION: FORMAT_VERSION,
-        StateKey.MIRAGE_VERSION: _mirage_version(),
+        StateKey.MIRAGE_VERSION: __version__,
         StateKey.MOUNTS: mounts_state,
         StateKey.SESSIONS: [s.to_dict() for s in ws._session_mgr.list()],
         StateKey.DEFAULT_SESSION_ID: ws._session_mgr.default_id,
@@ -143,8 +137,8 @@ def build_mount_args(state: dict, resources: dict | None = None) -> MountArgs:
     return MountArgs(
         mount_args=mount_args,
         consistency=ConsistencyPolicy.LAZY,
-        default_session_id=state.get(StateKey.DEFAULT_SESSION_ID, "default"),
-        default_agent_id=state.get(StateKey.DEFAULT_AGENT_ID, "default"),
+        default_session_id=state[StateKey.DEFAULT_SESSION_ID],
+        default_agent_id=state.get(StateKey.DEFAULT_AGENT_ID),
     )
 
 
@@ -188,6 +182,20 @@ async def _restore_nodes(ws, state: dict) -> None:
 
 async def _restore_sessions(ws, state: dict) -> None:
     default_sid = state.get(StateKey.DEFAULT_SESSION_ID)
+    if default_sid is not None:
+        # The snapshot's default session identity wins over the live
+        # one, and the discovery record's pointer follows it.
+        ws._session_mgr.adopt_default(default_sid)
+        ws._default_session_id = default_sid
+        existing = await ws._state_store.load_meta(ws._workspace_id)
+        await ws._state_store.set_meta(
+            ws._workspace_id, {
+                **(existing or {}),
+                "workspace_id": ws._workspace_id,
+                "default_session_id": default_sid,
+                "created_at": (existing or {}).get("created_at", time.time()),
+            })
+        ws._meta_written = True
     restored: list = []
     for s_data in state.get(StateKey.SESSIONS, []):
         sid = s_data[SessionKey.SESSION_ID]

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -49,11 +49,10 @@ from mirage.runtime.js import JsRuntime, select_js_runtime
 from mirage.runtime.python import PythonRuntime, select_python_runtime
 from mirage.shell.job_table import JobTable
 from mirage.shell.parse import find_syntax_error, parse
-from mirage.types import (DEFAULT_AGENT_ID, DEFAULT_SESSION_ID,
-                          DEFAULT_WORKSPACE_ID, ConsistencyPolicy, DriftPolicy,
-                          FileStat, MountMode, PathSpec, StateKey,
-                          parse_mount_mode)
+from mirage.types import (ConsistencyPolicy, DriftPolicy, FileStat, MountMode,
+                          PathSpec, StateKey, parse_mount_mode)
 from mirage.utils.errors import format_fs_error
+from mirage.utils.ids import new_session_id, new_workspace_id
 from mirage.workspace.abort import MirageAbortError
 from mirage.workspace.dispatcher import Dispatcher
 from mirage.workspace.file_prompt import build_file_prompt
@@ -93,7 +92,7 @@ class Workspace:
         index: IndexConfig | None = None,
         mode: MountMode = MountMode.READ,
         consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY,
-        session_id: str = DEFAULT_SESSION_ID,
+        session_id: str | None = None,
         agent_id: str | None = None,
         workspace_id: str | None = None,
         store: WorkspaceStateStore | None = None,
@@ -109,7 +108,13 @@ class Workspace:
         # the per-plane params (observe / namespace_store / session_store)
         # remain as direct overrides that win over the provider.
         self._workspace_id = workspace_id if workspace_id is not None \
-            else DEFAULT_WORKSPACE_ID
+            else new_workspace_id()
+        # A minted default session id is provisional: attaching to a
+        # workspace whose discovery record already names one adopts the
+        # stored pointer instead (see _ensure_meta).
+        self._session_id_explicit = session_id is not None
+        if session_id is None:
+            session_id = new_session_id()
         # A caller-passed provider may be shared with sibling workspaces,
         # so only a workspace that built its own provider closes it.
         self._owns_state_store = store is None
@@ -146,10 +151,9 @@ class Workspace:
         # First dispatch/execute drains via asyncio.gather, then clears.
         self._pending_drift: list[tuple[MountEntry, str, str]] = []
         self.job_table = JobTable()
-        resolved_agent = agent_id if agent_id is not None else DEFAULT_AGENT_ID
-        self._current_agent_id: str = resolved_agent
+        self._current_agent_id: str | None = agent_id
         self._default_session_id = session_id
-        self._default_agent_id = resolved_agent
+        self._default_agent_id = agent_id
         self._session_mgr = SessionManager(session_id, store=session_store)
         self._consistency = consistency
         self._registry.set_consistency(consistency)
@@ -204,7 +208,7 @@ class Workspace:
         self._ops = Ops(self._registry.ops_mounts(),
                         on_write=self._invalidate_after_write_by_path,
                         observer=self.observer,
-                        agent_id=resolved_agent,
+                        agent_id=agent_id or "",
                         session_id=session_id,
                         links=self._namespace,
                         stat_overlay=self._merge_overlay)
@@ -662,13 +666,21 @@ class Workspace:
         return self._session_mgr.list()
 
     async def ensure_sessions_loaded(self) -> None:
-        """Hydrate sessions from the session store (idempotent)."""
-        await self._session_mgr.ensure_loaded()
+        """Hydrate sessions from the session store (idempotent).
+
+        The discovery record resolves first so a minted default session
+        id can adopt the stored pointer before hydration keys off it.
+        """
         await self._ensure_meta()
+        await self._session_mgr.ensure_loaded()
 
     @property
     def workspace_id(self) -> str:
         return self._workspace_id
+
+    @property
+    def default_session_id(self) -> str:
+        return self._session_mgr.default_id
 
     @property
     def state_store(self) -> WorkspaceStateStore:
@@ -698,6 +710,11 @@ class Workspace:
                     "default_session_id": self._default_session_id,
                     "created_at": time.time(),
                 })
+        else:
+            stored = existing.get("default_session_id")
+            if not self._session_id_explicit and isinstance(stored, str):
+                self._session_mgr.adopt_default(stored)
+                self._default_session_id = stored
         self._meta_written = True
 
     async def flush_sessions(self) -> None:
@@ -817,7 +834,7 @@ class Workspace:
                       session_id: str | None = ...,
                       stdin: AsyncIterator[bytes] | bytes | None = ...,
                       provision: Literal[False] = ...,
-                      agent_id: str = ...,
+                      agent_id: str | None = ...,
                       cwd: str | None = ...,
                       env: dict[str, str] | None = ...,
                       cancel: asyncio.Event | None = ...,
@@ -831,7 +848,7 @@ class Workspace:
                       stdin: AsyncIterator[bytes] | bytes | None = ...,
                       *,
                       provision: Literal[True],
-                      agent_id: str = ...,
+                      agent_id: str | None = ...,
                       cwd: str | None = ...,
                       env: dict[str, str] | None = ...,
                       cancel: asyncio.Event | None = ...,
@@ -844,7 +861,7 @@ class Workspace:
         session_id: str | None = None,
         stdin: AsyncIterator[bytes] | bytes | None = None,
         provision: bool = False,
-        agent_id: str = DEFAULT_AGENT_ID,
+        agent_id: str | None = None,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
         cancel: asyncio.Event | None = None,
@@ -879,8 +896,8 @@ class Workspace:
         if cancel is not None and cancel.is_set():
             raise MirageAbortError()
         await self._namespace.ensure_loaded()
-        await self._session_mgr.ensure_loaded()
         await self._ensure_meta()
+        await self._session_mgr.ensure_loaded()
         if self._drift_check_pending:
             await self._run_pending_drift_check()
 
@@ -897,7 +914,8 @@ class Workspace:
             effective_session = session.fork(**overrides)
         else:
             effective_session = session
-        self._current_agent_id = agent_id
+        self._current_agent_id = (agent_id if agent_id is not None else
+                                  self._default_agent_id)
         io = IOResult()
         # The line-reader decision (GNU: history is appended where the
         # typed line is read, never inside the evaluator). Internal
@@ -935,7 +953,7 @@ class Workspace:
                 self._namespace,
                 self.job_table,
                 exec_recursion,
-                self._current_agent_id,
+                self._current_agent_id or "",
                 ast,
                 effective_session,
                 stdin,
@@ -983,5 +1001,5 @@ class Workspace:
             self._ops.records.extend(scope.records)
             if is_line:
                 await self.observer.log_execution(
-                    command, io, scope.records, agent_id, session_id,
-                    self._session_cwd(session_id))
+                    command, io, scope.records, self._current_agent_id or "",
+                    session_id, self._session_cwd(session_id))

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "jq>=1.11.0",
     "pyjwt[crypto]>=2.13.0",
     "dulwich>=1.2.5",
+    "uuid6>=2025.0.1",
 ]
 
 [project.urls]

--- a/python/tests/cli/test_cli_end_to_end.py
+++ b/python/tests/cli/test_cli_end_to_end.py
@@ -15,6 +15,7 @@
 import json
 import subprocess
 import sys
+import uuid
 from pathlib import Path
 
 CONFIG_YAML = """\
@@ -58,7 +59,7 @@ def test_workspace_lifecycle(daemon, tmp_path):
     cfg = _write_config(tmp_path)
     created = _run_cli(daemon["env"], "workspace", "create", str(cfg))
     wid = created["id"]
-    assert wid.startswith("ws_")
+    assert uuid.UUID(wid).version == 7
 
     listed = _run_cli(daemon["env"], "workspace", "list")
     assert any(w["id"] == wid for w in listed)

--- a/python/tests/commands/builtin/disk/test_cat.py
+++ b/python/tests/commands/builtin/disk/test_cat.py
@@ -26,7 +26,7 @@ def workspace(tmp_path):
 @pytest.mark.asyncio
 async def test_cat_basic(workspace):
     await workspace.ops.write("/f.txt", b"hello\nworld\n")
-    io = await workspace.execute("cat /f.txt", session_id="default")
+    io = await workspace.execute("cat /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"hello\nworld\n"
 
@@ -34,7 +34,7 @@ async def test_cat_basic(workspace):
 @pytest.mark.asyncio
 async def test_cat_n_single_digit_alignment(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\n")
-    io = await workspace.execute("cat -n /f.txt", session_id="default")
+    io = await workspace.execute("cat -n /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"     1\ta\n     2\tb\n"
 
@@ -43,7 +43,7 @@ async def test_cat_n_single_digit_alignment(workspace):
 async def test_cat_n_multidigit_alignment(workspace):
     body = b"".join(f"line{i}\n".encode() for i in range(1, 13))
     await workspace.ops.write("/big.txt", body)
-    io = await workspace.execute("cat -n /big.txt", session_id="default")
+    io = await workspace.execute("cat -n /big.txt")
     assert io.exit_code == 0
     lines = io.stdout.split(b"\n")
     assert lines[0] == b"     1\tline1"
@@ -55,7 +55,7 @@ async def test_cat_n_multidigit_alignment(workspace):
 @pytest.mark.asyncio
 async def test_cat_preserves_no_trailing_newline(workspace):
     await workspace.ops.write("/partial.txt", b"hello")
-    io = await workspace.execute("cat /partial.txt", session_id="default")
+    io = await workspace.execute("cat /partial.txt")
     assert io.exit_code == 0
     assert io.stdout == b"hello"
 
@@ -63,7 +63,7 @@ async def test_cat_preserves_no_trailing_newline(workspace):
 @pytest.mark.asyncio
 async def test_cat_n_preserves_no_trailing_newline(workspace):
     await workspace.ops.write("/partial.txt", b"hello")
-    io = await workspace.execute("cat -n /partial.txt", session_id="default")
+    io = await workspace.execute("cat -n /partial.txt")
     assert io.exit_code == 0
     assert io.stdout == b"     1\thello"
 
@@ -71,7 +71,7 @@ async def test_cat_n_preserves_no_trailing_newline(workspace):
 @pytest.mark.asyncio
 async def test_cat_empty_file(workspace):
     await workspace.ops.write("/empty.txt", b"")
-    io = await workspace.execute("cat /empty.txt", session_id="default")
+    io = await workspace.execute("cat /empty.txt")
     assert io.exit_code == 0
     assert io.stdout == b""
 
@@ -79,6 +79,6 @@ async def test_cat_empty_file(workspace):
 @pytest.mark.asyncio
 async def test_cat_only_newlines(workspace):
     await workspace.ops.write("/nl.txt", b"\n\n\n")
-    io = await workspace.execute("cat -n /nl.txt", session_id="default")
+    io = await workspace.execute("cat -n /nl.txt")
     assert io.exit_code == 0
     assert io.stdout == b"     1\t\n     2\t\n     3\t\n"

--- a/python/tests/commands/builtin/disk/test_du.py
+++ b/python/tests/commands/builtin/disk/test_du.py
@@ -26,7 +26,7 @@ def workspace(tmp_path):
 @pytest.mark.asyncio
 async def test_du_single_file(workspace):
     await workspace.ops.write("/f.txt", b"hello")
-    io = await workspace.execute("du /f.txt", session_id="default")
+    io = await workspace.execute("du /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().strip() == "5\t/f.txt"
 
@@ -36,7 +36,7 @@ async def test_du_directory_collapses(workspace):
     await workspace.ops.mkdir("/dir")
     await workspace.ops.write("/dir/a.txt", b"aaa")
     await workspace.ops.write("/dir/b.txt", b"bb")
-    io = await workspace.execute("du /dir", session_id="default")
+    io = await workspace.execute("du /dir")
     assert io.exit_code == 0
     assert io.stdout.decode().strip() == "5\t/dir"
 
@@ -46,7 +46,7 @@ async def test_du_a_lists_files(workspace):
     await workspace.ops.mkdir("/dir")
     await workspace.ops.write("/dir/a.txt", b"aaa")
     await workspace.ops.write("/dir/b.txt", b"bb")
-    io = await workspace.execute("du -a /dir", session_id="default")
+    io = await workspace.execute("du -a /dir")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "a.txt" in out
@@ -59,7 +59,7 @@ async def test_du_s_summary(workspace):
     await workspace.ops.mkdir("/dir/sub")
     await workspace.ops.write("/dir/a.txt", b"hello")
     await workspace.ops.write("/dir/sub/b.txt", b"world")
-    io = await workspace.execute("du -s /dir", session_id="default")
+    io = await workspace.execute("du -s /dir")
     assert io.exit_code == 0
     lines = io.stdout.decode().strip().splitlines()
     assert len(lines) == 1
@@ -69,7 +69,7 @@ async def test_du_s_summary(workspace):
 async def test_du_c_total(workspace):
     await workspace.ops.write("/a.txt", b"hello")
     await workspace.ops.write("/b.txt", b"world")
-    io = await workspace.execute("du -c /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("du -c /a.txt /b.txt")
     assert io.exit_code == 0
     lines = io.stdout.decode().strip().splitlines()
     assert lines[-1] == "10\ttotal"
@@ -78,7 +78,7 @@ async def test_du_c_total(workspace):
 @pytest.mark.asyncio
 async def test_du_h_human(workspace):
     await workspace.ops.write("/big.txt", b"x" * 2048)
-    io = await workspace.execute("du -h /big.txt", session_id="default")
+    io = await workspace.execute("du -h /big.txt")
     assert io.exit_code == 0
     size_str = io.stdout.decode().strip().split("\t")[0]
     assert size_str.endswith("K")
@@ -86,6 +86,6 @@ async def test_du_h_human(workspace):
 
 @pytest.mark.asyncio
 async def test_du_missing_operand_errors(workspace):
-    io = await workspace.execute("du", session_id="default")
+    io = await workspace.execute("du")
     assert io.exit_code != 0
     assert b"missing operand" in (io.stderr or b"")

--- a/python/tests/commands/builtin/disk/test_find.py
+++ b/python/tests/commands/builtin/disk/test_find.py
@@ -27,7 +27,7 @@ def workspace(tmp_path):
 async def test_find_name_glob(workspace):
     await workspace.ops.write("/hello.txt", b"hi")
     await workspace.ops.write("/world.py", b"hi")
-    io = await workspace.execute("find / -name '*.txt'", session_id="default")
+    io = await workspace.execute("find / -name '*.txt'")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "hello.txt" in out
@@ -39,7 +39,7 @@ async def test_find_type_f(workspace):
     await workspace.ops.mkdir("/sub")
     await workspace.ops.write("/a.txt", b"a")
     await workspace.ops.write("/sub/b.txt", b"b")
-    io = await workspace.execute("find / -type f", session_id="default")
+    io = await workspace.execute("find / -type f")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "/a.txt" in out
@@ -50,7 +50,7 @@ async def test_find_type_f(workspace):
 async def test_find_type_d(workspace):
     await workspace.ops.mkdir("/sub")
     await workspace.ops.write("/a.txt", b"a")
-    io = await workspace.execute("find / -type d", session_id="default")
+    io = await workspace.execute("find / -type d")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "/sub" in out
@@ -61,8 +61,7 @@ async def test_find_type_d(workspace):
 async def test_find_size_lower_bound(workspace):
     await workspace.ops.write("/big.txt", b"x" * 1000)
     await workspace.ops.write("/small.txt", b"x")
-    io = await workspace.execute("find / -size +500c -type f",
-                                 session_id="default")
+    io = await workspace.execute("find / -size +500c -type f")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "big.txt" in out
@@ -75,8 +74,7 @@ async def test_find_maxdepth(workspace):
     await workspace.ops.mkdir("/sub/deep")
     await workspace.ops.write("/a.txt", b"a")
     await workspace.ops.write("/sub/deep/c.txt", b"c")
-    io = await workspace.execute("find / -maxdepth 1 -type f",
-                                 session_id="default")
+    io = await workspace.execute("find / -maxdepth 1 -type f")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "/a.txt" in out

--- a/python/tests/commands/builtin/disk/test_head.py
+++ b/python/tests/commands/builtin/disk/test_head.py
@@ -27,7 +27,7 @@ def workspace(tmp_path):
 async def test_head_default_n_10(workspace):
     body = b"".join(f"line{i}\n".encode() for i in range(1, 15))
     await workspace.ops.write("/f.txt", body)
-    io = await workspace.execute("head /f.txt", session_id="default")
+    io = await workspace.execute("head /f.txt")
     assert io.exit_code == 0
     lines = io.stdout.decode().splitlines()
     assert len(lines) == 10
@@ -38,7 +38,7 @@ async def test_head_default_n_10(workspace):
 @pytest.mark.asyncio
 async def test_head_n_explicit(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\nd\n")
-    io = await workspace.execute("head -n 2 /f.txt", session_id="default")
+    io = await workspace.execute("head -n 2 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"a\nb\n"
 
@@ -46,7 +46,7 @@ async def test_head_n_explicit(workspace):
 @pytest.mark.asyncio
 async def test_head_c_bytes(workspace):
     await workspace.ops.write("/f.txt", b"hello world")
-    io = await workspace.execute("head -c 5 /f.txt", session_id="default")
+    io = await workspace.execute("head -c 5 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"hello"
 
@@ -54,7 +54,7 @@ async def test_head_c_bytes(workspace):
 @pytest.mark.asyncio
 async def test_head_negative_n_excludes_last(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\nd\n")
-    io = await workspace.execute("head -n -1 /f.txt", session_id="default")
+    io = await workspace.execute("head -n -1 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"a\nb\nc\n"
 
@@ -62,7 +62,7 @@ async def test_head_negative_n_excludes_last(workspace):
 @pytest.mark.asyncio
 async def test_head_no_trailing_newline(workspace):
     await workspace.ops.write("/partial.txt", b"hello")
-    io = await workspace.execute("head /partial.txt", session_id="default")
+    io = await workspace.execute("head /partial.txt")
     assert io.exit_code == 0
     assert io.stdout == b"hello"
 
@@ -70,6 +70,6 @@ async def test_head_no_trailing_newline(workspace):
 @pytest.mark.asyncio
 async def test_head_empty_file(workspace):
     await workspace.ops.write("/empty.txt", b"")
-    io = await workspace.execute("head /empty.txt", session_id="default")
+    io = await workspace.execute("head /empty.txt")
     assert io.exit_code == 0
     assert io.stdout == b""

--- a/python/tests/commands/builtin/disk/test_ls.py
+++ b/python/tests/commands/builtin/disk/test_ls.py
@@ -27,7 +27,7 @@ def workspace(tmp_path):
 async def test_ls_lists_files(workspace):
     await workspace.ops.write("/a.txt", b"a")
     await workspace.ops.write("/b.txt", b"b")
-    io = await workspace.execute("ls /", session_id="default")
+    io = await workspace.execute("ls /")
     assert io.exit_code == 0
     names = set(io.stdout.decode().strip().split("\n"))
     assert "a.txt" in names
@@ -38,7 +38,7 @@ async def test_ls_lists_files(workspace):
 async def test_ls_a_shows_dotfiles(workspace):
     await workspace.ops.write("/.hidden", b"h")
     await workspace.ops.write("/visible.txt", b"v")
-    io = await workspace.execute("ls -a /", session_id="default")
+    io = await workspace.execute("ls -a /")
     assert io.exit_code == 0
     names = set(io.stdout.decode().strip().split("\n"))
     assert ".hidden" in names
@@ -48,7 +48,7 @@ async def test_ls_a_shows_dotfiles(workspace):
 @pytest.mark.asyncio
 async def test_ls_l_long_format_includes_size(workspace):
     await workspace.ops.write("/f.txt", b"hello")
-    io = await workspace.execute("ls -l /", session_id="default")
+    io = await workspace.execute("ls -l /")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "f.txt" in out
@@ -59,7 +59,7 @@ async def test_ls_l_long_format_includes_size(workspace):
 async def test_ls_F_classify_marks_dirs(workspace):
     await workspace.ops.mkdir("/sub")
     await workspace.ops.write("/sub/a.txt", b"a")
-    io = await workspace.execute("ls -F /", session_id="default")
+    io = await workspace.execute("ls -F /")
     assert io.exit_code == 0
     assert "sub/" in io.stdout.decode()
 
@@ -68,7 +68,7 @@ async def test_ls_F_classify_marks_dirs(workspace):
 async def test_ls_R_recursive(workspace):
     await workspace.ops.mkdir("/sub")
     await workspace.ops.write("/sub/a.txt", b"a")
-    io = await workspace.execute("ls -R /", session_id="default")
+    io = await workspace.execute("ls -R /")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "sub" in out
@@ -78,13 +78,13 @@ async def test_ls_R_recursive(workspace):
 @pytest.mark.asyncio
 async def test_ls_d_lists_dir_itself(workspace):
     await workspace.ops.mkdir("/sub")
-    io = await workspace.execute("ls -d /sub", session_id="default")
+    io = await workspace.execute("ls -d /sub")
     assert io.exit_code == 0
     assert "sub" in io.stdout.decode()
 
 
 @pytest.mark.asyncio
 async def test_ls_missing_path_returns_exit_1(workspace):
-    io = await workspace.execute("ls /nope", session_id="default")
+    io = await workspace.execute("ls /nope")
     assert io.exit_code == 1
     assert b"nope" in (io.stderr or b"")

--- a/python/tests/commands/builtin/disk/test_rm.py
+++ b/python/tests/commands/builtin/disk/test_rm.py
@@ -27,7 +27,7 @@ def workspace(tmp_path):
 async def test_rm_v_terminates_verbose_output(workspace):
     await workspace.ops.write("/a.txt", b"a")
 
-    io = await workspace.execute("rm -v /a.txt", session_id="default")
+    io = await workspace.execute("rm -v /a.txt")
 
     assert io.exit_code == 0
     assert io.stdout == b"removed '/a.txt'\n"

--- a/python/tests/commands/builtin/disk/test_tail.py
+++ b/python/tests/commands/builtin/disk/test_tail.py
@@ -27,7 +27,7 @@ def workspace(tmp_path):
 async def test_tail_default_n_10(workspace):
     body = b"\n".join(f"line{i}".encode() for i in range(1, 21)) + b"\n"
     await workspace.ops.write("/f.txt", body)
-    io = await workspace.execute("tail /f.txt", session_id="default")
+    io = await workspace.execute("tail /f.txt")
     assert io.exit_code == 0
     expected = b"\n".join(f"line{i}".encode() for i in range(11, 21)) + b"\n"
     assert io.stdout == expected
@@ -36,7 +36,7 @@ async def test_tail_default_n_10(workspace):
 @pytest.mark.asyncio
 async def test_tail_n_explicit(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\nd\ne\n")
-    io = await workspace.execute("tail -n 3 /f.txt", session_id="default")
+    io = await workspace.execute("tail -n 3 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"c\nd\ne\n"
 
@@ -44,7 +44,7 @@ async def test_tail_n_explicit(workspace):
 @pytest.mark.asyncio
 async def test_tail_c_bytes(workspace):
     await workspace.ops.write("/f.txt", b"hello world")
-    io = await workspace.execute("tail -c 5 /f.txt", session_id="default")
+    io = await workspace.execute("tail -c 5 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"world"
 
@@ -52,7 +52,7 @@ async def test_tail_c_bytes(workspace):
 @pytest.mark.asyncio
 async def test_tail_plus_n_streams_from_line(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\nd\ne\n")
-    io = await workspace.execute("tail -n +3 /f.txt", session_id="default")
+    io = await workspace.execute("tail -n +3 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"c\nd\ne\n"
 
@@ -60,7 +60,7 @@ async def test_tail_plus_n_streams_from_line(workspace):
 @pytest.mark.asyncio
 async def test_tail_no_trailing_newline(workspace):
     await workspace.ops.write("/partial.txt", b"hello")
-    io = await workspace.execute("tail /partial.txt", session_id="default")
+    io = await workspace.execute("tail /partial.txt")
     assert io.exit_code == 0
     assert io.stdout == b"hello"
 
@@ -68,7 +68,7 @@ async def test_tail_no_trailing_newline(workspace):
 @pytest.mark.asyncio
 async def test_tail_empty_file(workspace):
     await workspace.ops.write("/empty.txt", b"")
-    io = await workspace.execute("tail /empty.txt", session_id="default")
+    io = await workspace.execute("tail /empty.txt")
     assert io.exit_code == 0
     assert io.stdout == b""
 
@@ -77,7 +77,7 @@ async def test_tail_empty_file(workspace):
 async def test_tail_multi_file_emits_headers(workspace):
     await workspace.ops.write("/a.txt", b"x\ny\n")
     await workspace.ops.write("/b.txt", b"z\n")
-    io = await workspace.execute("tail /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("tail /a.txt /b.txt")
     assert io.exit_code == 0
     assert b"==> /a.txt <==" in io.stdout
     assert b"==> /b.txt <==" in io.stdout

--- a/python/tests/commands/builtin/disk/test_tree.py
+++ b/python/tests/commands/builtin/disk/test_tree.py
@@ -28,7 +28,7 @@ async def test_tree_basic(workspace):
     await workspace.ops.mkdir("/d1")
     await workspace.ops.write("/d1/a.txt", b"a")
     await workspace.ops.write("/d1/b.txt", b"b")
-    io = await workspace.execute("tree /d1", session_id="default")
+    io = await workspace.execute("tree /d1")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "a.txt" in out
@@ -41,7 +41,7 @@ async def test_tree_L_max_depth(workspace):
     await workspace.ops.mkdir("/d1/sub")
     await workspace.ops.mkdir("/d1/sub/deep")
     await workspace.ops.write("/d1/sub/deep/file.txt", b"d")
-    io = await workspace.execute("tree -L 1 /d1", session_id="default")
+    io = await workspace.execute("tree -L 1 /d1")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "sub" in out
@@ -54,7 +54,7 @@ async def test_tree_d_dirs_only(workspace):
     await workspace.ops.mkdir("/d1")
     await workspace.ops.mkdir("/d1/sub")
     await workspace.ops.write("/d1/file.txt", b"x")
-    io = await workspace.execute("tree -d /d1", session_id="default")
+    io = await workspace.execute("tree -d /d1")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "sub" in out

--- a/python/tests/commands/builtin/disk/test_wc.py
+++ b/python/tests/commands/builtin/disk/test_wc.py
@@ -26,7 +26,7 @@ def workspace(tmp_path):
 @pytest.mark.asyncio
 async def test_wc_default(workspace):
     await workspace.ops.write("/f.txt", b"hello world\nfoo bar\n")
-    io = await workspace.execute("wc /f.txt", session_id="default")
+    io = await workspace.execute("wc /f.txt")
     assert io.exit_code == 0
     parts = io.stdout.decode().rstrip("\n").split()
     assert parts[0] == "2"
@@ -38,7 +38,7 @@ async def test_wc_default(workspace):
 @pytest.mark.asyncio
 async def test_wc_l(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\n")
-    io = await workspace.execute("wc -l /f.txt", session_id="default")
+    io = await workspace.execute("wc -l /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().split()[0] == "3"
 
@@ -46,7 +46,7 @@ async def test_wc_l(workspace):
 @pytest.mark.asyncio
 async def test_wc_w(workspace):
     await workspace.ops.write("/f.txt", b"hello world\nfoo\n")
-    io = await workspace.execute("wc -w /f.txt", session_id="default")
+    io = await workspace.execute("wc -w /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().split()[0] == "3"
 
@@ -54,7 +54,7 @@ async def test_wc_w(workspace):
 @pytest.mark.asyncio
 async def test_wc_c(workspace):
     await workspace.ops.write("/f.txt", b"hello\n")
-    io = await workspace.execute("wc -c /f.txt", session_id="default")
+    io = await workspace.execute("wc -c /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().split()[0] == "6"
 
@@ -62,7 +62,7 @@ async def test_wc_c(workspace):
 @pytest.mark.asyncio
 async def test_wc_m_multibyte(workspace):
     await workspace.ops.write("/f.txt", "café".encode())
-    io = await workspace.execute("wc -m /f.txt", session_id="default")
+    io = await workspace.execute("wc -m /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().split()[0] == "4"
 
@@ -70,7 +70,7 @@ async def test_wc_m_multibyte(workspace):
 @pytest.mark.asyncio
 async def test_wc_L(workspace):
     await workspace.ops.write("/f.txt", b"short\na much longer line\nmed\n")
-    io = await workspace.execute("wc -L /f.txt", session_id="default")
+    io = await workspace.execute("wc -L /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().split()[0] == str(len("a much longer line"))
 
@@ -78,7 +78,7 @@ async def test_wc_L(workspace):
 @pytest.mark.asyncio
 async def test_wc_empty_file(workspace):
     await workspace.ops.write("/f.txt", b"")
-    io = await workspace.execute("wc /f.txt", session_id="default")
+    io = await workspace.execute("wc /f.txt")
     assert io.exit_code == 0
     parts = io.stdout.decode().split()
     assert parts[:3] == ["0", "0", "0"]
@@ -88,7 +88,7 @@ async def test_wc_empty_file(workspace):
 async def test_wc_multi_file_emits_total(workspace):
     await workspace.ops.write("/a.txt", b"hello\n")
     await workspace.ops.write("/b.txt", b"world\nfoo\n")
-    io = await workspace.execute("wc /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("wc /a.txt /b.txt")
     assert io.exit_code == 0
     lines = io.stdout.decode().splitlines()
     assert any(line.endswith("/a.txt") for line in lines)

--- a/python/tests/commands/builtin/ram/cat/test_cat.py
+++ b/python/tests/commands/builtin/ram/cat/test_cat.py
@@ -25,7 +25,7 @@ def workspace():
 @pytest.mark.asyncio
 async def test_cat_basic(workspace):
     await workspace.ops.write("/f.txt", b"hello\nworld\n")
-    io = await workspace.execute("cat /f.txt", session_id="default")
+    io = await workspace.execute("cat /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"hello\nworld\n"
 
@@ -33,7 +33,7 @@ async def test_cat_basic(workspace):
 @pytest.mark.asyncio
 async def test_cat_n_single_digit_alignment(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\n")
-    io = await workspace.execute("cat -n /f.txt", session_id="default")
+    io = await workspace.execute("cat -n /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"     1\ta\n     2\tb\n"
 
@@ -45,7 +45,7 @@ async def test_cat_n_multidigit_alignment(workspace):
     this for files with >= 10 lines."""
     body = b"".join(f"line{i}\n".encode() for i in range(1, 13))
     await workspace.ops.write("/big.txt", body)
-    io = await workspace.execute("cat -n /big.txt", session_id="default")
+    io = await workspace.execute("cat -n /big.txt")
     assert io.exit_code == 0
     lines = io.stdout.split(b"\n")
     assert lines[0] == b"     1\tline1"
@@ -59,7 +59,7 @@ async def test_cat_preserves_no_trailing_newline(workspace):
     """Native `printf "hello" | cat` emits no trailing newline. Old MIRAGE
     cat always added one via `line + b"\\n"` in _number_lines_stream."""
     await workspace.ops.write("/partial.txt", b"hello")
-    io = await workspace.execute("cat /partial.txt", session_id="default")
+    io = await workspace.execute("cat /partial.txt")
     assert io.exit_code == 0
     assert io.stdout == b"hello"
 
@@ -67,7 +67,7 @@ async def test_cat_preserves_no_trailing_newline(workspace):
 @pytest.mark.asyncio
 async def test_cat_n_preserves_no_trailing_newline(workspace):
     await workspace.ops.write("/partial.txt", b"hello")
-    io = await workspace.execute("cat -n /partial.txt", session_id="default")
+    io = await workspace.execute("cat -n /partial.txt")
     assert io.exit_code == 0
     assert io.stdout == b"     1\thello"
 
@@ -76,7 +76,7 @@ async def test_cat_n_preserves_no_trailing_newline(workspace):
 async def test_cat_multi_file_concatenation(workspace):
     await workspace.ops.write("/a.txt", b"aaa\n")
     await workspace.ops.write("/b.txt", b"bbb\n")
-    io = await workspace.execute("cat /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("cat /a.txt /b.txt")
     assert io.exit_code == 0
     assert io.stdout == b"aaa\nbbb\n"
 
@@ -86,7 +86,7 @@ async def test_cat_n_across_multiple_files(workspace):
     """cat -n on multiple files numbers globally, not per-file."""
     await workspace.ops.write("/a.txt", b"x\ny\n")
     await workspace.ops.write("/b.txt", b"z\n")
-    io = await workspace.execute("cat -n /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("cat -n /a.txt /b.txt")
     assert io.exit_code == 0
     assert io.stdout == b"     1\tx\n     2\ty\n     3\tz\n"
 
@@ -94,7 +94,7 @@ async def test_cat_n_across_multiple_files(workspace):
 @pytest.mark.asyncio
 async def test_cat_empty_file(workspace):
     await workspace.ops.write("/empty.txt", b"")
-    io = await workspace.execute("cat /empty.txt", session_id="default")
+    io = await workspace.execute("cat /empty.txt")
     assert io.exit_code == 0
     assert io.stdout == b""
 
@@ -102,6 +102,6 @@ async def test_cat_empty_file(workspace):
 @pytest.mark.asyncio
 async def test_cat_only_newlines(workspace):
     await workspace.ops.write("/nl.txt", b"\n\n\n")
-    io = await workspace.execute("cat -n /nl.txt", session_id="default")
+    io = await workspace.execute("cat -n /nl.txt")
     assert io.exit_code == 0
     assert io.stdout == b"     1\t\n     2\t\n     3\t\n"

--- a/python/tests/commands/builtin/ram/head/test_head.py
+++ b/python/tests/commands/builtin/ram/head/test_head.py
@@ -26,7 +26,7 @@ def workspace():
 async def test_head_default_n_10(workspace):
     body = b"".join(f"line{i}\n".encode() for i in range(1, 15))
     await workspace.ops.write("/f.txt", body)
-    io = await workspace.execute("head /f.txt", session_id="default")
+    io = await workspace.execute("head /f.txt")
     assert io.exit_code == 0
     lines = io.stdout.decode().splitlines()
     assert len(lines) == 10
@@ -37,7 +37,7 @@ async def test_head_default_n_10(workspace):
 @pytest.mark.asyncio
 async def test_head_n_explicit(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\nd\n")
-    io = await workspace.execute("head -n 2 /f.txt", session_id="default")
+    io = await workspace.execute("head -n 2 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"a\nb\n"
 
@@ -45,7 +45,7 @@ async def test_head_n_explicit(workspace):
 @pytest.mark.asyncio
 async def test_head_c_bytes(workspace):
     await workspace.ops.write("/f.txt", b"hello world")
-    io = await workspace.execute("head -c 5 /f.txt", session_id="default")
+    io = await workspace.execute("head -c 5 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"hello"
 
@@ -53,7 +53,7 @@ async def test_head_c_bytes(workspace):
 @pytest.mark.asyncio
 async def test_head_negative_n_excludes_last(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\nd\n")
-    io = await workspace.execute("head -n -1 /f.txt", session_id="default")
+    io = await workspace.execute("head -n -1 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"a\nb\nc\n"
 
@@ -61,7 +61,7 @@ async def test_head_negative_n_excludes_last(workspace):
 @pytest.mark.asyncio
 async def test_head_n_larger_than_file(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\n")
-    io = await workspace.execute("head -n 100 /f.txt", session_id="default")
+    io = await workspace.execute("head -n 100 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"a\nb\n"
 
@@ -69,7 +69,7 @@ async def test_head_n_larger_than_file(workspace):
 @pytest.mark.asyncio
 async def test_head_no_trailing_newline(workspace):
     await workspace.ops.write("/partial.txt", b"hello")
-    io = await workspace.execute("head /partial.txt", session_id="default")
+    io = await workspace.execute("head /partial.txt")
     assert io.exit_code == 0
     assert io.stdout == b"hello"
 
@@ -79,7 +79,7 @@ async def test_head_multi_file_emits_headers(workspace):
     """POSIX head with multiple files emits `==> name <==` headers."""
     await workspace.ops.write("/a.txt", b"x\ny\n")
     await workspace.ops.write("/b.txt", b"z\n")
-    io = await workspace.execute("head /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("head /a.txt /b.txt")
     assert io.exit_code == 0
     assert b"==> /a.txt <==\n" in io.stdout
     assert b"==> /b.txt <==\n" in io.stdout
@@ -90,6 +90,6 @@ async def test_head_multi_file_emits_headers(workspace):
 @pytest.mark.asyncio
 async def test_head_empty_file(workspace):
     await workspace.ops.write("/empty.txt", b"")
-    io = await workspace.execute("head /empty.txt", session_id="default")
+    io = await workspace.execute("head /empty.txt")
     assert io.exit_code == 0
     assert io.stdout == b""

--- a/python/tests/commands/builtin/ram/ls/test_ls.py
+++ b/python/tests/commands/builtin/ram/ls/test_ls.py
@@ -26,7 +26,7 @@ def workspace():
 async def test_ls_lists_files(workspace):
     await workspace.ops.write("/a.txt", b"a")
     await workspace.ops.write("/b.txt", b"b")
-    io = await workspace.execute("ls /", session_id="default")
+    io = await workspace.execute("ls /")
     assert io.exit_code == 0
     names = set(io.stdout.decode().strip().split("\n"))
     assert "a.txt" in names
@@ -37,7 +37,7 @@ async def test_ls_lists_files(workspace):
 async def test_ls_a_shows_dotfiles(workspace):
     await workspace.ops.write("/.hidden", b"h")
     await workspace.ops.write("/visible.txt", b"v")
-    io = await workspace.execute("ls -a /", session_id="default")
+    io = await workspace.execute("ls -a /")
     assert io.exit_code == 0
     names = set(io.stdout.decode().strip().split("\n"))
     assert ".hidden" in names
@@ -48,7 +48,7 @@ async def test_ls_a_shows_dotfiles(workspace):
 async def test_ls_no_dotfiles_by_default(workspace):
     await workspace.ops.write("/.hidden", b"h")
     await workspace.ops.write("/visible.txt", b"v")
-    io = await workspace.execute("ls /", session_id="default")
+    io = await workspace.execute("ls /")
     assert io.exit_code == 0
     names = set(io.stdout.decode().strip().split("\n"))
     assert ".hidden" not in names
@@ -58,7 +58,7 @@ async def test_ls_no_dotfiles_by_default(workspace):
 @pytest.mark.asyncio
 async def test_ls_l_long_format_includes_size(workspace):
     await workspace.ops.write("/f.txt", b"hello")
-    io = await workspace.execute("ls -l /", session_id="default")
+    io = await workspace.execute("ls -l /")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "f.txt" in out
@@ -69,7 +69,7 @@ async def test_ls_l_long_format_includes_size(workspace):
 async def test_ls_F_classify_marks_dirs(workspace):
     await workspace.ops.mkdir("/sub")
     await workspace.ops.write("/sub/a.txt", b"a")
-    io = await workspace.execute("ls -F /", session_id="default")
+    io = await workspace.execute("ls -F /")
     assert io.exit_code == 0
     assert "sub/" in io.stdout.decode()
 
@@ -78,7 +78,7 @@ async def test_ls_F_classify_marks_dirs(workspace):
 async def test_ls_R_recursive(workspace):
     await workspace.ops.mkdir("/sub")
     await workspace.ops.write("/sub/a.txt", b"a")
-    io = await workspace.execute("ls -R /", session_id="default")
+    io = await workspace.execute("ls -R /")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "sub" in out
@@ -88,13 +88,13 @@ async def test_ls_R_recursive(workspace):
 @pytest.mark.asyncio
 async def test_ls_d_lists_dir_itself(workspace):
     await workspace.ops.mkdir("/sub")
-    io = await workspace.execute("ls -d /sub", session_id="default")
+    io = await workspace.execute("ls -d /sub")
     assert io.exit_code == 0
     assert "sub" in io.stdout.decode()
 
 
 @pytest.mark.asyncio
 async def test_ls_missing_path_returns_exit_1(workspace):
-    io = await workspace.execute("ls /nope", session_id="default")
+    io = await workspace.execute("ls /nope")
     assert io.exit_code == 1
     assert b"nope" in (io.stderr or b"")

--- a/python/tests/commands/builtin/ram/tail/test_tail.py
+++ b/python/tests/commands/builtin/ram/tail/test_tail.py
@@ -26,7 +26,7 @@ def workspace():
 async def test_tail_default_n_10(workspace):
     body = b"\n".join(f"line{i}".encode() for i in range(1, 21)) + b"\n"
     await workspace.ops.write("/f.txt", body)
-    io = await workspace.execute("tail /f.txt", session_id="default")
+    io = await workspace.execute("tail /f.txt")
     assert io.exit_code == 0
     expected = b"\n".join(f"line{i}".encode() for i in range(11, 21)) + b"\n"
     assert io.stdout == expected
@@ -35,7 +35,7 @@ async def test_tail_default_n_10(workspace):
 @pytest.mark.asyncio
 async def test_tail_n_explicit(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\nd\ne\n")
-    io = await workspace.execute("tail -n 3 /f.txt", session_id="default")
+    io = await workspace.execute("tail -n 3 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"c\nd\ne\n"
 
@@ -43,7 +43,7 @@ async def test_tail_n_explicit(workspace):
 @pytest.mark.asyncio
 async def test_tail_c_bytes(workspace):
     await workspace.ops.write("/f.txt", b"hello world")
-    io = await workspace.execute("tail -c 5 /f.txt", session_id="default")
+    io = await workspace.execute("tail -c 5 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"world"
 
@@ -51,7 +51,7 @@ async def test_tail_c_bytes(workspace):
 @pytest.mark.asyncio
 async def test_tail_plus_n_streams_from_line(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\nd\ne\n")
-    io = await workspace.execute("tail -n +3 /f.txt", session_id="default")
+    io = await workspace.execute("tail -n +3 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"c\nd\ne\n"
 
@@ -59,7 +59,7 @@ async def test_tail_plus_n_streams_from_line(workspace):
 @pytest.mark.asyncio
 async def test_tail_no_trailing_newline(workspace):
     await workspace.ops.write("/partial.txt", b"hello")
-    io = await workspace.execute("tail /partial.txt", session_id="default")
+    io = await workspace.execute("tail /partial.txt")
     assert io.exit_code == 0
     assert io.stdout == b"hello"
 
@@ -67,7 +67,7 @@ async def test_tail_no_trailing_newline(workspace):
 @pytest.mark.asyncio
 async def test_tail_empty_file(workspace):
     await workspace.ops.write("/empty.txt", b"")
-    io = await workspace.execute("tail /empty.txt", session_id="default")
+    io = await workspace.execute("tail /empty.txt")
     assert io.exit_code == 0
     assert io.stdout == b""
 
@@ -76,7 +76,7 @@ async def test_tail_empty_file(workspace):
 async def test_tail_multi_file_emits_headers(workspace):
     await workspace.ops.write("/a.txt", b"x\ny\n")
     await workspace.ops.write("/b.txt", b"z\n")
-    io = await workspace.execute("tail /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("tail /a.txt /b.txt")
     assert io.exit_code == 0
     assert b"==> /a.txt <==" in io.stdout
     assert b"==> /b.txt <==" in io.stdout
@@ -86,7 +86,7 @@ async def test_tail_multi_file_emits_headers(workspace):
 async def test_tail_q_suppresses_headers(workspace):
     await workspace.ops.write("/a.txt", b"x\n")
     await workspace.ops.write("/b.txt", b"y\n")
-    io = await workspace.execute("tail -q /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("tail -q /a.txt /b.txt")
     assert io.exit_code == 0
     assert b"==>" not in io.stdout
     assert b"x\n" in io.stdout
@@ -96,7 +96,7 @@ async def test_tail_q_suppresses_headers(workspace):
 @pytest.mark.asyncio
 async def test_tail_v_forces_header_on_single_file(workspace):
     await workspace.ops.write("/a.txt", b"aaa\n")
-    io = await workspace.execute("tail -v /a.txt", session_id="default")
+    io = await workspace.execute("tail -v /a.txt")
     assert io.exit_code == 0
     assert b"==> /a.txt <==" in io.stdout
     assert b"aaa\n" in io.stdout

--- a/python/tests/commands/builtin/ram/test_cp.py
+++ b/python/tests/commands/builtin/ram/test_cp.py
@@ -26,17 +26,17 @@ def workspace():
 async def test_cp_recursive_into_itself_refused(workspace):
     await workspace.ops.mkdir("/d")
     await workspace.ops.write("/d/a.txt", b"a")
-    io = await workspace.execute("cp -r /d /d", session_id="default")
+    io = await workspace.execute("cp -r /d /d")
     assert io.exit_code != 0
     assert b"into itself" in io.stderr
-    io = await workspace.execute("find /d -type f", session_id="default")
+    io = await workspace.execute("find /d -type f")
     assert io.stdout.decode().split() == ["/d/a.txt"]
 
 
 @pytest.mark.asyncio
 async def test_cp_onto_same_path_errors(workspace):
     await workspace.ops.write("/a.txt", b"keep")
-    io = await workspace.execute("cp /a.txt /a.txt", session_id="default")
+    io = await workspace.execute("cp /a.txt /a.txt")
     assert io.exit_code != 0
     assert b"are the same file" in io.stderr
     assert await workspace.ops.read("/a.txt") == b"keep"
@@ -46,8 +46,7 @@ async def test_cp_onto_same_path_errors(workspace):
 async def test_cp_missing_source_continues_with_rest(workspace):
     await workspace.ops.mkdir("/d")
     await workspace.ops.write("/b.txt", b"b")
-    io = await workspace.execute("cp /missing.txt /b.txt /d",
-                                 session_id="default")
+    io = await workspace.execute("cp /missing.txt /b.txt /d")
     assert io.exit_code != 0
     assert b"cannot stat" in io.stderr
     assert await workspace.ops.read("/d/b.txt") == b"b"

--- a/python/tests/commands/builtin/ram/test_du.py
+++ b/python/tests/commands/builtin/ram/test_du.py
@@ -25,7 +25,7 @@ def workspace():
 @pytest.mark.asyncio
 async def test_du_single_file(workspace):
     await workspace.ops.write("/f.txt", b"hello")
-    io = await workspace.execute("du /f.txt", session_id="default")
+    io = await workspace.execute("du /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().strip() == "5\t/f.txt"
 
@@ -35,7 +35,7 @@ async def test_du_directory_collapses(workspace):
     await workspace.ops.mkdir("/dir")
     await workspace.ops.write("/dir/a.txt", b"aaa")
     await workspace.ops.write("/dir/b.txt", b"bb")
-    io = await workspace.execute("du /dir", session_id="default")
+    io = await workspace.execute("du /dir")
     assert io.exit_code == 0
     assert io.stdout.decode().strip() == "5\t/dir"
 
@@ -45,7 +45,7 @@ async def test_du_a_lists_files(workspace):
     await workspace.ops.mkdir("/dir")
     await workspace.ops.write("/dir/a.txt", b"aaa")
     await workspace.ops.write("/dir/b.txt", b"bb")
-    io = await workspace.execute("du -a /dir", session_id="default")
+    io = await workspace.execute("du -a /dir")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "a.txt" in out
@@ -58,7 +58,7 @@ async def test_du_s_summary(workspace):
     await workspace.ops.mkdir("/dir/sub")
     await workspace.ops.write("/dir/a.txt", b"hello")
     await workspace.ops.write("/dir/sub/b.txt", b"world")
-    io = await workspace.execute("du -s /dir", session_id="default")
+    io = await workspace.execute("du -s /dir")
     assert io.exit_code == 0
     lines = io.stdout.decode().strip().splitlines()
     assert len(lines) == 1
@@ -68,7 +68,7 @@ async def test_du_s_summary(workspace):
 async def test_du_c_total(workspace):
     await workspace.ops.write("/a.txt", b"hello")
     await workspace.ops.write("/b.txt", b"world")
-    io = await workspace.execute("du -c /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("du -c /a.txt /b.txt")
     assert io.exit_code == 0
     lines = io.stdout.decode().strip().splitlines()
     assert lines[-1] == "10\ttotal"
@@ -77,7 +77,7 @@ async def test_du_c_total(workspace):
 @pytest.mark.asyncio
 async def test_du_h_human(workspace):
     await workspace.ops.write("/big.txt", b"x" * 2048)
-    io = await workspace.execute("du -h /big.txt", session_id="default")
+    io = await workspace.execute("du -h /big.txt")
     assert io.exit_code == 0
     size_str = io.stdout.decode().strip().split("\t")[0]
     assert size_str.endswith("K")
@@ -89,8 +89,7 @@ async def test_du_max_depth_one(workspace):
     await workspace.ops.mkdir("/dir/sub")
     await workspace.ops.mkdir("/dir/sub/deep")
     await workspace.ops.write("/dir/sub/deep/a.txt", b"hello")
-    io = await workspace.execute("du -a --max-depth 1 /dir",
-                                 session_id="default")
+    io = await workspace.execute("du -a --max-depth 1 /dir")
     assert io.exit_code == 0
     lines = io.stdout.decode().strip().splitlines()
     assert not any("deep" in ln for ln in lines)
@@ -98,6 +97,6 @@ async def test_du_max_depth_one(workspace):
 
 @pytest.mark.asyncio
 async def test_du_missing_operand_errors(workspace):
-    io = await workspace.execute("du", session_id="default")
+    io = await workspace.execute("du")
     assert io.exit_code != 0
     assert b"missing operand" in (io.stderr or b"")

--- a/python/tests/commands/builtin/ram/test_find.py
+++ b/python/tests/commands/builtin/ram/test_find.py
@@ -26,7 +26,7 @@ def workspace():
 async def test_find_name_glob(workspace):
     await workspace.ops.write("/hello.txt", b"hi")
     await workspace.ops.write("/world.py", b"hi")
-    io = await workspace.execute("find / -name '*.txt'", session_id="default")
+    io = await workspace.execute("find / -name '*.txt'")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "hello.txt" in out
@@ -38,7 +38,7 @@ async def test_find_type_f(workspace):
     await workspace.ops.mkdir("/sub")
     await workspace.ops.write("/a.txt", b"a")
     await workspace.ops.write("/sub/b.txt", b"b")
-    io = await workspace.execute("find / -type f", session_id="default")
+    io = await workspace.execute("find / -type f")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "/a.txt" in out
@@ -50,7 +50,7 @@ async def test_find_type_f(workspace):
 async def test_find_type_d(workspace):
     await workspace.ops.mkdir("/sub")
     await workspace.ops.write("/a.txt", b"a")
-    io = await workspace.execute("find / -type d", session_id="default")
+    io = await workspace.execute("find / -type d")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "/sub" in out
@@ -61,8 +61,7 @@ async def test_find_type_d(workspace):
 async def test_find_size_lower_bound(workspace):
     await workspace.ops.write("/big.txt", b"x" * 1000)
     await workspace.ops.write("/small.txt", b"x")
-    io = await workspace.execute("find / -size +500c -type f",
-                                 session_id="default")
+    io = await workspace.execute("find / -size +500c -type f")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "big.txt" in out
@@ -75,8 +74,7 @@ async def test_find_maxdepth(workspace):
     await workspace.ops.mkdir("/sub/deep")
     await workspace.ops.write("/a.txt", b"a")
     await workspace.ops.write("/sub/deep/c.txt", b"c")
-    io = await workspace.execute("find / -maxdepth 1 -type f",
-                                 session_id="default")
+    io = await workspace.execute("find / -maxdepth 1 -type f")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "/a.txt" in out
@@ -86,14 +84,13 @@ async def test_find_maxdepth(workspace):
 @pytest.mark.asyncio
 async def test_find_iname(workspace):
     await workspace.ops.write("/Hello.txt", b"hi")
-    io = await workspace.execute("find / -iname hello.txt",
-                                 session_id="default")
+    io = await workspace.execute("find / -iname hello.txt")
     assert io.exit_code == 0
     assert "Hello.txt" in io.stdout.decode()
 
 
 @pytest.mark.asyncio
 async def test_find_missing_path_returns_exit_1(workspace):
-    io = await workspace.execute("find /nonexistent", session_id="default")
+    io = await workspace.execute("find /nonexistent")
     assert io.exit_code == 1
     assert b"nonexistent" in (io.stderr or b"")

--- a/python/tests/commands/builtin/ram/test_grep.py
+++ b/python/tests/commands/builtin/ram/test_grep.py
@@ -27,8 +27,7 @@ async def test_grep_positional_pattern(workspace):
     await workspace.ops.mkdir("/data")
     await workspace.ops.write("/data/a.txt", b"orange line\nplain line\n")
 
-    io = await workspace.execute("grep orange /data/a.txt",
-                                 session_id="default")
+    io = await workspace.execute("grep orange /data/a.txt")
     assert io.exit_code == 0
     assert (io.stdout or b"").decode() == "orange line\n"
 
@@ -38,8 +37,7 @@ async def test_grep_dash_e_matches_like_positional_pattern(workspace):
     await workspace.ops.mkdir("/data")
     await workspace.ops.write("/data/a.txt", b"orange line\nplain line\n")
 
-    io = await workspace.execute("grep -e orange /data/a.txt",
-                                 session_id="default")
+    io = await workspace.execute("grep -e orange /data/a.txt")
     assert io.exit_code == 0
     assert (io.stdout or b"").decode() == "orange line\n"
 
@@ -50,8 +48,7 @@ async def test_grep_repeated_dash_e_matches_any_pattern(workspace):
     await workspace.ops.write("/data/a.txt",
                               b"orange line\nplain line\nlast line\n")
 
-    io = await workspace.execute("grep -e orange -e plain /data/a.txt",
-                                 session_id="default")
+    io = await workspace.execute("grep -e orange -e plain /data/a.txt")
     assert io.exit_code == 0
     assert (io.stdout or b"").decode() == "orange line\nplain line\n"
 
@@ -63,8 +60,7 @@ async def test_grep_dash_f_reads_patterns_from_file(workspace):
                               b"orange line\nplain line\nlast line\n")
     await workspace.ops.write("/data/pats.txt", b"orange\nlast\n")
 
-    io = await workspace.execute("grep -f /data/pats.txt /data/a.txt",
-                                 session_id="default")
+    io = await workspace.execute("grep -f /data/pats.txt /data/a.txt")
     assert io.exit_code == 0
     assert (io.stdout or b"").decode() == "orange line\nlast line\n"
 
@@ -76,8 +72,7 @@ async def test_grep_dash_e_and_dash_f_union(workspace):
                               b"orange line\nplain line\nlast line\n")
     await workspace.ops.write("/data/pats.txt", b"last\n")
 
-    io = await workspace.execute("grep -e plain -f /data/pats.txt /data/a.txt",
-                                 session_id="default")
+    io = await workspace.execute("grep -e plain -f /data/pats.txt /data/a.txt")
     assert io.exit_code == 0
     assert (io.stdout or b"").decode() == "plain line\nlast line\n"
 
@@ -91,8 +86,7 @@ async def test_grep_repeated_dash_f_unions_pattern_files(workspace):
     await workspace.ops.write("/data/p2.txt", b"last\n")
 
     io = await workspace.execute(
-        "grep -f /data/p1.txt -f /data/p2.txt /data/a.txt",
-        session_id="default")
+        "grep -f /data/p1.txt -f /data/p2.txt /data/a.txt")
     assert io.exit_code == 0
     assert (io.stdout or b"").decode() == "orange line\nlast line\n"
 
@@ -106,8 +100,7 @@ async def test_grep_dash_e_and_repeated_dash_f_union(workspace):
     await workspace.ops.write("/data/p2.txt", b"last\n")
 
     io = await workspace.execute(
-        "grep -e plain -f /data/p1.txt -f /data/p2.txt /data/a.txt",
-        session_id="default")
+        "grep -e plain -f /data/p1.txt -f /data/p2.txt /data/a.txt")
     assert io.exit_code == 0
     assert (io.stdout
             or b"").decode() == "orange line\nplain line\nlast line\n"
@@ -118,8 +111,7 @@ async def test_grep_color_accepted_as_gnu_noop(workspace):
     await workspace.ops.mkdir("/data")
     await workspace.ops.write("/data/a.txt", b"orange line\nplain line\n")
 
-    io = await workspace.execute("grep --color=auto orange /data/a.txt",
-                                 session_id="default")
+    io = await workspace.execute("grep --color=auto orange /data/a.txt")
     assert io.exit_code == 0
     assert (io.stdout or b"").decode() == "orange line\n"
     stderr = io.stderr if isinstance(io.stderr, bytes) else b""
@@ -131,8 +123,7 @@ async def test_grep_unknown_flag_refuses_with_gnu_error(workspace):
     await workspace.ops.mkdir("/data")
     await workspace.ops.write("/data/a.txt", b"orange line\nplain line\n")
 
-    io = await workspace.execute("grep --bogus orange /data/a.txt",
-                                 session_id="default")
+    io = await workspace.execute("grep --bogus orange /data/a.txt")
     assert io.exit_code == 2
     stderr = io.stderr if isinstance(io.stderr, bytes) else b""
     assert b"grep: unrecognized option '--bogus'" in stderr
@@ -146,8 +137,7 @@ async def test_grep_dash_f_empty_file_matches_nothing(workspace):
     await workspace.ops.write("/data/a.txt", b"orange line\n")
     await workspace.ops.write("/data/empty.txt", b"")
 
-    io = await workspace.execute("grep -f /data/empty.txt /data/a.txt",
-                                 session_id="default")
+    io = await workspace.execute("grep -f /data/empty.txt /data/a.txt")
     assert io.exit_code == 1
     assert (io.stdout or b"") == b""
 
@@ -158,8 +148,7 @@ async def test_grep_v_dash_f_empty_file_matches_all(workspace):
     await workspace.ops.write("/data/a.txt", b"orange line\nplain line\n")
     await workspace.ops.write("/data/empty.txt", b"")
 
-    io = await workspace.execute("grep -v -f /data/empty.txt /data/a.txt",
-                                 session_id="default")
+    io = await workspace.execute("grep -v -f /data/empty.txt /data/a.txt")
     assert io.exit_code == 0
     assert (io.stdout or b"").decode() == "orange line\nplain line\n"
 
@@ -170,7 +159,7 @@ async def test_usage_error_is_exit_2_with_newline(workspace):
     # and exit 2 (grep and rg do; zgrep prints usage with exit 2 here for
     # consistency across the family).
     for cmd in ("grep", "rg", "zgrep"):
-        io = await workspace.execute(cmd, session_id="default")
+        io = await workspace.execute(cmd)
         assert io.exit_code == 2
         stderr = io.stderr if isinstance(io.stderr, bytes) else b""
         usage = f"{cmd}: usage: {cmd} [flags] pattern [path]\n"

--- a/python/tests/commands/builtin/ram/test_grep_recursive_dir.py
+++ b/python/tests/commands/builtin/ram/test_grep_recursive_dir.py
@@ -29,7 +29,7 @@ async def test_grep_recursive_dir_returns_matches(workspace):
                               b"hello world\ngoodbye\nhello again")
     await workspace.ops.write("/sub/b.txt", b"nothing here\n")
 
-    io = await workspace.execute("grep -rn hello /sub", session_id="default")
+    io = await workspace.execute("grep -rn hello /sub")
     output = (io.stdout or b"").decode()
     assert io.exit_code == 0
     assert "hello" in output

--- a/python/tests/commands/builtin/ram/test_mv.py
+++ b/python/tests/commands/builtin/ram/test_mv.py
@@ -25,7 +25,7 @@ def workspace():
 @pytest.mark.asyncio
 async def test_mv_onto_same_path_errors_and_preserves_file(workspace):
     await workspace.ops.write("/a.txt", b"keep")
-    io = await workspace.execute("mv /a.txt /a.txt", session_id="default")
+    io = await workspace.execute("mv /a.txt /a.txt")
     assert io.exit_code != 0
     assert b"are the same file" in io.stderr
     assert await workspace.ops.read("/a.txt") == b"keep"
@@ -36,7 +36,7 @@ async def test_mv_into_own_subtree_refused(workspace):
     await workspace.ops.mkdir("/d")
     await workspace.ops.write("/d/a.txt", b"a")
     await workspace.ops.mkdir("/d/sub")
-    io = await workspace.execute("mv /d /d/sub", session_id="default")
+    io = await workspace.execute("mv /d /d/sub")
     assert io.exit_code != 0
     assert b"subdirectory of itself" in io.stderr
     assert await workspace.ops.read("/d/a.txt") == b"a"
@@ -44,7 +44,6 @@ async def test_mv_into_own_subtree_refused(workspace):
 
 @pytest.mark.asyncio
 async def test_mv_missing_source_reports_cannot_stat(workspace):
-    io = await workspace.execute("mv /missing.txt /dst.txt",
-                                 session_id="default")
+    io = await workspace.execute("mv /missing.txt /dst.txt")
     assert io.exit_code != 0
     assert b"mv: cannot stat" in io.stderr

--- a/python/tests/commands/builtin/ram/test_rg.py
+++ b/python/tests/commands/builtin/ram/test_rg.py
@@ -27,8 +27,7 @@ async def test_rg_dash_e_matches_like_positional_pattern(workspace):
     await workspace.ops.mkdir("/data")
     await workspace.ops.write("/data/a.txt", b"orange line\nplain line\n")
 
-    io = await workspace.execute("rg -e orange /data/a.txt",
-                                 session_id="default")
+    io = await workspace.execute("rg -e orange /data/a.txt")
     assert io.exit_code == 0
     assert "orange line" in (io.stdout or b"").decode()
 
@@ -39,8 +38,7 @@ async def test_rg_repeated_dash_e_matches_any_pattern(workspace):
     await workspace.ops.write("/data/a.txt",
                               b"orange line\nplain line\nlast line\n")
 
-    io = await workspace.execute("rg -e orange -e plain /data/a.txt",
-                                 session_id="default")
+    io = await workspace.execute("rg -e orange -e plain /data/a.txt")
     assert io.exit_code == 0
     out = (io.stdout or b"").decode()
     assert "orange line" in out
@@ -55,8 +53,7 @@ async def test_rg_dash_f_reads_patterns_from_file(workspace):
                               b"orange line\nplain line\nlast line\n")
     await workspace.ops.write("/data/pats.txt", b"orange\nlast\n")
 
-    io = await workspace.execute("rg -f /data/pats.txt /data/a.txt",
-                                 session_id="default")
+    io = await workspace.execute("rg -f /data/pats.txt /data/a.txt")
     assert io.exit_code == 0
     out = (io.stdout or b"").decode()
     assert "orange line" in out
@@ -71,8 +68,7 @@ async def test_rg_dash_e_and_dash_f_union(workspace):
                               b"orange line\nplain line\nlast line\n")
     await workspace.ops.write("/data/pats.txt", b"last\n")
 
-    io = await workspace.execute("rg -e plain -f /data/pats.txt /data/a.txt",
-                                 session_id="default")
+    io = await workspace.execute("rg -e plain -f /data/pats.txt /data/a.txt")
     assert io.exit_code == 0
     out = (io.stdout or b"").decode()
     assert "plain line" in out

--- a/python/tests/commands/builtin/ram/test_rm.py
+++ b/python/tests/commands/builtin/ram/test_rm.py
@@ -26,7 +26,7 @@ def workspace():
 async def test_rm_v_terminates_verbose_output(workspace):
     await workspace.ops.write("/a.txt", b"a")
 
-    io = await workspace.execute("rm -v /a.txt", session_id="default")
+    io = await workspace.execute("rm -v /a.txt")
 
     assert io.exit_code == 0
     assert io.stdout == b"removed '/a.txt'\n"

--- a/python/tests/commands/builtin/ram/test_tree.py
+++ b/python/tests/commands/builtin/ram/test_tree.py
@@ -27,7 +27,7 @@ async def test_tree_basic(workspace):
     await workspace.ops.mkdir("/d1")
     await workspace.ops.write("/d1/a.txt", b"a")
     await workspace.ops.write("/d1/b.txt", b"b")
-    io = await workspace.execute("tree /d1", session_id="default")
+    io = await workspace.execute("tree /d1")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "a.txt" in out
@@ -40,7 +40,7 @@ async def test_tree_L_max_depth(workspace):
     await workspace.ops.mkdir("/d1/sub")
     await workspace.ops.mkdir("/d1/sub/deep")
     await workspace.ops.write("/d1/sub/deep/file.txt", b"d")
-    io = await workspace.execute("tree -L 1 /d1", session_id="default")
+    io = await workspace.execute("tree -L 1 /d1")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "sub" in out
@@ -53,7 +53,7 @@ async def test_tree_a_shows_dotfiles(workspace):
     await workspace.ops.mkdir("/d1")
     await workspace.ops.write("/d1/.hidden", b"h")
     await workspace.ops.write("/d1/visible.txt", b"v")
-    io = await workspace.execute("tree -a /d1", session_id="default")
+    io = await workspace.execute("tree -a /d1")
     assert io.exit_code == 0
     assert ".hidden" in io.stdout.decode()
 
@@ -63,7 +63,7 @@ async def test_tree_d_dirs_only(workspace):
     await workspace.ops.mkdir("/d1")
     await workspace.ops.mkdir("/d1/sub")
     await workspace.ops.write("/d1/file.txt", b"x")
-    io = await workspace.execute("tree -d /d1", session_id="default")
+    io = await workspace.execute("tree -d /d1")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "sub" in out

--- a/python/tests/commands/builtin/ram/wc/test_wc.py
+++ b/python/tests/commands/builtin/ram/wc/test_wc.py
@@ -25,7 +25,7 @@ def workspace():
 @pytest.mark.asyncio
 async def test_wc_default(workspace):
     await workspace.ops.write("/f.txt", b"hello world\nfoo bar\n")
-    io = await workspace.execute("wc /f.txt", session_id="default")
+    io = await workspace.execute("wc /f.txt")
     assert io.exit_code == 0
     parts = io.stdout.decode().split()
     assert parts[0] == "2"
@@ -37,7 +37,7 @@ async def test_wc_default(workspace):
 @pytest.mark.asyncio
 async def test_wc_l(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\n")
-    io = await workspace.execute("wc -l /f.txt", session_id="default")
+    io = await workspace.execute("wc -l /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().split()[0] == "3"
 
@@ -45,7 +45,7 @@ async def test_wc_l(workspace):
 @pytest.mark.asyncio
 async def test_wc_w(workspace):
     await workspace.ops.write("/f.txt", b"hello world\nfoo\n")
-    io = await workspace.execute("wc -w /f.txt", session_id="default")
+    io = await workspace.execute("wc -w /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().split()[0] == "3"
 
@@ -53,7 +53,7 @@ async def test_wc_w(workspace):
 @pytest.mark.asyncio
 async def test_wc_c(workspace):
     await workspace.ops.write("/f.txt", b"hello\n")
-    io = await workspace.execute("wc -c /f.txt", session_id="default")
+    io = await workspace.execute("wc -c /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().split()[0] == "6"
 
@@ -62,7 +62,7 @@ async def test_wc_c(workspace):
 async def test_wc_m_multibyte(workspace):
     """`café` is 4 chars / 5 bytes."""
     await workspace.ops.write("/f.txt", "café".encode())
-    io = await workspace.execute("wc -m /f.txt", session_id="default")
+    io = await workspace.execute("wc -m /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().split()[0] == "4"
 
@@ -70,7 +70,7 @@ async def test_wc_m_multibyte(workspace):
 @pytest.mark.asyncio
 async def test_wc_L(workspace):
     await workspace.ops.write("/f.txt", b"short\na much longer line\nmed\n")
-    io = await workspace.execute("wc -L /f.txt", session_id="default")
+    io = await workspace.execute("wc -L /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().split()[0] == str(len("a much longer line"))
 
@@ -78,7 +78,7 @@ async def test_wc_L(workspace):
 @pytest.mark.asyncio
 async def test_wc_empty_file(workspace):
     await workspace.ops.write("/f.txt", b"")
-    io = await workspace.execute("wc /f.txt", session_id="default")
+    io = await workspace.execute("wc /f.txt")
     assert io.exit_code == 0
     parts = io.stdout.decode().split()
     assert parts[:3] == ["0", "0", "0"]
@@ -86,18 +86,14 @@ async def test_wc_empty_file(workspace):
 
 @pytest.mark.asyncio
 async def test_wc_l_stdin(workspace):
-    io = await workspace.execute("wc -l",
-                                 session_id="default",
-                                 stdin=b"a\nb\nc\n")
+    io = await workspace.execute("wc -l", stdin=b"a\nb\nc\n")
     assert io.exit_code == 0
     assert io.stdout == b"3\n"
 
 
 @pytest.mark.asyncio
 async def test_wc_default_stdin(workspace):
-    io = await workspace.execute("wc",
-                                 session_id="default",
-                                 stdin=b"one two\nthree\n")
+    io = await workspace.execute("wc", stdin=b"one two\nthree\n")
     assert io.exit_code == 0
     parts = io.stdout.decode().strip().split()
     assert parts == ["2", "3", "14"]
@@ -105,16 +101,14 @@ async def test_wc_default_stdin(workspace):
 
 @pytest.mark.asyncio
 async def test_wc_m_stdin_ascii(workspace):
-    io = await workspace.execute("wc -m", session_id="default", stdin=b"hello")
+    io = await workspace.execute("wc -m", stdin=b"hello")
     assert io.exit_code == 0
     assert io.stdout.decode().strip() == "5"
 
 
 @pytest.mark.asyncio
 async def test_wc_m_stdin_multibyte(workspace):
-    io = await workspace.execute("wc -m",
-                                 session_id="default",
-                                 stdin="café".encode())
+    io = await workspace.execute("wc -m", stdin="café".encode())
     assert io.exit_code == 0
     assert io.stdout.decode().strip() == "4"
 
@@ -122,7 +116,6 @@ async def test_wc_m_stdin_multibyte(workspace):
 @pytest.mark.asyncio
 async def test_wc_L_stdin(workspace):
     io = await workspace.execute("wc -L",
-                                 session_id="default",
                                  stdin=b"short\na much longer line\nmed\n")
     assert io.exit_code == 0
     assert io.stdout.decode().strip() == str(len("a much longer line"))
@@ -132,7 +125,7 @@ async def test_wc_L_stdin(workspace):
 async def test_wc_multi_file_emits_total(workspace):
     await workspace.ops.write("/a.txt", b"hello\n")
     await workspace.ops.write("/b.txt", b"world\nfoo\n")
-    io = await workspace.execute("wc /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("wc /a.txt /b.txt")
     assert io.exit_code == 0
     assert io.stdout.endswith(b"\n")
     lines = io.stdout.decode().splitlines()

--- a/python/tests/commands/builtin/redis/cat/test_cat.py
+++ b/python/tests/commands/builtin/redis/cat/test_cat.py
@@ -37,7 +37,7 @@ async def workspace():
 @pytest.mark.asyncio
 async def test_cat_basic(workspace):
     await workspace.ops.write("/f.txt", b"hello\nworld\n")
-    io = await workspace.execute("cat /f.txt", session_id="default")
+    io = await workspace.execute("cat /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"hello\nworld\n"
 
@@ -45,7 +45,7 @@ async def test_cat_basic(workspace):
 @pytest.mark.asyncio
 async def test_cat_n_single_digit_alignment(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\n")
-    io = await workspace.execute("cat -n /f.txt", session_id="default")
+    io = await workspace.execute("cat -n /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"     1\ta\n     2\tb\n"
 
@@ -54,7 +54,7 @@ async def test_cat_n_single_digit_alignment(workspace):
 async def test_cat_n_multidigit_alignment(workspace):
     body = b"".join(f"line{i}\n".encode() for i in range(1, 13))
     await workspace.ops.write("/big.txt", body)
-    io = await workspace.execute("cat -n /big.txt", session_id="default")
+    io = await workspace.execute("cat -n /big.txt")
     assert io.exit_code == 0
     lines = io.stdout.split(b"\n")
     assert lines[0] == b"     1\tline1"
@@ -66,7 +66,7 @@ async def test_cat_n_multidigit_alignment(workspace):
 @pytest.mark.asyncio
 async def test_cat_preserves_no_trailing_newline(workspace):
     await workspace.ops.write("/partial.txt", b"hello")
-    io = await workspace.execute("cat /partial.txt", session_id="default")
+    io = await workspace.execute("cat /partial.txt")
     assert io.exit_code == 0
     assert io.stdout == b"hello"
 
@@ -74,7 +74,7 @@ async def test_cat_preserves_no_trailing_newline(workspace):
 @pytest.mark.asyncio
 async def test_cat_n_preserves_no_trailing_newline(workspace):
     await workspace.ops.write("/partial.txt", b"hello")
-    io = await workspace.execute("cat -n /partial.txt", session_id="default")
+    io = await workspace.execute("cat -n /partial.txt")
     assert io.exit_code == 0
     assert io.stdout == b"     1\thello"
 
@@ -83,6 +83,6 @@ async def test_cat_n_preserves_no_trailing_newline(workspace):
 async def test_cat_multi_file_concatenation(workspace):
     await workspace.ops.write("/a.txt", b"aaa\n")
     await workspace.ops.write("/b.txt", b"bbb\n")
-    io = await workspace.execute("cat /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("cat /a.txt /b.txt")
     assert io.exit_code == 0
     assert io.stdout == b"aaa\nbbb\n"

--- a/python/tests/commands/builtin/redis/head/test_head.py
+++ b/python/tests/commands/builtin/redis/head/test_head.py
@@ -38,7 +38,7 @@ async def workspace():
 async def test_head_default_n_10(workspace):
     body = b"".join(f"line{i}\n".encode() for i in range(1, 15))
     await workspace.ops.write("/f.txt", body)
-    io = await workspace.execute("head /f.txt", session_id="default")
+    io = await workspace.execute("head /f.txt")
     assert io.exit_code == 0
     lines = io.stdout.decode().splitlines()
     assert len(lines) == 10
@@ -49,7 +49,7 @@ async def test_head_default_n_10(workspace):
 @pytest.mark.asyncio
 async def test_head_n_explicit(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\nd\n")
-    io = await workspace.execute("head -n 2 /f.txt", session_id="default")
+    io = await workspace.execute("head -n 2 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"a\nb\n"
 
@@ -57,7 +57,7 @@ async def test_head_n_explicit(workspace):
 @pytest.mark.asyncio
 async def test_head_c_bytes(workspace):
     await workspace.ops.write("/f.txt", b"hello world")
-    io = await workspace.execute("head -c 5 /f.txt", session_id="default")
+    io = await workspace.execute("head -c 5 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"hello"
 
@@ -65,7 +65,7 @@ async def test_head_c_bytes(workspace):
 @pytest.mark.asyncio
 async def test_head_negative_n_excludes_last(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\nd\n")
-    io = await workspace.execute("head -n -1 /f.txt", session_id="default")
+    io = await workspace.execute("head -n -1 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"a\nb\nc\n"
 
@@ -74,7 +74,7 @@ async def test_head_negative_n_excludes_last(workspace):
 async def test_head_multi_file_emits_headers(workspace):
     await workspace.ops.write("/a.txt", b"x\ny\n")
     await workspace.ops.write("/b.txt", b"z\n")
-    io = await workspace.execute("head /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("head /a.txt /b.txt")
     assert io.exit_code == 0
     assert b"==> /a.txt <==" in io.stdout
     assert b"==> /b.txt <==" in io.stdout

--- a/python/tests/commands/builtin/redis/ls/test_ls.py
+++ b/python/tests/commands/builtin/redis/ls/test_ls.py
@@ -39,7 +39,7 @@ async def workspace():
 async def test_ls_lists_files(workspace):
     await workspace.ops.write("/a.txt", b"a")
     await workspace.ops.write("/b.txt", b"b")
-    io = await workspace.execute("ls /", session_id="default")
+    io = await workspace.execute("ls /")
     assert io.exit_code == 0
     names = set(io.stdout.decode().strip().split("\n"))
     assert "a.txt" in names
@@ -50,7 +50,7 @@ async def test_ls_lists_files(workspace):
 async def test_ls_a_shows_dotfiles(workspace):
     await workspace.ops.write("/.hidden", b"h")
     await workspace.ops.write("/visible.txt", b"v")
-    io = await workspace.execute("ls -a /", session_id="default")
+    io = await workspace.execute("ls -a /")
     assert io.exit_code == 0
     names = set(io.stdout.decode().strip().split("\n"))
     assert ".hidden" in names
@@ -60,7 +60,7 @@ async def test_ls_a_shows_dotfiles(workspace):
 @pytest.mark.asyncio
 async def test_ls_l_long_format_includes_size(workspace):
     await workspace.ops.write("/f.txt", b"hello")
-    io = await workspace.execute("ls -l /", session_id="default")
+    io = await workspace.execute("ls -l /")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "f.txt" in out
@@ -70,13 +70,13 @@ async def test_ls_l_long_format_includes_size(workspace):
 @pytest.mark.asyncio
 async def test_ls_d_lists_dir_itself(workspace):
     await workspace.ops.mkdir("/sub")
-    io = await workspace.execute("ls -d /sub", session_id="default")
+    io = await workspace.execute("ls -d /sub")
     assert io.exit_code == 0
     assert "sub" in io.stdout.decode()
 
 
 @pytest.mark.asyncio
 async def test_ls_missing_path_returns_exit_1(workspace):
-    io = await workspace.execute("ls /nope", session_id="default")
+    io = await workspace.execute("ls /nope")
     assert io.exit_code == 1
     assert b"nope" in (io.stderr or b"")

--- a/python/tests/commands/builtin/redis/tail/test_tail.py
+++ b/python/tests/commands/builtin/redis/tail/test_tail.py
@@ -38,7 +38,7 @@ async def workspace():
 async def test_tail_default_n_10(workspace):
     body = b"\n".join(f"line{i}".encode() for i in range(1, 21)) + b"\n"
     await workspace.ops.write("/f.txt", body)
-    io = await workspace.execute("tail /f.txt", session_id="default")
+    io = await workspace.execute("tail /f.txt")
     assert io.exit_code == 0
     expected = b"\n".join(f"line{i}".encode() for i in range(11, 21)) + b"\n"
     assert io.stdout == expected
@@ -47,7 +47,7 @@ async def test_tail_default_n_10(workspace):
 @pytest.mark.asyncio
 async def test_tail_n_explicit(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\nd\ne\n")
-    io = await workspace.execute("tail -n 3 /f.txt", session_id="default")
+    io = await workspace.execute("tail -n 3 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"c\nd\ne\n"
 
@@ -55,7 +55,7 @@ async def test_tail_n_explicit(workspace):
 @pytest.mark.asyncio
 async def test_tail_c_bytes(workspace):
     await workspace.ops.write("/f.txt", b"hello world")
-    io = await workspace.execute("tail -c 5 /f.txt", session_id="default")
+    io = await workspace.execute("tail -c 5 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"world"
 
@@ -63,7 +63,7 @@ async def test_tail_c_bytes(workspace):
 @pytest.mark.asyncio
 async def test_tail_plus_n_streams_from_line(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\nd\ne\n")
-    io = await workspace.execute("tail -n +3 /f.txt", session_id="default")
+    io = await workspace.execute("tail -n +3 /f.txt")
     assert io.exit_code == 0
     assert io.stdout == b"c\nd\ne\n"
 
@@ -72,7 +72,7 @@ async def test_tail_plus_n_streams_from_line(workspace):
 async def test_tail_multi_file_emits_headers(workspace):
     await workspace.ops.write("/a.txt", b"x\ny\n")
     await workspace.ops.write("/b.txt", b"z\n")
-    io = await workspace.execute("tail /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("tail /a.txt /b.txt")
     assert io.exit_code == 0
     assert b"==> /a.txt <==" in io.stdout
     assert b"==> /b.txt <==" in io.stdout

--- a/python/tests/commands/builtin/redis/test_du.py
+++ b/python/tests/commands/builtin/redis/test_du.py
@@ -37,7 +37,7 @@ async def workspace():
 @pytest.mark.asyncio
 async def test_du_single_file(workspace):
     await workspace.ops.write("/f.txt", b"hello")
-    io = await workspace.execute("du /f.txt", session_id="default")
+    io = await workspace.execute("du /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().strip() == "5\t/f.txt"
 
@@ -47,7 +47,7 @@ async def test_du_directory_collapses(workspace):
     await workspace.ops.mkdir("/dir")
     await workspace.ops.write("/dir/a.txt", b"aaa")
     await workspace.ops.write("/dir/b.txt", b"bb")
-    io = await workspace.execute("du /dir", session_id="default")
+    io = await workspace.execute("du /dir")
     assert io.exit_code == 0
     assert io.stdout.decode().strip() == "5\t/dir"
 
@@ -57,7 +57,7 @@ async def test_du_a_lists_files(workspace):
     await workspace.ops.mkdir("/dir")
     await workspace.ops.write("/dir/a.txt", b"aaa")
     await workspace.ops.write("/dir/b.txt", b"bb")
-    io = await workspace.execute("du -a /dir", session_id="default")
+    io = await workspace.execute("du -a /dir")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "a.txt" in out
@@ -68,7 +68,7 @@ async def test_du_a_lists_files(workspace):
 async def test_du_c_total(workspace):
     await workspace.ops.write("/a.txt", b"hello")
     await workspace.ops.write("/b.txt", b"world")
-    io = await workspace.execute("du -c /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("du -c /a.txt /b.txt")
     assert io.exit_code == 0
     lines = io.stdout.decode().strip().splitlines()
     assert lines[-1] == "10\ttotal"
@@ -76,6 +76,6 @@ async def test_du_c_total(workspace):
 
 @pytest.mark.asyncio
 async def test_du_missing_operand_errors(workspace):
-    io = await workspace.execute("du", session_id="default")
+    io = await workspace.execute("du")
     assert io.exit_code != 0
     assert b"missing operand" in (io.stderr or b"")

--- a/python/tests/commands/builtin/redis/test_find.py
+++ b/python/tests/commands/builtin/redis/test_find.py
@@ -39,7 +39,7 @@ async def workspace():
 async def test_find_name_glob(workspace):
     await workspace.ops.write("/hello.txt", b"hi")
     await workspace.ops.write("/world.py", b"hi")
-    io = await workspace.execute("find / -name '*.txt'", session_id="default")
+    io = await workspace.execute("find / -name '*.txt'")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "hello.txt" in out
@@ -51,7 +51,7 @@ async def test_find_type_f(workspace):
     await workspace.ops.mkdir("/sub")
     await workspace.ops.write("/a.txt", b"a")
     await workspace.ops.write("/sub/b.txt", b"b")
-    io = await workspace.execute("find / -type f", session_id="default")
+    io = await workspace.execute("find / -type f")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "/a.txt" in out
@@ -62,8 +62,7 @@ async def test_find_type_f(workspace):
 async def test_find_size_lower_bound(workspace):
     await workspace.ops.write("/big.txt", b"x" * 1000)
     await workspace.ops.write("/small.txt", b"x")
-    io = await workspace.execute("find / -size +500c -type f",
-                                 session_id="default")
+    io = await workspace.execute("find / -size +500c -type f")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "big.txt" in out
@@ -72,6 +71,6 @@ async def test_find_size_lower_bound(workspace):
 
 @pytest.mark.asyncio
 async def test_find_missing_path_returns_exit_1(workspace):
-    io = await workspace.execute("find /nonexistent", session_id="default")
+    io = await workspace.execute("find /nonexistent")
     assert io.exit_code == 1
     assert b"nonexistent" in (io.stderr or b"")

--- a/python/tests/commands/builtin/redis/test_rm.py
+++ b/python/tests/commands/builtin/redis/test_rm.py
@@ -38,7 +38,7 @@ async def workspace():
 async def test_rm_v_terminates_verbose_output(workspace):
     await workspace.ops.write("/a.txt", b"a")
 
-    io = await workspace.execute("rm -v /a.txt", session_id="default")
+    io = await workspace.execute("rm -v /a.txt")
 
     assert io.exit_code == 0
     assert io.stdout == b"removed '/a.txt'\n"

--- a/python/tests/commands/builtin/redis/test_tree.py
+++ b/python/tests/commands/builtin/redis/test_tree.py
@@ -40,7 +40,7 @@ async def test_tree_basic(workspace):
     await workspace.ops.mkdir("/d1")
     await workspace.ops.write("/d1/a.txt", b"a")
     await workspace.ops.write("/d1/b.txt", b"b")
-    io = await workspace.execute("tree /d1", session_id="default")
+    io = await workspace.execute("tree /d1")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "a.txt" in out
@@ -53,7 +53,7 @@ async def test_tree_L_max_depth(workspace):
     await workspace.ops.mkdir("/d1/sub")
     await workspace.ops.mkdir("/d1/sub/deep")
     await workspace.ops.write("/d1/sub/deep/file.txt", b"d")
-    io = await workspace.execute("tree -L 1 /d1", session_id="default")
+    io = await workspace.execute("tree -L 1 /d1")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "sub" in out
@@ -66,7 +66,7 @@ async def test_tree_d_dirs_only(workspace):
     await workspace.ops.mkdir("/d1")
     await workspace.ops.mkdir("/d1/sub")
     await workspace.ops.write("/d1/file.txt", b"x")
-    io = await workspace.execute("tree -d /d1", session_id="default")
+    io = await workspace.execute("tree -d /d1")
     assert io.exit_code == 0
     out = io.stdout.decode()
     assert "sub" in out

--- a/python/tests/commands/builtin/redis/wc/test_wc.py
+++ b/python/tests/commands/builtin/redis/wc/test_wc.py
@@ -37,7 +37,7 @@ async def workspace():
 @pytest.mark.asyncio
 async def test_wc_default(workspace):
     await workspace.ops.write("/f.txt", b"hello world\nfoo bar\n")
-    io = await workspace.execute("wc /f.txt", session_id="default")
+    io = await workspace.execute("wc /f.txt")
     assert io.exit_code == 0
     parts = io.stdout.decode().split()
     assert parts[0] == "2"
@@ -48,7 +48,7 @@ async def test_wc_default(workspace):
 @pytest.mark.asyncio
 async def test_wc_l(workspace):
     await workspace.ops.write("/f.txt", b"a\nb\nc\n")
-    io = await workspace.execute("wc -l /f.txt", session_id="default")
+    io = await workspace.execute("wc -l /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().split()[0] == "3"
 
@@ -56,7 +56,7 @@ async def test_wc_l(workspace):
 @pytest.mark.asyncio
 async def test_wc_c(workspace):
     await workspace.ops.write("/f.txt", b"hello\n")
-    io = await workspace.execute("wc -c /f.txt", session_id="default")
+    io = await workspace.execute("wc -c /f.txt")
     assert io.exit_code == 0
     assert io.stdout.decode().split()[0] == "6"
 
@@ -65,7 +65,7 @@ async def test_wc_c(workspace):
 async def test_wc_multi_file_emits_total(workspace):
     await workspace.ops.write("/a.txt", b"hello\n")
     await workspace.ops.write("/b.txt", b"world\nfoo\n")
-    io = await workspace.execute("wc /a.txt /b.txt", session_id="default")
+    io = await workspace.execute("wc /a.txt /b.txt")
     assert io.exit_code == 0
     assert io.stdout.endswith(b"\n")
     lines = io.stdout.decode().splitlines()

--- a/python/tests/commands/builtin/test_net.py
+++ b/python/tests/commands/builtin/test_net.py
@@ -61,7 +61,7 @@ def multi_mount_ws():
         },
         mode=MountMode.WRITE,
     )
-    ws.get_session("default").cwd = "/"
+    ws.get_session(ws.default_session_id).cwd = "/"
     return ws
 
 

--- a/python/tests/commands/native/test_cross_mount.py
+++ b/python/tests/commands/native/test_cross_mount.py
@@ -24,7 +24,7 @@ from mirage.provision import Precision
 from mirage.resource.disk import DiskResource
 from mirage.resource.ram import RAMResource
 from mirage.resource.s3 import S3Config, S3Resource
-from mirage.types import DEFAULT_SESSION_ID, MountMode
+from mirage.types import MountMode
 from mirage.workspace import Workspace
 from tests.commands.native.conftest import (_CORE_MODULES, BUCKET, REGION,
                                             MockAsyncSession)
@@ -139,7 +139,7 @@ def cross(request, tmp_path):
         "/m2": (p2, MountMode.WRITE)
     },
                    mode=MountMode.WRITE)
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/m1"
+    ws.get_session(ws.default_session_id).cwd = "/m1"
 
     p1_acc = p1.accessor if hasattr(p1, "accessor") else None
     p2_acc = p2.accessor if hasattr(p2, "accessor") else None

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -17,7 +17,7 @@ import resource
 import pytest
 
 from mirage.resource.ram import RAMResource
-from mirage.types import DEFAULT_SESSION_ID, MountMode
+from mirage.types import MountMode
 from mirage.workspace import Workspace
 
 _soft, _hard = resource.getrlimit(resource.RLIMIT_NOFILE)
@@ -36,5 +36,5 @@ def write_ws():
         {"/tmp/": RAMResource()},
         mode=MountMode.WRITE,
     )
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/"
+    ws.get_session(ws.default_session_id).cwd = "/"
     return ws

--- a/python/tests/integration/test_cross_mount_matrix.py
+++ b/python/tests/integration/test_cross_mount_matrix.py
@@ -28,7 +28,7 @@ from mirage.resource.gdrive import GoogleDriveConfig, GoogleDriveResource
 from mirage.resource.ram import RAMResource
 from mirage.resource.redis import RedisResource
 from mirage.resource.s3 import S3Config, S3Resource
-from mirage.types import DEFAULT_SESSION_ID, MountMode, PathSpec
+from mirage.types import MountMode, PathSpec
 from mirage.workspace import Workspace
 from tests.integration.gdrive_mock import FakeGDrive, patch_gdrive
 from tests.integration.s3_mock import patch_s3_multi
@@ -249,7 +249,7 @@ def cross(request, tmp_path):
         },
         mode=MountMode.WRITE,
     )
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/m1"
+    ws.get_session(ws.default_session_id).cwd = "/m1"
 
     buckets: dict[str, dict[str, bytes]] = {}
     if m1.ptype == "s3":

--- a/python/tests/integration/test_pipeline.py
+++ b/python/tests/integration/test_pipeline.py
@@ -17,7 +17,7 @@ import asyncio
 import pytest
 
 from mirage.resource.ram import RAMResource
-from mirage.types import DEFAULT_SESSION_ID, MountMode
+from mirage.types import MountMode
 from mirage.workspace import Workspace
 
 
@@ -40,7 +40,7 @@ def ws():
         {"/data": (mem, MountMode.WRITE)},
         mode=MountMode.WRITE,
     )
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/"
+    ws.get_session(ws.default_session_id).cwd = "/"
     return ws
 
 
@@ -168,13 +168,13 @@ async def test_heredoc(ws):
 async def test_subshell_cd_isolated(ws):
     await ws.execute("cd /data")
     await ws.execute("(cd /data/subdir)")
-    assert ws.get_session(DEFAULT_SESSION_ID).cwd == "/data"
+    assert ws.get_session(ws.default_session_id).cwd == "/data"
 
 
 @pytest.mark.asyncio
 async def test_subshell_export_isolated(ws):
     await ws.execute("(export LEAK=yes)")
-    assert "LEAK" not in ws.get_session(DEFAULT_SESSION_ID).env
+    assert "LEAK" not in ws.get_session(ws.default_session_id).env
 
 
 @pytest.mark.asyncio
@@ -187,7 +187,7 @@ async def test_subshell_inherits_parent_env(ws):
 @pytest.mark.asyncio
 async def test_nested_subshell(ws):
     await ws.execute("((export DEEP=yes))")
-    assert "DEEP" not in ws.get_session(DEFAULT_SESSION_ID).env
+    assert "DEEP" not in ws.get_session(ws.default_session_id).env
 
 
 # --- Background jobs ---
@@ -204,14 +204,14 @@ async def test_background_basic(ws):
 async def test_background_isolation_env(ws):
     await ws.execute("export BG_VAR=leaked &")
     await ws.execute("wait %1")
-    assert "BG_VAR" not in ws.get_session(DEFAULT_SESSION_ID).env
+    assert "BG_VAR" not in ws.get_session(ws.default_session_id).env
 
 
 @pytest.mark.asyncio
 async def test_background_isolation_cwd(ws):
     await ws.execute("cd /data &")
     await ws.execute("wait %1")
-    assert ws.get_session(DEFAULT_SESSION_ID).cwd == "/"
+    assert ws.get_session(ws.default_session_id).cwd == "/"
 
 
 @pytest.mark.asyncio
@@ -250,9 +250,9 @@ async def test_export_then_variable_expansion(ws):
 @pytest.mark.asyncio
 async def test_export_unset_cycle(ws):
     await ws.execute("export TMP=val")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["TMP"] == "val"
+    assert ws.get_session(ws.default_session_id).env["TMP"] == "val"
     await ws.execute("unset TMP")
-    assert "TMP" not in ws.get_session(DEFAULT_SESSION_ID).env
+    assert "TMP" not in ws.get_session(ws.default_session_id).env
 
 
 @pytest.mark.asyncio
@@ -328,7 +328,7 @@ async def test_for_loop_basic(ws):
 async def test_for_loop_variable_restored(ws):
     await ws.execute("export i=original")
     await ws.execute("for i in 1 2 3; do echo $i; done")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["i"] == "original"
+    assert ws.get_session(ws.default_session_id).env["i"] == "original"
 
 
 # --- If/else ---

--- a/python/tests/server/test_sessions_router.py
+++ b/python/tests/server/test_sessions_router.py
@@ -53,7 +53,7 @@ async def test_create_list_delete_session_round_trip():
         r = await client.get(f"/v1/workspaces/{wid}/sessions")
         ids = {s["session_id"] for s in r.json()}
         assert "agent_a" in ids
-        assert "default" in ids
+        assert len(ids) == 2
 
         r = await client.delete(f"/v1/workspaces/{wid}/sessions/agent_a")
         assert r.status_code == 200

--- a/python/tests/server/test_workspaces_router.py
+++ b/python/tests/server/test_workspaces_router.py
@@ -15,6 +15,7 @@
 import asyncio
 import os
 import time
+import uuid
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -54,7 +55,7 @@ async def test_create_list_get_delete_round_trip():
         assert r.status_code == 201, r.text
         detail = r.json()
         wid = detail["id"]
-        assert wid.startswith("ws_")
+        assert uuid.UUID(wid).version == 7
         assert detail["mode"] == "write"
         assert any(m["prefix"] == "/" for m in detail["mounts"])
 
@@ -164,7 +165,7 @@ async def test_clone_returns_new_workspace_with_same_mounts():
         assert r.status_code == 201, r.text
         clone = r.json()
         assert clone["id"] != wid
-        assert clone["id"].startswith("ws_")
+        assert uuid.UUID(clone["id"]).version == 7
         assert {m["prefix"] for m in clone["mounts"]} == {"/"}
 
         r = await client.get("/v1/workspaces")

--- a/python/tests/shell/conftest.py
+++ b/python/tests/shell/conftest.py
@@ -18,7 +18,7 @@ import subprocess
 import pytest
 
 from mirage.resource.ram import RAMResource
-from mirage.types import DEFAULT_SESSION_ID, MountMode
+from mirage.types import MountMode
 from mirage.workspace import Workspace
 
 
@@ -36,7 +36,7 @@ class ShellTestEnv:
             {"/data": (self.mem, MountMode.WRITE)},
             mode=MountMode.WRITE,
         )
-        self.ws.get_session(DEFAULT_SESSION_ID).cwd = "/data"
+        self.ws.get_session(self.ws.default_session_id).cwd = "/data"
 
     def create_file(self, name: str, content: bytes):
         local_path = self.tmp_path / name

--- a/python/tests/shell/test_background_jobs.py
+++ b/python/tests/shell/test_background_jobs.py
@@ -17,7 +17,7 @@ import asyncio
 from mirage.io.types import IOResult
 from mirage.resource.ram import RAMResource
 from mirage.shell.job_table import JobStatus, JobTable
-from mirage.types import DEFAULT_SESSION_ID, MountMode
+from mirage.types import MountMode
 from mirage.workspace import Workspace
 from mirage.workspace.types import ExecutionNode
 
@@ -86,7 +86,7 @@ def test_background_does_not_consume_stdin():
             {"/data": (mem, MountMode.WRITE)},
             mode=MountMode.WRITE,
         )
-        ws.get_session(DEFAULT_SESSION_ID).cwd = "/data"
+        ws.get_session(ws.default_session_id).cwd = "/data"
         io = await ws.execute("sleep 0 & cat", stdin=b"hello\n")
         assert (await io.stdout_str()).strip() == "hello"
 

--- a/python/tests/shell/test_quoting_coverage.py
+++ b/python/tests/shell/test_quoting_coverage.py
@@ -23,7 +23,7 @@ import asyncio
 import pytest
 
 from mirage.resource.ram import RAMResource
-from mirage.types import DEFAULT_SESSION_ID, MountMode
+from mirage.types import MountMode
 from mirage.workspace import Workspace
 
 
@@ -41,7 +41,7 @@ def _ws_with_paths():
     ram._store.dirs.add("/my folder")
     ram._store.dirs.add("/数据")
     ws = Workspace(resources={"/data/": (ram, MountMode.WRITE)}, )
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/data"
+    ws.get_session(ws.default_session_id).cwd = "/data"
     return ws
 
 

--- a/python/tests/utils/test_ids.py
+++ b/python/tests/utils/test_ids.py
@@ -1,0 +1,53 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import time
+import uuid
+
+from mirage.utils.ids import new_session_id, new_workspace_id, uuid7
+
+
+def test_uuid7_is_canonical_and_version_7():
+    value = uuid7()
+    parsed = uuid.UUID(value)
+    assert value == str(parsed)
+    assert value == value.lower()
+    assert parsed.version == 7
+    assert parsed.variant == uuid.RFC_4122
+
+
+def test_uuid7_embeds_current_timestamp():
+    # uuid6 smooths its clock for monotonicity, so allow a little skew.
+    before_ms = time.time_ns() // 1_000_000
+    parsed = uuid.UUID(uuid7())
+    after_ms = time.time_ns() // 1_000_000
+    embedded_ms = parsed.int >> 80
+    assert before_ms - 10 <= embedded_ms <= after_ms + 10
+
+
+def test_uuid7_orders_across_milliseconds():
+    first = uuid7()
+    time.sleep(0.002)
+    second = uuid7()
+    assert first < second
+
+
+def test_uuid7_unique():
+    values = {uuid7() for _ in range(1000)}
+    assert len(values) == 1000
+
+
+def test_id_kinds_share_the_format():
+    assert uuid.UUID(new_workspace_id()).version == 7
+    assert uuid.UUID(new_session_id()).version == 7

--- a/python/tests/workspace/executor/builtins/test_vars.py
+++ b/python/tests/workspace/executor/builtins/test_vars.py
@@ -89,7 +89,8 @@ async def test_whoami_prints_workspace_user():
 
 
 @pytest.mark.asyncio
-async def test_whoami_defaults_without_identity():
+async def test_whoami_errors_without_identity():
     out, io, _ = await handle_whoami(Namespace(MagicMock()))
-    assert io.exit_code == 0
-    assert out == b"default\n"
+    assert io.exit_code == 1
+    assert out is None
+    assert io.stderr == b"whoami: cannot find name for user ID\n"

--- a/python/tests/workspace/mount/namespace/test_namespace.py
+++ b/python/tests/workspace/mount/namespace/test_namespace.py
@@ -323,8 +323,8 @@ async def test_drop_overlay_missing_node_is_noop(namespace):
     assert await namespace.drop_overlay("/data/nope.txt") is False
 
 
-def test_user_defaults_before_resolution(namespace):
-    assert namespace.user == "default"
+def test_user_none_before_resolution(namespace):
+    assert namespace.user is None
 
 
 @pytest.mark.asyncio
@@ -348,11 +348,11 @@ async def test_bare_launch_adopts_stored_user(registry):
 
 
 @pytest.mark.asyncio
-async def test_bare_launch_empty_store_stays_default(registry):
+async def test_bare_launch_empty_store_has_no_user(registry):
     store = RAMNamespaceStore()
     namespace = Namespace(registry, store=store)
     await namespace.ensure_loaded()
-    assert namespace.user == "default"
+    assert namespace.user is None
     assert await store.load_user() is None
 
 

--- a/python/tests/workspace/node/test_execute_node.py
+++ b/python/tests/workspace/node/test_execute_node.py
@@ -382,18 +382,19 @@ def test_printenv_all():
 # ── whoami ──────────────────────────────────────
 
 
-def test_whoami_default():
+def test_whoami_errors_without_identity():
+    # No agent ever claimed this workspace: GNU errors for a uid with
+    # no passwd entry, and so do we.
     stdout, io, _, _, _, _ = _exec("whoami", env={})
-    assert io.exit_code == 0
-    assert stdout == b"default\n"
-    assert io.stderr in (None, b"")
+    assert io.exit_code == 1
+    assert io.stderr == b"whoami: cannot find name for user ID\n"
 
 
 def test_whoami_ignores_env_user():
     # GNU whoami reports the effective user, never $USER.
     stdout, io, _, _, _, _ = _exec("whoami", env={"USER": "alice"})
-    assert io.exit_code == 0
-    assert stdout == b"default\n"
+    assert io.exit_code == 1
+    assert stdout != b"alice\n"
 
 
 # ── unsupported node raises ─────────────────────

--- a/python/tests/workspace/store/test_redis.py
+++ b/python/tests/workspace/store/test_redis.py
@@ -94,7 +94,7 @@ async def test_workspace_discovery_and_session_sharing(prefix):
 
         meta = await store_b.load_meta("agent-ws")
         assert meta is not None
-        assert meta["default_session_id"] == "default"
+        assert meta["default_session_id"] == ws.default_session_id
         sessions = await store_b.sessions("agent-ws").load()
         assert sessions["narrow"]["mount_modes"]["/data"] == "read"
     finally:

--- a/python/tests/workspace/store/test_workspace_wiring.py
+++ b/python/tests/workspace/store/test_workspace_wiring.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import uuid
+
 import pytest
 
 from mirage.observe.store import RAMObserverStore
@@ -32,9 +34,67 @@ async def test_meta_written_on_first_execute():
     meta = await store.load_meta("ws-a")
     assert meta is not None
     assert meta["workspace_id"] == "ws-a"
-    assert meta["default_session_id"] == "default"
+    assert meta["default_session_id"] == ws.default_session_id
+    assert uuid.UUID(meta["default_session_id"]).version == 7
     assert meta["created_at"] > 0
     await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_bare_workspace_mints_uuid7_ids():
+    ws = Workspace({"/data": RAMResource()}, mode=MountMode.EXEC)
+    assert uuid.UUID(ws.workspace_id).version == 7
+    assert uuid.UUID(ws.default_session_id).version == 7
+    sibling = Workspace({"/data": RAMResource()}, mode=MountMode.EXEC)
+    assert sibling.workspace_id != ws.workspace_id
+    await ws.close()
+    await sibling.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_adopts_stored_default_session():
+    """A minted default session id yields to the discovery record's
+    pointer, so a fresh attach lands on the writer's default session."""
+    store = RAMWorkspaceStateStore()
+    ws_a = Workspace({"/data": RAMResource()},
+                     mode=MountMode.EXEC,
+                     workspace_id="shared",
+                     store=store)
+    await ws_a.execute("export MARK=1")
+    await ws_a.flush_sessions()
+
+    ws_b = Workspace({"/data": RAMResource()},
+                     mode=MountMode.EXEC,
+                     workspace_id="shared",
+                     store=store)
+    minted = ws_b.default_session_id
+    await ws_b.ensure_sessions_loaded()
+    assert ws_b.default_session_id == ws_a.default_session_id
+    assert ws_b.default_session_id != minted
+    session = ws_b.get_session(ws_b.default_session_id)
+    assert session.env.get("MARK") == "1"
+    await ws_a.close()
+    await ws_b.close()
+
+
+@pytest.mark.asyncio
+async def test_explicit_session_id_is_not_adopted_away():
+    store = RAMWorkspaceStateStore()
+    ws_a = Workspace({"/data": RAMResource()},
+                     mode=MountMode.EXEC,
+                     workspace_id="shared",
+                     store=store)
+    await ws_a.execute("echo hi")
+
+    ws_b = Workspace({"/data": RAMResource()},
+                     mode=MountMode.EXEC,
+                     workspace_id="shared",
+                     session_id="pinned",
+                     store=store)
+    await ws_b.ensure_sessions_loaded()
+    assert ws_b.default_session_id == "pinned"
+    await ws_a.close()
+    await ws_b.close()
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/test_execute_options.py
+++ b/python/tests/workspace/test_execute_options.py
@@ -18,7 +18,6 @@ import pytest
 
 from mirage import MountMode, Workspace
 from mirage.resource.ram import RAMResource
-from mirage.types import DEFAULT_SESSION_ID
 
 
 def _make_ws():
@@ -45,18 +44,18 @@ async def test_cwd_runs_in_override():
 @pytest.mark.asyncio
 async def test_cwd_does_not_mutate_session():
     ws = _make_ws()
-    before = ws.get_session(DEFAULT_SESSION_ID).cwd
+    before = ws.get_session(ws.default_session_id).cwd
     await ws.execute("pwd", cwd="/ram/subdir")
-    after = ws.get_session(DEFAULT_SESSION_ID).cwd
+    after = ws.get_session(ws.default_session_id).cwd
     assert before == after
 
 
 @pytest.mark.asyncio
 async def test_cwd_cd_does_not_leak():
     ws = _make_ws()
-    before = ws.get_session(DEFAULT_SESSION_ID).cwd
+    before = ws.get_session(ws.default_session_id).cwd
     await ws.execute("cd /ram/subdir", cwd="/ram")
-    after = ws.get_session(DEFAULT_SESSION_ID).cwd
+    after = ws.get_session(ws.default_session_id).cwd
     assert before == after
 
 
@@ -75,19 +74,19 @@ async def test_cwd_parallel_isolation():
 async def test_setup_persists_overrides_inherit():
     ws = _make_ws()
     await ws.execute("export DEBUG=1")
-    assert ws.get_session(DEFAULT_SESSION_ID).env.get("DEBUG") == "1"
-    before_cwd = ws.get_session(DEFAULT_SESSION_ID).cwd
+    assert ws.get_session(ws.default_session_id).env.get("DEBUG") == "1"
+    before_cwd = ws.get_session(ws.default_session_id).cwd
     r = await ws.execute("printenv DEBUG", cwd="/ram/subdir")
     assert (await r.stdout_str()).strip() == "1"
-    assert ws.get_session(DEFAULT_SESSION_ID).cwd == before_cwd
-    assert ws.get_session(DEFAULT_SESSION_ID).env.get("DEBUG") == "1"
+    assert ws.get_session(ws.default_session_id).cwd == before_cwd
+    assert ws.get_session(ws.default_session_id).env.get("DEBUG") == "1"
 
 
 @pytest.mark.asyncio
 async def test_function_definitions_do_not_leak():
     ws = _make_ws()
     await ws.execute("greet() { echo hi; }", cwd="/ram/subdir")
-    session = ws.get_session(DEFAULT_SESSION_ID)
+    session = ws.get_session(ws.default_session_id)
     assert "greet" not in session.functions
 
 
@@ -105,9 +104,9 @@ async def test_env_exposes_override():
 @pytest.mark.asyncio
 async def test_env_does_not_mutate_session():
     ws = _make_ws()
-    before = dict(ws.get_session(DEFAULT_SESSION_ID).env)
+    before = dict(ws.get_session(ws.default_session_id).env)
     await ws.execute("printenv FOO", env={"FOO": "bar"})
-    after = dict(ws.get_session(DEFAULT_SESSION_ID).env)
+    after = dict(ws.get_session(ws.default_session_id).env)
     assert before == after
 
 
@@ -115,19 +114,19 @@ async def test_env_does_not_mutate_session():
 async def test_env_export_does_not_leak():
     ws = _make_ws()
     await ws.execute("export LEAKED=yes", env={"FOO": "bar"})
-    assert "LEAKED" not in ws.get_session(DEFAULT_SESSION_ID).env
+    assert "LEAKED" not in ws.get_session(ws.default_session_id).env
 
 
 @pytest.mark.asyncio
 async def test_env_layers_onto_session():
     ws = _make_ws()
     await ws.execute("export BASE=keep")
-    assert ws.get_session(DEFAULT_SESSION_ID).env.get("BASE") == "keep"
+    assert ws.get_session(ws.default_session_id).env.get("BASE") == "keep"
     r_base = await ws.execute("printenv BASE", env={"FOO": "bar"})
     assert (await r_base.stdout_str()).strip() == "keep"
     r_foo = await ws.execute("printenv FOO", env={"FOO": "bar"})
     assert (await r_foo.stdout_str()).strip() == "bar"
-    session_env = ws.get_session(DEFAULT_SESSION_ID).env
+    session_env = ws.get_session(ws.default_session_id).env
     assert session_env.get("BASE") == "keep"
     assert "FOO" not in session_env
 
@@ -264,7 +263,7 @@ async def test_agent_pattern_parallel_tool_calls_each_with_own_options():
     assert "one" in a.stdout.decode()
     assert "/ram" in b.stdout.decode()
     assert "two" in b.stdout.decode()
-    session = ws.get_session(DEFAULT_SESSION_ID)
+    session = ws.get_session(ws.default_session_id)
     assert session.cwd != "/ram/subdir"
     assert "DEBUG" not in session.env
 

--- a/python/tests/workspace/test_index_integration.py
+++ b/python/tests/workspace/test_index_integration.py
@@ -20,7 +20,7 @@ from moto import mock_aws
 from mirage.cache.index import LookupStatus
 from mirage.resource.ram import RAMResource
 from mirage.resource.s3.s3 import S3Config, S3Resource
-from mirage.types import DEFAULT_SESSION_ID, MountMode
+from mirage.types import MountMode
 from mirage.workspace import Workspace
 
 
@@ -66,7 +66,7 @@ def _ram_ws():
     p._store.files["/sub/b.txt"] = b"bbb\n"
     p._store.files["/sub/c.csv"] = b"col\n"
     ws = Workspace(resources={"/data/": (p, MountMode.WRITE)}, )
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/data"
+    ws.get_session(ws.default_session_id).cwd = "/data"
     return ws, p
 
 
@@ -157,7 +157,7 @@ def test_index_expired_refetches():
     p._store.dirs.add("/sub")
     p._store.files["/sub/a.txt"] = b"aaa\n"
     ws = Workspace(resources={"/data/": (p, MountMode.WRITE)}, )
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/data"
+    ws.get_session(ws.default_session_id).cwd = "/data"
     _run(ws.execute("cat /data/sub/*.txt"))
     listing = _run(p.index.list_dir("/data/sub"))
     # RAM ttl=0 → expired immediately after set

--- a/python/tests/workspace/test_pipeline_budget.py
+++ b/python/tests/workspace/test_pipeline_budget.py
@@ -18,7 +18,6 @@ import pytest
 
 from mirage import MountMode, Workspace
 from mirage.resource.ram import RAMResource
-from mirage.workspace.workspace import DEFAULT_SESSION_ID
 
 
 async def _slow_stdin():
@@ -50,7 +49,7 @@ def _ws():
 @pytest.mark.asyncio
 async def test_pipeline_budget_bounds_slow_final_stage():
     ws = _ws()
-    ws._session_mgr.get(DEFAULT_SESSION_ID).pipeline_timeout_seconds = 0.1
+    ws.get_session(ws.default_session_id).pipeline_timeout_seconds = 0.1
     r = await ws.execute("cat | cat", stdin=_slow_stdin())
     assert r.exit_code == 124
     assert "pipeline: timed out after 0.1s" in (await r.stderr_str())
@@ -67,7 +66,7 @@ async def test_pipeline_without_budget_is_unbounded():
 @pytest.mark.asyncio
 async def test_pipeline_budget_tears_down_upstream_producer():
     ws = _ws()
-    ws._session_mgr.get(DEFAULT_SESSION_ID).pipeline_timeout_seconds = 0.1
+    ws.get_session(ws.default_session_id).pipeline_timeout_seconds = 0.1
     flag = {"closed": False}
     r = await ws.execute("cat | cat", stdin=_probed_stdin(flag))
     assert r.exit_code == 124
@@ -77,7 +76,7 @@ async def test_pipeline_budget_tears_down_upstream_producer():
 @pytest.mark.asyncio
 async def test_early_finish_reports_downstream_code_not_sigpipe():
     ws = _ws()
-    session = ws._session_mgr.get(DEFAULT_SESSION_ID)
+    session = ws.get_session(ws.default_session_id)
     session.shell_options["pipefail"] = True
     r = await ws.execute("cat | head -n1", stdin=_multiline_stdin())
     assert r.exit_code == 0

--- a/python/tests/workspace/test_provider_integration.py
+++ b/python/tests/workspace/test_provider_integration.py
@@ -18,7 +18,7 @@ import pytest
 
 from mirage.resource.disk import DiskResource
 from mirage.resource.ram import RAMResource
-from mirage.types import DEFAULT_SESSION_ID, MountMode
+from mirage.types import MountMode
 from mirage.workspace import Workspace
 
 
@@ -48,7 +48,7 @@ def _ram_ws():
     p._store.dirs.add("/sub")
     p._store.files["/sub/nested.txt"] = b"nested content\n"
     ws = Workspace(resources={"/ram/": (p, MountMode.WRITE)}, )
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/ram"
+    ws.get_session(ws.default_session_id).cwd = "/ram"
     return ws
 
 
@@ -130,7 +130,7 @@ def disk_ws(tmp_path):
 
     p = DiskResource(root=str(data_dir))
     ws = Workspace(resources={"/disk/": (p, MountMode.WRITE)}, )
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/disk"
+    ws.get_session(ws.default_session_id).cwd = "/disk"
     return ws
 
 
@@ -213,7 +213,7 @@ def multi_ws(tmp_path):
         "/ram/": (ram, MountMode.WRITE),
         "/disk/": (disk, MountMode.WRITE),
     }, )
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/ram"
+    ws.get_session(ws.default_session_id).cwd = "/ram"
     return ws
 
 

--- a/python/tests/workspace/test_workspace.py
+++ b/python/tests/workspace/test_workspace.py
@@ -16,7 +16,7 @@ import asyncio
 
 from mirage.resource.ram import RAMResource
 from mirage.runtime.python import select_python_runtime
-from mirage.types import DEFAULT_SESSION_ID, MountMode
+from mirage.types import MountMode
 from mirage.workspace import Workspace
 
 
@@ -59,7 +59,7 @@ def _ws():
         "/disk/": (disk, MountMode.EXEC),
         "/ram/": (ram, MountMode.EXEC),
     }, )
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/s3"
+    ws.get_session(ws.default_session_id).cwd = "/s3"
     return ws
 
 
@@ -112,7 +112,7 @@ def test_head_file():
 def test_export():
     ws = _ws()
     _exec(ws, "export MSG=hello")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["MSG"] == "hello"
+    assert ws.get_session(ws.default_session_id).env["MSG"] == "hello"
 
 
 def test_export_used_in_command():
@@ -129,7 +129,7 @@ def test_export_used_in_command():
 def test_cd():
     ws = _ws()
     _exec(ws, "cd /disk")
-    assert ws.get_session(DEFAULT_SESSION_ID).cwd == "/disk"
+    assert ws.get_session(ws.default_session_id).cwd == "/disk"
 
 
 def test_cd_nonexistent():
@@ -180,32 +180,32 @@ def test_redirect_append():
 def test_if_true():
     ws = _ws()
     _exec(ws, "if true; then export R=yes; fi")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["R"] == "yes"
+    assert ws.get_session(ws.default_session_id).env["R"] == "yes"
 
 
 def test_if_false_else():
     ws = _ws()
     _exec(ws, "if false; then export R=yes; else export R=no; fi")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["R"] == "no"
+    assert ws.get_session(ws.default_session_id).env["R"] == "no"
 
 
 def test_for_loop():
     ws = _ws()
     _exec(ws, "for x in a b c; do export LAST=$x; done")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["LAST"] == "c"
+    assert ws.get_session(ws.default_session_id).env["LAST"] == "c"
 
 
 def test_while_false():
     ws = _ws()
     io = _exec(ws, "while false; do export RAN=yes; done")
     assert io.exit_code == 0
-    assert "RAN" not in ws.get_session(DEFAULT_SESSION_ID).env
+    assert "RAN" not in ws.get_session(ws.default_session_id).env
 
 
 def test_case_match():
     ws = _ws()
     _exec(ws, "case hello in hello) export M=yes;; esac")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["M"] == "yes"
+    assert ws.get_session(ws.default_session_id).env["M"] == "yes"
 
 
 # ── operators ──────────────────────────────────
@@ -214,7 +214,7 @@ def test_case_match():
 def test_semicolons():
     ws = _ws()
     _exec(ws, "export A=1; export B=2; export C=3")
-    s = ws.get_session(DEFAULT_SESSION_ID)
+    s = ws.get_session(ws.default_session_id)
     assert s.env["A"] == "1"
     assert s.env["B"] == "2"
     assert s.env["C"] == "3"
@@ -223,19 +223,19 @@ def test_semicolons():
 def test_and_chain():
     ws = _ws()
     _exec(ws, "true && export OK=yes")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["OK"] == "yes"
+    assert ws.get_session(ws.default_session_id).env["OK"] == "yes"
 
 
 def test_and_short_circuit():
     ws = _ws()
     _exec(ws, "false && export SKIP=yes")
-    assert "SKIP" not in ws.get_session(DEFAULT_SESSION_ID).env
+    assert "SKIP" not in ws.get_session(ws.default_session_id).env
 
 
 def test_or_fallback():
     ws = _ws()
     _exec(ws, "false || export FALL=yes")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["FALL"] == "yes"
+    assert ws.get_session(ws.default_session_id).env["FALL"] == "yes"
 
 
 # ── subshell ───────────────────────────────────
@@ -245,7 +245,7 @@ def test_subshell_isolates_env():
     ws = _ws()
     _exec(ws, "export X=outer")
     _exec(ws, "(export X=inner)")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["X"] == "outer"
+    assert ws.get_session(ws.default_session_id).env["X"] == "outer"
 
 
 # ── function ───────────────────────────────────
@@ -254,13 +254,13 @@ def test_subshell_isolates_env():
 def test_function_define_call():
     ws = _ws()
     _exec(ws, "greet() { export MSG=hello; }; greet")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["MSG"] == "hello"
+    assert ws.get_session(ws.default_session_id).env["MSG"] == "hello"
 
 
 def test_function_with_args():
     ws = _ws()
     _exec(ws, "f() { export A=$1; export B=$2; }; f x y")
-    s = ws.get_session(DEFAULT_SESSION_ID)
+    s = ws.get_session(ws.default_session_id)
     assert s.env["A"] == "x"
     assert s.env["B"] == "y"
 
@@ -286,7 +286,7 @@ def test_negated_false():
 def test_brace_group():
     ws = _ws()
     _exec(ws, "{ export A=1; export B=2; }")
-    s = ws.get_session(DEFAULT_SESSION_ID)
+    s = ws.get_session(ws.default_session_id)
     assert s.env["A"] == "1"
     assert s.env["B"] == "2"
 
@@ -316,14 +316,14 @@ def test_var_concat_path():
 def test_bare_assignment():
     ws = _ws()
     _exec(ws, "X=hello")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["X"] == "hello"
+    assert ws.get_session(ws.default_session_id).env["X"] == "hello"
 
 
 def test_assignment_expansion():
     ws = _ws()
     _exec(ws, "export BASE=/s3")
     _exec(ws, "OUT=$BASE/result.txt")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["OUT"] == "/s3/result.txt"
+    assert ws.get_session(ws.default_session_id).env["OUT"] == "/s3/result.txt"
 
 
 # ── while read ─────────────────────────────────
@@ -334,7 +334,7 @@ def test_while_read():
     _exec(ws,
           "while read LINE; do export LAST=$LINE; done",
           stdin=b"a\nb\nc\n")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["LAST"] == "c"
+    assert ws.get_session(ws.default_session_id).env["LAST"] == "c"
 
 
 # ── cross-mount ────────────────────────────────
@@ -396,9 +396,9 @@ def test_exit_code_propagation():
 def test_last_exit_code():
     ws = _ws()
     _exec(ws, "true")
-    assert ws.get_session(DEFAULT_SESSION_ID).last_exit_code == 0
+    assert ws.get_session(ws.default_session_id).last_exit_code == 0
     _exec(ws, "false")
-    assert ws.get_session(DEFAULT_SESSION_ID).last_exit_code == 1
+    assert ws.get_session(ws.default_session_id).last_exit_code == 1
 
 
 # ═══════════════════════════════════════════════
@@ -508,7 +508,7 @@ def test_nested_for_cross_mount():
     done
     """
     ws = _ws()
-    s = ws.get_session(DEFAULT_SESSION_ID)
+    s = ws.get_session(ws.default_session_id)
     _exec(
         ws, "for src in /s3 /ram; do "
         "for f in report.csv notes.txt; do "
@@ -529,7 +529,7 @@ def test_background_with_foreground_work():
     _exec(
         ws, "sleep 0.01 & export A=1; export B=2; "
         "cat /s3/report.csv > /disk/copy.txt")
-    s = ws.get_session(DEFAULT_SESSION_ID)
+    s = ws.get_session(ws.default_session_id)
     assert s.env["A"] == "1"
     assert s.env["B"] == "2"
     io = _exec(ws, "cat /disk/copy.txt")
@@ -544,7 +544,7 @@ def test_subshell_pipeline_redirect():
     ws = _ws()
     _exec(ws, "(export TMP=inner; cat /s3/report.csv) | "
           "sort > /disk/out.txt")
-    s = ws.get_session(DEFAULT_SESSION_ID)
+    s = ws.get_session(ws.default_session_id)
     assert "TMP" not in s.env
     io = _exec(ws, "cat /disk/out.txt")
     out = _stdout(io)
@@ -810,7 +810,7 @@ def test_nl_numbers():
 def test_unset_removes():
     ws = _ws()
     _exec(ws, "export FOO=bar; unset FOO")
-    assert "FOO" not in ws.get_session(DEFAULT_SESSION_ID).env
+    assert "FOO" not in ws.get_session(ws.default_session_id).env
 
 
 def test_printenv_single():
@@ -832,7 +832,7 @@ def test_printenv_all():
 def test_export_override():
     ws = _ws()
     _exec(ws, "export X=first; export X=second")
-    assert ws.get_session(DEFAULT_SESSION_ID).env["X"] == "second"
+    assert ws.get_session(ws.default_session_id).env["X"] == "second"
 
 
 def test_env_in_pipeline():
@@ -922,7 +922,7 @@ def test_config_loader():
     _exec(ws,
           "while read LINE; do export $LINE; done",
           stdin=b"DB_HOST=localhost\nDB_PORT=5432\n")
-    s = ws.get_session(DEFAULT_SESSION_ID)
+    s = ws.get_session(ws.default_session_id)
     assert s.env["DB_HOST"] == "localhost"
     assert s.env["DB_PORT"] == "5432"
 
@@ -1178,7 +1178,7 @@ def test_pipeline_four_stages():
 def test_pipeline_with_default_cwd():
     """Pipeline works even with default cwd=/mirage."""
     ws = _ws()
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/mirage"
+    ws.get_session(ws.default_session_id).cwd = "/mirage"
     io = _exec(ws, "cat /s3/report.csv | wc -l")
     assert io.exit_code == 0
     assert b"3" in _stdout(io)
@@ -1198,7 +1198,7 @@ def test_pipeline_sed():
 def test_cache_fallback_wc():
     """wc uses cache resource when cwd has no mount."""
     ws = _ws()
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/mirage"
+    ws.get_session(ws.default_session_id).cwd = "/mirage"
     io = _exec(ws, "cat /s3/report.csv | wc -l")
     assert io.exit_code == 0
     assert b"3" in _stdout(io)
@@ -1207,7 +1207,7 @@ def test_cache_fallback_wc():
 def test_cache_fallback_head():
     """head uses cache resource fallback."""
     ws = _ws()
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/nonexistent"
+    ws.get_session(ws.default_session_id).cwd = "/nonexistent"
     io = _exec(ws, "cat /ram/notes.txt | head -n 1")
     assert io.exit_code == 0
     assert b"line1" in _stdout(io)
@@ -1216,7 +1216,7 @@ def test_cache_fallback_head():
 def test_cache_fallback_grep():
     """grep uses cache resource fallback in pipeline."""
     ws = _ws()
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/mirage"
+    ws.get_session(ws.default_session_id).cwd = "/mirage"
     io = _exec(ws, "cat /s3/report.csv | grep alice")
     assert io.exit_code == 0
     assert b"alice" in _stdout(io)
@@ -1225,7 +1225,7 @@ def test_cache_fallback_grep():
 def test_cache_fallback_sort_uniq():
     """sort | uniq uses cache resource."""
     ws = _ws()
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/mirage"
+    ws.get_session(ws.default_session_id).cwd = "/mirage"
     io = _exec(ws, "cat /ram/words.txt | sort | uniq")
     assert io.exit_code == 0
     assert _stdout(io).count(b"apple") == 1
@@ -1234,7 +1234,7 @@ def test_cache_fallback_sort_uniq():
 def test_cache_fallback_multi_pipe():
     """Four-stage pipeline with cache fallback."""
     ws = _ws()
-    ws.get_session(DEFAULT_SESSION_ID).cwd = "/mirage"
+    ws.get_session(ws.default_session_id).cwd = "/mirage"
     io = _exec(ws, "cat /s3/report.csv | grep -v name "
                "| cut -d, -f1 | sort")
     assert io.exit_code == 0
@@ -2510,11 +2510,11 @@ def test_unmount_after_close_raises():
 
 def test_cd_nonexistent_under_mount_keeps_cwd():
     ws = Workspace(resources={"/": (RAMResource(), MountMode.WRITE)}, )
-    before = ws.get_session(DEFAULT_SESSION_ID).cwd
+    before = ws.get_session(ws.default_session_id).cwd
     io = _exec(ws, "cd /missing")
     assert io.exit_code != 0
     assert b"No such file or directory" in io.stderr
-    assert ws.get_session(DEFAULT_SESSION_ID).cwd == before
+    assert ws.get_session(ws.default_session_id).cwd == before
 
 
 def test_cd_into_mount_root_succeeds():
@@ -2524,7 +2524,7 @@ def test_cd_into_mount_root_succeeds():
     }, )
     io = _exec(ws, "cd /data")
     assert io.exit_code == 0
-    assert ws.get_session(DEFAULT_SESSION_ID).cwd == "/data"
+    assert ws.get_session(ws.default_session_id).cwd == "/data"
 
 
 # ── ls injects child mounts as virtual subdirectories ─────────────

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -4008,6 +4008,7 @@ dependencies = [
     { name = "tree-sitter" },
     { name = "tree-sitter-bash" },
     { name = "typer" },
+    { name = "uuid6" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -4252,6 +4253,7 @@ requires-dist = [
     { name = "tree-sitter", specifier = ">=0.25.2" },
     { name = "tree-sitter-bash", specifier = ">=0.25.1" },
     { name = "typer", specifier = ">=0.12.0" },
+    { name = "uuid6", specifier = ">=2025.0.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
     { name = "wasmtime", marker = "extra == 'quickjs'", specifier = ">=46" },
     { name = "wasmtime", marker = "extra == 'wasi'", specifier = ">=46" },
@@ -10754,6 +10756,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/20/049418d094d396dfa6606b30af925cc68a6670c3b9103b23e6990f84b589/uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50fffc2827348c1e48972eed3d1c698959e63f9d030aa5dd82ba451113158a62", size = 476731, upload-time = "2026-02-20T22:50:30.589Z" },
     { url = "https://files.pythonhosted.org/packages/77/a1/0857f64d53a90321e6a46a3d4cc394f50e1366132dcd2ae147f9326ca98b/uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dbe718765f70f5b7f9b7f66b6a937802941b1cc56bcf642ce0274169741e01", size = 338902, upload-time = "2026-02-20T22:50:33.927Z" },
     { url = "https://files.pythonhosted.org/packages/ed/d0/5bf7cbf1ac138c92b9ac21066d18faf4d7e7f651047b700eb192ca4b9fdb/uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:258186964039a8e36db10810c1ece879d229b01331e09e9030bc5dcabe231bd2", size = 364700, upload-time = "2026-02-20T22:50:21.732Z" },
+]
+
+[[package]]
+name = "uuid6"
+version = "2025.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/b7/4c0f736ca824b3a25b15e8213d1bcfc15f8ac2ae48d1b445b310892dc4da/uuid6-2025.0.1.tar.gz", hash = "sha256:cd0af94fa428675a44e32c5319ec5a3485225ba2179eefcf4c3f205ae30a81bd", size = 13932, upload-time = "2025-07-04T18:30:35.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b2/93faaab7962e2aa8d6e174afb6f76be2ca0ce89fde14d3af835acebcaa59/uuid6-2025.0.1-py3-none-any.whl", hash = "sha256:80530ce4d02a93cdf82e7122ca0da3ebbbc269790ec1cb902481fa3e9cc9ff99", size = 6979, upload-time = "2025-07-04T18:30:34.001Z" },
 ]
 
 [[package]]

--- a/typescript/packages/cli/src/e2e.test.ts
+++ b/typescript/packages/cli/src/e2e.test.ts
@@ -149,7 +149,9 @@ describe('mirage CLI end-to-end', () => {
     const cfgPath = writeRamConfig(tmp, 'config.yaml')
 
     const created = (await runCli(env, ['workspace', 'create', cfgPath])) as { id: string }
-    expect(created.id).toMatch(/^ws_/)
+    expect(created.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    )
 
     const listed = (await runCli(env, ['workspace', 'list'])) as { id: string }[]
     expect(listed.some((w) => w.id === created.id)).toBe(true)

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -48,16 +48,16 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@pydantic/monty": "0.0.19-beta.4",
     "@qdrant/js-client-rest": "^1.18.0",
     "chromadb": "^3.4.3",
     "hyparquet-writer": "^0.13.0",
     "pyodide": "^0.29.3",
+    "quickjs-emscripten": "^0.31.0",
     "tree-sitter-bash": "^0.25.1",
     "tsup": "^8.5.0",
     "typescript": "^6.0.0",
-    "vitest": "^3.2.6",
-    "@pydantic/monty": "0.0.19-beta.4",
-    "quickjs-emscripten": "^0.31.0"
+    "vitest": "^3.2.6"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.0.0",
@@ -67,16 +67,17 @@
     "h5wasm": "^0.10.1",
     "hyparquet": "^1.25.6",
     "jq-wasm": "1.1.0-jq-1.8.1",
+    "uuid": "^14.0.1",
     "web-tree-sitter": "^0.26.8",
     "zod": "^4.3.6"
   },
   "peerDependencies": {
+    "@pydantic/monty": ">=0.0.19-beta.4",
     "@qdrant/js-client-rest": "^1.18.0",
     "chromadb": "^3.4.3",
     "pyodide": "^0.29.0",
-    "redis": "^5.0.0",
-    "@pydantic/monty": ">=0.0.19-beta.4",
-    "quickjs-emscripten": "^0.31.0"
+    "quickjs-emscripten": "^0.31.0",
+    "redis": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "@qdrant/js-client-rest": {

--- a/typescript/packages/core/src/commands/builtin/history/history_cmd.ts
+++ b/typescript/packages/core/src/commands/builtin/history/history_cmd.ts
@@ -15,7 +15,7 @@
 import type { HistoryAccessor } from '../../../accessor/history.ts'
 import { renderHistoryListing } from '../../../core/history/render.ts'
 import { IOResult } from '../../../io/types.ts'
-import { DEFAULT_SESSION_ID, type PathSpec } from '../../../types.ts'
+import { type PathSpec } from '../../../types.ts'
 import { command } from '../../config.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
@@ -55,7 +55,10 @@ async function historyFn(
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const observer = accessor.observer
-  const session = opts.sessionId ?? DEFAULT_SESSION_ID
+  if (opts.sessionId === undefined) {
+    throw new Error("history requires the caller's session id")
+  }
+  const session = opts.sessionId
   const flags = opts.flags
   const c = flags.c === true
   const s = flags.s === true

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -17,8 +17,6 @@ export {
   CommandSafeguard,
   type CommandSafeguardInit,
   ConsistencyPolicy,
-  DEFAULT_AGENT_ID,
-  DEFAULT_SESSION_ID,
   DriftPolicy,
   FileStat,
   type FileStatInit,
@@ -147,6 +145,7 @@ export {
   setVirtualPrefix,
 } from './observe/context.ts'
 export { guessType } from './utils/filetype.ts'
+export { newSessionId, newWorkspaceId, uuid7 } from './utils/ids.ts'
 export { Accessor, NOOPAccessor, RAMAccessor } from './accessor/index.ts'
 export { cat as featherCat, describe as featherDescribe } from './core/filetype/feather.ts'
 export { cat as hdf5Cat, describe as hdf5Describe } from './core/filetype/hdf5.ts'

--- a/typescript/packages/core/src/shell/background_stdin.test.ts
+++ b/typescript/packages/core/src/shell/background_stdin.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, it } from 'vitest'
 import { OpsRegistry } from '../ops/registry.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
-import { DEFAULT_SESSION_ID, MountMode } from '../types.ts'
+import { MountMode } from '../types.ts'
 import { getTestParser, stdoutStr } from '../workspace/fixtures/workspace_fixture.ts'
 import { Workspace } from '../workspace/workspace.ts'
 
@@ -36,7 +36,7 @@ describe('background jobs + stdin (port of tests/shell/test_background_jobs.py)'
       { '/data': ram },
       { mode: MountMode.WRITE, ops: registry, shellParser: parser },
     )
-    ws.getSession(DEFAULT_SESSION_ID).cwd = '/data'
+    ws.getSession(ws.defaultSessionId).cwd = '/data'
     const io = await ws.execute('sleep 0 & cat', { stdin: ENC.encode('hello\n') })
     if (!('stdout' in io)) throw new Error('expected ExecuteResult')
     expect(stdoutStr(io).trim()).toBe('hello')

--- a/typescript/packages/core/src/shell/job_table.test.ts
+++ b/typescript/packages/core/src/shell/job_table.test.ts
@@ -65,7 +65,7 @@ describe('JobTable.submit', () => {
       cwd: '/',
     })
     expect(j.agent).toBe('unknown')
-    expect(j.sessionId).toBe('default')
+    expect(j.sessionId).toBe('')
     expect(j.status).toBe(JobStatus.RUNNING)
   })
 })

--- a/typescript/packages/core/src/shell/job_table.ts
+++ b/typescript/packages/core/src/shell/job_table.ts
@@ -13,7 +13,6 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { ByteSource, IOResult } from '../io/types.ts'
-import { DEFAULT_SESSION_ID } from '../types.ts'
 import type { ExecutionNode } from '../workspace/types.ts'
 
 export const JobStatus = Object.freeze({
@@ -64,7 +63,7 @@ export class Job {
     this.abort = init.abort ?? null
     this.cwd = init.cwd
     this.agent = init.agent ?? 'unknown'
-    this.sessionId = init.sessionId ?? DEFAULT_SESSION_ID
+    this.sessionId = init.sessionId ?? ''
     this.createdAt = init.createdAt ?? Date.now() / 1000
     if (init.status !== undefined) this.status = init.status
     if (init.stdout !== undefined) this.stdout = init.stdout

--- a/typescript/packages/core/src/shell/quoting_coverage.test.ts
+++ b/typescript/packages/core/src/shell/quoting_coverage.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, it } from 'vitest'
 import { OpsRegistry } from '../ops/registry.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
-import { DEFAULT_SESSION_ID, MountMode } from '../types.ts'
+import { MountMode } from '../types.ts'
 import { getTestParser, stdoutStr } from '../workspace/fixtures/workspace_fixture.ts'
 import { Workspace } from '../workspace/workspace.ts'
 
@@ -43,7 +43,7 @@ async function makeQuotingWs(): Promise<Workspace> {
     { '/data': ram },
     { mode: MountMode.WRITE, ops: registry, shellParser: parser },
   )
-  ws.getSession(DEFAULT_SESSION_ID).cwd = '/data'
+  ws.getSession(ws.defaultSessionId).cwd = '/data'
   return ws
 }
 

--- a/typescript/packages/core/src/types.test.ts
+++ b/typescript/packages/core/src/types.test.ts
@@ -16,8 +16,6 @@ import { mountKey, mountPrefixOf } from './utils/key_prefix.ts'
 import { describe, expect, it } from 'vitest'
 import {
   ConsistencyPolicy,
-  DEFAULT_AGENT_ID,
-  DEFAULT_SESSION_ID,
   FileStat,
   FileType,
   MountMode,
@@ -93,16 +91,6 @@ describe('ResourceName', () => {
 
   it('is frozen at runtime', () => {
     expect(Object.isFrozen(ResourceName)).toBe(true)
-  })
-})
-
-describe('default id constants', () => {
-  it('DEFAULT_SESSION_ID is "default"', () => {
-    expect(DEFAULT_SESSION_ID).toBe('default')
-  })
-
-  it('DEFAULT_AGENT_ID is "default"', () => {
-    expect(DEFAULT_AGENT_ID).toBe('default')
   })
 })
 

--- a/typescript/packages/core/src/types.ts
+++ b/typescript/packages/core/src/types.ts
@@ -190,10 +190,6 @@ export const ResourceName = Object.freeze({
 
 export type ResourceName = (typeof ResourceName)[keyof typeof ResourceName]
 
-export const DEFAULT_SESSION_ID = 'default'
-export const DEFAULT_AGENT_ID = 'default'
-export const DEFAULT_WORKSPACE_ID = 'default'
-
 export const FileType = Object.freeze({
   DIRECTORY: 'directory',
   TEXT: 'text',

--- a/typescript/packages/core/src/utils/ids.test.ts
+++ b/typescript/packages/core/src/utils/ids.test.ts
@@ -1,0 +1,52 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { newSessionId, newWorkspaceId, uuid7 } from './ids.ts'
+
+const UUID7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+describe('uuid7', () => {
+  it('is canonical lowercase and version 7', () => {
+    expect(uuid7()).toMatch(UUID7_RE)
+  })
+
+  it('embeds the current timestamp', () => {
+    const before = Date.now()
+    const value = uuid7()
+    const after = Date.now()
+    const embedded = parseInt(value.slice(0, 8) + value.slice(9, 13), 16)
+    expect(embedded).toBeGreaterThanOrEqual(before - 10)
+    expect(embedded).toBeLessThanOrEqual(after + 10)
+  })
+
+  it('orders across milliseconds', async () => {
+    const first = uuid7()
+    await new Promise((r) => setTimeout(r, 2))
+    const second = uuid7()
+    expect(first < second).toBe(true)
+  })
+
+  it('is unique', () => {
+    const values = new Set(Array.from({ length: 1000 }, () => uuid7()))
+    expect(values.size).toBe(1000)
+  })
+})
+
+describe('id kinds', () => {
+  it('share the format', () => {
+    expect(newWorkspaceId()).toMatch(UUID7_RE)
+    expect(newSessionId()).toMatch(UUID7_RE)
+  })
+})

--- a/typescript/packages/core/src/utils/ids.ts
+++ b/typescript/packages/core/src/utils/ids.ts
@@ -12,12 +12,25 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { ConsistencyPolicy, MountMode } from '../../types.ts'
-import type { Resource } from '../../resource/base.ts'
+import { v7 as uuidV7 } from 'uuid'
 
-export interface MountArgs {
-  mountArgs: Record<string, [Resource, MountMode]>
-  consistency: ConsistencyPolicy
-  defaultSessionId: string
-  defaultAgentId: string | null
+/**
+ * Mint an RFC 9562 UUIDv7 in canonical lowercase hyphenated form.
+ *
+ * The first 48 bits are a unix-millisecond timestamp, so ids sort by
+ * creation time and stay index-friendly as database primary keys; the
+ * remaining 74 bits are random.
+ */
+export function uuid7(): string {
+  return uuidV7()
+}
+
+/** Mint a fresh workspace id (UUIDv7). */
+export function newWorkspaceId(): string {
+  return uuid7()
+}
+
+/** Mint a fresh session id (UUIDv7). */
+export function newSessionId(): string {
+  return uuid7()
 }

--- a/typescript/packages/core/src/workspace/executor/builtins.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins.test.ts
@@ -129,11 +129,12 @@ describe('handleWhoami', () => {
     expect(io.stderr).toBeNull()
   })
 
-  it('defaults without an identity', () => {
+  it('errors without an identity', () => {
     const ns = new Namespace(emptyRegistry(), unusedResolve)
     const [out, io] = handleWhoami(ns)
-    expect(decode(out as Uint8Array)).toBe('default\n')
-    expect(io.exitCode).toBe(0)
+    expect(out).toBeNull()
+    expect(io.exitCode).toBe(1)
+    expect(decode(io.stderr as Uint8Array)).toBe('whoami: cannot find name for user ID\n')
   })
 })
 

--- a/typescript/packages/core/src/workspace/executor/builtins/vars.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/vars.ts
@@ -108,7 +108,16 @@ export function handlePrintenv(name: string | null, session: Session): Result {
 export function handleWhoami(namespace: Namespace): Result {
   // GNU whoami reports the effective user and never consults $USER; the
   // workspace user (launch agentId, shared via the namespace store) is
-  // the effective identity here.
+  // the effective identity here. With no claimed identity it fails like
+  // GNU does for a uid with no passwd entry.
+  if (namespace.user === null) {
+    const err = new TextEncoder().encode('whoami: cannot find name for user ID\n')
+    return [
+      null,
+      new IOResult({ exitCode: 1, stderr: err }),
+      new ExecutionNode({ command: 'whoami', exitCode: 1, stderr: err }),
+    ]
+  }
   const out = new TextEncoder().encode(`${namespace.user}\n`)
   return [out, new IOResult(), new ExecutionNode({ command: 'whoami', exitCode: 0 })]
 }

--- a/typescript/packages/core/src/workspace/executor/python/python.test.ts
+++ b/typescript/packages/core/src/workspace/executor/python/python.test.ts
@@ -13,12 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import {
-  DEFAULT_SESSION_ID,
-  makeWorkspace,
-  stderrStr,
-  stdoutStr,
-} from '../../fixtures/workspace_fixture.ts'
+import { makeWorkspace, stderrStr, stdoutStr } from '../../fixtures/workspace_fixture.ts'
 
 // All tests in this file are direct ports of Python mirage's python3 tests
 // in tests/workspace/test_workspace.py. Citations are in the `it()` title.
@@ -102,7 +97,7 @@ describe('python3: core (ports of Python tests_workspace)', { timeout: 30000 }, 
   it('bare-filename script in subdir: python3 sub/deep.py runs via cwd', async () => {
     const { ws, disk } = await makeWorkspace()
     disk.store.files.set('/sub/deep.py', new TextEncoder().encode("print('deep ok')\n"))
-    ws.getSession(DEFAULT_SESSION_ID).cwd = '/disk'
+    ws.getSession(ws.defaultSessionId).cwd = '/disk'
     const io = await ws.execute('python3 sub/deep.py')
     expect(io.exitCode).toBe(0)
     expect(stdoutStr(io)).toBe('deep ok\n')
@@ -153,7 +148,7 @@ describe('python3: core (ports of Python tests_workspace)', { timeout: 30000 }, 
       '/with_argv.py',
       new TextEncoder().encode('import sys; print(sys.argv[1:])\n'),
     )
-    ws.getSession(DEFAULT_SESSION_ID).cwd = '/disk'
+    ws.getSession(ws.defaultSessionId).cwd = '/disk'
     const io = await ws.execute('python3 with_argv.py one two')
     expect(io.exitCode).toBe(0)
     expect(stdoutStr(io)).toBe("['one', 'two']\n")

--- a/typescript/packages/core/src/workspace/fixtures/workspace_fixture.ts
+++ b/typescript/packages/core/src/workspace/fixtures/workspace_fixture.ts
@@ -17,7 +17,7 @@ import { createRequire } from 'node:module'
 import { OpsRegistry } from '../../ops/registry.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
 import { createShellParser, type ShellParser } from '../../shell/parse.ts'
-import { DEFAULT_SESSION_ID, MountMode } from '../../types.ts'
+import { MountMode } from '../../types.ts'
 import { Workspace } from '../workspace.ts'
 
 const require = createRequire(import.meta.url)
@@ -83,7 +83,7 @@ export async function makeWorkspace(extra: { agentId?: string } = {}): Promise<T
     { '/s3': s3, '/disk': disk, '/ram': ram },
     { mode: MountMode.EXEC, ops: registry, shellParser: parser, ...extra },
   )
-  ws.getSession(DEFAULT_SESSION_ID).cwd = '/s3'
+  ws.getSession(ws.defaultSessionId).cwd = '/s3'
   return { ws, s3, disk, ram }
 }
 
@@ -103,5 +103,3 @@ export function countOccurrences(buf: Uint8Array, needle: string): number {
   const hay = DEC.decode(buf)
   return hay.split(needle).length - 1
 }
-
-export { DEFAULT_SESSION_ID }

--- a/typescript/packages/core/src/workspace/mount/namespace/namespace.test.ts
+++ b/typescript/packages/core/src/workspace/mount/namespace/namespace.test.ts
@@ -319,9 +319,9 @@ describe('Namespace + NamespaceStore', () => {
     await ws.close()
   })
 
-  it('user defaults before resolution', async () => {
+  it('user is null before resolution', async () => {
     const ws = new Workspace({ '/data': new RAMResource() })
-    expect(ws.namespace.user).toBe('default')
+    expect(ws.namespace.user).toBeNull()
     await ws.close()
   })
 
@@ -348,11 +348,11 @@ describe('Namespace + NamespaceStore', () => {
     await ws.close()
   })
 
-  it('bare launch with an empty store stays default', async () => {
+  it('bare launch with an empty store has no user', async () => {
     const store = new RAMNamespaceStore()
     const ws = new Workspace({ '/data': new RAMResource() }, { namespaceStore: store })
     await ws.namespace.ensureLoaded()
-    expect(ws.namespace.user).toBe('default')
+    expect(ws.namespace.user).toBeNull()
     expect(await store.loadUser()).toBeNull()
     await ws.close()
   })

--- a/typescript/packages/core/src/workspace/mount/namespace/namespace.ts
+++ b/typescript/packages/core/src/workspace/mount/namespace/namespace.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { Resource } from '../../../resource/base.ts'
-import { DEFAULT_AGENT_ID, type MountMode, type PathSpec } from '../../../types.ts'
+import { type MountMode, type PathSpec } from '../../../types.ts'
 import { globPrefixMatch, resolveSymlinks } from '../../../utils/path.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
 import type { ResolveFn } from '../../dispatcher.ts'
@@ -107,12 +107,12 @@ export class Namespace {
   }
 
   // The workspace user (whoami identity). Before store resolution the
-  // launch claim (or DEFAULT_AGENT_ID) answers; after it, the resolved
-  // identity.
-  get user(): string {
+  // launch claim answers; after it, the resolved identity. Null when no
+  // agent ever claimed the workspace, mirroring a uid with no passwd
+  // entry.
+  get user(): string | null {
     if (this.workspaceUser !== null) return this.workspaceUser
-    if (this.claim !== null) return this.claim
-    return DEFAULT_AGENT_ID
+    return this.claim
   }
 
   // Resolve the workspace user against the store, once. An explicit launch

--- a/typescript/packages/core/src/workspace/pipeline_timeout.test.ts
+++ b/typescript/packages/core/src/workspace/pipeline_timeout.test.ts
@@ -53,7 +53,7 @@ function buildWs(): Workspace {
 describe('pipeline timeout', () => {
   it('bounds a slow final stage', async () => {
     const ws = buildWs()
-    ws.getSession('default').pipelineTimeoutSeconds = 0.1
+    ws.getSession(ws.defaultSessionId).pipelineTimeoutSeconds = 0.1
     try {
       const r = await ws.execute('cat | cat', { stdin: slowStdin() })
       expect(r.exitCode).toBe(124)

--- a/typescript/packages/core/src/workspace/session/manager.test.ts
+++ b/typescript/packages/core/src/workspace/session/manager.test.ts
@@ -13,15 +13,33 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { DEFAULT_SESSION_ID, MountMode } from '../../types.ts'
+import { MountMode } from '../../types.ts'
 import { SessionManager } from './manager.ts'
 import { RAMSessionStore } from './ram.ts'
 
 describe('SessionManager', () => {
   it('seeds the default session on construction', () => {
-    const m = new SessionManager(DEFAULT_SESSION_ID)
-    expect(m.defaultId).toBe(DEFAULT_SESSION_ID)
-    expect(m.get(DEFAULT_SESSION_ID).sessionId).toBe(DEFAULT_SESSION_ID)
+    const m = new SessionManager('def')
+    expect(m.defaultId).toBe('def')
+    expect(m.get('def').sessionId).toBe('def')
+    expect(m.list()).toHaveLength(1)
+  })
+
+  it('adoptDefault re-keys the placeholder before hydration', () => {
+    const m = new SessionManager('minted')
+    m.get('minted').cwd = '/kept'
+    m.adoptDefault('stored')
+    expect(m.defaultId).toBe('stored')
+    expect(m.get('stored').cwd).toBe('/kept')
+    expect(m.list()).toHaveLength(1)
+    expect(() => m.get('minted')).toThrow()
+  })
+
+  it('adoptDefault switches to an existing session of that id', () => {
+    const m = new SessionManager('minted')
+    m.create('stored')
+    m.adoptDefault('stored')
+    expect(m.defaultId).toBe('stored')
     expect(m.list()).toHaveLength(1)
   })
 

--- a/typescript/packages/core/src/workspace/session/manager.ts
+++ b/typescript/packages/core/src/workspace/session/manager.ts
@@ -32,18 +32,45 @@ type StoredSession = Parameters<typeof Session.fromJSON>[0]
 export class SessionManager {
   private readonly sessions = new Map<string, Session>()
   private readonly sessionStore: SessionStore
-  readonly defaultId: string
+  private defaultIdInternal: string
   private loaded = false
   private loadPromise: Promise<void> | null = null
 
   constructor(defaultSessionId: string, store?: SessionStore) {
-    this.defaultId = defaultSessionId
+    this.defaultIdInternal = defaultSessionId
     this.sessionStore = store ?? new RAMSessionStore()
     this.sessions.set(defaultSessionId, new Session({ sessionId: defaultSessionId }))
   }
 
   get store(): SessionStore {
     return this.sessionStore
+  }
+
+  get defaultId(): string {
+    return this.defaultIdInternal
+  }
+
+  /**
+   * Re-key the default session to an externally decided id.
+   *
+   * Two callers: attach (the discovery record already names a default
+   * session, so the freshly minted placeholder re-keys before hydration
+   * lands the stored durable fields on it) and snapshot restore (the
+   * snapshot's default identity wins). The store itself is untouched;
+   * the next flush or snapshot replace writes the new key.
+   */
+  adoptDefault(sessionId: string): void {
+    if (sessionId === this.defaultIdInternal) return
+    const existing = this.sessions.get(sessionId)
+    if (existing !== undefined) {
+      this.sessions.delete(this.defaultIdInternal)
+    } else {
+      const session = this.defaultSession()
+      this.sessions.delete(this.defaultIdInternal)
+      session.sessionId = sessionId
+      this.sessions.set(sessionId, session)
+    }
+    this.defaultIdInternal = sessionId
   }
 
   get cwd(): string {

--- a/typescript/packages/core/src/workspace/session/session.ts
+++ b/typescript/packages/core/src/workspace/session/session.ts
@@ -40,7 +40,7 @@ export interface SessionInit {
 }
 
 export class Session {
-  readonly sessionId: string
+  sessionId: string
   cwd: string
   env: Record<string, string>
   createdAt: number

--- a/typescript/packages/core/src/workspace/snapshot/state.ts
+++ b/typescript/packages/core/src/workspace/snapshot/state.ts
@@ -211,6 +211,9 @@ async function restoreNodes(ws: Workspace, state: WorkspaceStateDict): Promise<v
 }
 
 async function restoreSessions(ws: Workspace, state: WorkspaceStateDict): Promise<void> {
+  // The snapshot's default session identity wins over the live one,
+  // and the discovery record's pointer follows it.
+  await ws.adoptDefaultSession(state.default_session_id)
   const restored: Session[] = []
   for (const s of state.sessions) {
     const exists = ws.sessionManager.list().some((x) => x.sessionId === s.session_id)

--- a/typescript/packages/core/src/workspace/snapshot/types.ts
+++ b/typescript/packages/core/src/workspace/snapshot/types.ts
@@ -113,8 +113,8 @@ export interface WorkspaceStateDict {
   version: number
   mirage_version: string
   default_session_id: string
-  default_agent_id: string
-  current_agent_id: string
+  default_agent_id: string | null
+  current_agent_id: string | null
   sessions: SessionSnapshot[]
   mounts: MountSnapshot[]
   cache: CacheSnapshot

--- a/typescript/packages/core/src/workspace/store/workspace_wiring.test.ts
+++ b/typescript/packages/core/src/workspace/store/workspace_wiring.test.ts
@@ -20,6 +20,8 @@ import { getTestParser } from '../fixtures/workspace_fixture.ts'
 import { Workspace } from '../workspace.ts'
 import { RAMWorkspaceStateStore } from './ram.ts'
 
+const UUID7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
 const open: Workspace[] = []
 
 afterEach(async () => {
@@ -43,8 +45,61 @@ describe('Workspace on a WorkspaceStateStore', () => {
     await ws.execute('echo hi')
     const meta = await store.loadMeta('ws-a')
     expect(meta?.workspace_id).toBe('ws-a')
-    expect(meta?.default_session_id).toBe('default')
+    expect(meta?.default_session_id).toBe(ws.defaultSessionId)
+    expect(meta?.default_session_id).toMatch(UUID7_RE)
     expect(meta?.created_at as number).toBeGreaterThan(0)
+  })
+
+  it('a bare workspace mints uuid7 ids', async () => {
+    const parser = await getTestParser()
+    const ws = new Workspace(
+      { '/data': new RAMResource() },
+      { mode: MountMode.EXEC, shellParser: parser },
+    )
+    open.push(ws)
+    const sibling = new Workspace(
+      { '/data': new RAMResource() },
+      { mode: MountMode.EXEC, shellParser: parser },
+    )
+    open.push(sibling)
+    expect(ws.workspaceId).toMatch(UUID7_RE)
+    expect(ws.defaultSessionId).toMatch(UUID7_RE)
+    expect(sibling.workspaceId).not.toBe(ws.workspaceId)
+  })
+
+  it('attach adopts the stored default session pointer', async () => {
+    const store = new RAMWorkspaceStateStore()
+    const wsA = await mkWs(store, 'shared')
+    await wsA.execute('export MARK=1')
+    await wsA.flushSessions()
+
+    const wsB = await mkWs(store, 'shared')
+    const minted = wsB.defaultSessionId
+    await wsB.ensureSessionsLoaded()
+    expect(wsB.defaultSessionId).toBe(wsA.defaultSessionId)
+    expect(wsB.defaultSessionId).not.toBe(minted)
+    expect(wsB.getSession(wsB.defaultSessionId).env.MARK).toBe('1')
+  })
+
+  it('an explicit session id is not adopted away', async () => {
+    const store = new RAMWorkspaceStateStore()
+    const wsA = await mkWs(store, 'shared')
+    await wsA.execute('echo hi')
+
+    const parser = await getTestParser()
+    const wsB = new Workspace(
+      { '/data': new RAMResource() },
+      {
+        mode: MountMode.EXEC,
+        shellParser: parser,
+        workspaceId: 'shared',
+        store,
+        sessionId: 'pinned',
+      },
+    )
+    open.push(wsB)
+    await wsB.ensureSessionsLoaded()
+    expect(wsB.defaultSessionId).toBe('pinned')
   })
 
   it('an existing discovery record wins', async () => {

--- a/typescript/packages/core/src/workspace/types.test.ts
+++ b/typescript/packages/core/src/workspace/types.test.ts
@@ -14,7 +14,6 @@
 
 import { describe, expect, it } from 'vitest'
 import { OpRecord } from '../observe/record.ts'
-import { DEFAULT_SESSION_ID } from '../types.ts'
 import { ExecutionNode, ExecutionRecord } from './types.ts'
 
 describe('ExecutionNode', () => {
@@ -80,7 +79,7 @@ describe('ExecutionNode', () => {
 })
 
 describe('ExecutionRecord', () => {
-  it('defaults sessionId to DEFAULT_SESSION_ID', () => {
+  it('defaults sessionId to empty when unattributed', () => {
     const tree = new ExecutionNode()
     const r = new ExecutionRecord({
       agent: 'a',
@@ -90,7 +89,7 @@ describe('ExecutionRecord', () => {
       tree,
       timestamp: 100,
     })
-    expect(r.sessionId).toBe(DEFAULT_SESSION_ID)
+    expect(r.sessionId).toBe('')
   })
 
   it('toJSON decodes stdout and stdin', () => {

--- a/typescript/packages/core/src/workspace/types.ts
+++ b/typescript/packages/core/src/workspace/types.ts
@@ -14,7 +14,6 @@
 
 import type { OpRecord } from '../observe/record.ts'
 import type { PathSpec } from '../types.ts'
-import { DEFAULT_SESSION_ID } from '../types.ts'
 
 export interface ExecutionNodeInit {
   command?: string | null
@@ -89,7 +88,7 @@ export class ExecutionRecord {
     this.exitCode = init.exitCode
     this.tree = init.tree
     this.timestamp = init.timestamp
-    this.sessionId = init.sessionId ?? DEFAULT_SESSION_ID
+    this.sessionId = init.sessionId ?? ''
   }
 
   toJSON(): Record<string, unknown> {

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -45,8 +45,6 @@ import type { FileStat } from '../types.ts'
 import {
   type CommandSafeguard,
   ConsistencyPolicy,
-  DEFAULT_AGENT_ID,
-  DEFAULT_WORKSPACE_ID,
   DriftPolicy,
   FileType,
   MountMode,
@@ -82,6 +80,7 @@ import type { WorkspaceFields, WorkspaceStateStore } from './store/base.ts'
 import type { Session } from './session/session.ts'
 import type { ExecutionNode } from './types.ts'
 import { errorVirtualPath, gnuStrerror } from '../utils/errors.ts'
+import { newSessionId, newWorkspaceId } from '../utils/ids.ts'
 import { stripSlash } from '../utils/slash.ts'
 
 /**
@@ -211,6 +210,7 @@ export class Workspace {
   private readonly stateStoreInternal: WorkspaceStateStore
   private readonly ownsStateStore: boolean
   private metaWritten = false
+  private readonly sessionIdExplicit: boolean
   private readonly opsRegistry: OpsRegistry
   private shellParser: ShellParser | null
   private readonly shellParserFactory: (() => Promise<ShellParser>) | null
@@ -218,7 +218,7 @@ export class Workspace {
   private readonly opened = new Set<Resource>()
   private readonly openOrder: Resource[] = []
   readonly jobTable = new JobTable()
-  readonly agentId: string
+  readonly agentId: string | null
   readonly cache: FileCache & Resource
   readonly namespace: Namespace
   private readonly dispatcher: Dispatcher
@@ -273,17 +273,21 @@ export class Workspace {
     // as direct overrides that win over the provider. A caller-passed
     // provider may be shared with sibling workspaces, so only a
     // workspace that built its own provider closes it.
-    this.wsId = options.workspaceId ?? DEFAULT_WORKSPACE_ID
+    this.wsId = options.workspaceId ?? newWorkspaceId()
+    // A minted default session id is provisional: attaching to a
+    // workspace whose discovery record already names one adopts the
+    // stored pointer instead (see ensureMeta).
+    this.sessionIdExplicit = options.sessionId !== undefined
     this.ownsStateStore = options.store === undefined
     this.stateStoreInternal = options.store ?? new RAMWorkspaceStateStore()
     const observeStore = options.observe ?? this.stateStoreInternal.observer(this.wsId)
     const namespaceStore = options.namespaceStore ?? this.stateStoreInternal.namespace(this.wsId)
     const sessionStore = options.sessionStore ?? this.stateStoreInternal.sessions(this.wsId)
-    this.sessionManager = new SessionManager(options.sessionId ?? 'default', sessionStore)
+    this.sessionManager = new SessionManager(options.sessionId ?? newSessionId(), sessionStore)
     this.opsRegistry = options.ops ?? new OpsRegistry()
     this.shellParser = options.shellParser ?? null
     this.shellParserFactory = options.shellParserFactory ?? null
-    this.agentId = options.agentId ?? DEFAULT_AGENT_ID
+    this.agentId = options.agentId ?? null
     const userPython = options.python ?? {}
     this.pythonRuntime = selectPythonRuntime(
       options.pythonRuntime,
@@ -364,7 +368,7 @@ export class Workspace {
       this.opsRegistry,
       async (rec) => {
         this.records.push(rec)
-        await this.observer.logOp(rec, this.agentId, this.sessionManager.defaultId)
+        await this.observer.logOp(rec, this.agentId ?? '', this.sessionManager.defaultId)
       },
       this.namespace,
       (path, stat) => mergeOverlayStat(this.namespace.metaFor(path), stat),
@@ -536,18 +540,42 @@ export class Workspace {
     return this.sessionManager.closeAll()
   }
 
-  /** Hydrate sessions from the session store (idempotent). */
+  /**
+   * Hydrate sessions from the session store (idempotent). The discovery
+   * record resolves first so a minted default session id can adopt the
+   * stored pointer before hydration keys off it.
+   */
   async ensureSessionsLoaded(): Promise<void> {
-    await this.sessionManager.ensureLoaded()
     await this.ensureMeta()
+    await this.sessionManager.ensureLoaded()
   }
 
   get workspaceId(): string {
     return this.wsId
   }
 
+  get defaultSessionId(): string {
+    return this.sessionManager.defaultId
+  }
+
   get stateStore(): WorkspaceStateStore {
     return this.stateStoreInternal
+  }
+
+  /**
+   * Snapshot restore: adopt the snapshot's default session identity and
+   * point the discovery record at it.
+   */
+  async adoptDefaultSession(sessionId: string): Promise<void> {
+    this.sessionManager.adoptDefault(sessionId)
+    const existing = await this.stateStoreInternal.loadMeta(this.wsId)
+    await this.stateStoreInternal.setMeta(this.wsId, {
+      ...(existing ?? {}),
+      workspace_id: this.wsId,
+      default_session_id: sessionId,
+      created_at: existing?.created_at ?? Date.now() / 1000,
+    })
+    this.metaWritten = true
   }
 
   /** This workspace's metadata record (discovery surface). */
@@ -572,6 +600,11 @@ export class Workspace {
         default_session_id: this.sessionManager.defaultId,
         created_at: Date.now() / 1000,
       })
+    } else {
+      const stored = existing.default_session_id
+      if (!this.sessionIdExplicit && typeof stored === 'string') {
+        this.sessionManager.adoptDefault(stored)
+      }
     }
     this.metaWritten = true
   }
@@ -873,8 +906,8 @@ export class Workspace {
       throw makeAbortError()
     }
     await this.namespace.ensureLoaded()
-    await this.sessionManager.ensureLoaded()
     await this.ensureMeta()
+    await this.sessionManager.ensureLoaded()
     if (this.driftCheckPending) {
       await this.runPendingDriftCheck()
     }
@@ -918,7 +951,7 @@ export class Workspace {
       this.openOrder.push(resource)
     }
 
-    const callAgentId = options.agentId ?? this.agentId
+    const callAgentId = options.agentId ?? this.agentId ?? ''
     const deps = {
       dispatch,
       registry: this.registry,
@@ -955,7 +988,7 @@ export class Workspace {
     targetSession: Session,
     stdin: ByteSource | null,
   ): Promise<ExecuteResult> {
-    const callAgentId = options.agentId ?? this.agentId
+    const callAgentId = options.agentId ?? this.agentId ?? ''
     const useOverride = options.cwd !== undefined || options.env !== undefined
     const effectiveSession = useOverride
       ? targetSession.fork({
@@ -1090,7 +1123,7 @@ export class Workspace {
     }
     const mergedOptions: WorkspaceOptions = {
       sessionId: args.defaultSessionId,
-      agentId: args.defaultAgentId,
+      ...(args.defaultAgentId !== null ? { agentId: args.defaultAgentId } : {}),
       ...options,
     }
     const ws = new this(resources, mergedOptions) as InstanceType<T>
@@ -1106,8 +1139,9 @@ export class Workspace {
     const state = await toStateDict(this)
     const opts: WorkspaceOptions = {
       mode: options.mode ?? MountMode.WRITE,
-      agentId: options.agentId ?? this.agentId,
     }
+    const copyAgentId = options.agentId ?? this.agentId
+    if (copyAgentId !== null) opts.agentId = copyAgentId
     opts.ops = options.ops ?? this.opsRegistry
     const parser = options.shellParser ?? this.shellParser
     if (parser !== null) opts.shellParser = parser

--- a/typescript/packages/core/src/workspace/workspace_parity_basic.test.ts
+++ b/typescript/packages/core/src/workspace/workspace_parity_basic.test.ts
@@ -14,7 +14,6 @@
 
 import { describe, expect, it } from 'vitest'
 import {
-  DEFAULT_SESSION_ID,
   countOccurrences,
   makeWorkspace,
   stdoutBytes,
@@ -57,7 +56,7 @@ describe('workspace: export / env', () => {
   it('export sets session env', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('export MSG=hello')
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.MSG).toBe('hello')
+    expect(ws.getSession(ws.defaultSessionId).env.MSG).toBe('hello')
     await ws.close()
   })
 
@@ -75,7 +74,7 @@ describe('workspace: cd', () => {
   it('cd sets cwd', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('cd /disk')
-    expect(ws.getSession(DEFAULT_SESSION_ID).cwd).toBe('/disk')
+    expect(ws.getSession(ws.defaultSessionId).cwd).toBe('/disk')
     await ws.close()
   })
 
@@ -129,21 +128,21 @@ describe('workspace: control flow', () => {
   it('if true', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('if true; then export R=yes; fi')
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.R).toBe('yes')
+    expect(ws.getSession(ws.defaultSessionId).env.R).toBe('yes')
     await ws.close()
   })
 
   it('if false else', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('if false; then export R=yes; else export R=no; fi')
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.R).toBe('no')
+    expect(ws.getSession(ws.defaultSessionId).env.R).toBe('no')
     await ws.close()
   })
 
   it('for loop', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('for x in a b c; do export LAST=$x; done')
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.LAST).toBe('c')
+    expect(ws.getSession(ws.defaultSessionId).env.LAST).toBe('c')
     await ws.close()
   })
 
@@ -151,14 +150,14 @@ describe('workspace: control flow', () => {
     const { ws } = await makeWorkspace()
     const io = await ws.execute('while false; do export RAN=yes; done')
     expect(io.exitCode).toBe(0)
-    expect('RAN' in ws.getSession(DEFAULT_SESSION_ID).env).toBe(false)
+    expect('RAN' in ws.getSession(ws.defaultSessionId).env).toBe(false)
     await ws.close()
   })
 
   it('case match', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('case hello in hello) export M=yes;; esac')
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.M).toBe('yes')
+    expect(ws.getSession(ws.defaultSessionId).env.M).toBe('yes')
     await ws.close()
   })
 })
@@ -167,7 +166,7 @@ describe('workspace: operators', () => {
   it('semicolons chain', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('export A=1; export B=2; export C=3')
-    const s = ws.getSession(DEFAULT_SESSION_ID)
+    const s = ws.getSession(ws.defaultSessionId)
     expect(s.env.A).toBe('1')
     expect(s.env.B).toBe('2')
     expect(s.env.C).toBe('3')
@@ -177,21 +176,21 @@ describe('workspace: operators', () => {
   it('&& chain', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('true && export OK=yes')
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.OK).toBe('yes')
+    expect(ws.getSession(ws.defaultSessionId).env.OK).toBe('yes')
     await ws.close()
   })
 
   it('&& short-circuits on false', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('false && export SKIP=yes')
-    expect('SKIP' in ws.getSession(DEFAULT_SESSION_ID).env).toBe(false)
+    expect('SKIP' in ws.getSession(ws.defaultSessionId).env).toBe(false)
     await ws.close()
   })
 
   it('|| fallback', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('false || export FALL=yes')
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.FALL).toBe('yes')
+    expect(ws.getSession(ws.defaultSessionId).env.FALL).toBe('yes')
     await ws.close()
   })
 })
@@ -201,7 +200,7 @@ describe('workspace: subshell', () => {
     const { ws } = await makeWorkspace()
     await ws.execute('export X=outer')
     await ws.execute('(export X=inner)')
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.X).toBe('outer')
+    expect(ws.getSession(ws.defaultSessionId).env.X).toBe('outer')
     await ws.close()
   })
 })
@@ -210,14 +209,14 @@ describe('workspace: function', () => {
   it('define and call', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('greet() { export MSG=hello; }; greet')
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.MSG).toBe('hello')
+    expect(ws.getSession(ws.defaultSessionId).env.MSG).toBe('hello')
     await ws.close()
   })
 
   it('with args', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('f() { export A=$1; export B=$2; }; f x y')
-    const s = ws.getSession(DEFAULT_SESSION_ID)
+    const s = ws.getSession(ws.defaultSessionId)
     expect(s.env.A).toBe('x')
     expect(s.env.B).toBe('y')
     await ws.close()
@@ -244,7 +243,7 @@ describe('workspace: brace group', () => {
   it('{ ... } runs sequentially in same session', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('{ export A=1; export B=2; }')
-    const s = ws.getSession(DEFAULT_SESSION_ID)
+    const s = ws.getSession(ws.defaultSessionId)
     expect(s.env.A).toBe('1')
     expect(s.env.B).toBe('2')
     await ws.close()
@@ -275,7 +274,7 @@ describe('workspace: assignment', () => {
   it('bare assignment X=hello', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('X=hello')
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.X).toBe('hello')
+    expect(ws.getSession(ws.defaultSessionId).env.X).toBe('hello')
     await ws.close()
   })
 
@@ -283,7 +282,7 @@ describe('workspace: assignment', () => {
     const { ws } = await makeWorkspace()
     await ws.execute('export BASE=/s3')
     await ws.execute('OUT=$BASE/result.txt')
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.OUT).toBe('/s3/result.txt')
+    expect(ws.getSession(ws.defaultSessionId).env.OUT).toBe('/s3/result.txt')
     await ws.close()
   })
 })
@@ -294,7 +293,7 @@ describe('workspace: while read', () => {
     await ws.execute('while read LINE; do export LAST=$LINE; done', {
       stdin: new TextEncoder().encode('a\nb\nc\n'),
     })
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.LAST).toBe('c')
+    expect(ws.getSession(ws.defaultSessionId).env.LAST).toBe('c')
     await ws.close()
   })
 })
@@ -355,9 +354,9 @@ describe('workspace: exit code', () => {
   it('last_exit_code tracks last command', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('true')
-    expect(ws.getSession(DEFAULT_SESSION_ID).lastExitCode).toBe(0)
+    expect(ws.getSession(ws.defaultSessionId).lastExitCode).toBe(0)
     await ws.execute('false')
-    expect(ws.getSession(DEFAULT_SESSION_ID).lastExitCode).toBe(1)
+    expect(ws.getSession(ws.defaultSessionId).lastExitCode).toBe(1)
     await ws.close()
   })
 })
@@ -425,7 +424,7 @@ describe('workspace: complex nested patterns', () => {
 
   it('nested for across mounts', async () => {
     const { ws } = await makeWorkspace()
-    const s = ws.getSession(DEFAULT_SESSION_ID)
+    const s = ws.getSession(ws.defaultSessionId)
     await ws.execute(
       'for src in /s3 /ram; do for f in report.csv notes.txt; do cat $src/$f && export FOUND=$src/$f; done; done',
     )
@@ -436,7 +435,7 @@ describe('workspace: complex nested patterns', () => {
   it('background sleep + foreground work', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('sleep 0.01 & export A=1; export B=2; cat /s3/report.csv > /disk/copy.txt')
-    const s = ws.getSession(DEFAULT_SESSION_ID)
+    const s = ws.getSession(ws.defaultSessionId)
     expect(s.env.A).toBe('1')
     expect(s.env.B).toBe('2')
     const io = await ws.execute('cat /disk/copy.txt')
@@ -447,7 +446,7 @@ describe('workspace: complex nested patterns', () => {
   it('subshell pipeline redirect', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('(export TMP=inner; cat /s3/report.csv) | sort > /disk/out.txt')
-    const s = ws.getSession(DEFAULT_SESSION_ID)
+    const s = ws.getSession(ws.defaultSessionId)
     expect('TMP' in s.env).toBe(false)
     const io = await ws.execute('cat /disk/out.txt')
     expect(stdoutBytes(io).byteLength).toBeGreaterThan(0)

--- a/typescript/packages/core/src/workspace/workspace_parity_env_redir.test.ts
+++ b/typescript/packages/core/src/workspace/workspace_parity_env_redir.test.ts
@@ -14,7 +14,6 @@
 
 import { describe, expect, it } from 'vitest'
 import {
-  DEFAULT_SESSION_ID,
   countOccurrences,
   makeWorkspace,
   stdoutBytes,
@@ -25,7 +24,7 @@ describe('workspace: env set / unset / printenv', () => {
   it('unset removes env var', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('export FOO=bar; unset FOO')
-    expect('FOO' in ws.getSession(DEFAULT_SESSION_ID).env).toBe(false)
+    expect('FOO' in ws.getSession(ws.defaultSessionId).env).toBe(false)
     await ws.close()
   })
 
@@ -50,7 +49,7 @@ describe('workspace: env set / unset / printenv', () => {
   it('export override keeps latest', async () => {
     const { ws } = await makeWorkspace()
     await ws.execute('export X=first; export X=second')
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.X).toBe('second')
+    expect(ws.getSession(ws.defaultSessionId).env.X).toBe('second')
     await ws.close()
   })
 
@@ -72,11 +71,13 @@ describe('workspace: whoami', () => {
     await ws.close()
   })
 
-  it('defaults without an agentId', async () => {
+  it('errors without an agentId', async () => {
+    // No agent ever claimed this workspace: GNU errors for a uid with
+    // no passwd entry, and so do we.
     const { ws } = await makeWorkspace()
     const io = await ws.execute('whoami')
-    expect(stdoutStr(io)).toBe('default\n')
-    expect(io.exitCode).toBe(0)
+    expect(io.exitCode).toBe(1)
+    expect(new TextDecoder().decode(io.stderr)).toBe('whoami: cannot find name for user ID\n')
     await ws.close()
   })
 
@@ -157,7 +158,7 @@ describe('workspace: real-world scripts', () => {
     await ws.execute('while read LINE; do export $LINE; done', {
       stdin: new TextEncoder().encode('DB_HOST=localhost\nDB_PORT=5432\n'),
     })
-    const s = ws.getSession(DEFAULT_SESSION_ID)
+    const s = ws.getSession(ws.defaultSessionId)
     expect(s.env.DB_HOST).toBe('localhost')
     expect(s.env.DB_PORT).toBe('5432')
     await ws.close()
@@ -396,7 +397,7 @@ describe('workspace: pipeline mount fallback (cwd-less commands)', () => {
 
   it('pipeline with default cwd /mirage', async () => {
     const { ws } = await makeWorkspace()
-    ws.getSession(DEFAULT_SESSION_ID).cwd = '/mirage'
+    ws.getSession(ws.defaultSessionId).cwd = '/mirage'
     const io = await ws.execute('cat /s3/report.csv | wc -l')
     expect(io.exitCode).toBe(0)
     expect(stdoutStr(io)).toContain('3')
@@ -415,7 +416,7 @@ describe('workspace: pipeline mount fallback (cwd-less commands)', () => {
 describe('workspace: cache resource fallback', () => {
   it('wc under /mirage cwd', async () => {
     const { ws } = await makeWorkspace()
-    ws.getSession(DEFAULT_SESSION_ID).cwd = '/mirage'
+    ws.getSession(ws.defaultSessionId).cwd = '/mirage'
     const io = await ws.execute('cat /s3/report.csv | wc -l')
     expect(io.exitCode).toBe(0)
     expect(stdoutStr(io)).toContain('3')
@@ -424,7 +425,7 @@ describe('workspace: cache resource fallback', () => {
 
   it('head under /nonexistent cwd', async () => {
     const { ws } = await makeWorkspace()
-    ws.getSession(DEFAULT_SESSION_ID).cwd = '/nonexistent'
+    ws.getSession(ws.defaultSessionId).cwd = '/nonexistent'
     const io = await ws.execute('cat /ram/notes.txt | head -n 1')
     expect(io.exitCode).toBe(0)
     expect(stdoutStr(io)).toContain('line1')
@@ -433,7 +434,7 @@ describe('workspace: cache resource fallback', () => {
 
   it('grep in pipeline under /mirage cwd', async () => {
     const { ws } = await makeWorkspace()
-    ws.getSession(DEFAULT_SESSION_ID).cwd = '/mirage'
+    ws.getSession(ws.defaultSessionId).cwd = '/mirage'
     const io = await ws.execute('cat /s3/report.csv | grep alice')
     expect(io.exitCode).toBe(0)
     expect(stdoutStr(io)).toContain('alice')
@@ -442,7 +443,7 @@ describe('workspace: cache resource fallback', () => {
 
   it('sort|uniq under /mirage cwd', async () => {
     const { ws } = await makeWorkspace()
-    ws.getSession(DEFAULT_SESSION_ID).cwd = '/mirage'
+    ws.getSession(ws.defaultSessionId).cwd = '/mirage'
     const io = await ws.execute('cat /ram/words.txt | sort | uniq')
     expect(io.exitCode).toBe(0)
     expect(countOccurrences(stdoutBytes(io), 'apple')).toBe(1)
@@ -451,7 +452,7 @@ describe('workspace: cache resource fallback', () => {
 
   it('4-stage pipeline under /mirage cwd', async () => {
     const { ws } = await makeWorkspace()
-    ws.getSession(DEFAULT_SESSION_ID).cwd = '/mirage'
+    ws.getSession(ws.defaultSessionId).cwd = '/mirage'
     const io = await ws.execute('cat /s3/report.csv | grep -v name | cut -d, -f1 | sort')
     expect(io.exitCode).toBe(0)
     const out = stdoutStr(io)

--- a/typescript/packages/node/src/resource/s3/pipeline.test.ts
+++ b/typescript/packages/node/src/resource/s3/pipeline.test.ts
@@ -12,13 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import {
-  DEFAULT_SESSION_ID,
-  MountMode,
-  PathSpec,
-  RAMResource,
-  stripSlash,
-} from '@struktoai/mirage-core'
+import { MountMode, PathSpec, RAMResource, stripSlash } from '@struktoai/mirage-core'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { Workspace } from '../../workspace.ts'
 
@@ -171,12 +165,12 @@ describe('pipeline', () => {
   it('subshell cd isolated', async () => {
     await ws.execute('cd /data')
     await ws.execute('(cd /data/subdir)')
-    expect(ws.getSession(DEFAULT_SESSION_ID).cwd).toBe('/data')
+    expect(ws.getSession(ws.defaultSessionId).cwd).toBe('/data')
   })
 
   it('subshell export isolated', async () => {
     await ws.execute('(export LEAK=yes)')
-    expect(Object.hasOwn(ws.getSession(DEFAULT_SESSION_ID).env, 'LEAK')).toBe(false)
+    expect(Object.hasOwn(ws.getSession(ws.defaultSessionId).env, 'LEAK')).toBe(false)
   })
 
   it('subshell inherits parent env', async () => {
@@ -187,7 +181,7 @@ describe('pipeline', () => {
 
   it('nested subshell export does not leak', async () => {
     await ws.execute('((export DEEP=yes))')
-    expect(Object.hasOwn(ws.getSession(DEFAULT_SESSION_ID).env, 'DEEP')).toBe(false)
+    expect(Object.hasOwn(ws.getSession(ws.defaultSessionId).env, 'DEEP')).toBe(false)
   })
 
   // ── Background jobs ──────────────────────────────────────────────
@@ -201,13 +195,13 @@ describe('pipeline', () => {
   it('background isolation env', async () => {
     await ws.execute('export BG_VAR=leaked &')
     await ws.execute('wait %1')
-    expect(Object.hasOwn(ws.getSession(DEFAULT_SESSION_ID).env, 'BG_VAR')).toBe(false)
+    expect(Object.hasOwn(ws.getSession(ws.defaultSessionId).env, 'BG_VAR')).toBe(false)
   })
 
   it('background isolation cwd', async () => {
     await ws.execute('cd /data &')
     await ws.execute('wait %1')
-    expect(ws.getSession(DEFAULT_SESSION_ID).cwd).toBe('/')
+    expect(ws.getSession(ws.defaultSessionId).cwd).toBe('/')
   })
 
   it('background sees parent env', async () => {
@@ -240,9 +234,9 @@ describe('pipeline', () => {
 
   it('export unset cycle', async () => {
     await ws.execute('export TMP=val')
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.TMP).toBe('val')
+    expect(ws.getSession(ws.defaultSessionId).env.TMP).toBe('val')
     await ws.execute('unset TMP')
-    expect(Object.hasOwn(ws.getSession(DEFAULT_SESSION_ID).env, 'TMP')).toBe(false)
+    expect(Object.hasOwn(ws.getSession(ws.defaultSessionId).env, 'TMP')).toBe(false)
   })
 
   it('printenv shows all', async () => {
@@ -305,7 +299,7 @@ describe('pipeline', () => {
   it('for loop variable restored', async () => {
     await ws.execute('export i=original')
     await ws.execute('for i in 1 2 3; do echo $i; done')
-    expect(ws.getSession(DEFAULT_SESSION_ID).env.i).toBe('original')
+    expect(ws.getSession(ws.defaultSessionId).env.i).toBe('original')
   })
 
   // ── If/else ──────────────────────────────────────────────────────

--- a/typescript/packages/node/src/workspace/store/redis.test.ts
+++ b/typescript/packages/node/src/workspace/store/redis.test.ts
@@ -98,7 +98,7 @@ describe.skipIf(skip)('RedisWorkspaceStateStore', () => {
       await ws.flushSessions()
 
       const meta = await storeB.loadMeta('agent-ws')
-      expect(meta?.default_session_id).toBe('default')
+      expect(meta?.default_session_id).toBe(ws.defaultSessionId)
       const sessions = await storeB.sessions('agent-ws').load()
       const narrow = sessions.get('narrow') as { mount_modes?: Record<string, string> }
       expect(narrow.mount_modes?.['/data']).toBe('read')

--- a/typescript/packages/server/src/config.ts
+++ b/typescript/packages/server/src/config.ts
@@ -335,8 +335,8 @@ export interface WorkspaceArgs {
   options: {
     mode: MountMode
     consistency: ConsistencyPolicy
-    sessionId: string
-    agentId: string
+    sessionId?: string
+    agentId?: string
     cache?: FileCache & Resource
     index?: IndexConfig
     workspaceId?: string
@@ -437,8 +437,8 @@ export async function configToWorkspaceArgs(cfg: WorkspaceConfigRaw): Promise<Wo
     options: {
       mode: wsMode,
       consistency,
-      sessionId: cfg.defaultSessionId ?? 'default',
-      agentId: cfg.defaultAgentId ?? 'default',
+      ...(cfg.defaultSessionId !== undefined ? { sessionId: cfg.defaultSessionId } : {}),
+      ...(cfg.defaultAgentId !== undefined ? { agentId: cfg.defaultAgentId } : {}),
       ...(cfg.workspaceId !== undefined ? { workspaceId: cfg.workspaceId } : {}),
       ...(cache !== undefined ? { cache } : {}),
       ...(index !== undefined ? { index } : {}),

--- a/typescript/packages/server/src/registry.test.ts
+++ b/typescript/packages/server/src/registry.test.ts
@@ -14,11 +14,13 @@
 
 import { describe, expect, it, vi } from 'vitest'
 import { RAMResource, Workspace, MountMode } from '@struktoai/mirage-node'
-import { WorkspaceRegistry, newWorkspaceId } from './registry.ts'
+import { newWorkspaceId } from '@struktoai/mirage-node'
+import { WorkspaceRegistry } from './registry.ts'
 
 describe('newWorkspaceId', () => {
-  it('mints ws_<hex16> ids', () => {
-    expect(newWorkspaceId()).toMatch(/^ws_[a-f0-9]{16}$/)
+  it('mints canonical UUIDv7 ids', () => {
+    const id = newWorkspaceId()
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
   })
 })
 

--- a/typescript/packages/server/src/registry.ts
+++ b/typescript/packages/server/src/registry.ts
@@ -12,12 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { randomBytes } from 'node:crypto'
-import { WorkspaceRunner, type Workspace } from '@struktoai/mirage-node'
-
-export function newWorkspaceId(): string {
-  return `ws_${randomBytes(8).toString('hex')}`
-}
+import { newWorkspaceId, WorkspaceRunner, type Workspace } from '@struktoai/mirage-node'
 
 export class WorkspaceEntry {
   readonly id: string

--- a/typescript/packages/server/src/routers/workspaces.test.ts
+++ b/typescript/packages/server/src/routers/workspaces.test.ts
@@ -18,6 +18,8 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { buildApp } from '../app.ts'
 
+const UUID7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
 describe('workspaces router', () => {
   it('GET /v1/health returns ok', async () => {
     const app = buildApp()
@@ -38,7 +40,7 @@ describe('workspaces router', () => {
     })
     expect(res.statusCode).toBe(201)
     const body = res.json<{ id: string }>()
-    expect(body.id).toMatch(/^ws_/)
+    expect(body.id).toMatch(UUID7_RE)
     await app.close()
   })
 
@@ -112,7 +114,7 @@ describe('workspaces router', () => {
     })
     expect(res.statusCode).toBe(201)
     const body = res.json<{ id: string }>()
-    expect(body.id).toMatch(/^ws_/)
+    expect(body.id).toMatch(UUID7_RE)
     expect(body.id).not.toBe('src-w')
     await app.close()
   })

--- a/typescript/packages/server/src/routers/workspaces.ts
+++ b/typescript/packages/server/src/routers/workspaces.ts
@@ -17,7 +17,8 @@ import { dirname, resolve, sep } from 'node:path'
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import type { CommandSafeguard, MountSpec } from '@struktoai/mirage-node'
 import { Workspace, type Resource } from '@struktoai/mirage-node'
-import { newWorkspaceId, type WorkspaceRegistry } from '../registry.ts'
+import { newWorkspaceId } from '@struktoai/mirage-node'
+import { type WorkspaceRegistry } from '../registry.ts'
 import { buildOverrideResources, cloneWorkspaceWithOverride, type OverrideShape } from '../clone.ts'
 import {
   configToWorkspaceArgs,
@@ -103,8 +104,8 @@ export function registerWorkspacesRoutes(app: FastifyInstance, deps: WorkspaceRo
         ws = new Workspace(resourceMap, {
           mode: args.options.mode,
           consistency: args.options.consistency,
-          sessionId: args.options.sessionId,
-          agentId: args.options.agentId,
+          ...(args.options.sessionId !== undefined ? { sessionId: args.options.sessionId } : {}),
+          ...(args.options.agentId !== undefined ? { agentId: args.options.agentId } : {}),
           workspaceId: wid,
           ...(args.options.store !== undefined ? { store: args.options.store } : {}),
           ...(Object.keys(commandSafeguards).length > 0 ? { commandSafeguards } : {}),

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -386,6 +386,9 @@ importers:
       redis:
         specifier: ^5.0.0
         version: 5.12.1(@opentelemetry/api@1.9.0)
+      uuid:
+        specifier: ^14.0.1
+        version: 14.0.1
       web-tree-sitter:
         specifier: ^0.26.8
         version: 0.26.8
@@ -5973,16 +5976,16 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@11.1.1:
-    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
-    hasBin: true
-
   uuid@13.0.2:
     resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
     hasBin: true
 
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   vary@1.1.2:
@@ -6212,7 +6215,7 @@ snapshots:
 
   '@a2a-js/sdk@0.3.13(@grpc/grpc-js@1.14.4)(express@5.2.1)':
     dependencies:
-      uuid: 11.1.1
+      uuid: 14.0.0
     optionalDependencies:
       '@grpc/grpc-js': 1.14.4
       express: 5.2.1
@@ -7671,7 +7674,7 @@ snapshots:
       langsmith: 0.7.7(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       mustache: 4.2.0
       p-queue: 6.6.2
-      uuid: 11.1.1
+      uuid: 14.0.0
       zod: 4.3.6
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -10930,7 +10933,7 @@ snapshots:
       '@langchain/langgraph': 1.2.9(@langchain/core@1.1.41(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
       '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.41(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       langsmith: 0.7.7(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
-      uuid: 11.1.1
+      uuid: 14.0.0
       zod: 4.3.6
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -12710,11 +12713,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@11.1.1: {}
-
   uuid@13.0.2: {}
 
   uuid@14.0.0: {}
+
+  uuid@14.0.1: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## What

- Deletes the reserved "default" ids: DEFAULT_WORKSPACE_ID, DEFAULT_SESSION_ID, and DEFAULT_AGENT_ID are gone in both languages.
- Ids the system allocates are now UUIDv7 (RFC 9562, time-ordered, database-friendly), minted by the Workspace constructor when not passed. Python uses the uuid6 package (uuid7() backport until stdlib 3.14), TypeScript uses the uuid package's v7(). Generators are exported (mirage.new_workspace_id / new_session_id / uuid7 and the core index equivalents).
- User-supplied ids stay free-form: passing an explicit workspace_id/session_id/agent_id is unchanged and is how a second process attaches to an existing workspace.
- Attach adopts the discovery record: a workspace constructed without a session id re-keys its minted default to the stored default_session_id pointer before hydration, so a fresh attach lands on the writer's default session (covered cross-language in the integ).
- Snapshot restore adopts the snapshot's default session identity and repoints the discovery record.
- agent_id is truly optional. With no claimed identity, whoami fails like GNU for a uid with no passwd entry (exit 1); observer events and jobs record empty attribution.
- Version cleanup: mirage/version.py reads the installed distribution version (pyproject is the single source, mirroring TS version.ts reading package.json). The hardcoded 0.0.3 and the "unknown" fallback are removed.

## Testing

- Full unit suites green in both languages (fuse excluded locally per policy), mypy zero, pre-commit clean.
- integ/state_store.sh both directions: reader asserts the meta pointer is a valid UUIDv7 and that attach adopts the other language's minted default session.
- CLI parity probe (python) produces all expected values under minted ids.