### PR TITLE
feat(version): content-pure commit trees (strip cache + sessions)

### DIFF
--- a/python/mirage/server/version/api.py
+++ b/python/mirage/server/version/api.py
@@ -13,9 +13,9 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.server.version.errors import NoSuchBranchError
-from mirage.server.version.state_tree import (CACHE_PREFIX, META_PATH,
-                                              blob_to_meta, meta_to_blob,
-                                              to_state, tree_inputs_from_state)
+from mirage.server.version.state_tree import (META_PATH, blob_to_meta,
+                                              meta_to_blob, to_state,
+                                              tree_inputs_from_state)
 from mirage.server.version.store import VersionStore
 from mirage.types import DriftPolicy, StateKey
 from mirage.workspace.snapshot import (apply_state_dict, install_fingerprints,
@@ -101,10 +101,7 @@ async def checkout(store: VersionStore,
 
 def _strip_meta(changes: dict[str, list[str]]) -> dict[str, list[str]]:
     return {
-        kind: [
-            p for p in paths
-            if p != META_PATH and not p.startswith(CACHE_PREFIX)
-        ]
+        kind: [p for p in paths if p != META_PATH]
         for kind, paths in changes.items()
     }
 

--- a/python/mirage/server/version/state_tree.py
+++ b/python/mirage/server/version/state_tree.py
@@ -20,11 +20,10 @@ from mirage.workspace.snapshot.tar_io import _json_default
 from mirage.workspace.snapshot.utils import FORMAT_VERSION
 
 META_PATH = ".mirage-meta.json"
-CACHE_PREFIX = ".mirage-cache/"
 
 
 def _is_reserved(tree_path: str) -> bool:
-    return tree_path == META_PATH or tree_path.startswith(CACHE_PREFIX)
+    return tree_path == META_PATH
 
 
 def _tree_path(prefix: str, rel: str) -> str:
@@ -89,24 +88,10 @@ def tree_inputs_from_state(state: dict) -> tuple[dict[str, bytes], dict]:
         CacheKey.LIMIT: cache[CacheKey.LIMIT],
         CacheKey.MAX_DRAIN_BYTES: cache[CacheKey.MAX_DRAIN_BYTES],
     }
-    cache_meta: list[dict] = []
-    for i, entry in enumerate(cache[CacheKey.ENTRIES]):
-        ref = f"{CACHE_PREFIX}{i}"
-        entries[ref] = entry[CacheKey.DATA]
-        cache_meta.append({
-            CacheKey.KEY: entry[CacheKey.KEY],
-            CacheKey.FINGERPRINT: entry.get(CacheKey.FINGERPRINT),
-            CacheKey.TTL: entry.get(CacheKey.TTL),
-            CacheKey.CACHED_AT: entry.get(CacheKey.CACHED_AT),
-            CacheKey.SIZE: entry.get(CacheKey.SIZE),
-            "ref": ref,
-        })
     meta = {
         "mounts": mounts_meta,
         "config": config,
-        "cache": cache_meta,
         "fingerprints": state.get(StateKey.FINGERPRINTS) or [],
-        "sessions": state.get(StateKey.SESSIONS) or [],
     }
     return entries, meta
 
@@ -133,29 +118,19 @@ def to_state(entries: dict[str, bytes], meta: dict) -> dict:
             MountKey.RESOURCE_STATE: resource_state,
         })
     config = meta.get("config", {})
-    cache_entries: list[dict] = []
-    for c in meta.get("cache", []):
-        cache_entries.append({
-            CacheKey.KEY: c[CacheKey.KEY],
-            CacheKey.DATA: entries[c["ref"]],
-            CacheKey.FINGERPRINT: c.get(CacheKey.FINGERPRINT),
-            CacheKey.TTL: c.get(CacheKey.TTL),
-            CacheKey.CACHED_AT: c.get(CacheKey.CACHED_AT),
-            CacheKey.SIZE: c.get(CacheKey.SIZE),
-        })
     return {
         StateKey.VERSION: FORMAT_VERSION,
         StateKey.MIRAGE_VERSION: config.get(StateKey.MIRAGE_VERSION,
                                             "unknown"),
         StateKey.MOUNTS: mounts,
-        StateKey.SESSIONS: meta.get("sessions", []),
+        StateKey.SESSIONS: [],
         StateKey.DEFAULT_SESSION_ID: config.get(StateKey.DEFAULT_SESSION_ID),
         StateKey.DEFAULT_AGENT_ID: config.get(StateKey.DEFAULT_AGENT_ID),
         StateKey.CURRENT_AGENT_ID: config.get(StateKey.CURRENT_AGENT_ID),
         StateKey.CACHE: {
             CacheKey.LIMIT: config.get(CacheKey.LIMIT, "512MB"),
             CacheKey.MAX_DRAIN_BYTES: config.get(CacheKey.MAX_DRAIN_BYTES),
-            CacheKey.ENTRIES: cache_entries,
+            CacheKey.ENTRIES: [],
         },
         StateKey.HISTORY: None,
         StateKey.JOBS: [],

--- a/python/tests/server/version/test_state_tree.py
+++ b/python/tests/server/version/test_state_tree.py
@@ -97,7 +97,7 @@ async def test_to_state_is_tar_loadable():
 
 
 @pytest.mark.asyncio
-async def test_cache_fingerprints_sessions_round_trip():
+async def test_content_pure_tree_keeps_files_and_fingerprints():
     ws = Workspace({"/": (RAMResource(), MountMode.WRITE)},
                    mode=MountMode.WRITE)
     await ws.execute("echo hi > /a.txt")
@@ -128,64 +128,40 @@ async def test_cache_fingerprints_sessions_round_trip():
     meta = blob_to_meta(meta_to_blob(meta))
     restored = to_state(entries, meta)
 
-    cache_entries = restored[StateKey.CACHE][CacheKey.ENTRIES]
-    assert len(cache_entries) == 1
-    assert cache_entries[0][CacheKey.DATA] == b"cached-bytes"
-    assert cache_entries[0][CacheKey.KEY] == "/a.txt"
-    assert restored[StateKey.FINGERPRINTS][0][FingerprintKey.REVISION] == "v1"
-    assert restored[StateKey.SESSIONS][0][SessionKey.CWD] == "/sub"
-    assert restored[StateKey.SESSIONS][0][SessionKey.ENV] == {"FOO": "bar"}
-
     files = _mount_files(restored, "/")
     assert files["/a.txt"] == b"hi\n"
-    assert all(".mirage-cache" not in k for k in files)
+    assert restored[StateKey.FINGERPRINTS][0][FingerprintKey.REVISION] == "v1"
+
+    # Cache is derived and sessions are control-plane state: neither
+    # enters the commit tree (content-pure commits). They travel via
+    # snapshots (tar) and the session store instead.
+    assert restored[StateKey.CACHE][CacheKey.ENTRIES] == []
+    assert restored[StateKey.SESSIONS] == []
+    assert all(not k.startswith(".mirage-cache") for k in entries)
 
 
 @pytest.mark.asyncio
-async def test_cache_and_pins_survive_tar():
+async def test_commit_tree_excludes_session_env_secrets():
     ws = Workspace({"/": (RAMResource(), MountMode.WRITE)},
                    mode=MountMode.WRITE)
     await ws.execute("echo hi > /a.txt")
     state = await to_state_dict(ws)
-    state[StateKey.CACHE][CacheKey.ENTRIES] = [{
-        CacheKey.KEY: "/a.txt",
-        CacheKey.DATA: b"cached-bytes",
-        CacheKey.FINGERPRINT: "etag-1",
-        CacheKey.TTL: None,
-        CacheKey.CACHED_AT: 1.0,
-        CacheKey.SIZE: 12,
-    }]
-    state[StateKey.FINGERPRINTS] = [{
-        FingerprintKey.PATH: "/a.txt",
-        FingerprintKey.MOUNT_PREFIX: "/",
-        FingerprintKey.REVISION: "v1",
-    }]
     state[StateKey.SESSIONS] = [{
         SessionKey.SESSION_ID: "agent_a",
-        SessionKey.CWD: "/sub",
         SessionKey.ENV: {
-            "FOO": "bar"
+            "API_KEY": "sk-SECRET-LEAK-TOKEN"
         },
     }]
 
     entries, meta = tree_inputs_from_state(state)
-    meta = blob_to_meta(meta_to_blob(meta))
-    rebuilt = to_state(entries, meta)
+    meta_blob = meta_to_blob(meta)
 
-    manifest, blobs = split_manifest_and_blobs(rebuilt)
-    buf = io.BytesIO()
-    write_tar(buf, manifest, blobs)
-    buf.seek(0)
-    restored = read_tar(buf)
-
-    ce = restored[StateKey.CACHE][CacheKey.ENTRIES]
-    assert ce[0][CacheKey.DATA] == b"cached-bytes"
-    assert restored[StateKey.FINGERPRINTS][0][FingerprintKey.REVISION] == "v1"
-    sessions = {
-        s[SessionKey.SESSION_ID]: s
-        for s in restored[StateKey.SESSIONS]
-    }
-    assert sessions["agent_a"][SessionKey.CWD] == "/sub"
+    # No session env byte may be reachable from the commit tree: this is
+    # the precondition for pushing commits to real remotes (V2).
+    assert b"sk-SECRET-LEAK-TOKEN" not in meta_blob
+    assert all(b"sk-SECRET-LEAK-TOKEN" not in data
+               for data in entries.values())
+    assert "sessions" not in blob_to_meta(meta_blob)
 
 
 def test_meta_blob_round_trip():

--- a/typescript/packages/server/src/version/api.ts
+++ b/typescript/packages/server/src/version/api.ts
@@ -16,7 +16,6 @@ import { applyStateDict, type Workspace as CoreWorkspace } from '@struktoai/mira
 import { NoSuchBranchError } from './errors.ts'
 import {
   blobToMeta,
-  CACHE_PREFIX,
   META_PATH,
   metaToBlob,
   toState,
@@ -40,8 +39,7 @@ const EMPTY_META: VersionMeta = {
 }
 
 function stripMeta(d: DiffResult): DiffResult {
-  const keep = (xs: string[]): string[] =>
-    xs.filter((p) => p !== META_PATH && !p.startsWith(CACHE_PREFIX))
+  const keep = (xs: string[]): string[] => xs.filter((p) => p !== META_PATH)
   return { added: keep(d.added), modified: keep(d.modified), deleted: keep(d.deleted) }
 }
 

--- a/typescript/packages/server/src/version/stateTree.test.ts
+++ b/typescript/packages/server/src/version/stateTree.test.ts
@@ -53,15 +53,16 @@ function makeState(): WorkspaceStateDict {
 }
 
 describe('stateTree', () => {
-  it('pulls mount files and cache out into tree entries', () => {
+  it('pulls only mount files into tree entries (content-pure, no cache)', () => {
     const { entries, meta } = treeInputsFromState(makeState())
-    expect(Object.keys(entries).sort()).toEqual(['.mirage-cache/0', 'm/a.txt', 'm/sub/b.txt'])
+    expect(Object.keys(entries).sort()).toEqual(['m/a.txt', 'm/sub/b.txt'])
     expect(entries['m/a.txt']).toEqual(enc('hi'))
     expect(meta.mounts[0]?.resourceState).not.toHaveProperty('files')
-    expect(meta.cache.entries[0]?.ref).toBe('.mirage-cache/0')
+    expect(Object.keys(entries).every((k) => !k.startsWith('.mirage-cache'))).toBe(true)
+    expect(meta.cache.entries).toEqual([])
   })
 
-  it('round-trips state through tree inputs and a JSON meta blob', () => {
+  it('round-trips files through tree inputs; cache and sessions are dropped', () => {
     const { entries, meta } = treeInputsFromState(makeState())
     const back = toState(entries, blobToMeta(metaToBlob(meta)))
     const mounts = back.mounts as unknown as {
@@ -70,7 +71,10 @@ describe('stateTree', () => {
     const rs = mounts[0]?.resource_state
     expect(rs?.files['/a.txt']).toEqual(enc('hi'))
     expect(rs?.files['/sub/b.txt']).toEqual(enc('bee'))
-    expect(back.cache.entries[0]?.data).toEqual(enc('CACHE'))
+    // Cache is derived, sessions are control-plane: neither enters the
+    // commit tree (content-pure commits).
+    expect(back.cache.entries).toEqual([])
+    expect(back.sessions).toEqual([])
     expect(back.history).toEqual([])
   })
 })

--- a/typescript/packages/server/src/version/stateTree.ts
+++ b/typescript/packages/server/src/version/stateTree.ts
@@ -19,7 +19,6 @@ export type { WorkspaceStateDict }
 type AnyDict = Record<string, unknown>
 
 export const META_PATH = '.mirage-meta.json'
-export const CACHE_PREFIX = '.mirage-cache/'
 
 export interface VersionMeta {
   version: number
@@ -56,7 +55,7 @@ function belongs(treePrefix: string, tp: string): boolean {
 }
 
 function isReserved(tp: string): boolean {
-  return tp === META_PATH || tp.startsWith(CACHE_PREFIX)
+  return tp === META_PATH
 }
 
 export function metaToBlob(meta: VersionMeta): Uint8Array {
@@ -85,25 +84,11 @@ export function treeInputsFromState(state: WorkspaceStateDict): TreeInputs {
     })
   }
 
-  const cache = state.cache as unknown as { limit: number; entries: AnyDict[] }
-  const cacheMeta: AnyDict[] = []
-  cache.entries.forEach((entry, i) => {
-    const ref = `${CACHE_PREFIX}${String(i)}`
-    entries[ref] = entry.data as Uint8Array
-    cacheMeta.push({
-      key: entry.key,
-      fingerprint: entry.fingerprint ?? null,
-      ttl: entry.ttl ?? null,
-      cachedAt: entry.cached_at ?? 0,
-      size: entry.size ?? 0,
-      ref,
-    })
-  })
-
+  const cache = state.cache as unknown as { limit: number }
   const meta: VersionMeta = {
     version: state.version,
     mounts: mountsMeta,
-    cache: { limit: cache.limit, entries: cacheMeta },
+    cache: { limit: cache.limit, entries: [] },
     fingerprints: (state.fingerprints as unknown[] | undefined) ?? [],
     liveOnlyMounts: state.live_only_mounts ?? [],
   }
@@ -134,19 +119,10 @@ export function toState(
     })
   }
 
-  const cacheEntries: AnyDict[] = meta.cache.entries.map((c) => ({
-    key: c.key,
-    data: entries[c.ref as string],
-    fingerprint: c.fingerprint ?? null,
-    ttl: c.ttl ?? null,
-    cached_at: c.cachedAt ?? 0,
-    size: c.size ?? 0,
-  }))
-
   return {
     version: meta.version,
     mounts,
-    cache: { limit: meta.cache.limit, entries: cacheEntries },
+    cache: { limit: meta.cache.limit, entries: [] },
     sessions: [],
     history: [],
     jobs: [],


### PR DESCRIPTION
V1 of the versioning arc (roadmap items 4/5 of the CAS plan). A commit tree becomes pure filesystem content, so it is a value anyone can share and, critically, a value that is safe to push to a real remote.

## What changed
Version-store commit trees previously baked in three planes: file content, `.mirage-cache/<i>` cache blobs, and session records inside `.mirage-meta.json`. The last two are removed:

- **Cache stripped** (derived, rebuildable, and bloats every commit). Checkout now starts with a cold cache, which is correct — cache is not content. Snapshots (tar) still carry cache via the separate `to_state_dict` path.
- **Sessions stripped** (control-plane state, and session env carries secrets). Sessions already persist independently in the session store (#530) and travel via the state store, so they do not belong in a commit. This is the hard blocker for V2 remotes: you cannot push a commit to GitHub if it embeds session env.

The commit tree now holds file blobs plus a slim `.mirage-meta.json` (mounts layout, config scalars, fingerprints). `checkout` still restores content in place; sessions stay live; the default-session pointer is unaffected.

## Notes
- TS was already content-pure on sessions (a pre-existing py/ts divergence: TS `toState` never restored sessions and `VersionMeta` had no sessions field). This PR brings the cache-stripping to both languages, so the two sides now match on the content-pure contract.
- New `test_commit_tree_excludes_session_env_secrets` asserts no session env byte is reachable from the commit tree — the secret-safety precondition for remotes.
- Deferred to a follow-up: the snapshot commit-id pointer (leg C), which needs a decision on how a snapshot references the version store (the Workspace does not currently own one). Also deferred: V1.5 token-agnostic tree/manifest layer (blob SHA vs S3 version id in one code path).

## Verification
Python: full suite green (fuse excluded per the local-wedge rule). TS: `tsc` clean + all 205 server tests. Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)