### PR TITLE
Align TypeScript types and constants with Python structure

### DIFF
--- a/typescript/packages/browser/src/commands/builtin/opfs/cp.ts
+++ b/typescript/packages/browser/src/commands/builtin/opfs/cp.ts
@@ -20,7 +20,6 @@ import {
   specOf,
   type CommandFnResult,
   type CommandOpts,
-  type FindOptions,
   type PathSpec,
 } from '@struktoai/mirage-core'
 import { copy as coreCopy } from '../../../core/opfs/copy.ts'
@@ -43,9 +42,11 @@ function cpCommand(
   const recursive = opts.flags.r === true || opts.flags.R === true || opts.flags.a === true
   return cpGeneric(
     paths,
-    (src: PathSpec, target: PathSpec) => coreCopy(accessor, src, target),
-    (src: PathSpec, options: FindOptions) => coreFind(accessor, src, options),
     (p: PathSpec) => coreStat(accessor, p),
+    {
+      copy: (src: PathSpec, target: PathSpec) => coreCopy(accessor, src, target),
+      find: (src, options) => coreFind(accessor, src, options),
+    },
     recursive,
     opts.flags.n === true,
     opts.flags.v === true,

--- a/typescript/packages/browser/src/commands/builtin/opfs/mv.ts
+++ b/typescript/packages/browser/src/commands/builtin/opfs/mv.ts
@@ -40,8 +40,8 @@ function mvCommand(
   }
   return mvGeneric(
     paths,
-    (src: PathSpec, target: PathSpec) => coreRename(accessor, src, target),
     (p: PathSpec) => coreStat(accessor, p),
+    { rename: (src: PathSpec, target: PathSpec) => coreRename(accessor, src, target) },
     opts.flags.n === true,
     opts.flags.v === true,
     opts.index ?? undefined,

--- a/typescript/packages/core/src/cache/read_through.ts
+++ b/typescript/packages/core/src/cache/read_through.ts
@@ -13,23 +13,19 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { Accessor } from '../accessor/base.ts'
-import { PathSpec } from '../types.ts'
+import { PathSpec, type ReadBytesFn, type ReadStreamFn } from '../types.ts'
 import type { IndexCacheStore } from './index/store.ts'
 import { type CacheInvalidator, activeCacheManager } from './context.ts'
 
-type OpStream<A extends Accessor> = (
-  accessor: A,
-  path: PathSpec,
-  index?: IndexCacheStore,
-) => AsyncIterable<Uint8Array>
+type OpStream<A extends Accessor> = ReadStreamFn<
+  [accessor: A, path: PathSpec, index?: IndexCacheStore]
+>
 
-type OpBytes<A extends Accessor> = (
-  accessor: A,
-  path: PathSpec,
-  index?: IndexCacheStore,
-) => Promise<Uint8Array>
+type OpBytes<A extends Accessor> = ReadBytesFn<
+  [accessor: A, path: PathSpec, index?: IndexCacheStore]
+>
 
-type PathStream = (path: PathSpec) => AsyncIterable<Uint8Array>
+type PathStream = ReadStreamFn
 
 async function* serveStream(
   manager: CacheInvalidator | null,

--- a/typescript/packages/core/src/commands/builtin/constants.ts
+++ b/typescript/packages/core/src/commands/builtin/constants.ts
@@ -12,5 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export const SCOPE_WARN = 5000
-export const SCOPE_ERROR = 50000
+export enum PatternType {
+  EXACT = 'exact',
+  SIMPLE = 'simple',
+  REGEX = 'regex',
+}

--- a/typescript/packages/core/src/commands/builtin/filetype_factory/extensions.ts
+++ b/typescript/packages/core/src/commands/builtin/filetype_factory/extensions.ts
@@ -17,7 +17,7 @@ import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import * as featherModule from '../../../core/filetype/feather.ts'
 import * as hdf5Module from '../../../core/filetype/hdf5.ts'
 import * as parquetModule from '../../../core/filetype/parquet.ts'
-import type { PathSpec } from '../../../types.ts'
+import type { PathSpec, ReadBytesFn } from '../../../types.ts'
 
 export interface FiletypeModule {
   describe(raw: Uint8Array): string | Promise<string>
@@ -42,11 +42,9 @@ export const FILETYPE_ENTRIES: readonly FiletypeEntry[] = [
   { fmt: 'hdf5', exts: ['.h5', '.hdf5'], module: hdf5Module },
 ]
 
-export type ReadBytesFn<A extends Accessor = Accessor> = (
-  accessor: A,
-  path: PathSpec,
-  index?: IndexCacheStore,
-) => Promise<Uint8Array>
+export type FiletypeReadBytesFn<A extends Accessor = Accessor> = ReadBytesFn<
+  [accessor: A, path: PathSpec, index?: IndexCacheStore]
+>
 
 export type StatEntryFn<A extends Accessor = Accessor> = (
   accessor: A,

--- a/typescript/packages/core/src/commands/builtin/filetype_factory/factory.ts
+++ b/typescript/packages/core/src/commands/builtin/filetype_factory/factory.ts
@@ -15,12 +15,12 @@
 import type { Accessor } from '../../../accessor/base.ts'
 import { command, type RegisteredCommand } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
-import { FILETYPE_ENTRIES, type ReadBytesFn, type StatEntryFn } from './extensions.ts'
+import { FILETYPE_ENTRIES, type FiletypeReadBytesFn, type StatEntryFn } from './extensions.ts'
 import { BUILDERS } from './handlers/index.ts'
 
 export interface FiletypeCommandsOptions<A extends Accessor = Accessor> {
   resource: string
-  readBytes: ReadBytesFn<A>
+  readBytes: FiletypeReadBytesFn<A>
   statEntry: StatEntryFn<A>
 }
 

--- a/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/cat.ts
+++ b/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/cat.ts
@@ -16,12 +16,12 @@ import type { Accessor } from '../../../../accessor/base.ts'
 import { IOResult, type ByteSource } from '../../../../io/types.ts'
 import type { PathSpec } from '../../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../../config.ts'
-import type { FiletypeEntry, ReadBytesFn, StatEntryFn } from '../extensions.ts'
+import type { FiletypeEntry, FiletypeReadBytesFn, StatEntryFn } from '../extensions.ts'
 
 const ENC = new TextEncoder()
 
 export async function ftCat<A extends Accessor>(
-  readBytes: ReadBytesFn<A>,
+  readBytes: FiletypeReadBytesFn<A>,
   _statEntry: StatEntryFn<A>,
   entry: FiletypeEntry,
   accessor: A,

--- a/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/cut.ts
+++ b/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/cut.ts
@@ -16,12 +16,12 @@ import type { Accessor } from '../../../../accessor/base.ts'
 import { IOResult, type ByteSource } from '../../../../io/types.ts'
 import type { PathSpec } from '../../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../../config.ts'
-import type { FiletypeEntry, ReadBytesFn, StatEntryFn } from '../extensions.ts'
+import type { FiletypeEntry, FiletypeReadBytesFn, StatEntryFn } from '../extensions.ts'
 
 const ENC = new TextEncoder()
 
 export async function ftCut<A extends Accessor>(
-  readBytes: ReadBytesFn<A>,
+  readBytes: FiletypeReadBytesFn<A>,
   _statEntry: StatEntryFn<A>,
   entry: FiletypeEntry,
   accessor: A,

--- a/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/file.ts
+++ b/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/file.ts
@@ -16,12 +16,12 @@ import type { Accessor } from '../../../../accessor/base.ts'
 import { IOResult, type ByteSource } from '../../../../io/types.ts'
 import type { PathSpec } from '../../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../../config.ts'
-import type { FiletypeEntry, ReadBytesFn, StatEntryFn } from '../extensions.ts'
+import type { FiletypeEntry, FiletypeReadBytesFn, StatEntryFn } from '../extensions.ts'
 
 const ENC = new TextEncoder()
 
 export async function ftFile<A extends Accessor>(
-  readBytes: ReadBytesFn<A>,
+  readBytes: FiletypeReadBytesFn<A>,
   _statEntry: StatEntryFn<A>,
   entry: FiletypeEntry,
   accessor: A,

--- a/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/grep.ts
@@ -16,12 +16,12 @@ import type { Accessor } from '../../../../accessor/base.ts'
 import { IOResult, type ByteSource } from '../../../../io/types.ts'
 import type { PathSpec } from '../../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../../config.ts'
-import type { FiletypeEntry, ReadBytesFn, StatEntryFn } from '../extensions.ts'
+import type { FiletypeEntry, FiletypeReadBytesFn, StatEntryFn } from '../extensions.ts'
 
 const ENC = new TextEncoder()
 
 export async function ftGrep<A extends Accessor>(
-  readBytes: ReadBytesFn<A>,
+  readBytes: FiletypeReadBytesFn<A>,
   _statEntry: StatEntryFn<A>,
   entry: FiletypeEntry,
   accessor: A,

--- a/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/head.ts
+++ b/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/head.ts
@@ -16,12 +16,12 @@ import type { Accessor } from '../../../../accessor/base.ts'
 import { IOResult, type ByteSource } from '../../../../io/types.ts'
 import type { PathSpec } from '../../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../../config.ts'
-import type { FiletypeEntry, ReadBytesFn, StatEntryFn } from '../extensions.ts'
+import type { FiletypeEntry, FiletypeReadBytesFn, StatEntryFn } from '../extensions.ts'
 
 const ENC = new TextEncoder()
 
 export async function ftHead<A extends Accessor>(
-  readBytes: ReadBytesFn<A>,
+  readBytes: FiletypeReadBytesFn<A>,
   _statEntry: StatEntryFn<A>,
   entry: FiletypeEntry,
   accessor: A,

--- a/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/index.ts
+++ b/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/index.ts
@@ -15,7 +15,7 @@
 import type { Accessor } from '../../../../accessor/base.ts'
 import type { PathSpec } from '../../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../../config.ts'
-import type { FiletypeEntry, ReadBytesFn, StatEntryFn } from '../extensions.ts'
+import type { FiletypeEntry, FiletypeReadBytesFn, StatEntryFn } from '../extensions.ts'
 import { ftCat } from './cat.ts'
 import { ftCut } from './cut.ts'
 import { ftFile } from './file.ts'
@@ -26,7 +26,7 @@ import { ftTail } from './tail.ts'
 import { ftWc } from './wc.ts'
 
 export type FiletypeHandler = <A extends Accessor>(
-  readBytes: ReadBytesFn<A>,
+  readBytes: FiletypeReadBytesFn<A>,
   statEntry: StatEntryFn<A>,
   entry: FiletypeEntry,
   accessor: A,

--- a/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/stat.ts
@@ -16,12 +16,12 @@ import type { Accessor } from '../../../../accessor/base.ts'
 import { IOResult, type ByteSource } from '../../../../io/types.ts'
 import type { PathSpec } from '../../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../../config.ts'
-import type { FiletypeEntry, ReadBytesFn, StatEntryFn } from '../extensions.ts'
+import type { FiletypeEntry, FiletypeReadBytesFn, StatEntryFn } from '../extensions.ts'
 
 const ENC = new TextEncoder()
 
 export async function ftStat<A extends Accessor>(
-  readBytes: ReadBytesFn<A>,
+  readBytes: FiletypeReadBytesFn<A>,
   _statEntry: StatEntryFn<A>,
   entry: FiletypeEntry,
   accessor: A,

--- a/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/tail.ts
+++ b/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/tail.ts
@@ -16,12 +16,12 @@ import type { Accessor } from '../../../../accessor/base.ts'
 import { IOResult, type ByteSource } from '../../../../io/types.ts'
 import type { PathSpec } from '../../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../../config.ts'
-import type { FiletypeEntry, ReadBytesFn, StatEntryFn } from '../extensions.ts'
+import type { FiletypeEntry, FiletypeReadBytesFn, StatEntryFn } from '../extensions.ts'
 
 const ENC = new TextEncoder()
 
 export async function ftTail<A extends Accessor>(
-  readBytes: ReadBytesFn<A>,
+  readBytes: FiletypeReadBytesFn<A>,
   _statEntry: StatEntryFn<A>,
   entry: FiletypeEntry,
   accessor: A,

--- a/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/filetype_factory/handlers/wc.ts
@@ -16,12 +16,12 @@ import type { Accessor } from '../../../../accessor/base.ts'
 import { IOResult, type ByteSource } from '../../../../io/types.ts'
 import type { PathSpec } from '../../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../../config.ts'
-import type { FiletypeEntry, ReadBytesFn, StatEntryFn } from '../extensions.ts'
+import type { FiletypeEntry, FiletypeReadBytesFn, StatEntryFn } from '../extensions.ts'
 
 const ENC = new TextEncoder()
 
 export async function ftWc<A extends Accessor>(
-  readBytes: ReadBytesFn<A>,
+  readBytes: FiletypeReadBytesFn<A>,
   _statEntry: StatEntryFn<A>,
   entry: FiletypeEntry,
   accessor: A,

--- a/typescript/packages/core/src/commands/builtin/generic/cp.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cp.test.ts
@@ -68,9 +68,8 @@ async function run(
   const { stat, copy, find } = makeBackend(files, dirs)
   const result = await cpGeneric(
     paths.map(spec),
-    copy,
-    find,
     stat,
+    { copy, find },
     flags.recursive === true,
     flags.n === true,
     flags.v === true,

--- a/typescript/packages/core/src/commands/builtin/generic/cp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cp.ts
@@ -15,8 +15,14 @@
 import { rekey } from '../../../utils/key_prefix.ts'
 import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
-import type { FindOptions } from '../../../resource/base.ts'
-import { FileType, PathSpec } from '../../../types.ts'
+import {
+  FileType,
+  PathSpec,
+  type CopyStrategy,
+  type PrimitiveCopy,
+  type ReaddirFn,
+  type StatFn,
+} from '../../../types.ts'
 import type { CommandFnResult } from '../../config.ts'
 import {
   backendKeyDefault,
@@ -24,22 +30,13 @@ import {
   isDirectory,
   pathExists,
   type BackendKeyFn,
-  type StatFn,
 } from '../utils/copy.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
 
 const ENC = new TextEncoder()
 
-type CopyFn = (src: PathSpec, target: PathSpec) => Promise<void>
-type FindFn = (src: PathSpec, options: FindOptions) => Promise<string[]>
-
-// Low-level primitives for the no-native-copy recursive path (cross-mount).
-// Backends that inject copy/find never use these.
-export interface CpPrimitives {
-  readBytes: (p: PathSpec) => Promise<Uint8Array>
-  write: (p: PathSpec, data: Uint8Array) => Promise<void>
-  mkdir: (p: PathSpec) => Promise<void>
-  readdir: (p: PathSpec) => Promise<string[]>
+function isPrimitiveCopy(strategy: CopyStrategy): strategy is PrimitiveCopy {
+  return 'readBytes' in strategy
 }
 
 // List a tree as {path, isDir} pairs, parents before children. The type is
@@ -47,7 +44,7 @@ export interface CpPrimitives {
 // never re-stats a path whose virtual parent has since vanished. Mirrors the
 // Python cp `walk`; used only by the primitive (no native copy) path.
 export async function cpWalk(
-  readdir: (p: PathSpec) => Promise<string[]>,
+  readdir: ReaddirFn,
   stat: StatFn,
   root: PathSpec,
   index?: IndexCacheStore,
@@ -72,16 +69,13 @@ export async function cpWalk(
 
 export async function cpGeneric(
   paths: PathSpec[],
-  copy: CopyFn,
-  find: FindFn,
   stat: StatFn,
+  strategy: CopyStrategy,
   recursive: boolean,
   noClobber: boolean,
   verbose: boolean,
   index?: IndexCacheStore,
   backendKey?: BackendKeyFn,
-  dirCopy?: CopyFn,
-  prim?: CpPrimitives,
 ): Promise<CommandFnResult> {
   const keyOf = backendKey ?? backendKeyDefault
   const sources = paths.slice(0, -1)
@@ -111,47 +105,51 @@ export async function cpGeneric(
     if (recursive) {
       const srcBase = rstripSlash(src.mountPath)
       const dstBase = rstripSlash(target.mountPath)
-      if (prim !== undefined) {
-        for (const { path: entry, isDir } of await cpWalk(prim.readdir, stat, src, index)) {
+      if (isPrimitiveCopy(strategy)) {
+        for (const { path: entry, isDir } of await cpWalk(strategy.readdir, stat, src, index)) {
           const entryDst = dstBase + entry.slice(srcBase.length)
           const entryDstSpec = PathSpec.fromStrPath(entryDst)
           if (isDir) {
             if (!(await isDirectory(stat, entryDstSpec, index))) {
-              await prim.mkdir(entryDstSpec)
+              await strategy.mkdir(entryDstSpec)
               writes[entryDst] = new Uint8Array()
               if (verbose) lines.push(`'${entry}' -> '${entryDst}'`)
             }
             continue
           }
           if (noClobber && (await pathExists(stat, entryDstSpec))) continue
-          await prim.write(entryDstSpec, await prim.readBytes(PathSpec.fromStrPath(entry)))
+          await strategy.write(entryDstSpec, await strategy.readBytes(PathSpec.fromStrPath(entry)))
           writes[entryDst] = new Uint8Array()
           if (verbose) lines.push(`'${entry}' -> '${entryDst}'`)
         }
         continue
       }
-      if (dirCopy !== undefined) {
+      if (strategy.dirCopy !== undefined) {
         if (noClobber && (await pathExists(stat, target))) continue
-        await dirCopy(src, target)
-        for (const entry of await find(src, { type: 'f' })) {
+        await strategy.dirCopy(src, target)
+        for (const entry of await strategy.find(src, { type: 'f' })) {
           const entryDst = dstBase + entry.slice(srcBase.length)
           writes[entryDst] = new Uint8Array()
           if (verbose) lines.push(`'${entry}' -> '${entryDst}'`)
         }
         continue
       }
-      for (const entry of await find(src, { type: 'f' })) {
+      for (const entry of await strategy.find(src, { type: 'f' })) {
         const entryDst = dstBase + entry.slice(srcBase.length)
         const entryDstSpec = PathSpec.fromStrPath(entryDst)
         if (noClobber && (await pathExists(stat, entryDstSpec))) continue
-        await copy(PathSpec.fromStrPath(entry), entryDstSpec)
+        await strategy.copy(PathSpec.fromStrPath(entry), entryDstSpec)
         writes[entryDst] = new Uint8Array()
         if (verbose) lines.push(`'${entry}' -> '${entryDst}'`)
       }
       continue
     }
     if (noClobber && (await pathExists(stat, target))) continue
-    await copy(src, target)
+    if (isPrimitiveCopy(strategy)) {
+      await strategy.write(target, await strategy.readBytes(src))
+    } else {
+      await strategy.copy(src, target)
+    }
     writes[target.mountPath] = new Uint8Array()
     if (verbose) lines.push(`'${src.virtual}' -> '${target.virtual}'`)
   }

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/cp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/cp.ts
@@ -13,9 +13,8 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { IOResult } from '../../../../../io/types.ts'
-import type { FindOptions } from '../../../../../resource/base.ts'
 import type { PathSpec } from '../../../../../types.ts'
-import { cpGeneric, cpWalk } from '../../cp.ts'
+import { cpGeneric } from '../../cp.ts'
 import type { CrossResult, DispatchFn } from '../types.ts'
 import { flatten, readBytesOp, readdirOp, statOp } from '../utils.ts'
 
@@ -49,25 +48,13 @@ export async function runCp(
     reads[p.virtual] = data
     return data
   }
-  const copy = async (src: PathSpec, target: PathSpec): Promise<void> => {
-    await write(target, await recordingRead(src))
-  }
-  const find = async (src: PathSpec, _options: FindOptions): Promise<string[]> => {
-    const tree = await cpWalk(readdir, stat, src)
-    return tree.filter((e) => !e.isDir).map((e) => e.path)
-  }
   const result = await cpGeneric(
     flat,
-    copy,
-    find,
     stat,
+    { readBytes: recordingRead, write, mkdir, readdir },
     recursive,
     noClobber,
     verbose,
-    undefined,
-    undefined,
-    undefined,
-    { readBytes: recordingRead, write, mkdir, readdir },
   )
   const [out, io] = result ?? [null, new IOResult()]
   io.reads = { ...io.reads, ...reads }

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/mv.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/mv.ts
@@ -45,12 +45,7 @@ export async function runMv(
   }
   const [out, io] = await mvGeneric(
     flat,
-    undefined,
     stat,
-    noClobber,
-    verbose,
-    undefined,
-    undefined,
     {
       readBytes,
       write,
@@ -59,6 +54,8 @@ export async function runMv(
       unlink,
       rmdir,
     },
+    noClobber,
+    verbose,
   )
   return [out, io]
 }

--- a/typescript/packages/core/src/commands/builtin/generic/mv.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/mv.test.ts
@@ -61,7 +61,7 @@ async function run(
   flags: { n?: boolean; v?: boolean } = {},
 ): Promise<[ByteSource | null, IOResult]> {
   const { stat, rename } = makeBackend(files, dirs)
-  return mvGeneric(paths.map(spec), rename, stat, flags.n === true, flags.v === true)
+  return mvGeneric(paths.map(spec), stat, { rename }, flags.n === true, flags.v === true)
 }
 
 describe('mvGeneric guards', () => {

--- a/typescript/packages/core/src/commands/builtin/generic/mv.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/mv.ts
@@ -15,39 +15,31 @@
 import { rekey } from '../../../utils/key_prefix.ts'
 import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
-import { PathSpec } from '../../../types.ts'
+import { PathSpec, type MoveStrategy, type PrimitiveMove, type StatFn } from '../../../types.ts'
 import {
   backendKeyDefault,
   copyTargets,
   isDirectory,
   pathExists,
   type BackendKeyFn,
-  type StatFn,
 } from '../utils/copy.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
-import { cpWalk, type CpPrimitives } from './cp.ts'
+import { cpWalk } from './cp.ts'
 
 const ENC = new TextEncoder()
 
-type RenameFn = (src: PathSpec, target: PathSpec) => Promise<void>
-
-// Low-level primitives for the no-native-rename path (cross-mount): the source
-// tree is copied (parents first) then removed (children first), mirroring the
-// Python mv generic. Backends that inject a native rename never use these.
-export interface MvPrimitives extends CpPrimitives {
-  unlink: (p: PathSpec) => Promise<void>
-  rmdir: (p: PathSpec) => Promise<void>
+function isPrimitiveMove(strategy: MoveStrategy): strategy is PrimitiveMove {
+  return 'readBytes' in strategy
 }
 
 export async function mvGeneric(
   paths: PathSpec[],
-  rename: RenameFn | undefined,
   stat: StatFn,
+  strategy: MoveStrategy,
   noClobber: boolean,
   verbose: boolean,
   index?: IndexCacheStore,
   backendKey?: BackendKeyFn,
-  prim?: MvPrimitives,
 ): Promise<[ByteSource | null, IOResult]> {
   const keyOf = backendKey ?? backendKeyDefault
   const sources = paths.slice(0, -1)
@@ -73,17 +65,17 @@ export async function mvGeneric(
       continue
     }
     if (noClobber && (await pathExists(stat, target))) continue
-    if (rename === undefined && prim !== undefined) {
+    if (isPrimitiveMove(strategy)) {
       const srcBase = rstripSlash(src.mountPath)
       const dstBase = rstripSlash(target.mountPath)
-      const entries = await cpWalk(prim.readdir, stat, src, index)
+      const entries = await cpWalk(strategy.readdir, stat, src, index)
       for (const { path: entry, isDir } of entries) {
         const entryDst = dstBase + entry.slice(srcBase.length)
         const entryDstSpec = PathSpec.fromStrPath(entryDst)
         if (isDir) {
-          if (!(await isDirectory(stat, entryDstSpec, index))) await prim.mkdir(entryDstSpec)
+          if (!(await isDirectory(stat, entryDstSpec, index))) await strategy.mkdir(entryDstSpec)
         } else {
-          await prim.write(entryDstSpec, await prim.readBytes(PathSpec.fromStrPath(entry)))
+          await strategy.write(entryDstSpec, await strategy.readBytes(PathSpec.fromStrPath(entry)))
         }
       }
       for (let i = entries.length - 1; i >= 0; i -= 1) {
@@ -93,11 +85,11 @@ export async function mvGeneric(
           node.path,
           rekey(src.virtual, src.resourcePath, node.path),
         )
-        if (node.isDir) await prim.rmdir(spec)
-        else await prim.unlink(spec)
+        if (node.isDir) await strategy.rmdir(spec)
+        else await strategy.unlink(spec)
       }
-    } else if (rename !== undefined) {
-      await rename(src, target)
+    } else {
+      await strategy.rename(src, target)
     }
     writes[src.mountPath] = new Uint8Array()
     writes[target.mountPath] = new Uint8Array()

--- a/typescript/packages/core/src/commands/builtin/generic/tar.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tar.ts
@@ -20,10 +20,10 @@ import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { readTar, writeTar, type TarEntry } from '../tar_helper.ts'
 import { lstripSlash, rstripSlash, stripSlash } from '../../../utils/slash.ts'
 import { fnmatch } from '../../../utils/fnmatch.ts'
+import { COMPRESSION_SIGNATURES } from './tar/constants.ts'
+import type { Compression, CompressionKind } from './tar/types.ts'
 
 const ENC = new TextEncoder()
-
-type Compression = 'gzip' | 'bzip2' | 'xz' | null
 
 function makePathSpec(virtual: string, prefix: string): PathSpec {
   return new PathSpec({
@@ -35,19 +35,14 @@ function makePathSpec(virtual: string, prefix: string): PathSpec {
 }
 
 function detectCompression(data: Uint8Array): Compression {
-  if (data.byteLength >= 2 && data[0] === 0x1f && data[1] === 0x8b) return 'gzip'
-  if (data.byteLength >= 3 && data[0] === 0x42 && data[1] === 0x5a && data[2] === 0x68)
-    return 'bzip2'
-  if (
-    data.byteLength >= 6 &&
-    data[0] === 0xfd &&
-    data[1] === 0x37 &&
-    data[2] === 0x7a &&
-    data[3] === 0x58 &&
-    data[4] === 0x5a &&
-    data[5] === 0x00
-  ) {
-    return 'xz'
+  for (const kind of Object.keys(COMPRESSION_SIGNATURES) as CompressionKind[]) {
+    const signature = COMPRESSION_SIGNATURES[kind]
+    if (
+      data.byteLength >= signature.length &&
+      signature.every((byte, index) => data[index] === byte)
+    ) {
+      return kind
+    }
   }
   return null
 }

--- a/typescript/packages/core/src/commands/builtin/generic/tar/constants.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tar/constants.ts
@@ -12,5 +12,11 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export const SCOPE_WARN = 5000
-export const SCOPE_ERROR = 50000
+import type { CompressionKind } from './types.ts'
+
+export const COMPRESSION_SIGNATURES: Readonly<Record<CompressionKind, readonly number[]>> =
+  Object.freeze({
+    gzip: [0x1f, 0x8b],
+    bzip2: [0x42, 0x5a, 0x68],
+    xz: [0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00],
+  })

--- a/typescript/packages/core/src/commands/builtin/generic/tar/types.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tar/types.ts
@@ -12,5 +12,5 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export const SCOPE_WARN = 5000
-export const SCOPE_ERROR = 50000
+export type CompressionKind = 'gzip' | 'bzip2' | 'xz'
+export type Compression = CompressionKind | null

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
@@ -15,36 +15,39 @@
 import type { Accessor } from '../../../accessor/base.ts'
 import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import type { FindOptions } from '../../../resource/base.ts'
-import { FileType, PathSpec, type FileStat } from '../../../types.ts'
+import {
+  FileType,
+  PathSpec,
+  type CopyFn,
+  type FindFn,
+  type FileStat,
+  type MoveFn,
+  type ReadBytesFn,
+  type ReadStreamFn,
+  type ReaddirFn,
+  type StatFn,
+} from '../../../types.ts'
 import { eisdir } from '../../../utils/errors.ts'
 import { DEFAULT_MAX_GLOB_MATCHES, resolveGlobWith } from '../../../utils/glob_walk.ts'
 import { norm, parent } from '../../../utils/path.ts'
 import { stripSlash } from '../../../utils/slash.ts'
 import type { AggregateFn, CommandFnResult, CommandOpts, ProvisionFn } from '../../config.ts'
 
-export type ReaddirOp<A extends Accessor = Accessor> = (
-  accessor: A,
-  path: PathSpec,
-  index?: IndexCacheStore,
-) => Promise<string[]>
+export type ReaddirOp<A extends Accessor = Accessor> = ReaddirFn<
+  [accessor: A, path: PathSpec, index?: IndexCacheStore]
+>
 
-type ReadBytesOp<A extends Accessor = Accessor> = (
-  accessor: A,
-  path: PathSpec,
-  index?: IndexCacheStore,
-) => Promise<Uint8Array>
+type ReadBytesOp<A extends Accessor = Accessor> = ReadBytesFn<
+  [accessor: A, path: PathSpec, index?: IndexCacheStore]
+>
 
-type ReadStreamOp<A extends Accessor = Accessor> = (
-  accessor: A,
-  path: PathSpec,
-  index?: IndexCacheStore,
-) => AsyncIterable<Uint8Array>
+type ReadStreamOp<A extends Accessor = Accessor> = ReadStreamFn<
+  [accessor: A, path: PathSpec, index?: IndexCacheStore]
+>
 
-export type StatOp<A extends Accessor = Accessor> = (
-  accessor: A,
-  path: PathSpec,
-  index?: IndexCacheStore,
-) => Promise<FileStat>
+export type StatOp<A extends Accessor = Accessor> = StatFn<
+  [accessor: A, path: PathSpec, index?: IndexCacheStore]
+>
 
 type WriteOp<A extends Accessor = Accessor> = (
   accessor: A,
@@ -62,23 +65,13 @@ type MkdirOp<A extends Accessor = Accessor> = (
   parents?: boolean,
 ) => Promise<void>
 
-type RenameOp<A extends Accessor = Accessor> = (
-  accessor: A,
-  src: PathSpec,
-  dst: PathSpec,
-) => Promise<void>
+type RenameOp<A extends Accessor = Accessor> = MoveFn<[accessor: A, src: PathSpec, dst: PathSpec]>
 
-type CopyOp<A extends Accessor = Accessor> = (
-  accessor: A,
-  src: PathSpec,
-  dst: PathSpec,
-) => Promise<void>
+type CopyOp<A extends Accessor = Accessor> = CopyFn<[accessor: A, src: PathSpec, dst: PathSpec]>
 
-type FindOp<A extends Accessor = Accessor> = (
-  accessor: A,
-  path: PathSpec,
-  options: FindOptions,
-) => Promise<string[]>
+type FindOp<A extends Accessor = Accessor> = FindFn<
+  [accessor: A, path: PathSpec, options: FindOptions]
+>
 
 type IsDirNameOp<A extends Accessor = Accessor> = (accessor: A, child: string) => boolean | null
 

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/cp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/cp.ts
@@ -13,8 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { IOResult } from '../../../../io/types.ts'
-import type { FindOptions } from '../../../../resource/base.ts'
-import type { PathSpec } from '../../../../types.ts'
+import type { NativeCopy, PathSpec } from '../../../../types.ts'
 import { cpGeneric } from '../../generic/cp.ts'
 import type { Builder } from '../adapter.ts'
 
@@ -28,16 +27,22 @@ export const CP_BUILDER: Builder = {
         new IOResult({ exitCode: 1, stderr: new TextEncoder().encode('cp: missing operand\n') }),
       ])
     }
-    const { copy, find } = ops
+    const { copy, dirCopy, find } = ops
     if (copy === undefined || find === undefined) {
       throw new Error('cp: backend provides no copy/find op')
     }
     const recursive = opts.flags.r === true || opts.flags.R === true || opts.flags.a === true
+    const strategy: NativeCopy = {
+      copy: (src: PathSpec, target: PathSpec) => copy(accessor, src, target),
+      find: (src, options) => find(accessor, src, options),
+      ...(dirCopy === undefined
+        ? {}
+        : { dirCopy: (src: PathSpec, target: PathSpec) => dirCopy(accessor, src, target) }),
+    }
     return cpGeneric(
       paths,
-      (src: PathSpec, target: PathSpec) => copy(accessor, src, target),
-      (src: PathSpec, options: FindOptions) => find(accessor, src, options),
       (p: PathSpec) => ops.stat(accessor, p, opts.index ?? undefined),
+      strategy,
       recursive,
       opts.flags.n === true,
       opts.flags.v === true,

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/mv.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/mv.ts
@@ -33,8 +33,8 @@ export const MV_BUILDER: Builder = {
     }
     return mvGeneric(
       paths,
-      (src: PathSpec, target: PathSpec) => rename(accessor, src, target),
       (p: PathSpec) => ops.stat(accessor, p, opts.index ?? undefined),
+      { rename: (src: PathSpec, target: PathSpec) => rename(accessor, src, target) },
       opts.flags.n === true,
       opts.flags.v === true,
       opts.index ?? undefined,

--- a/typescript/packages/core/src/commands/builtin/github/narrow.ts
+++ b/typescript/packages/core/src/commands/builtin/github/narrow.ts
@@ -22,8 +22,9 @@ import { narrowPaths } from '../../../core/github/search.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import { rebaseRaw } from '../../../utils/path.ts'
+import { PatternType } from '../constants.ts'
 import { formatRecords } from '../utils/output.ts'
-import { classifyPattern, PatternType, searchQuery } from '../grep_helper.ts'
+import { classifyPattern, searchQuery } from '../grep_helper.ts'
 
 const resolveGlob = resolveGlobOf(GITHUB_CMD_OPS)
 

--- a/typescript/packages/core/src/commands/builtin/grep_helper.test.ts
+++ b/typescript/packages/core/src/commands/builtin/grep_helper.test.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
+import { PatternType } from './constants.ts'
 import {
   classifyPattern,
   compilePattern,
@@ -20,7 +21,6 @@ import {
   isRegexPattern,
   mergePatternList,
   NEVER_MATCH,
-  PatternType,
   searchQuery,
 } from './grep_helper.ts'
 

--- a/typescript/packages/core/src/commands/builtin/grep_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/grep_helper.ts
@@ -17,7 +17,9 @@ import { AsyncLineIterator } from '../../io/async_line_iterator.ts'
 import { materialize, type IOResult } from '../../io/types.ts'
 import { type FileStat, FileType, PathSpec } from '../../types.ts'
 import { getExtension } from '../resolve.ts'
+import { PatternType } from './constants.ts'
 import { grepContextLines } from './grep_context.ts'
+import type { AsyncReadBytesFn, AsyncReaddirFn, AsyncStatFn } from './utils/types.ts'
 
 export const BINARY_EXTENSIONS: ReadonlySet<string> = new Set([
   '.parquet',
@@ -139,12 +141,6 @@ export function isRegexPattern(pattern: string, fixedString: boolean): boolean {
   if (pattern.includes('\n')) return true
   if (fixedString) return false
   return !/^[\w\s\-.]+$/.test(pattern)
-}
-
-export enum PatternType {
-  EXACT = 'exact',
-  SIMPLE = 'simple',
-  REGEX = 'regex',
 }
 
 // Classify a grep pattern for API push-down decisions.
@@ -371,10 +367,6 @@ export async function* grepStream(
   if (opts.countOnly) yield enc.encode(String(matchCount) + '\n')
 }
 
-export type AsyncReaddir = (path: string) => Promise<string[]>
-export type AsyncStat = (path: string) => Promise<FileStat>
-export type AsyncReadBytes = (path: string) => Promise<Uint8Array>
-
 export interface GrepFilesOnlyOptions {
   recursive: boolean
   ignoreCase: boolean
@@ -388,9 +380,9 @@ export interface GrepFilesOnlyOptions {
 }
 
 export async function grepRecursive(
-  readdirFn: AsyncReaddir,
-  statFn: AsyncStat,
-  readBytesFn: AsyncReadBytes,
+  readdirFn: AsyncReaddirFn,
+  statFn: AsyncStatFn,
+  readBytesFn: AsyncReadBytesFn,
   path: string,
   compiled: RegExp,
   opts: GrepFilesOnlyOptions,
@@ -460,9 +452,9 @@ export async function grepRecursive(
 }
 
 export async function grepFilesOnly(
-  readdirFn: AsyncReaddir,
-  statFn: AsyncStat,
-  readBytesFn: AsyncReadBytes,
+  readdirFn: AsyncReaddirFn,
+  statFn: AsyncStatFn,
+  readBytesFn: AsyncReadBytesFn,
   path: string,
   pattern: string,
   opts: GrepFilesOnlyOptions,

--- a/typescript/packages/core/src/commands/builtin/rg_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/rg_helper.ts
@@ -19,6 +19,7 @@ import { gnuBasename } from '../../utils/path.ts'
 import { getExtension } from '../resolve.ts'
 import { BINARY_EXTENSIONS, compilePattern, grepLines } from './grep_helper.ts'
 import { fnmatch } from '../../utils/fnmatch.ts'
+import type { AsyncReadBytesFn, AsyncReaddirFn, AsyncStatFn } from './utils/types.ts'
 
 export const TYPE_EXTENSIONS: Record<string, string[]> = {
   py: ['.py'],
@@ -42,10 +43,6 @@ export const TYPE_EXTENSIONS: Record<string, string[]> = {
   sh: ['.sh', '.bash'],
   csv: ['.csv'],
 }
-
-export type AsyncReaddirFn = (path: string) => Promise<string[]>
-export type AsyncStatFn = (path: string) => Promise<FileStat>
-export type AsyncReadBytesFn = (path: string) => Promise<Uint8Array>
 
 export function rgMatchesFilter(
   entry: string,

--- a/typescript/packages/core/src/commands/builtin/utils/copy.ts
+++ b/typescript/packages/core/src/commands/builtin/utils/copy.ts
@@ -14,11 +14,9 @@
 
 import { rekey } from '../../../utils/key_prefix.ts'
 import type { IndexCacheStore } from '../../../cache/index/store.ts'
-import { FileType, PathSpec, type FileStat } from '../../../types.ts'
+import { FileType, PathSpec, type StatFn } from '../../../types.ts'
 import { enotdir } from '../../../utils/errors.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
-
-export type StatFn = (path: PathSpec, index?: IndexCacheStore) => Promise<FileStat>
 
 export type BackendKeyFn = (path: PathSpec) => string
 

--- a/typescript/packages/core/src/commands/builtin/utils/types.ts
+++ b/typescript/packages/core/src/commands/builtin/utils/types.ts
@@ -12,5 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export const SCOPE_WARN = 5000
-export const SCOPE_ERROR = 50000
+import type { FileStat } from '../../../types.ts'
+
+export type AsyncReadBytesFn = (path: string) => Promise<Uint8Array>
+export type AsyncReaddirFn = (path: string) => Promise<string[]>
+export type AsyncStatFn = (path: string) => Promise<FileStat>

--- a/typescript/packages/core/src/core/ram/constants.test.ts
+++ b/typescript/packages/core/src/core/ram/constants.test.ts
@@ -12,5 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export const SCOPE_WARN = 5000
-export const SCOPE_ERROR = 50000
+import { describe, expect, it } from 'vitest'
+import { SCOPE_ERROR, SCOPE_WARN } from './constants.ts'
+
+describe('RAM scope constants', () => {
+  it('keeps the warning threshold below the error threshold', () => {
+    expect(SCOPE_WARN).toBe(5000)
+    expect(SCOPE_ERROR).toBe(50000)
+  })
+})

--- a/typescript/packages/core/src/core/s3/constants.test.ts
+++ b/typescript/packages/core/src/core/s3/constants.test.ts
@@ -12,5 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export const SCOPE_WARN = 5000
-export const SCOPE_ERROR = 50000
+import { describe, expect, it } from 'vitest'
+import { SCOPE_ERROR, SCOPE_WARN } from './constants.ts'
+
+describe('S3 scope constants', () => {
+  it('keeps the warning threshold below the error threshold', () => {
+    expect(SCOPE_WARN).toBe(500)
+    expect(SCOPE_ERROR).toBe(5000)
+  })
+})

--- a/typescript/packages/core/src/core/s3/constants.ts
+++ b/typescript/packages/core/src/core/s3/constants.ts
@@ -12,4 +12,5 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+export const SCOPE_WARN = 500
 export const SCOPE_ERROR = 5000

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -17,15 +17,30 @@ export {
   CommandSafeguard,
   type CommandSafeguardInit,
   ConsistencyPolicy,
+  type CopyFn,
+  type CopyStrategy,
   DriftPolicy,
   FileStat,
   type FileStatInit,
   FileType,
+  type FindFn,
   MountMode,
+  type MoveFn,
+  type MoveStrategy,
+  type NativeCopy,
+  type NativeMove,
   OnExceed,
   PathSpec,
   type PathSpecInit,
+  type PolymorphicReadFn,
+  type PolymorphicReadResult,
+  type PrimitiveCopy,
+  type PrimitiveMove,
+  type ReadBytesFn,
+  type ReaddirFn,
+  type ReadStreamFn,
   ResourceName,
+  type StatFn,
 } from './types.ts'
 export {
   captureFingerprints,
@@ -180,7 +195,7 @@ export {
   FILETYPE_ENTRIES,
   type FiletypeEntry,
   type FiletypeModule,
-  type ReadBytesFn,
+  type FiletypeReadBytesFn,
   type StatEntryFn,
 } from './commands/builtin/filetype_factory/extensions.ts'
 export { numberLines } from './commands/builtin/generic/cat.ts'
@@ -275,9 +290,6 @@ export {
 } from './commands/builtin/grep_helper.ts'
 export { grepContextLines } from './commands/builtin/grep_context.ts'
 export {
-  type AsyncReaddirFn,
-  type AsyncReadBytesFn,
-  type AsyncStatFn,
   rgFolderFiletype,
   type RgFolderFiletypeOptions,
   rgFull,
@@ -285,6 +297,11 @@ export {
   rgMatchesFilter,
   TYPE_EXTENSIONS,
 } from './commands/builtin/rg_helper.ts'
+export type {
+  AsyncReadBytesFn,
+  AsyncReaddirFn,
+  AsyncStatFn,
+} from './commands/builtin/utils/types.ts'
 export {
   compareKeys,
   parseKeyOptions,

--- a/typescript/packages/core/src/types.ts
+++ b/typescript/packages/core/src/types.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { IndexCacheStore } from './cache/index/store.ts'
+import type { FindOptions } from './resource/base.ts'
 import { rstripSlash, stripSlash } from './utils/slash.ts'
 
 export const MountMode = Object.freeze({
@@ -252,6 +254,73 @@ export class FileStat {
     Object.freeze(this)
   }
 }
+
+export type ReadBytesFn<Args extends unknown[] = [path: PathSpec]> = (
+  ...args: Args
+) => Promise<Uint8Array>
+
+export type ReadStreamFn<Args extends unknown[] = [path: PathSpec]> = (
+  ...args: Args
+) => AsyncIterable<Uint8Array>
+
+export type PolymorphicReadResult =
+  | Uint8Array
+  | AsyncIterable<Uint8Array>
+  | Promise<Uint8Array | AsyncIterable<Uint8Array>>
+
+export type PolymorphicReadFn<Args extends unknown[] = [path: PathSpec]> = (
+  ...args: Args
+) => PolymorphicReadResult
+
+export type CopyFn<Args extends unknown[] = [src: PathSpec, target: PathSpec]> = (
+  ...args: Args
+) => Promise<void>
+
+export type MoveFn<Args extends unknown[] = [src: PathSpec, target: PathSpec]> = (
+  ...args: Args
+) => Promise<void>
+
+export type FindFn<Args extends unknown[] = [src: PathSpec, options: FindOptions]> = (
+  ...args: Args
+) => Promise<string[]>
+
+export type ReaddirFn<Args extends unknown[] = [path: PathSpec]> = (
+  ...args: Args
+) => Promise<string[]>
+
+export type StatFn<Args extends unknown[] = [path: PathSpec, index?: IndexCacheStore]> = (
+  ...args: Args
+) => Promise<FileStat>
+
+export interface NativeCopy {
+  copy: CopyFn
+  find: FindFn
+  dirCopy?: CopyFn
+}
+
+export interface PrimitiveCopy {
+  readBytes: ReadBytesFn
+  write: CopyFn<[target: PathSpec, data: Uint8Array]>
+  mkdir: CopyFn<[path: PathSpec]>
+  readdir: ReaddirFn
+}
+
+export type CopyStrategy = NativeCopy | PrimitiveCopy
+
+export interface NativeMove {
+  rename: MoveFn
+}
+
+export interface PrimitiveMove {
+  readBytes: ReadBytesFn
+  write: MoveFn<[target: PathSpec, data: Uint8Array]>
+  mkdir: MoveFn<[path: PathSpec]>
+  readdir: ReaddirFn
+  unlink: MoveFn<[path: PathSpec]>
+  rmdir: MoveFn<[path: PathSpec]>
+}
+
+export type MoveStrategy = NativeMove | PrimitiveMove
 
 export interface PathSpecInit {
   virtual: string

--- a/typescript/packages/node/src/core/redis/constants.test.ts
+++ b/typescript/packages/node/src/core/redis/constants.test.ts
@@ -12,5 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export const SCOPE_WARN = 5000
-export const SCOPE_ERROR = 50000
+import { describe, expect, it } from 'vitest'
+import { SCOPE_ERROR, SCOPE_WARN } from './constants.ts'
+
+describe('Redis scope constants', () => {
+  it('keeps the warning threshold below the error threshold', () => {
+    expect(SCOPE_WARN).toBe(5000)
+    expect(SCOPE_ERROR).toBe(50000)
+  })
+})

--- a/typescript/packages/node/src/core/redis/constants.ts
+++ b/typescript/packages/node/src/core/redis/constants.ts
@@ -12,4 +12,5 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+export const SCOPE_WARN = 5000
 export const SCOPE_ERROR = 50000

--- a/typescript/packages/node/src/core/ssh/constants.test.ts
+++ b/typescript/packages/node/src/core/ssh/constants.test.ts
@@ -12,5 +12,12 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export const SCOPE_WARN = 5000
-export const SCOPE_ERROR = 50000
+import { describe, expect, it } from 'vitest'
+import { SCOPE_ERROR, SCOPE_WARN } from './constants.ts'
+
+describe('SSH scope constants', () => {
+  it('keeps the warning threshold below the error threshold', () => {
+    expect(SCOPE_WARN).toBe(500)
+    expect(SCOPE_ERROR).toBe(5000)
+  })
+})

--- a/typescript/packages/node/src/core/ssh/constants.ts
+++ b/typescript/packages/node/src/core/ssh/constants.ts
@@ -12,4 +12,5 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+export const SCOPE_WARN = 500
 export const SCOPE_ERROR = 5000


### PR DESCRIPTION
## Summary

- centralize shared read, copy, move, find, readdir, stat, and strategy declarations in the TypeScript core types module
- move grep pattern, helper callback, and tar compression declarations into types/constants modules matching the Python layout
- update cache, generic binders, filetype handlers, copy/move commands, cross-mount relays, and OPFS consumers to use the shared declarations
- add the missing RAM, S3, Redis, and SSH warning thresholds with parity tests

## Why

The Python implementation already centralizes these contracts, while TypeScript still defined several equivalent types, interfaces, and constants inline. That duplication made the sibling implementations easier to drift and created a naming collision between the general read callback and the filetype-specific reader.

## Impact

The refactor consolidates the TypeScript contracts and keeps Python/TypeScript architecture aligned. Copy and move now consume explicit native or primitive strategies, and the generic copy builder wires the existing native directory-copy operation when available.

## Validation

- `pre-commit run --all-files`
- TypeScript monorepo build, typecheck, ESLint, Prettier, and Knip
- 71 focused TypeScript tests
- TypeScript core suite: 4,097 passed, 7 skipped, 2 todo; five restricted-environment network/Pyodide cases could not run
- Python suite outside the sandbox: 8,835 passed and 347 skipped; five Redis fixture errors remain because `REDIS_URL` is not configured, and one macFUSE test cannot run because the filesystem extension is unavailable