### PR TITLE
refactor(msgraph): shared drive core for onedrive and sharepoint

### DIFF
--- a/python/mirage/accessor/onedrive.py
+++ b/python/mirage/accessor/onedrive.py
@@ -12,22 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from collections.abc import Callable
-
-from pydantic import BaseModel, ConfigDict, SecretStr
-
 from mirage.accessor.base import Accessor
+from mirage.core.msgraph.config import MsGraphConfig
 
 
-class OneDriveConfig(BaseModel):
-    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
-
-    access_token: SecretStr | Callable[[], str | SecretStr]
+class OneDriveConfig(MsGraphConfig):
     drive_id: str | None = None
     site_id: str | None = None
     key_prefix: str | None = None
-    timeout: int = 30
-    max_retries: int = 5
 
 
 class OneDriveAccessor(Accessor):

--- a/python/mirage/core/msgraph/drive_ops.py
+++ b/python/mirage/core/msgraph/drive_ops.py
@@ -1,0 +1,211 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import posixpath
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+
+from mirage.cache.context import invalidate_after_write
+from mirage.core.msgraph._client import (GraphError, graph_delete, graph_get,
+                                         graph_list, graph_patch, graph_post,
+                                         graph_post_monitor, poll_monitor,
+                                         upload_chunk)
+from mirage.core.msgraph.config import MsGraphConfig
+
+SIMPLE_UPLOAD_MAX = 4 * 1024 * 1024
+UPLOAD_CHUNK = 10 * 327680
+
+
+@dataclass(frozen=True, slots=True)
+class DriveLoc:
+    """One drive item address, independent of how the backend spells URLs.
+
+    OneDrive builds URLs from its config (one implicit drive plus
+    ``key_prefix``); SharePoint resolves site and drive segments first.
+    Both hand the shared drive operations a ``DriveLoc`` so the conflict
+    machinery is written once.
+
+    Args:
+        drive (str): Opaque drive identity for cross-drive comparison
+            (empty for single-drive backends).
+        path (str): Backend-addressing item path.
+        virt (str): Mount-relative path for cache invalidation.
+        url (Callable[[str, str], str]): Maps ``(path, action)`` to a
+            full Graph URL.
+        ref (Callable[[str], str]): Maps a folder path to a
+            ``parentReference`` drive ref path.
+    """
+
+    drive: str
+    path: str
+    virt: str
+    url: Callable[[str, str], str]
+    ref: Callable[[str], str]
+
+    def item(self, action: str = "") -> str:
+        return self.url(self.path, action)
+
+    def child(self, name: str) -> "DriveLoc":
+        return replace(self,
+                       path=f"{self.path}/{name}",
+                       virt=f"{self.virt}/{name}")
+
+    def parent(self) -> str:
+        return posixpath.dirname("/" + self.path).strip("/")
+
+
+def _parent_reference(src: DriveLoc, dst: DriveLoc) -> dict:
+    ref: dict = {"path": dst.ref(dst.parent())}
+    if src.drive != dst.drive and dst.drive:
+        ref["driveId"] = dst.drive
+    return ref
+
+
+async def copy_once(config: MsGraphConfig, src: DriveLoc,
+                    dst: DriveLoc) -> tuple[str, str] | None:
+    """One Graph copy attempt, surfacing a conflict instead of raising.
+
+    Graph copies default to ``fail`` on a name conflict and the
+    ``@microsoft.graph.conflictBehavior=replace`` query parameter is
+    files-only (and unsupported on OneDrive Consumer), so the caller
+    resolves conflicts itself (delete-and-retry for files, per-child
+    merge for folders).
+
+    Args:
+        config (MsGraphConfig): Graph config.
+        src (DriveLoc): source item.
+        dst (DriveLoc): destination item.
+
+    Returns:
+        tuple[str, str] | None: ``(code, message)`` of a failed copy, or
+        None when the copy completed.
+    """
+    body = {
+        "name": posixpath.basename(dst.path),
+        "parentReference": _parent_reference(src, dst),
+    }
+    try:
+        monitor = await graph_post_monitor(config, src.item("/copy"), body)
+    except GraphError as exc:
+        if exc.status == 409 or exc.code == "nameAlreadyExists":
+            return exc.code, str(exc)
+        raise
+    if not monitor:
+        return None
+    result = await poll_monitor(monitor, timeout=config.timeout)
+    status = result.get("status")
+    if status == "failed":
+        err = result.get("error", {}) if isinstance(result, dict) else {}
+        return (err.get("code", "copyFailed"),
+                err.get("message", f"copy {src.path} -> {dst.path} failed"))
+    if status not in ("completed", None):
+        raise GraphError(504, "copyTimeout",
+                         f"copy {src.path} -> {dst.path} not confirmed")
+    return None
+
+
+async def copy_tree(config: MsGraphConfig, src: DriveLoc,
+                    dst: DriveLoc) -> None:
+    err = await copy_once(config, src, dst)
+    if err is None:
+        await invalidate_after_write(dst.virt)
+        return
+    code, message = err
+    if code != "nameAlreadyExists":
+        raise GraphError(500, code, message)
+    src_item = await graph_get(config, src.item())
+    dst_item = await graph_get(config, dst.item())
+    if "folder" in src_item and "folder" in dst_item:
+        # GNU cp -r merges into an existing directory; Graph never merges
+        # folders, so recurse per child instead.
+        children = await graph_list(config, src.item("/children"))
+        for child in children:
+            name = child.get("name", "")
+            await copy_tree(config, src.child(name), dst.child(name))
+        return
+    if "folder" in src_item or "folder" in dst_item:
+        raise GraphError(409, code, message)
+    await graph_delete(config, dst.item())
+    err = await copy_once(config, src, dst)
+    if err is not None:
+        raise GraphError(500, err[0], err[1])
+    await invalidate_after_write(dst.virt)
+
+
+def _move_body(src: DriveLoc, dst: DriveLoc) -> dict:
+    body: dict = {"name": posixpath.basename(dst.path)}
+    if dst.parent() != src.parent() or src.drive != dst.drive:
+        body["parentReference"] = {"path": dst.ref(dst.parent())}
+    return body
+
+
+async def rename_replace(config: MsGraphConfig, src: DriveLoc,
+                         dst: DriveLoc) -> None:
+    body = _move_body(src, dst)
+    try:
+        await graph_patch(config, src.item(), body)
+    except GraphError as exc:
+        if exc.status != 409 and exc.code != "nameAlreadyExists":
+            raise
+        # GNU mv overwrites the destination, but a Graph move has no
+        # conflictBehavior that works across account types: drop the
+        # conflicting file (or empty folder) and retry. A non-empty
+        # folder conflict keeps the original error, mirroring mv's
+        # "Directory not empty".
+        dst_item = await graph_get(config, dst.item())
+        if "folder" in dst_item:
+            children = await graph_list(config, dst.item("/children"))
+            if children:
+                raise
+        await graph_delete(config, dst.item())
+        await graph_patch(config, src.item(), body)
+
+
+async def create_child_folder(config: MsGraphConfig, parent_url: str,
+                              name: str) -> None:
+    body = {
+        "name": name,
+        "folder": {},
+        "@microsoft.graph.conflictBehavior": "fail",
+    }
+    try:
+        await graph_post(config, parent_url, body)
+    except GraphError as exc:
+        # mkdir is idempotent on object-store-style backends (matches the
+        # s3 core); "replace" is unreliable for folders on real Graph, so
+        # create with "fail" and tolerate the existing item.
+        if exc.status != 409 and exc.code != "nameAlreadyExists":
+            raise
+
+
+async def upload_session_write(config: MsGraphConfig, session_url: str,
+                               data: bytes) -> None:
+    # createUploadSession defaults to "fail": without replace, overwriting
+    # an existing file 409s on the final chunk.
+    session = await graph_post(
+        config, session_url,
+        {"item": {
+            "@microsoft.graph.conflictBehavior": "replace"
+        }})
+    upload_url = session["uploadUrl"]
+    total = len(data)
+    start = 0
+    while start < total:
+        chunk = data[start:start + UPLOAD_CHUNK]
+        result = await upload_chunk(config, upload_url, chunk, start, total)
+        ranges = result.get("nextExpectedRanges") if result else None
+        if ranges:
+            start = int(ranges[0].split("-", 1)[0])
+        else:
+            start += len(chunk)

--- a/python/mirage/core/onedrive/_client.py
+++ b/python/mirage/core/onedrive/_client.py
@@ -12,32 +12,50 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import asyncio
 from urllib.parse import quote
 
-import aiohttp
-
+# yapf: enable
 from mirage.accessor.onedrive import OneDriveConfig
-from mirage.resource.secrets import reveal_secret
+# yapf: disable
+from mirage.core.msgraph._client import (GRAPH_API, MAX_BACKOFF,
+                                         RETRY_STATUSES, GraphError,
+                                         graph_delete, graph_get,
+                                         graph_get_bytes, graph_list,
+                                         graph_patch, graph_post,
+                                         graph_post_monitor, graph_put_bytes,
+                                         graph_stream, headers, new_session,
+                                         poll_monitor, upload_chunk)
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_prefix_of
 
-GRAPH_API = "https://graph.microsoft.com/v1.0"
-RETRY_STATUSES = {429, 503, 504}
-MAX_BACKOFF = 30.0
+__all__ = [
+    "GRAPH_API",
+    "MAX_BACKOFF",
+    "RETRY_STATUSES",
+    "GraphError",
+    "drive_base",
+    "drive_ref_path",
+    "graph_delete",
+    "graph_get",
+    "graph_get_bytes",
+    "graph_list",
+    "graph_patch",
+    "graph_post",
+    "graph_post_monitor",
+    "graph_put_bytes",
+    "graph_stream",
+    "headers",
+    "item_url",
+    "new_session",
+    "poll_monitor",
+    "split_path",
+    "upload_chunk",
+]
 
 
 def split_path(path: PathSpec) -> tuple[str, str]:
     prefix = mount_prefix_of(path.virtual, path.resource_path) or ""
     return prefix, path.resource_path
-
-
-class GraphError(RuntimeError):
-
-    def __init__(self, status: int, code: str, message: str) -> None:
-        self.status = status
-        self.code = code
-        super().__init__(f"Graph API error {status} ({code}): {message}")
 
 
 def drive_base(config: OneDriveConfig) -> str:
@@ -75,290 +93,3 @@ def drive_ref_path(config: OneDriveConfig, folder: str = "") -> str:
     if full:
         return f"{base}/root:/{quote(full, safe='/')}"
     return f"{base}/root:"
-
-
-def _resolve_token(config: OneDriveConfig) -> str:
-    token = config.access_token
-    resolved = token() if callable(token) else token
-    return reveal_secret(resolved)
-
-
-def headers(config: OneDriveConfig) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {_resolve_token(config)}",
-        "Content-Type": "application/json",
-    }
-
-
-def _timeout(config: OneDriveConfig) -> aiohttp.ClientTimeout:
-    return aiohttp.ClientTimeout(total=config.timeout)
-
-
-def new_session(config: OneDriveConfig) -> aiohttp.ClientSession:
-    return aiohttp.ClientSession(timeout=_timeout(config))
-
-
-async def _raise_for_status(method: str, url: str,
-                            resp: aiohttp.ClientResponse) -> None:
-    if resp.status < 400:
-        return
-    try:
-        data = await resp.json()
-        err = data.get("error", {}) if isinstance(data, dict) else {}
-    except (aiohttp.ContentTypeError, ValueError):
-        err = {}
-    raise GraphError(resp.status, err.get("code", "unknownError"),
-                     err.get("message", f"{method} {url}"))
-
-
-def _retry_delay(resp: aiohttp.ClientResponse, attempt: int) -> float:
-    retry_after = resp.headers.get("Retry-After")
-    if retry_after:
-        try:
-            return float(retry_after)
-        except ValueError:
-            # malformed Retry-After header: fall back to exponential backoff
-            pass
-    return min(2.0**attempt, MAX_BACKOFF)
-
-
-def _should_retry(status: int, attempt: int, config: OneDriveConfig) -> bool:
-    return status in RETRY_STATUSES and attempt < config.max_retries
-
-
-async def _retry_action(resp: aiohttp.ClientResponse, attempt: int,
-                        refreshed: bool, config: OneDriveConfig,
-                        auth: bool) -> str:
-    if _should_retry(resp.status, attempt, config):
-        await asyncio.sleep(_retry_delay(resp, attempt))
-        return "retry"
-    if (resp.status == 401 and auth and not refreshed
-            and callable(config.access_token)):
-        return "refresh"
-    return "ok"
-
-
-async def _request(config: OneDriveConfig,
-                   method: str,
-                   url: str,
-                   *,
-                   session: aiohttp.ClientSession | None = None,
-                   params: dict | None = None,
-                   json_body: dict | None = None,
-                   data: bytes | None = None,
-                   extra_headers: dict | None = None,
-                   auth: bool = True,
-                   read: str = "json"):
-    own = session is None
-    sess = session or aiohttp.ClientSession(timeout=_timeout(config))
-    try:
-        attempt = 0
-        refreshed = False
-        while True:
-            hdrs = headers(config) if auth else {}
-            if extra_headers:
-                hdrs.update(extra_headers)
-            async with sess.request(method,
-                                    url,
-                                    headers=hdrs,
-                                    params=params,
-                                    json=json_body,
-                                    data=data) as resp:
-                action = await _retry_action(resp, attempt, refreshed, config,
-                                             auth)
-                if action == "retry":
-                    attempt += 1
-                    continue
-                if action == "refresh":
-                    refreshed = True
-                    continue
-                await _raise_for_status(method, url, resp)
-                if read == "bytes":
-                    return await resp.read()
-                if read == "none":
-                    return None
-                if read == "location":
-                    return resp.headers.get("Location")
-                if resp.status == 204 or resp.content_length == 0:
-                    return {}
-                try:
-                    return await resp.json()
-                except (aiohttp.ContentTypeError, ValueError):
-                    return {}
-    finally:
-        if own:
-            await sess.close()
-
-
-async def graph_get(config: OneDriveConfig,
-                    url: str,
-                    params: dict | None = None,
-                    session: aiohttp.ClientSession | None = None) -> dict:
-    return await _request(config, "GET", url, params=params, session=session)
-
-
-async def graph_list(
-        config: OneDriveConfig,
-        url: str,
-        params: dict | None = None,
-        session: aiohttp.ClientSession | None = None) -> list[dict]:
-    items: list[dict] = []
-    next_url: str | None = url
-    next_params = params
-    own = session is None
-    sess = session or aiohttp.ClientSession(timeout=_timeout(config))
-    try:
-        while next_url:
-            data = await _request(config,
-                                  "GET",
-                                  next_url,
-                                  params=next_params,
-                                  session=sess)
-            items.extend(data.get("value", []))
-            next_url = data.get("@odata.nextLink")
-            next_params = None
-    finally:
-        if own:
-            await sess.close()
-    return items
-
-
-async def graph_get_bytes(config: OneDriveConfig,
-                          url: str,
-                          range_header: str | None = None,
-                          session: aiohttp.ClientSession | None = None,
-                          auth: bool = True) -> bytes:
-    extra = {"Range": range_header} if range_header else None
-    return await _request(config,
-                          "GET",
-                          url,
-                          extra_headers=extra,
-                          session=session,
-                          auth=auth,
-                          read="bytes")
-
-
-async def graph_stream(config: OneDriveConfig,
-                       url: str,
-                       chunk_size: int = 8192,
-                       session: aiohttp.ClientSession | None = None,
-                       auth: bool = True):
-    own = session is None
-    sess = session or aiohttp.ClientSession(timeout=_timeout(config))
-    try:
-        attempt = 0
-        refreshed = False
-        while True:
-            hdrs = headers(config) if auth else {}
-            async with sess.get(url, headers=hdrs) as resp:
-                action = await _retry_action(resp, attempt, refreshed, config,
-                                             auth)
-                if action == "retry":
-                    attempt += 1
-                    continue
-                if action == "refresh":
-                    refreshed = True
-                    continue
-                await _raise_for_status("GET", url, resp)
-                async for chunk in resp.content.iter_chunked(chunk_size):
-                    yield chunk
-                return
-    finally:
-        if own:
-            await sess.close()
-
-
-async def graph_post(config: OneDriveConfig,
-                     url: str,
-                     body: dict | None = None,
-                     session: aiohttp.ClientSession | None = None) -> dict:
-    return await _request(config,
-                          "POST",
-                          url,
-                          json_body=body or {},
-                          session=session)
-
-
-async def graph_post_monitor(
-        config: OneDriveConfig,
-        url: str,
-        body: dict | None = None,
-        session: aiohttp.ClientSession | None = None) -> str | None:
-    return await _request(config,
-                          "POST",
-                          url,
-                          json_body=body or {},
-                          session=session,
-                          read="location")
-
-
-async def graph_patch(config: OneDriveConfig,
-                      url: str,
-                      body: dict,
-                      session: aiohttp.ClientSession | None = None) -> dict:
-    return await _request(config,
-                          "PATCH",
-                          url,
-                          json_body=body,
-                          session=session)
-
-
-async def graph_delete(config: OneDriveConfig,
-                       url: str,
-                       session: aiohttp.ClientSession | None = None) -> None:
-    await _request(config, "DELETE", url, session=session, read="none")
-
-
-async def graph_put_bytes(
-        config: OneDriveConfig,
-        url: str,
-        data: bytes,
-        content_type: str = "application/octet-stream",
-        session: aiohttp.ClientSession | None = None) -> dict:
-    return await _request(config,
-                          "PUT",
-                          url,
-                          data=data,
-                          extra_headers={"Content-Type": content_type},
-                          session=session)
-
-
-async def poll_monitor(url: str,
-                       timeout: float,
-                       interval: float = 1.0) -> dict:
-    waited = 0.0
-    async with aiohttp.ClientSession() as session:
-        while True:
-            async with session.get(url) as resp:
-                if resp.status >= 400:
-                    raise GraphError(resp.status, "monitorError", f"GET {url}")
-                payload = await resp.json()
-            status = payload.get("status")
-            if status in ("completed", "failed"):
-                return payload
-            if waited >= timeout:
-                return payload
-            await asyncio.sleep(interval)
-            waited += interval
-
-
-async def upload_chunk(config: OneDriveConfig, upload_url: str, data: bytes,
-                       start: int, total: int) -> dict:
-    end = start + len(data) - 1
-    hdrs = {"Content-Range": f"bytes {start}-{end}/{total}"}
-    async with aiohttp.ClientSession(timeout=_timeout(config)) as session:
-        attempt = 0
-        while True:
-            async with session.put(upload_url, headers=hdrs,
-                                   data=data) as resp:
-                if _should_retry(resp.status, attempt, config):
-                    await asyncio.sleep(_retry_delay(resp, attempt))
-                    attempt += 1
-                    continue
-                await _raise_for_status("PUT", upload_url, resp)
-                if resp.status == 204 or resp.content_length == 0:
-                    return {}
-                try:
-                    return await resp.json()
-                except (aiohttp.ContentTypeError, ValueError):
-                    return {}

--- a/python/mirage/core/onedrive/copy.py
+++ b/python/mirage/core/onedrive/copy.py
@@ -12,94 +12,25 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import posixpath
+from functools import partial
 
 from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
-from mirage.cache.context import invalidate_after_write
-from mirage.core.onedrive._client import (GraphError, drive_ref_path,
-                                          graph_delete, graph_get, graph_list,
-                                          graph_post_monitor, item_url,
-                                          poll_monitor, split_path)
+from mirage.core.msgraph.drive_ops import DriveLoc, copy_tree
+from mirage.core.onedrive._client import drive_ref_path, item_url, split_path
 from mirage.types import PathSpec
 
 
-async def _copy_once(config: OneDriveConfig, src_s: str,
-                     dst_s: str) -> tuple[str, str] | None:
-    """One Graph copy attempt, surfacing a conflict instead of raising.
-
-    Graph copies default to ``fail`` on a name conflict and the
-    ``@microsoft.graph.conflictBehavior=replace`` query parameter is not
-    supported on OneDrive Consumer, so the caller resolves conflicts
-    itself (delete-and-retry for files, per-child merge for folders).
-
-    Args:
-        config (OneDriveConfig): OneDrive config.
-        src_s (str): resource-relative source path.
-        dst_s (str): resource-relative destination path.
-
-    Returns:
-        tuple[str, str] | None: ``(code, message)`` of a failed copy, or
-        None when the copy completed.
-    """
-    dst_parent = posixpath.dirname("/" + dst_s).strip("/")
-    body = {
-        "name": posixpath.basename(dst_s),
-        "parentReference": {
-            "path": drive_ref_path(config, dst_parent)
-        },
-    }
-    url = item_url(config, "/" + src_s, action="/copy")
-    try:
-        monitor = await graph_post_monitor(config, url, body)
-    except GraphError as exc:
-        if exc.status == 409 or exc.code == "nameAlreadyExists":
-            return exc.code, str(exc)
-        raise
-    if not monitor:
-        return None
-    result = await poll_monitor(monitor, timeout=config.timeout)
-    status = result.get("status")
-    if status == "failed":
-        err = result.get("error", {}) if isinstance(result, dict) else {}
-        return (err.get("code", "copyFailed"),
-                err.get("message", f"copy {src_s} -> {dst_s} failed"))
-    if status not in ("completed", None):
-        raise GraphError(504, "copyTimeout",
-                         f"copy {src_s} -> {dst_s} not confirmed complete")
-    return None
-
-
-async def _copy_tree(config: OneDriveConfig, src_s: str, dst_s: str) -> None:
-    err = await _copy_once(config, src_s, dst_s)
-    if err is None:
-        await invalidate_after_write(dst_s)
-        return
-    code, message = err
-    if code != "nameAlreadyExists":
-        raise GraphError(500, code, message)
-    src_item = await graph_get(config, item_url(config, "/" + src_s))
-    dst_item = await graph_get(config, item_url(config, "/" + dst_s))
-    if "folder" in src_item and "folder" in dst_item:
-        # GNU cp -r merges into an existing directory; Graph never merges
-        # folders, so recurse per child instead.
-        children = await graph_list(
-            config, item_url(config, "/" + src_s, action="/children"))
-        for child in children:
-            name = child.get("name", "")
-            await _copy_tree(config, f"{src_s}/{name}", f"{dst_s}/{name}")
-        return
-    if "folder" in src_item or "folder" in dst_item:
-        raise GraphError(409, code, message)
-    await graph_delete(config, item_url(config, "/" + dst_s))
-    err = await _copy_once(config, src_s, dst_s)
-    if err is not None:
-        raise GraphError(500, err[0], err[1])
-    await invalidate_after_write(dst_s)
+def drive_loc(config: OneDriveConfig, stripped: str) -> DriveLoc:
+    return DriveLoc(drive="",
+                    path=stripped,
+                    virt=stripped,
+                    url=partial(item_url, config),
+                    ref=partial(drive_ref_path, config))
 
 
 async def copy(accessor: OneDriveAccessor, src: PathSpec,
                dst: PathSpec) -> None:
     _, src_s = split_path(src)
     _, dst_s = split_path(dst)
-    await _copy_tree(accessor.config, src_s, dst_s)
-    await invalidate_after_write(dst)
+    config = accessor.config
+    await copy_tree(config, drive_loc(config, src_s), drive_loc(config, dst_s))

--- a/python/mirage/core/onedrive/mkdir.py
+++ b/python/mirage/core/onedrive/mkdir.py
@@ -16,30 +16,18 @@ import posixpath
 
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.context import invalidate_after_write
-from mirage.core.onedrive._client import (GraphError, graph_post, item_url,
-                                          split_path)
+from mirage.core.msgraph.drive_ops import create_child_folder
+from mirage.core.onedrive._client import item_url, split_path
 from mirage.types import PathSpec
 
 
 async def _create_dir(accessor: OneDriveAccessor, stripped: str) -> None:
     parent = posixpath.dirname("/" + stripped).strip("/")
-    name = posixpath.basename(stripped)
     url = item_url(accessor.config,
                    "/" + parent if parent else "/",
                    action="/children")
-    body = {
-        "name": name,
-        "folder": {},
-        "@microsoft.graph.conflictBehavior": "fail",
-    }
-    try:
-        await graph_post(accessor.config, url, body)
-    except GraphError as exc:
-        # mkdir is idempotent on object-store-style backends (matches the
-        # s3 core); "replace" is unreliable for folders on real Graph, so
-        # create with "fail" and tolerate the existing item.
-        if exc.status != 409 and exc.code != "nameAlreadyExists":
-            raise
+    await create_child_folder(accessor.config, url,
+                              posixpath.basename(stripped))
 
 
 async def mkdir(accessor: OneDriveAccessor,

--- a/python/mirage/core/onedrive/rename.py
+++ b/python/mirage/core/onedrive/rename.py
@@ -12,24 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import posixpath
-
-from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
+from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.context import (invalidate_after_unlink,
                                   invalidate_after_write)
-from mirage.core.onedrive._client import (GraphError, drive_ref_path,
-                                          graph_delete, graph_get, graph_list,
-                                          graph_patch, item_url, split_path)
+from mirage.core.msgraph.drive_ops import rename_replace
+from mirage.core.onedrive._client import split_path
+from mirage.core.onedrive.copy import drive_loc
 from mirage.types import PathSpec
-
-
-def _move_body(config: OneDriveConfig, src_s: str, dst_s: str) -> dict:
-    src_parent = posixpath.dirname("/" + src_s).strip("/")
-    dst_parent = posixpath.dirname("/" + dst_s).strip("/")
-    body: dict = {"name": posixpath.basename(dst_s)}
-    if dst_parent != src_parent:
-        body["parentReference"] = {"path": drive_ref_path(config, dst_parent)}
-    return body
 
 
 async def rename(accessor: OneDriveAccessor, src: PathSpec,
@@ -37,24 +26,7 @@ async def rename(accessor: OneDriveAccessor, src: PathSpec,
     _, src_s = split_path(src)
     _, dst_s = split_path(dst)
     config = accessor.config
-    body = _move_body(config, src_s, dst_s)
-    try:
-        await graph_patch(config, item_url(config, "/" + src_s), body)
-    except GraphError as exc:
-        if exc.status != 409 and exc.code != "nameAlreadyExists":
-            raise
-        # GNU mv overwrites the destination, but a Graph move has no
-        # conflictBehavior that works across account types: drop the
-        # conflicting file (or empty folder) and retry. A non-empty
-        # folder conflict keeps the original error, mirroring mv's
-        # "Directory not empty".
-        dst_item = await graph_get(config, item_url(config, "/" + dst_s))
-        if "folder" in dst_item:
-            children = await graph_list(
-                config, item_url(config, "/" + dst_s, action="/children"))
-            if children:
-                raise
-        await graph_delete(config, item_url(config, "/" + dst_s))
-        await graph_patch(config, item_url(config, "/" + src_s), body)
+    await rename_replace(config, drive_loc(config, src_s),
+                         drive_loc(config, dst_s))
     await invalidate_after_write(dst)
     await invalidate_after_unlink(src)

--- a/python/mirage/core/onedrive/write.py
+++ b/python/mirage/core/onedrive/write.py
@@ -16,39 +16,11 @@ import time
 
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.context import invalidate_after_write
-from mirage.core.onedrive._client import (graph_post, graph_put_bytes,
-                                          item_url, split_path, upload_chunk)
+from mirage.core.msgraph.drive_ops import (SIMPLE_UPLOAD_MAX,
+                                           upload_session_write)
+from mirage.core.onedrive._client import graph_put_bytes, item_url, split_path
 from mirage.observe.context import record
 from mirage.types import PathSpec
-
-SIMPLE_UPLOAD_MAX = 4 * 1024 * 1024
-UPLOAD_CHUNK = 10 * 327680
-
-
-async def _upload_session(accessor: OneDriveAccessor, stripped: str,
-                          data: bytes) -> None:
-    config = accessor.config
-    session_url = item_url(config,
-                           "/" + stripped,
-                           action="/createUploadSession")
-    # createUploadSession defaults to "fail": without replace, overwriting
-    # an existing file 409s on the final chunk.
-    session = await graph_post(
-        config, session_url,
-        {"item": {
-            "@microsoft.graph.conflictBehavior": "replace"
-        }})
-    upload_url = session["uploadUrl"]
-    total = len(data)
-    start = 0
-    while start < total:
-        chunk = data[start:start + UPLOAD_CHUNK]
-        result = await upload_chunk(config, upload_url, chunk, start, total)
-        ranges = result.get("nextExpectedRanges") if result else None
-        if ranges:
-            start = int(ranges[0].split("-", 1)[0])
-        else:
-            start += len(chunk)
 
 
 async def write_bytes(accessor: OneDriveAccessor, path: PathSpec,
@@ -60,6 +32,9 @@ async def write_bytes(accessor: OneDriveAccessor, path: PathSpec,
         url = item_url(config, "/" + stripped, action="/content")
         await graph_put_bytes(config, url, data)
     else:
-        await _upload_session(accessor, stripped, data)
+        session_url = item_url(config,
+                               "/" + stripped,
+                               action="/createUploadSession")
+        await upload_session_write(config, session_url, data)
     record("write", stripped, "onedrive", len(data), start_ms)
     await invalidate_after_write(path)

--- a/python/mirage/core/sharepoint/copy.py
+++ b/python/mirage/core/sharepoint/copy.py
@@ -1,96 +1,21 @@
-import posixpath
+from functools import partial
 
-from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
-from mirage.cache.context import invalidate_after_write
-from mirage.core.sharepoint._client import (GraphError, drive_ref_path,
-                                            graph_delete, graph_get,
-                                            graph_list, graph_post_monitor,
-                                            item_url, poll_monitor)
-from mirage.core.sharepoint._resolver import resolve
+from mirage.accessor.sharepoint import SharePointAccessor
+from mirage.core.msgraph.drive_ops import DriveLoc, copy_tree
+from mirage.core.sharepoint._client import drive_ref_path, item_url
+from mirage.core.sharepoint._resolver import ResolvedPath, resolve
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
 
-async def _copy_once(config: SharePointConfig, src_drive: str, src_path: str,
-                     dst_drive: str, dst_path: str) -> tuple[str, str] | None:
-    """One Graph copy attempt, surfacing a conflict instead of raising.
-
-    Graph copies default to ``fail`` on a name conflict and the
-    ``@microsoft.graph.conflictBehavior=replace`` query parameter is
-    files-only, so the caller resolves conflicts itself
-    (delete-and-retry for files, per-child merge for folders).
-
-    Args:
-        config (SharePointConfig): SharePoint config.
-        src_drive (str): source drive id.
-        src_path (str): drive-relative source path.
-        dst_drive (str): destination drive id.
-        dst_path (str): drive-relative destination path.
-
-    Returns:
-        tuple[str, str] | None: ``(code, message)`` of a failed copy, or
-        None when the copy completed.
-    """
-    dst_parent = posixpath.dirname("/" + dst_path).strip("/")
-    body: dict = {"name": posixpath.basename(dst_path)}
-    if src_drive == dst_drive:
-        body["parentReference"] = {
-            "path": drive_ref_path(dst_drive, dst_parent)
-        }
-    else:
-        body["parentReference"] = {
-            "driveId": dst_drive,
-            "path": drive_ref_path(dst_drive, dst_parent),
-        }
-    url = item_url(src_drive, src_path, action="/copy")
-    try:
-        monitor = await graph_post_monitor(config, url, body)
-    except GraphError as exc:
-        if exc.status == 409 or exc.code == "nameAlreadyExists":
-            return exc.code, str(exc)
-        raise
-    if not monitor:
-        return None
-    result = await poll_monitor(monitor, timeout=config.timeout)
-    status = result.get("status")
-    if status == "failed":
-        err = result.get("error", {}) if isinstance(result, dict) else {}
-        return (err.get("code", "copyFailed"), err.get("message",
-                                                       "copy failed"))
-    if status not in ("completed", None):
-        raise GraphError(504, "copyTimeout", "copy not confirmed complete")
-    return None
-
-
-async def _copy_tree(config: SharePointConfig, src_drive: str, src_path: str,
-                     dst_drive: str, dst_path: str, dst_virt: str) -> None:
-    err = await _copy_once(config, src_drive, src_path, dst_drive, dst_path)
-    if err is None:
-        await invalidate_after_write(dst_virt)
-        return
-    code, message = err
-    if code != "nameAlreadyExists":
-        raise GraphError(500, code, message)
-    src_item = await graph_get(config, item_url(src_drive, src_path))
-    dst_item = await graph_get(config, item_url(dst_drive, dst_path))
-    if "folder" in src_item and "folder" in dst_item:
-        # GNU cp -r merges into an existing directory; Graph never merges
-        # folders, so recurse per child instead.
-        children = await graph_list(
-            config, item_url(src_drive, src_path, action="/children"))
-        for child in children:
-            name = child.get("name", "")
-            await _copy_tree(config, src_drive, f"{src_path}/{name}",
-                             dst_drive, f"{dst_path}/{name}",
-                             f"{dst_virt}/{name}")
-        return
-    if "folder" in src_item or "folder" in dst_item:
-        raise GraphError(409, code, message)
-    await graph_delete(config, item_url(dst_drive, dst_path))
-    err = await _copy_once(config, src_drive, src_path, dst_drive, dst_path)
-    if err is not None:
-        raise GraphError(500, err[0], err[1])
-    await invalidate_after_write(dst_virt)
+def drive_loc(resolved: ResolvedPath, virt: str) -> DriveLoc:
+    assert resolved.drive_id is not None
+    assert resolved.item_path is not None
+    return DriveLoc(drive=resolved.drive_id,
+                    path=resolved.item_path,
+                    virt=virt,
+                    url=partial(item_url, resolved.drive_id),
+                    ref=partial(drive_ref_path, resolved.drive_id))
 
 
 async def copy(accessor: SharePointAccessor, src: PathSpec,
@@ -102,6 +27,6 @@ async def copy(accessor: SharePointAccessor, src: PathSpec,
             or dst_resolved.item_path is None):
         raise enoent(src.virtual if isinstance(src, PathSpec) else src)
     dst_virt = dst.mount_path if isinstance(dst, PathSpec) else dst
-    await _copy_tree(accessor.config, src_resolved.drive_id,
-                     src_resolved.item_path, dst_resolved.drive_id,
-                     dst_resolved.item_path, dst_virt)
+    src_virt = src.mount_path if isinstance(src, PathSpec) else src
+    await copy_tree(accessor.config, drive_loc(src_resolved, src_virt),
+                    drive_loc(dst_resolved, dst_virt))

--- a/python/mirage/core/sharepoint/mkdir.py
+++ b/python/mirage/core/sharepoint/mkdir.py
@@ -2,8 +2,8 @@ import posixpath
 
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.context import invalidate_after_write
-from mirage.core.sharepoint._client import (GraphError, graph_post, item_url,
-                                            split_path)
+from mirage.core.msgraph.drive_ops import create_child_folder
+from mirage.core.sharepoint._client import item_url, split_path
 from mirage.core.sharepoint._resolver import resolve
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
@@ -12,23 +12,11 @@ from mirage.utils.errors import enoent
 async def _create_dir(accessor: SharePointAccessor, drive_id: str,
                       stripped: str) -> None:
     parent = posixpath.dirname("/" + stripped).strip("/")
-    name = posixpath.basename(stripped)
     url = item_url(drive_id,
                    "/" + parent if parent else "/",
                    action="/children")
-    body = {
-        "name": name,
-        "folder": {},
-        "@microsoft.graph.conflictBehavior": "fail",
-    }
-    try:
-        await graph_post(accessor.config, url, body)
-    except GraphError as exc:
-        # mkdir is idempotent on object-store-style backends (matches the
-        # s3 core); "replace" is unreliable for folders on real Graph, so
-        # create with "fail" and tolerate the existing item.
-        if exc.status != 409 and exc.code != "nameAlreadyExists":
-            raise
+    await create_child_folder(accessor.config, url,
+                              posixpath.basename(stripped))
 
 
 async def mkdir(accessor: SharePointAccessor,

--- a/python/mirage/core/sharepoint/rename.py
+++ b/python/mirage/core/sharepoint/rename.py
@@ -1,29 +1,11 @@
-import posixpath
-
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.context import (invalidate_after_unlink,
                                   invalidate_after_write)
-from mirage.core.sharepoint._client import (GraphError, drive_ref_path,
-                                            graph_delete, graph_get,
-                                            graph_list, graph_patch, item_url)
-from mirage.core.sharepoint._resolver import ResolvedPath, resolve
+from mirage.core.msgraph.drive_ops import rename_replace
+from mirage.core.sharepoint._resolver import resolve
+from mirage.core.sharepoint.copy import drive_loc
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
-
-
-def _move_body(src_resolved: ResolvedPath, dst_resolved: ResolvedPath) -> dict:
-    assert src_resolved.item_path is not None
-    assert dst_resolved.item_path is not None
-    assert dst_resolved.drive_id is not None
-    src_parent = posixpath.dirname("/" + src_resolved.item_path).strip("/")
-    dst_parent = posixpath.dirname("/" + dst_resolved.item_path).strip("/")
-    body: dict = {"name": posixpath.basename(dst_resolved.item_path)}
-    if (dst_parent != src_parent
-            or src_resolved.drive_id != dst_resolved.drive_id):
-        body["parentReference"] = {
-            "path": drive_ref_path(dst_resolved.drive_id, dst_parent)
-        }
-    return body
 
 
 async def rename(accessor: SharePointAccessor, src: PathSpec,
@@ -34,30 +16,9 @@ async def rename(accessor: SharePointAccessor, src: PathSpec,
             or dst_resolved.drive_id is None
             or dst_resolved.item_path is None):
         raise enoent(src.virtual if isinstance(src, PathSpec) else src)
-    config = accessor.config
-    body = _move_body(src_resolved, dst_resolved)
-    src_url = item_url(src_resolved.drive_id, src_resolved.item_path)
-    dst_url = item_url(dst_resolved.drive_id, dst_resolved.item_path)
-    try:
-        await graph_patch(config, src_url, body)
-    except GraphError as exc:
-        if exc.status != 409 and exc.code != "nameAlreadyExists":
-            raise
-        # GNU mv overwrites the destination, but a Graph move has no
-        # conflictBehavior that works across account types: drop the
-        # conflicting file (or empty folder) and retry. A non-empty
-        # folder conflict keeps the original error, mirroring mv's
-        # "Directory not empty".
-        dst_item = await graph_get(config, dst_url)
-        if "folder" in dst_item:
-            children = await graph_list(
-                config,
-                item_url(dst_resolved.drive_id,
-                         dst_resolved.item_path,
-                         action="/children"))
-            if children:
-                raise
-        await graph_delete(config, dst_url)
-        await graph_patch(config, src_url, body)
+    src_virt = src.mount_path if isinstance(src, PathSpec) else src
+    dst_virt = dst.mount_path if isinstance(dst, PathSpec) else dst
+    await rename_replace(accessor.config, drive_loc(src_resolved, src_virt),
+                         drive_loc(dst_resolved, dst_virt))
     await invalidate_after_write(dst)
     await invalidate_after_unlink(src)

--- a/python/mirage/core/sharepoint/write.py
+++ b/python/mirage/core/sharepoint/write.py
@@ -2,39 +2,14 @@ import time
 
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.context import invalidate_after_write
-from mirage.core.sharepoint._client import (graph_post, graph_put_bytes,
-                                            item_url, split_path, upload_chunk)
+from mirage.core.msgraph.drive_ops import (SIMPLE_UPLOAD_MAX,
+                                           upload_session_write)
+from mirage.core.sharepoint._client import (graph_put_bytes, item_url,
+                                            split_path)
 from mirage.core.sharepoint._resolver import resolve
 from mirage.observe.context import record
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
-
-SIMPLE_UPLOAD_MAX = 4 * 1024 * 1024
-UPLOAD_CHUNK = 10 * 327680
-
-
-async def _upload_session(accessor: SharePointAccessor, drive_id: str,
-                          item_path: str, data: bytes) -> None:
-    config = accessor.config
-    session_url = item_url(drive_id, item_path, action="/createUploadSession")
-    # createUploadSession defaults to "fail": without replace, overwriting
-    # an existing file 409s on the final chunk.
-    session = await graph_post(
-        config, session_url,
-        {"item": {
-            "@microsoft.graph.conflictBehavior": "replace"
-        }})
-    upload_url = session["uploadUrl"]
-    total = len(data)
-    start = 0
-    while start < total:
-        chunk = data[start:start + UPLOAD_CHUNK]
-        result = await upload_chunk(config, upload_url, chunk, start, total)
-        ranges = result.get("nextExpectedRanges") if result else None
-        if ranges:
-            start = int(ranges[0].split("-", 1)[0])
-        else:
-            start += len(chunk)
 
 
 async def write_bytes(accessor: SharePointAccessor, path: PathSpec,
@@ -52,6 +27,7 @@ async def write_bytes(accessor: SharePointAccessor, path: PathSpec,
         url = item_url(drive_id, item_p, action="/content")
         await graph_put_bytes(config, url, data)
     else:
-        await _upload_session(accessor, drive_id, item_p, data)
+        session_url = item_url(drive_id, item_p, action="/createUploadSession")
+        await upload_session_write(config, session_url, data)
     record("write", stripped, "sharepoint", len(data), start_ms)
     await invalidate_after_write(path)

--- a/python/tests/core/msgraph/test_drive_ops.py
+++ b/python/tests/core/msgraph/test_drive_ops.py
@@ -1,0 +1,50 @@
+from mirage.core.msgraph.drive_ops import (DriveLoc, _move_body,
+                                           _parent_reference)
+
+
+def _url(path: str, action: str = "") -> str:
+    return f"https://graph.example/drives/d1/root:/{path}:{action}"
+
+
+def _ref(folder: str) -> str:
+    return f"/drives/d1/root:/{folder}"
+
+
+def _loc(drive: str, path: str) -> DriveLoc:
+    return DriveLoc(drive=drive,
+                    path=path,
+                    virt=f"/{path}",
+                    url=_url,
+                    ref=_ref)
+
+
+def test_child_extends_path_and_virt():
+    child = _loc("d1", "a/b").child("c.txt")
+    assert child.path == "a/b/c.txt"
+    assert child.virt == "/a/b/c.txt"
+    assert child.drive == "d1"
+
+
+def test_parent_of_top_level_item_is_empty():
+    assert _loc("d1", "a.txt").parent() == ""
+    assert _loc("d1", "a/b.txt").parent() == "a"
+
+
+def test_parent_reference_same_drive_has_no_drive_id():
+    ref = _parent_reference(_loc("d1", "a.txt"), _loc("d1", "sub/b.txt"))
+    assert ref == {"path": _ref("sub")}
+
+
+def test_parent_reference_cross_drive_adds_drive_id():
+    ref = _parent_reference(_loc("d1", "a.txt"), _loc("d2", "sub/b.txt"))
+    assert ref["driveId"] == "d2"
+
+
+def test_move_body_same_parent_is_rename_only():
+    body = _move_body(_loc("d1", "a.txt"), _loc("d1", "b.txt"))
+    assert body == {"name": "b.txt"}
+
+
+def test_move_body_new_parent_includes_reference():
+    body = _move_body(_loc("d1", "a.txt"), _loc("d1", "sub/b.txt"))
+    assert body["parentReference"] == {"path": _ref("sub")}

--- a/python/tests/core/onedrive/test_write.py
+++ b/python/tests/core/onedrive/test_write.py
@@ -1,6 +1,7 @@
 import pytest
 from aioresponses import CallbackResult, aioresponses
 
+import mirage.core.msgraph.drive_ops as drive_ops
 import mirage.core.onedrive.write as write_mod
 from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
 from mirage.core.onedrive.write import write_bytes
@@ -36,7 +37,7 @@ async def test_write_small_file_puts_content():
 @pytest.mark.asyncio
 async def test_write_large_file_uses_upload_session(monkeypatch):
     monkeypatch.setattr(write_mod, "SIMPLE_UPLOAD_MAX", 4)
-    monkeypatch.setattr(write_mod, "UPLOAD_CHUNK", 4)
+    monkeypatch.setattr(drive_ops, "UPLOAD_CHUNK", 4)
     ranges = []
 
     def _chunk_cb(url, **kwargs):
@@ -60,7 +61,7 @@ async def test_write_large_file_uses_upload_session(monkeypatch):
 @pytest.mark.asyncio
 async def test_upload_session_requests_replace(monkeypatch):
     monkeypatch.setattr(write_mod, "SIMPLE_UPLOAD_MAX", 4)
-    monkeypatch.setattr(write_mod, "UPLOAD_CHUNK", 8)
+    monkeypatch.setattr(drive_ops, "UPLOAD_CHUNK", 8)
     captured = {}
 
     def _session_cb(url, **kwargs):
@@ -80,7 +81,7 @@ async def test_upload_session_requests_replace(monkeypatch):
 @pytest.mark.asyncio
 async def test_upload_resumes_from_next_expected_ranges(monkeypatch):
     monkeypatch.setattr(write_mod, "SIMPLE_UPLOAD_MAX", 4)
-    monkeypatch.setattr(write_mod, "UPLOAD_CHUNK", 4)
+    monkeypatch.setattr(drive_ops, "UPLOAD_CHUNK", 4)
     ranges = []
 
     def _chunk_cb(url, **kwargs):

--- a/python/tests/core/sharepoint/test_write.py
+++ b/python/tests/core/sharepoint/test_write.py
@@ -1,6 +1,7 @@
 import pytest
 from aioresponses import CallbackResult, aioresponses
 
+import mirage.core.msgraph.drive_ops as drive_ops
 import mirage.core.sharepoint.write as write_mod
 from mirage.accessor.sharepoint import SharePointAccessor, SharePointConfig
 from mirage.core.sharepoint._resolver import _drive_cache, _site_cache
@@ -57,7 +58,7 @@ async def test_write_small_file():
 @pytest.mark.asyncio
 async def test_write_large_file_uses_upload_session(monkeypatch):
     monkeypatch.setattr(write_mod, "SIMPLE_UPLOAD_MAX", 4)
-    monkeypatch.setattr(write_mod, "UPLOAD_CHUNK", 4)
+    monkeypatch.setattr(drive_ops, "UPLOAD_CHUNK", 4)
     ranges = []
 
     def _chunk_cb(url, **kwargs):
@@ -86,7 +87,7 @@ async def test_write_large_file_uses_upload_session(monkeypatch):
 @pytest.mark.asyncio
 async def test_upload_session_requests_replace(monkeypatch):
     monkeypatch.setattr(write_mod, "SIMPLE_UPLOAD_MAX", 4)
-    monkeypatch.setattr(write_mod, "UPLOAD_CHUNK", 8)
+    monkeypatch.setattr(drive_ops, "UPLOAD_CHUNK", 8)
     captured = {}
 
     def _session_cb(url, **kwargs):


### PR DESCRIPTION
OneDrive and SharePoint are the same Graph drive API spelled two ways; after #531 they carried duplicated transport and freshly duplicated conflict machinery. This unifies both onto shared code so future Graph fixes land in each by construction.

- `OneDriveConfig` subclasses `MsGraphConfig` (the SharePoint precedent); `onedrive/_client.py` keeps only its addressing helpers (`item_url`/`drive_base`/`drive_ref_path`/`split_path`) and re-exports the shared msgraph transport. The two transports were byte-identical apart from config annotations. `GRAPH_API` stays patchable in `onedrive/_client` for the fake.
- New `mirage/core/msgraph/drive_ops.py`: `DriveLoc` is the addressing seam (maps `(path, action)` to URLs, carries a drive identity for cross-drive comparison and a mount-relative path for cache invalidation) so onedrive's key_prefix drive and sharepoint's resolved drive ids plug into the same ops: `copy_once`/`copy_tree` (conflict merge recipe), `rename_replace`, `create_child_folder`, `upload_session_write`.
- onedrive and sharepoint `copy`/`rename`/`mkdir`/`write` become thin wrappers. Net −298 lines.

## Verification
- onedrive + sharepoint + msgraph unit suites green (150 tests, incl. all conflict-path tests from #531 unchanged)
- onedrive shared battery 890/890 against the strict fake, on top of merged main
- Legacy `integ/onedrive.py` and `integ/onedrive_cases.py` byte-match their truth files
- mypy 1579 files clean, pre-commit clean