### PR TITLE
fix(onedrive): GNU overwrite semantics against real Graph conflict defaults

### DIFF
--- a/integ/onedrive_server.py
+++ b/integ/onedrive_server.py
@@ -14,14 +14,14 @@
 
 import posixpath
 from collections import Counter
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from aiohttp import web
 
 import mirage.core.onedrive._client as onedrive_client
 
-MODIFIED = datetime(2026, 3, 31,
-                    tzinfo=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+BASE_TIME = datetime(2026, 3, 31, tzinfo=timezone.utc)
+MODIFIED = BASE_TIME.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _norm(path: str) -> str:
@@ -62,9 +62,14 @@ class FakeGraph:
         prior = self.files.get(path)
         versions = prior["versions"] if prior else []
         ctag = self._tag()
+        # Version timestamps are distinct (real Graph never ties them);
+        # a shared constant would make "current version" detection
+        # order-dependent and mask stale-version bugs.
+        stamp = (BASE_TIME +
+                 timedelta(seconds=self._seq)).strftime("%Y-%m-%dT%H:%M:%SZ")
         versions = versions + [{
             "id": ctag,
-            "lastModifiedDateTime": MODIFIED,
+            "lastModifiedDateTime": stamp,
             "content": content,
         }]
         entry = {
@@ -111,7 +116,7 @@ class FakeGraph:
             "versions": [{
                 "id": v["id"],
                 "lastModifiedDateTime": v["lastModifiedDateTime"],
-            } for v in entry["versions"]],
+            } for v in reversed(entry["versions"])],
         }
 
     def _folder_size(self, path: str) -> int:
@@ -166,6 +171,23 @@ def _not_found() -> web.Response:
         status=404)
 
 
+def _name_exists() -> web.Response:
+    return web.json_response(
+        {
+            "error": {
+                "code": "nameAlreadyExists",
+                "message": "Name already exists"
+            }
+        },
+        status=409)
+
+
+def _conflict_behavior(request: web.Request) -> str:
+    # Real Graph defaults to "fail" for copy, move and folder creation;
+    # the permissive blind-overwrite fake masked real client bugs.
+    return request.query.get("@microsoft.graph.conflictBehavior", "fail")
+
+
 def _parse_item_path(path: str) -> tuple[str, str]:
     idx = path.find("/root")
     if idx < 0:
@@ -191,8 +213,10 @@ class GraphServer:
     def __init__(self, state: FakeGraph) -> None:
         self.state = state
         self.uploads: dict[str, dict] = {}
+        self.monitors: dict[str, dict] = {}
         self.calls: Counter = Counter()
         self._upload_seq = 0
+        self._monitor_seq = 0
 
     async def handle(self, request: web.Request) -> web.StreamResponse:
         path = request.path
@@ -203,7 +227,9 @@ class GraphServer:
         if path.startswith("/upload/"):
             return await self._upload(request, path[len("/upload/"):])
         if path.startswith("/monitor/"):
-            return web.json_response({"status": "completed"})
+            token = path[len("/monitor/"):]
+            return web.json_response(
+                self.monitors.get(token, {"status": "completed"}))
         item_path, action = _parse_item_path(path)
         if method == "GET":
             kind = action if action in ("children", "content") else "item"
@@ -223,7 +249,7 @@ class GraphServer:
                 return web.json_response(state._write_file(item_path, data))
             return self._content_response(request, item_path)
         if action == "createUploadSession":
-            return self._create_upload(item_path)
+            return await self._create_upload(request, item_path)
         if action == "copy":
             return await self._copy(request, item_path)
         if action.startswith("versions/") and action.endswith("/content"):
@@ -234,6 +260,15 @@ class GraphServer:
         if action == "versions":
             return self._versions_response(item_path)
         if method == "DELETE":
+            if not item_path:
+                return web.json_response(
+                    {
+                        "error": {
+                            "code": "invalidRequest",
+                            "message": "Cannot delete root"
+                        }
+                    },
+                    status=400)
             return web.Response(
                 status=204) if state._delete(item_path) else _not_found()
         if method == "PATCH":
@@ -280,10 +315,11 @@ class GraphServer:
         entry = self.state.files.get(_norm(item_path))
         if entry is None:
             return _not_found()
+        # Real Graph lists versions newest-first.
         value = [{
             "id": v["id"],
             "lastModifiedDateTime": v["lastModifiedDateTime"],
-        } for v in entry["versions"]]
+        } for v in reversed(entry["versions"])]
         return web.json_response({"value": value})
 
     def _version_content(self, request: web.Request, item_path: str,
@@ -297,17 +333,38 @@ class GraphServer:
         return _not_found()
 
     async def _mkdir(self, request: web.Request, parent: str) -> web.Response:
+        state = self.state
+        parent = _norm(parent)
+        if parent and parent not in state.dirs:
+            return _not_found()
         body = await request.json()
         name = body.get("name", "")
+        behavior = body.get("@microsoft.graph.conflictBehavior", "fail")
         target = _norm(posixpath.join(parent, name))
-        self.state._ensure_parents(target)
-        self.state.dirs.add(target)
-        return web.json_response(self.state._folder_item(target))
+        if target in state.dirs or target in state.files:
+            if behavior == "replace" and target in state.dirs:
+                # Real Graph returns the existing folder; children survive.
+                return web.json_response(state._folder_item(target))
+            if behavior == "rename":
+                n = 1
+                while (_norm(posixpath.join(parent,
+                                            f"{name} {n}")) in state.dirs
+                       or _norm(posixpath.join(parent,
+                                               f"{name} {n}")) in state.files):
+                    n += 1
+                target = _norm(posixpath.join(parent, f"{name} {n}"))
+            else:
+                return _name_exists()
+        state._ensure_parents(target)
+        state.dirs.add(target)
+        return web.json_response(state._folder_item(target))
 
     async def _patch(self, request: web.Request,
                      item_path: str) -> web.Response:
         state = self.state
         item_path = _norm(item_path)
+        if item_path not in state.files and item_path not in state.dirs:
+            return _not_found()
         body = await request.json()
         name = body.get("name") or posixpath.basename(item_path)
         ref = body.get("parentReference", {})
@@ -316,15 +373,24 @@ class GraphServer:
         else:
             parent = posixpath.dirname(item_path)
         dest = _norm(posixpath.join(parent, name))
+        if dest != item_path:
+            behavior = _conflict_behavior(request)
+            conflict = dest in state.files or dest in state.dirs
+            replaceable = (behavior == "replace" and item_path in state.files
+                           and dest in state.files)
+            if conflict and not replaceable:
+                return _name_exists()
+            if conflict:
+                del state.files[dest]
         if item_path in state.files:
             entry = state.files.pop(item_path)
+            # A metadata change bumps eTag; cTag only moves with content.
+            entry["etag"] = state._tag()
             state._ensure_parents(dest)
             state.files[dest] = entry
             return web.json_response(state._file_item(dest))
-        if item_path in state.dirs:
-            self._move_dir(item_path, dest)
-            return web.json_response(state._folder_item(dest))
-        return _not_found()
+        self._move_dir(item_path, dest)
+        return web.json_response(state._folder_item(dest))
 
     def _move_dir(self, src: str, dest: str) -> None:
         state = self.state
@@ -344,18 +410,39 @@ class GraphServer:
                     item_path: str) -> web.Response:
         state = self.state
         item_path = _norm(item_path)
+        if item_path not in state.files and item_path not in state.dirs:
+            return _not_found()
         body = await request.json()
         name = body.get("name") or posixpath.basename(item_path)
         parent = _ref_parent(body.get("parentReference", {}).get("path", ""))
         dest = _norm(posixpath.join(parent, name))
-        if item_path in state.files:
+        behavior = _conflict_behavior(request)
+        is_file = item_path in state.files
+        conflict = dest in state.files or dest in state.dirs
+        # replace only applies to file-onto-file; folder conflicts always
+        # fail (reported through the monitor, like real Graph).
+        replaceable = (behavior == "replace" and is_file
+                       and dest in state.files)
+        if conflict and not replaceable:
+            return self._accept_monitor({
+                "status": "failed",
+                "error": {
+                    "code": "nameAlreadyExists",
+                    "message": "Name already exists"
+                },
+            })
+        if is_file:
             state._write_file(dest, state.files[item_path]["content"])
-        elif item_path in state.dirs:
-            self._copy_dir(item_path, dest)
         else:
-            return _not_found()
+            self._copy_dir(item_path, dest)
+        return self._accept_monitor({"status": "completed"})
+
+    def _accept_monitor(self, payload: dict) -> web.Response:
+        self._monitor_seq += 1
+        token = f"op{self._monitor_seq}"
+        self.monitors[token] = payload
         resp = web.Response(status=202)
-        resp.headers["Location"] = f"{state.base}/monitor/{dest}"
+        resp.headers["Location"] = f"{self.state.base}/monitor/{token}"
         return resp
 
     def _copy_dir(self, src: str, dest: str) -> None:
@@ -370,10 +457,25 @@ class GraphServer:
             if d != src and d.startswith(src + "/"):
                 state.dirs.add(dest + d[len(src):])
 
-    def _create_upload(self, item_path: str) -> web.Response:
+    async def _create_upload(self, request: web.Request,
+                             item_path: str) -> web.Response:
+        body: dict = {}
+        if request.can_read_body:
+            try:
+                body = await request.json()
+            except ValueError:
+                body = {}
+        item = body.get("item") or {}
+        behavior = item.get("@microsoft.graph.conflictBehavior", "fail")
         self._upload_seq += 1
-        token = f"{_norm(item_path)}#{self._upload_seq}"
-        self.uploads[token] = {"path": _norm(item_path), "buffer": bytearray()}
+        # The token must be fragment- and path-safe: a "#" would be
+        # stripped by the HTTP client as a URL fragment.
+        token = f"u{self._upload_seq}"
+        self.uploads[token] = {
+            "path": _norm(item_path),
+            "buffer": bytearray(),
+            "behavior": behavior,
+        }
         return web.json_response({
             "uploadUrl": f"{self.state.base}/upload/{token}",
             "expirationDateTime": MODIFIED,
@@ -389,8 +491,13 @@ class GraphServer:
         total = int(content_range.rsplit("/", 1)[-1]) if "/" in content_range \
             else len(session["buffer"])
         if len(session["buffer"]) >= total:
-            item = self.state._write_file(session["path"],
-                                          bytes(session["buffer"]))
+            path = session["path"]
+            # Sessions default to "fail": the conflict surfaces on the
+            # final chunk, exactly like real Graph.
+            if path in self.state.files and session["behavior"] != "replace":
+                del self.uploads[token]
+                return _name_exists()
+            item = self.state._write_file(path, bytes(session["buffer"]))
             del self.uploads[token]
             return web.json_response(item, status=201)
         return web.json_response(

--- a/integ/unix/overwrite.json
+++ b/integ/unix/overwrite.json
@@ -1,0 +1,118 @@
+{
+  "cases": [
+    {
+      "id": "ow_seed",
+      "seq": 203000,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive"
+      ],
+      "command": "mkdir -p /data/ow/t /data/ow/s/t && printf old | tee /data/ow/dst.txt > /dev/null && printf new | tee /data/ow/src.txt > /dev/null && printf keep | tee /data/ow/t/f.old > /dev/null && printf merged | tee /data/ow/s/t/f.txt > /dev/null && echo seeded",
+      "expect": {
+        "exit": 0,
+        "stdout": "seeded\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ow_cp_onto_existing_file",
+      "seq": 203001,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive"
+      ],
+      "command": "cp /data/ow/src.txt /data/ow/dst.txt && cat /data/ow/dst.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "new",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ow_cp_r_merges_existing_dir",
+      "seq": 203002,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive"
+      ],
+      "command": "cp -r /data/ow/s/t /data/ow && cat /data/ow/t/f.txt && ls /data/ow/t",
+      "expect": {
+        "exit": 0,
+        "stdout": "mergedf.old\nf.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ow_mv_onto_existing_file",
+      "seq": 203003,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive"
+      ],
+      "command": "mv /data/ow/src.txt /data/ow/dst.txt && cat /data/ow/dst.txt && ls /data/ow",
+      "expect": {
+        "exit": 0,
+        "stdout": "newdst.txt\ns\nt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ow_mkdir_p_existing_nonempty",
+      "seq": 203004,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive"
+      ],
+      "command": "mkdir -p /data/ow/t && ls /data/ow/t",
+      "expect": {
+        "exit": 0,
+        "stdout": "f.old\nf.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ow_cleanup",
+      "seq": 203005,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive"
+      ],
+      "command": "rm -r /data/ow && echo cleaned",
+      "expect": {
+        "exit": 0,
+        "stdout": "cleaned\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/python/mirage/core/onedrive/copy.py
+++ b/python/mirage/core/onedrive/copy.py
@@ -14,37 +14,92 @@
 
 import posixpath
 
-from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
 from mirage.cache.context import invalidate_after_write
 from mirage.core.onedrive._client import (GraphError, drive_ref_path,
+                                          graph_delete, graph_get, graph_list,
                                           graph_post_monitor, item_url,
                                           poll_monitor, split_path)
 from mirage.types import PathSpec
+
+
+async def _copy_once(config: OneDriveConfig, src_s: str,
+                     dst_s: str) -> tuple[str, str] | None:
+    """One Graph copy attempt, surfacing a conflict instead of raising.
+
+    Graph copies default to ``fail`` on a name conflict and the
+    ``@microsoft.graph.conflictBehavior=replace`` query parameter is not
+    supported on OneDrive Consumer, so the caller resolves conflicts
+    itself (delete-and-retry for files, per-child merge for folders).
+
+    Args:
+        config (OneDriveConfig): OneDrive config.
+        src_s (str): resource-relative source path.
+        dst_s (str): resource-relative destination path.
+
+    Returns:
+        tuple[str, str] | None: ``(code, message)`` of a failed copy, or
+        None when the copy completed.
+    """
+    dst_parent = posixpath.dirname("/" + dst_s).strip("/")
+    body = {
+        "name": posixpath.basename(dst_s),
+        "parentReference": {
+            "path": drive_ref_path(config, dst_parent)
+        },
+    }
+    url = item_url(config, "/" + src_s, action="/copy")
+    try:
+        monitor = await graph_post_monitor(config, url, body)
+    except GraphError as exc:
+        if exc.status == 409 or exc.code == "nameAlreadyExists":
+            return exc.code, str(exc)
+        raise
+    if not monitor:
+        return None
+    result = await poll_monitor(monitor, timeout=config.timeout)
+    status = result.get("status")
+    if status == "failed":
+        err = result.get("error", {}) if isinstance(result, dict) else {}
+        return (err.get("code", "copyFailed"),
+                err.get("message", f"copy {src_s} -> {dst_s} failed"))
+    if status not in ("completed", None):
+        raise GraphError(504, "copyTimeout",
+                         f"copy {src_s} -> {dst_s} not confirmed complete")
+    return None
+
+
+async def _copy_tree(config: OneDriveConfig, src_s: str, dst_s: str) -> None:
+    err = await _copy_once(config, src_s, dst_s)
+    if err is None:
+        await invalidate_after_write(dst_s)
+        return
+    code, message = err
+    if code != "nameAlreadyExists":
+        raise GraphError(500, code, message)
+    src_item = await graph_get(config, item_url(config, "/" + src_s))
+    dst_item = await graph_get(config, item_url(config, "/" + dst_s))
+    if "folder" in src_item and "folder" in dst_item:
+        # GNU cp -r merges into an existing directory; Graph never merges
+        # folders, so recurse per child instead.
+        children = await graph_list(
+            config, item_url(config, "/" + src_s, action="/children"))
+        for child in children:
+            name = child.get("name", "")
+            await _copy_tree(config, f"{src_s}/{name}", f"{dst_s}/{name}")
+        return
+    if "folder" in src_item or "folder" in dst_item:
+        raise GraphError(409, code, message)
+    await graph_delete(config, item_url(config, "/" + dst_s))
+    err = await _copy_once(config, src_s, dst_s)
+    if err is not None:
+        raise GraphError(500, err[0], err[1])
+    await invalidate_after_write(dst_s)
 
 
 async def copy(accessor: OneDriveAccessor, src: PathSpec,
                dst: PathSpec) -> None:
     _, src_s = split_path(src)
     _, dst_s = split_path(dst)
-    dst_parent = posixpath.dirname("/" + dst_s).strip("/")
-    name = posixpath.basename(dst_s)
-    url = item_url(accessor.config, "/" + src_s, action="/copy")
-    body = {
-        "name": name,
-        "parentReference": {
-            "path": drive_ref_path(accessor.config, dst_parent)
-        },
-    }
-    monitor = await graph_post_monitor(accessor.config, url, body)
-    if not monitor:
-        return
-    result = await poll_monitor(monitor, timeout=accessor.config.timeout)
-    status = result.get("status")
-    if status == "failed":
-        err = result.get("error", {}) if isinstance(result, dict) else {}
-        raise GraphError(500, err.get("code", "copyFailed"),
-                         err.get("message", f"copy {src_s} -> {dst_s} failed"))
-    if status not in ("completed", None):
-        raise GraphError(504, "copyTimeout",
-                         f"copy {src_s} -> {dst_s} not confirmed complete")
+    await _copy_tree(accessor.config, src_s, dst_s)
     await invalidate_after_write(dst)

--- a/python/mirage/core/onedrive/mkdir.py
+++ b/python/mirage/core/onedrive/mkdir.py
@@ -16,7 +16,8 @@ import posixpath
 
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.context import invalidate_after_write
-from mirage.core.onedrive._client import graph_post, item_url, split_path
+from mirage.core.onedrive._client import (GraphError, graph_post, item_url,
+                                          split_path)
 from mirage.types import PathSpec
 
 
@@ -29,9 +30,16 @@ async def _create_dir(accessor: OneDriveAccessor, stripped: str) -> None:
     body = {
         "name": name,
         "folder": {},
-        "@microsoft.graph.conflictBehavior": "replace",
+        "@microsoft.graph.conflictBehavior": "fail",
     }
-    await graph_post(accessor.config, url, body)
+    try:
+        await graph_post(accessor.config, url, body)
+    except GraphError as exc:
+        # mkdir is idempotent on object-store-style backends (matches the
+        # s3 core); "replace" is unreliable for folders on real Graph, so
+        # create with "fail" and tolerate the existing item.
+        if exc.status != 409 and exc.code != "nameAlreadyExists":
+            raise
 
 
 async def mkdir(accessor: OneDriveAccessor,

--- a/python/mirage/core/onedrive/rename.py
+++ b/python/mirage/core/onedrive/rename.py
@@ -14,27 +14,47 @@
 
 import posixpath
 
-from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
 from mirage.cache.context import (invalidate_after_unlink,
                                   invalidate_after_write)
-from mirage.core.onedrive._client import (drive_ref_path, graph_patch,
-                                          item_url, split_path)
+from mirage.core.onedrive._client import (GraphError, drive_ref_path,
+                                          graph_delete, graph_get, graph_list,
+                                          graph_patch, item_url, split_path)
 from mirage.types import PathSpec
+
+
+def _move_body(config: OneDriveConfig, src_s: str, dst_s: str) -> dict:
+    src_parent = posixpath.dirname("/" + src_s).strip("/")
+    dst_parent = posixpath.dirname("/" + dst_s).strip("/")
+    body: dict = {"name": posixpath.basename(dst_s)}
+    if dst_parent != src_parent:
+        body["parentReference"] = {"path": drive_ref_path(config, dst_parent)}
+    return body
 
 
 async def rename(accessor: OneDriveAccessor, src: PathSpec,
                  dst: PathSpec) -> None:
     _, src_s = split_path(src)
     _, dst_s = split_path(dst)
-    src_parent = posixpath.dirname("/" + src_s).strip("/")
-    dst_parent = posixpath.dirname("/" + dst_s).strip("/")
-    name = posixpath.basename(dst_s)
-    body: dict = {"name": name}
-    if dst_parent != src_parent:
-        body["parentReference"] = {
-            "path": drive_ref_path(accessor.config, dst_parent)
-        }
-    await graph_patch(accessor.config, item_url(accessor.config, "/" + src_s),
-                      body)
+    config = accessor.config
+    body = _move_body(config, src_s, dst_s)
+    try:
+        await graph_patch(config, item_url(config, "/" + src_s), body)
+    except GraphError as exc:
+        if exc.status != 409 and exc.code != "nameAlreadyExists":
+            raise
+        # GNU mv overwrites the destination, but a Graph move has no
+        # conflictBehavior that works across account types: drop the
+        # conflicting file (or empty folder) and retry. A non-empty
+        # folder conflict keeps the original error, mirroring mv's
+        # "Directory not empty".
+        dst_item = await graph_get(config, item_url(config, "/" + dst_s))
+        if "folder" in dst_item:
+            children = await graph_list(
+                config, item_url(config, "/" + dst_s, action="/children"))
+            if children:
+                raise
+        await graph_delete(config, item_url(config, "/" + dst_s))
+        await graph_patch(config, item_url(config, "/" + src_s), body)
     await invalidate_after_write(dst)
     await invalidate_after_unlink(src)

--- a/python/mirage/core/onedrive/write.py
+++ b/python/mirage/core/onedrive/write.py
@@ -31,7 +31,13 @@ async def _upload_session(accessor: OneDriveAccessor, stripped: str,
     session_url = item_url(config,
                            "/" + stripped,
                            action="/createUploadSession")
-    session = await graph_post(config, session_url)
+    # createUploadSession defaults to "fail": without replace, overwriting
+    # an existing file 409s on the final chunk.
+    session = await graph_post(
+        config, session_url,
+        {"item": {
+            "@microsoft.graph.conflictBehavior": "replace"
+        }})
     upload_url = session["uploadUrl"]
     total = len(data)
     start = 0

--- a/python/mirage/core/sharepoint/copy.py
+++ b/python/mirage/core/sharepoint/copy.py
@@ -1,13 +1,96 @@
 import posixpath
 
-from mirage.accessor.sharepoint import SharePointAccessor
+from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
 from mirage.cache.context import invalidate_after_write
 from mirage.core.sharepoint._client import (GraphError, drive_ref_path,
-                                            graph_post_monitor, item_url,
-                                            poll_monitor)
+                                            graph_delete, graph_get,
+                                            graph_list, graph_post_monitor,
+                                            item_url, poll_monitor)
 from mirage.core.sharepoint._resolver import resolve
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
+
+
+async def _copy_once(config: SharePointConfig, src_drive: str, src_path: str,
+                     dst_drive: str, dst_path: str) -> tuple[str, str] | None:
+    """One Graph copy attempt, surfacing a conflict instead of raising.
+
+    Graph copies default to ``fail`` on a name conflict and the
+    ``@microsoft.graph.conflictBehavior=replace`` query parameter is
+    files-only, so the caller resolves conflicts itself
+    (delete-and-retry for files, per-child merge for folders).
+
+    Args:
+        config (SharePointConfig): SharePoint config.
+        src_drive (str): source drive id.
+        src_path (str): drive-relative source path.
+        dst_drive (str): destination drive id.
+        dst_path (str): drive-relative destination path.
+
+    Returns:
+        tuple[str, str] | None: ``(code, message)`` of a failed copy, or
+        None when the copy completed.
+    """
+    dst_parent = posixpath.dirname("/" + dst_path).strip("/")
+    body: dict = {"name": posixpath.basename(dst_path)}
+    if src_drive == dst_drive:
+        body["parentReference"] = {
+            "path": drive_ref_path(dst_drive, dst_parent)
+        }
+    else:
+        body["parentReference"] = {
+            "driveId": dst_drive,
+            "path": drive_ref_path(dst_drive, dst_parent),
+        }
+    url = item_url(src_drive, src_path, action="/copy")
+    try:
+        monitor = await graph_post_monitor(config, url, body)
+    except GraphError as exc:
+        if exc.status == 409 or exc.code == "nameAlreadyExists":
+            return exc.code, str(exc)
+        raise
+    if not monitor:
+        return None
+    result = await poll_monitor(monitor, timeout=config.timeout)
+    status = result.get("status")
+    if status == "failed":
+        err = result.get("error", {}) if isinstance(result, dict) else {}
+        return (err.get("code", "copyFailed"), err.get("message",
+                                                       "copy failed"))
+    if status not in ("completed", None):
+        raise GraphError(504, "copyTimeout", "copy not confirmed complete")
+    return None
+
+
+async def _copy_tree(config: SharePointConfig, src_drive: str, src_path: str,
+                     dst_drive: str, dst_path: str, dst_virt: str) -> None:
+    err = await _copy_once(config, src_drive, src_path, dst_drive, dst_path)
+    if err is None:
+        await invalidate_after_write(dst_virt)
+        return
+    code, message = err
+    if code != "nameAlreadyExists":
+        raise GraphError(500, code, message)
+    src_item = await graph_get(config, item_url(src_drive, src_path))
+    dst_item = await graph_get(config, item_url(dst_drive, dst_path))
+    if "folder" in src_item and "folder" in dst_item:
+        # GNU cp -r merges into an existing directory; Graph never merges
+        # folders, so recurse per child instead.
+        children = await graph_list(
+            config, item_url(src_drive, src_path, action="/children"))
+        for child in children:
+            name = child.get("name", "")
+            await _copy_tree(config, src_drive, f"{src_path}/{name}",
+                             dst_drive, f"{dst_path}/{name}",
+                             f"{dst_virt}/{name}")
+        return
+    if "folder" in src_item or "folder" in dst_item:
+        raise GraphError(409, code, message)
+    await graph_delete(config, item_url(dst_drive, dst_path))
+    err = await _copy_once(config, src_drive, src_path, dst_drive, dst_path)
+    if err is not None:
+        raise GraphError(500, err[0], err[1])
+    await invalidate_after_write(dst_virt)
 
 
 async def copy(accessor: SharePointAccessor, src: PathSpec,
@@ -18,30 +101,7 @@ async def copy(accessor: SharePointAccessor, src: PathSpec,
             or dst_resolved.drive_id is None
             or dst_resolved.item_path is None):
         raise enoent(src.virtual if isinstance(src, PathSpec) else src)
-    dst_parent = posixpath.dirname("/" + dst_resolved.item_path).strip("/")
-    name = posixpath.basename(dst_resolved.item_path)
-    url = item_url(src_resolved.drive_id,
-                   src_resolved.item_path,
-                   action="/copy")
-    body: dict = {"name": name}
-    if src_resolved.drive_id == dst_resolved.drive_id:
-        body["parentReference"] = {
-            "path": drive_ref_path(dst_resolved.drive_id, dst_parent)
-        }
-    else:
-        body["parentReference"] = {
-            "driveId": dst_resolved.drive_id,
-            "path": drive_ref_path(dst_resolved.drive_id, dst_parent),
-        }
-    monitor = await graph_post_monitor(accessor.config, url, body)
-    if not monitor:
-        return
-    result = await poll_monitor(monitor, timeout=accessor.config.timeout)
-    status = result.get("status")
-    if status == "failed":
-        err = result.get("error", {}) if isinstance(result, dict) else {}
-        raise GraphError(500, err.get("code", "copyFailed"),
-                         err.get("message", "copy failed"))
-    if status not in ("completed", None):
-        raise GraphError(504, "copyTimeout", "copy not confirmed complete")
-    await invalidate_after_write(dst)
+    dst_virt = dst.mount_path if isinstance(dst, PathSpec) else dst
+    await _copy_tree(accessor.config, src_resolved.drive_id,
+                     src_resolved.item_path, dst_resolved.drive_id,
+                     dst_resolved.item_path, dst_virt)

--- a/python/mirage/core/sharepoint/mkdir.py
+++ b/python/mirage/core/sharepoint/mkdir.py
@@ -2,7 +2,8 @@ import posixpath
 
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.context import invalidate_after_write
-from mirage.core.sharepoint._client import graph_post, item_url, split_path
+from mirage.core.sharepoint._client import (GraphError, graph_post, item_url,
+                                            split_path)
 from mirage.core.sharepoint._resolver import resolve
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
@@ -18,9 +19,16 @@ async def _create_dir(accessor: SharePointAccessor, drive_id: str,
     body = {
         "name": name,
         "folder": {},
-        "@microsoft.graph.conflictBehavior": "replace",
+        "@microsoft.graph.conflictBehavior": "fail",
     }
-    await graph_post(accessor.config, url, body)
+    try:
+        await graph_post(accessor.config, url, body)
+    except GraphError as exc:
+        # mkdir is idempotent on object-store-style backends (matches the
+        # s3 core); "replace" is unreliable for folders on real Graph, so
+        # create with "fail" and tolerate the existing item.
+        if exc.status != 409 and exc.code != "nameAlreadyExists":
+            raise
 
 
 async def mkdir(accessor: SharePointAccessor,

--- a/python/mirage/core/sharepoint/rename.py
+++ b/python/mirage/core/sharepoint/rename.py
@@ -3,11 +3,27 @@ import posixpath
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.context import (invalidate_after_unlink,
                                   invalidate_after_write)
-from mirage.core.sharepoint._client import (drive_ref_path, graph_patch,
-                                            item_url)
-from mirage.core.sharepoint._resolver import resolve
+from mirage.core.sharepoint._client import (GraphError, drive_ref_path,
+                                            graph_delete, graph_get,
+                                            graph_list, graph_patch, item_url)
+from mirage.core.sharepoint._resolver import ResolvedPath, resolve
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
+
+
+def _move_body(src_resolved: ResolvedPath, dst_resolved: ResolvedPath) -> dict:
+    assert src_resolved.item_path is not None
+    assert dst_resolved.item_path is not None
+    assert dst_resolved.drive_id is not None
+    src_parent = posixpath.dirname("/" + src_resolved.item_path).strip("/")
+    dst_parent = posixpath.dirname("/" + dst_resolved.item_path).strip("/")
+    body: dict = {"name": posixpath.basename(dst_resolved.item_path)}
+    if (dst_parent != src_parent
+            or src_resolved.drive_id != dst_resolved.drive_id):
+        body["parentReference"] = {
+            "path": drive_ref_path(dst_resolved.drive_id, dst_parent)
+        }
+    return body
 
 
 async def rename(accessor: SharePointAccessor, src: PathSpec,
@@ -18,17 +34,30 @@ async def rename(accessor: SharePointAccessor, src: PathSpec,
             or dst_resolved.drive_id is None
             or dst_resolved.item_path is None):
         raise enoent(src.virtual if isinstance(src, PathSpec) else src)
-    src_parent = posixpath.dirname("/" + src_resolved.item_path).strip("/")
-    dst_parent = posixpath.dirname("/" + dst_resolved.item_path).strip("/")
-    name = posixpath.basename(dst_resolved.item_path)
-    body: dict = {"name": name}
-    if (dst_parent != src_parent
-            or src_resolved.drive_id != dst_resolved.drive_id):
-        body["parentReference"] = {
-            "path": drive_ref_path(dst_resolved.drive_id, dst_parent)
-        }
-    await graph_patch(accessor.config,
-                      item_url(src_resolved.drive_id, src_resolved.item_path),
-                      body)
+    config = accessor.config
+    body = _move_body(src_resolved, dst_resolved)
+    src_url = item_url(src_resolved.drive_id, src_resolved.item_path)
+    dst_url = item_url(dst_resolved.drive_id, dst_resolved.item_path)
+    try:
+        await graph_patch(config, src_url, body)
+    except GraphError as exc:
+        if exc.status != 409 and exc.code != "nameAlreadyExists":
+            raise
+        # GNU mv overwrites the destination, but a Graph move has no
+        # conflictBehavior that works across account types: drop the
+        # conflicting file (or empty folder) and retry. A non-empty
+        # folder conflict keeps the original error, mirroring mv's
+        # "Directory not empty".
+        dst_item = await graph_get(config, dst_url)
+        if "folder" in dst_item:
+            children = await graph_list(
+                config,
+                item_url(dst_resolved.drive_id,
+                         dst_resolved.item_path,
+                         action="/children"))
+            if children:
+                raise
+        await graph_delete(config, dst_url)
+        await graph_patch(config, src_url, body)
     await invalidate_after_write(dst)
     await invalidate_after_unlink(src)

--- a/python/mirage/core/sharepoint/write.py
+++ b/python/mirage/core/sharepoint/write.py
@@ -17,7 +17,13 @@ async def _upload_session(accessor: SharePointAccessor, drive_id: str,
                           item_path: str, data: bytes) -> None:
     config = accessor.config
     session_url = item_url(drive_id, item_path, action="/createUploadSession")
-    session = await graph_post(config, session_url)
+    # createUploadSession defaults to "fail": without replace, overwriting
+    # an existing file 409s on the final chunk.
+    session = await graph_post(
+        config, session_url,
+        {"item": {
+            "@microsoft.graph.conflictBehavior": "replace"
+        }})
     upload_url = session["uploadUrl"]
     total = len(data)
     start = 0

--- a/python/tests/core/onedrive/test_copy_truncate.py
+++ b/python/tests/core/onedrive/test_copy_truncate.py
@@ -59,13 +59,93 @@ async def test_copy_raises_when_monitor_reports_failed():
               payload={
                   "status": "failed",
                   "error": {
-                      "code": "nameAlreadyExists",
+                      "code": "generalException",
                       "message": "x"
                   }
               })
         with pytest.raises(GraphError):
             await copy(_accessor(), PathSpec.from_str_path("/a.txt"),
                        PathSpec.from_str_path("/b.txt"))
+
+
+@pytest.mark.asyncio
+async def test_copy_file_conflict_deletes_destination_and_retries():
+    monitor = "https://monitor.example/op/789"
+    with aioresponses() as m:
+        m.post(_BASE + "/root:/a.txt:/copy",
+               status=202,
+               headers={"Location": monitor})
+        m.get(monitor,
+              payload={
+                  "status": "failed",
+                  "error": {
+                      "code": "nameAlreadyExists",
+                      "message": "x"
+                  }
+              })
+        m.get(_BASE + "/root:/a.txt",
+              payload={
+                  "id": "1",
+                  "name": "a.txt",
+                  "size": 1,
+                  "file": {}
+              })
+        m.get(_BASE + "/root:/b.txt",
+              payload={
+                  "id": "2",
+                  "name": "b.txt",
+                  "size": 1,
+                  "file": {}
+              })
+        m.delete(_BASE + "/root:/b.txt", status=204)
+        m.post(_BASE + "/root:/a.txt:/copy", status=202, payload={})
+        await copy(_accessor(), PathSpec.from_str_path("/a.txt"),
+                   PathSpec.from_str_path("/b.txt"))
+
+
+@pytest.mark.asyncio
+async def test_copy_dir_conflict_merges_per_child():
+    monitor = "https://monitor.example/op/m1"
+    with aioresponses() as m:
+        m.post(_BASE + "/root:/src:/copy",
+               status=202,
+               headers={"Location": monitor})
+        m.get(monitor,
+              payload={
+                  "status": "failed",
+                  "error": {
+                      "code": "nameAlreadyExists",
+                      "message": "x"
+                  }
+              })
+        m.get(_BASE + "/root:/src",
+              payload={
+                  "id": "1",
+                  "name": "src",
+                  "folder": {
+                      "childCount": 1
+                  }
+              })
+        m.get(_BASE + "/root:/dst",
+              payload={
+                  "id": "2",
+                  "name": "dst",
+                  "folder": {
+                      "childCount": 0
+                  }
+              })
+        m.get(_BASE + "/root:/src:/children",
+              payload={
+                  "value": [{
+                      "id": "3",
+                      "name": "f.txt",
+                      "size": 1,
+                      "file": {}
+                  }]
+              })
+        m.post(_BASE + "/root:/src/f.txt:/copy", status=202, payload={})
+        await copy(_accessor(), PathSpec.from_str_path("/src"),
+                   PathSpec.from_str_path("/dst"))
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/onedrive/test_mkdir.py
+++ b/python/tests/core/onedrive/test_mkdir.py
@@ -1,0 +1,74 @@
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.core.onedrive._client import GraphError
+from mirage.core.onedrive.mkdir import mkdir
+from mirage.types import PathSpec
+
+_BASE = "https://graph.microsoft.com/v1.0/me/drive"
+
+
+def _accessor(**kw) -> OneDriveAccessor:
+    return OneDriveAccessor(OneDriveConfig(access_token="tok", **kw))
+
+
+@pytest.mark.asyncio
+async def test_mkdir_posts_folder_with_fail_behavior():
+    body = {}
+
+    def _cb(url, **kwargs):
+        body.update(kwargs.get("json") or {})
+        return CallbackResult(status=201, payload={"id": "1"})
+
+    with aioresponses() as m:
+        m.post(_BASE + "/root:/parent:/children", callback=_cb)
+        await mkdir(_accessor(), PathSpec.from_str_path("/parent/new"))
+    assert body["name"] == "new"
+    assert body["folder"] == {}
+    assert body["@microsoft.graph.conflictBehavior"] == "fail"
+
+
+@pytest.mark.asyncio
+async def test_mkdir_tolerates_existing_item():
+    with aioresponses() as m:
+        m.post(
+            _BASE + "/root:/parent:/children",
+            status=409,
+            payload={"error": {
+                "code": "nameAlreadyExists",
+                "message": "x"
+            }})
+        await mkdir(_accessor(), PathSpec.from_str_path("/parent/new"))
+
+
+@pytest.mark.asyncio
+async def test_mkdir_raises_on_other_errors():
+    with aioresponses() as m:
+        m.post(
+            _BASE + "/root:/parent:/children",
+            status=507,
+            payload={"error": {
+                "code": "insufficientStorage",
+                "message": "x"
+            }})
+        with pytest.raises(GraphError):
+            await mkdir(_accessor(), PathSpec.from_str_path("/parent/new"))
+
+
+@pytest.mark.asyncio
+async def test_mkdir_parents_creates_each_level():
+    posts: list[str] = []
+
+    def _cb(url, **kwargs):
+        posts.append(str(url))
+        return CallbackResult(status=201, payload={"id": "1"})
+
+    with aioresponses() as m:
+        m.post(_BASE + "/root/children", callback=_cb)
+        m.post(_BASE + "/root:/a:/children", callback=_cb)
+        await mkdir(_accessor(), PathSpec.from_str_path("/a/b"), parents=True)
+    assert posts == [
+        _BASE + "/root/children",
+        _BASE + "/root:/a:/children",
+    ]

--- a/python/tests/core/onedrive/test_rename.py
+++ b/python/tests/core/onedrive/test_rename.py
@@ -1,0 +1,108 @@
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.core.onedrive._client import GraphError
+from mirage.core.onedrive.rename import rename
+from mirage.types import PathSpec
+
+_BASE = "https://graph.microsoft.com/v1.0/me/drive"
+
+_CONFLICT = {"error": {"code": "nameAlreadyExists", "message": "x"}}
+
+
+def _accessor(**kw) -> OneDriveAccessor:
+    return OneDriveAccessor(OneDriveConfig(access_token="tok", **kw))
+
+
+@pytest.mark.asyncio
+async def test_rename_patches_name_and_parent():
+    body = {}
+
+    def _cb(url, **kwargs):
+        body.update(kwargs.get("json") or {})
+        return CallbackResult(status=200, payload={"id": "1"})
+
+    with aioresponses() as m:
+        m.patch(_BASE + "/root:/a.txt", callback=_cb)
+        await rename(_accessor(), PathSpec.from_str_path("/a.txt"),
+                     PathSpec.from_str_path("/sub/b.txt"))
+    assert body["name"] == "b.txt"
+    assert "/root:/sub" in body["parentReference"]["path"]
+
+
+@pytest.mark.asyncio
+async def test_rename_same_parent_omits_parent_reference():
+    body = {}
+
+    def _cb(url, **kwargs):
+        body.update(kwargs.get("json") or {})
+        return CallbackResult(status=200, payload={"id": "1"})
+
+    with aioresponses() as m:
+        m.patch(_BASE + "/root:/a.txt", callback=_cb)
+        await rename(_accessor(), PathSpec.from_str_path("/a.txt"),
+                     PathSpec.from_str_path("/b.txt"))
+    assert body == {"name": "b.txt"}
+
+
+@pytest.mark.asyncio
+async def test_rename_conflict_deletes_file_destination_and_retries():
+    with aioresponses() as m:
+        m.patch(_BASE + "/root:/a.txt", status=409, payload=_CONFLICT)
+        m.get(_BASE + "/root:/b.txt",
+              payload={
+                  "id": "2",
+                  "name": "b.txt",
+                  "size": 1,
+                  "file": {}
+              })
+        m.delete(_BASE + "/root:/b.txt", status=204)
+        m.patch(_BASE + "/root:/a.txt", status=200, payload={"id": "1"})
+        await rename(_accessor(), PathSpec.from_str_path("/a.txt"),
+                     PathSpec.from_str_path("/b.txt"))
+
+
+@pytest.mark.asyncio
+async def test_rename_conflict_replaces_empty_dir_destination():
+    with aioresponses() as m:
+        m.patch(_BASE + "/root:/src", status=409, payload=_CONFLICT)
+        m.get(_BASE + "/root:/dst",
+              payload={
+                  "id": "2",
+                  "name": "dst",
+                  "folder": {
+                      "childCount": 0
+                  }
+              })
+        m.get(_BASE + "/root:/dst:/children", payload={"value": []})
+        m.delete(_BASE + "/root:/dst", status=204)
+        m.patch(_BASE + "/root:/src", status=200, payload={"id": "1"})
+        await rename(_accessor(), PathSpec.from_str_path("/src"),
+                     PathSpec.from_str_path("/dst"))
+
+
+@pytest.mark.asyncio
+async def test_rename_conflict_keeps_error_for_nonempty_dir():
+    with aioresponses() as m:
+        m.patch(_BASE + "/root:/src", status=409, payload=_CONFLICT)
+        m.get(_BASE + "/root:/dst",
+              payload={
+                  "id": "2",
+                  "name": "dst",
+                  "folder": {
+                      "childCount": 1
+                  }
+              })
+        m.get(_BASE + "/root:/dst:/children",
+              payload={
+                  "value": [{
+                      "id": "3",
+                      "name": "kid",
+                      "size": 0,
+                      "file": {}
+                  }]
+              })
+        with pytest.raises(GraphError):
+            await rename(_accessor(), PathSpec.from_str_path("/src"),
+                         PathSpec.from_str_path("/dst"))

--- a/python/tests/core/onedrive/test_write.py
+++ b/python/tests/core/onedrive/test_write.py
@@ -58,6 +58,26 @@ async def test_write_large_file_uses_upload_session(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_upload_session_requests_replace(monkeypatch):
+    monkeypatch.setattr(write_mod, "SIMPLE_UPLOAD_MAX", 4)
+    monkeypatch.setattr(write_mod, "UPLOAD_CHUNK", 8)
+    captured = {}
+
+    def _session_cb(url, **kwargs):
+        captured.update(kwargs.get("json") or {})
+        return CallbackResult(status=200, payload={"uploadUrl": upload_url})
+
+    upload_url = "https://upload.example/session3"
+    with aioresponses() as m:
+        m.post(_SESSION, callback=_session_cb)
+        m.put(upload_url, status=201, payload={"id": "X"})
+        await write_bytes(_accessor(), PathSpec.from_str_path("/Docs/a.txt"),
+                          b"abcdef")
+    behavior = captured["item"]["@microsoft.graph.conflictBehavior"]
+    assert behavior == "replace"
+
+
+@pytest.mark.asyncio
 async def test_upload_resumes_from_next_expected_ranges(monkeypatch):
     monkeypatch.setattr(write_mod, "SIMPLE_UPLOAD_MAX", 4)
     monkeypatch.setattr(write_mod, "UPLOAD_CHUNK", 4)

--- a/python/tests/core/sharepoint/test_copy.py
+++ b/python/tests/core/sharepoint/test_copy.py
@@ -1,0 +1,142 @@
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
+from mirage.core.sharepoint._client import GraphError
+from mirage.core.sharepoint._resolver import _drive_cache, _site_cache
+from mirage.core.sharepoint.copy import copy
+from mirage.types import PathSpec
+from mirage.utils.key_prefix import mount_key
+
+_BASE = "https://graph.microsoft.com/v1.0"
+_SITE_ID = "tenant.sharepoint.com,site-guid,web-guid"
+_DRIVE_ID = "b!driveXYZ"
+_DRIVE = f"{_BASE}/drives/{_DRIVE_ID}"
+_CONFLICT = {
+    "status": "failed",
+    "error": {
+        "code": "nameAlreadyExists",
+        "message": "x"
+    },
+}
+
+
+def _accessor() -> SharePointAccessor:
+    return SharePointAccessor(SharePointConfig(access_token="tok"))
+
+
+def _spec(rel: str) -> PathSpec:
+    virtual = f"/sp/Engineering/Documents/{rel}"
+    return PathSpec(resource_path=mount_key(virtual, "/sp"),
+                    virtual=virtual,
+                    directory=virtual)
+
+
+@pytest.fixture(autouse=True)
+def _seeded_caches():
+    _site_cache.clear()
+    _drive_cache.clear()
+    _site_cache["Engineering"] = _SITE_ID
+    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    yield
+    _site_cache.clear()
+    _drive_cache.clear()
+
+
+@pytest.mark.asyncio
+async def test_copy_posts_copy_action_with_name():
+    body = {}
+
+    def _cb(url, **kwargs):
+        body.update(kwargs.get("json") or {})
+        return CallbackResult(status=202, payload={})
+
+    with aioresponses() as m:
+        m.post(_DRIVE + "/root:/a.txt:/copy", callback=_cb)
+        await copy(_accessor(), _spec("a.txt"), _spec("sub/b.txt"))
+    assert body["name"] == "b.txt"
+    assert body["parentReference"]["path"].endswith("/root:/sub")
+    assert "driveId" not in body["parentReference"]
+
+
+@pytest.mark.asyncio
+async def test_copy_raises_when_monitor_reports_failed():
+    monitor = "https://monitor.example/sp/0"
+    with aioresponses() as m:
+        m.post(_DRIVE + "/root:/a.txt:/copy",
+               status=202,
+               headers={"Location": monitor})
+        m.get(monitor,
+              payload={
+                  "status": "failed",
+                  "error": {
+                      "code": "generalException",
+                      "message": "x"
+                  }
+              })
+        with pytest.raises(GraphError):
+            await copy(_accessor(), _spec("a.txt"), _spec("b.txt"))
+
+
+@pytest.mark.asyncio
+async def test_copy_file_conflict_deletes_destination_and_retries():
+    monitor = "https://monitor.example/sp/1"
+    with aioresponses() as m:
+        m.post(_DRIVE + "/root:/a.txt:/copy",
+               status=202,
+               headers={"Location": monitor})
+        m.get(monitor, payload=_CONFLICT)
+        m.get(_DRIVE + "/root:/a.txt",
+              payload={
+                  "id": "1",
+                  "name": "a.txt",
+                  "size": 1,
+                  "file": {}
+              })
+        m.get(_DRIVE + "/root:/b.txt",
+              payload={
+                  "id": "2",
+                  "name": "b.txt",
+                  "size": 1,
+                  "file": {}
+              })
+        m.delete(_DRIVE + "/root:/b.txt", status=204)
+        m.post(_DRIVE + "/root:/a.txt:/copy", status=202, payload={})
+        await copy(_accessor(), _spec("a.txt"), _spec("b.txt"))
+
+
+@pytest.mark.asyncio
+async def test_copy_dir_conflict_merges_per_child():
+    monitor = "https://monitor.example/sp/2"
+    with aioresponses() as m:
+        m.post(_DRIVE + "/root:/src:/copy",
+               status=202,
+               headers={"Location": monitor})
+        m.get(monitor, payload=_CONFLICT)
+        m.get(_DRIVE + "/root:/src",
+              payload={
+                  "id": "1",
+                  "name": "src",
+                  "folder": {
+                      "childCount": 1
+                  }
+              })
+        m.get(_DRIVE + "/root:/dst",
+              payload={
+                  "id": "2",
+                  "name": "dst",
+                  "folder": {
+                      "childCount": 0
+                  }
+              })
+        m.get(_DRIVE + "/root:/src:/children",
+              payload={
+                  "value": [{
+                      "id": "3",
+                      "name": "f.txt",
+                      "size": 1,
+                      "file": {}
+                  }]
+              })
+        m.post(_DRIVE + "/root:/src/f.txt:/copy", status=202, payload={})
+        await copy(_accessor(), _spec("src"), _spec("dst"))

--- a/python/tests/core/sharepoint/test_mkdir.py
+++ b/python/tests/core/sharepoint/test_mkdir.py
@@ -1,0 +1,97 @@
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
+from mirage.core.sharepoint._client import GraphError
+from mirage.core.sharepoint._resolver import _drive_cache, _site_cache
+from mirage.core.sharepoint.mkdir import mkdir
+from mirage.types import PathSpec
+from mirage.utils.key_prefix import mount_key
+
+_BASE = "https://graph.microsoft.com/v1.0"
+_SITE_ID = "tenant.sharepoint.com,site-guid,web-guid"
+_DRIVE_ID = "b!driveXYZ"
+_DRIVE = f"{_BASE}/drives/{_DRIVE_ID}"
+
+
+def _accessor() -> SharePointAccessor:
+    return SharePointAccessor(SharePointConfig(access_token="tok"))
+
+
+def _spec(rel: str) -> PathSpec:
+    virtual = f"/sp/Engineering/Documents/{rel}"
+    return PathSpec(resource_path=mount_key(virtual, "/sp"),
+                    virtual=virtual,
+                    directory=virtual)
+
+
+@pytest.fixture(autouse=True)
+def _seeded_caches():
+    _site_cache.clear()
+    _drive_cache.clear()
+    _site_cache["Engineering"] = _SITE_ID
+    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    yield
+    _site_cache.clear()
+    _drive_cache.clear()
+
+
+@pytest.mark.asyncio
+async def test_mkdir_posts_folder_with_fail_behavior():
+    body = {}
+
+    def _cb(url, **kwargs):
+        body.update(kwargs.get("json") or {})
+        return CallbackResult(status=201, payload={"id": "1"})
+
+    with aioresponses() as m:
+        m.post(_DRIVE + "/root/children", callback=_cb)
+        await mkdir(_accessor(), _spec("new"))
+    assert body["name"] == "new"
+    assert body["folder"] == {}
+    assert body["@microsoft.graph.conflictBehavior"] == "fail"
+
+
+@pytest.mark.asyncio
+async def test_mkdir_tolerates_existing_item():
+    with aioresponses() as m:
+        m.post(
+            _DRIVE + "/root/children",
+            status=409,
+            payload={"error": {
+                "code": "nameAlreadyExists",
+                "message": "x"
+            }})
+        await mkdir(_accessor(), _spec("new"))
+
+
+@pytest.mark.asyncio
+async def test_mkdir_raises_on_other_errors():
+    with aioresponses() as m:
+        m.post(
+            _DRIVE + "/root/children",
+            status=507,
+            payload={"error": {
+                "code": "insufficientStorage",
+                "message": "x"
+            }})
+        with pytest.raises(GraphError):
+            await mkdir(_accessor(), _spec("new"))
+
+
+@pytest.mark.asyncio
+async def test_mkdir_parents_creates_each_level():
+    posts: list[str] = []
+
+    def _cb(url, **kwargs):
+        posts.append(str(url))
+        return CallbackResult(status=201, payload={"id": "1"})
+
+    with aioresponses() as m:
+        m.post(_DRIVE + "/root/children", callback=_cb)
+        m.post(_DRIVE + "/root:/a:/children", callback=_cb)
+        await mkdir(_accessor(), _spec("a/b"), parents=True)
+    assert posts == [
+        _DRIVE + "/root/children",
+        _DRIVE + "/root:/a:/children",
+    ]

--- a/python/tests/core/sharepoint/test_rename.py
+++ b/python/tests/core/sharepoint/test_rename.py
@@ -1,0 +1,107 @@
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
+from mirage.core.sharepoint._client import GraphError
+from mirage.core.sharepoint._resolver import _drive_cache, _site_cache
+from mirage.core.sharepoint.rename import rename
+from mirage.types import PathSpec
+from mirage.utils.key_prefix import mount_key
+
+_BASE = "https://graph.microsoft.com/v1.0"
+_SITE_ID = "tenant.sharepoint.com,site-guid,web-guid"
+_DRIVE_ID = "b!driveXYZ"
+_DRIVE = f"{_BASE}/drives/{_DRIVE_ID}"
+_CONFLICT = {"error": {"code": "nameAlreadyExists", "message": "x"}}
+
+
+def _accessor() -> SharePointAccessor:
+    return SharePointAccessor(SharePointConfig(access_token="tok"))
+
+
+def _spec(rel: str) -> PathSpec:
+    virtual = f"/sp/Engineering/Documents/{rel}"
+    return PathSpec(resource_path=mount_key(virtual, "/sp"),
+                    virtual=virtual,
+                    directory=virtual)
+
+
+@pytest.fixture(autouse=True)
+def _seeded_caches():
+    _site_cache.clear()
+    _drive_cache.clear()
+    _site_cache["Engineering"] = _SITE_ID
+    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+    yield
+    _site_cache.clear()
+    _drive_cache.clear()
+
+
+@pytest.mark.asyncio
+async def test_rename_patches_name_and_parent():
+    body = {}
+
+    def _cb(url, **kwargs):
+        body.update(kwargs.get("json") or {})
+        return CallbackResult(status=200, payload={"id": "1"})
+
+    with aioresponses() as m:
+        m.patch(_DRIVE + "/root:/a.txt", callback=_cb)
+        await rename(_accessor(), _spec("a.txt"), _spec("sub/b.txt"))
+    assert body["name"] == "b.txt"
+    assert body["parentReference"]["path"].endswith("/root:/sub")
+
+
+@pytest.mark.asyncio
+async def test_rename_same_parent_omits_parent_reference():
+    body = {}
+
+    def _cb(url, **kwargs):
+        body.update(kwargs.get("json") or {})
+        return CallbackResult(status=200, payload={"id": "1"})
+
+    with aioresponses() as m:
+        m.patch(_DRIVE + "/root:/a.txt", callback=_cb)
+        await rename(_accessor(), _spec("a.txt"), _spec("b.txt"))
+    assert body == {"name": "b.txt"}
+
+
+@pytest.mark.asyncio
+async def test_rename_conflict_deletes_file_destination_and_retries():
+    with aioresponses() as m:
+        m.patch(_DRIVE + "/root:/a.txt", status=409, payload=_CONFLICT)
+        m.get(_DRIVE + "/root:/b.txt",
+              payload={
+                  "id": "2",
+                  "name": "b.txt",
+                  "size": 1,
+                  "file": {}
+              })
+        m.delete(_DRIVE + "/root:/b.txt", status=204)
+        m.patch(_DRIVE + "/root:/a.txt", status=200, payload={"id": "1"})
+        await rename(_accessor(), _spec("a.txt"), _spec("b.txt"))
+
+
+@pytest.mark.asyncio
+async def test_rename_conflict_keeps_error_for_nonempty_dir():
+    with aioresponses() as m:
+        m.patch(_DRIVE + "/root:/src", status=409, payload=_CONFLICT)
+        m.get(_DRIVE + "/root:/dst",
+              payload={
+                  "id": "2",
+                  "name": "dst",
+                  "folder": {
+                      "childCount": 1
+                  }
+              })
+        m.get(_DRIVE + "/root:/dst:/children",
+              payload={
+                  "value": [{
+                      "id": "3",
+                      "name": "kid",
+                      "size": 0,
+                      "file": {}
+                  }]
+              })
+        with pytest.raises(GraphError):
+            await rename(_accessor(), _spec("src"), _spec("dst"))

--- a/python/tests/core/sharepoint/test_write.py
+++ b/python/tests/core/sharepoint/test_write.py
@@ -81,3 +81,28 @@ async def test_write_large_file_uses_upload_session(monkeypatch):
                         directory="/sp/Engineering/Documents/big.bin")
         await write_bytes(_accessor(), path, b"abcdef")
     assert ranges == ["bytes 0-3/6", "bytes 4-5/6"]
+
+
+@pytest.mark.asyncio
+async def test_upload_session_requests_replace(monkeypatch):
+    monkeypatch.setattr(write_mod, "SIMPLE_UPLOAD_MAX", 4)
+    monkeypatch.setattr(write_mod, "UPLOAD_CHUNK", 8)
+    captured = {}
+
+    def _session_cb(url, **kwargs):
+        captured.update(kwargs.get("json") or {})
+        return CallbackResult(status=200, payload={"uploadUrl": upload_url})
+
+    session_url = (f"{_BASE}/drives/{_DRIVE_ID}"
+                   "/root:/big.bin:/createUploadSession")
+    upload_url = "https://upload.example/session2"
+    with aioresponses() as m:
+        m.post(session_url, callback=_session_cb)
+        m.put(upload_url, status=201, payload={"id": "X"})
+        path = PathSpec(resource_path=mount_key(
+            "/sp/Engineering/Documents/big.bin", "/sp"),
+                        virtual="/sp/Engineering/Documents/big.bin",
+                        directory="/sp/Engineering/Documents/big.bin")
+        await write_bytes(_accessor(), path, b"abcdef")
+    behavior = captured["item"]["@microsoft.graph.conflictBehavior"]
+    assert behavior == "replace"


### PR DESCRIPTION
Graph copy, move and createUploadSession default to fail on name conflicts, and `@microsoft.graph.conflictBehavior=replace` is files-only and unsupported on OneDrive Consumer. The fake blindly overwrote, so `cp`/`mv`/large writes onto existing items passed integ but would fail on real OneDrive.

## Client
- **copy**: default-fail attempt; on `nameAlreadyExists` delete-and-retry for file conflicts, per-child recursive merge for `cp -r` into an existing directory (GNU merge; Graph never merges folders), per-node cache invalidation so merged children are visible
- **rename**: 409 fallback deletes a conflicting file or empty folder and retries; non-empty folder conflicts keep the error (mv "Directory not empty")
- **write**: upload sessions send `item.@microsoft.graph.conflictBehavior: replace` (default 409s on the final chunk of an overwrite)
- **mkdir**: create with `fail` and tolerate `nameAlreadyExists` (idempotent, matches the s3 core; `replace` is unreliable for folders)

## Fake Graph (integ/onedrive_server.py)
- Enforces documented conflict defaults on copy/PATCH/mkdir/uploadSession (honors query-param and item-body conflictBehavior, replace is file-only)
- Per-operation monitor payloads (`/monitor/opN`), 409 error shapes, root DELETE guard, parent-must-exist on folder create
- Versions listed newest-first with distinct timestamps (shared timestamp made current-version detection order-dependent), eTag-not-cTag bump on rename
- Fragment-safe upload URLs: the old `#` token was stripped by the HTTP client, 404ing every upload session

## Cases
`integ/unix/overwrite.json`: 6 shared cases (cp onto existing file, cp -r merge, mv onto existing file, mkdir -p on non-empty dir) on all 7 targets. New unit tests for mkdir/rename plus copy conflict/merge and upload-replace paths.

## Verification
- 9/9 targeted conflict probes against the strict fake
- Python battery: ram+onedrive 1764, disk/redis/s3/s3-prefix 3528, 0 failed
- TS runner: ram 874 / opfs 890 / disk+redis 874 each / s3+s3-prefix 1780 (local moto), 0 failed
- Legacy `integ/onedrive.py` and `integ/onedrive_cases.py` byte-match their truth files
- mypy 1578 files clean, pre-commit clean

## SharePoint mirror (commit 2)
`mirage/core/sharepoint/` had parallel copies of the same conflict bugs. Mirrored the recipe drive-id aware: copy delete-and-retry + per-child folder merge, rename 409 fallback (file or empty folder), upload sessions request replace, mkdir fail + tolerate existing. New unit tests (copy/rename/mkdir + upload-replace assert), 61 sharepoint tests green, mypy 1578 clean, pre-commit clean.