### PR TITLE
integ: onedrive as a shared-harness target, fix key_prefix copy/rename

### DIFF
--- a/integ/bash/arith.json
+++ b/integ/bash/arith.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(( 2 > 1 )); echo code=$?",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(( 0 )); echo code=$?",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "i=0; (( i++ )); echo code=$? i=$i; (( i++ )); echo code=$? i=$i; unset i",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "x=$(( y = 3, y + 2 )); echo $x $y; unset x y",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo $(( -7 / 2 )) $(( -7 % 2 )) $(( 2 ** 10 )) $(( 0x10 )) $(( 010 ))",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "n=0; while (( n < 3 )); do (( n++ )); done; echo n=$n; unset n",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "if (( 2 > 1 )); then echo yes; fi",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(( 1 / 0 )) 2>&1; echo code=$?",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(( 0 && (q = 7) )); echo q=${q:-unset}",
       "expect": {

--- a/integ/bash/bash.json
+++ b/integ/bash/bash.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -v '^#' /.bash_history | tail -n 3",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -v '^#' /.bash_history | tail -n 1",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /.bash_history | sed 's/^#[0-9]*$/#TS/' | tail -n 4",
       "expect": {

--- a/integ/bash/case.json
+++ b/integ/bash/case.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "case x in x) echo one; echo two;; esac",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "case y in x) echo one;; *) echo fall; echo through;; esac",
       "expect": {

--- a/integ/bash/cwd.json
+++ b/integ/bash/cwd.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(pwd)",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && pwd)",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data/sub && pwd)",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data/sub && cd .. && pwd)",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && cat a.txt)",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && cat ./a.txt)",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && cat sub/nested.txt)",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data/sub && cat ../a.txt)",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data/sub && csplit -s -f cs_ nested.txt 2 && cat cs_00 cs_01 && rm cs_00 cs_01)",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data/sub && echo $PWD)",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(echo \"[$HOME]\")",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && cd /data/sub && echo $OLDPWD)",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && cd /data/sub && cd -)",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && cd /data/sub && cd - > /dev/null && pwd)",
       "expect": {
@@ -261,7 +275,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(export HOME=/data && cd ~ && pwd)",
       "expect": {
@@ -279,7 +294,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(export HOME=/data && echo $HOME)",
       "expect": {
@@ -297,7 +313,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(export HOME=/data && cat ~/a.txt)",
       "expect": {
@@ -315,7 +332,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(export HOME=/data && cat ~/sub/nested.txt)",
       "expect": {
@@ -333,7 +351,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd //data && pwd)",
       "expect": {
@@ -351,7 +370,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd -P /data/sub && pwd)",
       "expect": {
@@ -369,7 +389,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd -L /data && pwd)",
       "expect": {
@@ -387,7 +408,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd -- /data && pwd)",
       "expect": {
@@ -405,7 +427,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(export CDPATH=/data && cd sub && pwd)",
       "expect": {
@@ -423,7 +446,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cd /data /data/sub 2>&1",
       "expect": {
@@ -441,7 +465,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cd -x /data 2>&1",
       "expect": {
@@ -459,7 +484,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(unset HOME; cd) 2>&1",
       "expect": {
@@ -477,7 +503,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && cd '~') 2>&1",
       "expect": {

--- a/integ/bash/glob.json
+++ b/integ/bash/glob.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo /data/*.nope",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "test -f /data/one_b* && echo yes",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "f() { echo $1 $#; }; f /data/sorted_*.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo /data/sorted_*.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/g8 && printf 'x *.txt y\\n' | tee /data/g8/l1.txt > /dev/null && printf 'plain\\n' | tee /data/g8/l2.txt > /dev/null && cd /data/g8 && grep -F '*.txt' *.txt && cd / && rm -r /data/g8",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo sub/*.txt && echo *.nope",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "for f in sub/*.txt; do echo $f; done",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "f() { echo $1 $#; }; f sub/*.txt && cd / && rm -r /data/g12",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat *.nope 2>&1",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l s*/x.txt && grep -l hi sub/*.txt",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls sub/*.txt && cd / && rm -r /data/g15",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ln -s /data/sorted_*.txt /data/lnk_multi",
       "expect": {

--- a/integ/bash/history.json
+++ b/integ/bash/history.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "history 2",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /.bash_history",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /.bash_history -type d",
       "expect": {

--- a/integ/bash/midglob.json
+++ b/integ/bash/midglob.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/g15/sub /data/g15/sea && cd /data/g15 && printf 'hi\n' | tee sub/x.txt > /dev/null && printf 'yo\n' | tee sea/x.txt > /dev/null",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo s*/x.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat s*/x.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/g15/s*/x.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo n*/x.txt",
       "expect": {

--- a/integ/bash/pipe.json
+++ b/integ/bash/pipe.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -v c /data/dup.txt | sort | uniq | wc -l",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/csv.csv | cut -d , -f 2 | sort -n",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \".id\" /data/data.jsonl | grep 2",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -name \"*.txt\" | grep dup | wc -l",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/dup.txt | tr a-z A-Z | sort | uniq -c",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head /data/numbers.txt | tail -n 2",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tail /data/a.txt | head -n 1",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk '{print $2}' /data/fields.txt | sort -n",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -v name /data/csv.csv | cut -d , -f 1",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 's/hello/hi/g' /data/mixed.txt | wc -l",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data/sub -name \"*.txt\" | sort | head -n 1",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/dup.txt | tr a-z A-Z | sort | uniq -c | sort -n",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sorted_a.txt /data/sorted_b.txt | head -n 2",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sorted_a.txt /data/sorted_b.txt | head -n 4",
       "expect": {
@@ -261,7 +275,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sorted_a.txt",
       "expect": {
@@ -279,7 +294,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sorted_b.txt",
       "expect": {

--- a/integ/bash/quoted.json
+++ b/integ/bash/quoted.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "\"cat\" /data/a.txt",
       "expect": {

--- a/integ/bash/read.json
+++ b/integ/bash/read.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "printf 'hi there\\n' | read -r v; echo code=$?",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "read -q v 2>&1; echo code=$?",
       "expect": {

--- a/integ/bash/redirect.json
+++ b/integ/bash/redirect.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/g9 && cd /data/g9",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo hi > OUT && cat OUT && cd / && rm -r /data/g9",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo one > sub/LOG",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo two >> sub/LOG && cat sub/LOG",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l < sub/LOG && cd / && rm -r /data/g11",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/g13 && cd /data/g13 && echo hi > CDOUT && cat /data/g13/CDOUT",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo one && echo two > captured && cat captured",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo a > chain && echo b >> chain && cat chain && wc -l < chain",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "{ echo g1; echo g2; } > gout && cat gout && cd / && rm -r /data/g13",
       "expect": {

--- a/integ/bash/relative.json
+++ b/integ/bash/relative.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/g11/sub && cd /data/g11 && printf 'one\\ntwo\\n' | tee sub/README > /dev/null",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat sub/README && wc -l sub/README && head -1 sub/README",
       "expect": {

--- a/integ/bash/relspell.json
+++ b/integ/bash/relspell.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/g14/sub && cd /data/g14 && printf 'hello\n' | tee sub/a.txt > /dev/null && printf 'hello\n' | tee sub/b.txt > /dev/null",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -r hello sub",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find sub -name '*.txt'",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat sub/missing.txt 2>&1",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep hello sub/missing.txt 2>&1",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo ./sub/*.txt",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "du -s sub/",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l sub/a.txt && head -v sub/a.txt && cd / && rm -r /data/g14",
       "expect": {

--- a/integ/bash/relword.json
+++ b/integ/bash/relword.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/g12/sub && cd /data/g12 && printf 'y\n' | tee plain.txt > /dev/null && printf 'x\n' | tee sub/a.txt > /dev/null && printf 'x\n' | tee sub/b.txt > /dev/null",
       "expect": {

--- a/integ/bash/return.json
+++ b/integ/bash/return.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "f() { return x; }; f 2>&1; echo code=$?",
       "expect": {

--- a/integ/bash/shift.json
+++ b/integ/bash/shift.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "shift x 2>&1; echo code=$?",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "shift 1 2 2>&1; echo code=$?",
       "expect": {

--- a/integ/bash/source.json
+++ b/integ/bash/source.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/g10 && cd /data/g10 && printf 'echo sourced-ok\\n' | tee lib.sh > /dev/null",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "source lib.sh && . /data/g10/lib.sh && cd / && rm -r /data/g10",
       "expect": {

--- a/integ/bash/subshell.json
+++ b/integ/bash/subshell.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(x=1; (x=2); echo $x)",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(x=7; (echo $x))",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(export Z=9); echo [$Z]",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(f(){ echo A; }; (f(){ echo B; }); f)",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(nofn(){ echo x; }); nofn 2>/dev/null || echo gone",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(set -- a b c; (set -- x); echo $#)",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(set -- a b; (echo $1 $2))",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data); pwd",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && (cd /data/sub) && pwd)",
       "expect": {

--- a/integ/bash/test.json
+++ b/integ/bash/test.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "test -f plain.txt && echo yes-f && test -d sub && echo yes-d && test -f missing.txt || echo no-f",
       "expect": {

--- a/integ/bash/var.json
+++ b/integ/bash/var.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "E=echo; $E hi",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "C=cat; $C /data/a.txt",
       "expect": {

--- a/integ/crossmount/awk.json
+++ b/integ/crossmount/awk.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk '{print $1}' /data/a.txt /data2/xm.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk 'END{print NR}' /data/a.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/cat.json
+++ b/integ/crossmount/cat.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt /data2/xm.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat -n /data/b.txt /data2/xm.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sorted_*.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/cd.json
+++ b/integ/crossmount/cd.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data2 && cat xm.txt && cd /data && ls b.txt)",
       "expect": {

--- a/integ/crossmount/cmp.json
+++ b/integ/crossmount/cmp.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cmp /data/xdiff.txt /data2/xdiff.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cp /data/xdiff.txt /data2/xsame.txt && cmp /data/xdiff.txt /data2/xsame.txt && rm /data/xdiff.txt /data2/xdiff.txt /data2/xsame.txt",
       "expect": {

--- a/integ/crossmount/comm.json
+++ b/integ/crossmount/comm.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "printf 'a\\nb\\nc\\n' | tee /data/xc1.txt > /dev/null && printf 'b\\nc\\nd\\n' | tee /data2/xc2.txt > /dev/null && comm /data/xc1.txt /data2/xc2.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "comm -12 /data/xc1.txt /data2/xc2.txt",
       "expect": {

--- a/integ/crossmount/cp.json
+++ b/integ/crossmount/cp.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cp /data/a.txt /data2/xm_copy.txt && cat /data2/xm_copy.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cp /data2/xm.txt /data/xm_back.txt && cat /data/xm_back.txt",
       "expect": {

--- a/integ/crossmount/cut.json
+++ b/integ/crossmount/cut.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cut -c1 /data/a.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/diff.json
+++ b/integ/crossmount/diff.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "printf 'same\\nold\\n' | tee /data/xdiff.txt > /dev/null && printf 'same\\nnew\\n' | tee /data2/xdiff.txt > /dev/null && diff /data/xdiff.txt /data2/xdiff.txt",
       "expect": {

--- a/integ/crossmount/du.json
+++ b/integ/crossmount/du.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "du /data/b.txt /data2/xm.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "du -c /data/b.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/file.json
+++ b/integ/crossmount/file.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "file /data/a.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/find.json
+++ b/integ/crossmount/find.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data2 -type f | sort",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data/sub /data2 -name '*.txt'",
       "expect": {

--- a/integ/crossmount/grep.json
+++ b/integ/crossmount/grep.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -c s /data/a.txt /data2/xm.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -n o /data/a.txt /data2/xm.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -h o /data/a.txt /data2/xm.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep zzz /data/a.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/head.json
+++ b/integ/crossmount/head.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -n 2 /data/a.txt /data2/xm.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -q -n 1 /data/a.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/join.json
+++ b/integ/crossmount/join.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "printf '1 alpha\\n2 beta\\n' | tee /data/xj1.txt > /dev/null && printf '1 one\\n3 three\\n' | tee /data2/xj2.txt > /dev/null && join /data/xj1.txt /data2/xj2.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "join -a 1 /data/xj1.txt /data2/xj2.txt && rm /data/xc1.txt /data2/xc2.txt /data/xj1.txt /data2/xj2.txt",
       "expect": {

--- a/integ/crossmount/link.json
+++ b/integ/crossmount/link.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -c cross /data/xm_rlink.txt",
       "expect": {

--- a/integ/crossmount/ln.json
+++ b/integ/crossmount/ln.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ln -s /data/a.txt /data2/xm_link.txt && cat /data2/xm_link.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "readlink /data2/xm_link.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ln -s /data2/xm.txt /data/xm_rlink.txt && cat /data/xm_rlink.txt",
       "expect": {

--- a/integ/crossmount/ls.json
+++ b/integ/crossmount/ls.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls /data2",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls /data/b.txt /data2/xm.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls /data/sub /data2",
       "expect": {

--- a/integ/crossmount/md5.json
+++ b/integ/crossmount/md5.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "md5 /data/b.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/mkdir.json
+++ b/integ/crossmount/mkdir.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir /data/xd /data2/xd && ls /data2 && rm -r /data/xd /data2/xd",
       "expect": {

--- a/integ/crossmount/mv.json
+++ b/integ/crossmount/mv.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mv /data/xm_back.txt /data2/xm_moved.txt && cat /data2/xm_moved.txt && ls /data2",
       "expect": {

--- a/integ/crossmount/nl.json
+++ b/integ/crossmount/nl.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "nl /data/b.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/paste.json
+++ b/integ/crossmount/paste.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "paste /data/b.txt /data2/xm.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "paste -d, /data/b.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/pipe.json
+++ b/integ/crossmount/pipe.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data2/xm.txt | tr a-z A-Z",
       "expect": {

--- a/integ/crossmount/refuse.json
+++ b/integ/crossmount/refuse.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "uniq /data/a.txt /data2/xm_uniq_out.txt",
       "expect": {

--- a/integ/crossmount/rev.json
+++ b/integ/crossmount/rev.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rev /data/b.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/rg.json
+++ b/integ/crossmount/rg.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rg -c o /data/a.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/sed.json
+++ b/integ/crossmount/sed.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed s/l/L/ /data/a.txt /data2/xm.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo abc | tee /data/xi.txt /data2/xi.txt > /dev/null && sed -i s/b/B/ /data/xi.txt /data2/xi.txt && cat /data/xi.txt /data2/xi.txt && rm /data/xi.txt /data2/xi.txt",
       "expect": {

--- a/integ/crossmount/seed.json
+++ b/integ/crossmount/seed.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo cross | tee /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/sha256.json
+++ b/integ/crossmount/sha256.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sha256sum /data/b.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/sort.json
+++ b/integ/crossmount/sort.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort /data/numbers.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/strings.json
+++ b/integ/crossmount/strings.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "strings /data/binary.bin /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/tac.json
+++ b/integ/crossmount/tac.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tac /data/b.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/tail.json
+++ b/integ/crossmount/tail.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tail -n 1 /data/a.txt /data2/xm.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tail -q -n 1 /data/a.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/tee.json
+++ b/integ/crossmount/tee.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo dual | tee /data/xdual.txt /data2/xdual.txt && cat /data/xdual.txt /data2/xdual.txt && rm /data/xdual.txt /data2/xdual.txt",
       "expect": {

--- a/integ/crossmount/touch.json
+++ b/integ/crossmount/touch.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "touch /data/xt.txt /data2/xt.txt && ls /data/xt.txt /data2/xt.txt && rm /data/xt.txt /data2/xt.txt && ls /data2",
       "expect": {

--- a/integ/crossmount/unknown.json
+++ b/integ/crossmount/unknown.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep --bogus s /data/a.txt /data2/xm.txt 2>&1; echo code=$?",
       "expect": {

--- a/integ/crossmount/wc.json
+++ b/integ/crossmount/wc.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l /data/a.txt /data2/xm.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc /data/b.txt /data2/xm.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l /data/sorted_*.txt /data2/xm.txt",
       "expect": {

--- a/integ/onedrive_server.py
+++ b/integ/onedrive_server.py
@@ -400,7 +400,9 @@ class GraphServer:
 async def start_fake_graph() -> tuple[FakeGraph, "GraphServer", web.AppRunner]:
     state = FakeGraph()
     server = GraphServer(state)
-    app = web.Application()
+    # Real Graph accepts simple PUTs up to 4 MiB; aiohttp's default
+    # client_max_size (1 MiB) would 413 them before the handler runs.
+    app = web.Application(client_max_size=8 * 1024 * 1024)
     app.router.add_route("*", "/{tail:.*}", server.handle)
     runner = web.AppRunner(app)
     await runner.setup()

--- a/integ/resources/columnar.json
+++ b/integ/resources/columnar.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls /res",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls /res/example.parquet",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls /res/*.parquet",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "file /res/example.parquet",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /res/example.parquet",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -n 3 /res/example.parquet",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tail -n 2 /res/example.parquet",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l /res/example.parquet",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep item /res/example.parquet",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -c item /res/example.parquet",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "file /res/example.feather",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /res/example.feather",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -n 3 /res/example.feather",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tail -n 2 /res/example.feather",
       "expect": {
@@ -261,7 +275,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l /res/example.feather",
       "expect": {
@@ -279,7 +294,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep item /res/example.feather",
       "expect": {
@@ -297,7 +313,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -c item /res/example.feather",
       "expect": {
@@ -315,7 +332,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "file /res/example.h5",
       "expect": {
@@ -333,7 +351,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /res/example.h5",
       "expect": {
@@ -351,7 +370,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -n 3 /res/example.h5",
       "expect": {
@@ -369,7 +389,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tail -n 2 /res/example.h5",
       "expect": {
@@ -387,7 +408,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l /res/example.h5",
       "expect": {
@@ -405,7 +427,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep item /res/example.h5",
       "expect": {
@@ -423,7 +446,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -c item /res/example.h5",
       "expect": {

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -12,18 +12,23 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import importlib.util
 import logging
 import os
 import shutil
 import tempfile
 import uuid
 from collections.abc import Awaitable, Callable
+from pathlib import Path
+from types import ModuleType
 
 import boto3
 from moto.server import ThreadedMotoServer
 
 from mirage import MountMode, Workspace
+from mirage.accessor.onedrive import OneDriveConfig
 from mirage.resource.disk import DiskResource
+from mirage.resource.onedrive.onedrive import OneDriveResource
 from mirage.resource.ram import RAMResource
 from mirage.resource.redis import RedisResource
 from mirage.resource.s3 import S3Config, S3Resource
@@ -79,7 +84,7 @@ class S3Service:
                      path_style=True,
                      key_prefix=mount.get("prefix")))
 
-    def teardown(self) -> None:
+    async def teardown(self) -> None:
         for bucket in self.buckets:
             paginator = self.client.get_paginator("list_objects_v2")
             for page in paginator.paginate(Bucket=bucket):
@@ -89,15 +94,49 @@ class S3Service:
         self.stop()
 
 
+def _load_onedrive_server() -> ModuleType:
+    # The fake Graph lives at the integ root, which never goes on sys.path
+    # (integ/redis.py would shadow the redis package); load it by file.
+    path = Path(__file__).resolve().parents[2] / "onedrive_server.py"
+    spec = importlib.util.spec_from_file_location("onedrive_server", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class OneDriveService:
+
+    def __init__(self, runner) -> None:
+        self.runner = runner
+
+    @classmethod
+    async def create(cls) -> "OneDriveService":
+        module = _load_onedrive_server()
+        _state, _server, runner = await module.start_fake_graph()
+        return cls(runner)
+
+    def resource(self, mount: dict) -> OneDriveResource:
+        return OneDriveResource(
+            OneDriveConfig(access_token="integ-token",
+                           key_prefix=mount.get("prefix")))
+
+    async def teardown(self) -> None:
+        await self.runner.cleanup()
+
+
+Service = S3Service | OneDriveService
+
+
 def build_ram(
-        mount: dict, run_id: str,
-        s3: S3Service | None) -> tuple[object, Callable[[], Awaitable[None]]]:
+        mount: dict, run_id: str, service: Service | None
+) -> tuple[object, Callable[[], Awaitable[None]]]:
     return RAMResource(), _noop
 
 
 def build_disk(
-        mount: dict, run_id: str,
-        s3: S3Service | None) -> tuple[object, Callable[[], Awaitable[None]]]:
+        mount: dict, run_id: str, service: Service | None
+) -> tuple[object, Callable[[], Awaitable[None]]]:
     root = tempfile.mkdtemp(prefix=f"mirage-integ-disk-{run_id}-")
 
     async def cleanup() -> None:
@@ -107,18 +146,25 @@ def build_disk(
 
 
 def build_redis(
-        mount: dict, run_id: str,
-        s3: S3Service | None) -> tuple[object, Callable[[], Awaitable[None]]]:
+        mount: dict, run_id: str, service: Service | None
+) -> tuple[object, Callable[[], Awaitable[None]]]:
     safe_path = mount["path"].strip("/").replace("/", "-") or "root"
     prefix = f"mirage-integ-{run_id}-{safe_path}/"
     return RedisResource(url=REDIS_URL, key_prefix=prefix), _noop
 
 
 def build_s3(
-        mount: dict, run_id: str,
-        s3: S3Service | None) -> tuple[object, Callable[[], Awaitable[None]]]:
-    assert s3 is not None
-    return s3.resource(mount), _noop
+        mount: dict, run_id: str, service: Service | None
+) -> tuple[object, Callable[[], Awaitable[None]]]:
+    assert isinstance(service, S3Service)
+    return service.resource(mount), _noop
+
+
+def build_onedrive(
+        mount: dict, run_id: str, service: Service | None
+) -> tuple[object, Callable[[], Awaitable[None]]]:
+    assert isinstance(service, OneDriveService)
+    return service.resource(mount), _noop
 
 
 BUILDERS = {
@@ -126,18 +172,23 @@ BUILDERS = {
     "disk": build_disk,
     "redis": build_redis,
     "s3": build_s3,
+    "onedrive": build_onedrive,
 }
 
 
 async def open_target(
         target: dict) -> tuple[Workspace, Callable[[], Awaitable[None]]]:
     run_id = uuid.uuid4().hex[:8]
-    s3 = S3Service(run_id) if target.get("service") == "s3" else None
+    service: Service | None = None
+    if target.get("service") == "s3":
+        service = S3Service(run_id)
+    elif target.get("service") == "onedrive":
+        service = await OneDriveService.create()
     mounts: dict[str, object] = {}
     cleanups: list[Callable[[], Awaitable[None]]] = []
     for mount in target["mounts"]:
         builder = BUILDERS[mount["resource"]]
-        resource, cleanup = builder(mount, run_id, s3)
+        resource, cleanup = builder(mount, run_id, service)
         mounts[mount["path"]] = resource
         cleanups.append(cleanup)
     ws = Workspace(mounts, mode=MountMode.WRITE)
@@ -146,7 +197,7 @@ async def open_target(
         await ws.close()
         for cleanup in cleanups:
             await cleanup()
-        if s3 is not None:
-            s3.teardown()
+        if service is not None:
+            await service.teardown()
 
     return ws, cleanup_all

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -2,59 +2,198 @@
   "targets": [
     {
       "id": "ram",
-      "hosts": ["python", "typescript-node"],
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
       "mounts": [
-        { "path": "/data", "resource": "ram", "backend": "memory", "fixture": "files/v1" },
-        { "path": "/data2", "resource": "ram", "backend": "memory" },
-        { "path": "/res", "resource": "ram", "backend": "memory", "fixture": "columnar/v1" }
+        {
+          "path": "/data",
+          "resource": "ram",
+          "backend": "memory",
+          "fixture": "files/v1"
+        },
+        {
+          "path": "/data2",
+          "resource": "ram",
+          "backend": "memory"
+        },
+        {
+          "path": "/res",
+          "resource": "ram",
+          "backend": "memory",
+          "fixture": "columnar/v1"
+        }
       ]
     },
     {
       "id": "disk",
-      "hosts": ["python", "typescript-node"],
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
       "mounts": [
-        { "path": "/data", "resource": "disk", "backend": "tmpdir", "fixture": "files/v1" },
-        { "path": "/data2", "resource": "disk", "backend": "tmpdir" },
-        { "path": "/res", "resource": "disk", "backend": "tmpdir", "fixture": "columnar/v1" }
+        {
+          "path": "/data",
+          "resource": "disk",
+          "backend": "tmpdir",
+          "fixture": "files/v1"
+        },
+        {
+          "path": "/data2",
+          "resource": "disk",
+          "backend": "tmpdir"
+        },
+        {
+          "path": "/res",
+          "resource": "disk",
+          "backend": "tmpdir",
+          "fixture": "columnar/v1"
+        }
       ]
     },
     {
       "id": "redis",
-      "hosts": ["python", "typescript-node"],
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
       "service": "redis",
       "mounts": [
-        { "path": "/data", "resource": "redis", "backend": "redis", "fixture": "files/v1" },
-        { "path": "/data2", "resource": "redis", "backend": "redis" },
-        { "path": "/res", "resource": "redis", "backend": "redis", "fixture": "columnar/v1" }
+        {
+          "path": "/data",
+          "resource": "redis",
+          "backend": "redis",
+          "fixture": "files/v1"
+        },
+        {
+          "path": "/data2",
+          "resource": "redis",
+          "backend": "redis"
+        },
+        {
+          "path": "/res",
+          "resource": "redis",
+          "backend": "redis",
+          "fixture": "columnar/v1"
+        }
       ]
     },
     {
       "id": "opfs",
-      "hosts": ["typescript-browser"],
+      "hosts": [
+        "typescript-browser"
+      ],
       "mounts": [
-        { "path": "/data", "resource": "opfs", "backend": "memory", "fixture": "files/v1" },
-        { "path": "/data2", "resource": "opfs", "backend": "memory" },
-        { "path": "/res", "resource": "opfs", "backend": "memory", "fixture": "columnar/v1" }
+        {
+          "path": "/data",
+          "resource": "opfs",
+          "backend": "memory",
+          "fixture": "files/v1"
+        },
+        {
+          "path": "/data2",
+          "resource": "opfs",
+          "backend": "memory"
+        },
+        {
+          "path": "/res",
+          "resource": "opfs",
+          "backend": "memory",
+          "fixture": "columnar/v1"
+        }
       ]
     },
     {
       "id": "s3",
-      "hosts": ["python", "typescript-node"],
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
       "service": "s3",
       "mounts": [
-        { "path": "/data", "resource": "s3", "backend": "s3", "bucket": "data", "fixture": "files/v1" },
-        { "path": "/data2", "resource": "s3", "backend": "s3", "bucket": "data2" },
-        { "path": "/res", "resource": "s3", "backend": "s3", "bucket": "res", "fixture": "columnar/v1" }
+        {
+          "path": "/data",
+          "resource": "s3",
+          "backend": "s3",
+          "bucket": "data",
+          "fixture": "files/v1"
+        },
+        {
+          "path": "/data2",
+          "resource": "s3",
+          "backend": "s3",
+          "bucket": "data2"
+        },
+        {
+          "path": "/res",
+          "resource": "s3",
+          "backend": "s3",
+          "bucket": "res",
+          "fixture": "columnar/v1"
+        }
       ]
     },
     {
       "id": "s3-prefix",
-      "hosts": ["python", "typescript-node"],
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
       "service": "s3",
       "mounts": [
-        { "path": "/data", "resource": "s3", "backend": "s3", "bucket": "shared", "prefix": "team/reports/data", "fixture": "files/v1" },
-        { "path": "/data2", "resource": "s3", "backend": "s3", "bucket": "shared", "prefix": "team/reports/data2" },
-        { "path": "/res", "resource": "s3", "backend": "s3", "bucket": "shared", "prefix": "team/reports/res", "fixture": "columnar/v1" }
+        {
+          "path": "/data",
+          "resource": "s3",
+          "backend": "s3",
+          "bucket": "shared",
+          "prefix": "team/reports/data",
+          "fixture": "files/v1"
+        },
+        {
+          "path": "/data2",
+          "resource": "s3",
+          "backend": "s3",
+          "bucket": "shared",
+          "prefix": "team/reports/data2"
+        },
+        {
+          "path": "/res",
+          "resource": "s3",
+          "backend": "s3",
+          "bucket": "shared",
+          "prefix": "team/reports/res",
+          "fixture": "columnar/v1"
+        }
+      ]
+    },
+    {
+      "id": "onedrive",
+      "hosts": [
+        "python"
+      ],
+      "service": "onedrive",
+      "mounts": [
+        {
+          "path": "/data",
+          "resource": "onedrive",
+          "backend": "onedrive",
+          "fixture": "files/v1",
+          "prefix": "data"
+        },
+        {
+          "path": "/data2",
+          "resource": "onedrive",
+          "backend": "onedrive",
+          "prefix": "xm2"
+        },
+        {
+          "path": "/res",
+          "resource": "onedrive",
+          "backend": "onedrive",
+          "prefix": "res",
+          "fixture": "columnar/v1"
+        }
       ]
     }
   ]

--- a/integ/unix/arch.json
+++ b/integ/unix/arch.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/arch && echo gz-data | tee /data/arch/g.txt > /dev/null && gzip /data/arch/g.txt && gunzip /data/arch/g.txt.gz && cat /data/arch/g.txt && ls /data/arch",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tar -c -v -z -f /data/arch/a.tgz /data/arch/g.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tar -t -z -f /data/arch/a.tgz",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tar -x -z -f /data/arch/a.tgz --strip-components 2 -C /data/arch/out && cat /data/arch/out/g.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo noise | tee /data/arch/skip.log > /dev/null && tar -c -v -f /data/arch/b.tar --exclude '*.log' /data/arch/g.txt /data/arch/skip.log",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "zip -q /data/arch/z.zip /data/arch/g.txt && unzip -p /data/arch/z.zip",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "split -b 4 /data/arch/g.txt /data/arch/pt_ && cat /data/arch/pt_aa /data/arch/pt_ab",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | tee /data/arch/c.txt > /dev/null && csplit -s -f /data/arch/cs_ /data/arch/c.txt /foo/ && cat /data/arch/cs_00",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "iconv -f utf-8 -t utf-8 /data/arch/g.txt",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mktemp -p /data/arch | wc -l",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/arch2 && echo two | tee /data/arch2/h.txt > /dev/null && gzip /data/arch2/h.txt && ls /data/arch2 && gunzip /data/arch2/h.txt.gz && cat /data/arch2/h.txt && ls /data/arch2",
       "expect": {

--- a/integ/unix/arity.json
+++ b/integ/unix/arity.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "uniq /data/a.txt /data/b.txt /data/mixed.txt 2>&1; echo code=$?",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tr a b /data/a.txt 2>&1; echo code=$?",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "diff /data/a.txt /data/b.txt /data/mixed.txt 2>&1; echo code=$?",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "seq 1 2 3 4 2>&1; echo code=$?",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mktemp t1 t2 2>&1; echo code=$?",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && uniq a.txt b.txt extra.txt 2>&1); echo code=$?",
       "expect": {

--- a/integ/unix/awk.json
+++ b/integ/unix/awk.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/csv.csv | awk -F, '{print $1}'",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk 'NR==2' /data/a.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk '{s+=$1} END{print s}' /data/numbers.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk '{print NF}' /data/fields.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk 'END{print NR}' /data/a.txt",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk '{print $NF}' /data/fields.txt",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk '$2 > 28' /data/fields.txt",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk 'BEGIN{print \"start\"} {print} END{print \"done\"}' /data/b.txt",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk -F , '{print $2}' /data/csv.csv",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk -F , 'BEGIN{OFS=\":\"} {print $1, $2}' /data/csv.csv",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk 'NR>=2 && NR<=4' /data/a.txt",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk -v a=va1 -v b=vb2 '{print a, b}' /data/one_byte.txt",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk -v x=eq=val '{print x}' /data/one_byte.txt",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo '{print $3, $1}' | tee /data/prog.awk > /dev/null && awk -f /data/prog.awk /data/fields.txt && rm /data/prog.awk",
       "expect": {
@@ -261,7 +275,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk '{print NF, $1}' /data/spaced.txt",
       "expect": {
@@ -279,7 +294,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk '{print NR, $1}' /data/a.txt /data/b.txt",
       "expect": {
@@ -297,7 +313,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo '{sum += $1}' | tee /data/pa.awk > /dev/null && echo 'END {print sum}' | tee /data/pb.awk > /dev/null && awk -f /data/pa.awk -f /data/pb.awk /data/numbers.txt && rm /data/pa.awk /data/pb.awk",
       "expect": {
@@ -315,7 +332,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk '{print}'",
       "expect": {
@@ -333,7 +351,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk",
       "expect": {
@@ -351,7 +370,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "awk -f /data/nope.awk /data/a.txt",
       "expect": {

--- a/integ/unix/base64.json
+++ b/integ/unix/base64.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "base64 /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | base64 | base64 -d",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo hello | base64",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo aGVsbG8= | base64 -d",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "base64",
       "expect": {

--- a/integ/unix/basename.json
+++ b/integ/unix/basename.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "basename /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "basename /data/a.txt .txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "basename /data/sub/",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "basename /",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "basename data/a.txt",
       "expect": {

--- a/integ/unix/bc.json
+++ b/integ/unix/bc.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "bc",
       "expect": {

--- a/integ/unix/cat.json
+++ b/integ/unix/cat.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt /data/b.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat -n /data/a.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt /data/b.txt /data/dup.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | head -n 2",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/dup.txt | sort | uniq -c",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | tr a-z A-Z | sort",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | tr -d aeiou | wc -c",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/empty.txt",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/no_nl.txt",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sub/nested.txt",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat --bogus /data/a.txt 2>&1; echo code=$?",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat -E /data/a.txt",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat -T /data/tabbed.txt",
       "expect": {
@@ -261,7 +275,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat -A /data/tabbed.txt",
       "expect": {

--- a/integ/unix/cmp.json
+++ b/integ/unix/cmp.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cmp /data/a.txt /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cmp /data/a.txt /data/b.txt",
       "expect": {

--- a/integ/unix/column.json
+++ b/integ/unix/column.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "column -s , -t /data/csv.csv",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "column -t /data/fields.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "column",
       "expect": {

--- a/integ/unix/comm.json
+++ b/integ/unix/comm.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "comm /data/sorted_a.txt /data/sorted_b.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "comm -12 /data/sorted_a.txt /data/sorted_b.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "comm -23 /data/sorted_a.txt /data/sorted_b.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "comm -13 /data/sorted_a.txt /data/sorted_b.txt",
       "expect": {

--- a/integ/unix/cp.json
+++ b/integ/unix/cp.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cp /data/a.txt /data/b.txt /data/sub",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sub/a.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sub/b.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cp /data/a.txt /data/b.txt /data/c.txt",
       "expect": {

--- a/integ/unix/csplit.json
+++ b/integ/unix/csplit.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "csplit",
       "expect": {

--- a/integ/unix/cut.json
+++ b/integ/unix/cut.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cut -f 1 -d , /data/csv.csv",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cut -f 2 -d , /data/csv.csv",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cut -c 2-4 /data/a.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cut -f 1 /data/tabbed.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cut -c 1 /data/a.txt",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cut -c 3- /data/a.txt",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cut -d ' ' -f 2 /data/fields.txt",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cut -d , -f 1,2 /data/csv.csv",
       "expect": {

--- a/integ/unix/diff.json
+++ b/integ/unix/diff.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "diff /data/a.txt /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "diff /data/a.txt /data/b.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "diff -u /data/sorted_a.txt /data/sorted_b.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/dr/x/sub /data/dr/y/sub && echo aaa | tee /data/dr/x/a.txt > /dev/null && echo AAA | tee /data/dr/y/a.txt > /dev/null && echo keep | tee /data/dr/x/c.txt > /dev/null && echo keep | tee /data/dr/y/c.txt > /dev/null && echo deep1 | tee /data/dr/x/sub/d.txt > /dev/null && echo deep2 | tee /data/dr/y/sub/d.txt > /dev/null && echo L | tee /data/dr/x/leftonly.txt > /dev/null && echo R | tee /data/dr/y/rightonly.txt > /dev/null && diff -r /data/dr/x /data/dr/y",
       "expect": {

--- a/integ/unix/dirname.json
+++ b/integ/unix/dirname.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "dirname /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "dirname /data/sub/",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "dirname /data/a.txt /data/sub/nested.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "dirname a.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "dirname /",
       "expect": {

--- a/integ/unix/disp.json
+++ b/integ/unix/disp.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && wc -l a.txt)",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && wc -l a.txt b.txt)",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && wc -l ./a.txt)",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data/sub && wc -l ../a.txt)",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && grep world a.txt b.txt)",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && md5 a.txt)",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && stat -c %n a.txt)",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && find sub -name nested.txt)",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && head -n 1 a.txt b.txt)",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && grep -l world a.txt b.txt)",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && grep -r nested disptree)",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && rg nested disptree)",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && ls -R disptree)",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && find disptree)",
       "expect": {

--- a/integ/unix/du.json
+++ b/integ/unix/du.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "du /data/a.txt /data/b.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "du --max-depth=1 /data/sub",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "du --max-depth 2>&1; echo code=$?",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "du /data/a.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "du /data",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "du -h /data/a.txt",
       "expect": {

--- a/integ/unix/echo.json
+++ b/integ/unix/echo.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo hi -n",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo -ne 'ab\\tcd'; echo",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo -nq hi",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo a '' b",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo a \"\" b",
       "expect": {

--- a/integ/unix/expand.json
+++ b/integ/unix/expand.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/tabbed.txt | expand",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "expand -t 4 /data/tabbed.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo expandisp=$(printf ' \\tX\\n' | expand -i | wc -c)",
       "expect": {

--- a/integ/unix/file.json
+++ b/integ/unix/file.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "file /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "file /data/user.json",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "file -b /data/a.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "file /data/a.txt /data/user.json",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "file /data/empty.txt",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "file /data/binary.bin",
       "expect": {

--- a/integ/unix/find.json
+++ b/integ/unix/find.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -name \"*.txt\"",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -type f",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -mindepth 1 -type f",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -maxdepth 1 -type f",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -name \"*.txt\" -o -name \"*.json\"",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -name \"*.txt\" | wc -l",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -name \"*.txt\" | sort | head -n 2",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -type d",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -iname \"*.TXT\"",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -size +10c",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -name \"*.txt\"",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -path \"*sub*\"",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data/sub -type f",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -empty",
       "expect": {
@@ -261,7 +275,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -not -name \"*.txt\"",
       "expect": {
@@ -279,7 +294,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -name data",
       "expect": {
@@ -297,7 +313,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -maxdepth 0",
       "expect": {
@@ -315,7 +332,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -mindepth 0 -type d",
       "expect": {
@@ -333,7 +351,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -size -5c",
       "expect": {
@@ -351,7 +370,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -depth -type f",
       "expect": {
@@ -369,7 +389,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -mtime +0 -o -mtime -1",
       "expect": {
@@ -387,7 +408,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/fs/sub && printf 12345678 > /data/fs/sub/big.bin && printf x > /data/fs/small.bin && find /data/fs -size +4c",
       "expect": {
@@ -405,7 +427,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data/fs -size -4c",
       "expect": {
@@ -423,7 +446,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "printf 1234 > /data/fs/four.bin && find /data/fs -size +4c",
       "expect": {
@@ -441,7 +465,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data/fs -size -4c",
       "expect": {
@@ -459,7 +484,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data/fs -size 4c",
       "expect": {
@@ -477,7 +503,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data/fs -size -1k",
       "expect": {
@@ -495,7 +522,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data/fs -path '*data/fs/sub*'",
       "expect": {
@@ -513,7 +541,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data/fs -path '/data/fs/sub'",
       "expect": {
@@ -531,7 +560,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data/fs -path '*sub*' -o -name small.bin",
       "expect": {
@@ -549,7 +579,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -maxdepth abc",
       "expect": {
@@ -567,7 +598,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -mindepth xx",
       "expect": {
@@ -585,7 +617,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -size abc",
       "expect": {
@@ -603,7 +636,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -size ''",
       "expect": {
@@ -621,7 +655,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -mtime abc",
       "expect": {
@@ -639,7 +674,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -regex '.*deep.*'",
       "expect": {
@@ -657,7 +693,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -boguspredicate",
       "expect": {

--- a/integ/unix/fmt.json
+++ b/integ/unix/fmt.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | fmt -w 20",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "fmt -w 10 /data/c.txt",
       "expect": {

--- a/integ/unix/fold.json
+++ b/integ/unix/fold.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | fold -w 3",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "fold -s -w 6 /data/a.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "fold -w 3 /data/a.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "fold -w 4 /data/a.txt /data/b.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "fold /data/c.txt",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "fold -s -w 8 /data/mixed.txt",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo foldemptyf=$(fold /data/empty.txt | wc -c)",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo foldblankin=$(echo | fold | wc -c)",
       "expect": {

--- a/integ/unix/grep.json
+++ b/integ/unix/grep.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep world /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -n bar /data/a.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -v foo /data/a.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -i HELLO /data/mixed.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -c hello /data/mixed.txt",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -E \"foo|bar\" /data/a.txt",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -A 1 world /data/a.txt",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -B 1 foo /data/a.txt",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -o ll /data/a.txt",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -l hello /data/mixed.txt /data/a.txt",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep world /data/a.txt | wc -l",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -w world /data/a.txt",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -c nothere /data/a.txt",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -n -v foo /data/a.txt",
       "expect": {
@@ -261,7 +275,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -F . /data/user.json",
       "expect": {
@@ -279,7 +294,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -m 1 o /data/a.txt",
       "expect": {
@@ -297,7 +313,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -h hello /data/mixed.txt /data/a.txt",
       "expect": {
@@ -315,7 +332,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -o o /data/a.txt",
       "expect": {
@@ -333,7 +351,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -r hello /data/sub",
       "expect": {
@@ -351,7 +370,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep '' /data/b.txt",
       "expect": {
@@ -369,7 +389,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -e world /data/a.txt",
       "expect": {
@@ -387,7 +408,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -n -e bar /data/a.txt",
       "expect": {
@@ -405,7 +427,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -e hello /data/mixed.txt /data/a.txt",
       "expect": {
@@ -423,7 +446,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -e world -e bar /data/a.txt",
       "expect": {
@@ -441,7 +465,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -n -e hello -e baz /data/a.txt",
       "expect": {
@@ -459,7 +484,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -F -e a.b -e foo /data/a.txt",
       "expect": {
@@ -477,7 +503,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -f /data/patterns.txt /data/a.txt",
       "expect": {
@@ -495,7 +522,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -e hello -f /data/patterns.txt /data/a.txt",
       "expect": {
@@ -513,7 +541,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -f /data/patterns.txt -f /data/patterns2.txt /data/a.txt",
       "expect": {
@@ -531,7 +560,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -ne world /data/a.txt",
       "expect": {
@@ -549,7 +579,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep --bogus world /data/a.txt 2>&1; echo code=$?",
       "expect": {
@@ -567,7 +598,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -Y world /data/a.txt 2>&1; echo code=$?",
       "expect": {
@@ -585,7 +617,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -m 2>&1; echo code=$?",
       "expect": {
@@ -603,7 +636,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep --color=auto world /data/a.txt",
       "expect": {
@@ -621,7 +655,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep --color world /data/a.txt",
       "expect": {
@@ -639,7 +674,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep --line-buffered world /data/a.txt",
       "expect": {
@@ -657,7 +693,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -neworld /data/a.txt",
       "expect": {
@@ -675,7 +712,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -im1 l /data/mixed.txt",
       "expect": {
@@ -693,7 +731,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -f /data/empty.txt /data/a.txt",
       "expect": {
@@ -711,7 +750,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -c hello /data/a.txt",
       "expect": {
@@ -729,7 +769,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -c zzz /data/a.txt",
       "expect": {
@@ -747,7 +788,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo hi | grep -c zzz",
       "expect": {
@@ -765,7 +807,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -c zzz /data/a.txt /data/b.txt",
       "expect": {
@@ -783,7 +826,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep",
       "expect": {
@@ -801,7 +845,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep foo",
       "expect": {
@@ -819,7 +864,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo hi | grep",
       "expect": {
@@ -837,7 +883,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep hello /data/sub",
       "expect": {
@@ -855,7 +902,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep hello /data/a.txt /data/sub",
       "expect": {

--- a/integ/unix/guard.json
+++ b/integ/unix/guard.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cp /data/guard/g.txt /data/guard/g.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mv /data/guard/g.txt /data/guard/g.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/guard/g.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mv /data/guard/sub/s.txt /data/guard/sub",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cp -r /data/guard/sub /data/guard/sub",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mv /data/guard /data/guard/sub",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cp /data/missing.txt /data/guard/g.txt /data/guard/sub",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data/guard -type f",
       "expect": {

--- a/integ/unix/gunzip.json
+++ b/integ/unix/gunzip.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "gunzip",
       "expect": {

--- a/integ/unix/gzip.json
+++ b/integ/unix/gzip.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | gzip | gunzip",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | gzip | zcat",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/b.txt | gzip -c | zcat",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "gzip -d",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "gzip | gunzip | sha256sum",
       "expect": {

--- a/integ/unix/head.json
+++ b/integ/unix/head.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -n 1 /data/a.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -n 2 /data/a.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -c 5 /data/a.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -n 3 /data/a.txt | tail -n 1",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head /data/empty.txt",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -2 /data/a.txt",
       "expect": {

--- a/integ/unix/iconv.json
+++ b/integ/unix/iconv.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | iconv -f utf-8 -t utf-8",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "iconv",
       "expect": {

--- a/integ/unix/inv.json
+++ b/integ/unix/inv.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls -1 /data/sub",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "touch /data/sub/inv_late.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rm /data/sub/inv_late.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sub/inv_late.txt",
       "expect": {

--- a/integ/unix/join.json
+++ b/integ/unix/join.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "join /data/sorted_a.txt /data/sorted_b.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "join -t , /data/abc.csv /data/abc.csv",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "join /data/sorted_a.txt /data/sorted_c.txt",
       "expect": {

--- a/integ/unix/jq.json
+++ b/integ/unix/jq.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \".\" /data/user.json",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \".name\" /data/user.json",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \".age\" /data/user.json",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq -r \".name\" /data/user.json",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \".users[].name\" /data/users.json",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \".id\" /data/data.jsonl",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \".[].id\" /data/data.jsonl",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq -r \".[].msg\" /data/chat.jsonl",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/user.json | jq",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \".id\" /data/data.jsonl | wc -l",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \".id\" /data/data.jsonl | sort -n",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \"keys\" /data/user.json",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \". | length\" /data/users.json",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \".users[] | select(.age > 27)\" /data/users.json",
       "expect": {
@@ -261,7 +275,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \"select(.id > 1)\" /data/data.jsonl",
       "expect": {
@@ -279,7 +294,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq",
       "expect": {
@@ -297,7 +313,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \".\"",
       "expect": {

--- a/integ/unix/lazy.json
+++ b/integ/unix/lazy.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep hello /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep zzz /data/a.txt",
       "expect": {

--- a/integ/unix/ln.json
+++ b/integ/unix/ln.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ln -s /data/sub/nested.txt /data/sub/link.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "readlink /data/sub/link.txt",
       "expect": {

--- a/integ/unix/lnzip.json
+++ b/integ/unix/lnzip.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls -1 /data/sub",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls -1 /data/sub",
       "expect": {

--- a/integ/unix/look.json
+++ b/integ/unix/look.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "look hel /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "look foo",
       "expect": {

--- a/integ/unix/ls.json
+++ b/integ/unix/ls.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls /data/",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls -1 /data/",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls /data/a.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls /data/*.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls /data/sub/",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls --color /data/sub",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls -a /data/sub",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls -R /data/sub",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls /data/sub/deep",
       "expect": {

--- a/integ/unix/md5.json
+++ b/integ/unix/md5.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "md5 /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "md5 /data/a.txt /data/b.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "md5 /data/a.txt /data/b.txt /data/dup.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "md5 /data/empty.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "md5 /data/one_byte.txt",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo hello | md5",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | md5",
       "expect": {

--- a/integ/unix/meta.json
+++ b/integ/unix/meta.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/metad && echo alpha > /data/metad/f.txt && touch -t 202601021530 /data/metad/f.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls -l /data/metad",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "chmod 601 /data/metad/f.txt && ls -l /data/metad",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "chmod u+x,go-r /data/metad/f.txt && ls -l /data/metad",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "chown 500:dev /data/metad/f.txt && ls -l /data/metad",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "chown alice /data/metad/f.txt && ls -l /data/metad",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "touch -t 202601021530 /data/metad/new.txt && ls -l /data/metad",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "touch -c /data/metad/ghost.txt && ls /data/metad",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "touch -t 202603041200 /data/metad/f.txt && ls -l /data/metad",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mv /data/metad/f.txt /data/metad/g.txt && ls -l /data/metad",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rm /data/metad/g.txt && echo fresh > /data/metad/g.txt && touch -t 202601021530 /data/metad/g.txt && ls -l /data/metad",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ln -s /data/metad/g.txt /data/metad/ln.txt && chmod 604 /data/metad/ln.txt && ls -l /data/metad",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "touch -h -t 202601021530 /data/metad/ln.txt && readlink /data/metad/ln.txt",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "chmod 999 /data/metad/g.txt 2>&1",
       "expect": {
@@ -261,7 +275,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "chmod u+q /data/metad/g.txt 2>&1",
       "expect": {
@@ -279,7 +294,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "chmod 644 /data/metad/missing.txt 2>&1",
       "expect": {
@@ -297,7 +313,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "chown alice /data/metad/missing.txt 2>&1",
       "expect": {
@@ -315,7 +332,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "touch -t 99 /data/metad/g.txt 2>&1",
       "expect": {
@@ -333,7 +351,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rm /data/metad/ln.txt && rm -r /data/metad",
       "expect": {

--- a/integ/unix/meta_overlay.json
+++ b/integ/unix/meta_overlay.json
@@ -6,7 +6,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/metao && echo alpha > /data/metao/f.txt && touch -t 202601021530 /data/metao/f.txt",
       "check": {
@@ -30,7 +31,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "chmod 601 /data/metao/f.txt",
       "check": {
@@ -52,7 +54,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "chmod u+x,go-r /data/metao/f.txt",
       "check": {
@@ -73,7 +76,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "chown 500:dev /data/metao/f.txt",
       "check": {
@@ -95,7 +99,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "chown alice /data/metao/f.txt",
       "check": {
@@ -117,7 +122,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "touch -t 202601021530 /data/metao/new.txt",
       "check": {
@@ -139,7 +145,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "touch -c /data/metao/ghost.txt",
       "check": {
@@ -160,7 +167,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "touch -t 202603041200 /data/metao/f.txt",
       "check": {
@@ -181,7 +189,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "chmod 750 /data/metao",
       "check": {
@@ -202,7 +211,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mv /data/metao/f.txt /data/metao/g.txt",
       "check": {
@@ -226,7 +236,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rm /data/metao/g.txt && echo fresh > /data/metao/g.txt",
       "check": {
@@ -249,7 +260,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ln -s /data/metao/g.txt /data/metao/ln.txt && chmod 604 /data/metao/ln.txt",
       "check": {
@@ -270,7 +282,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "touch -t 202601021530 /data/metao/g.txt && touch -h -t 202603041200 /data/metao/ln.txt",
       "check": {
@@ -291,7 +304,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "chmod 644 /data/metao/missing.txt 2>&1",
       "expect": {
@@ -306,7 +320,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "touch -t 99 /data/metao/g.txt 2>&1",
       "expect": {
@@ -321,7 +336,8 @@
       "targets": [
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rm /data/metao/ln.txt && rm -r /data/metao",
       "expect": {

--- a/integ/unix/mv.json
+++ b/integ/unix/mv.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mv /data/sub/a.txt /data/sub/b.txt /data/sub/deep",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sub/deep/a.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sub/deep/b.txt",
       "expect": {

--- a/integ/unix/nf.json
+++ b/integ/unix/nf.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/missing.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head /data/missing.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tail /data/missing.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc /data/missing.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "stat /data/missing.txt",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep x /data/missing.txt",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sub/missing.txt",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/missing.txt | cat",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && cat missing.txt)",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && cat sub/missing.txt)",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cd /data && grep -r x missing)",
       "expect": {

--- a/integ/unix/nl.json
+++ b/integ/unix/nl.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "nl /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "nl -b a /data/a.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "nl -d ! /data/a.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "nl -w 3 /data/a.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "du /data/b.txt | wc -c",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "stat -c %n /data/b.txt | wc -c",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "file /data/b.txt | wc -c",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tree /data/sub | wc -c",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls /data/sub | wc -c",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l /data/b.txt | wc -c",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "md5 /data/b.txt | wc -c",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cmp /data/a.txt /data/b.txt | wc -c",
       "expect": {

--- a/integ/unix/paste.json
+++ b/integ/unix/paste.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "paste /data/a.txt /data/b.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "paste -s /data/b.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "paste -d , /data/a.txt /data/b.txt",
       "expect": {

--- a/integ/unix/patch.json
+++ b/integ/unix/patch.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "patch -p1 /data/poem.diff > /dev/null && cat /data/poem.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "patch -N -p1 /data/poem.diff > /dev/null && cat /data/poem.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "patch -R -p1 /data/poem.diff > /dev/null && cat /data/poem.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "patch",
       "expect": {

--- a/integ/unix/poison.json
+++ b/integ/unix/poison.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sorted_a.txt /data/sorted_b.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sorted_a.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/sorted_b.txt",
       "expect": {

--- a/integ/unix/pr.json
+++ b/integ/unix/pr.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/pr && printf '1\\n2\\n' > /data/pr/one.txt && printf '3\\n4\\n' > /data/pr/two.txt && printf 'hello\\n' > /data/pr/h1.txt && printf 'worlds\\n' > /data/pr/h2.txt && printf 'z\\n' > /data/pr/z1.txt && printf 'y\\n' > /data/pr/z2.txt && gzip /data/pr/z1.txt /data/pr/z2.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cut -c1 /data/pr/one.txt /data/pr/two.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tac /data/pr/one.txt /data/pr/two.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "nl /data/pr/one.txt /data/pr/two.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "strings /data/pr/h1.txt /data/pr/h2.txt",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "zcat /data/pr/z1.txt.gz /data/pr/z2.txt.gz",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -n 1 /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tail -n 1 /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "nl /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "md5 /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sha256sum /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "strings /data/pr/h1.txt /data/pr/missing.txt",
       "expect": {
@@ -261,7 +275,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tac /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -279,7 +294,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rev /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -297,7 +313,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cut -c1 /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -315,7 +332,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "expand /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -333,7 +351,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "unexpand /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -351,7 +370,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "fold /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -369,7 +389,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "fmt /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -387,7 +408,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "zcat /data/pr/z1.txt.gz /data/pr/missing.gz",
       "expect": {
@@ -405,7 +427,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed s/1/X/ /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -423,7 +446,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -441,7 +465,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/pr/missing.txt /data/pr/one.txt",
       "expect": {
@@ -459,7 +484,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l /data/pr/m1.txt /data/pr/m2.txt",
       "expect": {
@@ -477,7 +503,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/pr/one.txt /data/pr",
       "expect": {
@@ -495,7 +522,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head /data/pr",
       "expect": {
@@ -513,7 +541,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc /data/pr/one.txt /data/pr",
       "expect": {
@@ -531,7 +560,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tac /data/pr",
       "expect": {
@@ -549,7 +579,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rm -r /data/pr",
       "expect": {

--- a/integ/unix/provision.json
+++ b/integ/unix/provision.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt",
       "provision": true,
@@ -29,7 +30,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt /data/b.txt",
       "provision": true,
@@ -48,7 +50,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l /data/a.txt",
       "provision": true,
@@ -67,7 +70,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort /data/numbers.txt",
       "provision": true,
@@ -86,7 +90,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "md5 /data/b.txt",
       "provision": true,
@@ -105,7 +110,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep world /data/a.txt",
       "provision": true,
@@ -124,7 +130,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep hello /data/a.txt /data/mixed.txt",
       "provision": true,
@@ -143,7 +150,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rg world /data/a.txt",
       "provision": true,
@@ -162,7 +170,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head /data/a.txt",
       "provision": true,
@@ -181,7 +190,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -c 5 /data/a.txt",
       "provision": true,
@@ -200,7 +210,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tail -n 1 /data/a.txt",
       "provision": true,
@@ -219,7 +230,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls /data",
       "provision": true,
@@ -238,7 +250,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "find /data -name \"*.txt\"",
       "provision": true,
@@ -257,7 +270,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "du /data/a.txt",
       "provision": true,
@@ -276,7 +290,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "stat /data/a.txt",
       "provision": true,
@@ -295,7 +310,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \".name\" /data/user.json",
       "provision": true,
@@ -314,7 +330,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "jq \".id\" /data/data.jsonl",
       "provision": true,
@@ -333,7 +350,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/missing.txt",
       "provision": true,
@@ -352,7 +370,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed s/a/b/ /data/a.txt",
       "provision": true,
@@ -371,7 +390,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed -i s/a/b/ /data/a.txt",
       "provision": true,
@@ -390,7 +410,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tee /data/prov_out.txt",
       "provision": true,
@@ -409,7 +430,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | head -c 4",
       "provision": true,
@@ -428,7 +450,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep world /data/a.txt | wc -l",
       "provision": true,
@@ -447,7 +470,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt && cat /data/b.txt",
       "provision": true,
@@ -466,7 +490,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt; cat /data/b.txt",
       "provision": true,
@@ -485,7 +510,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/b.txt || cat /data/a.txt",
       "provision": true,
@@ -504,7 +530,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "for i in 1 2 3; do cat /data/a.txt; done",
       "provision": true,
@@ -523,7 +550,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "while true; do cat /data/a.txt; done",
       "provision": true,
@@ -542,7 +570,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "file /data/a.txt",
       "provision": true,
@@ -561,7 +590,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "iconv -f utf-8 -t utf-8 /data/a.txt",
       "provision": true,
@@ -580,7 +610,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cp /data/a.txt /data/sub",
       "provision": true,
@@ -599,7 +630,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "gzip /data/b.txt",
       "provision": true,
@@ -618,7 +650,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rm /data/dup.txt",
       "provision": true,
@@ -637,7 +670,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rm -r /data/guard",
       "provision": true,
@@ -656,7 +690,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir /data/provdir",
       "provision": true,
@@ -675,7 +710,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mv /data/a.txt /data/moved.txt",
       "provision": true,
@@ -694,7 +730,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "seq 3",
       "provision": true,
@@ -713,7 +750,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "date",
       "provision": true,
@@ -732,7 +770,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | grep hello | wc -l",
       "provision": true,
@@ -751,7 +790,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt && cat /data/b.txt || cat /data/numbers.txt",
       "provision": true,
@@ -770,7 +810,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt || cat /data/b.txt && cat /data/numbers.txt",
       "provision": true,
@@ -789,7 +830,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "if true; then cat /data/a.txt; else cat /data/b.txt; fi",
       "provision": true,
@@ -808,7 +850,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "if grep -q hello /data/a.txt; then cat /data/b.txt; fi",
       "provision": true,
@@ -827,7 +870,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "case x in x) cat /data/a.txt;; *) cat /data/b.txt;; esac",
       "provision": true,
@@ -846,7 +890,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "(cat /data/a.txt; cat /data/b.txt)",
       "provision": true,
@@ -865,7 +910,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "{ cat /data/a.txt; cat /data/b.txt; }",
       "provision": true,
@@ -884,7 +930,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "! grep zzz /data/a.txt",
       "provision": true,
@@ -903,7 +950,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt > /data/prov_redir.txt",
       "provision": true,
@@ -922,7 +970,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tee /data/prov_x.txt || cat /data/a.txt",
       "provision": true,
@@ -941,7 +990,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "for i in 1 2; do cat /data/a.txt | wc -l; done",
       "provision": true,
@@ -960,7 +1010,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "for i in 1 2; do for j in 1 2; do cat /data/b.txt; done; done",
       "provision": true,
@@ -979,7 +1030,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat $(echo /data/a.txt)",
       "provision": true,
@@ -998,7 +1050,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "for i in 1 2; do cat /data/a.txt | wc -l && cat /data/b.txt; done",
       "provision": true,
@@ -1017,7 +1070,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "FOO=1 cat /data/a.txt",
       "provision": true,
@@ -1036,7 +1090,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "pfn() { cat /data/b.txt; }; pfn; pfn",
       "provision": true,
@@ -1055,7 +1110,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "prec() { prec; }; prec",
       "provision": true,
@@ -1074,7 +1130,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "eval 'cat /data/a.txt'",
       "provision": true,
@@ -1093,7 +1150,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "select x in a b; do cat /data/a.txt; done",
       "provision": true,
@@ -1112,7 +1170,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "until false; do cat /data/a.txt; done",
       "provision": true,
@@ -1131,7 +1190,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l < /data/a.txt",
       "provision": true,
@@ -1150,7 +1210,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt > /dev/null",
       "provision": true,
@@ -1169,7 +1230,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data2/xm_link.txt",
       "provision": true,
@@ -1188,7 +1250,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep x /data/xm_rlink.txt",
       "provision": true,
@@ -1207,7 +1270,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt /data2/xm.txt",
       "provision": true,
@@ -1226,7 +1290,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep s /data/a.txt /data2/xm.txt",
       "provision": true,
@@ -1245,7 +1310,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt /data2/xm.txt | wc -c",
       "provision": true,
@@ -1264,7 +1330,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "md5 /data/a.txt /data2/xm.txt",
       "provision": true,
@@ -1283,7 +1350,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "du /data/a.txt /data2/xm.txt",
       "provision": true,
@@ -1302,7 +1370,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/rgm/d1/*.txt",
       "provision": true,
@@ -1321,7 +1390,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/rgm/d1/*.nope",
       "provision": true,
@@ -1340,7 +1410,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep -r hello /data/rgm",
       "provision": true,
@@ -1359,7 +1430,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l",
       "provision": true,
@@ -1378,7 +1450,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -c <<EOF\nhello\nEOF",
       "provision": true,
@@ -1397,7 +1470,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "for i in $(echo 1 2); do cat /data/a.txt; done",
       "provision": true,
@@ -1416,7 +1490,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt > $(echo /data/prov_out.txt)",
       "provision": true,

--- a/integ/unix/realpath.json
+++ b/integ/unix/realpath.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "realpath /data/a.txt",
       "expect": {

--- a/integ/unix/rev.json
+++ b/integ/unix/rev.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rev /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo revemptyf=$(rev /data/empty.txt | wc -c)",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo revblankin=$(echo | rev | wc -c)",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rev /data/b.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo hello | rev",
       "expect": {

--- a/integ/unix/rg.json
+++ b/integ/unix/rg.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rg world /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rg -i WORLD /data/mixed.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rg -c hello /data/mixed.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rg -f /data/patterns.txt -f /data/patterns2.txt /data/a.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rg -e world /data/a.txt",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rg -e world -e bar /data/a.txt",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rg -f /data/patterns.txt /data/a.txt",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/rgm/d1",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/rgm/d2",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cp /data/a.txt /data/rgm/d1/f1.txt",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cp /data/mixed.txt /data/rgm/d2/f2.txt",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rg -i hello /data/rgm/d1 /data/rgm/d2",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rg -l hello /data/rgm/d1/f1.txt /data/rgm/d2/f2.txt",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cp /data/a.txt /data/rgm/d1/skip.parquet",
       "expect": {
@@ -261,7 +275,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rg world /data/rgm/d1",
       "expect": {
@@ -279,7 +294,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rg",
       "expect": {
@@ -297,7 +313,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rg foo",
       "expect": {

--- a/integ/unix/root.json
+++ b/integ/unix/root.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo atroot | tee /data/at_root.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/at_root.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir /data/rootdir && find /data/rootdir -type d",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "basename /data/at_root.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "dirname /data/at_root.txt",
       "expect": {

--- a/integ/unix/sed.json
+++ b/integ/unix/sed.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | sed s/world/UNIVERSE/",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/mixed.txt | sed s/hello/HI/g",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 1d /data/a.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed '$d' /data/a.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed -n '2,3p' /data/a.txt",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed -n '/world/p' /data/a.txt",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 's/o/O/2' /data/a.txt",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed '/foo/d' /data/a.txt",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed '2a\\\nINSERTED' /data/a.txt",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/anchors.txt | sed 's/^#[0-9]*$/#TS/'",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/anchors.txt | sed -E 's/^#[0-9]+$/#TS/'",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/anchors.txt | sed 's/^#[0-9]*$/#TS/g'",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/anchors.txt | sed '/^#[0-9]*$/d'",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 's/^#[0-9]*$/#TS/' /data/anchors.txt",
       "expect": {
@@ -261,7 +275,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 's/o/O/' /data/multi.txt",
       "expect": {
@@ -279,7 +294,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 's/o/O/2' /data/oooo.txt",
       "expect": {
@@ -297,7 +313,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 's/o/O/2g' /data/oooo.txt",
       "expect": {
@@ -315,7 +332,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/oooo.txt | sed -n 's/o/O/p'",
       "expect": {
@@ -333,7 +351,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo hello | sed 'y/el/ip/'",
       "expect": {
@@ -351,7 +370,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed '2cCHANGED' /data/a.txt",
       "expect": {
@@ -369,7 +389,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed '2,4cMID' /data/a.txt",
       "expect": {
@@ -387,7 +408,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo foo | sed 's/\\(foo\\)/[\\1]/'",
       "expect": {
@@ -405,7 +427,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo aaab | sed 's/a\\+/X/'",
       "expect": {
@@ -423,7 +446,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo cat | sed 's/cat\\|dog/PET/'",
       "expect": {
@@ -441,7 +465,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo foo | sed -E 's/(foo)/[\\1]/'",
       "expect": {
@@ -459,7 +484,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo aaab | sed -E 's/a+/X/'",
       "expect": {
@@ -477,7 +503,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo aaab | sed -r 's/a+/X/'",
       "expect": {
@@ -495,7 +522,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo a | sed -e 's/a/b/' -e 's/b/c/'",
       "expect": {
@@ -513,7 +541,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed -e s/world/EARTH/ /data/a.txt",
       "expect": {
@@ -531,7 +560,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo 's/world/EARTH/' | tee /data/prog.sed > /dev/null && sed -f /data/prog.sed /data/a.txt && rm /data/prog.sed",
       "expect": {
@@ -549,7 +579,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo 's/world/EARTH/;s/foo/FOO/' | tee /data/prog.sed > /dev/null && sed -f /data/prog.sed /data/a.txt && rm /data/prog.sed",
       "expect": {
@@ -567,7 +598,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo 's/foo/FOO/' | tee /data/prog.sed > /dev/null && sed -e s/world/EARTH/ -f /data/prog.sed /data/a.txt && rm /data/prog.sed",
       "expect": {
@@ -585,7 +617,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo 's/world/EARTH/' | tee /data/prog.sed > /dev/null && cat /data/a.txt | sed -f /data/prog.sed && rm /data/prog.sed",
       "expect": {
@@ -603,7 +636,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 's/world/[&]/' /data/a.txt",
       "expect": {
@@ -621,7 +655,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 's/world/[\\&]/' /data/a.txt",
       "expect": {
@@ -639,7 +674,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 's/hello/HI/i' /data/mixed.txt",
       "expect": {
@@ -657,7 +693,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 's|o|O|g' /data/a.txt",
       "expect": {
@@ -675,7 +712,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed '2,3d' /data/a.txt",
       "expect": {
@@ -693,7 +731,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed -n '2p' /data/a.txt",
       "expect": {
@@ -711,7 +750,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed -n '$p' /data/a.txt",
       "expect": {
@@ -729,7 +769,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed '2iINSERTED' /data/a.txt",
       "expect": {
@@ -747,7 +788,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 'cX' /data/a.txt",
       "expect": {
@@ -765,7 +807,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed '/world/cCHANGED' /data/a.txt",
       "expect": {
@@ -783,7 +826,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed '2q' /data/a.txt",
       "expect": {
@@ -801,7 +845,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 'G' /data/a.txt",
       "expect": {
@@ -819,7 +864,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 'N;s/\\n/ /' /data/a.txt",
       "expect": {
@@ -837,7 +883,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed '/world/{s/world/W/;s/W/X/}' /data/a.txt",
       "expect": {
@@ -855,7 +902,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 's/o/0/;s/a/A/' /data/a.txt",
       "expect": {
@@ -873,7 +921,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed -E 's/(section)([0-9])/\\2\\1/' /data/sections.txt",
       "expect": {
@@ -891,7 +940,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed '2!d' /data/a.txt",
       "expect": {
@@ -909,7 +959,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed '/world/!d' /data/a.txt",
       "expect": {
@@ -927,7 +978,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed -n '$!p' /data/a.txt",
       "expect": {
@@ -945,7 +997,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed '1,3!s/./X/' /data/a.txt",
       "expect": {
@@ -963,7 +1016,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed ':a;N;$!ba;s/\\n/,/g' /data/a.txt",
       "expect": {
@@ -981,7 +1035,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed -n 'H;${x;p}' /data/a.txt",
       "expect": {
@@ -999,7 +1054,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo 'a/b' | sed 's/a\\/b/c/'",
       "expect": {
@@ -1017,7 +1073,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 's/no/NO/' /data/no_nl.txt",
       "expect": {
@@ -1035,7 +1092,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sed 's/o/O/0'",
       "expect": {

--- a/integ/unix/sha256.json
+++ b/integ/unix/sha256.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sha256sum /data/empty.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo hello | sha256sum",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | sha256sum",
       "expect": {

--- a/integ/unix/sha256sum.json
+++ b/integ/unix/sha256sum.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sha256sum /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sha256sum /data/a.txt /data/b.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sha256sum",
       "expect": {

--- a/integ/unix/sleep.json
+++ b/integ/unix/sleep.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sleep abc",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sleep",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sleep -1",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sleep Infinity",
       "expect": {
@@ -81,14 +85,18 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sleep 0",
       "expect": {
         "exit": 0,
         "stdout": "",
         "stderr": "",
-        "elapsed": { "min": 0, "max": 2.0 }
+        "elapsed": {
+          "min": 0,
+          "max": 2.0
+        }
       }
     },
     {
@@ -100,14 +108,18 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sleep 0.2",
       "expect": {
         "exit": 0,
         "stdout": "",
         "stderr": "",
-        "elapsed": { "min": 0.15, "max": 2.2 }
+        "elapsed": {
+          "min": 0.15,
+          "max": 2.2
+        }
       }
     },
     {
@@ -119,14 +131,18 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sleep 1",
       "expect": {
         "exit": 0,
         "stdout": "",
         "stderr": "",
-        "elapsed": { "min": 0.95, "max": 3.0 }
+        "elapsed": {
+          "min": 0.95,
+          "max": 3.0
+        }
       }
     }
   ]

--- a/integ/unix/sort.json
+++ b/integ/unix/sort.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort -r /data/a.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort -n /data/numbers.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort /data/dup.txt | uniq",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort /data/a.txt | head -n 2",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort /data/a.txt | tail -n 2",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort -u /data/dup.txt",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort -k 2 -t , /data/csv.csv",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort -f /data/mixed.txt",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort -n -r /data/numbers.txt",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort -t , -k 1 /data/abc.csv",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort -t ' ' -k 2 -n /data/fields.txt",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo -e 'Feb\\nJan\\nMar' | sort -M",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "sort -b /data/spaced.txt",
       "expect": {
@@ -261,7 +275,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo sortemptyf=$(sort /data/empty.txt | wc -c)",
       "expect": {
@@ -279,7 +294,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo sortblankin=$(echo | sort | wc -c)",
       "expect": {
@@ -297,7 +313,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/dup.txt | sort",
       "expect": {

--- a/integ/unix/split.json
+++ b/integ/unix/split.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "split",
       "expect": {

--- a/integ/unix/stat.json
+++ b/integ/unix/stat.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "stat -c \"%s\" /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "stat -c \"%n\" /data/a.txt",
       "expect": {

--- a/integ/unix/strings.json
+++ b/integ/unix/strings.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "strings /data/binary.bin",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "strings",
       "expect": {

--- a/integ/unix/sym.json
+++ b/integ/unix/sym.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mkdir -p /data/symd && echo alpha > /data/symd/t.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ln -s /data/symd/t.txt /data/symd/l.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/symd/l.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "grep alpha /data/symd/l.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo beta > /data/symd/l.txt && cat /data/symd/t.txt",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls -F /data/symd",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ls -l /data/symd | grep -- '->'",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ln -s /data/symd /data/dl && cat /data/dl/t.txt",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "mv /data/symd/l.txt /data/symd/m.txt && readlink /data/symd/m.txt",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cp /data/symd/m.txt /data/symd/copy.txt && cat /data/symd/copy.txt",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rm /data/symd/m.txt && readlink /data/symd/m.txt 2>&1",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ln -s /data/symd/none /data/symd/dangle && cat /data/symd/dangle 2>&1",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "ln -s /data/lp2 /data/lp1 && ln -s /data/lp1 /data/lp2 && cat /data/lp1 2>&1",
       "expect": {
@@ -243,7 +256,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "rm /data/symd/dangle /data/lp1 /data/lp2 /data/dl && rm -r /data/symd",
       "expect": {

--- a/integ/unix/tac.json
+++ b/integ/unix/tac.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tac /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tac /data/sub/nested.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tac",
       "expect": {

--- a/integ/unix/tail.json
+++ b/integ/unix/tail.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tail /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tail -n 1 /data/a.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tail -n 2 /data/a.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tail -c 5 /data/a.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tail -2 /data/a.txt",
       "expect": {

--- a/integ/unix/timeout.json
+++ b/integ/unix/timeout.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "timeout 5 echo hello",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "timeout 5 echo 'a  b'",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "timeout 0.2 sleep 5; echo code=$?",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "timeout 5 echo fast",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "timeout xx sleep 1 2>&1; echo code=$?",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "timeout -s KILL 1 sleep 1 2>&1; echo code=$?",
       "expect": {

--- a/integ/unix/tr.json
+++ b/integ/unix/tr.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | tr a-z A-Z",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | tr -d aeiou",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo aaabbbccc | tr -s a-z",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | tr -c 'a-z\\n' '*'",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo abc123def | tr -d 0-9",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo 'a b c' | tr ' ' '\\n'",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tr a-z A-Z",
       "expect": {

--- a/integ/unix/tree.json
+++ b/integ/unix/tree.json
@@ -9,12 +9,13 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tree /data/sub",
       "expect": {
         "exit": 0,
-        "stdout": "├── deep\n│   └── deeper.txt\n└── nested.txt\n",
+        "stdout": "\u251c\u2500\u2500 deep\n\u2502   \u2514\u2500\u2500 deeper.txt\n\u2514\u2500\u2500 nested.txt\n",
         "stderr": ""
       }
     }

--- a/integ/unix/tsort.json
+++ b/integ/unix/tsort.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "tsort",
       "expect": {

--- a/integ/unix/unexpand.json
+++ b/integ/unix/unexpand.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/tabbed.txt | unexpand",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo '    hi' | unexpand -a",
       "expect": {

--- a/integ/unix/uniq.json
+++ b/integ/unix/uniq.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "uniq /data/dup.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "uniq -c /data/dup.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "uniq -d /data/dup.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "uniq -u /data/dup.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "uniq /data/repeats.txt",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "uniq -c /data/repeats.txt",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "uniq -f 1 /data/prefix_dup.txt",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "uniq -s 1 /data/prefix_dup.txt",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "uniq -w 3 /data/prefix_dup.txt",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "uniq -w 0 /data/prefix_dup.txt",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "uniq -c -f 1 /data/prefix_dup.txt",
       "expect": {

--- a/integ/unix/unknown.json
+++ b/integ/unix/unknown.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "nosuchcmd /data/a.txt",
       "expect": {

--- a/integ/unix/wc.json
+++ b/integ/unix/wc.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc /data/a.txt",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l /data/a.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -w /data/a.txt",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -c /data/a.txt",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc /data/a.txt /data/b.txt",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -l /data/a.txt /data/b.txt",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc /data/empty.txt",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc /data/no_nl.txt",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc /data/one_byte.txt",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -m /data/a.txt",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "wc -L /data/a.txt",
       "expect": {
@@ -207,7 +218,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo 'a b c' | wc",
       "expect": {
@@ -225,7 +237,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | wc -l",
       "expect": {

--- a/integ/unix/xargs.json
+++ b/integ/unix/xargs.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo c | xargs echo a b",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo /data/a.txt | xargs wc -l",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo '$(echo pwned)' | xargs echo",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo \"don't\" | xargs echo",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo a b c | xargs -n1 echo",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo a b c d e | xargs -n2 echo",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo hi | xargs -q echo 2>&1; echo code=$?",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo x | xargs -n0 echo 2>&1; echo code=$?",
       "expect": {
@@ -153,7 +161,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "printf 'a,b,c' | xargs -d, echo",
       "expect": {
@@ -171,7 +180,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "printf '' | xargs -r echo hi; echo code=$?",
       "expect": {
@@ -189,7 +199,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "printf '' | xargs echo hi",
       "expect": {

--- a/integ/unix/xxd.json
+++ b/integ/unix/xxd.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -c 8 /data/a.txt | xxd",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -c 8 /data/a.txt | xxd -p",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | xxd | xxd -r",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -c 12 /data/a.txt | xxd -c 4",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -c 8 /data/a.txt | xxd -g 1",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "head -c 8 /data/a.txt | xxd -u",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "xxd",
       "expect": {

--- a/integ/unix/zcat.json
+++ b/integ/unix/zcat.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "zcat",
       "expect": {

--- a/integ/unix/zgrep.json
+++ b/integ/unix/zgrep.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | gzip | zgrep -e world -e baz",
       "expect": {
@@ -27,7 +28,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | gzip | zgrep -f /data/patterns.txt",
       "expect": {
@@ -45,7 +47,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | gzip | zgrep world",
       "expect": {
@@ -63,7 +66,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "cat /data/a.txt | gzip | zgrep -e world",
       "expect": {
@@ -81,7 +85,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "zgrep foo",
       "expect": {
@@ -99,7 +104,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo hello | gzip | zgrep -c hello",
       "expect": {
@@ -117,7 +123,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "echo hello | gzip | zgrep -c zzz",
       "expect": {
@@ -135,7 +142,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "zgrep",
       "expect": {

--- a/integ/unix/zip.json
+++ b/integ/unix/zip.json
@@ -9,7 +9,8 @@
         "redis",
         "opfs",
         "s3",
-        "s3-prefix"
+        "s3-prefix",
+        "onedrive"
       ],
       "command": "zip /data/sub/arch.zip /data/sub/nested.txt",
       "expect": {

--- a/python/mirage/core/onedrive/_client.py
+++ b/python/mirage/core/onedrive/_client.py
@@ -68,9 +68,12 @@ def item_url(config: OneDriveConfig, path: str, action: str = "") -> str:
 
 
 def drive_ref_path(config: OneDriveConfig, folder: str = "") -> str:
+    # `folder` is resource-relative; the key_prefix must apply here exactly
+    # like item_url, or copy/rename destinations land at the drive root.
     base = drive_base(config)[len(GRAPH_API):]
-    if folder:
-        return f"{base}/root:/{quote(folder, safe='/')}"
+    full = _full_path(config, folder)
+    if full:
+        return f"{base}/root:/{quote(full, safe='/')}"
     return f"{base}/root:"
 
 


### PR DESCRIPTION
## What

- **onedrive joins the shared harness** as the 7th target and the first non-s3 API backend, running the complete 884-case battery: legacy cases, columnar, META, META_OVERLAY, SLEEP, and PROVISION, with the same expectations as every other target. It is a python-only host (there is no TypeScript onedrive backend), driven by the existing fake Graph server started in-process by the new OneDriveService adapter. The three mounts partition one fake drive via prefixes (data / xm2 / res).
- **Real backend bug fixed**: `drive_ref_path` never applied `key_prefix`, so `cp` on a prefixed onedrive mount silently copied to the drive root (exit 0, destination missing), and cross-directory `mv` had the same latent bug. Fixed at the helper so both copy and rename inherit it. SharePoint's sibling helper takes a bare drive_id with no key_prefix concept and is unaffected.
- **Fake Graph upload limit fixed**: aiohttp's default `client_max_size` (1 MiB) 413'd uploads that real Graph accepts (simple PUT up to 4 MB); raised to 8 MB.

## Verification

- onedrive target: 884/884 (full battery)
- onedrive unit tests 71 passed; mypy zero-gate clean (1578 files)
- legacy onedrive_cases.py still diffs clean against truth.txt
- ram regression green both languages (868/868; the TS runner skips the py-only target)
- pre-commit --all-files clean