### PR TITLE
feat(store): generation CAS on the workspace meta record

### DIFF
--- a/integ/state_store.py
+++ b/integ/state_store.py
@@ -77,6 +77,8 @@ async def read(prefix: str) -> None:
     probe = RedisWorkspaceStateStore(url=REDIS_URL, key_prefix=prefix)
     meta = await probe.load_meta(WORKSPACE_ID)
     check("py read: meta record found", meta is not None)
+    check("py read: meta carries a CAS generation", meta is not None
+          and int(meta.get("generation", 0)) >= 1, f"got {meta!r}")
     pointer = meta.get("default_session_id") if meta is not None else None
     check("py read: default session id is uuid7",
           isinstance(pointer, str) and uuid.UUID(pointer).version == 7,

--- a/integ/state_store.ts
+++ b/integ/state_store.ts
@@ -70,6 +70,11 @@ async function read(prefix: string): Promise<void> {
   const probe = new RedisWorkspaceStateStore({ url: REDIS_URL, keyPrefix: prefix })
   const meta = await probe.loadMeta(WORKSPACE_ID)
   check('ts read: meta record found', meta !== null)
+  check(
+    'ts read: meta carries a CAS generation',
+    meta !== null && Number(meta.generation ?? 0) >= 1,
+    JSON.stringify(meta),
+  )
   const pointer = meta?.default_session_id
   const UUID7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
   check(

--- a/python/mirage/workspace/session/manager.py
+++ b/python/mirage/workspace/session/manager.py
@@ -18,9 +18,8 @@ import copy
 from mirage.types import MountMode
 from mirage.workspace.session.ram import RAMSessionStore
 from mirage.workspace.session.session import Session
-from mirage.workspace.session.store import SessionFields, SessionStore
-
-MAX_FLUSH_RETRIES = 3
+from mirage.workspace.session.store import (CAS_MAX_RETRIES, SessionFields,
+                                            SessionStore, generation_of)
 
 
 class SessionManager:
@@ -146,7 +145,7 @@ class SessionManager:
         sid = session.session_id
         if session.to_dict() == self._persisted.get(sid):
             return  # clean: the store already has exactly this state
-        for _ in range(MAX_FLUSH_RETRIES):
+        for _ in range(CAS_MAX_RETRIES):
             expected = session.generation
             session.generation = expected + 1
             fields = session.to_dict()
@@ -161,7 +160,7 @@ class SessionManager:
             session.generation = expected
             stored = (await self._store.load()).get(sid)
             if stored is not None:
-                session.generation = int(stored.get("generation", 0))
+                session.generation = generation_of(stored)
         raise RuntimeError(
             f"session {sid!r} flush kept conflicting with another writer")
 

--- a/python/mirage/workspace/session/ram.py
+++ b/python/mirage/workspace/session/ram.py
@@ -14,7 +14,8 @@
 
 from collections.abc import Iterable
 
-from mirage.workspace.session.store import SessionFields, SessionStore
+from mirage.workspace.session.store import (SessionFields, SessionStore,
+                                            generation_of)
 
 
 class RAMSessionStore(SessionStore):
@@ -36,8 +37,7 @@ class RAMSessionStore(SessionStore):
     async def cas_set(self, session_id: str, fields: SessionFields,
                       expected_generation: int) -> bool:
         stored = self._entries.get(session_id)
-        current = 0 if stored is None else int(stored.get("generation", 0))
-        if current != expected_generation:
+        if generation_of(stored) != expected_generation:
             return False
         self._entries[session_id] = dict(fields)
         return True

--- a/python/mirage/workspace/session/store.py
+++ b/python/mirage/workspace/session/store.py
@@ -21,6 +21,23 @@ from typing import Any
 # shell state (functions, arrays, stdin buffers) never persists.
 SessionFields = dict[str, Any]
 
+# Shared cap for every generation-CAS retry loop (session flush,
+# workspace meta): losing this many times in a row on a rarely written
+# record is a bug to surface, not contention to absorb.
+CAS_MAX_RETRIES = 3
+
+
+def generation_of(fields: SessionFields | None) -> int:
+    """A stored record's CAS generation; a missing record or a legacy
+    record without the field counts as 0.
+
+    Args:
+        fields (SessionFields | None): the stored record, or None.
+    """
+    if fields is None:
+        return 0
+    return int(fields.get("generation", 0))
+
 
 class SessionStore(ABC):
     """Storage seam for durable session state.

--- a/python/mirage/workspace/snapshot/state.py
+++ b/python/mirage/workspace/snapshot/state.py
@@ -14,7 +14,6 @@
 
 import importlib
 import tempfile
-import time
 
 from mirage.observe.log_entry import EVENT_CLEAR, EVENT_COMMAND, EVENT_DELETE
 from mirage.resource.history import HISTORY_PREFIX
@@ -187,14 +186,10 @@ async def _restore_sessions(ws, state: dict) -> None:
         # one, and the discovery record's pointer follows it.
         ws._session_mgr.adopt_default(default_sid)
         ws._default_session_id = default_sid
-        existing = await ws._state_store.load_meta(ws._workspace_id)
-        await ws._state_store.set_meta(
-            ws._workspace_id, {
-                **(existing or {}),
-                "workspace_id": ws._workspace_id,
-                "default_session_id": default_sid,
-                "created_at": (existing or {}).get("created_at", time.time()),
-            })
+        await ws._state_store.replace_meta(ws._workspace_id, {
+            "workspace_id": ws._workspace_id,
+            "default_session_id": default_sid,
+        })
         ws._meta_written = True
     restored: list = []
     for s_data in state.get(StateKey.SESSIONS, []):

--- a/python/mirage/workspace/store/base.py
+++ b/python/mirage/workspace/store/base.py
@@ -18,15 +18,14 @@ from typing import Any
 
 from mirage.observe.store import ObserverStore
 from mirage.workspace.mount.namespace import NamespaceStore
-from mirage.workspace.session.store import SessionStore
+from mirage.workspace.session.store import (CAS_MAX_RETRIES, SessionStore,
+                                            generation_of)
 
 # One workspace's metadata record: the JSON-able discovery payload
 # (workspace_id, default_session_id, created_at, generation). This is
 # what another process reads to find a workspace's sessions and its
 # default session before binding to it.
 WorkspaceFields = dict[str, Any]
-
-MAX_META_RETRIES = 3
 
 
 class WorkspaceStateStore(ABC):
@@ -109,10 +108,10 @@ class WorkspaceStateStore(ABC):
         ``created_at``, bumps the generation, and retries when another
         writer got there first. Returns the record as written.
         """
-        for _ in range(MAX_META_RETRIES):
+        for _ in range(CAS_MAX_RETRIES):
             existing = await self.load_meta(workspace_id)
             stored = existing if existing is not None else {}
-            expected = int(stored.get("generation", 0))
+            expected = generation_of(existing)
             merged = {
                 **stored,
                 **fields,

--- a/python/mirage/workspace/store/base.py
+++ b/python/mirage/workspace/store/base.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import time
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -20,10 +21,12 @@ from mirage.workspace.mount.namespace import NamespaceStore
 from mirage.workspace.session.store import SessionStore
 
 # One workspace's metadata record: the JSON-able discovery payload
-# (workspace_id, default_session_id, created_at). This is what another
-# process reads to find a workspace's sessions and its default session
-# before binding to it.
+# (workspace_id, default_session_id, created_at, generation). This is
+# what another process reads to find a workspace's sessions and its
+# default session before binding to it.
 WorkspaceFields = dict[str, Any]
+
+MAX_META_RETRIES = 3
 
 
 class WorkspaceStateStore(ABC):
@@ -83,6 +86,44 @@ class WorkspaceStateStore(ABC):
         target = self._workspace_override or self
         await target._set_meta(workspace_id, fields)
 
+    async def cas_set_meta(self, workspace_id: str, fields: WorkspaceFields,
+                           expected_generation: int) -> bool:
+        """Write the metadata record iff its stored generation matches.
+
+        Same optimistic-concurrency contract as SessionStore.cas_set: a
+        missing record (and a legacy record without the field) counts as
+        generation 0, so create-if-absent is ``expected_generation=0``.
+        Returns True when the write landed, False on conflict.
+        """
+        target = self._workspace_override or self
+        return await target._cas_set_meta(workspace_id, fields,
+                                          expected_generation)
+
+    async def replace_meta(self, workspace_id: str,
+                           fields: WorkspaceFields) -> WorkspaceFields:
+        """CAS-write ``fields`` over the stored record, retrying on
+        conflict.
+
+        Ours-wins content (snapshot restore semantics): each attempt
+        merges ``fields`` over the stored record, preserves the stored
+        ``created_at``, bumps the generation, and retries when another
+        writer got there first. Returns the record as written.
+        """
+        for _ in range(MAX_META_RETRIES):
+            existing = await self.load_meta(workspace_id)
+            stored = existing if existing is not None else {}
+            expected = int(stored.get("generation", 0))
+            merged = {
+                **stored,
+                **fields,
+                "created_at": stored.get("created_at", time.time()),
+                "generation": expected + 1,
+            }
+            if await self.cas_set_meta(workspace_id, merged, expected):
+                return merged
+        raise RuntimeError(f"workspace {workspace_id!r} meta kept "
+                           "conflicting with another writer")
+
     async def close(self) -> None:
         """Release connections held by this provider and its overrides."""
         for override in (self._namespace_override, self._observer_override,
@@ -111,6 +152,11 @@ class WorkspaceStateStore(ABC):
     async def _set_meta(self, workspace_id: str,
                         fields: WorkspaceFields) -> None:
         """Backend write of one metadata record."""
+
+    @abstractmethod
+    async def _cas_set_meta(self, workspace_id: str, fields: WorkspaceFields,
+                            expected_generation: int) -> bool:
+        """Backend conditional write of one metadata record."""
 
     @abstractmethod
     async def _close(self) -> None:

--- a/python/mirage/workspace/store/ram.py
+++ b/python/mirage/workspace/store/ram.py
@@ -15,7 +15,7 @@
 from mirage.observe.store import ObserverStore, RAMObserverStore
 from mirage.workspace.mount.namespace import NamespaceStore, RAMNamespaceStore
 from mirage.workspace.session.ram import RAMSessionStore
-from mirage.workspace.session.store import SessionStore
+from mirage.workspace.session.store import SessionStore, generation_of
 from mirage.workspace.store.base import WorkspaceFields, WorkspaceStateStore
 
 
@@ -60,8 +60,7 @@ class RAMWorkspaceStateStore(WorkspaceStateStore):
     async def _cas_set_meta(self, workspace_id: str, fields: WorkspaceFields,
                             expected_generation: int) -> bool:
         stored = self._meta.get(workspace_id)
-        current = 0 if stored is None else int(stored.get("generation", 0))
-        if current != expected_generation:
+        if generation_of(stored) != expected_generation:
             return False
         self._meta[workspace_id] = dict(fields)
         return True

--- a/python/mirage/workspace/store/ram.py
+++ b/python/mirage/workspace/store/ram.py
@@ -57,5 +57,14 @@ class RAMWorkspaceStateStore(WorkspaceStateStore):
                         fields: WorkspaceFields) -> None:
         self._meta[workspace_id] = dict(fields)
 
+    async def _cas_set_meta(self, workspace_id: str, fields: WorkspaceFields,
+                            expected_generation: int) -> bool:
+        stored = self._meta.get(workspace_id)
+        current = 0 if stored is None else int(stored.get("generation", 0))
+        if current != expected_generation:
+            return False
+        self._meta[workspace_id] = dict(fields)
+        return True
+
     async def _close(self) -> None:
         pass

--- a/python/mirage/workspace/store/redis.py
+++ b/python/mirage/workspace/store/redis.py
@@ -21,7 +21,7 @@ from mirage.observe.redis_store import RedisObserverStore
 from mirage.observe.store import ObserverStore
 from mirage.workspace.mount.namespace.redis import RedisNamespaceStore
 from mirage.workspace.mount.namespace.store import NamespaceStore
-from mirage.workspace.session.redis import RedisSessionStore
+from mirage.workspace.session.redis import CAS_SCRIPT, RedisSessionStore
 from mirage.workspace.session.store import SessionStore
 from mirage.workspace.store.base import WorkspaceFields, WorkspaceStateStore
 
@@ -51,6 +51,9 @@ class RedisWorkspaceStateStore(WorkspaceStateStore):
         self._prefix = key_prefix
         self._meta_client = aioredis.from_url(url)
         self._meta_key = f"{key_prefix}workspaces"
+        # Same generic hash-field CAS the session store uses: the meta
+        # hash is keyed by workspace id instead of session id.
+        self._meta_cas = self._meta_client.register_script(CAS_SCRIPT)
         self._namespaces: dict[str, RedisNamespaceStore] = {}
         self._observers: dict[str, RedisObserverStore] = {}
         self._sessions: dict[str, RedisSessionStore] = {}
@@ -86,6 +89,16 @@ class RedisWorkspaceStateStore(WorkspaceStateStore):
             Awaitable,
             self._meta_client.hset(self._meta_key, workspace_id,
                                    json.dumps(fields)))
+
+    async def _cas_set_meta(self, workspace_id: str, fields: WorkspaceFields,
+                            expected_generation: int) -> bool:
+        result = await self._meta_cas(keys=[self._meta_key],
+                                      args=[
+                                          workspace_id,
+                                          json.dumps(fields),
+                                          expected_generation,
+                                      ])
+        return bool(result)
 
     async def _close(self) -> None:
         for ns in self._namespaces.values():

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -704,13 +704,19 @@ class Workspace:
             return
         existing = await self._state_store.load_meta(self._workspace_id)
         if existing is None:
-            await self._state_store.set_meta(
+            created = await self._state_store.cas_set_meta(
                 self._workspace_id, {
                     "workspace_id": self._workspace_id,
                     "default_session_id": self._default_session_id,
                     "created_at": time.time(),
-                })
-        else:
+                    "generation": 1,
+                }, 0)
+            if not created:
+                # Lost the create race: a sibling registered first and
+                # its record wins, like any other existing record.
+                existing = await self._state_store.load_meta(self._workspace_id
+                                                             )
+        if existing is not None:
             stored = existing.get("default_session_id")
             if not self._session_id_explicit and isinstance(stored, str):
                 self._session_mgr.adopt_default(stored)

--- a/python/tests/workspace/store/test_ram.py
+++ b/python/tests/workspace/store/test_ram.py
@@ -50,3 +50,59 @@ async def test_meta_roundtrip_and_copies():
     loaded["default_session_id"] = "mutated"
     assert (await store.load_meta("a"))["default_session_id"] == "default"
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_cas_set_meta_create_if_absent():
+    store = RAMWorkspaceStateStore()
+    fields = {"workspace_id": "a", "generation": 1}
+    assert await store.cas_set_meta("a", fields, 0) is True
+    # A second create loses: the record now exists at generation 1.
+    assert await store.cas_set_meta("a", {"generation": 1}, 0) is False
+    assert (await store.load_meta("a"))["workspace_id"] == "a"
+
+
+@pytest.mark.asyncio
+async def test_cas_set_meta_stale_generation_conflicts():
+    store = RAMWorkspaceStateStore()
+    await store.set_meta("a", {"workspace_id": "a", "generation": 2})
+    lost = {"workspace_id": "a", "generation": 1}
+    assert await store.cas_set_meta("a", lost, 0) is False
+    assert (await store.load_meta("a"))["generation"] == 2
+
+
+@pytest.mark.asyncio
+async def test_cas_set_meta_legacy_record_counts_as_generation_zero():
+    store = RAMWorkspaceStateStore()
+    await store.set_meta("a", {"workspace_id": "a"})
+    fields = {"workspace_id": "a", "default_session_id": "s", "generation": 1}
+    assert await store.cas_set_meta("a", fields, 0) is True
+    assert (await store.load_meta("a"))["default_session_id"] == "s"
+
+
+@pytest.mark.asyncio
+async def test_replace_meta_preserves_created_at_and_serializes():
+    store = RAMWorkspaceStateStore()
+    await store.set_meta(
+        "a", {
+            "workspace_id": "a",
+            "default_session_id": "old",
+            "created_at": 1.0,
+            "generation": 4,
+        })
+    written = await store.replace_meta("a", {"default_session_id": "new"})
+    assert written["default_session_id"] == "new"
+    assert written["created_at"] == 1.0
+    assert written["generation"] == 5
+    assert await store.load_meta("a") == written
+
+
+@pytest.mark.asyncio
+async def test_replace_meta_creates_when_absent():
+    store = RAMWorkspaceStateStore()
+    written = await store.replace_meta("a", {
+        "workspace_id": "a",
+        "default_session_id": "s",
+    })
+    assert written["generation"] == 1
+    assert written["created_at"] > 0

--- a/python/tests/workspace/store/test_redis.py
+++ b/python/tests/workspace/store/test_redis.py
@@ -77,6 +77,57 @@ async def test_meta_visible_across_providers(prefix, store):
 
 
 @pytest.mark.asyncio
+async def test_cas_set_meta_create_race_one_winner(prefix, store):
+    """Two providers race the discovery-record create; exactly one
+    conditional write lands and the loser sees the winner's record."""
+    sibling = RedisWorkspaceStateStore(url=REDIS_URL, key_prefix=prefix)
+    try:
+        mine = {
+            "workspace_id": "ws1",
+            "default_session_id": "a",
+            "generation": 1
+        }
+        theirs = {
+            "workspace_id": "ws1",
+            "default_session_id": "b",
+            "generation": 1
+        }
+        assert await store.cas_set_meta("ws1", mine, 0) is True
+        assert await sibling.cas_set_meta("ws1", theirs, 0) is False
+        loaded = await sibling.load_meta("ws1")
+        assert loaded is not None
+        assert loaded["default_session_id"] == "a"
+    finally:
+        await sibling.close()
+
+
+@pytest.mark.asyncio
+async def test_cas_set_meta_stale_generation_conflicts(store):
+    await store.set_meta("ws1", {"workspace_id": "ws1", "generation": 2})
+    lost = {"workspace_id": "ws1", "generation": 1}
+    assert await store.cas_set_meta("ws1", lost, 0) is False
+    meta = await store.load_meta("ws1")
+    assert meta is not None
+    assert meta["generation"] == 2
+
+
+@pytest.mark.asyncio
+async def test_replace_meta_serializes_over_the_wire(store):
+    await store.set_meta(
+        "ws1", {
+            "workspace_id": "ws1",
+            "default_session_id": "old",
+            "created_at": 1.0,
+            "generation": 4,
+        })
+    written = await store.replace_meta("ws1", {"default_session_id": "new"})
+    assert written["generation"] == 5
+    assert written["created_at"] == 1.0
+    loaded = await store.load_meta("ws1")
+    assert loaded == written
+
+
+@pytest.mark.asyncio
 async def test_workspace_discovery_and_session_sharing(prefix):
     """The kernel-tier flow: one process runs a workspace, a sibling
     with only the store config + workspace id finds its default

--- a/python/tests/workspace/store/test_workspace_wiring.py
+++ b/python/tests/workspace/store/test_workspace_wiring.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
 import uuid
 
 import pytest
@@ -20,7 +21,17 @@ from mirage.observe.store import RAMObserverStore
 from mirage.resource.ram import RAMResource
 from mirage.types import MountMode
 from mirage.workspace import Workspace
+from mirage.workspace.store.base import WorkspaceFields
 from mirage.workspace.store.ram import RAMWorkspaceStateStore
+
+
+class YieldingStore(RAMWorkspaceStateStore):
+    """Yields to the event loop on meta reads so two concurrent
+    attaches both observe the record as absent before either writes."""
+
+    async def _load_meta(self, workspace_id: str) -> WorkspaceFields | None:
+        await asyncio.sleep(0)
+        return await super()._load_meta(workspace_id)
 
 
 @pytest.mark.asyncio
@@ -114,6 +125,32 @@ async def test_existing_meta_wins():
     assert meta["default_session_id"] == "sess_x"
     assert meta["created_at"] == 1.0
     await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_attach_single_discovery_record():
+    """Two processes attach the same fresh workspace id at once: the
+    CAS create admits exactly one discovery record and the loser adopts
+    the winner's default session instead of clobbering the pointer."""
+    store = YieldingStore()
+    ram = RAMResource()
+    ws_a = Workspace({"/data": ram},
+                     mode=MountMode.EXEC,
+                     workspace_id="ws-a",
+                     store=store)
+    ws_b = Workspace({"/data": ram},
+                     mode=MountMode.EXEC,
+                     workspace_id="ws-a",
+                     store=store)
+    await asyncio.gather(ws_a.ensure_sessions_loaded(),
+                         ws_b.ensure_sessions_loaded())
+    meta = await store.load_meta("ws-a")
+    assert meta is not None
+    assert meta["generation"] == 1
+    assert ws_a.default_session_id == ws_b.default_session_id
+    assert meta["default_session_id"] == ws_a.default_session_id
+    await ws_a.close()
+    await ws_b.close()
 
 
 @pytest.mark.asyncio

--- a/typescript/packages/core/src/workspace/session/manager.ts
+++ b/typescript/packages/core/src/workspace/session/manager.ts
@@ -14,12 +14,10 @@
 
 import { Session } from './session.ts'
 import { RAMSessionStore } from './ram.ts'
-import type { SessionFields, SessionStore } from './store.ts'
+import { CAS_MAX_RETRIES, generationOf, type SessionFields, type SessionStore } from './store.ts'
 import type { MountMode } from '../../types.ts'
 
 type StoredSession = Parameters<typeof Session.fromJSON>[0]
-
-const MAX_FLUSH_RETRIES = 3
 
 /**
  * Owns the live session table over a storage-agnostic SessionStore.
@@ -146,7 +144,7 @@ export class SessionManager {
     const sid = session.sessionId
     // Clean: the store already has exactly this state.
     if (JSON.stringify(session.toJSON()) === this.persisted.get(sid)) return
-    for (let attempt = 0; attempt < MAX_FLUSH_RETRIES; attempt++) {
+    for (let attempt = 0; attempt < CAS_MAX_RETRIES; attempt++) {
       const expected = session.generation
       session.generation = expected + 1
       const fields = session.toJSON() as SessionFields
@@ -159,7 +157,7 @@ export class SessionManager {
       session.generation = expected
       const stored = (await this.sessionStore.load()).get(sid)
       if (stored !== undefined) {
-        session.generation = Number(stored.generation ?? 0)
+        session.generation = generationOf(stored)
       }
     }
     throw new Error(`session ${sid} flush kept conflicting with another writer`)

--- a/typescript/packages/core/src/workspace/session/ram.ts
+++ b/typescript/packages/core/src/workspace/session/ram.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { SessionStore, type SessionFields } from './store.ts'
+import { generationOf, SessionStore, type SessionFields } from './store.ts'
 
 // SessionStore held in process memory (the default). Durability equals
 // the process lifetime; snapshots remain the only persistence. Redis-backed
@@ -33,8 +33,7 @@ export class RAMSessionStore extends SessionStore {
 
   casSet(sessionId: string, fields: SessionFields, expectedGeneration: number): Promise<boolean> {
     const stored = this.entries.get(sessionId)
-    const current = stored === undefined ? 0 : Number(stored.generation ?? 0)
-    if (current !== expectedGeneration) return Promise.resolve(false)
+    if (generationOf(stored) !== expectedGeneration) return Promise.resolve(false)
     this.entries.set(sessionId, { ...fields })
     return Promise.resolve(true)
   }

--- a/typescript/packages/core/src/workspace/session/store.ts
+++ b/typescript/packages/core/src/workspace/session/store.ts
@@ -18,6 +18,20 @@
 // (functions, arrays, stdin buffers) never persists.
 export type SessionFields = Record<string, unknown>
 
+// Shared cap for every generation-CAS retry loop (session flush,
+// workspace meta): losing this many times in a row on a rarely written
+// record is a bug to surface, not contention to absorb.
+export const CAS_MAX_RETRIES = 3
+
+/**
+ * A stored record's CAS generation; a missing record or a legacy
+ * record without the field counts as 0.
+ */
+export function generationOf(fields: Record<string, unknown> | null | undefined): number {
+  if (fields === null || fields === undefined) return 0
+  return Number(fields.generation ?? 0)
+}
+
 /**
  * Storage seam for durable session state. Abstract base.
  *

--- a/typescript/packages/core/src/workspace/store/base.ts
+++ b/typescript/packages/core/src/workspace/store/base.ts
@@ -14,15 +14,13 @@
 
 import type { ObserverStore } from '../../observe/store.ts'
 import type { NamespaceStore } from '../mount/namespace/store.ts'
-import type { SessionStore } from '../session/store.ts'
+import { CAS_MAX_RETRIES, generationOf, type SessionStore } from '../session/store.ts'
 
 // One workspace's metadata record: the JSON-able discovery payload
 // (workspace_id, default_session_id, created_at, generation). This is
 // what another process reads to find a workspace's sessions and its
 // default session before binding to it.
 export type WorkspaceFields = Record<string, unknown>
-
-const MAX_META_RETRIES = 3
 
 export interface WorkspaceStateStoreOverrides {
   namespace?: WorkspaceStateStore
@@ -112,10 +110,10 @@ export abstract class WorkspaceStateStore {
    * writer got there first. Resolves with the record as written.
    */
   async replaceMeta(workspaceId: string, fields: WorkspaceFields): Promise<WorkspaceFields> {
-    for (let attempt = 0; attempt < MAX_META_RETRIES; attempt++) {
+    for (let attempt = 0; attempt < CAS_MAX_RETRIES; attempt++) {
       const existing = await this.loadMeta(workspaceId)
       const stored = existing ?? {}
-      const expected = Number(stored.generation ?? 0)
+      const expected = generationOf(existing)
       const merged = {
         ...stored,
         ...fields,

--- a/typescript/packages/core/src/workspace/store/base.ts
+++ b/typescript/packages/core/src/workspace/store/base.ts
@@ -17,10 +17,12 @@ import type { NamespaceStore } from '../mount/namespace/store.ts'
 import type { SessionStore } from '../session/store.ts'
 
 // One workspace's metadata record: the JSON-able discovery payload
-// (workspace_id, default_session_id, created_at). This is what another
-// process reads to find a workspace's sessions and its default session
-// before binding to it.
+// (workspace_id, default_session_id, created_at, generation). This is
+// what another process reads to find a workspace's sessions and its
+// default session before binding to it.
 export type WorkspaceFields = Record<string, unknown>
+
+const MAX_META_RETRIES = 3
 
 export interface WorkspaceStateStoreOverrides {
   namespace?: WorkspaceStateStore
@@ -85,6 +87,46 @@ export abstract class WorkspaceStateStore {
     return (this.workspaceOverride ?? this).writeMeta(workspaceId, fields)
   }
 
+  /**
+   * Write the metadata record iff its stored generation matches.
+   *
+   * Same optimistic-concurrency contract as SessionStore.casSet: a
+   * missing record (and a legacy record without the field) counts as
+   * generation 0, so create-if-absent is `expectedGeneration = 0`.
+   * Resolves true when the write landed, false on conflict.
+   */
+  casSetMeta(
+    workspaceId: string,
+    fields: WorkspaceFields,
+    expectedGeneration: number,
+  ): Promise<boolean> {
+    return (this.workspaceOverride ?? this).casWriteMeta(workspaceId, fields, expectedGeneration)
+  }
+
+  /**
+   * CAS-write `fields` over the stored record, retrying on conflict.
+   *
+   * Ours-wins content (snapshot restore semantics): each attempt
+   * merges `fields` over the stored record, preserves the stored
+   * `created_at`, bumps the generation, and retries when another
+   * writer got there first. Resolves with the record as written.
+   */
+  async replaceMeta(workspaceId: string, fields: WorkspaceFields): Promise<WorkspaceFields> {
+    for (let attempt = 0; attempt < MAX_META_RETRIES; attempt++) {
+      const existing = await this.loadMeta(workspaceId)
+      const stored = existing ?? {}
+      const expected = Number(stored.generation ?? 0)
+      const merged = {
+        ...stored,
+        ...fields,
+        created_at: stored.created_at ?? Date.now() / 1000,
+        generation: expected + 1,
+      }
+      if (await this.casSetMeta(workspaceId, merged, expected)) return merged
+    }
+    throw new Error(`workspace ${workspaceId} meta kept conflicting with another writer`)
+  }
+
   /** Release connections held by this provider and its overrides. */
   async close(): Promise<void> {
     for (const override of [this.namespaceOverride, this.observerOverride, this.workspaceOverride])
@@ -97,5 +139,10 @@ export abstract class WorkspaceStateStore {
   protected abstract makeSessions(workspaceId: string): SessionStore
   protected abstract readMeta(workspaceId: string): Promise<WorkspaceFields | null>
   protected abstract writeMeta(workspaceId: string, fields: WorkspaceFields): Promise<void>
+  protected abstract casWriteMeta(
+    workspaceId: string,
+    fields: WorkspaceFields,
+    expectedGeneration: number,
+  ): Promise<boolean>
   protected abstract closeSelf(): Promise<void>
 }

--- a/typescript/packages/core/src/workspace/store/ram.test.ts
+++ b/typescript/packages/core/src/workspace/store/ram.test.ts
@@ -48,6 +48,51 @@ describe('RAMWorkspaceStateStore', () => {
     expect((await store.loadMeta('a'))?.default_session_id).toBe('default')
     await store.close()
   })
+
+  it('casSetMeta creates if absent and admits one winner', async () => {
+    const store = new RAMWorkspaceStateStore()
+    expect(await store.casSetMeta('a', { workspace_id: 'a', generation: 1 }, 0)).toBe(true)
+    expect(await store.casSetMeta('a', { workspace_id: 'b', generation: 1 }, 0)).toBe(false)
+    expect((await store.loadMeta('a'))?.workspace_id).toBe('a')
+  })
+
+  it('casSetMeta rejects a stale generation', async () => {
+    const store = new RAMWorkspaceStateStore()
+    await store.setMeta('a', { workspace_id: 'a', generation: 2 })
+    expect(await store.casSetMeta('a', { workspace_id: 'a', generation: 1 }, 0)).toBe(false)
+    expect((await store.loadMeta('a'))?.generation).toBe(2)
+  })
+
+  it('casSetMeta treats a legacy record as generation 0', async () => {
+    const store = new RAMWorkspaceStateStore()
+    await store.setMeta('a', { workspace_id: 'a' })
+    expect(
+      await store.casSetMeta('a', { workspace_id: 'a', default_session_id: 's', generation: 1 }, 0),
+    ).toBe(true)
+    expect((await store.loadMeta('a'))?.default_session_id).toBe('s')
+  })
+
+  it('replaceMeta preserves created_at and serializes on the counter', async () => {
+    const store = new RAMWorkspaceStateStore()
+    await store.setMeta('a', {
+      workspace_id: 'a',
+      default_session_id: 'old',
+      created_at: 1.0,
+      generation: 4,
+    })
+    const written = await store.replaceMeta('a', { default_session_id: 'new' })
+    expect(written.default_session_id).toBe('new')
+    expect(written.created_at).toBe(1.0)
+    expect(written.generation).toBe(5)
+    expect(await store.loadMeta('a')).toEqual(written)
+  })
+
+  it('replaceMeta creates when absent', async () => {
+    const store = new RAMWorkspaceStateStore()
+    const written = await store.replaceMeta('a', { workspace_id: 'a', default_session_id: 's' })
+    expect(written.generation).toBe(1)
+    expect(Number(written.created_at)).toBeGreaterThan(0)
+  })
 })
 
 describe('WorkspaceStateStore group overrides', () => {

--- a/typescript/packages/core/src/workspace/store/ram.ts
+++ b/typescript/packages/core/src/workspace/store/ram.ts
@@ -74,6 +74,18 @@ export class RAMWorkspaceStateStore extends WorkspaceStateStore {
     return Promise.resolve()
   }
 
+  protected casWriteMeta(
+    workspaceId: string,
+    fields: WorkspaceFields,
+    expectedGeneration: number,
+  ): Promise<boolean> {
+    const stored = this.meta.get(workspaceId)
+    const current = stored === undefined ? 0 : Number(stored.generation ?? 0)
+    if (current !== expectedGeneration) return Promise.resolve(false)
+    this.meta.set(workspaceId, { ...fields })
+    return Promise.resolve(true)
+  }
+
   protected closeSelf(): Promise<void> {
     return Promise.resolve()
   }

--- a/typescript/packages/core/src/workspace/store/ram.ts
+++ b/typescript/packages/core/src/workspace/store/ram.ts
@@ -16,7 +16,7 @@ import { RAMObserverStore, type ObserverStore } from '../../observe/store.ts'
 import { RAMNamespaceStore } from '../mount/namespace/ram.ts'
 import type { NamespaceStore } from '../mount/namespace/store.ts'
 import { RAMSessionStore } from '../session/ram.ts'
-import type { SessionStore } from '../session/store.ts'
+import { generationOf, type SessionStore } from '../session/store.ts'
 import {
   WorkspaceStateStore,
   type WorkspaceFields,
@@ -80,8 +80,7 @@ export class RAMWorkspaceStateStore extends WorkspaceStateStore {
     expectedGeneration: number,
   ): Promise<boolean> {
     const stored = this.meta.get(workspaceId)
-    const current = stored === undefined ? 0 : Number(stored.generation ?? 0)
-    if (current !== expectedGeneration) return Promise.resolve(false)
+    if (generationOf(stored) !== expectedGeneration) return Promise.resolve(false)
     this.meta.set(workspaceId, { ...fields })
     return Promise.resolve(true)
   }

--- a/typescript/packages/core/src/workspace/store/workspace_wiring.test.ts
+++ b/typescript/packages/core/src/workspace/store/workspace_wiring.test.ts
@@ -22,6 +22,15 @@ import { RAMWorkspaceStateStore } from './ram.ts'
 
 const UUID7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
 
+// Yields to the microtask queue on meta reads so two concurrent
+// attaches both observe the record as absent before either writes.
+class YieldingStore extends RAMWorkspaceStateStore {
+  protected override async readMeta(workspaceId: string) {
+    await Promise.resolve()
+    return super.readMeta(workspaceId)
+  }
+}
+
 const open: Workspace[] = []
 
 afterEach(async () => {
@@ -114,6 +123,19 @@ describe('Workspace on a WorkspaceStateStore', () => {
     const meta = await ws.workspaceMeta()
     expect(meta.default_session_id).toBe('sess_x')
     expect(meta.created_at).toBe(1)
+  })
+
+  it('concurrent attach admits a single discovery record', async () => {
+    const store = new YieldingStore()
+    const ram = new RAMResource()
+    const wsA = await mkWs(store, 'ws-a', ram)
+    const wsB = await mkWs(store, 'ws-a', ram)
+    await Promise.all([wsA.ensureSessionsLoaded(), wsB.ensureSessionsLoaded()])
+    const meta = await store.loadMeta('ws-a')
+    expect(meta).not.toBeNull()
+    expect(meta?.generation).toBe(1)
+    expect(wsA.defaultSessionId).toBe(wsB.defaultSessionId)
+    expect(meta?.default_session_id).toBe(wsA.defaultSessionId)
   })
 
   it('same workspace id shares sessions across workspaces', async () => {

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -568,12 +568,9 @@ export class Workspace {
    */
   async adoptDefaultSession(sessionId: string): Promise<void> {
     this.sessionManager.adoptDefault(sessionId)
-    const existing = await this.stateStoreInternal.loadMeta(this.wsId)
-    await this.stateStoreInternal.setMeta(this.wsId, {
-      ...(existing ?? {}),
+    await this.stateStoreInternal.replaceMeta(this.wsId, {
       workspace_id: this.wsId,
       default_session_id: sessionId,
-      created_at: existing?.created_at ?? Date.now() / 1000,
     })
     this.metaWritten = true
   }
@@ -593,14 +590,25 @@ export class Workspace {
    */
   private async ensureMeta(): Promise<void> {
     if (this.metaWritten) return
-    const existing = await this.stateStoreInternal.loadMeta(this.wsId)
+    let existing = await this.stateStoreInternal.loadMeta(this.wsId)
     if (existing === null) {
-      await this.stateStoreInternal.setMeta(this.wsId, {
-        workspace_id: this.wsId,
-        default_session_id: this.sessionManager.defaultId,
-        created_at: Date.now() / 1000,
-      })
-    } else {
+      const created = await this.stateStoreInternal.casSetMeta(
+        this.wsId,
+        {
+          workspace_id: this.wsId,
+          default_session_id: this.sessionManager.defaultId,
+          created_at: Date.now() / 1000,
+          generation: 1,
+        },
+        0,
+      )
+      if (!created) {
+        // Lost the create race: a sibling registered first and its
+        // record wins, like any other existing record.
+        existing = await this.stateStoreInternal.loadMeta(this.wsId)
+      }
+    }
+    if (existing !== null) {
       const stored = existing.default_session_id
       if (!this.sessionIdExplicit && typeof stored === 'string') {
         this.sessionManager.adoptDefault(stored)

--- a/typescript/packages/node/src/workspace/session/redis.ts
+++ b/typescript/packages/node/src/workspace/session/redis.ts
@@ -18,8 +18,9 @@ import { SessionStore, type SessionFields } from '@struktoai/mirage-core'
 import { loadOptionalPeer } from '../../optional_peer.ts'
 
 // Shipped next to this module in src and copied beside the bundle in
-// dist (tsup onSuccess); byte-identical to the Python cas.lua.
-const CAS_SCRIPT = readFileSync(new URL('./cas.lua', import.meta.url), 'utf8')
+// dist (tsup onSuccess); byte-identical to the Python cas.lua. Generic
+// hash-field CAS, shared with the workspace meta record.
+export const CAS_SCRIPT = readFileSync(new URL('./cas.lua', import.meta.url), 'utf8')
 
 export interface RedisSessionStoreOptions {
   url?: string

--- a/typescript/packages/node/src/workspace/store/redis.test.ts
+++ b/typescript/packages/node/src/workspace/store/redis.test.ts
@@ -84,6 +84,43 @@ describe.skipIf(skip)('RedisWorkspaceStateStore', () => {
     }
   })
 
+  it('casSetMeta admits one create winner across providers', async () => {
+    const prefix = testPrefix()
+    const storeA = makeStore(prefix)
+    const storeB = makeStore(prefix)
+    try {
+      const mine = { workspace_id: 'ws1', default_session_id: 'a', generation: 1 }
+      const theirs = { workspace_id: 'ws1', default_session_id: 'b', generation: 1 }
+      expect(await storeA.casSetMeta('ws1', mine, 0)).toBe(true)
+      expect(await storeB.casSetMeta('ws1', theirs, 0)).toBe(false)
+      expect((await storeB.loadMeta('ws1'))?.default_session_id).toBe('a')
+    } finally {
+      await cleanup(prefix)
+      await storeA.close()
+      await storeB.close()
+    }
+  })
+
+  it('replaceMeta serializes over the wire', async () => {
+    const prefix = testPrefix()
+    const store = makeStore(prefix)
+    try {
+      await store.setMeta('ws1', {
+        workspace_id: 'ws1',
+        default_session_id: 'old',
+        created_at: 1.0,
+        generation: 4,
+      })
+      const written = await store.replaceMeta('ws1', { default_session_id: 'new' })
+      expect(written.generation).toBe(5)
+      expect(written.created_at).toBe(1.0)
+      expect(await store.loadMeta('ws1')).toEqual(written)
+    } finally {
+      await cleanup(prefix)
+      await store.close()
+    }
+  })
+
   it('a sibling process discovers the workspace and reads its sessions', async () => {
     const prefix = testPrefix()
     const storeA = makeStore(prefix)

--- a/typescript/packages/node/src/workspace/store/redis.ts
+++ b/typescript/packages/node/src/workspace/store/redis.ts
@@ -24,7 +24,7 @@ import {
 import { RedisObserverStore } from '../../observe/redis_store.ts'
 import { loadOptionalPeer } from '../../optional_peer.ts'
 import { RedisNamespaceStore } from '../namespace/redis.ts'
-import { RedisSessionStore } from '../session/redis.ts'
+import { CAS_SCRIPT, RedisSessionStore } from '../session/redis.ts'
 
 export interface RedisWorkspaceStateStoreOptions extends WorkspaceStateStoreOverrides {
   url?: string
@@ -127,6 +127,21 @@ export class RedisWorkspaceStateStore extends WorkspaceStateStore {
   protected async writeMeta(workspaceId: string, fields: WorkspaceFields): Promise<void> {
     const c = await this.client()
     await c.hSet(this.metaKey, workspaceId, JSON.stringify(fields))
+  }
+
+  // Same generic hash-field CAS the session store uses: the meta hash
+  // is keyed by workspace id instead of session id.
+  protected async casWriteMeta(
+    workspaceId: string,
+    fields: WorkspaceFields,
+    expectedGeneration: number,
+  ): Promise<boolean> {
+    const c = await this.client()
+    const result = await c.eval(CAS_SCRIPT, {
+      keys: [this.metaKey],
+      arguments: [workspaceId, JSON.stringify(fields), String(expectedGeneration)],
+    })
+    return result === 1
   }
 
   protected async closeSelf(): Promise<void> {


### PR DESCRIPTION
Applies the #530 session-record pattern to the other mutable control-plane cell: the workspace discovery record.

- `cas_set_meta(workspace_id, fields, expected_generation)` on the state store ABC. RAM compares in process; Redis reuses the same shipped `cas.lua` (generic hash-field CAS, the meta hash is keyed by workspace id instead of session id). Missing or legacy records count as generation 0.
- `replace_meta` retry helper on the base: merges ours over stored, preserves `created_at`, bumps the generation, 3 attempts. Snapshot restore repoints the discovery record through it, serialized on the counter.
- Race fix in `_ensure_meta`: the create path is a conditional create (`expected_generation=0`). Two processes attaching a fresh workspace id at once mint exactly one discovery record; the loser reloads and adopts the winner's default-session pointer instead of clobbering it. New deterministic race tests in both languages (a store that yields on meta reads so both attaches observe the record as absent before either writes).
- Integ: `state_store` asserts the meta record carries a CAS generation across the wire, both directions.