### PR TITLE
feat(store): s3 backend for the sessions+meta group

### DIFF
--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -731,6 +731,7 @@ jobs:
           chmod +x /tmp/mc
           /tmp/mc alias set local http://localhost:9000 minio minio123
           /tmp/mc mb local/mirage-cross || true
+          /tmp/mc mb local/mirage-state || true
 
       - name: Run cross-language snapshot interop (both directions)
         run: |
@@ -740,6 +741,10 @@ jobs:
 
       - name: Run cross-language state store interop (both directions)
         run: bash integ/state_store.sh
+        env:
+          STORE_S3: "1"
+          STORE_S3_ENDPOINT: http://localhost:9000
+          STORE_S3_BUCKET: mirage-state
 
       - name: Run CLI feature parity (subshell, sessions, session modes, versioning, fuse)
         run: |

--- a/integ/state_store.py
+++ b/integ/state_store.py
@@ -22,13 +22,39 @@ import os  # noqa: E402
 import uuid  # noqa: E402
 
 from mirage import MountMode, Workspace  # noqa: E402
+from mirage.accessor.s3 import S3Config  # noqa: E402
 from mirage.resource.ram import RAMResource  # noqa: E402
 from mirage.workspace.session.store import SessionStore  # noqa: E402
 from mirage.workspace.store.redis import RedisWorkspaceStateStore  # noqa: E402
+from mirage.workspace.store.s3 import S3WorkspaceStateStore  # noqa: E402
 
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+STORE_BACKEND = os.environ.get("STORE_BACKEND", "redis")
+S3_ENDPOINT = os.environ.get("STORE_S3_ENDPOINT", "http://localhost:9000")
+S3_BUCKET = os.environ.get("STORE_S3_BUCKET", "mirage-state")
 WORKSPACE_ID = "xstore"
 MARKER = "xstore-history-marker"
+
+
+def make_state_store(prefix: str) -> RedisWorkspaceStateStore:
+    """The store under test: redis for every plane, or (STORE_BACKEND=s3)
+    the sessions+meta group riding S3 as the workspace group override."""
+    if STORE_BACKEND == "s3":
+        s3 = S3WorkspaceStateStore(
+            S3Config(bucket=S3_BUCKET,
+                     region="us-east-1",
+                     endpoint_url=S3_ENDPOINT,
+                     aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID",
+                                                      "minio"),
+                     aws_secret_access_key=os.environ.get(
+                         "AWS_SECRET_ACCESS_KEY", "minio123"),
+                     path_style=True,
+                     key_prefix=prefix))
+        return RedisWorkspaceStateStore(url=REDIS_URL,
+                                        key_prefix=prefix,
+                                        workspace=s3)
+    return RedisWorkspaceStateStore(url=REDIS_URL, key_prefix=prefix)
+
 
 fail = 0
 
@@ -43,7 +69,7 @@ def check(name: str, ok: bool, detail: str = "") -> None:
 
 
 def make_workspace(prefix: str) -> tuple[Workspace, RedisWorkspaceStateStore]:
-    store = RedisWorkspaceStateStore(url=REDIS_URL, key_prefix=prefix)
+    store = make_state_store(prefix)
     ws = Workspace({"/data": RAMResource()},
                    mode=MountMode.EXEC,
                    workspace_id=WORKSPACE_ID,
@@ -74,7 +100,7 @@ async def write(prefix: str) -> None:
 async def read(prefix: str) -> None:
     """Attach with only the store config + workspace id and verify every
     plane written by the other language."""
-    probe = RedisWorkspaceStateStore(url=REDIS_URL, key_prefix=prefix)
+    probe = make_state_store(prefix)
     meta = await probe.load_meta(WORKSPACE_ID)
     check("py read: meta record found", meta is not None)
     check("py read: meta carries a CAS generation", meta is not None
@@ -167,7 +193,7 @@ async def hammer(prefix: str, rounds: int) -> None:
 
     Announce with one increment, wait until the peer's counter shows
     up (so both main loops genuinely overlap), then run the rest."""
-    store = RedisWorkspaceStateStore(url=REDIS_URL, key_prefix=prefix)
+    store = make_state_store(prefix)
     sess = store.sessions(WORKSPACE_ID)
     await cas_increment(sess, "py", 1)
     for _ in range(300):
@@ -184,7 +210,7 @@ async def hammer(prefix: str, rounds: int) -> None:
 
 async def cas_verify(prefix: str, rounds: int) -> None:
     """Both hammers done: no increment may be lost."""
-    store = RedisWorkspaceStateStore(url=REDIS_URL, key_prefix=prefix)
+    store = make_state_store(prefix)
     sess = store.sessions(WORKSPACE_ID)
     final = (await sess.load())["hot"]
     check(

--- a/integ/state_store.sh
+++ b/integ/state_store.sh
@@ -6,9 +6,16 @@
 # same discovery record, same symlink, same history, and the narrowed
 # session's grants enforced.
 #
+# With STORE_S3=1 the whole battery runs a second time with the
+# sessions+meta group on S3 (conditional-PUT CAS against MinIO) as the
+# workspace group override, exercising the exact same checks.
+#
 # Usage: state_store.sh
 #   Requires REDIS_URL (defaults to redis://localhost:6379/0), the python
 #   venv at python/.venv, and built TypeScript dists (pnpm -r build).
+#   The s3 round additionally needs a reachable S3 endpoint
+#   (STORE_S3_ENDPOINT, default http://localhost:9000) with an existing
+#   bucket (STORE_S3_BUCKET, default mirage-state).
 set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -18,10 +25,10 @@ RUN_ID="$RANDOM$RANDOM"
 fail=0
 
 run_direction() {
-  local writer_name="$1" reader_name="$2"
-  local prefix="mirage-integ-xstore-${RUN_ID}-${writer_name}:"
+  local backend="$1" writer_name="$2" reader_name="$3"
+  local prefix="mirage-integ-xstore-${RUN_ID}-${backend}-${writer_name}:"
   echo
-  echo "===== $writer_name store write -> $reader_name attach ====="
+  echo "===== [$backend] $writer_name store write -> $reader_name attach ====="
   if [ "$writer_name" == "py" ]; then
     "$PY" "$HERE/state_store.py" write "$prefix" || fail=1
     (cd "$HERE" && pnpm exec tsx state_store.ts read "$prefix") || fail=1
@@ -32,10 +39,11 @@ run_direction() {
 }
 
 run_concurrent() {
-  local prefix="mirage-integ-xstore-${RUN_ID}-hammer:"
+  local backend="$1"
+  local prefix="mirage-integ-xstore-${RUN_ID}-${backend}-hammer:"
   local rounds=25
   echo
-  echo "===== concurrent py+ts CAS hammer ====="
+  echo "===== [$backend] concurrent py+ts CAS hammer ====="
   "$PY" "$HERE/state_store.py" hammer "$prefix" "$rounds" &
   local hammer_pid=$!
   (cd "$HERE" && pnpm exec tsx state_store.ts hammer "$prefix" "$rounds") || fail=1
@@ -44,9 +52,18 @@ run_concurrent() {
   (cd "$HERE" && pnpm exec tsx state_store.ts cas-verify "$prefix" "$rounds") || fail=1
 }
 
-run_direction "py" "ts"
-run_direction "ts" "py"
-run_concurrent
+run_battery() {
+  local backend="$1"
+  export STORE_BACKEND="$backend"
+  run_direction "$backend" "py" "ts"
+  run_direction "$backend" "ts" "py"
+  run_concurrent "$backend"
+}
+
+run_battery "redis"
+if [ "${STORE_S3:-0}" == "1" ]; then
+  run_battery "s3"
+fi
 
 if [ "$fail" != "0" ]; then
   echo

--- a/integ/state_store.ts
+++ b/integ/state_store.ts
@@ -13,11 +13,32 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { MountMode, RAMResource, type SessionStore } from '@struktoai/mirage-core'
-import { RedisWorkspaceStateStore, Workspace } from '@struktoai/mirage-node'
+import { RedisWorkspaceStateStore, S3WorkspaceStateStore, Workspace } from '@struktoai/mirage-node'
 
 const REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379/0'
+const STORE_BACKEND = process.env.STORE_BACKEND ?? 'redis'
+const S3_ENDPOINT = process.env.STORE_S3_ENDPOINT ?? 'http://localhost:9000'
+const S3_BUCKET = process.env.STORE_S3_BUCKET ?? 'mirage-state'
 const WORKSPACE_ID = 'xstore'
 const MARKER = 'xstore-history-marker'
+
+// The store under test: redis for every plane, or (STORE_BACKEND=s3) the
+// sessions+meta group riding S3 as the workspace group override.
+function makeStateStore(prefix: string): RedisWorkspaceStateStore {
+  if (STORE_BACKEND === 's3') {
+    const s3 = new S3WorkspaceStateStore({
+      bucket: S3_BUCKET,
+      region: 'us-east-1',
+      endpoint: S3_ENDPOINT,
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? 'minio',
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? 'minio123',
+      forcePathStyle: true,
+      keyPrefix: prefix,
+    })
+    return new RedisWorkspaceStateStore({ url: REDIS_URL, keyPrefix: prefix, workspace: s3 })
+  }
+  return new RedisWorkspaceStateStore({ url: REDIS_URL, keyPrefix: prefix })
+}
 
 let fail = 0
 
@@ -31,7 +52,7 @@ function check(name: string, ok: boolean, detail = ''): void {
 }
 
 function makeWorkspace(prefix: string): { ws: Workspace; store: RedisWorkspaceStateStore } {
-  const store = new RedisWorkspaceStateStore({ url: REDIS_URL, keyPrefix: prefix })
+  const store = makeStateStore(prefix)
   const ws = new Workspace(
     { '/data': new RAMResource() },
     { mode: MountMode.EXEC, workspaceId: WORKSPACE_ID, store },
@@ -67,7 +88,7 @@ async function write(prefix: string): Promise<void> {
 // Attach with only the store config + workspace id and verify every plane
 // written by the other language.
 async function read(prefix: string): Promise<void> {
-  const probe = new RedisWorkspaceStateStore({ url: REDIS_URL, keyPrefix: prefix })
+  const probe = makeStateStore(prefix)
   const meta = await probe.loadMeta(WORKSPACE_ID)
   check('ts read: meta record found', meta !== null)
   check(
@@ -166,7 +187,7 @@ async function casIncrement(sess: SessionStore, worker: string, rounds: number):
 // Announce with one increment, wait until the peer's counter shows up
 // (so both main loops genuinely overlap), then run the rest.
 async function hammer(prefix: string, rounds: number): Promise<void> {
-  const store = new RedisWorkspaceStateStore({ url: REDIS_URL, keyPrefix: prefix })
+  const store = makeStateStore(prefix)
   const sess = store.sessions(WORKSPACE_ID)
   await casIncrement(sess, 'ts', 1)
   let peerSeen = false
@@ -183,7 +204,7 @@ async function hammer(prefix: string, rounds: number): Promise<void> {
 
 // Both hammers done: no increment may be lost.
 async function casVerify(prefix: string, rounds: number): Promise<void> {
-  const store = new RedisWorkspaceStateStore({ url: REDIS_URL, keyPrefix: prefix })
+  const store = makeStateStore(prefix)
   const sess = store.sessions(WORKSPACE_ID)
   const final = (await sess.load()).get('hot')
   const env = (final?.env ?? {}) as Record<string, string>

--- a/python/mirage/config.py
+++ b/python/mirage/config.py
@@ -20,6 +20,7 @@ from typing import Annotated, Any, Literal
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from mirage.accessor.s3 import S3Config
 from mirage.cache.file.config import CacheConfig, RedisCacheConfig
 from mirage.cache.index.config import IndexConfig, RedisIndexConfig
 from mirage.resource.registry import build_resource
@@ -33,6 +34,11 @@ try:
     from mirage.workspace.store import RedisWorkspaceStateStore
 except ImportError:
     RedisWorkspaceStateStore = None
+
+try:
+    from mirage.workspace.store import S3WorkspaceStateStore
+except ImportError:
+    S3WorkspaceStateStore = None
 
 
 def _coerce_mount_mode(value):
@@ -159,8 +165,19 @@ class RedisStoreBlock(BaseModel):
     key_prefix: str = "mirage:"
 
 
+class S3StoreBlock(S3Config):
+    """An ``S3Config`` plus the union discriminator: the block IS the
+    backend config, so new S3Config fields flow into the store block
+    without re-declaring them here."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    type: Literal["s3"]
+    key_prefix: str | None = "mirage/"
+
+
 StoreGroupBlock = Annotated[
-    RamStoreBlock | RedisStoreBlock,
+    RamStoreBlock | RedisStoreBlock | S3StoreBlock,
     Field(discriminator="type"),
 ]
 
@@ -175,7 +192,9 @@ class StoreBlock(BaseModel):
     logs to a separate server. Sessions and workspace metadata move
     together by design (the default-session pointer must live beside
     the session table it points into), so there is one `workspace`
-    override, not two.
+    override, not two. An ``s3`` group hosts only the sessions+meta
+    group (conditional-PUT CAS), so it is valid as the ``workspace``
+    override, never as the top-level default.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -360,13 +379,19 @@ def _build_index_config(block: RamIndexBlock | RedisIndexBlock) -> IndexConfig:
 
 
 def _build_store_group(
-        block: RamStoreBlock | RedisStoreBlock) -> WorkspaceStateStore:
+    block: RamStoreBlock | RedisStoreBlock | S3StoreBlock
+) -> WorkspaceStateStore:
     if isinstance(block, RedisStoreBlock):
         if RedisWorkspaceStateStore is None:
             raise ImportError("A redis store requires the 'redis' extra. "
                               "Install with: pip install mirage-ai[redis]")
         return RedisWorkspaceStateStore(url=block.url,
                                         key_prefix=block.key_prefix)
+    if isinstance(block, S3StoreBlock):
+        if S3WorkspaceStateStore is None:
+            raise ImportError("An s3 store requires the 's3' extra. "
+                              "Install with: pip install mirage-ai[s3]")
+        return S3WorkspaceStateStore(block)
     return RAMWorkspaceStateStore()
 
 

--- a/python/mirage/workspace/session/__init__.py
+++ b/python/mirage/workspace/session/__init__.py
@@ -22,6 +22,7 @@ from mirage.workspace.session.store import SessionFields, SessionStore
 __all__ = [
     "RAMSessionStore",
     "RedisSessionStore",
+    "S3SessionStore",
     "Session",
     "SessionFields",
     "SessionManager",
@@ -37,4 +38,7 @@ def __getattr__(name: str):
     if name == "RedisSessionStore":
         from mirage.workspace.session.redis import RedisSessionStore
         return RedisSessionStore
+    if name == "S3SessionStore":
+        from mirage.workspace.session.s3 import S3SessionStore
+        return S3SessionStore
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/mirage/workspace/session/s3.py
+++ b/python/mirage/workspace/session/s3.py
@@ -1,0 +1,203 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import json
+from collections.abc import Iterable
+from typing import Any
+
+from mirage.accessor.s3 import S3Config
+from mirage.core.s3._client import _client_kwargs, async_session
+from mirage.workspace.session.store import (SessionFields, SessionStore,
+                                            generation_of)
+
+
+def _is_missing(exc: Exception) -> bool:
+    if hasattr(exc, "response"):
+        code = exc.response.get("Error", {}).get("Code")
+        return code in ("404", "NoSuchKey")
+    return False
+
+
+def _is_condition_lost(exc: Exception) -> bool:
+    """True when a conditional write lost: the object changed since the
+    read (412) or a concurrent conditional write is in flight (409)."""
+    if hasattr(exc, "response"):
+        code = exc.response.get("Error", {}).get("Code")
+        return code in ("412", "PreconditionFailed", "409",
+                        "ConditionalRequestConflict")
+    return False
+
+
+class S3RecordClient:
+    """One JSON-record-per-object client with ETag-anchored CAS.
+
+    The generic building block both S3 stores share (mirroring how the
+    Redis stores share one cas.lua): a record is one object at
+    ``{prefix}{name}.json``, and a conditional write anchors on the
+    exact ETag the compare-read returned, so the generation check and
+    the write hit the same stored version. Immutable-blob planes never
+    need this; it exists only for the few mutable control-plane cells.
+    """
+
+    def __init__(self, config: S3Config, prefix: str) -> None:
+        self._config = config
+        self._prefix = prefix
+        self._client: Any = None
+        self._client_cm: Any = None
+        self._client_lock = asyncio.Lock()
+
+    async def client(self) -> Any:
+        async with self._client_lock:
+            if self._client is None:
+                session = async_session(self._config)
+                self._client_cm = session.client(
+                    **_client_kwargs(self._config))
+                self._client = await self._client_cm.__aenter__()
+        return self._client
+
+    def key(self, name: str) -> str:
+        return f"{self._prefix}{name}.json"
+
+    async def get(self, name: str) -> tuple[dict[str, Any] | None, str]:
+        """Read one record; ``(fields, etag)``, ``(None, "")`` when absent."""
+        client = await self.client()
+        try:
+            resp = await client.get_object(Bucket=self._config.bucket,
+                                           Key=self.key(name))
+        except Exception as exc:
+            if _is_missing(exc):
+                return None, ""
+            raise
+        body = await resp["Body"].read()
+        return json.loads(body), resp.get("ETag", "")
+
+    async def put(self, name: str, fields: dict[str, Any]) -> None:
+        client = await self.client()
+        await client.put_object(Bucket=self._config.bucket,
+                                Key=self.key(name),
+                                Body=json.dumps(fields).encode())
+
+    async def cas_put(self, name: str, fields: dict[str, Any],
+                      expected_generation: int) -> bool:
+        """Write one record iff its stored generation matches.
+
+        Compare-read the record, check the generation client-side, then
+        make the write conditional on the exact version read: If-None-Match
+        for create (expected 0, nothing stored), If-Match on the read
+        ETag otherwise. A 412/409 means another writer moved the record
+        between our read and write; the caller adopts and retries.
+        """
+        stored, etag = await self.get(name)
+        if generation_of(stored) != expected_generation:
+            return False
+        client = await self.client()
+        condition = ({
+            "IfNoneMatch": "*"
+        } if stored is None else {
+            "IfMatch": etag
+        })
+        try:
+            await client.put_object(Bucket=self._config.bucket,
+                                    Key=self.key(name),
+                                    Body=json.dumps(fields).encode(),
+                                    **condition)
+        except Exception as exc:
+            if _is_condition_lost(exc):
+                return False
+            raise
+        return True
+
+    async def list_names(self) -> list[str]:
+        client = await self.client()
+        names: list[str] = []
+        paginator = client.get_paginator("list_objects_v2")
+        async for page in paginator.paginate(Bucket=self._config.bucket,
+                                             Prefix=self._prefix):
+            for entry in page.get("Contents", []):
+                key = entry["Key"][len(self._prefix):]
+                if key.endswith(".json"):
+                    names.append(key.removesuffix(".json"))
+        return names
+
+    async def load_all(self) -> dict[str, dict[str, Any]]:
+        """Every stored record, keyed by name; batch-first (one list,
+        then parallel reads)."""
+        names = await self.list_names()
+        records = await asyncio.gather(*(self.get(name) for name in names))
+        return {
+            name: fields
+            for name, (fields, _) in zip(names, records) if fields is not None
+        }
+
+    async def delete(self, names: Iterable[str]) -> None:
+        ids = [{"Key": self.key(name)} for name in names]
+        if not ids:
+            return
+        client = await self.client()
+        await client.delete_objects(Bucket=self._config.bucket,
+                                    Delete={"Objects": ids})
+
+    async def clear(self) -> None:
+        await self.delete(await self.list_names())
+
+    async def close(self) -> None:
+        async with self._client_lock:
+            if self._client_cm is not None:
+                await self._client_cm.__aexit__(None, None, None)
+                self._client_cm = None
+                self._client = None
+
+
+class S3SessionStore(SessionStore):
+    """SessionStore backed by per-session S3 objects.
+
+    One object per session at ``{key_prefix}sessions/{session_id}.json``
+    (the store appends the ``sessions/`` segment, mirroring the Redis
+    store's ``{key_prefix}sessions`` hash). Conditional writes
+    (If-Match on the compare-read's ETag) give the same generation-CAS
+    contract as the Redis Lua script, so the S3 control plane is safe
+    for the same multi-process sharing. Works on any S3-compatible
+    backend that honors conditional PUTs.
+    """
+
+    def __init__(self, config: S3Config) -> None:
+        self._records = S3RecordClient(config,
+                                       f"{config.key_prefix or ''}sessions/")
+
+    async def load(self) -> dict[str, SessionFields]:
+        return await self._records.load_all()
+
+    async def set(self, session_id: str, fields: SessionFields) -> None:
+        await self._records.put(session_id, fields)
+
+    async def cas_set(self, session_id: str, fields: SessionFields,
+                      expected_generation: int) -> bool:
+        return await self._records.cas_put(session_id, fields,
+                                           expected_generation)
+
+    async def delete(self, session_ids: Iterable[str]) -> None:
+        await self._records.delete(session_ids)
+
+    async def replace_all(self, entries: dict[str, SessionFields]) -> None:
+        stale = set(await self._records.list_names()) - set(entries)
+        await self._records.delete(stale)
+        await asyncio.gather(*(self._records.put(sid, fields)
+                               for sid, fields in entries.items()))
+
+    async def clear(self) -> None:
+        await self._records.clear()
+
+    async def close(self) -> None:
+        await self._records.close()

--- a/python/mirage/workspace/store/__init__.py
+++ b/python/mirage/workspace/store/__init__.py
@@ -18,6 +18,7 @@ from mirage.workspace.store.ram import RAMWorkspaceStateStore
 __all__ = [
     "RAMWorkspaceStateStore",
     "RedisWorkspaceStateStore",
+    "S3WorkspaceStateStore",
     "WorkspaceFields",
     "WorkspaceStateStore",
 ]
@@ -27,4 +28,7 @@ def __getattr__(name: str):
     if name == "RedisWorkspaceStateStore":
         from mirage.workspace.store.redis import RedisWorkspaceStateStore
         return RedisWorkspaceStateStore
+    if name == "S3WorkspaceStateStore":
+        from mirage.workspace.store.s3 import S3WorkspaceStateStore
+        return S3WorkspaceStateStore
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/mirage/workspace/store/s3.py
+++ b/python/mirage/workspace/store/s3.py
@@ -1,0 +1,83 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.s3 import S3Config
+from mirage.observe.store import ObserverStore
+from mirage.workspace.mount.namespace import NamespaceStore
+from mirage.workspace.session.s3 import S3RecordClient, S3SessionStore
+from mirage.workspace.session.store import SessionStore
+from mirage.workspace.store.base import WorkspaceFields, WorkspaceStateStore
+
+
+class S3WorkspaceStateStore(WorkspaceStateStore):
+    """WorkspaceStateStore hosting the sessions + metadata group on S3.
+
+    Object layout under one bucket and prefix:
+
+    - ``{prefix}workspaces/{ws}.json`` — metadata record
+    - ``{prefix}{ws}/sessions/{session_id}.json`` — session table
+
+    Every record write is CAS-gated by a conditional PUT anchored on
+    the compare-read's ETag, giving S3 the same generation contract as
+    the Redis Lua script; bucket versioning (when enabled) doubles as
+    an audit trail for free. This store hosts only the sessions+meta
+    group: namespace nodes and observer events are chatty per-op
+    planes that belong on RAM or Redis, so use this store as the
+    ``workspace`` group override of a RAM or Redis default store.
+    """
+
+    def __init__(self, config: S3Config,
+                 **overrides: "WorkspaceStateStore | None") -> None:
+        super().__init__(**overrides)
+        self._config = config
+        self._prefix = config.key_prefix or ""
+        self._meta = S3RecordClient(config, f"{self._prefix}workspaces/")
+        self._sessions: dict[str, S3SessionStore] = {}
+
+    def _make_namespace(self, workspace_id: str) -> NamespaceStore:
+        raise RuntimeError(
+            "The s3 store hosts only the sessions+meta group; keep the "
+            "namespace plane on ram or redis and pass the s3 store as "
+            "the 'workspace' group override.")
+
+    def _make_observer(self, workspace_id: str) -> ObserverStore:
+        raise RuntimeError(
+            "The s3 store hosts only the sessions+meta group; keep the "
+            "observer plane on ram or redis and pass the s3 store as "
+            "the 'workspace' group override.")
+
+    def _make_sessions(self, workspace_id: str) -> SessionStore:
+        if workspace_id not in self._sessions:
+            scoped = self._config.model_copy(
+                update={"key_prefix": f"{self._prefix}{workspace_id}/"})
+            self._sessions[workspace_id] = S3SessionStore(scoped)
+        return self._sessions[workspace_id]
+
+    async def _load_meta(self, workspace_id: str) -> WorkspaceFields | None:
+        fields, _ = await self._meta.get(workspace_id)
+        return fields
+
+    async def _set_meta(self, workspace_id: str,
+                        fields: WorkspaceFields) -> None:
+        await self._meta.put(workspace_id, fields)
+
+    async def _cas_set_meta(self, workspace_id: str, fields: WorkspaceFields,
+                            expected_generation: int) -> bool:
+        return await self._meta.cas_put(workspace_id, fields,
+                                        expected_generation)
+
+    async def _close(self) -> None:
+        for sess in self._sessions.values():
+            await sess.close()
+        await self._meta.close()

--- a/python/tests/config/test_loader.py
+++ b/python/tests/config/test_loader.py
@@ -19,7 +19,7 @@ import pytest
 from mirage import MountMode, Workspace
 from mirage.cache.file.config import CacheConfig, RedisCacheConfig
 from mirage.config import (RamCacheBlock, RedisCacheBlock, RedisStoreBlock,
-                           WorkspaceConfig, load_config)
+                           S3StoreBlock, WorkspaceConfig, load_config)
 from mirage.resource.ram import RAMResource
 from mirage.resource.s3 import S3Resource
 from mirage.types import ConsistencyPolicy
@@ -163,6 +163,30 @@ def test_store_group_override_redirects_one_plane():
     assert isinstance(store, RAMWorkspaceStateStore)
     assert isinstance(store.namespace("ws1"), RAMNamespaceStore)
     assert type(store.observer("ws1")).__name__ == "RedisObserverStore"
+
+
+def test_store_s3_workspace_group_builds_s3_provider():
+    cfg = load_config({
+        "store": {
+            "type": "ram",
+            "workspace": {
+                "type": "s3",
+                "bucket": "state-bucket",
+                "region": "us-east-1",
+                "key_prefix": "mirage/",
+            },
+        },
+        "mounts": {
+            "/": {
+                "resource": "ram"
+            }
+        },
+    })
+    assert isinstance(cfg.store.workspace, S3StoreBlock)
+    store = cfg.to_workspace_kwargs()["store"]
+    assert isinstance(store, RAMWorkspaceStateStore)
+    assert isinstance(store.namespace("ws1"), RAMNamespaceStore)
+    assert type(store.sessions("ws1")).__name__ == "S3SessionStore"
 
 
 def test_workspace_id_passes_through():

--- a/python/tests/workspace/s3_fake.py
+++ b/python/tests/workspace/s3_fake.py
@@ -1,0 +1,115 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import hashlib
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+
+
+class _Body:
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    async def read(self) -> bytes:
+        return self._data
+
+
+def _error(code: str, operation: str) -> ClientError:
+    return ClientError({"Error": {"Code": code}}, operation)
+
+
+def etag_of(data: bytes) -> str:
+    return '"' + hashlib.md5(data).hexdigest() + '"'
+
+
+class _Paginator:
+
+    def __init__(self, client: "FakeConditionalS3Client") -> None:
+        self._client = client
+
+    async def paginate(self, Bucket: str, Prefix: str = ""):
+        contents = [{
+            "Key": key,
+            "Size": len(data)
+        } for (bucket, key), data in sorted(self._client.objects.items())
+                    if bucket == Bucket and key.startswith(Prefix)]
+        yield {"Contents": contents}
+
+
+class FakeConditionalS3Client:
+    """In-memory S3 modeling exactly what the record stores rely on:
+    content ETags on GET and conditional PUTs (If-Match, If-None-Match)."""
+
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], bytes] = {}
+
+    async def get_object(self, Bucket: str, Key: str) -> dict:
+        data = self.objects.get((Bucket, Key))
+        if data is None:
+            raise _error("NoSuchKey", "GetObject")
+        return {"Body": _Body(data), "ETag": etag_of(data)}
+
+    async def put_object(self,
+                         Bucket: str,
+                         Key: str,
+                         Body: bytes,
+                         IfMatch: str | None = None,
+                         IfNoneMatch: str | None = None) -> dict:
+        current = self.objects.get((Bucket, Key))
+        if IfNoneMatch == "*" and current is not None:
+            raise _error("PreconditionFailed", "PutObject")
+        if IfMatch is not None and (current is None
+                                    or etag_of(current) != IfMatch):
+            raise _error("PreconditionFailed", "PutObject")
+        self.objects[(Bucket, Key)] = Body
+        return {}
+
+    async def delete_objects(self, Bucket: str, Delete: dict) -> dict:
+        for entry in Delete["Objects"]:
+            self.objects.pop((Bucket, entry["Key"]), None)
+        return {}
+
+    def get_paginator(self, name: str) -> _Paginator:
+        assert name == "list_objects_v2"
+        return _Paginator(self)
+
+
+class _ClientContext:
+
+    def __init__(self, client: FakeConditionalS3Client) -> None:
+        self._client = client
+
+    async def __aenter__(self) -> FakeConditionalS3Client:
+        return self._client
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+
+class FakeSession:
+
+    def __init__(self, client: FakeConditionalS3Client) -> None:
+        self._client = client
+
+    def client(self, **kwargs: object) -> _ClientContext:
+        return _ClientContext(self._client)
+
+
+def patch_record_s3(client: FakeConditionalS3Client):
+    """Patch the record stores' session factory to serve ``client``."""
+    session = FakeSession(client)
+    return patch("mirage.workspace.session.s3.async_session",
+                 lambda config: session)

--- a/python/tests/workspace/session/test_s3.py
+++ b/python/tests/workspace/session/test_s3.py
@@ -1,0 +1,194 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import json
+
+import pytest
+
+from mirage.accessor.s3 import S3Config
+from mirage.workspace.session.s3 import S3SessionStore
+from tests.workspace.s3_fake import FakeConditionalS3Client, patch_record_s3
+
+BUCKET = "state-bucket"
+
+
+def _config() -> S3Config:
+    return S3Config(bucket=BUCKET,
+                    region="us-east-1",
+                    aws_access_key_id="fake",
+                    aws_secret_access_key="fake",
+                    key_prefix="mirage/ws1/")
+
+
+async def cas_increment(store: S3SessionStore, worker: str,
+                        rounds: int) -> None:
+    """Read-modify-CAS one counter, retrying until each round lands."""
+    for _ in range(rounds):
+        for _ in range(200):
+            record = (await store.load()).get("hot", {
+                "session_id": "hot",
+                "env": {},
+            })
+            env = dict(record.get("env", {}))
+            env[worker] = str(int(env.get(worker, "0")) + 1)
+            expected = int(record.get("generation", 0))
+            fields = dict(record)
+            fields["env"] = env
+            fields["generation"] = expected + 1
+            if await store.cas_set("hot", fields, expected):
+                break
+            await asyncio.sleep(0)
+        else:
+            raise AssertionError("cas retry budget exhausted")
+
+
+@pytest.mark.asyncio
+async def test_set_load_roundtrip():
+    client = FakeConditionalS3Client()
+    with patch_record_s3(client):
+        store = S3SessionStore(_config())
+        await store.set("s1", {"session_id": "s1", "cwd": "/a", "env": {}})
+        await store.set(
+            "s2", {
+                "session_id": "s2",
+                "cwd": "/",
+                "env": {
+                    "K": "v"
+                },
+                "mount_modes": {
+                    "/data": "read"
+                }
+            })
+        entries = await store.load()
+        await store.close()
+    assert entries["s1"]["cwd"] == "/a"
+    assert entries["s2"]["mount_modes"] == {"/data": "read"}
+    assert (BUCKET, "mirage/ws1/sessions/s1.json") in client.objects
+
+
+@pytest.mark.asyncio
+async def test_delete_and_replace_all():
+    client = FakeConditionalS3Client()
+    with patch_record_s3(client):
+        store = S3SessionStore(_config())
+        await store.set("a", {"session_id": "a"})
+        await store.set("b", {"session_id": "b"})
+        await store.delete(["a", "missing"])
+        assert set(await store.load()) == {"b"}
+        await store.replace_all({"c": {"session_id": "c"}})
+        assert set(await store.load()) == {"c"}
+        await store.clear()
+        assert await store.load() == {}
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_cas_create_only_once():
+    client = FakeConditionalS3Client()
+    with patch_record_s3(client):
+        store = S3SessionStore(_config())
+        first = {"session_id": "s", "generation": 1}
+        assert await store.cas_set("s", first, 0) is True
+        assert await store.cas_set("s", {
+            "session_id": "s",
+            "generation": 1
+        }, 0) is False
+        await store.close()
+    stored = json.loads(client.objects[(BUCKET, "mirage/ws1/sessions/s.json")])
+    assert stored == first
+
+
+@pytest.mark.asyncio
+async def test_cas_stale_generation_rejected():
+    client = FakeConditionalS3Client()
+    with patch_record_s3(client):
+        store = S3SessionStore(_config())
+        await store.set("s", {"session_id": "s", "generation": 2})
+        assert await store.cas_set("s", {
+            "session_id": "s",
+            "generation": 2
+        }, 1) is False
+        assert await store.cas_set("s", {
+            "session_id": "s",
+            "cwd": "/x",
+            "generation": 3
+        }, 2) is True
+        entries = await store.load()
+        await store.close()
+    assert entries["s"]["cwd"] == "/x"
+
+
+@pytest.mark.asyncio
+async def test_cas_legacy_record_counts_as_generation_zero():
+    client = FakeConditionalS3Client()
+    with patch_record_s3(client):
+        store = S3SessionStore(_config())
+        await store.set("s", {"session_id": "s"})
+        assert await store.cas_set("s", {
+            "session_id": "s",
+            "generation": 1
+        }, 0) is True
+        await store.close()
+
+
+class RaceOnceClient(FakeConditionalS3Client):
+    """Move the stored record between a CAS's compare-read and its
+    conditional write, exactly once."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.raced = False
+
+    async def get_object(self, Bucket: str, Key: str) -> dict:
+        response = await super().get_object(Bucket, Key)
+        if not self.raced:
+            self.raced = True
+            self.objects[(Bucket, Key)] = json.dumps({
+                "session_id": "s",
+                "cwd": "/winner",
+                "generation": 2
+            }).encode()
+        return response
+
+
+@pytest.mark.asyncio
+async def test_cas_write_race_detected_by_conditional_put():
+    client = RaceOnceClient()
+    with patch_record_s3(client):
+        store = S3SessionStore(_config())
+        await store.set("s", {"session_id": "s", "generation": 1})
+        client.raced = False
+        assert await store.cas_set("s", {
+            "session_id": "s",
+            "cwd": "/loser",
+            "generation": 2
+        }, 1) is False
+        entries = await store.load()
+        await store.close()
+    assert entries["s"]["cwd"] == "/winner"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cas_writers_lose_nothing():
+    client = FakeConditionalS3Client()
+    with patch_record_s3(client):
+        store = S3SessionStore(_config())
+        workers = [f"w{i}" for i in range(5)]
+        await asyncio.gather(*(cas_increment(store, worker, 5)
+                               for worker in workers))
+        record = (await store.load())["hot"]
+        await store.close()
+    assert record["generation"] == 25
+    assert all(record["env"][worker] == "5" for worker in workers)

--- a/python/tests/workspace/store/test_s3.py
+++ b/python/tests/workspace/store/test_s3.py
@@ -1,0 +1,122 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+import pytest
+
+from mirage.accessor.s3 import S3Config
+from mirage.workspace.store.ram import RAMWorkspaceStateStore
+from mirage.workspace.store.s3 import S3WorkspaceStateStore
+from tests.workspace.s3_fake import FakeConditionalS3Client, patch_record_s3
+
+BUCKET = "state-bucket"
+
+
+def _config() -> S3Config:
+    return S3Config(bucket=BUCKET,
+                    region="us-east-1",
+                    aws_access_key_id="fake",
+                    aws_secret_access_key="fake",
+                    key_prefix="mirage/")
+
+
+@pytest.mark.asyncio
+async def test_meta_roundtrip_and_layout():
+    client = FakeConditionalS3Client()
+    with patch_record_s3(client):
+        store = S3WorkspaceStateStore(_config())
+        assert await store.load_meta("ws1") is None
+        await store.set_meta("ws1", {
+            "workspace_id": "ws1",
+            "default_session_id": "main"
+        })
+        meta = await store.load_meta("ws1")
+        await store.close()
+    assert meta == {"workspace_id": "ws1", "default_session_id": "main"}
+    assert (BUCKET, "mirage/workspaces/ws1.json") in client.objects
+
+
+@pytest.mark.asyncio
+async def test_cas_meta_conditional_create_single_winner():
+    client = FakeConditionalS3Client()
+    with patch_record_s3(client):
+        store_a = S3WorkspaceStateStore(_config())
+        store_b = S3WorkspaceStateStore(_config())
+        record = {"workspace_id": "ws1", "generation": 1}
+        results = await asyncio.gather(
+            store_a.cas_set_meta("ws1", record, 0),
+            store_b.cas_set_meta("ws1", dict(record), 0))
+        await store_a.close()
+        await store_b.close()
+    assert sorted(results) == [False, True]
+
+
+@pytest.mark.asyncio
+async def test_replace_meta_retries_over_competing_writer():
+    client = FakeConditionalS3Client()
+    with patch_record_s3(client):
+        store = S3WorkspaceStateStore(_config())
+        await store.set_meta("ws1", {
+            "workspace_id": "ws1",
+            "created_at": 111.0,
+            "generation": 4
+        })
+        written = await store.replace_meta("ws1", {
+            "workspace_id": "ws1",
+            "default_session_id": "restored"
+        })
+        await store.close()
+    assert written["default_session_id"] == "restored"
+    assert written["created_at"] == 111.0
+    assert written["generation"] == 5
+
+
+@pytest.mark.asyncio
+async def test_sessions_group_scoped_per_workspace():
+    client = FakeConditionalS3Client()
+    with patch_record_s3(client):
+        store = S3WorkspaceStateStore(_config())
+        sessions = store.sessions("ws1")
+        assert store.sessions("ws1") is sessions
+        await sessions.set("main", {"session_id": "main"})
+        await store.close()
+    assert (BUCKET, "mirage/ws1/sessions/main.json") in client.objects
+
+
+@pytest.mark.asyncio
+async def test_namespace_and_observer_planes_refused():
+    client = FakeConditionalS3Client()
+    with patch_record_s3(client):
+        store = S3WorkspaceStateStore(_config())
+        with pytest.raises(RuntimeError, match="sessions\\+meta group"):
+            store.namespace("ws1")
+        with pytest.raises(RuntimeError, match="sessions\\+meta group"):
+            store.observer("ws1")
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_workspace_group_override_routes_to_s3():
+    client = FakeConditionalS3Client()
+    with patch_record_s3(client):
+        s3_store = S3WorkspaceStateStore(_config())
+        store = RAMWorkspaceStateStore(workspace=s3_store)
+        store.namespace("ws1")
+        store.observer("ws1")
+        await store.sessions("ws1").set("main", {"session_id": "main"})
+        await store.set_meta("ws1", {"workspace_id": "ws1"})
+        await store.close()
+    assert (BUCKET, "mirage/ws1/sessions/main.json") in client.objects
+    assert (BUCKET, "mirage/workspaces/ws1.json") in client.objects

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -407,12 +407,14 @@ export { Session, type SessionInit } from './workspace/session/session.ts'
 export { SessionManager } from './workspace/session/manager.ts'
 export { SessionStore, type SessionFields } from './workspace/session/store.ts'
 export { RAMSessionStore } from './workspace/session/ram.ts'
+export { S3RecordClient, S3SessionStore, isConditionLostError } from './workspace/session/s3.ts'
 export {
   WorkspaceStateStore,
   type WorkspaceFields,
   type WorkspaceStateStoreOverrides,
 } from './workspace/store/base.ts'
 export { RAMWorkspaceStateStore } from './workspace/store/ram.ts'
+export { S3WorkspaceStateStore } from './workspace/store/s3.ts'
 export { runWithSession } from './context/session_context.ts'
 export { CallFrame, type CallFrameInit, CallStack } from './shell/call_stack.ts'
 export { Job, JobStatus, JobTable, type JobTaskResult } from './shell/job_table.ts'

--- a/typescript/packages/core/src/workspace/fixtures/s3_fake.ts
+++ b/typescript/packages/core/src/workspace/fixtures/s3_fake.ts
@@ -1,0 +1,152 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { S3Module } from '../../core/s3/_client.ts'
+
+class NoSuchKeyError extends Error {
+  override readonly name = 'NoSuchKey'
+}
+
+class PreconditionFailedError extends Error {
+  override readonly name = 'PreconditionFailed'
+}
+
+function etagOf(data: string): string {
+  let hash = 5381
+  for (let i = 0; i < data.length; i++) {
+    hash = ((hash * 33) ^ data.charCodeAt(i)) >>> 0
+  }
+  return `"${hash.toString(16)}"`
+}
+
+class FakeGetObjectCommand {
+  constructor(readonly input: Record<string, unknown>) {}
+}
+
+class FakePutObjectCommand {
+  constructor(readonly input: Record<string, unknown>) {}
+}
+
+class FakeListObjectsV2Command {
+  constructor(readonly input: Record<string, unknown>) {}
+}
+
+class FakeDeleteObjectsCommand {
+  constructor(readonly input: Record<string, unknown>) {}
+}
+
+class FakeUnusedCommand {
+  constructor(readonly input: Record<string, unknown>) {}
+}
+
+export const FAKE_S3_MODULE = {
+  S3Client: FakeUnusedCommand,
+  GetObjectCommand: FakeGetObjectCommand,
+  HeadObjectCommand: FakeUnusedCommand,
+  ListObjectsV2Command: FakeListObjectsV2Command,
+  PutObjectCommand: FakePutObjectCommand,
+  DeleteObjectCommand: FakeUnusedCommand,
+  DeleteObjectsCommand: FakeDeleteObjectsCommand,
+  CopyObjectCommand: FakeUnusedCommand,
+} as unknown as S3Module
+
+/**
+ * In-memory S3 modeling exactly what the record stores rely on:
+ * content ETags on GET and conditional PUTs (If-Match, If-None-Match).
+ * Mirrors the Python tests' FakeConditionalS3Client.
+ */
+export class FakeConditionalS3Client {
+  readonly objects = new Map<string, string>()
+
+  private static objectKey(bucket: string, key: string): string {
+    return `${bucket}/${key}`
+  }
+
+  entry(bucket: string, key: string): string | undefined {
+    return this.objects.get(FakeConditionalS3Client.objectKey(bucket, key))
+  }
+
+  setEntry(bucket: string, key: string, data: string): void {
+    this.objects.set(FakeConditionalS3Client.objectKey(bucket, key), data)
+  }
+
+  async send(cmd: unknown): Promise<Record<string, unknown>> {
+    if (cmd instanceof FakeGetObjectCommand) return this.getObject(cmd.input)
+    if (cmd instanceof FakePutObjectCommand) return this.putObject(cmd.input)
+    if (cmd instanceof FakeListObjectsV2Command) return this.listObjects(cmd.input)
+    if (cmd instanceof FakeDeleteObjectsCommand) return this.deleteObjects(cmd.input)
+    throw new Error(`unexpected command: ${String(cmd)}`)
+  }
+
+  protected getObject(input: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const data = this.entry(input.Bucket as string, input.Key as string)
+    if (data === undefined) throw new NoSuchKeyError(String(input.Key))
+    return Promise.resolve({
+      Body: { transformToByteArray: () => Promise.resolve(new TextEncoder().encode(data)) },
+      ETag: etagOf(data),
+    })
+  }
+
+  protected putObject(input: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const bucket = input.Bucket as string
+    const key = input.Key as string
+    const current = this.entry(bucket, key)
+    if (input.IfNoneMatch === '*' && current !== undefined) {
+      throw new PreconditionFailedError(key)
+    }
+    if (
+      input.IfMatch !== undefined &&
+      (current === undefined || etagOf(current) !== input.IfMatch)
+    ) {
+      throw new PreconditionFailedError(key)
+    }
+    this.setEntry(bucket, key, input.Body as string)
+    return Promise.resolve({})
+  }
+
+  protected listObjects(input: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const bucket = input.Bucket as string
+    const prefix = (input.Prefix as string | undefined) ?? ''
+    const contents: { Key: string }[] = []
+    const marker = FakeConditionalS3Client.objectKey(bucket, prefix)
+    for (const stored of [...this.objects.keys()].sort()) {
+      if (stored.startsWith(marker)) {
+        contents.push({ Key: stored.slice(bucket.length + 1) })
+      }
+    }
+    return Promise.resolve({ Contents: contents, IsTruncated: false })
+  }
+
+  protected deleteObjects(input: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const bucket = input.Bucket as string
+    const entries = (input.Delete as { Objects: { Key: string }[] }).Objects
+    for (const entry of entries) {
+      this.objects.delete(FakeConditionalS3Client.objectKey(bucket, entry.Key))
+    }
+    return Promise.resolve({})
+  }
+}
+
+let current: FakeConditionalS3Client | null = null
+
+/** Point the mocked client seam at a fresh fake; returns the fake. */
+export function installFakeS3(client?: FakeConditionalS3Client): FakeConditionalS3Client {
+  current = client ?? new FakeConditionalS3Client()
+  return current
+}
+
+export function currentFakeS3(): FakeConditionalS3Client {
+  if (current === null) throw new Error('installFakeS3() was not called')
+  return current
+}

--- a/typescript/packages/core/src/workspace/session/s3.test.ts
+++ b/typescript/packages/core/src/workspace/session/s3.test.ts
@@ -1,0 +1,166 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as s3ClientModule from '../../core/s3/_client.ts'
+import type { S3Config } from '../../resource/s3/config.ts'
+import { FakeConditionalS3Client, currentFakeS3, installFakeS3 } from '../fixtures/s3_fake.ts'
+import { S3SessionStore } from './s3.ts'
+import type { SessionFields } from './store.ts'
+
+vi.mock('../../core/s3/_client.ts', async (importOriginal) => {
+  const original = await importOriginal<typeof s3ClientModule>()
+  const fake = await import('../fixtures/s3_fake.ts')
+  return {
+    ...original,
+    createS3Client: () => Promise.resolve(fake.currentFakeS3() as never),
+    loadS3Module: () => Promise.resolve(fake.FAKE_S3_MODULE),
+  }
+})
+
+const BUCKET = 'state-bucket'
+
+function config(): S3Config {
+  return {
+    bucket: BUCKET,
+    region: 'us-east-1',
+    accessKeyId: 'fake',
+    secretAccessKey: 'fake',
+    keyPrefix: 'mirage/ws1/',
+  }
+}
+
+async function casIncrement(store: S3SessionStore, worker: string, rounds: number): Promise<void> {
+  for (let round = 0; round < rounds; round++) {
+    let landed = false
+    for (let attempt = 0; attempt < 200; attempt++) {
+      const record = (await store.load()).get('hot') ?? { session_id: 'hot', env: {} }
+      const env = { ...(record.env as Record<string, string>) }
+      env[worker] = String(Number(env[worker] ?? '0') + 1)
+      const expected = Number(record.generation ?? 0)
+      const fields: SessionFields = { ...record, env, generation: expected + 1 }
+      if (await store.casSet('hot', fields, expected)) {
+        landed = true
+        break
+      }
+      await Promise.resolve()
+    }
+    if (!landed) throw new Error('cas retry budget exhausted')
+  }
+}
+
+describe('S3SessionStore', () => {
+  beforeEach(() => {
+    installFakeS3()
+  })
+
+  it('round-trips set/load and writes the documented layout', async () => {
+    const store = new S3SessionStore(config())
+    await store.set('s1', { session_id: 's1', cwd: '/a', env: {} })
+    await store.set('s2', {
+      session_id: 's2',
+      cwd: '/',
+      env: { K: 'v' },
+      mount_modes: { '/data': 'read' },
+    })
+    const entries = await store.load()
+    await store.close()
+    expect(entries.get('s1')?.cwd).toBe('/a')
+    expect(entries.get('s2')?.mount_modes).toEqual({ '/data': 'read' })
+    expect(currentFakeS3().entry(BUCKET, 'mirage/ws1/sessions/s1.json')).toBeDefined()
+  })
+
+  it('deletes, replaces all, and clears', async () => {
+    const store = new S3SessionStore(config())
+    await store.set('a', { session_id: 'a' })
+    await store.set('b', { session_id: 'b' })
+    await store.delete(['a', 'missing'])
+    expect([...(await store.load()).keys()]).toEqual(['b'])
+    await store.replaceAll(new Map([['c', { session_id: 'c' }]]))
+    expect([...(await store.load()).keys()]).toEqual(['c'])
+    await store.clear()
+    expect((await store.load()).size).toBe(0)
+    await store.close()
+  })
+
+  it('cas create lands exactly once', async () => {
+    const store = new S3SessionStore(config())
+    const first = { session_id: 's', generation: 1 }
+    expect(await store.casSet('s', first, 0)).toBe(true)
+    expect(await store.casSet('s', { session_id: 's', generation: 1 }, 0)).toBe(false)
+    await store.close()
+    const stored = currentFakeS3().entry(BUCKET, 'mirage/ws1/sessions/s.json')
+    expect(JSON.parse(stored ?? '')).toEqual(first)
+  })
+
+  it('rejects a stale generation and accepts the current one', async () => {
+    const store = new S3SessionStore(config())
+    await store.set('s', { session_id: 's', generation: 2 })
+    expect(await store.casSet('s', { session_id: 's', generation: 2 }, 1)).toBe(false)
+    expect(await store.casSet('s', { session_id: 's', cwd: '/x', generation: 3 }, 2)).toBe(true)
+    const entries = await store.load()
+    await store.close()
+    expect(entries.get('s')?.cwd).toBe('/x')
+  })
+
+  it('treats a legacy record without generation as generation 0', async () => {
+    const store = new S3SessionStore(config())
+    await store.set('s', { session_id: 's' })
+    expect(await store.casSet('s', { session_id: 's', generation: 1 }, 0)).toBe(true)
+    await store.close()
+  })
+
+  it('detects a write racing between compare-read and conditional put', async () => {
+    class RaceOnceClient extends FakeConditionalS3Client {
+      raced = true
+
+      protected override async getObject(
+        input: Record<string, unknown>,
+      ): Promise<Record<string, unknown>> {
+        const response = await super.getObject(input)
+        if (!this.raced) {
+          this.raced = true
+          this.setEntry(
+            input.Bucket as string,
+            input.Key as string,
+            JSON.stringify({ session_id: 's', cwd: '/winner', generation: 2 }),
+          )
+        }
+        return response
+      }
+    }
+    const client = installFakeS3(new RaceOnceClient()) as RaceOnceClient
+    const store = new S3SessionStore(config())
+    await store.set('s', { session_id: 's', generation: 1 })
+    client.raced = false
+    expect(await store.casSet('s', { session_id: 's', cwd: '/loser', generation: 2 }, 1)).toBe(
+      false,
+    )
+    const entries = await store.load()
+    await store.close()
+    expect(entries.get('s')?.cwd).toBe('/winner')
+  })
+
+  it('loses nothing under concurrent cas writers', async () => {
+    const store = new S3SessionStore(config())
+    const workers = ['w0', 'w1', 'w2', 'w3', 'w4']
+    await Promise.all(workers.map((worker) => casIncrement(store, worker, 5)))
+    const record = (await store.load()).get('hot')
+    await store.close()
+    expect(record?.generation).toBe(25)
+    for (const worker of workers) {
+      expect((record?.env as Record<string, string>)[worker]).toBe('5')
+    }
+  })
+})

--- a/typescript/packages/core/src/workspace/session/s3.ts
+++ b/typescript/packages/core/src/workspace/session/s3.ts
@@ -1,0 +1,249 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import {
+  createS3Client,
+  isNotFoundError,
+  loadS3Module,
+  streamToBuffer,
+  type S3SendClient,
+} from '../../core/s3/_client.ts'
+import { normalizeKeyPrefix, type S3Config } from '../../resource/s3/config.ts'
+import { SessionStore, generationOf, type SessionFields } from './store.ts'
+
+/**
+ * True when a conditional write lost: the object changed since the
+ * compare-read (412) or a concurrent conditional write is in flight
+ * (409). Mirrors the Python `_is_condition_lost`.
+ */
+export function isConditionLostError(err: unknown): boolean {
+  if (err === null || typeof err !== 'object') return false
+  const e = err as { name?: string; $metadata?: { httpStatusCode?: number } }
+  if (e.name === 'PreconditionFailed' || e.name === 'ConditionalRequestConflict') return true
+  const status = e.$metadata?.httpStatusCode
+  return status === 412 || status === 409
+}
+
+const decoder = new TextDecoder()
+
+/**
+ * One JSON-record-per-object client with ETag-anchored CAS.
+ *
+ * The generic building block both S3 stores share (mirroring how the
+ * Redis stores share one cas.lua): a record is one object at
+ * `{prefix}{name}.json`, and a conditional write anchors on the exact
+ * ETag the compare-read returned, so the generation check and the
+ * write hit the same stored version. Immutable-blob planes never need
+ * this; it exists only for the few mutable control-plane cells.
+ * Mirrors the Python S3RecordClient.
+ */
+export class S3RecordClient {
+  private readonly config: S3Config
+  private readonly prefix: string
+  private clientPromise: Promise<S3SendClient> | null = null
+
+  constructor(config: S3Config, prefix: string) {
+    this.config = config
+    this.prefix = prefix
+  }
+
+  private client(): Promise<S3SendClient> {
+    this.clientPromise ??= createS3Client(this.config) as unknown as Promise<S3SendClient>
+    return this.clientPromise
+  }
+
+  key(name: string): string {
+    return `${this.prefix}${name}.json`
+  }
+
+  /** Read one record; `[fields, etag]`, `[null, '']` when absent. */
+  async get(name: string): Promise<[Record<string, unknown> | null, string]> {
+    const [client, mod] = await Promise.all([this.client(), loadS3Module(this.config)])
+    let response: Record<string, unknown>
+    try {
+      response = await client.send(
+        new mod.GetObjectCommand({ Bucket: this.config.bucket, Key: this.key(name) }),
+      )
+    } catch (err) {
+      if (isNotFoundError(err)) return [null, '']
+      throw err
+    }
+    const body = await streamToBuffer(response.Body)
+    const etag = typeof response.ETag === 'string' ? response.ETag : ''
+    return [JSON.parse(decoder.decode(body)) as Record<string, unknown>, etag]
+  }
+
+  async put(name: string, fields: Record<string, unknown>): Promise<void> {
+    const [client, mod] = await Promise.all([this.client(), loadS3Module(this.config)])
+    await client.send(
+      new mod.PutObjectCommand({
+        Bucket: this.config.bucket,
+        Key: this.key(name),
+        Body: JSON.stringify(fields),
+      }),
+    )
+  }
+
+  /**
+   * Write one record iff its stored generation matches.
+   *
+   * Compare-read the record, check the generation client-side, then
+   * make the write conditional on the exact version read: If-None-Match
+   * for create (expected 0, nothing stored), If-Match on the read ETag
+   * otherwise. A 412/409 means another writer moved the record between
+   * our read and write; the caller adopts and retries.
+   */
+  async casPut(
+    name: string,
+    fields: Record<string, unknown>,
+    expectedGeneration: number,
+  ): Promise<boolean> {
+    const [stored, etag] = await this.get(name)
+    if (generationOf(stored) !== expectedGeneration) return false
+    const [client, mod] = await Promise.all([this.client(), loadS3Module(this.config)])
+    const condition = stored === null ? { IfNoneMatch: '*' } : { IfMatch: etag }
+    try {
+      await client.send(
+        new mod.PutObjectCommand({
+          Bucket: this.config.bucket,
+          Key: this.key(name),
+          Body: JSON.stringify(fields),
+          ...condition,
+        }),
+      )
+    } catch (err) {
+      if (isConditionLostError(err)) return false
+      throw err
+    }
+    return true
+  }
+
+  async listNames(): Promise<string[]> {
+    const [client, mod] = await Promise.all([this.client(), loadS3Module(this.config)])
+    const names: string[] = []
+    let continuationToken: string | undefined
+    do {
+      const response = await client.send(
+        new mod.ListObjectsV2Command({
+          Bucket: this.config.bucket,
+          Prefix: this.prefix,
+          ...(continuationToken !== undefined ? { ContinuationToken: continuationToken } : {}),
+        }),
+      )
+      const contents = (response.Contents ?? []) as { Key: string }[]
+      for (const entry of contents) {
+        const key = entry.Key.slice(this.prefix.length)
+        if (key.endsWith('.json')) names.push(key.slice(0, -'.json'.length))
+      }
+      continuationToken =
+        response.IsTruncated === true ? (response.NextContinuationToken as string) : undefined
+    } while (continuationToken !== undefined)
+    return names
+  }
+
+  /** Every stored record, keyed by name; batch-first (one list, then parallel reads). */
+  async loadAll(): Promise<Map<string, Record<string, unknown>>> {
+    const names = await this.listNames()
+    const records = await Promise.all(names.map((name) => this.get(name)))
+    const out = new Map<string, Record<string, unknown>>()
+    for (const [i, name] of names.entries()) {
+      const record = records[i]
+      if (record === undefined) continue
+      const [fields] = record
+      if (fields !== null) out.set(name, fields)
+    }
+    return out
+  }
+
+  async delete(names: readonly string[]): Promise<void> {
+    if (names.length === 0) return
+    const [client, mod] = await Promise.all([this.client(), loadS3Module(this.config)])
+    await client.send(
+      new mod.DeleteObjectsCommand({
+        Bucket: this.config.bucket,
+        Delete: { Objects: names.map((name) => ({ Key: this.key(name) })) },
+      }),
+    )
+  }
+
+  async clear(): Promise<void> {
+    await this.delete(await this.listNames())
+  }
+
+  async close(): Promise<void> {
+    if (this.clientPromise !== null) {
+      const client = await this.clientPromise
+      client.destroy?.()
+      this.clientPromise = null
+    }
+  }
+}
+
+/**
+ * SessionStore backed by per-session S3 objects.
+ *
+ * One object per session at `{keyPrefix}sessions/{session_id}.json`
+ * (the store appends the `sessions/` segment, mirroring the Redis
+ * store's `{keyPrefix}sessions` hash). Conditional writes (If-Match
+ * on the compare-read's ETag) give the same generation-CAS contract
+ * as the Redis Lua script, so the S3 control plane is safe for the
+ * same multi-process sharing. Works on any S3-compatible backend that
+ * honors conditional PUTs. Mirrors the Python S3SessionStore.
+ */
+export class S3SessionStore extends SessionStore {
+  private readonly records: S3RecordClient
+
+  constructor(config: S3Config) {
+    super()
+    const prefix = normalizeKeyPrefix(config.keyPrefix) ?? ''
+    this.records = new S3RecordClient(config, `${prefix}sessions/`)
+  }
+
+  async load(): Promise<Map<string, SessionFields>> {
+    return this.records.loadAll()
+  }
+
+  async set(sessionId: string, fields: SessionFields): Promise<void> {
+    await this.records.put(sessionId, fields)
+  }
+
+  async casSet(
+    sessionId: string,
+    fields: SessionFields,
+    expectedGeneration: number,
+  ): Promise<boolean> {
+    return this.records.casPut(sessionId, fields, expectedGeneration)
+  }
+
+  async delete(sessionIds: readonly string[]): Promise<void> {
+    await this.records.delete(sessionIds)
+  }
+
+  async replaceAll(entries: Map<string, SessionFields>): Promise<void> {
+    const names = await this.records.listNames()
+    const stale = names.filter((name) => !entries.has(name))
+    await this.records.delete(stale)
+    await Promise.all(
+      [...entries].map(([sessionId, fields]) => this.records.put(sessionId, fields)),
+    )
+  }
+
+  async clear(): Promise<void> {
+    await this.records.clear()
+  }
+
+  async close(): Promise<void> {
+    await this.records.close()
+  }
+}

--- a/typescript/packages/core/src/workspace/store/s3.test.ts
+++ b/typescript/packages/core/src/workspace/store/s3.test.ts
@@ -1,0 +1,112 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as s3ClientModule from '../../core/s3/_client.ts'
+import type { S3Config } from '../../resource/s3/config.ts'
+import { currentFakeS3, installFakeS3 } from '../fixtures/s3_fake.ts'
+import { RAMWorkspaceStateStore } from './ram.ts'
+import { S3WorkspaceStateStore } from './s3.ts'
+
+vi.mock('../../core/s3/_client.ts', async (importOriginal) => {
+  const original = await importOriginal<typeof s3ClientModule>()
+  const fake = await import('../fixtures/s3_fake.ts')
+  return {
+    ...original,
+    createS3Client: () => Promise.resolve(fake.currentFakeS3() as never),
+    loadS3Module: () => Promise.resolve(fake.FAKE_S3_MODULE),
+  }
+})
+
+const BUCKET = 'state-bucket'
+
+function config(): S3Config {
+  return {
+    bucket: BUCKET,
+    region: 'us-east-1',
+    accessKeyId: 'fake',
+    secretAccessKey: 'fake',
+    keyPrefix: 'mirage/',
+  }
+}
+
+describe('S3WorkspaceStateStore', () => {
+  beforeEach(() => {
+    installFakeS3()
+  })
+
+  it('round-trips the meta record at the documented layout', async () => {
+    const store = new S3WorkspaceStateStore(config())
+    expect(await store.loadMeta('ws1')).toBeNull()
+    await store.setMeta('ws1', { workspace_id: 'ws1', default_session_id: 'main' })
+    const meta = await store.loadMeta('ws1')
+    await store.close()
+    expect(meta).toEqual({ workspace_id: 'ws1', default_session_id: 'main' })
+    expect(currentFakeS3().entry(BUCKET, 'mirage/workspaces/ws1.json')).toBeDefined()
+  })
+
+  it('conditional create admits exactly one winner', async () => {
+    const storeA = new S3WorkspaceStateStore(config())
+    const storeB = new S3WorkspaceStateStore(config())
+    const record = { workspace_id: 'ws1', generation: 1 }
+    const results = await Promise.all([
+      storeA.casSetMeta('ws1', record, 0),
+      storeB.casSetMeta('ws1', { ...record }, 0),
+    ])
+    await storeA.close()
+    await storeB.close()
+    expect([...results].sort()).toEqual([false, true])
+  })
+
+  it('replaceMeta merges over the stored record and bumps the generation', async () => {
+    const store = new S3WorkspaceStateStore(config())
+    await store.setMeta('ws1', { workspace_id: 'ws1', created_at: 111, generation: 4 })
+    const written = await store.replaceMeta('ws1', {
+      workspace_id: 'ws1',
+      default_session_id: 'restored',
+    })
+    await store.close()
+    expect(written.default_session_id).toBe('restored')
+    expect(written.created_at).toBe(111)
+    expect(written.generation).toBe(5)
+  })
+
+  it('scopes the session table per workspace and caches it', async () => {
+    const store = new S3WorkspaceStateStore(config())
+    const sessions = store.sessions('ws1')
+    expect(store.sessions('ws1')).toBe(sessions)
+    await sessions.set('main', { session_id: 'main' })
+    await store.close()
+    expect(currentFakeS3().entry(BUCKET, 'mirage/ws1/sessions/main.json')).toBeDefined()
+  })
+
+  it('refuses the namespace and observer planes', async () => {
+    const store = new S3WorkspaceStateStore(config())
+    expect(() => store.namespace('ws1')).toThrow(/sessions\+meta group/)
+    expect(() => store.observer('ws1')).toThrow(/sessions\+meta group/)
+    await store.close()
+  })
+
+  it('serves the workspace group override of a RAM default store', async () => {
+    const s3Store = new S3WorkspaceStateStore(config())
+    const store = new RAMWorkspaceStateStore({ workspace: s3Store })
+    store.namespace('ws1')
+    store.observer('ws1')
+    await store.sessions('ws1').set('main', { session_id: 'main' })
+    await store.setMeta('ws1', { workspace_id: 'ws1' })
+    await store.close()
+    expect(currentFakeS3().entry(BUCKET, 'mirage/ws1/sessions/main.json')).toBeDefined()
+    expect(currentFakeS3().entry(BUCKET, 'mirage/workspaces/ws1.json')).toBeDefined()
+  })
+})

--- a/typescript/packages/core/src/workspace/store/s3.ts
+++ b/typescript/packages/core/src/workspace/store/s3.ts
@@ -1,0 +1,100 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { ObserverStore } from '../../observe/store.ts'
+import { normalizeKeyPrefix, type S3Config } from '../../resource/s3/config.ts'
+import type { NamespaceStore } from '../mount/namespace/store.ts'
+import { S3RecordClient, S3SessionStore } from '../session/s3.ts'
+import type { SessionStore } from '../session/store.ts'
+import {
+  WorkspaceStateStore,
+  type WorkspaceFields,
+  type WorkspaceStateStoreOverrides,
+} from './base.ts'
+
+/**
+ * WorkspaceStateStore hosting the sessions + metadata group on S3.
+ *
+ * Object layout under one bucket and prefix:
+ *
+ * - `{prefix}workspaces/{ws}.json` — metadata record
+ * - `{prefix}{ws}/sessions/{session_id}.json` — session table
+ *
+ * Every record write is CAS-gated by a conditional PUT anchored on the
+ * compare-read's ETag, giving S3 the same generation contract as the
+ * Redis Lua script; bucket versioning (when enabled) doubles as an
+ * audit trail for free. This store hosts only the sessions+meta
+ * group: namespace nodes and observer events are chatty per-op planes
+ * that belong on RAM or Redis, so use this store as the `workspace`
+ * group override of a RAM or Redis default store. Mirrors the Python
+ * S3WorkspaceStateStore.
+ */
+export class S3WorkspaceStateStore extends WorkspaceStateStore {
+  private readonly config: S3Config
+  private readonly prefix: string
+  private readonly meta: S3RecordClient
+  private readonly sessionTables = new Map<string, S3SessionStore>()
+
+  constructor(config: S3Config, overrides: WorkspaceStateStoreOverrides = {}) {
+    super(overrides)
+    this.config = config
+    this.prefix = normalizeKeyPrefix(config.keyPrefix) ?? ''
+    this.meta = new S3RecordClient(config, `${this.prefix}workspaces/`)
+  }
+
+  protected makeNamespace(_workspaceId: string): NamespaceStore {
+    throw new Error(
+      'The s3 store hosts only the sessions+meta group; keep the namespace ' +
+        "plane on RAM or Redis and pass the s3 store as the 'workspace' group override.",
+    )
+  }
+
+  protected makeObserver(_workspaceId: string): ObserverStore {
+    throw new Error(
+      'The s3 store hosts only the sessions+meta group; keep the observer ' +
+        "plane on RAM or Redis and pass the s3 store as the 'workspace' group override.",
+    )
+  }
+
+  protected makeSessions(workspaceId: string): SessionStore {
+    let table = this.sessionTables.get(workspaceId)
+    if (table === undefined) {
+      table = new S3SessionStore({ ...this.config, keyPrefix: `${this.prefix}${workspaceId}/` })
+      this.sessionTables.set(workspaceId, table)
+    }
+    return table
+  }
+
+  protected async readMeta(workspaceId: string): Promise<WorkspaceFields | null> {
+    const [fields] = await this.meta.get(workspaceId)
+    return fields
+  }
+
+  protected async writeMeta(workspaceId: string, fields: WorkspaceFields): Promise<void> {
+    await this.meta.put(workspaceId, fields)
+  }
+
+  protected casWriteMeta(
+    workspaceId: string,
+    fields: WorkspaceFields,
+    expectedGeneration: number,
+  ): Promise<boolean> {
+    return this.meta.casPut(workspaceId, fields, expectedGeneration)
+  }
+
+  protected async closeSelf(): Promise<void> {
+    for (const table of this.sessionTables.values()) await table.close()
+    await this.meta.close()
+  }
+}


### PR DESCRIPTION
Roadmap item 3 of the CAS arc (after #530/#533): the sessions + workspace-metadata control plane can now live on S3 or any S3-compatible store, with the same generation-CAS contract the Redis Lua script gives.

- `S3RecordClient` (py `workspace/session/s3.py`, TS core `workspace/session/s3.ts`): one JSON record per object; `cas_put` compare-reads, checks the generation client-side, then conditional-PUTs anchored on the read ETag (`If-None-Match: *` create, `If-Match` update; 412/409 = conflict, caller adopts and retries).
- `S3SessionStore` + `S3WorkspaceStateStore`: layout `{prefix}workspaces/{ws}.json` and `{prefix}{ws}/sessions/{sid}.json`. Hosts only the sessions+meta group; namespace/observer raise and point at the `workspace` group override.
- Config: `S3StoreBlock(S3Config)` subclass with the `type` discriminator, so the block is the backend config (no field duplication, SecretStr creds).
- Unit tests both langs against a conditional-write S3 fake: create-exactly-once, stale generation, injected compare-read/put race, 5-writer hammer with zero lost updates, group-override wiring.
- `integ/state_store.sh` now runs the whole cross-language battery twice: redis, then `STORE_S3=1` with sessions+meta on S3 (MinIO in CI). Verified locally against real MinIO including the py+ts concurrent CAS hammer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)