### PR TITLE
refactor(msgraph): shared item ops, sharepoint joins the shared harness

### DIFF
--- a/integ/bash/arith.json
+++ b/integ/bash/arith.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(( 2 > 1 )); echo code=$?",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(( 0 )); echo code=$?",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "i=0; (( i++ )); echo code=$? i=$i; (( i++ )); echo code=$? i=$i; unset i",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "x=$(( y = 3, y + 2 )); echo $x $y; unset x y",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo $(( -7 / 2 )) $(( -7 % 2 )) $(( 2 ** 10 )) $(( 0x10 )) $(( 010 ))",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "n=0; while (( n < 3 )); do (( n++ )); done; echo n=$n; unset n",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "if (( 2 > 1 )); then echo yes; fi",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(( 1 / 0 )) 2>&1; echo code=$?",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(( 0 && (q = 7) )); echo q=${q:-unset}",
       "expect": {

--- a/integ/bash/bash.json
+++ b/integ/bash/bash.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -v '^#' /.bash_history | tail -n 3",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -v '^#' /.bash_history | tail -n 1",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /.bash_history | sed 's/^#[0-9]*$/#TS/' | tail -n 4",
       "expect": {

--- a/integ/bash/case.json
+++ b/integ/bash/case.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "case x in x) echo one; echo two;; esac",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "case y in x) echo one;; *) echo fall; echo through;; esac",
       "expect": {

--- a/integ/bash/cwd.json
+++ b/integ/bash/cwd.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(pwd)",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && pwd)",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data/sub && pwd)",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data/sub && cd .. && pwd)",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && cat a.txt)",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && cat ./a.txt)",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && cat sub/nested.txt)",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data/sub && cat ../a.txt)",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data/sub && csplit -s -f cs_ nested.txt 2 && cat cs_00 cs_01 && rm cs_00 cs_01)",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data/sub && echo $PWD)",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(echo \"[$HOME]\")",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && cd /data/sub && echo $OLDPWD)",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && cd /data/sub && cd -)",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && cd /data/sub && cd - > /dev/null && pwd)",
       "expect": {
@@ -276,7 +290,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(export HOME=/data && cd ~ && pwd)",
       "expect": {
@@ -295,7 +310,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(export HOME=/data && echo $HOME)",
       "expect": {
@@ -314,7 +330,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(export HOME=/data && cat ~/a.txt)",
       "expect": {
@@ -333,7 +350,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(export HOME=/data && cat ~/sub/nested.txt)",
       "expect": {
@@ -352,7 +370,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd //data && pwd)",
       "expect": {
@@ -371,7 +390,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd -P /data/sub && pwd)",
       "expect": {
@@ -390,7 +410,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd -L /data && pwd)",
       "expect": {
@@ -409,7 +430,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd -- /data && pwd)",
       "expect": {
@@ -428,7 +450,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(export CDPATH=/data && cd sub && pwd)",
       "expect": {
@@ -447,7 +470,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cd /data /data/sub 2>&1",
       "expect": {
@@ -466,7 +490,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cd -x /data 2>&1",
       "expect": {
@@ -485,7 +510,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(unset HOME; cd) 2>&1",
       "expect": {
@@ -504,7 +530,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && cd '~') 2>&1",
       "expect": {

--- a/integ/bash/glob.json
+++ b/integ/bash/glob.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo /data/*.nope",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "test -f /data/one_b* && echo yes",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "f() { echo $1 $#; }; f /data/sorted_*.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo /data/sorted_*.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/g8 && printf 'x *.txt y\\n' | tee /data/g8/l1.txt > /dev/null && printf 'plain\\n' | tee /data/g8/l2.txt > /dev/null && cd /data/g8 && grep -F '*.txt' *.txt && cd / && rm -r /data/g8",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo sub/*.txt && echo *.nope",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "for f in sub/*.txt; do echo $f; done",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "f() { echo $1 $#; }; f sub/*.txt && cd / && rm -r /data/g12",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat *.nope 2>&1",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l s*/x.txt && grep -l hi sub/*.txt",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls sub/*.txt && cd / && rm -r /data/g15",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ln -s /data/sorted_*.txt /data/lnk_multi",
       "expect": {

--- a/integ/bash/history.json
+++ b/integ/bash/history.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "history 2",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /.bash_history",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /.bash_history -type d",
       "expect": {

--- a/integ/bash/midglob.json
+++ b/integ/bash/midglob.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/g15/sub /data/g15/sea && cd /data/g15 && printf 'hi\n' | tee sub/x.txt > /dev/null && printf 'yo\n' | tee sea/x.txt > /dev/null",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo s*/x.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat s*/x.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/g15/s*/x.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo n*/x.txt",
       "expect": {

--- a/integ/bash/pipe.json
+++ b/integ/bash/pipe.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -v c /data/dup.txt | sort | uniq | wc -l",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/csv.csv | cut -d , -f 2 | sort -n",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \".id\" /data/data.jsonl | grep 2",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -name \"*.txt\" | grep dup | wc -l",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/dup.txt | tr a-z A-Z | sort | uniq -c",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head /data/numbers.txt | tail -n 2",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tail /data/a.txt | head -n 1",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk '{print $2}' /data/fields.txt | sort -n",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -v name /data/csv.csv | cut -d , -f 1",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 's/hello/hi/g' /data/mixed.txt | wc -l",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data/sub -name \"*.txt\" | sort | head -n 1",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/dup.txt | tr a-z A-Z | sort | uniq -c | sort -n",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sorted_a.txt /data/sorted_b.txt | head -n 2",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sorted_a.txt /data/sorted_b.txt | head -n 4",
       "expect": {
@@ -276,7 +290,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sorted_a.txt",
       "expect": {
@@ -295,7 +310,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sorted_b.txt",
       "expect": {

--- a/integ/bash/quoted.json
+++ b/integ/bash/quoted.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "\"cat\" /data/a.txt",
       "expect": {

--- a/integ/bash/read.json
+++ b/integ/bash/read.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "printf 'hi there\\n' | read -r v; echo code=$?",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "read -q v 2>&1; echo code=$?",
       "expect": {

--- a/integ/bash/redirect.json
+++ b/integ/bash/redirect.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/g9 && cd /data/g9",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo hi > OUT && cat OUT && cd / && rm -r /data/g9",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo one > sub/LOG",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo two >> sub/LOG && cat sub/LOG",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l < sub/LOG && cd / && rm -r /data/g11",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/g13 && cd /data/g13 && echo hi > CDOUT && cat /data/g13/CDOUT",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo one && echo two > captured && cat captured",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo a > chain && echo b >> chain && cat chain && wc -l < chain",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "{ echo g1; echo g2; } > gout && cat gout && cd / && rm -r /data/g13",
       "expect": {

--- a/integ/bash/relative.json
+++ b/integ/bash/relative.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/g11/sub && cd /data/g11 && printf 'one\\ntwo\\n' | tee sub/README > /dev/null",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat sub/README && wc -l sub/README && head -1 sub/README",
       "expect": {

--- a/integ/bash/relspell.json
+++ b/integ/bash/relspell.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/g14/sub && cd /data/g14 && printf 'hello\n' | tee sub/a.txt > /dev/null && printf 'hello\n' | tee sub/b.txt > /dev/null",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -r hello sub",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find sub -name '*.txt'",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat sub/missing.txt 2>&1",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep hello sub/missing.txt 2>&1",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo ./sub/*.txt",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "du -s sub/",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l sub/a.txt && head -v sub/a.txt && cd / && rm -r /data/g14",
       "expect": {

--- a/integ/bash/relword.json
+++ b/integ/bash/relword.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/g12/sub && cd /data/g12 && printf 'y\n' | tee plain.txt > /dev/null && printf 'x\n' | tee sub/a.txt > /dev/null && printf 'x\n' | tee sub/b.txt > /dev/null",
       "expect": {

--- a/integ/bash/return.json
+++ b/integ/bash/return.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "f() { return x; }; f 2>&1; echo code=$?",
       "expect": {

--- a/integ/bash/shift.json
+++ b/integ/bash/shift.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "shift x 2>&1; echo code=$?",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "shift 1 2 2>&1; echo code=$?",
       "expect": {

--- a/integ/bash/source.json
+++ b/integ/bash/source.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/g10 && cd /data/g10 && printf 'echo sourced-ok\\n' | tee lib.sh > /dev/null",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "source lib.sh && . /data/g10/lib.sh && cd / && rm -r /data/g10",
       "expect": {

--- a/integ/bash/subshell.json
+++ b/integ/bash/subshell.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(x=1; (x=2); echo $x)",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(x=7; (echo $x))",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(export Z=9); echo [$Z]",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(f(){ echo A; }; (f(){ echo B; }); f)",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(nofn(){ echo x; }); nofn 2>/dev/null || echo gone",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(set -- a b c; (set -- x); echo $#)",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(set -- a b; (echo $1 $2))",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data); pwd",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && (cd /data/sub) && pwd)",
       "expect": {

--- a/integ/bash/test.json
+++ b/integ/bash/test.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "test -f plain.txt && echo yes-f && test -d sub && echo yes-d && test -f missing.txt || echo no-f",
       "expect": {

--- a/integ/bash/var.json
+++ b/integ/bash/var.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "E=echo; $E hi",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "C=cat; $C /data/a.txt",
       "expect": {

--- a/integ/crossmount/awk.json
+++ b/integ/crossmount/awk.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk '{print $1}' /data/a.txt /data2/xm.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk 'END{print NR}' /data/a.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/cat.json
+++ b/integ/crossmount/cat.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt /data2/xm.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat -n /data/b.txt /data2/xm.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sorted_*.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/cd.json
+++ b/integ/crossmount/cd.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data2 && cat xm.txt && cd /data && ls b.txt)",
       "expect": {

--- a/integ/crossmount/cmp.json
+++ b/integ/crossmount/cmp.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cmp /data/xdiff.txt /data2/xdiff.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp /data/xdiff.txt /data2/xsame.txt && cmp /data/xdiff.txt /data2/xsame.txt && rm /data/xdiff.txt /data2/xdiff.txt /data2/xsame.txt",
       "expect": {

--- a/integ/crossmount/comm.json
+++ b/integ/crossmount/comm.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "printf 'a\\nb\\nc\\n' | tee /data/xc1.txt > /dev/null && printf 'b\\nc\\nd\\n' | tee /data2/xc2.txt > /dev/null && comm /data/xc1.txt /data2/xc2.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "comm -12 /data/xc1.txt /data2/xc2.txt",
       "expect": {

--- a/integ/crossmount/cp.json
+++ b/integ/crossmount/cp.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp /data/a.txt /data2/xm_copy.txt && cat /data2/xm_copy.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp /data2/xm.txt /data/xm_back.txt && cat /data/xm_back.txt",
       "expect": {

--- a/integ/crossmount/cut.json
+++ b/integ/crossmount/cut.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cut -c1 /data/a.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/diff.json
+++ b/integ/crossmount/diff.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "printf 'same\\nold\\n' | tee /data/xdiff.txt > /dev/null && printf 'same\\nnew\\n' | tee /data2/xdiff.txt > /dev/null && diff /data/xdiff.txt /data2/xdiff.txt",
       "expect": {

--- a/integ/crossmount/du.json
+++ b/integ/crossmount/du.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "du /data/b.txt /data2/xm.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "du -c /data/b.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/file.json
+++ b/integ/crossmount/file.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "file /data/a.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/find.json
+++ b/integ/crossmount/find.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data2 -type f | sort",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data/sub /data2 -name '*.txt'",
       "expect": {

--- a/integ/crossmount/grep.json
+++ b/integ/crossmount/grep.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -c s /data/a.txt /data2/xm.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -n o /data/a.txt /data2/xm.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -h o /data/a.txt /data2/xm.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep zzz /data/a.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/head.json
+++ b/integ/crossmount/head.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -n 2 /data/a.txt /data2/xm.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -q -n 1 /data/a.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/join.json
+++ b/integ/crossmount/join.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "printf '1 alpha\\n2 beta\\n' | tee /data/xj1.txt > /dev/null && printf '1 one\\n3 three\\n' | tee /data2/xj2.txt > /dev/null && join /data/xj1.txt /data2/xj2.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "join -a 1 /data/xj1.txt /data2/xj2.txt && rm /data/xc1.txt /data2/xc2.txt /data/xj1.txt /data2/xj2.txt",
       "expect": {

--- a/integ/crossmount/link.json
+++ b/integ/crossmount/link.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -c cross /data/xm_rlink.txt",
       "expect": {

--- a/integ/crossmount/ln.json
+++ b/integ/crossmount/ln.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ln -s /data/a.txt /data2/xm_link.txt && cat /data2/xm_link.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "readlink /data2/xm_link.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ln -s /data2/xm.txt /data/xm_rlink.txt && cat /data/xm_rlink.txt",
       "expect": {

--- a/integ/crossmount/ls.json
+++ b/integ/crossmount/ls.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls /data2",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls /data/b.txt /data2/xm.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls /data/sub /data2",
       "expect": {

--- a/integ/crossmount/md5.json
+++ b/integ/crossmount/md5.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "md5 /data/b.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/mkdir.json
+++ b/integ/crossmount/mkdir.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir /data/xd /data2/xd && ls /data2 && rm -r /data/xd /data2/xd",
       "expect": {

--- a/integ/crossmount/mv.json
+++ b/integ/crossmount/mv.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mv /data/xm_back.txt /data2/xm_moved.txt && cat /data2/xm_moved.txt && ls /data2",
       "expect": {

--- a/integ/crossmount/nl.json
+++ b/integ/crossmount/nl.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "nl /data/b.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/paste.json
+++ b/integ/crossmount/paste.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "paste /data/b.txt /data2/xm.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "paste -d, /data/b.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/pipe.json
+++ b/integ/crossmount/pipe.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data2/xm.txt | tr a-z A-Z",
       "expect": {

--- a/integ/crossmount/refuse.json
+++ b/integ/crossmount/refuse.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "uniq /data/a.txt /data2/xm_uniq_out.txt",
       "expect": {

--- a/integ/crossmount/rev.json
+++ b/integ/crossmount/rev.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rev /data/b.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/rg.json
+++ b/integ/crossmount/rg.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rg -c o /data/a.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/sed.json
+++ b/integ/crossmount/sed.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed s/l/L/ /data/a.txt /data2/xm.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo abc | tee /data/xi.txt /data2/xi.txt > /dev/null && sed -i s/b/B/ /data/xi.txt /data2/xi.txt && cat /data/xi.txt /data2/xi.txt && rm /data/xi.txt /data2/xi.txt",
       "expect": {

--- a/integ/crossmount/seed.json
+++ b/integ/crossmount/seed.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo cross | tee /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/sha256.json
+++ b/integ/crossmount/sha256.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sha256sum /data/b.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/sort.json
+++ b/integ/crossmount/sort.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort /data/numbers.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/strings.json
+++ b/integ/crossmount/strings.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "strings /data/binary.bin /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/tac.json
+++ b/integ/crossmount/tac.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tac /data/b.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/tail.json
+++ b/integ/crossmount/tail.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tail -n 1 /data/a.txt /data2/xm.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tail -q -n 1 /data/a.txt /data2/xm.txt",
       "expect": {

--- a/integ/crossmount/tee.json
+++ b/integ/crossmount/tee.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo dual | tee /data/xdual.txt /data2/xdual.txt && cat /data/xdual.txt /data2/xdual.txt && rm /data/xdual.txt /data2/xdual.txt",
       "expect": {

--- a/integ/crossmount/touch.json
+++ b/integ/crossmount/touch.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "touch /data/xt.txt /data2/xt.txt && ls /data/xt.txt /data2/xt.txt && rm /data/xt.txt /data2/xt.txt && ls /data2",
       "expect": {

--- a/integ/crossmount/unknown.json
+++ b/integ/crossmount/unknown.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep --bogus s /data/a.txt /data2/xm.txt 2>&1; echo code=$?",
       "expect": {

--- a/integ/crossmount/wc.json
+++ b/integ/crossmount/wc.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l /data/a.txt /data2/xm.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc /data/b.txt /data2/xm.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l /data/sorted_*.txt /data2/xm.txt",
       "expect": {

--- a/integ/onedrive_server.py
+++ b/integ/onedrive_server.py
@@ -19,9 +19,13 @@ from datetime import datetime, timedelta, timezone
 from aiohttp import web
 
 import mirage.core.onedrive._client as onedrive_client
+import mirage.core.sharepoint._client as sharepoint_client
+import mirage.core.sharepoint._resolver as sharepoint_resolver
 
 BASE_TIME = datetime(2026, 3, 31, tzinfo=timezone.utc)
 MODIFIED = BASE_TIME.strftime("%Y-%m-%dT%H:%M:%SZ")
+SITE_ID = "site-main"
+SITE_NAME = "Main"
 
 
 def _norm(path: str) -> str:
@@ -40,7 +44,8 @@ def _parse_range(header: str | None, size: int) -> tuple[int, int]:
 
 class FakeGraph:
 
-    def __init__(self) -> None:
+    def __init__(self, key: str = "default") -> None:
+        self.key = key
         self.files: dict[str, dict] = {}
         self.dirs: set[str] = {""}
         self.base = ""
@@ -48,7 +53,7 @@ class FakeGraph:
 
     def _tag(self) -> str:
         self._seq += 1
-        return f"tag{self._seq}"
+        return f"{self.key}-tag{self._seq}"
 
     def _ensure_parents(self, path: str) -> None:
         parent = posixpath.dirname(path)
@@ -112,7 +117,7 @@ class FakeGraph:
                 "mimeType": "application/octet-stream"
             },
             "@microsoft.graph.downloadUrl":
-            f"{self.base}/download/{path}",
+            f"{self.base}/download/{self.key}/{path}",
             "versions": [{
                 "id": v["id"],
                 "lastModifiedDateTime": v["lastModifiedDateTime"],
@@ -128,7 +133,7 @@ class FakeGraph:
 
     def _folder_item(self, path: str) -> dict:
         return {
-            "id": f"folder:{path}" if path else "root",
+            "id": f"{self.key}:folder:{path}" if path else f"{self.key}:root",
             "name": posixpath.basename(path) if path else "root",
             "size": self._folder_size(path),
             "lastModifiedDateTime": MODIFIED,
@@ -208,57 +213,105 @@ def _ref_parent(ref_path: str) -> str:
     return _norm(after)
 
 
+def _ref_drive(ref_path: str) -> str | None:
+    if "/drives/" not in ref_path:
+        return None
+    return ref_path.split("/drives/", 1)[1].split("/", 1)[0]
+
+
 class GraphServer:
+    """One fake Graph tenant: a site with one or more drives.
+
+    The default drive serves the OneDrive path shapes (``/me/drive``,
+    ``/sites/{id}/drive``); named drives serve the SharePoint shapes
+    (``/drives/{id}`` after ``/sites`` discovery).
+    """
 
     def __init__(self, state: FakeGraph) -> None:
         self.state = state
+        self.drives: dict[str, FakeGraph] = {state.key: state}
+        self.site_drives: list[str] = [state.key]
         self.uploads: dict[str, dict] = {}
         self.monitors: dict[str, dict] = {}
         self.calls: Counter = Counter()
         self._upload_seq = 0
         self._monitor_seq = 0
 
+    def add_drive(self, key: str) -> FakeGraph:
+        g = FakeGraph(key)
+        g.base = self.state.base
+        self.drives[key] = g
+        self.site_drives.append(key)
+        return g
+
+    def _drive_for(self, path: str) -> FakeGraph | None:
+        if path.startswith("/drives/"):
+            key = path.split("/", 3)[2]
+            return self.drives.get(key)
+        return self.state
+
     async def handle(self, request: web.Request) -> web.StreamResponse:
         path = request.path
         method = request.method
         if path.startswith("/download/"):
             self.calls["download"] += 1
-            return self._serve_bytes(request, path[len("/download/"):])
+            drive_key, _, rest = path[len("/download/"):].partition("/")
+            g = self.drives.get(drive_key)
+            if g is None:
+                return _not_found()
+            return self._serve_bytes(request, g, rest)
         if path.startswith("/upload/"):
             return await self._upload(request, path[len("/upload/"):])
         if path.startswith("/monitor/"):
             token = path[len("/monitor/"):]
             return web.json_response(
                 self.monitors.get(token, {"status": "completed"}))
+        if path == "/sites" and method == "GET":
+            return web.json_response({
+                "value": [{
+                    "id": SITE_ID,
+                    "name": SITE_NAME,
+                    "displayName": SITE_NAME,
+                }]
+            })
+        if path == f"/sites/{SITE_ID}/drives" and method == "GET":
+            return web.json_response({
+                "value": [{
+                    "id": key,
+                    "name": key,
+                } for key in self.site_drives]
+            })
+        g = self._drive_for(path)
+        if g is None:
+            return _not_found()
         item_path, action = _parse_item_path(path)
         if method == "GET":
             kind = action if action in ("children", "content") else "item"
             self.calls[kind] += 1
-        return await self._drive(request, method, item_path, action)
+        return await self._drive(request, g, method, item_path, action)
 
-    async def _drive(self, request: web.Request, method: str, item_path: str,
-                     action: str) -> web.StreamResponse:
-        state = self.state
+    async def _drive(self, request: web.Request, g: FakeGraph, method: str,
+                     item_path: str, action: str) -> web.StreamResponse:
         if action == "children":
             if method == "POST":
-                return await self._mkdir(request, item_path)
-            return self._children_response(item_path)
+                return await self._mkdir(request, g, item_path)
+            return self._children_response(g, item_path)
         if action == "content":
             if method == "PUT":
                 data = await request.read()
-                return web.json_response(state._write_file(item_path, data))
-            return self._content_response(request, item_path)
+                return web.json_response(g._write_file(item_path, data))
+            return self._serve_bytes(request, g, item_path)
         if action == "createUploadSession":
-            return await self._create_upload(request, item_path)
+            return await self._create_upload(request, g, item_path)
         if action == "copy":
-            return await self._copy(request, item_path)
+            return await self._copy(request, g, item_path)
         if action.startswith("versions/") and action.endswith("/content"):
             vid = action[len("versions/"):-len("/content")]
-            return self._version_content(request, item_path, vid)
+            return self._version_content(request, g, item_path, vid)
         if action.endswith("/restoreVersion"):
             return web.Response(status=204)
         if action == "versions":
-            return self._versions_response(item_path)
+            return self._versions_response(g, item_path)
         if method == "DELETE":
             if not item_path:
                 return web.json_response(
@@ -270,28 +323,24 @@ class GraphServer:
                     },
                     status=400)
             return web.Response(
-                status=204) if state._delete(item_path) else _not_found()
+                status=204) if g._delete(item_path) else _not_found()
         if method == "PATCH":
-            return await self._patch(request, item_path)
-        item = state._item(item_path)
+            return await self._patch(request, g, item_path)
+        item = g._item(item_path)
         return web.json_response(item) if item is not None else _not_found()
 
-    def _children_response(self, item_path: str) -> web.Response:
-        state = self.state
-        if item_path and item_path not in state.dirs:
+    def _children_response(self, g: FakeGraph, item_path: str) -> web.Response:
+        if item_path and item_path not in g.dirs:
             return _not_found()
         value = [
-            state._item(posixpath.join(item_path, name))
-            for name in state._children(item_path)
+            g._item(posixpath.join(item_path, name))
+            for name in g._children(item_path)
         ]
         return web.json_response({"value": value})
 
-    def _content_response(self, request: web.Request,
-                          item_path: str) -> web.Response:
-        return self._serve_bytes(request, item_path)
-
-    def _serve_bytes(self, request: web.Request, path: str) -> web.Response:
-        entry = self.state.files.get(_norm(path))
+    def _serve_bytes(self, request: web.Request, g: FakeGraph,
+                     path: str) -> web.Response:
+        entry = g.files.get(_norm(path))
         if entry is None:
             return _not_found()
         return self._range_body(request, entry["content"])
@@ -311,8 +360,8 @@ class GraphServer:
                                 })
         return web.Response(body=body, content_type="application/octet-stream")
 
-    def _versions_response(self, item_path: str) -> web.Response:
-        entry = self.state.files.get(_norm(item_path))
+    def _versions_response(self, g: FakeGraph, item_path: str) -> web.Response:
+        entry = g.files.get(_norm(item_path))
         if entry is None:
             return _not_found()
         # Real Graph lists versions newest-first.
@@ -322,9 +371,9 @@ class GraphServer:
         } for v in reversed(entry["versions"])]
         return web.json_response({"value": value})
 
-    def _version_content(self, request: web.Request, item_path: str,
-                         vid: str) -> web.Response:
-        entry = self.state.files.get(_norm(item_path))
+    def _version_content(self, request: web.Request, g: FakeGraph,
+                         item_path: str, vid: str) -> web.Response:
+        entry = g.files.get(_norm(item_path))
         if entry is None:
             return _not_found()
         for v in entry["versions"]:
@@ -332,38 +381,36 @@ class GraphServer:
                 return self._range_body(request, v["content"])
         return _not_found()
 
-    async def _mkdir(self, request: web.Request, parent: str) -> web.Response:
-        state = self.state
+    async def _mkdir(self, request: web.Request, g: FakeGraph,
+                     parent: str) -> web.Response:
         parent = _norm(parent)
-        if parent and parent not in state.dirs:
+        if parent and parent not in g.dirs:
             return _not_found()
         body = await request.json()
         name = body.get("name", "")
         behavior = body.get("@microsoft.graph.conflictBehavior", "fail")
         target = _norm(posixpath.join(parent, name))
-        if target in state.dirs or target in state.files:
-            if behavior == "replace" and target in state.dirs:
+        if target in g.dirs or target in g.files:
+            if behavior == "replace" and target in g.dirs:
                 # Real Graph returns the existing folder; children survive.
-                return web.json_response(state._folder_item(target))
+                return web.json_response(g._folder_item(target))
             if behavior == "rename":
                 n = 1
-                while (_norm(posixpath.join(parent,
-                                            f"{name} {n}")) in state.dirs
+                while (_norm(posixpath.join(parent, f"{name} {n}")) in g.dirs
                        or _norm(posixpath.join(parent,
-                                               f"{name} {n}")) in state.files):
+                                               f"{name} {n}")) in g.files):
                     n += 1
                 target = _norm(posixpath.join(parent, f"{name} {n}"))
             else:
                 return _name_exists()
-        state._ensure_parents(target)
-        state.dirs.add(target)
-        return web.json_response(state._folder_item(target))
+        g._ensure_parents(target)
+        g.dirs.add(target)
+        return web.json_response(g._folder_item(target))
 
-    async def _patch(self, request: web.Request,
+    async def _patch(self, request: web.Request, g: FakeGraph,
                      item_path: str) -> web.Response:
-        state = self.state
         item_path = _norm(item_path)
-        if item_path not in state.files and item_path not in state.dirs:
+        if item_path not in g.files and item_path not in g.dirs:
             return _not_found()
         body = await request.json()
         name = body.get("name") or posixpath.basename(item_path)
@@ -375,54 +422,55 @@ class GraphServer:
         dest = _norm(posixpath.join(parent, name))
         if dest != item_path:
             behavior = _conflict_behavior(request)
-            conflict = dest in state.files or dest in state.dirs
-            replaceable = (behavior == "replace" and item_path in state.files
-                           and dest in state.files)
+            conflict = dest in g.files or dest in g.dirs
+            replaceable = (behavior == "replace" and item_path in g.files
+                           and dest in g.files)
             if conflict and not replaceable:
                 return _name_exists()
             if conflict:
-                del state.files[dest]
-        if item_path in state.files:
-            entry = state.files.pop(item_path)
+                del g.files[dest]
+        if item_path in g.files:
+            entry = g.files.pop(item_path)
             # A metadata change bumps eTag; cTag only moves with content.
-            entry["etag"] = state._tag()
-            state._ensure_parents(dest)
-            state.files[dest] = entry
-            return web.json_response(state._file_item(dest))
-        self._move_dir(item_path, dest)
-        return web.json_response(state._folder_item(dest))
+            entry["etag"] = g._tag()
+            g._ensure_parents(dest)
+            g.files[dest] = entry
+            return web.json_response(g._file_item(dest))
+        self._move_dir(g, item_path, dest)
+        return web.json_response(g._folder_item(dest))
 
-    def _move_dir(self, src: str, dest: str) -> None:
-        state = self.state
-        state.dirs.discard(src)
-        state.dirs.add(dest)
-        state._ensure_parents(dest)
-        for f in list(state.files):
+    def _move_dir(self, g: FakeGraph, src: str, dest: str) -> None:
+        g.dirs.discard(src)
+        g.dirs.add(dest)
+        g._ensure_parents(dest)
+        for f in list(g.files):
             if f == src or f.startswith(src + "/"):
-                entry = state.files.pop(f)
-                state.files[dest + f[len(src):]] = entry
-        for d in list(state.dirs):
+                entry = g.files.pop(f)
+                g.files[dest + f[len(src):]] = entry
+        for d in list(g.dirs):
             if d != src and d.startswith(src + "/"):
-                state.dirs.discard(d)
-                state.dirs.add(dest + d[len(src):])
+                g.dirs.discard(d)
+                g.dirs.add(dest + d[len(src):])
 
-    async def _copy(self, request: web.Request,
+    async def _copy(self, request: web.Request, g: FakeGraph,
                     item_path: str) -> web.Response:
-        state = self.state
         item_path = _norm(item_path)
-        if item_path not in state.files and item_path not in state.dirs:
+        if item_path not in g.files and item_path not in g.dirs:
             return _not_found()
         body = await request.json()
         name = body.get("name") or posixpath.basename(item_path)
-        parent = _ref_parent(body.get("parentReference", {}).get("path", ""))
+        ref = body.get("parentReference", {})
+        dest_key = ref.get("driveId") or _ref_drive(ref.get("path", ""))
+        dest_g = self.drives.get(dest_key, g) if dest_key else g
+        parent = _ref_parent(ref.get("path", ""))
         dest = _norm(posixpath.join(parent, name))
         behavior = _conflict_behavior(request)
-        is_file = item_path in state.files
-        conflict = dest in state.files or dest in state.dirs
+        is_file = item_path in g.files
+        conflict = dest in dest_g.files or dest in dest_g.dirs
         # replace only applies to file-onto-file; folder conflicts always
         # fail (reported through the monitor, like real Graph).
         replaceable = (behavior == "replace" and is_file
-                       and dest in state.files)
+                       and dest in dest_g.files)
         if conflict and not replaceable:
             return self._accept_monitor({
                 "status": "failed",
@@ -432,9 +480,9 @@ class GraphServer:
                 },
             })
         if is_file:
-            state._write_file(dest, state.files[item_path]["content"])
+            dest_g._write_file(dest, g.files[item_path]["content"])
         else:
-            self._copy_dir(item_path, dest)
+            self._copy_dir(g, dest_g, item_path, dest)
         return self._accept_monitor({"status": "completed"})
 
     def _accept_monitor(self, payload: dict) -> web.Response:
@@ -445,19 +493,18 @@ class GraphServer:
         resp.headers["Location"] = f"{self.state.base}/monitor/{token}"
         return resp
 
-    def _copy_dir(self, src: str, dest: str) -> None:
-        state = self.state
-        state.dirs.add(dest)
-        state._ensure_parents(dest)
-        for f in list(state.files):
+    def _copy_dir(self, g: FakeGraph, dest_g: FakeGraph, src: str,
+                  dest: str) -> None:
+        dest_g.dirs.add(dest)
+        dest_g._ensure_parents(dest)
+        for f in list(g.files):
             if f == src or f.startswith(src + "/"):
-                state._write_file(dest + f[len(src):],
-                                  state.files[f]["content"])
-        for d in list(state.dirs):
+                dest_g._write_file(dest + f[len(src):], g.files[f]["content"])
+        for d in list(g.dirs):
             if d != src and d.startswith(src + "/"):
-                state.dirs.add(dest + d[len(src):])
+                dest_g.dirs.add(dest + d[len(src):])
 
-    async def _create_upload(self, request: web.Request,
+    async def _create_upload(self, request: web.Request, g: FakeGraph,
                              item_path: str) -> web.Response:
         body: dict = {}
         if request.can_read_body:
@@ -472,6 +519,7 @@ class GraphServer:
         # stripped by the HTTP client as a URL fragment.
         token = f"u{self._upload_seq}"
         self.uploads[token] = {
+            "drive": g,
             "path": _norm(item_path),
             "buffer": bytearray(),
             "behavior": behavior,
@@ -491,13 +539,14 @@ class GraphServer:
         total = int(content_range.rsplit("/", 1)[-1]) if "/" in content_range \
             else len(session["buffer"])
         if len(session["buffer"]) >= total:
+            g = session["drive"]
             path = session["path"]
             # Sessions default to "fail": the conflict surfaces on the
             # final chunk, exactly like real Graph.
-            if path in self.state.files and session["behavior"] != "replace":
+            if path in g.files and session["behavior"] != "replace":
                 del self.uploads[token]
                 return _name_exists()
-            item = self.state._write_file(path, bytes(session["buffer"]))
+            item = g._write_file(path, bytes(session["buffer"]))
             del self.uploads[token]
             return web.json_response(item, status=201)
         return web.json_response(
@@ -518,4 +567,6 @@ async def start_fake_graph() -> tuple[FakeGraph, "GraphServer", web.AppRunner]:
     port = site._server.sockets[0].getsockname()[1]
     state.base = f"http://127.0.0.1:{port}"
     onedrive_client.GRAPH_API = state.base
+    sharepoint_client.GRAPH_API = state.base
+    sharepoint_resolver.GRAPH_API = state.base
     return state, server, runner

--- a/integ/onedrive_server.py
+++ b/integ/onedrive_server.py
@@ -26,6 +26,14 @@ BASE_TIME = datetime(2026, 3, 31, tzinfo=timezone.utc)
 MODIFIED = BASE_TIME.strftime("%Y-%m-%dT%H:%M:%SZ")
 SITE_ID = "site-main"
 SITE_NAME = "Main"
+# SharePoint (and OneDrive for Business, which is SharePoint underneath)
+# rewrites Office documents server-side after an upload: metadata is
+# injected into the file, so downloaded bytes differ from uploaded bytes
+# and cTag changes without a user write. The real rewrite is an async
+# zip-internal edit; the fake models it as a synchronous, idempotent
+# marker append so shared-case expectations stay deterministic.
+OFFICE_EXTENSIONS = (".pptx", ".docx", ".xlsx")
+ENRICH_MARKER = b"<odsp-metadata/>"
 
 
 def _norm(path: str) -> str:
@@ -33,6 +41,9 @@ def _norm(path: str) -> str:
 
 
 def _parse_range(header: str | None, size: int) -> tuple[int, int]:
+    # Single-range requests only; real Graph also serves single ranges
+    # but returns 416 for unsatisfiable ones, which the fake clamps
+    # instead (no client path requests past EOF).
     if not header or not header.startswith("bytes="):
         return 0, size
     spec = header[len("bytes="):]
@@ -61,19 +72,33 @@ class FakeGraph:
             self.dirs.add(parent)
             parent = posixpath.dirname(parent)
 
-    def _write_file(self, path: str, content: bytes) -> dict:
+    def _write_file(self,
+                    path: str,
+                    content: bytes,
+                    enrich: bool = False) -> dict:
         path = _norm(path)
+        # Real Graph auto-creates missing parent folders for some
+        # path-addressed uploads and 404s for others (shared/remote
+        # folders); the fake always creates them (unpinned edge case).
         self._ensure_parents(path)
+        if (enrich and path.lower().endswith(OFFICE_EXTENSIONS)
+                and not content.endswith(ENRICH_MARKER)):
+            # Only uploads enrich; server-side copies of an already
+            # enriched file do not (mirrors real SharePoint, whose
+            # metadata rewrite is idempotent rather than accumulative).
+            content = content + ENRICH_MARKER
         prior = self.files.get(path)
         versions = prior["versions"] if prior else []
         ctag = self._tag()
+        # Version ids follow real Graph numbering ("1.0", "2.0", ...).
+        vid = f"{len(versions) + 1}.0"
         # Version timestamps are distinct (real Graph never ties them);
         # a shared constant would make "current version" detection
         # order-dependent and mask stale-version bugs.
         stamp = (BASE_TIME +
                  timedelta(seconds=self._seq)).strftime("%Y-%m-%dT%H:%M:%SZ")
         versions = versions + [{
-            "id": ctag,
+            "id": vid,
             "lastModifiedDateTime": stamp,
             "content": content,
         }]
@@ -263,6 +288,8 @@ class GraphServer:
         if path.startswith("/upload/"):
             return await self._upload(request, path[len("/upload/"):])
         if path.startswith("/monitor/"):
+            # Monitor URLs are unauthenticated, like real Graph
+            # long-running-operation URLs (they live outside /v1.0).
             token = path[len("/monitor/"):]
             return web.json_response(
                 self.monitors.get(token, {"status": "completed"}))
@@ -299,7 +326,8 @@ class GraphServer:
         if action == "content":
             if method == "PUT":
                 data = await request.read()
-                return web.json_response(g._write_file(item_path, data))
+                return web.json_response(
+                    g._write_file(item_path, data, enrich=True))
             return self._serve_bytes(request, g, item_path)
         if action == "createUploadSession":
             return await self._create_upload(request, g, item_path)
@@ -395,6 +423,9 @@ class GraphServer:
                 # Real Graph returns the existing folder; children survive.
                 return web.json_response(g._folder_item(target))
             if behavior == "rename":
+                # Real Graph inserts the counter before a file extension
+                # ("doc 1.pptx"); only folders are renamed here, where
+                # the plain " N" suffix matches.
                 n = 1
                 while (_norm(posixpath.join(parent, f"{name} {n}")) in g.dirs
                        or _norm(posixpath.join(parent,
@@ -464,6 +495,9 @@ class GraphServer:
         dest_g = self.drives.get(dest_key, g) if dest_key else g
         parent = _ref_parent(ref.get("path", ""))
         dest = _norm(posixpath.join(parent, name))
+        # conflictBehavior on copy models OneDrive for Business /
+        # SharePoint; real consumer OneDrive rejects the parameter (the
+        # client never sends it and resolves conflicts itself).
         behavior = _conflict_behavior(request)
         is_file = item_path in g.files
         conflict = dest in dest_g.files or dest in dest_g.dirs
@@ -530,6 +564,9 @@ class GraphServer:
         })
 
     async def _upload(self, request: web.Request, token: str) -> web.Response:
+        # Chunks are assumed sequential; real upload sessions also
+        # support a status GET, DELETE (cancel), expiration and 416 on
+        # overlapping ranges, none of which the client exercises.
         session = self.uploads.get(token)
         if session is None:
             return _not_found()
@@ -546,7 +583,7 @@ class GraphServer:
             if path in g.files and session["behavior"] != "replace":
                 del self.uploads[token]
                 return _name_exists()
-            item = g._write_file(path, bytes(session["buffer"]))
+            item = g._write_file(path, bytes(session["buffer"]), enrich=True)
             del self.uploads[token]
             return web.json_response(item, status=201)
         return web.json_response(

--- a/integ/resources/columnar.json
+++ b/integ/resources/columnar.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls /res",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls /res/example.parquet",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls /res/*.parquet",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "file /res/example.parquet",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /res/example.parquet",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -n 3 /res/example.parquet",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tail -n 2 /res/example.parquet",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l /res/example.parquet",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep item /res/example.parquet",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -c item /res/example.parquet",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "file /res/example.feather",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /res/example.feather",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -n 3 /res/example.feather",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tail -n 2 /res/example.feather",
       "expect": {
@@ -276,7 +290,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l /res/example.feather",
       "expect": {
@@ -295,7 +310,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep item /res/example.feather",
       "expect": {
@@ -314,7 +330,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -c item /res/example.feather",
       "expect": {
@@ -333,7 +350,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "file /res/example.h5",
       "expect": {
@@ -352,7 +370,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /res/example.h5",
       "expect": {
@@ -371,7 +390,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -n 3 /res/example.h5",
       "expect": {
@@ -390,7 +410,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tail -n 2 /res/example.h5",
       "expect": {
@@ -409,7 +430,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l /res/example.h5",
       "expect": {
@@ -428,7 +450,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep item /res/example.h5",
       "expect": {
@@ -447,7 +470,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -c item /res/example.h5",
       "expect": {

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -27,11 +27,14 @@ from moto.server import ThreadedMotoServer
 
 from mirage import MountMode, Workspace
 from mirage.accessor.onedrive import OneDriveConfig
+from mirage.accessor.sharepoint import SharePointConfig
+from mirage.core.sharepoint import _resolver as sharepoint_resolver
 from mirage.resource.disk import DiskResource
 from mirage.resource.onedrive.onedrive import OneDriveResource
 from mirage.resource.ram import RAMResource
 from mirage.resource.redis import RedisResource
 from mirage.resource.s3 import S3Config, S3Resource
+from mirage.resource.sharepoint.sharepoint import SharePointResource
 
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 S3_ENDPOINT = os.environ.get("S3_ENDPOINT")
@@ -125,7 +128,39 @@ class OneDriveService:
         await self.runner.cleanup()
 
 
-Service = S3Service | OneDriveService
+def _clear_sharepoint_caches() -> None:
+    # The resolver's site/drive id caches are module globals; a fresh
+    # fake tenant per run must not see ids from the previous one.
+    sharepoint_resolver._site_cache.clear()
+    sharepoint_resolver._drive_cache.clear()
+
+
+class SharePointService:
+
+    def __init__(self, server, runner) -> None:
+        self.server = server
+        self.runner = runner
+
+    @classmethod
+    async def create(cls) -> "SharePointService":
+        module = _load_onedrive_server()
+        _state, server, runner = await module.start_fake_graph()
+        _clear_sharepoint_caches()
+        return cls(server, runner)
+
+    def resource(self, mount: dict) -> SharePointResource:
+        self.server.add_drive(mount["drive"])
+        return SharePointResource(
+            SharePointConfig(access_token="integ-token",
+                             site="Main",
+                             drive=mount["drive"]))
+
+    async def teardown(self) -> None:
+        _clear_sharepoint_caches()
+        await self.runner.cleanup()
+
+
+Service = S3Service | OneDriveService | SharePointService
 
 
 def build_ram(
@@ -167,12 +202,20 @@ def build_onedrive(
     return service.resource(mount), _noop
 
 
+def build_sharepoint(
+        mount: dict, run_id: str, service: Service | None
+) -> tuple[object, Callable[[], Awaitable[None]]]:
+    assert isinstance(service, SharePointService)
+    return service.resource(mount), _noop
+
+
 BUILDERS = {
     "ram": build_ram,
     "disk": build_disk,
     "redis": build_redis,
     "s3": build_s3,
     "onedrive": build_onedrive,
+    "sharepoint": build_sharepoint,
 }
 
 
@@ -184,6 +227,8 @@ async def open_target(
         service = S3Service(run_id)
     elif target.get("service") == "onedrive":
         service = await OneDriveService.create()
+    elif target.get("service") == "sharepoint":
+        service = await SharePointService.create()
     mounts: dict[str, object] = {}
     cleanups: list[Callable[[], Awaitable[None]]] = []
     for mount in target["mounts"]:

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -195,6 +195,35 @@
           "fixture": "columnar/v1"
         }
       ]
+    },
+    {
+      "id": "sharepoint",
+      "hosts": [
+        "python"
+      ],
+      "service": "sharepoint",
+      "mounts": [
+        {
+          "path": "/data",
+          "resource": "sharepoint",
+          "backend": "sharepoint",
+          "drive": "data",
+          "fixture": "files/v1"
+        },
+        {
+          "path": "/data2",
+          "resource": "sharepoint",
+          "backend": "sharepoint",
+          "drive": "xm2"
+        },
+        {
+          "path": "/res",
+          "resource": "sharepoint",
+          "backend": "sharepoint",
+          "drive": "res",
+          "fixture": "columnar/v1"
+        }
+      ]
     }
   ]
 }

--- a/integ/unix/arch.json
+++ b/integ/unix/arch.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/arch && echo gz-data | tee /data/arch/g.txt > /dev/null && gzip /data/arch/g.txt && gunzip /data/arch/g.txt.gz && cat /data/arch/g.txt && ls /data/arch",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tar -c -v -z -f /data/arch/a.tgz /data/arch/g.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tar -t -z -f /data/arch/a.tgz",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tar -x -z -f /data/arch/a.tgz --strip-components 2 -C /data/arch/out && cat /data/arch/out/g.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo noise | tee /data/arch/skip.log > /dev/null && tar -c -v -f /data/arch/b.tar --exclude '*.log' /data/arch/g.txt /data/arch/skip.log",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "zip -q /data/arch/z.zip /data/arch/g.txt && unzip -p /data/arch/z.zip",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "split -b 4 /data/arch/g.txt /data/arch/pt_ && cat /data/arch/pt_aa /data/arch/pt_ab",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | tee /data/arch/c.txt > /dev/null && csplit -s -f /data/arch/cs_ /data/arch/c.txt /foo/ && cat /data/arch/cs_00",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "iconv -f utf-8 -t utf-8 /data/arch/g.txt",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mktemp -p /data/arch | wc -l",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/arch2 && echo two | tee /data/arch2/h.txt > /dev/null && gzip /data/arch2/h.txt && ls /data/arch2 && gunzip /data/arch2/h.txt.gz && cat /data/arch2/h.txt && ls /data/arch2",
       "expect": {

--- a/integ/unix/arity.json
+++ b/integ/unix/arity.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "uniq /data/a.txt /data/b.txt /data/mixed.txt 2>&1; echo code=$?",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tr a b /data/a.txt 2>&1; echo code=$?",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "diff /data/a.txt /data/b.txt /data/mixed.txt 2>&1; echo code=$?",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "seq 1 2 3 4 2>&1; echo code=$?",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mktemp t1 t2 2>&1; echo code=$?",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && uniq a.txt b.txt extra.txt 2>&1); echo code=$?",
       "expect": {

--- a/integ/unix/awk.json
+++ b/integ/unix/awk.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/csv.csv | awk -F, '{print $1}'",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk 'NR==2' /data/a.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk '{s+=$1} END{print s}' /data/numbers.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk '{print NF}' /data/fields.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk 'END{print NR}' /data/a.txt",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk '{print $NF}' /data/fields.txt",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk '$2 > 28' /data/fields.txt",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk 'BEGIN{print \"start\"} {print} END{print \"done\"}' /data/b.txt",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk -F , '{print $2}' /data/csv.csv",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk -F , 'BEGIN{OFS=\":\"} {print $1, $2}' /data/csv.csv",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk 'NR>=2 && NR<=4' /data/a.txt",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk -v a=va1 -v b=vb2 '{print a, b}' /data/one_byte.txt",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk -v x=eq=val '{print x}' /data/one_byte.txt",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo '{print $3, $1}' | tee /data/prog.awk > /dev/null && awk -f /data/prog.awk /data/fields.txt && rm /data/prog.awk",
       "expect": {
@@ -276,7 +290,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk '{print NF, $1}' /data/spaced.txt",
       "expect": {
@@ -295,7 +310,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk '{print NR, $1}' /data/a.txt /data/b.txt",
       "expect": {
@@ -314,7 +330,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo '{sum += $1}' | tee /data/pa.awk > /dev/null && echo 'END {print sum}' | tee /data/pb.awk > /dev/null && awk -f /data/pa.awk -f /data/pb.awk /data/numbers.txt && rm /data/pa.awk /data/pb.awk",
       "expect": {
@@ -333,7 +350,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk '{print}'",
       "expect": {
@@ -352,7 +370,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk",
       "expect": {
@@ -371,7 +390,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "awk -f /data/nope.awk /data/a.txt",
       "expect": {

--- a/integ/unix/base64.json
+++ b/integ/unix/base64.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "base64 /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | base64 | base64 -d",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo hello | base64",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo aGVsbG8= | base64 -d",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "base64",
       "expect": {

--- a/integ/unix/basename.json
+++ b/integ/unix/basename.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "basename /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "basename /data/a.txt .txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "basename /data/sub/",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "basename /",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "basename data/a.txt",
       "expect": {

--- a/integ/unix/bc.json
+++ b/integ/unix/bc.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "bc",
       "expect": {

--- a/integ/unix/cat.json
+++ b/integ/unix/cat.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt /data/b.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat -n /data/a.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt /data/b.txt /data/dup.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | head -n 2",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/dup.txt | sort | uniq -c",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | tr a-z A-Z | sort",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | tr -d aeiou | wc -c",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/empty.txt",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/no_nl.txt",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sub/nested.txt",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat --bogus /data/a.txt 2>&1; echo code=$?",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat -E /data/a.txt",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat -T /data/tabbed.txt",
       "expect": {
@@ -276,7 +290,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat -A /data/tabbed.txt",
       "expect": {

--- a/integ/unix/cmp.json
+++ b/integ/unix/cmp.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cmp /data/a.txt /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cmp /data/a.txt /data/b.txt",
       "expect": {

--- a/integ/unix/column.json
+++ b/integ/unix/column.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "column -s , -t /data/csv.csv",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "column -t /data/fields.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "column",
       "expect": {

--- a/integ/unix/comm.json
+++ b/integ/unix/comm.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "comm /data/sorted_a.txt /data/sorted_b.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "comm -12 /data/sorted_a.txt /data/sorted_b.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "comm -23 /data/sorted_a.txt /data/sorted_b.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "comm -13 /data/sorted_a.txt /data/sorted_b.txt",
       "expect": {

--- a/integ/unix/cp.json
+++ b/integ/unix/cp.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp /data/a.txt /data/b.txt /data/sub",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sub/a.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sub/b.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp /data/a.txt /data/b.txt /data/c.txt",
       "expect": {

--- a/integ/unix/csplit.json
+++ b/integ/unix/csplit.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "csplit",
       "expect": {

--- a/integ/unix/cut.json
+++ b/integ/unix/cut.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cut -f 1 -d , /data/csv.csv",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cut -f 2 -d , /data/csv.csv",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cut -c 2-4 /data/a.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cut -f 1 /data/tabbed.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cut -c 1 /data/a.txt",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cut -c 3- /data/a.txt",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cut -d ' ' -f 2 /data/fields.txt",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cut -d , -f 1,2 /data/csv.csv",
       "expect": {

--- a/integ/unix/diff.json
+++ b/integ/unix/diff.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "diff /data/a.txt /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "diff /data/a.txt /data/b.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "diff -u /data/sorted_a.txt /data/sorted_b.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/dr/x/sub /data/dr/y/sub && echo aaa | tee /data/dr/x/a.txt > /dev/null && echo AAA | tee /data/dr/y/a.txt > /dev/null && echo keep | tee /data/dr/x/c.txt > /dev/null && echo keep | tee /data/dr/y/c.txt > /dev/null && echo deep1 | tee /data/dr/x/sub/d.txt > /dev/null && echo deep2 | tee /data/dr/y/sub/d.txt > /dev/null && echo L | tee /data/dr/x/leftonly.txt > /dev/null && echo R | tee /data/dr/y/rightonly.txt > /dev/null && diff -r /data/dr/x /data/dr/y",
       "expect": {

--- a/integ/unix/dirname.json
+++ b/integ/unix/dirname.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "dirname /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "dirname /data/sub/",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "dirname /data/a.txt /data/sub/nested.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "dirname a.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "dirname /",
       "expect": {

--- a/integ/unix/disp.json
+++ b/integ/unix/disp.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && wc -l a.txt)",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && wc -l a.txt b.txt)",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && wc -l ./a.txt)",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data/sub && wc -l ../a.txt)",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && grep world a.txt b.txt)",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && md5 a.txt)",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && stat -c %n a.txt)",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && find sub -name nested.txt)",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && head -n 1 a.txt b.txt)",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && grep -l world a.txt b.txt)",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && grep -r nested disptree)",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && rg nested disptree)",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && ls -R disptree)",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && find disptree)",
       "expect": {

--- a/integ/unix/du.json
+++ b/integ/unix/du.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "du /data/a.txt /data/b.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "du --max-depth=1 /data/sub",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "du --max-depth 2>&1; echo code=$?",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "du /data/a.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "du /data",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "du -h /data/a.txt",
       "expect": {

--- a/integ/unix/echo.json
+++ b/integ/unix/echo.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo hi -n",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo -ne 'ab\\tcd'; echo",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo -nq hi",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo a '' b",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo a \"\" b",
       "expect": {

--- a/integ/unix/expand.json
+++ b/integ/unix/expand.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/tabbed.txt | expand",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "expand -t 4 /data/tabbed.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo expandisp=$(printf ' \\tX\\n' | expand -i | wc -c)",
       "expect": {

--- a/integ/unix/file.json
+++ b/integ/unix/file.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "file /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "file /data/user.json",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "file -b /data/a.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "file /data/a.txt /data/user.json",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "file /data/empty.txt",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "file /data/binary.bin",
       "expect": {

--- a/integ/unix/find.json
+++ b/integ/unix/find.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -name \"*.txt\"",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -type f",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -mindepth 1 -type f",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -maxdepth 1 -type f",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -name \"*.txt\" -o -name \"*.json\"",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -name \"*.txt\" | wc -l",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -name \"*.txt\" | sort | head -n 2",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -type d",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -iname \"*.TXT\"",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -size +10c",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -name \"*.txt\"",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -path \"*sub*\"",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data/sub -type f",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -empty",
       "expect": {
@@ -276,7 +290,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -not -name \"*.txt\"",
       "expect": {
@@ -295,7 +310,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -name data",
       "expect": {
@@ -314,7 +330,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -maxdepth 0",
       "expect": {
@@ -333,7 +350,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -mindepth 0 -type d",
       "expect": {
@@ -352,7 +370,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -size -5c",
       "expect": {
@@ -371,7 +390,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -depth -type f",
       "expect": {
@@ -390,7 +410,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -mtime +0 -o -mtime -1",
       "expect": {
@@ -409,7 +430,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/fs/sub && printf 12345678 > /data/fs/sub/big.bin && printf x > /data/fs/small.bin && find /data/fs -size +4c",
       "expect": {
@@ -428,7 +450,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data/fs -size -4c",
       "expect": {
@@ -447,7 +470,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "printf 1234 > /data/fs/four.bin && find /data/fs -size +4c",
       "expect": {
@@ -466,7 +490,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data/fs -size -4c",
       "expect": {
@@ -485,7 +510,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data/fs -size 4c",
       "expect": {
@@ -504,7 +530,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data/fs -size -1k",
       "expect": {
@@ -523,7 +550,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data/fs -path '*data/fs/sub*'",
       "expect": {
@@ -542,7 +570,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data/fs -path '/data/fs/sub'",
       "expect": {
@@ -561,7 +590,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data/fs -path '*sub*' -o -name small.bin",
       "expect": {
@@ -580,7 +610,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -maxdepth abc",
       "expect": {
@@ -599,7 +630,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -mindepth xx",
       "expect": {
@@ -618,7 +650,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -size abc",
       "expect": {
@@ -637,7 +670,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -size ''",
       "expect": {
@@ -656,7 +690,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -mtime abc",
       "expect": {
@@ -675,7 +710,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -regex '.*deep.*'",
       "expect": {
@@ -694,7 +730,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -boguspredicate",
       "expect": {

--- a/integ/unix/fmt.json
+++ b/integ/unix/fmt.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | fmt -w 20",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "fmt -w 10 /data/c.txt",
       "expect": {

--- a/integ/unix/fold.json
+++ b/integ/unix/fold.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | fold -w 3",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "fold -s -w 6 /data/a.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "fold -w 3 /data/a.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "fold -w 4 /data/a.txt /data/b.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "fold /data/c.txt",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "fold -s -w 8 /data/mixed.txt",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo foldemptyf=$(fold /data/empty.txt | wc -c)",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo foldblankin=$(echo | fold | wc -c)",
       "expect": {

--- a/integ/unix/grep.json
+++ b/integ/unix/grep.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep world /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -n bar /data/a.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -v foo /data/a.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -i HELLO /data/mixed.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -c hello /data/mixed.txt",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -E \"foo|bar\" /data/a.txt",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -A 1 world /data/a.txt",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -B 1 foo /data/a.txt",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -o ll /data/a.txt",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -l hello /data/mixed.txt /data/a.txt",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep world /data/a.txt | wc -l",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -w world /data/a.txt",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -c nothere /data/a.txt",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -n -v foo /data/a.txt",
       "expect": {
@@ -276,7 +290,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -F . /data/user.json",
       "expect": {
@@ -295,7 +310,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -m 1 o /data/a.txt",
       "expect": {
@@ -314,7 +330,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -h hello /data/mixed.txt /data/a.txt",
       "expect": {
@@ -333,7 +350,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -o o /data/a.txt",
       "expect": {
@@ -352,7 +370,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -r hello /data/sub",
       "expect": {
@@ -371,7 +390,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep '' /data/b.txt",
       "expect": {
@@ -390,7 +410,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -e world /data/a.txt",
       "expect": {
@@ -409,7 +430,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -n -e bar /data/a.txt",
       "expect": {
@@ -428,7 +450,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -e hello /data/mixed.txt /data/a.txt",
       "expect": {
@@ -447,7 +470,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -e world -e bar /data/a.txt",
       "expect": {
@@ -466,7 +490,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -n -e hello -e baz /data/a.txt",
       "expect": {
@@ -485,7 +510,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -F -e a.b -e foo /data/a.txt",
       "expect": {
@@ -504,7 +530,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -f /data/patterns.txt /data/a.txt",
       "expect": {
@@ -523,7 +550,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -e hello -f /data/patterns.txt /data/a.txt",
       "expect": {
@@ -542,7 +570,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -f /data/patterns.txt -f /data/patterns2.txt /data/a.txt",
       "expect": {
@@ -561,7 +590,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -ne world /data/a.txt",
       "expect": {
@@ -580,7 +610,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep --bogus world /data/a.txt 2>&1; echo code=$?",
       "expect": {
@@ -599,7 +630,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -Y world /data/a.txt 2>&1; echo code=$?",
       "expect": {
@@ -618,7 +650,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -m 2>&1; echo code=$?",
       "expect": {
@@ -637,7 +670,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep --color=auto world /data/a.txt",
       "expect": {
@@ -656,7 +690,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep --color world /data/a.txt",
       "expect": {
@@ -675,7 +710,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep --line-buffered world /data/a.txt",
       "expect": {
@@ -694,7 +730,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -neworld /data/a.txt",
       "expect": {
@@ -713,7 +750,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -im1 l /data/mixed.txt",
       "expect": {
@@ -732,7 +770,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -f /data/empty.txt /data/a.txt",
       "expect": {
@@ -751,7 +790,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -c hello /data/a.txt",
       "expect": {
@@ -770,7 +810,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -c zzz /data/a.txt",
       "expect": {
@@ -789,7 +830,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo hi | grep -c zzz",
       "expect": {
@@ -808,7 +850,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -c zzz /data/a.txt /data/b.txt",
       "expect": {
@@ -827,7 +870,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep",
       "expect": {
@@ -846,7 +890,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep foo",
       "expect": {
@@ -865,7 +910,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo hi | grep",
       "expect": {
@@ -884,7 +930,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep hello /data/sub",
       "expect": {
@@ -903,7 +950,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep hello /data/a.txt /data/sub",
       "expect": {

--- a/integ/unix/guard.json
+++ b/integ/unix/guard.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp /data/guard/g.txt /data/guard/g.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mv /data/guard/g.txt /data/guard/g.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/guard/g.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mv /data/guard/sub/s.txt /data/guard/sub",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp -r /data/guard/sub /data/guard/sub",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mv /data/guard /data/guard/sub",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp /data/missing.txt /data/guard/g.txt /data/guard/sub",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data/guard -type f",
       "expect": {

--- a/integ/unix/gunzip.json
+++ b/integ/unix/gunzip.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "gunzip",
       "expect": {

--- a/integ/unix/gzip.json
+++ b/integ/unix/gzip.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | gzip | gunzip",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | gzip | zcat",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/b.txt | gzip -c | zcat",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "gzip -d",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "gzip | gunzip | sha256sum",
       "expect": {

--- a/integ/unix/head.json
+++ b/integ/unix/head.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -n 1 /data/a.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -n 2 /data/a.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -c 5 /data/a.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -n 3 /data/a.txt | tail -n 1",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head /data/empty.txt",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -2 /data/a.txt",
       "expect": {

--- a/integ/unix/iconv.json
+++ b/integ/unix/iconv.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | iconv -f utf-8 -t utf-8",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "iconv",
       "expect": {

--- a/integ/unix/inv.json
+++ b/integ/unix/inv.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls -1 /data/sub",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "touch /data/sub/inv_late.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rm /data/sub/inv_late.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sub/inv_late.txt",
       "expect": {

--- a/integ/unix/join.json
+++ b/integ/unix/join.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "join /data/sorted_a.txt /data/sorted_b.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "join -t , /data/abc.csv /data/abc.csv",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "join /data/sorted_a.txt /data/sorted_c.txt",
       "expect": {

--- a/integ/unix/jq.json
+++ b/integ/unix/jq.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \".\" /data/user.json",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \".name\" /data/user.json",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \".age\" /data/user.json",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq -r \".name\" /data/user.json",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \".users[].name\" /data/users.json",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \".id\" /data/data.jsonl",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \".[].id\" /data/data.jsonl",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq -r \".[].msg\" /data/chat.jsonl",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/user.json | jq",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \".id\" /data/data.jsonl | wc -l",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \".id\" /data/data.jsonl | sort -n",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \"keys\" /data/user.json",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \". | length\" /data/users.json",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \".users[] | select(.age > 27)\" /data/users.json",
       "expect": {
@@ -276,7 +290,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \"select(.id > 1)\" /data/data.jsonl",
       "expect": {
@@ -295,7 +310,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq",
       "expect": {
@@ -314,7 +330,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \".\"",
       "expect": {

--- a/integ/unix/lazy.json
+++ b/integ/unix/lazy.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep hello /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep zzz /data/a.txt",
       "expect": {

--- a/integ/unix/ln.json
+++ b/integ/unix/ln.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ln -s /data/sub/nested.txt /data/sub/link.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "readlink /data/sub/link.txt",
       "expect": {

--- a/integ/unix/lnzip.json
+++ b/integ/unix/lnzip.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls -1 /data/sub",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls -1 /data/sub",
       "expect": {

--- a/integ/unix/look.json
+++ b/integ/unix/look.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "look hel /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "look foo",
       "expect": {

--- a/integ/unix/ls.json
+++ b/integ/unix/ls.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls /data/",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls -1 /data/",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls /data/a.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls /data/*.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls /data/sub/",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls --color /data/sub",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls -a /data/sub",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls -R /data/sub",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls /data/sub/deep",
       "expect": {

--- a/integ/unix/md5.json
+++ b/integ/unix/md5.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "md5 /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "md5 /data/a.txt /data/b.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "md5 /data/a.txt /data/b.txt /data/dup.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "md5 /data/empty.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "md5 /data/one_byte.txt",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo hello | md5",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | md5",
       "expect": {

--- a/integ/unix/meta.json
+++ b/integ/unix/meta.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/metad && echo alpha > /data/metad/f.txt && touch -t 202601021530 /data/metad/f.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls -l /data/metad",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "chmod 601 /data/metad/f.txt && ls -l /data/metad",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "chmod u+x,go-r /data/metad/f.txt && ls -l /data/metad",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "chown 500:dev /data/metad/f.txt && ls -l /data/metad",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "chown alice /data/metad/f.txt && ls -l /data/metad",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "touch -t 202601021530 /data/metad/new.txt && ls -l /data/metad",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "touch -c /data/metad/ghost.txt && ls /data/metad",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "touch -t 202603041200 /data/metad/f.txt && ls -l /data/metad",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mv /data/metad/f.txt /data/metad/g.txt && ls -l /data/metad",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rm /data/metad/g.txt && echo fresh > /data/metad/g.txt && touch -t 202601021530 /data/metad/g.txt && ls -l /data/metad",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ln -s /data/metad/g.txt /data/metad/ln.txt && chmod 604 /data/metad/ln.txt && ls -l /data/metad",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "touch -h -t 202601021530 /data/metad/ln.txt && readlink /data/metad/ln.txt",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "chmod 999 /data/metad/g.txt 2>&1",
       "expect": {
@@ -276,7 +290,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "chmod u+q /data/metad/g.txt 2>&1",
       "expect": {
@@ -295,7 +310,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "chmod 644 /data/metad/missing.txt 2>&1",
       "expect": {
@@ -314,7 +330,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "chown alice /data/metad/missing.txt 2>&1",
       "expect": {
@@ -333,7 +350,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "touch -t 99 /data/metad/g.txt 2>&1",
       "expect": {
@@ -352,7 +370,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rm /data/metad/ln.txt && rm -r /data/metad",
       "expect": {

--- a/integ/unix/meta_overlay.json
+++ b/integ/unix/meta_overlay.json
@@ -7,7 +7,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/metao && echo alpha > /data/metao/f.txt && touch -t 202601021530 /data/metao/f.txt",
       "check": {
@@ -32,7 +33,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "chmod 601 /data/metao/f.txt",
       "check": {
@@ -55,7 +57,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "chmod u+x,go-r /data/metao/f.txt",
       "check": {
@@ -77,7 +80,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "chown 500:dev /data/metao/f.txt",
       "check": {
@@ -100,7 +104,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "chown alice /data/metao/f.txt",
       "check": {
@@ -123,7 +128,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "touch -t 202601021530 /data/metao/new.txt",
       "check": {
@@ -146,7 +152,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "touch -c /data/metao/ghost.txt",
       "check": {
@@ -168,7 +175,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "touch -t 202603041200 /data/metao/f.txt",
       "check": {
@@ -190,7 +198,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "chmod 750 /data/metao",
       "check": {
@@ -212,7 +221,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mv /data/metao/f.txt /data/metao/g.txt",
       "check": {
@@ -237,7 +247,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rm /data/metao/g.txt && echo fresh > /data/metao/g.txt",
       "check": {
@@ -261,7 +272,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ln -s /data/metao/g.txt /data/metao/ln.txt && chmod 604 /data/metao/ln.txt",
       "check": {
@@ -283,7 +295,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "touch -t 202601021530 /data/metao/g.txt && touch -h -t 202603041200 /data/metao/ln.txt",
       "check": {
@@ -305,7 +318,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "chmod 644 /data/metao/missing.txt 2>&1",
       "expect": {
@@ -321,7 +335,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "touch -t 99 /data/metao/g.txt 2>&1",
       "expect": {
@@ -337,7 +352,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rm /data/metao/ln.txt && rm -r /data/metao",
       "expect": {

--- a/integ/unix/mv.json
+++ b/integ/unix/mv.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mv /data/sub/a.txt /data/sub/b.txt /data/sub/deep",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sub/deep/a.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sub/deep/b.txt",
       "expect": {

--- a/integ/unix/nf.json
+++ b/integ/unix/nf.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/missing.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head /data/missing.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tail /data/missing.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc /data/missing.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "stat /data/missing.txt",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep x /data/missing.txt",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sub/missing.txt",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/missing.txt | cat",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && cat missing.txt)",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && cat sub/missing.txt)",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cd /data && grep -r x missing)",
       "expect": {

--- a/integ/unix/nl.json
+++ b/integ/unix/nl.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "nl /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "nl -b a /data/a.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "nl -d ! /data/a.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "nl -w 3 /data/a.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "du /data/b.txt | wc -c",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "stat -c %n /data/b.txt | wc -c",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "file /data/b.txt | wc -c",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tree /data/sub | wc -c",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls /data/sub | wc -c",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l /data/b.txt | wc -c",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "md5 /data/b.txt | wc -c",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cmp /data/a.txt /data/b.txt | wc -c",
       "expect": {

--- a/integ/unix/office.json
+++ b/integ/unix/office.json
@@ -1,0 +1,116 @@
+{
+  "cases": [
+    {
+      "id": "office_write_read_enriched",
+      "seq": 204000,
+      "targets": [
+        "onedrive",
+        "sharepoint"
+      ],
+      "command": "mkdir -p /data/office && printf slide-bytes | tee /data/office/deck.pptx > /dev/null && cat /data/office/deck.pptx",
+      "expect": {
+        "exit": 0,
+        "stdout": "slide-bytes<odsp-metadata/>",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "office_size_reflects_enrichment",
+      "seq": 204001,
+      "targets": [
+        "onedrive",
+        "sharepoint"
+      ],
+      "command": "wc -c /data/office/deck.pptx",
+      "expect": {
+        "exit": 0,
+        "stdout": "27 /data/office/deck.pptx\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "office_repeat_read_stable",
+      "seq": 204002,
+      "targets": [
+        "onedrive",
+        "sharepoint"
+      ],
+      "command": "cat /data/office/deck.pptx && cat /data/office/deck.pptx",
+      "expect": {
+        "exit": 0,
+        "stdout": "slide-bytes<odsp-metadata/>slide-bytes<odsp-metadata/>",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "office_server_copy_no_reenrich",
+      "seq": 204003,
+      "targets": [
+        "onedrive",
+        "sharepoint"
+      ],
+      "command": "cp /data/office/deck.pptx /data/office/copy.pptx && wc -c /data/office/copy.pptx",
+      "expect": {
+        "exit": 0,
+        "stdout": "27 /data/office/copy.pptx\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "office_xmount_upload_idempotent",
+      "seq": 204004,
+      "targets": [
+        "onedrive",
+        "sharepoint"
+      ],
+      "command": "cp /data/office/deck.pptx /data2/deck.pptx && wc -c /data2/deck.pptx && rm /data2/deck.pptx",
+      "expect": {
+        "exit": 0,
+        "stdout": "27 /data2/deck.pptx\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "office_overwrite_enriches_once",
+      "seq": 204005,
+      "targets": [
+        "onedrive",
+        "sharepoint"
+      ],
+      "command": "printf v2 | tee /data/office/deck.pptx > /dev/null && cat /data/office/deck.pptx",
+      "expect": {
+        "exit": 0,
+        "stdout": "v2<odsp-metadata/>",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "office_plain_files_untouched",
+      "seq": 204006,
+      "targets": [
+        "onedrive",
+        "sharepoint"
+      ],
+      "command": "printf plain | tee /data/office/notes.txt > /dev/null && cat /data/office/notes.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "plain",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "office_cleanup",
+      "seq": 204007,
+      "targets": [
+        "onedrive",
+        "sharepoint"
+      ],
+      "command": "rm -r /data/office && echo cleaned",
+      "expect": {
+        "exit": 0,
+        "stdout": "cleaned\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/unix/overwrite.json
+++ b/integ/unix/overwrite.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/ow/t /data/ow/s/t && printf old | tee /data/ow/dst.txt > /dev/null && printf new | tee /data/ow/src.txt > /dev/null && printf keep | tee /data/ow/t/f.old > /dev/null && printf merged | tee /data/ow/s/t/f.txt > /dev/null && echo seeded",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp /data/ow/src.txt /data/ow/dst.txt && cat /data/ow/dst.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp -r /data/ow/s/t /data/ow && cat /data/ow/t/f.txt && ls /data/ow/t",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mv /data/ow/src.txt /data/ow/dst.txt && cat /data/ow/dst.txt && ls /data/ow",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/ow/t && ls /data/ow/t",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rm -r /data/ow && echo cleaned",
       "expect": {

--- a/integ/unix/paste.json
+++ b/integ/unix/paste.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "paste /data/a.txt /data/b.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "paste -s /data/b.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "paste -d , /data/a.txt /data/b.txt",
       "expect": {

--- a/integ/unix/patch.json
+++ b/integ/unix/patch.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "patch -p1 /data/poem.diff > /dev/null && cat /data/poem.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "patch -N -p1 /data/poem.diff > /dev/null && cat /data/poem.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "patch -R -p1 /data/poem.diff > /dev/null && cat /data/poem.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "patch",
       "expect": {

--- a/integ/unix/poison.json
+++ b/integ/unix/poison.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sorted_a.txt /data/sorted_b.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sorted_a.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/sorted_b.txt",
       "expect": {

--- a/integ/unix/pr.json
+++ b/integ/unix/pr.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/pr && printf '1\\n2\\n' > /data/pr/one.txt && printf '3\\n4\\n' > /data/pr/two.txt && printf 'hello\\n' > /data/pr/h1.txt && printf 'worlds\\n' > /data/pr/h2.txt && printf 'z\\n' > /data/pr/z1.txt && printf 'y\\n' > /data/pr/z2.txt && gzip /data/pr/z1.txt /data/pr/z2.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cut -c1 /data/pr/one.txt /data/pr/two.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tac /data/pr/one.txt /data/pr/two.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "nl /data/pr/one.txt /data/pr/two.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "strings /data/pr/h1.txt /data/pr/h2.txt",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "zcat /data/pr/z1.txt.gz /data/pr/z2.txt.gz",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -n 1 /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tail -n 1 /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "nl /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "md5 /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sha256sum /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "strings /data/pr/h1.txt /data/pr/missing.txt",
       "expect": {
@@ -276,7 +290,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tac /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -295,7 +310,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rev /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -314,7 +330,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cut -c1 /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -333,7 +350,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "expand /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -352,7 +370,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "unexpand /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -371,7 +390,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "fold /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -390,7 +410,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "fmt /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -409,7 +430,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "zcat /data/pr/z1.txt.gz /data/pr/missing.gz",
       "expect": {
@@ -428,7 +450,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed s/1/X/ /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -447,7 +470,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort /data/pr/one.txt /data/pr/missing.txt",
       "expect": {
@@ -466,7 +490,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/pr/missing.txt /data/pr/one.txt",
       "expect": {
@@ -485,7 +510,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l /data/pr/m1.txt /data/pr/m2.txt",
       "expect": {
@@ -504,7 +530,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/pr/one.txt /data/pr",
       "expect": {
@@ -523,7 +550,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head /data/pr",
       "expect": {
@@ -542,7 +570,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc /data/pr/one.txt /data/pr",
       "expect": {
@@ -561,7 +590,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tac /data/pr",
       "expect": {
@@ -580,7 +610,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rm -r /data/pr",
       "expect": {

--- a/integ/unix/provision.json
+++ b/integ/unix/provision.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt",
       "provision": true,
@@ -31,7 +32,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt /data/b.txt",
       "provision": true,
@@ -51,7 +53,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l /data/a.txt",
       "provision": true,
@@ -71,7 +74,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort /data/numbers.txt",
       "provision": true,
@@ -91,7 +95,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "md5 /data/b.txt",
       "provision": true,
@@ -111,7 +116,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep world /data/a.txt",
       "provision": true,
@@ -131,7 +137,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep hello /data/a.txt /data/mixed.txt",
       "provision": true,
@@ -151,7 +158,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rg world /data/a.txt",
       "provision": true,
@@ -171,7 +179,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head /data/a.txt",
       "provision": true,
@@ -191,7 +200,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -c 5 /data/a.txt",
       "provision": true,
@@ -211,7 +221,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tail -n 1 /data/a.txt",
       "provision": true,
@@ -231,7 +242,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls /data",
       "provision": true,
@@ -251,7 +263,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "find /data -name \"*.txt\"",
       "provision": true,
@@ -271,7 +284,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "du /data/a.txt",
       "provision": true,
@@ -291,7 +305,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "stat /data/a.txt",
       "provision": true,
@@ -311,7 +326,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \".name\" /data/user.json",
       "provision": true,
@@ -331,7 +347,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "jq \".id\" /data/data.jsonl",
       "provision": true,
@@ -351,7 +368,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/missing.txt",
       "provision": true,
@@ -371,7 +389,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed s/a/b/ /data/a.txt",
       "provision": true,
@@ -391,7 +410,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed -i s/a/b/ /data/a.txt",
       "provision": true,
@@ -411,7 +431,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tee /data/prov_out.txt",
       "provision": true,
@@ -431,7 +452,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | head -c 4",
       "provision": true,
@@ -451,7 +473,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep world /data/a.txt | wc -l",
       "provision": true,
@@ -471,7 +494,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt && cat /data/b.txt",
       "provision": true,
@@ -491,7 +515,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt; cat /data/b.txt",
       "provision": true,
@@ -511,7 +536,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/b.txt || cat /data/a.txt",
       "provision": true,
@@ -531,7 +557,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "for i in 1 2 3; do cat /data/a.txt; done",
       "provision": true,
@@ -551,7 +578,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "while true; do cat /data/a.txt; done",
       "provision": true,
@@ -571,7 +599,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "file /data/a.txt",
       "provision": true,
@@ -591,7 +620,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "iconv -f utf-8 -t utf-8 /data/a.txt",
       "provision": true,
@@ -611,7 +641,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp /data/a.txt /data/sub",
       "provision": true,
@@ -631,7 +662,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "gzip /data/b.txt",
       "provision": true,
@@ -651,7 +683,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rm /data/dup.txt",
       "provision": true,
@@ -671,7 +704,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rm -r /data/guard",
       "provision": true,
@@ -691,7 +725,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir /data/provdir",
       "provision": true,
@@ -711,7 +746,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mv /data/a.txt /data/moved.txt",
       "provision": true,
@@ -731,7 +767,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "seq 3",
       "provision": true,
@@ -751,7 +788,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "date",
       "provision": true,
@@ -771,7 +809,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | grep hello | wc -l",
       "provision": true,
@@ -791,7 +830,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt && cat /data/b.txt || cat /data/numbers.txt",
       "provision": true,
@@ -811,7 +851,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt || cat /data/b.txt && cat /data/numbers.txt",
       "provision": true,
@@ -831,7 +872,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "if true; then cat /data/a.txt; else cat /data/b.txt; fi",
       "provision": true,
@@ -851,7 +893,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "if grep -q hello /data/a.txt; then cat /data/b.txt; fi",
       "provision": true,
@@ -871,7 +914,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "case x in x) cat /data/a.txt;; *) cat /data/b.txt;; esac",
       "provision": true,
@@ -891,7 +935,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "(cat /data/a.txt; cat /data/b.txt)",
       "provision": true,
@@ -911,7 +956,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "{ cat /data/a.txt; cat /data/b.txt; }",
       "provision": true,
@@ -931,7 +977,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "! grep zzz /data/a.txt",
       "provision": true,
@@ -951,7 +998,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt > /data/prov_redir.txt",
       "provision": true,
@@ -971,7 +1019,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tee /data/prov_x.txt || cat /data/a.txt",
       "provision": true,
@@ -991,7 +1040,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "for i in 1 2; do cat /data/a.txt | wc -l; done",
       "provision": true,
@@ -1011,7 +1061,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "for i in 1 2; do for j in 1 2; do cat /data/b.txt; done; done",
       "provision": true,
@@ -1031,7 +1082,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat $(echo /data/a.txt)",
       "provision": true,
@@ -1051,7 +1103,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "for i in 1 2; do cat /data/a.txt | wc -l && cat /data/b.txt; done",
       "provision": true,
@@ -1071,7 +1124,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "FOO=1 cat /data/a.txt",
       "provision": true,
@@ -1091,7 +1145,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "pfn() { cat /data/b.txt; }; pfn; pfn",
       "provision": true,
@@ -1111,7 +1166,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "prec() { prec; }; prec",
       "provision": true,
@@ -1131,7 +1187,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "eval 'cat /data/a.txt'",
       "provision": true,
@@ -1151,7 +1208,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "select x in a b; do cat /data/a.txt; done",
       "provision": true,
@@ -1171,7 +1229,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "until false; do cat /data/a.txt; done",
       "provision": true,
@@ -1191,7 +1250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l < /data/a.txt",
       "provision": true,
@@ -1211,7 +1271,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt > /dev/null",
       "provision": true,
@@ -1231,7 +1292,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data2/xm_link.txt",
       "provision": true,
@@ -1251,7 +1313,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep x /data/xm_rlink.txt",
       "provision": true,
@@ -1271,7 +1334,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt /data2/xm.txt",
       "provision": true,
@@ -1291,7 +1355,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep s /data/a.txt /data2/xm.txt",
       "provision": true,
@@ -1311,7 +1376,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt /data2/xm.txt | wc -c",
       "provision": true,
@@ -1331,7 +1397,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "md5 /data/a.txt /data2/xm.txt",
       "provision": true,
@@ -1351,7 +1418,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "du /data/a.txt /data2/xm.txt",
       "provision": true,
@@ -1371,7 +1439,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/rgm/d1/*.txt",
       "provision": true,
@@ -1391,7 +1460,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/rgm/d1/*.nope",
       "provision": true,
@@ -1411,7 +1481,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep -r hello /data/rgm",
       "provision": true,
@@ -1431,7 +1502,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l",
       "provision": true,
@@ -1451,7 +1523,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -c <<EOF\nhello\nEOF",
       "provision": true,
@@ -1471,7 +1544,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "for i in $(echo 1 2); do cat /data/a.txt; done",
       "provision": true,
@@ -1491,7 +1565,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt > $(echo /data/prov_out.txt)",
       "provision": true,

--- a/integ/unix/realpath.json
+++ b/integ/unix/realpath.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "realpath /data/a.txt",
       "expect": {

--- a/integ/unix/rev.json
+++ b/integ/unix/rev.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rev /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo revemptyf=$(rev /data/empty.txt | wc -c)",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo revblankin=$(echo | rev | wc -c)",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rev /data/b.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo hello | rev",
       "expect": {

--- a/integ/unix/rg.json
+++ b/integ/unix/rg.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rg world /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rg -i WORLD /data/mixed.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rg -c hello /data/mixed.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rg -f /data/patterns.txt -f /data/patterns2.txt /data/a.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rg -e world /data/a.txt",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rg -e world -e bar /data/a.txt",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rg -f /data/patterns.txt /data/a.txt",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/rgm/d1",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/rgm/d2",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp /data/a.txt /data/rgm/d1/f1.txt",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp /data/mixed.txt /data/rgm/d2/f2.txt",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rg -i hello /data/rgm/d1 /data/rgm/d2",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rg -l hello /data/rgm/d1/f1.txt /data/rgm/d2/f2.txt",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp /data/a.txt /data/rgm/d1/skip.parquet",
       "expect": {
@@ -276,7 +290,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rg world /data/rgm/d1",
       "expect": {
@@ -295,7 +310,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rg",
       "expect": {
@@ -314,7 +330,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rg foo",
       "expect": {

--- a/integ/unix/root.json
+++ b/integ/unix/root.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo atroot | tee /data/at_root.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/at_root.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir /data/rootdir && find /data/rootdir -type d",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "basename /data/at_root.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "dirname /data/at_root.txt",
       "expect": {

--- a/integ/unix/sed.json
+++ b/integ/unix/sed.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | sed s/world/UNIVERSE/",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/mixed.txt | sed s/hello/HI/g",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 1d /data/a.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed '$d' /data/a.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed -n '2,3p' /data/a.txt",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed -n '/world/p' /data/a.txt",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 's/o/O/2' /data/a.txt",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed '/foo/d' /data/a.txt",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed '2a\\\nINSERTED' /data/a.txt",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/anchors.txt | sed 's/^#[0-9]*$/#TS/'",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/anchors.txt | sed -E 's/^#[0-9]+$/#TS/'",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/anchors.txt | sed 's/^#[0-9]*$/#TS/g'",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/anchors.txt | sed '/^#[0-9]*$/d'",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 's/^#[0-9]*$/#TS/' /data/anchors.txt",
       "expect": {
@@ -276,7 +290,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 's/o/O/' /data/multi.txt",
       "expect": {
@@ -295,7 +310,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 's/o/O/2' /data/oooo.txt",
       "expect": {
@@ -314,7 +330,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 's/o/O/2g' /data/oooo.txt",
       "expect": {
@@ -333,7 +350,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/oooo.txt | sed -n 's/o/O/p'",
       "expect": {
@@ -352,7 +370,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo hello | sed 'y/el/ip/'",
       "expect": {
@@ -371,7 +390,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed '2cCHANGED' /data/a.txt",
       "expect": {
@@ -390,7 +410,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed '2,4cMID' /data/a.txt",
       "expect": {
@@ -409,7 +430,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo foo | sed 's/\\(foo\\)/[\\1]/'",
       "expect": {
@@ -428,7 +450,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo aaab | sed 's/a\\+/X/'",
       "expect": {
@@ -447,7 +470,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo cat | sed 's/cat\\|dog/PET/'",
       "expect": {
@@ -466,7 +490,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo foo | sed -E 's/(foo)/[\\1]/'",
       "expect": {
@@ -485,7 +510,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo aaab | sed -E 's/a+/X/'",
       "expect": {
@@ -504,7 +530,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo aaab | sed -r 's/a+/X/'",
       "expect": {
@@ -523,7 +550,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo a | sed -e 's/a/b/' -e 's/b/c/'",
       "expect": {
@@ -542,7 +570,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed -e s/world/EARTH/ /data/a.txt",
       "expect": {
@@ -561,7 +590,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo 's/world/EARTH/' | tee /data/prog.sed > /dev/null && sed -f /data/prog.sed /data/a.txt && rm /data/prog.sed",
       "expect": {
@@ -580,7 +610,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo 's/world/EARTH/;s/foo/FOO/' | tee /data/prog.sed > /dev/null && sed -f /data/prog.sed /data/a.txt && rm /data/prog.sed",
       "expect": {
@@ -599,7 +630,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo 's/foo/FOO/' | tee /data/prog.sed > /dev/null && sed -e s/world/EARTH/ -f /data/prog.sed /data/a.txt && rm /data/prog.sed",
       "expect": {
@@ -618,7 +650,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo 's/world/EARTH/' | tee /data/prog.sed > /dev/null && cat /data/a.txt | sed -f /data/prog.sed && rm /data/prog.sed",
       "expect": {
@@ -637,7 +670,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 's/world/[&]/' /data/a.txt",
       "expect": {
@@ -656,7 +690,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 's/world/[\\&]/' /data/a.txt",
       "expect": {
@@ -675,7 +710,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 's/hello/HI/i' /data/mixed.txt",
       "expect": {
@@ -694,7 +730,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 's|o|O|g' /data/a.txt",
       "expect": {
@@ -713,7 +750,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed '2,3d' /data/a.txt",
       "expect": {
@@ -732,7 +770,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed -n '2p' /data/a.txt",
       "expect": {
@@ -751,7 +790,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed -n '$p' /data/a.txt",
       "expect": {
@@ -770,7 +810,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed '2iINSERTED' /data/a.txt",
       "expect": {
@@ -789,7 +830,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 'cX' /data/a.txt",
       "expect": {
@@ -808,7 +850,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed '/world/cCHANGED' /data/a.txt",
       "expect": {
@@ -827,7 +870,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed '2q' /data/a.txt",
       "expect": {
@@ -846,7 +890,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 'G' /data/a.txt",
       "expect": {
@@ -865,7 +910,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 'N;s/\\n/ /' /data/a.txt",
       "expect": {
@@ -884,7 +930,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed '/world/{s/world/W/;s/W/X/}' /data/a.txt",
       "expect": {
@@ -903,7 +950,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 's/o/0/;s/a/A/' /data/a.txt",
       "expect": {
@@ -922,7 +970,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed -E 's/(section)([0-9])/\\2\\1/' /data/sections.txt",
       "expect": {
@@ -941,7 +990,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed '2!d' /data/a.txt",
       "expect": {
@@ -960,7 +1010,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed '/world/!d' /data/a.txt",
       "expect": {
@@ -979,7 +1030,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed -n '$!p' /data/a.txt",
       "expect": {
@@ -998,7 +1050,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed '1,3!s/./X/' /data/a.txt",
       "expect": {
@@ -1017,7 +1070,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed ':a;N;$!ba;s/\\n/,/g' /data/a.txt",
       "expect": {
@@ -1036,7 +1090,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed -n 'H;${x;p}' /data/a.txt",
       "expect": {
@@ -1055,7 +1110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo 'a/b' | sed 's/a\\/b/c/'",
       "expect": {
@@ -1074,7 +1130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 's/no/NO/' /data/no_nl.txt",
       "expect": {
@@ -1093,7 +1150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sed 's/o/O/0'",
       "expect": {

--- a/integ/unix/sha256.json
+++ b/integ/unix/sha256.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sha256sum /data/empty.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo hello | sha256sum",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | sha256sum",
       "expect": {

--- a/integ/unix/sha256sum.json
+++ b/integ/unix/sha256sum.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sha256sum /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sha256sum /data/a.txt /data/b.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sha256sum",
       "expect": {

--- a/integ/unix/sleep.json
+++ b/integ/unix/sleep.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sleep abc",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sleep",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sleep -1",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sleep Infinity",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sleep 0",
       "expect": {
@@ -109,7 +114,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sleep 0.2",
       "expect": {
@@ -132,7 +138,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sleep 1",
       "expect": {

--- a/integ/unix/sort.json
+++ b/integ/unix/sort.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort -r /data/a.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort -n /data/numbers.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort /data/dup.txt | uniq",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort /data/a.txt | head -n 2",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort /data/a.txt | tail -n 2",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort -u /data/dup.txt",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort -k 2 -t , /data/csv.csv",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort -f /data/mixed.txt",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort -n -r /data/numbers.txt",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort -t , -k 1 /data/abc.csv",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort -t ' ' -k 2 -n /data/fields.txt",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo -e 'Feb\\nJan\\nMar' | sort -M",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "sort -b /data/spaced.txt",
       "expect": {
@@ -276,7 +290,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo sortemptyf=$(sort /data/empty.txt | wc -c)",
       "expect": {
@@ -295,7 +310,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo sortblankin=$(echo | sort | wc -c)",
       "expect": {
@@ -314,7 +330,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/dup.txt | sort",
       "expect": {

--- a/integ/unix/split.json
+++ b/integ/unix/split.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "split",
       "expect": {

--- a/integ/unix/stat.json
+++ b/integ/unix/stat.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "stat -c \"%s\" /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "stat -c \"%n\" /data/a.txt",
       "expect": {

--- a/integ/unix/strings.json
+++ b/integ/unix/strings.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "strings /data/binary.bin",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "strings",
       "expect": {

--- a/integ/unix/sym.json
+++ b/integ/unix/sym.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mkdir -p /data/symd && echo alpha > /data/symd/t.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ln -s /data/symd/t.txt /data/symd/l.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/symd/l.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "grep alpha /data/symd/l.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo beta > /data/symd/l.txt && cat /data/symd/t.txt",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls -F /data/symd",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ls -l /data/symd | grep -- '->'",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ln -s /data/symd /data/dl && cat /data/dl/t.txt",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "mv /data/symd/l.txt /data/symd/m.txt && readlink /data/symd/m.txt",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cp /data/symd/m.txt /data/symd/copy.txt && cat /data/symd/copy.txt",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rm /data/symd/m.txt && readlink /data/symd/m.txt 2>&1",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ln -s /data/symd/none /data/symd/dangle && cat /data/symd/dangle 2>&1",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "ln -s /data/lp2 /data/lp1 && ln -s /data/lp1 /data/lp2 && cat /data/lp1 2>&1",
       "expect": {
@@ -257,7 +270,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "rm /data/symd/dangle /data/lp1 /data/lp2 /data/dl && rm -r /data/symd",
       "expect": {

--- a/integ/unix/tac.json
+++ b/integ/unix/tac.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tac /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tac /data/sub/nested.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tac",
       "expect": {

--- a/integ/unix/tail.json
+++ b/integ/unix/tail.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tail /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tail -n 1 /data/a.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tail -n 2 /data/a.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tail -c 5 /data/a.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tail -2 /data/a.txt",
       "expect": {

--- a/integ/unix/timeout.json
+++ b/integ/unix/timeout.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "timeout 5 echo hello",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "timeout 5 echo 'a  b'",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "timeout 0.2 sleep 5; echo code=$?",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "timeout 5 echo fast",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "timeout xx sleep 1 2>&1; echo code=$?",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "timeout -s KILL 1 sleep 1 2>&1; echo code=$?",
       "expect": {

--- a/integ/unix/tr.json
+++ b/integ/unix/tr.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | tr a-z A-Z",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | tr -d aeiou",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo aaabbbccc | tr -s a-z",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | tr -c 'a-z\\n' '*'",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo abc123def | tr -d 0-9",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo 'a b c' | tr ' ' '\\n'",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tr a-z A-Z",
       "expect": {

--- a/integ/unix/tree.json
+++ b/integ/unix/tree.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tree /data/sub",
       "expect": {

--- a/integ/unix/tsort.json
+++ b/integ/unix/tsort.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "tsort",
       "expect": {

--- a/integ/unix/unexpand.json
+++ b/integ/unix/unexpand.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/tabbed.txt | unexpand",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo '    hi' | unexpand -a",
       "expect": {

--- a/integ/unix/uniq.json
+++ b/integ/unix/uniq.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "uniq /data/dup.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "uniq -c /data/dup.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "uniq -d /data/dup.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "uniq -u /data/dup.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "uniq /data/repeats.txt",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "uniq -c /data/repeats.txt",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "uniq -f 1 /data/prefix_dup.txt",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "uniq -s 1 /data/prefix_dup.txt",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "uniq -w 3 /data/prefix_dup.txt",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "uniq -w 0 /data/prefix_dup.txt",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "uniq -c -f 1 /data/prefix_dup.txt",
       "expect": {

--- a/integ/unix/unknown.json
+++ b/integ/unix/unknown.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "nosuchcmd /data/a.txt",
       "expect": {

--- a/integ/unix/wc.json
+++ b/integ/unix/wc.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc /data/a.txt",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l /data/a.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -w /data/a.txt",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -c /data/a.txt",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc /data/a.txt /data/b.txt",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -l /data/a.txt /data/b.txt",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc /data/empty.txt",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc /data/no_nl.txt",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc /data/one_byte.txt",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -m /data/a.txt",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "wc -L /data/a.txt",
       "expect": {
@@ -219,7 +230,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo 'a b c' | wc",
       "expect": {
@@ -238,7 +250,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | wc -l",
       "expect": {

--- a/integ/unix/xargs.json
+++ b/integ/unix/xargs.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo c | xargs echo a b",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo /data/a.txt | xargs wc -l",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo '$(echo pwned)' | xargs echo",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo \"don't\" | xargs echo",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo a b c | xargs -n1 echo",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo a b c d e | xargs -n2 echo",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo hi | xargs -q echo 2>&1; echo code=$?",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo x | xargs -n0 echo 2>&1; echo code=$?",
       "expect": {
@@ -162,7 +170,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "printf 'a,b,c' | xargs -d, echo",
       "expect": {
@@ -181,7 +190,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "printf '' | xargs -r echo hi; echo code=$?",
       "expect": {
@@ -200,7 +210,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "printf '' | xargs echo hi",
       "expect": {

--- a/integ/unix/xxd.json
+++ b/integ/unix/xxd.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -c 8 /data/a.txt | xxd",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -c 8 /data/a.txt | xxd -p",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | xxd | xxd -r",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -c 12 /data/a.txt | xxd -c 4",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -c 8 /data/a.txt | xxd -g 1",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "head -c 8 /data/a.txt | xxd -u",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "xxd",
       "expect": {

--- a/integ/unix/zcat.json
+++ b/integ/unix/zcat.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "zcat",
       "expect": {

--- a/integ/unix/zgrep.json
+++ b/integ/unix/zgrep.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | gzip | zgrep -e world -e baz",
       "expect": {
@@ -29,7 +30,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | gzip | zgrep -f /data/patterns.txt",
       "expect": {
@@ -48,7 +50,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | gzip | zgrep world",
       "expect": {
@@ -67,7 +70,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "cat /data/a.txt | gzip | zgrep -e world",
       "expect": {
@@ -86,7 +90,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "zgrep foo",
       "expect": {
@@ -105,7 +110,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo hello | gzip | zgrep -c hello",
       "expect": {
@@ -124,7 +130,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "echo hello | gzip | zgrep -c zzz",
       "expect": {
@@ -143,7 +150,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "zgrep",
       "expect": {

--- a/integ/unix/zip.json
+++ b/integ/unix/zip.json
@@ -10,7 +10,8 @@
         "opfs",
         "s3",
         "s3-prefix",
-        "onedrive"
+        "onedrive",
+        "sharepoint"
       ],
       "command": "zip /data/sub/arch.zip /data/sub/nested.txt",
       "expect": {

--- a/python/mirage/accessor/sharepoint.py
+++ b/python/mirage/accessor/sharepoint.py
@@ -4,6 +4,8 @@ from mirage.core.msgraph.config import MsGraphConfig
 
 class SharePointConfig(MsGraphConfig):
     site_filter: str | None = None
+    site: str | None = None
+    drive: str | None = None
 
 
 class SharePointAccessor(Accessor):

--- a/python/mirage/commands/builtin/sharepoint/du.py
+++ b/python/mirage/commands/builtin/sharepoint/du.py
@@ -17,6 +17,7 @@ from functools import partial
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.du import du_multi
+from mirage.commands.builtin.generic_bind.provision import metadata_provision
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.sharepoint.du import du as du_impl
@@ -26,7 +27,10 @@ from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
 
-@command("du", resource="sharepoint", spec=SPECS["du"])
+@command("du",
+         resource="sharepoint",
+         spec=SPECS["du"],
+         provision=metadata_provision)
 async def du(
     accessor: SharePointAccessor,
     paths: list[PathSpec],

--- a/python/mirage/core/msgraph/drive_ops.py
+++ b/python/mirage/core/msgraph/drive_ops.py
@@ -13,15 +13,29 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import posixpath
-from collections.abc import Callable
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, replace
+from urllib.parse import quote
+
+import aiohttp
 
 from mirage.cache.context import invalidate_after_write
+from mirage.cache.index import IndexCacheStore, IndexEntry, ResourceType
+from mirage.commands.builtin.find_eval import (FindEntry, PredNode, build_tree,
+                                               emit_start_path, keep)
 from mirage.core.msgraph._client import (GraphError, graph_delete, graph_get,
-                                         graph_list, graph_patch, graph_post,
-                                         graph_post_monitor, poll_monitor,
+                                         graph_get_bytes, graph_list,
+                                         graph_patch, graph_post,
+                                         graph_post_monitor, graph_stream,
+                                         new_session, poll_monitor,
                                          upload_chunk)
 from mirage.core.msgraph.config import MsGraphConfig
+from mirage.observe.context import (active_recorder, record, record_stream,
+                                    revision_for)
+from mirage.types import FileStat, FileType
+from mirage.utils.errors import enoent
+from mirage.utils.filetype import guess_type
 
 SIMPLE_UPLOAD_MAX = 4 * 1024 * 1024
 UPLOAD_CHUNK = 10 * 327680
@@ -57,9 +71,9 @@ class DriveLoc:
         return self.url(self.path, action)
 
     def child(self, name: str) -> "DriveLoc":
-        return replace(self,
-                       path=f"{self.path}/{name}",
-                       virt=f"{self.virt}/{name}")
+        path = f"{self.path}/{name}" if self.path else name
+        virt = f"{self.virt}/{name}" if self.virt else name
+        return replace(self, path=path, virt=virt)
 
     def parent(self) -> str:
         return posixpath.dirname("/" + self.path).strip("/")
@@ -209,3 +223,300 @@ async def upload_session_write(config: MsGraphConfig, session_url: str,
             start = int(ranges[0].split("-", 1)[0])
         else:
             start += len(chunk)
+
+
+def _range_header(offset: int, size: int | None) -> str | None:
+    if not offset and size is None:
+        return None
+    end = (offset + size - 1) if size is not None else ""
+    return f"bytes={offset}-{end}"
+
+
+def entry_stat(item: dict) -> FileStat:
+    name = item.get("name", "")
+    if "folder" in item:
+        return FileStat(name=name,
+                        type=FileType.DIRECTORY,
+                        size=item.get("size"),
+                        modified=item.get("lastModifiedDateTime"))
+    return FileStat(
+        name=name,
+        size=item.get("size"),
+        modified=item.get("lastModifiedDateTime"),
+        type=guess_type(name),
+        fingerprint=item.get("cTag"),
+        extra={
+            "id": item.get("id"),
+            "ctag": item.get("cTag"),
+            "etag": item.get("eTag"),
+        },
+    )
+
+
+def current_version_id(versions: list[dict]) -> str | None:
+    if not versions:
+        return None
+    current = max(versions, key=lambda v: v.get("lastModifiedDateTime") or "")
+    return current.get("id")
+
+
+async def capture_item_metadata(
+        config: MsGraphConfig,
+        loc: DriveLoc) -> tuple[str | None, str | None, str | None]:
+    item = await graph_get(config, loc.item(), params={"$expand": "versions"})
+    fingerprint = item.get("cTag")
+    revision = current_version_id(item.get("versions", []))
+    download_url = item.get("@microsoft.graph.downloadUrl")
+    return fingerprint, revision, download_url
+
+
+async def read_item(config: MsGraphConfig,
+                    loc: DriveLoc,
+                    virtual: str,
+                    label: str,
+                    backend: str,
+                    offset: int = 0,
+                    size: int | None = None) -> bytes:
+    pinned = revision_for(virtual)
+    range_header = _range_header(offset, size)
+    start_ms = int(time.monotonic() * 1000)
+    fingerprint = None
+    revision = pinned
+    try:
+        if pinned:
+            action = f"/versions/{quote(pinned, safe='')}/content"
+            data = await graph_get_bytes(config, loc.item(action),
+                                         range_header)
+        elif active_recorder() is not None:
+            fingerprint, revision, download_url = await capture_item_metadata(
+                config, loc)
+            if download_url:
+                data = await graph_get_bytes(config,
+                                             download_url,
+                                             range_header,
+                                             auth=False)
+            else:
+                data = await graph_get_bytes(config, loc.item("/content"),
+                                             range_header)
+        else:
+            data = await graph_get_bytes(config, loc.item("/content"),
+                                         range_header)
+    except GraphError as exc:
+        if exc.status == 404:
+            raise enoent(virtual)
+        raise
+    record("read",
+           label,
+           backend,
+           len(data),
+           start_ms,
+           fingerprint=fingerprint,
+           revision=revision)
+    return data
+
+
+async def stream_item(config: MsGraphConfig,
+                      loc: DriveLoc,
+                      virtual: str,
+                      label: str,
+                      backend: str,
+                      chunk_size: int = 8192) -> AsyncIterator[bytes]:
+    pinned = revision_for(virtual)
+    rec = record_stream("read", label, backend)
+    url = loc.item("/content")
+    auth = True
+    try:
+        if pinned is not None:
+            url = loc.item(f"/versions/{quote(pinned, safe='')}/content")
+            if rec is not None:
+                rec.revision = pinned
+        elif rec is not None:
+            (rec.fingerprint, rec.revision,
+             download_url) = await capture_item_metadata(config, loc)
+            if download_url:
+                url = download_url
+                auth = False
+        async for chunk in graph_stream(config, url, chunk_size, auth=auth):
+            if rec is not None:
+                rec.bytes += len(chunk)
+            yield chunk
+    except GraphError as exc:
+        if exc.status == 404:
+            raise enoent(virtual)
+        raise
+
+
+async def iter_tree(
+    config: MsGraphConfig,
+    loc: DriveLoc,
+    session: aiohttp.ClientSession | None = None,
+) -> AsyncIterator[tuple[str, dict, bool]]:
+    children = await graph_list(config, loc.item("/children"), session=session)
+    for child in children:
+        cname = child.get("name", "")
+        child_loc = loc.child(cname)
+        is_dir = "folder" in child
+        yield child_loc.path, child, is_dir
+        if is_dir:
+            async for entry in iter_tree(config, child_loc, session=session):
+                yield entry
+
+
+async def du_tree_total(config: MsGraphConfig, loc: DriveLoc) -> int:
+    total = 0
+    async with new_session(config) as session:
+        async for _rel, item, is_dir in iter_tree(config, loc,
+                                                  session=session):
+            if not is_dir:
+                total += item.get("size", 0)
+    return total
+
+
+async def du_tree_entries(config: MsGraphConfig,
+                          loc: DriveLoc) -> list[tuple[str, int]]:
+    results: list[tuple[str, int]] = []
+    total = 0
+    async with new_session(config) as session:
+        async for rel, item, is_dir in iter_tree(config, loc, session=session):
+            if is_dir:
+                continue
+            size = item.get("size", 0)
+            results.append(("/" + rel, size))
+            total += size
+    results.append(("/" + loc.path if loc.path else "/", total))
+    return results
+
+
+async def find_items(
+    config: MsGraphConfig,
+    loc: DriveLoc,
+    start_name: str,
+    dir_exists: Callable[[], Awaitable[bool]],
+    name: str | None = None,
+    type: str | None = None,
+    min_size: int | None = None,
+    max_size: int | None = None,
+    maxdepth: int | None = None,
+    name_exclude: str | None = None,
+    or_names: list[str] | None = None,
+    iname: str | None = None,
+    path_pattern: str | None = None,
+    mindepth: int | None = None,
+    empty: bool = False,
+    tree: PredNode | None = None,
+) -> list[str]:
+    base = loc.path
+    results: list[str] = []
+    saw_descendant = False
+    tree = tree if tree is not None else build_tree(name=name,
+                                                    iname=iname,
+                                                    path_pattern=path_pattern,
+                                                    type=type,
+                                                    name_exclude=name_exclude,
+                                                    or_names=or_names,
+                                                    empty=empty)
+    async with new_session(config) as session:
+        async for rel, item, is_dir in iter_tree(config, loc, session=session):
+            relative = rel[len(base):].lstrip("/") if base else rel
+            depth = relative.count("/") + 1
+            if maxdepth is not None and depth > maxdepth:
+                continue
+            saw_descendant = True
+            entry_name = rel.rsplit("/", 1)[-1]
+            full_path = "/" + rel
+            size = item.get("size", 0)
+            is_empty = (None if not empty else
+                        (size == 0 if not is_dir else False))
+            entry = FindEntry(key=full_path,
+                              name=entry_name,
+                              kind="d" if is_dir else "f",
+                              depth=depth,
+                              is_empty=is_empty)
+            if not keep(entry, tree, mindepth):
+                continue
+            if min_size is not None or max_size is not None:
+                # Directories count as size 0 for -size (deliberate GNU
+                # divergence).
+                effective = 0 if is_dir else size
+                if min_size is not None and effective < min_size:
+                    continue
+                if max_size is not None and effective > max_size:
+                    continue
+            results.append(full_path)
+    exists = saw_descendant or await dir_exists()
+    if exists:
+        root_key = "/" + base if base else "/"
+        emit_start_path(results,
+                        root_key,
+                        start_name,
+                        kind="d",
+                        is_empty=False if empty else None,
+                        exists=True,
+                        tree=tree,
+                        maxdepth=maxdepth,
+                        mindepth=mindepth,
+                        min_size=min_size,
+                        max_size=max_size)
+    return sorted(results)
+
+
+async def readdir_items(
+        config: MsGraphConfig, loc: DriveLoc, index: IndexCacheStore,
+        prefix: str, stripped: str, virtual_key: str,
+        stat_fn: Callable[[], Awaitable[FileStat]]) -> list[str]:
+    try:
+        children = await graph_list(config, loc.item("/children"))
+    except GraphError as exc:
+        if exc.status != 404:
+            raise
+        info = await stat_fn()
+        if info.type != FileType.DIRECTORY:
+            raise NotADirectoryError(virtual_key) from exc
+        raise enoent(virtual_key) from exc
+    base = "/" + stripped if stripped else ""
+    names: list[str] = []
+    index_entries: list[tuple[str, IndexEntry]] = []
+    for child in children:
+        cname = child.get("name", "")
+        key = f"{base}/{cname}"
+        names.append(key)
+        rtype = (ResourceType.FOLDER
+                 if "folder" in child else ResourceType.FILE)
+        index_entries.append(
+            (cname,
+             IndexEntry(id=key,
+                        name=cname,
+                        resource_type=rtype,
+                        size=child.get("size"),
+                        remote_time=child.get("lastModifiedDateTime", ""))))
+    names = sorted(names)
+    virtual_entries = sorted((prefix + e if prefix else e) for e in names)
+    await index.set_dir(virtual_key, index_entries)
+    return virtual_entries
+
+
+async def stat_item(config: MsGraphConfig, loc: DriveLoc, virtual: str,
+                    virtual_key: str, index: IndexCacheStore) -> FileStat:
+    lookup = await index.get(virtual_key)
+    if lookup.entry is not None:
+        entry = lookup.entry
+        if entry.resource_type == ResourceType.FOLDER:
+            return FileStat(name=entry.name,
+                            type=FileType.DIRECTORY,
+                            size=entry.size,
+                            modified=entry.remote_time or None)
+        return FileStat(name=entry.name,
+                        size=entry.size,
+                        modified=entry.remote_time or None,
+                        type=guess_type(entry.name))
+    parent = virtual_key.rsplit("/", 1)[0] or "/"
+    parent_listing = await index.list_dir(parent)
+    if parent_listing.entries is not None:
+        raise enoent(virtual)
+    try:
+        item = await graph_get(config, loc.item())
+    except GraphError as exc:
+        if exc.status == 404:
+            raise enoent(virtual)
+        raise
+    return entry_stat(item)

--- a/python/mirage/core/onedrive/_client.py
+++ b/python/mirage/core/onedrive/_client.py
@@ -12,9 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
 from urllib.parse import quote
 
-# yapf: enable
 from mirage.accessor.onedrive import OneDriveConfig
 # yapf: disable
 from mirage.core.msgraph._client import (GRAPH_API, MAX_BACKOFF,
@@ -25,11 +25,14 @@ from mirage.core.msgraph._client import (GRAPH_API, MAX_BACKOFF,
                                          graph_post_monitor, graph_put_bytes,
                                          graph_stream, headers, new_session,
                                          poll_monitor, upload_chunk)
+# yapf: enable
+from mirage.core.msgraph.drive_ops import DriveLoc
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_prefix_of
 
 __all__ = [
     "GRAPH_API",
+    "drive_loc",
     "MAX_BACKOFF",
     "RETRY_STATUSES",
     "GraphError",
@@ -93,3 +96,11 @@ def drive_ref_path(config: OneDriveConfig, folder: str = "") -> str:
     if full:
         return f"{base}/root:/{quote(full, safe='/')}"
     return f"{base}/root:"
+
+
+def drive_loc(config: OneDriveConfig, stripped: str) -> DriveLoc:
+    return DriveLoc(drive="",
+                    path=stripped,
+                    virt=stripped,
+                    url=partial(item_url, config),
+                    ref=partial(drive_ref_path, config))

--- a/python/mirage/core/onedrive/copy.py
+++ b/python/mirage/core/onedrive/copy.py
@@ -12,20 +12,10 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from functools import partial
-
-from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
-from mirage.core.msgraph.drive_ops import DriveLoc, copy_tree
-from mirage.core.onedrive._client import drive_ref_path, item_url, split_path
+from mirage.accessor.onedrive import OneDriveAccessor
+from mirage.core.msgraph.drive_ops import copy_tree
+from mirage.core.onedrive._client import drive_loc, split_path
 from mirage.types import PathSpec
-
-
-def drive_loc(config: OneDriveConfig, stripped: str) -> DriveLoc:
-    return DriveLoc(drive="",
-                    path=stripped,
-                    virt=stripped,
-                    url=partial(item_url, config),
-                    ref=partial(drive_ref_path, config))
 
 
 async def copy(accessor: OneDriveAccessor, src: PathSpec,

--- a/python/mirage/core/onedrive/du.py
+++ b/python/mirage/core/onedrive/du.py
@@ -14,8 +14,8 @@
 
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import NULL_INDEX
-from mirage.core.onedrive._client import new_session, split_path
-from mirage.core.onedrive.find import iter_tree
+from mirage.core.msgraph.drive_ops import du_tree_entries, du_tree_total
+from mirage.core.onedrive._client import drive_loc, split_path
 from mirage.core.onedrive.stat import stat
 from mirage.types import FileType, PathSpec
 
@@ -38,14 +38,8 @@ async def du(accessor: OneDriveAccessor, path: PathSpec) -> int:
     if info is not None and info.type != FileType.DIRECTORY:
         return info.size or 0
     _, base = split_path(path)
-    total = 0
-    async with new_session(accessor.config) as session:
-        async for _rel, item, is_dir in iter_tree(accessor.config,
-                                                  base,
-                                                  session=session):
-            if not is_dir:
-                total += item.get("size", 0)
-    return total
+    return await du_tree_total(accessor.config,
+                               drive_loc(accessor.config, base))
 
 
 async def du_all(accessor: OneDriveAccessor,
@@ -66,16 +60,5 @@ async def du_all(accessor: OneDriveAccessor,
     if info is not None and info.type != FileType.DIRECTORY:
         return []
     _, base = split_path(path)
-    results: list[tuple[str, int]] = []
-    total = 0
-    async with new_session(accessor.config) as session:
-        async for rel, item, is_dir in iter_tree(accessor.config,
-                                                 base,
-                                                 session=session):
-            if is_dir:
-                continue
-            size = item.get("size", 0)
-            results.append(("/" + rel, size))
-            total += size
-    results.append(("/" + base if base else "/", total))
-    return results
+    return await du_tree_entries(accessor.config,
+                                 drive_loc(accessor.config, base))

--- a/python/mirage/core/onedrive/find.py
+++ b/python/mirage/core/onedrive/find.py
@@ -12,36 +12,23 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from collections.abc import AsyncIterator
-
-import aiohttp
+from functools import partial
 
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import NULL_INDEX
-from mirage.commands.builtin.find_eval import (FindEntry, PredNode, build_tree,
-                                               emit_start_path, keep,
-                                               start_basename)
-from mirage.core.onedrive._client import (graph_list, item_url, new_session,
-                                          split_path)
+from mirage.commands.builtin.find_eval import PredNode, start_basename
+from mirage.core.msgraph.drive_ops import find_items
+from mirage.core.onedrive._client import drive_loc, split_path
 from mirage.core.onedrive.stat import stat
 from mirage.types import FileType, PathSpec
 
 
-async def iter_tree(
-    config,
-    base: str,
-    session: aiohttp.ClientSession | None = None,
-) -> AsyncIterator[tuple[str, dict, bool]]:
-    url = item_url(config, "/" + base if base else "/", action="/children")
-    children = await graph_list(config, url, session=session)
-    for child in children:
-        cname = child.get("name", "")
-        rel = f"{base}/{cname}" if base else cname
-        is_dir = "folder" in child
-        yield rel, child, is_dir
-        if is_dir:
-            async for entry in iter_tree(config, rel, session=session):
-                yield entry
+async def _dir_exists(accessor: OneDriveAccessor, path: PathSpec) -> bool:
+    try:
+        info = await stat(accessor, path, index=NULL_INDEX)
+    except FileNotFoundError:
+        return False
+    return info.type == FileType.DIRECTORY
 
 
 async def find(
@@ -62,66 +49,20 @@ async def find(
     empty: bool = False,
     tree: PredNode | None = None,
 ) -> list[str]:
-    start_name = start_basename(path)
     _, base = split_path(path)
-    results: list[str] = []
-    saw_descendant = False
-    tree = tree if tree is not None else build_tree(name=name,
-                                                    iname=iname,
-                                                    path_pattern=path_pattern,
-                                                    type=type,
-                                                    name_exclude=name_exclude,
-                                                    or_names=or_names,
-                                                    empty=empty)
-    async with new_session(accessor.config) as session:
-        async for rel, item, is_dir in iter_tree(accessor.config,
-                                                 base,
-                                                 session=session):
-            relative = rel[len(base):].lstrip("/") if base else rel
-            depth = relative.count("/") + 1
-            if maxdepth is not None and depth > maxdepth:
-                continue
-            saw_descendant = True
-            entry_name = rel.rsplit("/", 1)[-1]
-            full_path = "/" + rel
-            size = item.get("size", 0)
-            is_empty = (None if not empty else
-                        (size == 0 if not is_dir else False))
-            entry = FindEntry(key=full_path,
-                              name=entry_name,
-                              kind="d" if is_dir else "f",
-                              depth=depth,
-                              is_empty=is_empty)
-            if not keep(entry, tree, mindepth):
-                continue
-            if min_size is not None or max_size is not None:
-                # Directories count as size 0 for -size (deliberate GNU
-                # divergence).
-                effective = 0 if is_dir else size
-                if min_size is not None and effective < min_size:
-                    continue
-                if max_size is not None and effective > max_size:
-                    continue
-            results.append(full_path)
-    dir_exists = saw_descendant
-    if not dir_exists:
-        try:
-            dir_exists = (await
-                          stat(accessor, path,
-                               index=NULL_INDEX)).type == FileType.DIRECTORY
-        except FileNotFoundError:
-            dir_exists = False
-    if dir_exists:
-        root_key = "/" + base if base else "/"
-        emit_start_path(results,
-                        root_key,
-                        start_name,
-                        kind="d",
-                        is_empty=False if empty else None,
-                        exists=True,
-                        tree=tree,
-                        maxdepth=maxdepth,
-                        mindepth=mindepth,
-                        min_size=min_size,
-                        max_size=max_size)
-    return sorted(results)
+    return await find_items(accessor.config,
+                            drive_loc(accessor.config, base),
+                            start_basename(path),
+                            partial(_dir_exists, accessor, path),
+                            name=name,
+                            type=type,
+                            min_size=min_size,
+                            max_size=max_size,
+                            maxdepth=maxdepth,
+                            name_exclude=name_exclude,
+                            or_names=or_names,
+                            iname=iname,
+                            path_pattern=path_pattern,
+                            mindepth=mindepth,
+                            empty=empty,
+                            tree=tree)

--- a/python/mirage/core/onedrive/read.py
+++ b/python/mirage/core/onedrive/read.py
@@ -12,24 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import time
-from urllib.parse import quote
-
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.core.onedrive._client import (GraphError, graph_get_bytes,
-                                          item_url, split_path)
-from mirage.core.onedrive.versions import capture_metadata
-from mirage.observe.context import active_recorder, record, revision_for
+from mirage.core.msgraph.drive_ops import read_item
+from mirage.core.onedrive._client import drive_loc, split_path
 from mirage.types import PathSpec
-from mirage.utils.errors import enoent
-
-
-def _range_header(offset: int, size: int | None) -> str | None:
-    if not offset and size is None:
-        return None
-    end = (offset + size - 1) if size is not None else ""
-    return f"bytes={offset}-{end}"
 
 
 async def read_bytes(accessor: OneDriveAccessor,
@@ -38,41 +25,11 @@ async def read_bytes(accessor: OneDriveAccessor,
                      offset: int = 0,
                      size: int | None = None) -> bytes:
     virtual = path.virtual if isinstance(path, PathSpec) else path
-    prefix, stripped = split_path(path)
-    config = accessor.config
-    pinned = revision_for(virtual)
-    range_header = _range_header(offset, size)
-    start_ms = int(time.monotonic() * 1000)
-    fingerprint = None
-    revision = pinned
-    try:
-        if pinned:
-            action = f"/versions/{quote(pinned, safe='')}/content"
-            url = item_url(config, "/" + stripped, action=action)
-            data = await graph_get_bytes(config, url, range_header)
-        elif active_recorder() is not None:
-            fingerprint, revision, download_url = await capture_metadata(
-                accessor, path)
-            if download_url:
-                data = await graph_get_bytes(config,
-                                             download_url,
-                                             range_header,
-                                             auth=False)
-            else:
-                url = item_url(config, "/" + stripped, action="/content")
-                data = await graph_get_bytes(config, url, range_header)
-        else:
-            url = item_url(config, "/" + stripped, action="/content")
-            data = await graph_get_bytes(config, url, range_header)
-    except GraphError as exc:
-        if exc.status == 404:
-            raise enoent(virtual)
-        raise
-    record("read",
-           stripped,
-           "onedrive",
-           len(data),
-           start_ms,
-           fingerprint=fingerprint,
-           revision=revision)
-    return data
+    _, stripped = split_path(path)
+    return await read_item(accessor.config,
+                           drive_loc(accessor.config, stripped),
+                           virtual,
+                           stripped,
+                           "onedrive",
+                           offset=offset,
+                           size=size)

--- a/python/mirage/core/onedrive/readdir.py
+++ b/python/mirage/core/onedrive/readdir.py
@@ -12,13 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.onedrive import OneDriveAccessor
-from mirage.cache.index import (NULL_INDEX, IndexCacheStore, IndexEntry,
-                                ResourceType)
-from mirage.core.onedrive._client import GraphError, graph_list, item_url
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.core.msgraph.drive_ops import readdir_items
+from mirage.core.onedrive._client import drive_loc
 from mirage.core.onedrive.stat import stat
-from mirage.types import FileType, PathSpec
-from mirage.utils.errors import enoent
+from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_prefix_of
 
 
@@ -38,42 +39,7 @@ async def readdir(accessor: OneDriveAccessor,
     listing = await index.list_dir(virtual_key)
     if listing.entries is not None:
         return listing.entries
-
-    url = item_url(accessor.config,
-                   "/" + stripped if stripped else "/",
-                   action="/children")
-    try:
-        children = await graph_list(accessor.config, url)
-    except GraphError as exc:
-        if exc.status != 404:
-            raise
-        info = await stat(accessor, original, index=index)
-        if info.type != FileType.DIRECTORY:
-            raise NotADirectoryError(virtual_key) from exc
-        raise enoent(virtual_key) from exc
-    base = "/" + stripped if stripped else ""
-    names: list[str] = []
-    index_entries: list[tuple[str, IndexEntry]] = []
-    for child in children:
-        cname = child.get("name", "")
-        key = f"{base}/{cname}"
-        names.append(key)
-        if "folder" in child:
-            entry = IndexEntry(id=key,
-                               name=cname,
-                               resource_type=ResourceType.FOLDER,
-                               size=child.get("size"),
-                               remote_time=child.get("lastModifiedDateTime",
-                                                     ""))
-        else:
-            entry = IndexEntry(id=key,
-                               name=cname,
-                               resource_type=ResourceType.FILE,
-                               size=child.get("size"),
-                               remote_time=child.get("lastModifiedDateTime",
-                                                     ""))
-        index_entries.append((cname, entry))
-    names = sorted(names)
-    virtual_entries = sorted((prefix + e if prefix else e) for e in names)
-    await index.set_dir(virtual_key, index_entries)
-    return virtual_entries
+    return await readdir_items(accessor.config,
+                               drive_loc(accessor.config, stripped), index,
+                               prefix, stripped, virtual_key,
+                               partial(stat, accessor, original, index))

--- a/python/mirage/core/onedrive/rename.py
+++ b/python/mirage/core/onedrive/rename.py
@@ -16,8 +16,7 @@ from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.context import (invalidate_after_unlink,
                                   invalidate_after_write)
 from mirage.core.msgraph.drive_ops import rename_replace
-from mirage.core.onedrive._client import split_path
-from mirage.core.onedrive.copy import drive_loc
+from mirage.core.onedrive._client import drive_loc, split_path
 from mirage.types import PathSpec
 
 

--- a/python/mirage/core/onedrive/stat.py
+++ b/python/mirage/core/onedrive/stat.py
@@ -13,33 +13,10 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.onedrive import OneDriveAccessor
-from mirage.cache.index import NULL_INDEX, IndexCacheStore, ResourceType
-from mirage.core.onedrive._client import (GraphError, graph_get, item_url,
-                                          split_path)
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.core.msgraph.drive_ops import stat_item
+from mirage.core.onedrive._client import drive_loc, split_path
 from mirage.types import FileStat, FileType, PathSpec
-from mirage.utils.errors import enoent
-from mirage.utils.filetype import guess_type
-
-
-def _entry_stat(item: dict) -> FileStat:
-    name = item.get("name", "")
-    if "folder" in item:
-        return FileStat(name=name,
-                        type=FileType.DIRECTORY,
-                        size=item.get("size"),
-                        modified=item.get("lastModifiedDateTime"))
-    return FileStat(
-        name=name,
-        size=item.get("size"),
-        modified=item.get("lastModifiedDateTime"),
-        type=guess_type(name),
-        fingerprint=item.get("cTag"),
-        extra={
-            "id": item.get("id"),
-            "ctag": item.get("cTag"),
-            "etag": item.get("eTag"),
-        },
-    )
 
 
 async def stat(accessor: OneDriveAccessor,
@@ -49,30 +26,7 @@ async def stat(accessor: OneDriveAccessor,
     prefix, stripped = split_path(path)
     if not stripped:
         return FileStat(name="/", type=FileType.DIRECTORY)
-
     virtual_key = (prefix + "/" + stripped if prefix else "/" + stripped)
-    lookup = await index.get(virtual_key)
-    if lookup.entry is not None:
-        entry = lookup.entry
-        if entry.resource_type == ResourceType.FOLDER:
-            return FileStat(name=entry.name,
-                            type=FileType.DIRECTORY,
-                            size=entry.size,
-                            modified=entry.remote_time or None)
-        return FileStat(name=entry.name,
-                        size=entry.size,
-                        modified=entry.remote_time or None,
-                        type=guess_type(entry.name))
-    parent = virtual_key.rsplit("/", 1)[0] or "/"
-    parent_listing = await index.list_dir(parent)
-    if parent_listing.entries is not None:
-        raise enoent(virtual)
-
-    try:
-        item = await graph_get(accessor.config,
-                               item_url(accessor.config, "/" + stripped))
-    except GraphError as exc:
-        if exc.status == 404:
-            raise enoent(virtual)
-        raise
-    return _entry_stat(item)
+    return await stat_item(accessor.config, drive_loc(accessor.config,
+                                                      stripped), virtual,
+                           virtual_key, index)

--- a/python/mirage/core/onedrive/stream.py
+++ b/python/mirage/core/onedrive/stream.py
@@ -13,17 +13,13 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import AsyncIterator
-from urllib.parse import quote
 
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.core.onedrive._client import (GraphError, graph_stream, item_url,
-                                          split_path)
+from mirage.core.msgraph.drive_ops import stream_item
+from mirage.core.onedrive._client import drive_loc, split_path
 from mirage.core.onedrive.read import read_bytes
-from mirage.core.onedrive.versions import capture_metadata
-from mirage.observe.context import record_stream, revision_for
 from mirage.types import PathSpec
-from mirage.utils.errors import enoent
 
 
 async def read_stream(
@@ -33,32 +29,11 @@ async def read_stream(
     chunk_size: int = 8192,
 ) -> AsyncIterator[bytes]:
     virtual = path.virtual if isinstance(path, PathSpec) else path
-    prefix, stripped = split_path(path)
-    config = accessor.config
-    pinned = revision_for(virtual)
-    rec = record_stream("read", stripped, "onedrive")
-    url = item_url(config, "/" + stripped, action="/content")
-    auth = True
-    try:
-        if pinned is not None:
-            action = f"/versions/{quote(pinned, safe='')}/content"
-            url = item_url(config, "/" + stripped, action=action)
-            if rec is not None:
-                rec.revision = pinned
-        elif rec is not None:
-            (rec.fingerprint, rec.revision,
-             download_url) = await capture_metadata(accessor, path)
-            if download_url:
-                url = download_url
-                auth = False
-        async for chunk in graph_stream(config, url, chunk_size, auth=auth):
-            if rec is not None:
-                rec.bytes += len(chunk)
-            yield chunk
-    except GraphError as exc:
-        if exc.status == 404:
-            raise enoent(virtual)
-        raise
+    _, stripped = split_path(path)
+    loc = drive_loc(accessor.config, stripped)
+    async for chunk in stream_item(accessor.config, loc, virtual, stripped,
+                                   "onedrive", chunk_size):
+        yield chunk
 
 
 async def range_read(accessor: OneDriveAccessor, path: PathSpec, start: int,

--- a/python/mirage/core/onedrive/versions.py
+++ b/python/mirage/core/onedrive/versions.py
@@ -13,34 +13,21 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.accessor.onedrive import OneDriveAccessor
-from mirage.core.onedrive._client import (graph_get, graph_list, item_url,
-                                          split_path)
+from mirage.core.msgraph.drive_ops import capture_item_metadata
+from mirage.core.onedrive._client import drive_loc, graph_list, split_path
 from mirage.types import PathSpec
-
-
-def _current_version_id(versions: list[dict]) -> str | None:
-    if not versions:
-        return None
-    current = max(versions, key=lambda v: v.get("lastModifiedDateTime") or "")
-    return current.get("id")
 
 
 async def list_versions(accessor: OneDriveAccessor,
                         path: PathSpec) -> list[dict]:
     _, stripped = split_path(path)
-    url = item_url(accessor.config, "/" + stripped, action="/versions")
-    return await graph_list(accessor.config, url)
+    loc = drive_loc(accessor.config, stripped)
+    return await graph_list(accessor.config, loc.item("/versions"))
 
 
 async def capture_metadata(
         accessor: OneDriveAccessor,
         path: PathSpec) -> tuple[str | None, str | None, str | None]:
     _, stripped = split_path(path)
-    config = accessor.config
-    item = await graph_get(config,
-                           item_url(config, "/" + stripped),
-                           params={"$expand": "versions"})
-    fingerprint = item.get("cTag")
-    revision = _current_version_id(item.get("versions", []))
-    download_url = item.get("@microsoft.graph.downloadUrl")
-    return fingerprint, revision, download_url
+    return await capture_item_metadata(accessor.config,
+                                       drive_loc(accessor.config, stripped))

--- a/python/mirage/core/sharepoint/_resolver.py
+++ b/python/mirage/core/sharepoint/_resolver.py
@@ -1,8 +1,11 @@
 from dataclasses import dataclass
+from functools import partial
 from typing import Literal
 
 from mirage.accessor.sharepoint import SharePointAccessor
-from mirage.core.sharepoint._client import GRAPH_API, graph_list
+from mirage.core.msgraph.drive_ops import DriveLoc
+from mirage.core.sharepoint._client import (GRAPH_API, drive_ref_path,
+                                            graph_list, item_url)
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_prefix_of
 
@@ -77,6 +80,25 @@ async def resolve(accessor: SharePointAccessor,
             raw = rest or "/"
     raw = raw.strip("/")
 
+    config = accessor.config
+    if config.site is not None and config.drive is not None:
+        # Scoped mount: the whole mount lives inside one drive, so paths
+        # are drive-relative and the site/drive namespace levels vanish.
+        site_id = await _resolve_site_id(accessor, config.site)
+        if site_id is None:
+            return ResolvedPath(level="site", site_id=None)
+        drive_id = await _resolve_drive_id(accessor, site_id, config.drive)
+        if drive_id is None:
+            return ResolvedPath(level="drive", site_id=site_id, drive_id=None)
+        if not raw:
+            return ResolvedPath(level="drive",
+                                site_id=site_id,
+                                drive_id=drive_id)
+        return ResolvedPath(level="item",
+                            site_id=site_id,
+                            drive_id=drive_id,
+                            item_path=raw)
+
     if not raw:
         return ResolvedPath(level="root")
 
@@ -140,3 +162,12 @@ async def list_drives(accessor: SharePointAccessor, site_id: str) -> list[str]:
         names.append(name)
         _drive_cache[(site_id, name)] = d["id"]
     return sorted(names)
+
+
+def drive_loc(resolved: ResolvedPath, virt: str) -> DriveLoc:
+    assert resolved.drive_id is not None
+    return DriveLoc(drive=resolved.drive_id,
+                    path=resolved.item_path or "",
+                    virt=virt,
+                    url=partial(item_url, resolved.drive_id),
+                    ref=partial(drive_ref_path, resolved.drive_id))

--- a/python/mirage/core/sharepoint/du.py
+++ b/python/mirage/core/sharepoint/du.py
@@ -1,8 +1,7 @@
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.index import NULL_INDEX
-from mirage.core.sharepoint._client import new_session
-from mirage.core.sharepoint._resolver import resolve
-from mirage.core.sharepoint.find import iter_tree
+from mirage.core.msgraph.drive_ops import du_tree_entries, du_tree_total
+from mirage.core.sharepoint._resolver import drive_loc, resolve
 from mirage.core.sharepoint.stat import stat
 from mirage.types import FileType, PathSpec
 
@@ -17,16 +16,8 @@ async def du(accessor: SharePointAccessor, path: PathSpec) -> int:
     resolved = await resolve(accessor, path)
     if resolved.drive_id is None:
         return 0
-    item_base = resolved.item_path or ""
-    total = 0
-    async with new_session(accessor.config) as session:
-        async for _rel, item, is_dir in iter_tree(accessor.config,
-                                                  resolved.drive_id,
-                                                  item_base,
-                                                  session=session):
-            if not is_dir:
-                total += item.get("size", 0)
-    return total
+    virt = path.mount_path if isinstance(path, PathSpec) else path
+    return await du_tree_total(accessor.config, drive_loc(resolved, virt))
 
 
 async def du_all(accessor: SharePointAccessor,
@@ -40,18 +31,5 @@ async def du_all(accessor: SharePointAccessor,
     resolved = await resolve(accessor, path)
     if resolved.drive_id is None:
         return []
-    item_base = resolved.item_path or ""
-    results: list[tuple[str, int]] = []
-    total = 0
-    async with new_session(accessor.config) as session:
-        async for rel, item, is_dir in iter_tree(accessor.config,
-                                                 resolved.drive_id,
-                                                 item_base,
-                                                 session=session):
-            if is_dir:
-                continue
-            size = item.get("size", 0)
-            results.append(("/" + rel, size))
-            total += size
-    results.append(("/" + item_base if item_base else "/", total))
-    return results
+    virt = path.mount_path if isinstance(path, PathSpec) else path
+    return await du_tree_entries(accessor.config, drive_loc(resolved, virt))

--- a/python/mirage/core/sharepoint/find.py
+++ b/python/mirage/core/sharepoint/find.py
@@ -1,37 +1,20 @@
-from collections.abc import AsyncIterator
-
-import aiohttp
+from functools import partial
 
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.index import NULL_INDEX
-from mirage.commands.builtin.find_eval import (FindEntry, PredNode, build_tree,
-                                               emit_start_path, keep,
-                                               start_basename)
-from mirage.core.sharepoint._client import graph_list, item_url, new_session
-from mirage.core.sharepoint._resolver import resolve
+from mirage.commands.builtin.find_eval import PredNode, start_basename
+from mirage.core.msgraph.drive_ops import find_items
+from mirage.core.sharepoint._resolver import drive_loc, resolve
 from mirage.core.sharepoint.stat import stat
 from mirage.types import FileType, PathSpec
 
 
-async def iter_tree(
-    config,
-    drive_id: str,
-    base: str,
-    session: aiohttp.ClientSession | None = None,
-) -> AsyncIterator[tuple[str, dict, bool]]:
-    url = item_url(drive_id, "/" + base if base else "/", action="/children")
-    children = await graph_list(config, url, session=session)
-    for child in children:
-        cname = child.get("name", "")
-        rel = f"{base}/{cname}" if base else cname
-        is_dir = "folder" in child
-        yield rel, child, is_dir
-        if is_dir:
-            async for entry in iter_tree(config,
-                                         drive_id,
-                                         rel,
-                                         session=session):
-                yield entry
+async def _dir_exists(accessor: SharePointAccessor, path: PathSpec) -> bool:
+    try:
+        info = await stat(accessor, path, index=NULL_INDEX)
+    except FileNotFoundError:
+        return False
+    return info.type == FileType.DIRECTORY
 
 
 async def find(
@@ -52,71 +35,23 @@ async def find(
     empty: bool = False,
     tree: PredNode | None = None,
 ) -> list[str]:
-    start_name = start_basename(path)
     resolved = await resolve(accessor, path)
     if resolved.drive_id is None:
         return []
-    drive_id = resolved.drive_id
-    item_base = resolved.item_path or ""
-    results: list[str] = []
-    saw_descendant = False
-    tree = tree if tree is not None else build_tree(name=name,
-                                                    iname=iname,
-                                                    path_pattern=path_pattern,
-                                                    type=type,
-                                                    name_exclude=name_exclude,
-                                                    or_names=or_names,
-                                                    empty=empty)
-    async with new_session(accessor.config) as session:
-        async for rel, item, is_dir in iter_tree(accessor.config,
-                                                 drive_id,
-                                                 item_base,
-                                                 session=session):
-            relative = rel[len(item_base):].lstrip("/") if item_base else rel
-            depth = relative.count("/") + 1
-            if maxdepth is not None and depth > maxdepth:
-                continue
-            saw_descendant = True
-            entry_name = rel.rsplit("/", 1)[-1]
-            full_path = "/" + rel
-            size = item.get("size", 0)
-            is_empty = (None if not empty else
-                        (size == 0 if not is_dir else False))
-            entry = FindEntry(key=full_path,
-                              name=entry_name,
-                              kind="d" if is_dir else "f",
-                              depth=depth,
-                              is_empty=is_empty)
-            if not keep(entry, tree, mindepth):
-                continue
-            if min_size is not None or max_size is not None:
-                # Directories count as size 0 for -size (deliberate GNU
-                # divergence).
-                effective = 0 if is_dir else size
-                if min_size is not None and effective < min_size:
-                    continue
-                if max_size is not None and effective > max_size:
-                    continue
-            results.append(full_path)
-    dir_exists = saw_descendant
-    if not dir_exists:
-        try:
-            dir_exists = (await
-                          stat(accessor, path,
-                               index=NULL_INDEX)).type == FileType.DIRECTORY
-        except FileNotFoundError:
-            dir_exists = False
-    if dir_exists:
-        root_key = "/" + item_base if item_base else "/"
-        emit_start_path(results,
-                        root_key,
-                        start_name,
-                        kind="d",
-                        is_empty=False if empty else None,
-                        exists=True,
-                        tree=tree,
-                        maxdepth=maxdepth,
-                        mindepth=mindepth,
-                        min_size=min_size,
-                        max_size=max_size)
-    return sorted(results)
+    virt = path.mount_path if isinstance(path, PathSpec) else path
+    return await find_items(accessor.config,
+                            drive_loc(resolved, virt),
+                            start_basename(path),
+                            partial(_dir_exists, accessor, path),
+                            name=name,
+                            type=type,
+                            min_size=min_size,
+                            max_size=max_size,
+                            maxdepth=maxdepth,
+                            name_exclude=name_exclude,
+                            or_names=or_names,
+                            iname=iname,
+                            path_pattern=path_pattern,
+                            mindepth=mindepth,
+                            empty=empty,
+                            tree=tree)

--- a/python/mirage/core/sharepoint/read.py
+++ b/python/mirage/core/sharepoint/read.py
@@ -1,22 +1,10 @@
-import time
-from urllib.parse import quote
-
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.core.sharepoint._client import (GraphError, graph_get_bytes,
-                                            item_url, split_path)
-from mirage.core.sharepoint._resolver import resolve
-from mirage.core.sharepoint.versions import capture_metadata
-from mirage.observe.context import active_recorder, record, revision_for
+from mirage.core.msgraph.drive_ops import read_item
+from mirage.core.sharepoint._client import split_path
+from mirage.core.sharepoint._resolver import drive_loc, resolve
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
-
-
-def _range_header(offset: int, size: int | None) -> str | None:
-    if not offset and size is None:
-        return None
-    end = (offset + size - 1) if size is not None else ""
-    return f"bytes={offset}-{end}"
 
 
 async def read_bytes(accessor: SharePointAccessor,
@@ -29,42 +17,10 @@ async def read_bytes(accessor: SharePointAccessor,
     resolved = await resolve(accessor, path)
     if resolved.drive_id is None or resolved.item_path is None:
         raise enoent(virtual)
-    config = accessor.config
-    drive_id = resolved.drive_id
-    item_p = resolved.item_path
-    pinned = revision_for(virtual)
-    range_header = _range_header(offset, size)
-    start_ms = int(time.monotonic() * 1000)
-    fingerprint = None
-    revision = pinned
-    try:
-        if pinned:
-            action = f"/versions/{quote(pinned, safe='')}/content"
-            url = item_url(drive_id, item_p, action=action)
-            data = await graph_get_bytes(config, url, range_header)
-        elif active_recorder() is not None:
-            fingerprint, revision, download_url = await capture_metadata(
-                accessor, path)
-            if download_url:
-                data = await graph_get_bytes(config,
-                                             download_url,
-                                             range_header,
-                                             auth=False)
-            else:
-                url = item_url(drive_id, item_p, action="/content")
-                data = await graph_get_bytes(config, url, range_header)
-        else:
-            url = item_url(drive_id, item_p, action="/content")
-            data = await graph_get_bytes(config, url, range_header)
-    except GraphError as exc:
-        if exc.status == 404:
-            raise enoent(virtual)
-        raise
-    record("read",
-           stripped,
-           "sharepoint",
-           len(data),
-           start_ms,
-           fingerprint=fingerprint,
-           revision=revision)
-    return data
+    return await read_item(accessor.config,
+                           drive_loc(resolved, stripped),
+                           virtual,
+                           stripped,
+                           "sharepoint",
+                           offset=offset,
+                           size=size)

--- a/python/mirage/core/sharepoint/readdir.py
+++ b/python/mirage/core/sharepoint/readdir.py
@@ -1,11 +1,13 @@
+from functools import partial
+
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.index import (NULL_INDEX, IndexCacheStore, IndexEntry,
                                 ResourceType)
-from mirage.core.sharepoint._client import GraphError, graph_list, item_url
-from mirage.core.sharepoint._resolver import list_drives, list_sites, resolve
+from mirage.core.msgraph.drive_ops import readdir_items
+from mirage.core.sharepoint._resolver import (drive_loc, list_drives,
+                                              list_sites, resolve)
 from mirage.core.sharepoint.stat import stat
-from mirage.types import FileType, PathSpec
-from mirage.utils.errors import enoent
+from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_prefix_of
 
 
@@ -58,43 +60,6 @@ async def readdir(accessor: SharePointAccessor,
     if resolved.drive_id is None:
         return []
 
-    drive_id = resolved.drive_id
-    item_path = resolved.item_path or ""
-    url = item_url(drive_id,
-                   "/" + item_path if item_path else "/",
-                   action="/children")
-    try:
-        children = await graph_list(accessor.config, url)
-    except GraphError as exc:
-        if exc.status != 404:
-            raise
-        info = await stat(accessor, original, index=index)
-        if info.type != FileType.DIRECTORY:
-            raise NotADirectoryError(virtual_key) from exc
-        raise enoent(virtual_key) from exc
-    base = "/" + stripped if stripped else ""
-    names = []
-    index_entries = []
-    for child in children:
-        cname = child.get("name", "")
-        key = f"{base}/{cname}"
-        names.append(key)
-        if "folder" in child:
-            entry = IndexEntry(id=key,
-                               name=cname,
-                               resource_type=ResourceType.FOLDER,
-                               size=child.get("size"),
-                               remote_time=child.get("lastModifiedDateTime",
-                                                     ""))
-        else:
-            entry = IndexEntry(id=key,
-                               name=cname,
-                               resource_type=ResourceType.FILE,
-                               size=child.get("size"),
-                               remote_time=child.get("lastModifiedDateTime",
-                                                     ""))
-        index_entries.append((cname, entry))
-    names = sorted(names)
-    virtual_entries = sorted((prefix + e if prefix else e) for e in names)
-    await index.set_dir(virtual_key, index_entries)
-    return virtual_entries
+    return await readdir_items(accessor.config, drive_loc(resolved, stripped),
+                               index, prefix, stripped, virtual_key,
+                               partial(stat, accessor, original, index))

--- a/python/mirage/core/sharepoint/stat.py
+++ b/python/mirage/core/sharepoint/stat.py
@@ -1,32 +1,10 @@
 from mirage.accessor.sharepoint import SharePointAccessor
-from mirage.cache.index import NULL_INDEX, IndexCacheStore, ResourceType
-from mirage.core.sharepoint._client import (GraphError, graph_get, item_url,
-                                            split_path)
-from mirage.core.sharepoint._resolver import resolve
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.core.msgraph.drive_ops import stat_item
+from mirage.core.sharepoint._client import split_path
+from mirage.core.sharepoint._resolver import drive_loc, resolve
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.errors import enoent
-from mirage.utils.filetype import guess_type
-
-
-def _entry_stat(item: dict) -> FileStat:
-    name = item.get("name", "")
-    if "folder" in item:
-        return FileStat(name=name,
-                        type=FileType.DIRECTORY,
-                        size=item.get("size"),
-                        modified=item.get("lastModifiedDateTime"))
-    return FileStat(
-        name=name,
-        size=item.get("size"),
-        modified=item.get("lastModifiedDateTime"),
-        type=guess_type(name),
-        fingerprint=item.get("cTag"),
-        extra={
-            "id": item.get("id"),
-            "ctag": item.get("cTag"),
-            "etag": item.get("eTag"),
-        },
-    )
 
 
 async def stat(accessor: SharePointAccessor,
@@ -54,28 +32,5 @@ async def stat(accessor: SharePointAccessor,
         raise enoent(virtual)
 
     virtual_key = (prefix + "/" + stripped if prefix else "/" + stripped)
-    lookup = await index.get(virtual_key)
-    if lookup.entry is not None:
-        entry = lookup.entry
-        if entry.resource_type == ResourceType.FOLDER:
-            return FileStat(name=entry.name,
-                            type=FileType.DIRECTORY,
-                            size=entry.size,
-                            modified=entry.remote_time or None)
-        return FileStat(name=entry.name,
-                        size=entry.size,
-                        modified=entry.remote_time or None,
-                        type=guess_type(entry.name))
-    parent = virtual_key.rsplit("/", 1)[0] or "/"
-    parent_listing = await index.list_dir(parent)
-    if parent_listing.entries is not None:
-        raise enoent(virtual)
-
-    try:
-        item = await graph_get(accessor.config,
-                               item_url(resolved.drive_id, resolved.item_path))
-    except GraphError as exc:
-        if exc.status == 404:
-            raise enoent(virtual)
-        raise
-    return _entry_stat(item)
+    return await stat_item(accessor.config, drive_loc(resolved, stripped),
+                           virtual, virtual_key, index)

--- a/python/mirage/core/sharepoint/stream.py
+++ b/python/mirage/core/sharepoint/stream.py
@@ -1,14 +1,11 @@
 from collections.abc import AsyncIterator
-from urllib.parse import quote
 
 from mirage.accessor.sharepoint import SharePointAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.core.sharepoint._client import (GraphError, graph_stream, item_url,
-                                            split_path)
-from mirage.core.sharepoint._resolver import resolve
+from mirage.core.msgraph.drive_ops import stream_item
+from mirage.core.sharepoint._client import split_path
+from mirage.core.sharepoint._resolver import drive_loc, resolve
 from mirage.core.sharepoint.read import read_bytes
-from mirage.core.sharepoint.versions import capture_metadata
-from mirage.observe.context import record_stream, revision_for
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
@@ -24,33 +21,10 @@ async def read_stream(
     resolved = await resolve(accessor, path)
     if resolved.drive_id is None or resolved.item_path is None:
         raise enoent(virtual)
-    config = accessor.config
-    drive_id = resolved.drive_id
-    item_p = resolved.item_path
-    pinned = revision_for(virtual)
-    rec = record_stream("read", stripped, "sharepoint")
-    url = item_url(drive_id, item_p, action="/content")
-    auth = True
-    try:
-        if pinned is not None:
-            action = f"/versions/{quote(pinned, safe='')}/content"
-            url = item_url(drive_id, item_p, action=action)
-            if rec is not None:
-                rec.revision = pinned
-        elif rec is not None:
-            (rec.fingerprint, rec.revision,
-             download_url) = await capture_metadata(accessor, path)
-            if download_url:
-                url = download_url
-                auth = False
-        async for chunk in graph_stream(config, url, chunk_size, auth=auth):
-            if rec is not None:
-                rec.bytes += len(chunk)
-            yield chunk
-    except GraphError as exc:
-        if exc.status == 404:
-            raise enoent(virtual)
-        raise
+    loc = drive_loc(resolved, stripped)
+    async for chunk in stream_item(accessor.config, loc, virtual, stripped,
+                                   "sharepoint", chunk_size):
+        yield chunk
 
 
 async def range_read(accessor: SharePointAccessor, path: PathSpec, start: int,

--- a/python/mirage/core/sharepoint/versions.py
+++ b/python/mirage/core/sharepoint/versions.py
@@ -1,14 +1,7 @@
 from mirage.accessor.sharepoint import SharePointAccessor
-from mirage.core.sharepoint._client import graph_get, item_url
-from mirage.core.sharepoint._resolver import resolve
+from mirage.core.msgraph.drive_ops import capture_item_metadata
+from mirage.core.sharepoint._resolver import drive_loc, resolve
 from mirage.types import PathSpec
-
-
-def _current_version_id(versions: list[dict]) -> str | None:
-    if not versions:
-        return None
-    current = max(versions, key=lambda v: v.get("lastModifiedDateTime") or "")
-    return current.get("id")
 
 
 async def capture_metadata(
@@ -17,11 +10,6 @@ async def capture_metadata(
     resolved = await resolve(accessor, path)
     if resolved.drive_id is None or resolved.item_path is None:
         return None, None, None
-    config = accessor.config
-    item = await graph_get(config,
-                           item_url(resolved.drive_id, resolved.item_path),
-                           params={"$expand": "versions"})
-    fingerprint = item.get("cTag")
-    revision = _current_version_id(item.get("versions", []))
-    download_url = item.get("@microsoft.graph.downloadUrl")
-    return fingerprint, revision, download_url
+    virt = path.mount_path if isinstance(path, PathSpec) else path
+    return await capture_item_metadata(accessor.config,
+                                       drive_loc(resolved, virt))

--- a/python/tests/core/sharepoint/test_find.py
+++ b/python/tests/core/sharepoint/test_find.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import mirage.core.msgraph.drive_ops as drive_ops
 from mirage.core.sharepoint import find as find_mod
 from mirage.core.sharepoint._resolver import ResolvedPath
 from mirage.types import PathSpec
@@ -32,7 +33,7 @@ class _FakeSession:
         return False
 
 
-async def _fake_iter_tree(config, drive_id, base, session=None):
+async def _fake_iter_tree(config, loc, session=None):
     for rel, item, is_dir in _TREE:
         yield rel, item, is_dir
 
@@ -44,8 +45,9 @@ async def _fake_resolve(accessor, path):
 @pytest.fixture
 def _patched(monkeypatch):
     monkeypatch.setattr(find_mod, "resolve", _fake_resolve)
-    monkeypatch.setattr(find_mod, "iter_tree", _fake_iter_tree)
-    monkeypatch.setattr(find_mod, "new_session", lambda config: _FakeSession())
+    monkeypatch.setattr(drive_ops, "iter_tree", _fake_iter_tree)
+    monkeypatch.setattr(drive_ops, "new_session",
+                        lambda config: _FakeSession())
 
 
 def _spec() -> PathSpec:

--- a/python/tests/core/sharepoint/test_resolver.py
+++ b/python/tests/core/sharepoint/test_resolver.py
@@ -95,3 +95,50 @@ async def test_resolve_unknown_site():
         result = await resolve(_accessor(), path)
     assert result.level == "site"
     assert result.site_id is None
+
+
+def _scoped_accessor() -> SharePointAccessor:
+    return SharePointAccessor(
+        SharePointConfig(access_token="tok",
+                         site="Engineering",
+                         drive="Documents"))
+
+
+def _seed_scoped():
+    _site_cache["Engineering"] = _SITE_ID
+    _drive_cache[(_SITE_ID, "Documents")] = _DRIVE_ID
+
+
+def _spec(virtual: str) -> PathSpec:
+    return PathSpec(resource_path=mount_key(virtual, "/sp"),
+                    virtual=virtual,
+                    directory=virtual)
+
+
+@pytest.mark.asyncio
+async def test_scoped_resolve_root_is_drive_level():
+    _seed_scoped()
+    result = await resolve(_scoped_accessor(), _spec("/sp/"))
+    assert result.level == "drive"
+    assert result.drive_id == _DRIVE_ID
+    assert result.item_path is None
+
+
+@pytest.mark.asyncio
+async def test_scoped_resolve_path_is_drive_relative_item():
+    _seed_scoped()
+    result = await resolve(_scoped_accessor(), _spec("/sp/sub/a.txt"))
+    assert result.level == "item"
+    assert result.drive_id == _DRIVE_ID
+    assert result.item_path == "sub/a.txt"
+
+
+@pytest.mark.asyncio
+async def test_scoped_resolve_unknown_drive():
+    _site_cache["Engineering"] = _SITE_ID
+    drives_url = re.compile(r".*/sites/.*/drives.*")
+    with aioresponses() as m:
+        m.get(drives_url, payload={"value": [{"id": "x", "name": "Other"}]})
+        result = await resolve(_scoped_accessor(), _spec("/sp/a.txt"))
+    assert result.level == "drive"
+    assert result.drive_id is None


### PR DESCRIPTION
Phase 2 of the Graph unification (#532 was phase 1). Large refactor as discussed.

## Shared item ops
`msgraph/drive_ops.py` now carries the whole drive item layer both backends duplicated: `entry_stat`, cached `readdir_items`/`stat_item`, `iter_tree`, `find_items`, du walkers, versioned `read_item`/`stream_item` with observer capture, `capture_item_metadata`. The onedrive and sharepoint op files are addressing shells now (onedrive: config-scoped drive + key_prefix; sharepoint: resolver levels for the site/drive namespace). Every Graph fix lands in both by construction.

## SharePoint mount scoping
`SharePointConfig` gains `site` + `drive`: a mount can point inside one document library, making paths drive-relative (the site/drive namespace levels vanish). Unscoped mounts behave exactly as before; new resolver tests cover both.

## Fake Graph becomes a tenant
Per-drive `FakeGraph` states, `/sites` discovery + `/sites/{id}/drives` listing, `/drives/{id}/root` routing, drive-aware download/upload-session handling, cross-drive copy via `parentReference.driveId`. `start_fake_graph` also patches the sharepoint client/resolver `GRAPH_API`.

## sharepoint = 8th shared-harness target
Three scoped drives in one fake site (`/data`, `/data2`, `/res`), full 890-case battery, py-only host. The battery immediately caught a real divergence: **the sharepoint du command was missing `provision=metadata_provision`**, so du cost plans reported `precision=unknown` — fixed.

## Verification
- Full python battery: **6182 passed, 0 failed** across all 7 targets, plus sharepoint 890/890 (8 targets total)
- Legacy `integ/onedrive.py` + `integ/onedrive_cases.py` byte-match truth against the reworked fake
- Graph unit suites green (incl. new scoped-resolver tests); TS runner ram unchanged (874/874)
- mypy 1579 files clean, pre-commit clean

## Office enrichment (commit 2)
Real SharePoint rewrites Office documents server-side after upload (metadata injection: bytes change, cTag changes without a user write). The fake now models this as a synchronous idempotent marker append on `.pptx/.docx/.xlsx` uploads; server-side copies do not re-enrich. `integ/unix/office.json` (8 cases, onedrive + sharepoint) proves mirage's cache copes with the self-modifying file: read-after-write returns enriched content, sizes consistent, repeat reads stable, cross-mount re-upload doesn't accumulate markers, plain files untouched. Version ids now follow real Graph numbering (`1.0`, `2.0`), and the fake's simplified-vs-real edge cases are documented inline. Both legacy truths still byte-match.