### PR TITLE
Align text filters with GNU semantics

### DIFF
--- a/integ/unix/comm.json
+++ b/integ/unix/comm.json
@@ -87,6 +87,28 @@
         "stdout": "date\nelder\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "comm_check_order_unsorted",
+      "seq": 600000,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "comm --check-order /data/a.txt /data/sorted_b.txt > /dev/null",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "comm: file 1 is not in sorted order\n"
+      }
     }
   ]
 }

--- a/integ/unix/paste.json
+++ b/integ/unix/paste.json
@@ -65,6 +65,72 @@
         "stdout": "hello,1\nworld,2\nfoo,3\nbar,\nbaz,\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "paste_no_input",
+      "seq": 600001,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "paste",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "paste_empty_file",
+      "seq": 600002,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "paste /data/empty.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "paste_s_empty_file",
+      "seq": 600003,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "paste -s /data/empty.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/unix/sort.json
+++ b/integ/unix/sort.json
@@ -373,6 +373,28 @@
         "stdout": "a\na\nb\nb\nc\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "sort_no_input",
+      "seq": 600004,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "sort",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/unix/uniq.json
+++ b/integ/unix/uniq.json
@@ -241,6 +241,50 @@
         "stdout": "      2 1 apple\n      1 3 banana\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "uniq_no_input",
+      "seq": 600005,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "uniq",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "uniq_invalid_count",
+      "seq": 600006,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "uniq -f 2junk /data/dup.txt",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "uniq: invalid count: '2junk'"
+      }
     }
   ]
 }

--- a/python/mirage/commands/builtin/generic/comm.py
+++ b/python/mirage/commands/builtin/generic/comm.py
@@ -80,7 +80,9 @@ async def comm(
     merged = _comm_merge(lines1, lines2)
     output = _format_comm(merged, suppress1, suppress2, suppress3)
     return output.encode(), IOResult(
-        stderr=stderr.encode() if stderr else None)
+        stderr=stderr.encode() if stderr else None,
+        exit_code=1 if stderr else 0,
+    )
 
 
 __all__ = ["comm"]

--- a/python/mirage/commands/builtin/generic/paste.py
+++ b/python/mirage/commands/builtin/generic/paste.py
@@ -26,22 +26,20 @@ async def paste(
             data = (await read_bytes(p)).decode(errors="replace")
         file_lines.append(split_lines(data))
 
-    if not file_lines and remaining_stdin is not None:
-        raw = await _read_stdin_async(remaining_stdin)
-        if raw:
-            file_lines.append(split_lines(raw.decode(errors="replace")))
-
     if not file_lines:
-        raise ValueError("paste: missing operand")
+        raw = await _read_stdin_async(remaining_stdin)
+        data = raw.decode(errors="replace") if raw is not None else ""
+        file_lines.append(split_lines(data))
 
     if serial:
-        out_lines = [delimiter.join(lines) for lines in file_lines]
+        out_lines = [delimiter.join(lines) for lines in file_lines if lines]
     else:
         out_lines = [
             delimiter.join(row)
             for row in zip_longest(*file_lines, fillvalue="")
         ]
-    return ("\n".join(out_lines) + "\n").encode(), IOResult()
+    output = ("\n".join(out_lines) + "\n").encode() if out_lines else b""
+    return output, IOResult()
 
 
 __all__ = ["paste"]

--- a/python/mirage/commands/builtin/generic/sort.py
+++ b/python/mirage/commands/builtin/generic/sort.py
@@ -30,9 +30,7 @@ async def sort(
             all_lines.extend(split_lines(data))
     else:
         raw = await _read_stdin_async(stdin)
-        if raw is None:
-            raise ValueError("sort: missing operand")
-        all_lines = split_lines(raw.decode(errors="replace"))
+        all_lines = split_lines((raw or b"").decode(errors="replace"))
 
     key_args = (key_field, field_separator, fold_case, numeric, human_numeric,
                 version_sort, month_sort, ignore_blanks)

--- a/python/mirage/commands/builtin/generic/uniq.py
+++ b/python/mirage/commands/builtin/generic/uniq.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import AsyncIterator, Callable
 
 from mirage.commands.builtin.utils.stream import _resolve_source
@@ -11,7 +12,10 @@ from mirage.types import PathSpec
 def _parse_count(value: str | None) -> int | None:
     if value is None:
         return None
-    count = int(value)
+    normalized = value.strip()
+    if re.fullmatch(r"[+-]?[0-9]+", normalized) is None:
+        raise ValueError(f"uniq: invalid count: '{value}'")
+    count = int(normalized)
     if count < 0:
         raise ValueError(f"uniq: invalid count: '{value}'")
     return count
@@ -105,7 +109,7 @@ async def uniq(
         source: AsyncIterator[bytes] = read_stream(paths[0])
         cache = [paths[0].mount_path]
     else:
-        source = _resolve_source(stdin, "uniq: missing operand")
+        source = _resolve_source(stdin)
 
     return _uniq_stream(
         source,

--- a/python/tests/commands/builtin/generic/test_comm.py
+++ b/python/tests/commands/builtin/generic/test_comm.py
@@ -4,7 +4,6 @@ from mirage.commands.builtin.generic.comm import comm
 from mirage.io.types import materialize
 from mirage.types import PathSpec
 
-
 _COMM_FILES = {
     "/left.txt": b"b\na\n",
     "/right.txt": b"b\nc\n",
@@ -27,6 +26,6 @@ async def test_check_order_unsorted_input_exits_nonzero():
     )
 
     await materialize(stdout)
+    stderr = await materialize(io.stderr)
     assert io.exit_code == 1
-    assert await materialize(io.stderr) == (
-        b"comm: file 1 is not in sorted order\n")
+    assert stderr == b"comm: file 1 is not in sorted order\n"

--- a/python/tests/commands/builtin/generic/test_comm.py
+++ b/python/tests/commands/builtin/generic/test_comm.py
@@ -1,0 +1,32 @@
+import pytest
+
+from mirage.commands.builtin.generic.comm import comm
+from mirage.io.types import materialize
+from mirage.types import PathSpec
+
+
+_COMM_FILES = {
+    "/left.txt": b"b\na\n",
+    "/right.txt": b"b\nc\n",
+}
+
+
+async def _read_comm_file(path: PathSpec) -> bytes:
+    return _COMM_FILES[path.virtual]
+
+
+@pytest.mark.asyncio
+async def test_check_order_unsorted_input_exits_nonzero():
+    stdout, io = await comm(
+        [
+            PathSpec.from_str_path("/left.txt"),
+            PathSpec.from_str_path("/right.txt"),
+        ],
+        read_bytes=_read_comm_file,
+        check_order=True,
+    )
+
+    await materialize(stdout)
+    assert io.exit_code == 1
+    assert await materialize(io.stderr) == (
+        b"comm: file 1 is not in sorted order\n")

--- a/python/tests/commands/builtin/generic/test_paste.py
+++ b/python/tests/commands/builtin/generic/test_paste.py
@@ -1,0 +1,30 @@
+import pytest
+
+from mirage.commands.builtin.generic.paste import paste
+from mirage.io.types import materialize
+from mirage.types import PathSpec
+
+
+async def _read_empty_file(_path: PathSpec) -> bytes:
+    return b""
+
+
+@pytest.mark.asyncio
+async def test_no_operand_uses_empty_standard_input():
+    stdout, io = await paste([], read_bytes=_read_empty_file)
+
+    assert await materialize(stdout) == b""
+    assert io.exit_code == 0
+
+
+@pytest.mark.parametrize("serial", [False, True])
+@pytest.mark.asyncio
+async def test_empty_file_produces_no_output(serial: bool):
+    stdout, io = await paste(
+        [PathSpec.from_str_path("/empty.txt")],
+        read_bytes=_read_empty_file,
+        serial=serial,
+    )
+
+    assert await materialize(stdout) == b""
+    assert io.exit_code == 0

--- a/python/tests/commands/builtin/generic/test_sort.py
+++ b/python/tests/commands/builtin/generic/test_sort.py
@@ -1,0 +1,17 @@
+import pytest
+
+from mirage.commands.builtin.generic.sort import sort
+from mirage.io.types import materialize
+from mirage.types import PathSpec
+
+
+async def _unused_read_bytes(_path: PathSpec) -> bytes:
+    raise AssertionError("read_bytes should not be called")
+
+
+@pytest.mark.asyncio
+async def test_no_operand_uses_empty_standard_input():
+    stdout, io = await sort([], read_bytes=_unused_read_bytes)
+
+    assert await materialize(stdout) == b""
+    assert io.exit_code == 0

--- a/python/tests/commands/builtin/generic/test_uniq.py
+++ b/python/tests/commands/builtin/generic/test_uniq.py
@@ -12,7 +12,7 @@ async def _generator_read_stream(_path):
     yield b"dup\ndup\nsolo\n"
 
 
-async def _collect(stdin: bytes, **kwargs) -> bytes:
+async def _collect(stdin: bytes | None, **kwargs) -> bytes:
     source, _io = await uniq(
         [],
         read_stream=_unused_read_stream,
@@ -38,6 +38,16 @@ def test_parse_count_positive():
 def test_parse_count_negative_raises():
     with pytest.raises(ValueError, match="invalid count"):
         _parse_count("-1")
+
+
+def test_parse_count_trailing_text_raises():
+    with pytest.raises(ValueError, match="invalid count"):
+        _parse_count("2junk")
+
+
+@pytest.mark.asyncio
+async def test_no_operand_uses_empty_standard_input():
+    assert await _collect(None) == b""
 
 
 @pytest.mark.asyncio

--- a/typescript/packages/core/src/commands/builtin/generic/comm.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/comm.test.ts
@@ -1,0 +1,48 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { materialize } from '../../../io/types.ts'
+import { PathSpec } from '../../../types.ts'
+import type { CommandOpts } from '../../config.ts'
+import { commGeneric } from './comm.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+const FILES: Record<string, string> = {
+  '/left.txt': 'b\na\n',
+  '/right.txt': 'b\nc\n',
+}
+
+function opts(flags: Record<string, string | boolean | string[]>): CommandOpts {
+  return { stdin: null, flags, filetypeFns: null, cwd: '/', resource: {} } as CommandOpts
+}
+
+async function* stream(path: PathSpec): AsyncIterable<Uint8Array> {
+  await Promise.resolve()
+  yield ENC.encode(FILES[path.virtual] ?? '')
+}
+
+describe('commGeneric', () => {
+  it('--check-order exits nonzero for unsorted input', async () => {
+    const result = await commGeneric(
+      [PathSpec.fromStrPath('/left.txt'), PathSpec.fromStrPath('/right.txt')],
+      opts({ 'check-order': true }),
+      stream,
+    )
+    const [, io] = result
+    expect(io.exitCode).toBe(1)
+    expect(DEC.decode(await materialize(io.stderr))).toBe('comm: file 1 is not in sorted order\n')
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/generic/comm.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/comm.test.ts
@@ -38,9 +38,11 @@ describe('commGeneric', () => {
   it('--check-order exits nonzero for unsorted input', async () => {
     const result = await commGeneric(
       [PathSpec.fromStrPath('/left.txt'), PathSpec.fromStrPath('/right.txt')],
-      opts({ 'check-order': true }),
+      opts({ check_order: true }),
       stream,
     )
+    expect(result).not.toBeNull()
+    if (result === null) throw new Error('expected comm result')
     const [, io] = result
     expect(io.exitCode).toBe(1)
     expect(DEC.decode(await materialize(io.stderr))).toBe('comm: file 1 is not in sorted order\n')

--- a/typescript/packages/core/src/commands/builtin/generic/comm.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/comm.ts
@@ -105,7 +105,7 @@ export async function commGeneric(
   const lines1 = splitLinesNoTrailing(data1)
   const lines2 = splitLinesNoTrailing(data2)
   let stderr = ''
-  if (opts.flags['check-order'] === true) {
+  if (opts.flags.check_order === true) {
     if (!isSorted(lines1)) stderr = 'comm: file 1 is not in sorted order\n'
     else if (!isSorted(lines2)) stderr = 'comm: file 2 is not in sorted order\n'
   }

--- a/typescript/packages/core/src/commands/builtin/generic/comm.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/comm.ts
@@ -115,5 +115,11 @@ export async function commGeneric(
   const merged = commMerge(lines1, lines2)
   const output = formatComm(merged, suppress1, suppress2, suppress3)
   const result: ByteSource = ENC.encode(output)
-  return [result, new IOResult({ stderr: stderr !== '' ? ENC.encode(stderr) : null })]
+  return [
+    result,
+    new IOResult({
+      stderr: stderr !== '' ? ENC.encode(stderr) : null,
+      exitCode: stderr !== '' ? 1 : 0,
+    }),
+  ]
 }

--- a/typescript/packages/core/src/commands/builtin/generic/paste.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/paste.test.ts
@@ -29,18 +29,24 @@ async function* emptyStream(_path: PathSpec): AsyncIterable<Uint8Array> {
 
 describe('pasteGeneric', () => {
   it('uses empty standard input when no operands are given', async () => {
-    const [stdout, io] = await pasteGeneric([], opts(), emptyStream)
+    const result = await pasteGeneric([], opts(), emptyStream)
+    expect(result).not.toBeNull()
+    if (result === null) throw new Error('expected paste result')
+    const [stdout, io] = result
     expect(await materialize(stdout)).toEqual(new Uint8Array(0))
     expect(io.exitCode).toBe(0)
   })
 
   it.each([false, true])('produces no output for an empty file with serial=%s', async (serial) => {
     const flags = serial ? { s: true } : {}
-    const [stdout, io] = await pasteGeneric(
+    const result = await pasteGeneric(
       [PathSpec.fromStrPath('/empty.txt')],
       opts(flags),
       emptyStream,
     )
+    expect(result).not.toBeNull()
+    if (result === null) throw new Error('expected paste result')
+    const [stdout, io] = result
     expect(await materialize(stdout)).toEqual(new Uint8Array(0))
     expect(io.exitCode).toBe(0)
   })

--- a/typescript/packages/core/src/commands/builtin/generic/paste.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/paste.test.ts
@@ -1,0 +1,47 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { materialize } from '../../../io/types.ts'
+import { PathSpec } from '../../../types.ts'
+import type { CommandOpts } from '../../config.ts'
+import { pasteGeneric } from './paste.ts'
+
+function opts(flags: Record<string, string | boolean | string[]> = {}): CommandOpts {
+  return { stdin: null, flags, filetypeFns: null, cwd: '/', resource: {} } as CommandOpts
+}
+
+async function* emptyStream(_path: PathSpec): AsyncIterable<Uint8Array> {
+  await Promise.resolve()
+  yield new Uint8Array(0)
+}
+
+describe('pasteGeneric', () => {
+  it('uses empty standard input when no operands are given', async () => {
+    const [stdout, io] = await pasteGeneric([], opts(), emptyStream)
+    expect(await materialize(stdout)).toEqual(new Uint8Array(0))
+    expect(io.exitCode).toBe(0)
+  })
+
+  it.each([false, true])('produces no output for an empty file with serial=%s', async (serial) => {
+    const flags = serial ? { s: true } : {}
+    const [stdout, io] = await pasteGeneric(
+      [PathSpec.fromStrPath('/empty.txt')],
+      opts(flags),
+      emptyStream,
+    )
+    expect(await materialize(stdout)).toEqual(new Uint8Array(0))
+    expect(io.exitCode).toBe(0)
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/generic/paste.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/paste.ts
@@ -46,14 +46,11 @@ export async function pasteGeneric(
   }
   if (fileLines.length === 0 && !stdinConsumed) {
     const raw = await readStdinAsync(opts.stdin)
-    if (raw !== null) fileLines.push(splitLinesNoEnds(DEC.decode(raw)))
-  }
-  if (fileLines.length === 0) {
-    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('paste: missing operand\n') })]
+    fileLines.push(splitLinesNoEnds(raw !== null ? DEC.decode(raw) : ''))
   }
   let outLines: string[]
   if (serial) {
-    outLines = fileLines.map((lines) => lines.join(delimiter))
+    outLines = fileLines.filter((lines) => lines.length > 0).map((lines) => lines.join(delimiter))
   } else {
     const maxLen = Math.max(...fileLines.map((l) => l.length))
     outLines = []
@@ -61,6 +58,7 @@ export async function pasteGeneric(
       outLines.push(fileLines.map((lines) => lines[i] ?? '').join(delimiter))
     }
   }
-  const out: ByteSource = ENC.encode(outLines.join('\n') + '\n')
+  const out: ByteSource =
+    outLines.length === 0 ? new Uint8Array(0) : ENC.encode(outLines.join('\n') + '\n')
   return [out, new IOResult()]
 }

--- a/typescript/packages/core/src/commands/builtin/generic/sort.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/sort.ts
@@ -37,10 +37,7 @@ export async function sortGeneric(
     }
   } else {
     const raw = await readStdinAsync(opts.stdin)
-    if (raw === null) {
-      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('sort: missing operand\n') })]
-    }
-    allLines = splitSortLines(DEC.decode(raw))
+    allLines = splitSortLines(DEC.decode(raw ?? new Uint8Array(0)))
   }
   const sorted = sortAndDedupe(allLines, keyOpts, reverse, unique)
   const out: ByteSource =

--- a/typescript/packages/core/src/commands/builtin/generic/uniq.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/uniq.ts
@@ -123,7 +123,13 @@ export async function uniqGeneric(
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
   if (paths.length > 2) throw extraOperandError(CommandName.UNIQ, paths[2]?.rawPath ?? '')
-  const uniqOpts = parseOptions(opts.flags)
+  let uniqOpts: UniqOptions
+  try {
+    uniqOpts = parseOptions(opts.flags)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(`${msg}\n`) })]
+  }
   if (paths.length > 0) {
     const first = paths[0]
     if (first === undefined) return [null, new IOResult()]

--- a/typescript/packages/core/src/commands/builtin/generic/uniq.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/uniq.ts
@@ -35,8 +35,10 @@ interface UniqOptions {
 
 function parseCount(value: string | boolean | string[] | undefined): number | null {
   if (typeof value !== 'string') return null
-  const count = Number.parseInt(value, 10)
-  if (Number.isNaN(count) || count < 0) throw new Error(`uniq: invalid count: '${value}'`)
+  const normalized = value.trim()
+  if (!/^[+-]?\d+$/.test(normalized)) throw new Error(`uniq: invalid count: '${value}'`)
+  const count = Number(normalized)
+  if (!Number.isSafeInteger(count) || count < 0) throw new Error(`uniq: invalid count: '${value}'`)
   return count
 }
 
@@ -128,7 +130,7 @@ export async function uniqGeneric(
     return [uniqStream(stream(first), uniqOpts), new IOResult({ cache: [first.mountPath] })]
   }
   try {
-    const source = resolveSource(opts.stdin, 'uniq: missing operand')
+    const source = resolveSource(opts.stdin)
     return [uniqStream(source, uniqOpts), new IOResult()]
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)

--- a/typescript/packages/core/src/commands/builtin/ram/sort.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/sort.test.ts
@@ -126,9 +126,10 @@ describe('sort', () => {
     expect(r.lines).toEqual(['30', '10', '2', '1'])
   })
 
-  it('missing stdin and no path returns error', async () => {
+  it('missing stdin and no path uses empty standard input', async () => {
     const resource = new RAMResource()
     const r = await runSort(resource, [])
-    expect(r.exitCode).toBe(1)
+    expect(r.exitCode).toBe(0)
+    expect(r.lines).toEqual([])
   })
 })

--- a/typescript/packages/core/src/commands/builtin/ram/uniq.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/uniq.test.ts
@@ -27,7 +27,7 @@ async function runUniq(
   paths: PathSpec[],
   flags: Record<string, string | boolean | string[]> = {},
   stdin: Uint8Array | null = null,
-): Promise<{ lines: string[]; exitCode: number }> {
+): Promise<{ lines: string[]; exitCode: number; stderr: string }> {
   const cmd = RAM_UNIQ[0]
   if (cmd === undefined) throw new Error('uniq not registered')
   const result = await cmd.fn((resource as { accessor?: unknown }).accessor as never, paths, [], {
@@ -37,7 +37,7 @@ async function runUniq(
     cwd: '/',
     resource,
   })
-  if (result === null) return { lines: [], exitCode: -1 }
+  if (result === null) return { lines: [], exitCode: -1, stderr: '' }
   const [out, ioResult] = result
   const buf =
     out === null
@@ -48,7 +48,8 @@ async function runUniq(
   const text = DEC.decode(buf)
   const stripped = text.endsWith('\n') ? text.slice(0, -1) : text
   const lines = stripped === '' ? [] : stripped.split('\n')
-  return { lines, exitCode: ioResult.exitCode }
+  const stderr = DEC.decode(await materialize(ioResult.stderr))
+  return { lines, exitCode: ioResult.exitCode, stderr }
 }
 
 describe('uniq', () => {
@@ -134,8 +135,8 @@ describe('uniq', () => {
 
   it('rejects trailing text in numeric options', async () => {
     const resource = new RAMResource()
-    await expect(runUniq(resource, [], { f: '2junk' })).rejects.toThrow(
-      "uniq: invalid count: '2junk'",
-    )
+    const r = await runUniq(resource, [], { f: '2junk' })
+    expect(r.exitCode).toBe(1)
+    expect(r.stderr).toBe("uniq: invalid count: '2junk'\n")
   })
 })

--- a/typescript/packages/core/src/commands/builtin/ram/uniq.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/uniq.test.ts
@@ -124,4 +124,18 @@ describe('uniq', () => {
     const r = await runUniq(resource, [], {}, ENC.encode('a\na\nb\n'))
     expect(r.lines).toEqual(['a', 'b'])
   })
+
+  it('missing stdin and no path uses empty standard input', async () => {
+    const resource = new RAMResource()
+    const r = await runUniq(resource, [])
+    expect(r.exitCode).toBe(0)
+    expect(r.lines).toEqual([])
+  })
+
+  it('rejects trailing text in numeric options', async () => {
+    const resource = new RAMResource()
+    await expect(runUniq(resource, [], { f: '2junk' })).rejects.toThrow(
+      "uniq: invalid count: '2junk'",
+    )
+  })
 })

--- a/typescript/packages/node/src/core/ssh/read.ts
+++ b/typescript/packages/node/src/core/ssh/read.ts
@@ -15,6 +15,7 @@
 import type { PathSpec } from '@struktoai/mirage-core'
 import { enoent } from '@struktoai/mirage-core'
 import type { SSHAccessor } from '../../accessor/ssh.ts'
+import { readChunks } from './stream.ts'
 import { isNoSuchFile, joinRoot, stripPrefix } from './utils.ts'
 
 export async function read(accessor: SSHAccessor, p: PathSpec): Promise<Uint8Array> {
@@ -29,9 +30,7 @@ export async function read(accessor: SSHAccessor, p: PathSpec): Promise<Uint8Arr
   const chunks: Uint8Array[] = []
   let total = 0
   try {
-    for await (const chunk of rs) {
-      const buf = chunk as Buffer
-      const u8 = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+    for await (const u8 of readChunks(rs)) {
       chunks.push(u8)
       total += u8.byteLength
     }

--- a/typescript/packages/node/src/core/ssh/stream.test.ts
+++ b/typescript/packages/node/src/core/ssh/stream.test.ts
@@ -12,10 +12,79 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { Readable } from 'node:stream'
+import { setImmediate as nextTurn } from 'node:timers/promises'
 import { describe, expect, it } from 'vitest'
 import { PathSpec } from '@struktoai/mirage-core'
+import type { ReadStream, SFTPWrapper } from 'ssh2'
+import { SSHAccessor } from '../../accessor/ssh.ts'
 import { makeFakeAccessor } from './_test_utils.ts'
 import { rangeRead, stream } from './stream.ts'
+
+class DelayedCloseStream extends Readable {
+  private sent = false
+  private closeCallback: ((error?: Error | null) => void) | null = null
+  private closeError: Error | null = null
+
+  constructor() {
+    super({ emitClose: false, autoDestroy: false })
+    this.on('end', this.destroyOnEnd.bind(this))
+  }
+
+  private destroyOnEnd(): void {
+    this.destroy()
+  }
+
+  override _read(): void {
+    if (this.sent) return
+    this.sent = true
+    this.push(Buffer.from('x'))
+    this.push(null)
+  }
+
+  override _destroy(error: Error | null, callback: (error?: Error | null) => void): void {
+    this.closeError = error
+    this.closeCallback = callback
+  }
+
+  releaseClose(): void {
+    const callback = this.closeCallback
+    if (callback === null) throw new Error('stream close was not requested')
+    this.closeCallback = null
+    callback(this.closeError)
+    if (this.closeError === null) this.emit('close')
+  }
+}
+
+class DelayedCloseSftp {
+  constructor(private readonly rs: ReadStream) {}
+
+  createReadStream(): ReadStream {
+    return this.rs
+  }
+}
+
+class DelayedCloseAccessor extends SSHAccessor {
+  private readonly fakeSftp: SFTPWrapper
+
+  constructor(rs: ReadStream) {
+    super({ host: 'fake' })
+    this.fakeSftp = new DelayedCloseSftp(rs) as unknown as SFTPWrapper
+  }
+
+  override sftp(): Promise<SFTPWrapper> {
+    return Promise.resolve(this.fakeSftp)
+  }
+}
+
+function markSettled(): boolean {
+  return true
+}
+
+async function markPending(): Promise<boolean> {
+  await nextTurn()
+  return false
+}
 
 function spec(p: string): PathSpec {
   return PathSpec.fromStrPath(p)
@@ -40,6 +109,18 @@ describe('core/ssh/stream', () => {
     })
     const it = stream(accessor, spec('/missing'))
     await expect(it[Symbol.asyncIterator]().next()).rejects.toBeDefined()
+  })
+
+  it('waits for the remote handle to close after reading ends', async () => {
+    const rs = new DelayedCloseStream()
+    const accessor = new DelayedCloseAccessor(rs as unknown as ReadStream)
+    const iterator = stream(accessor, spec('/x'))[Symbol.asyncIterator]()
+    await expect(iterator.next()).resolves.toMatchObject({ done: false })
+    const done = iterator.next()
+    const settledBeforeClose = await Promise.race([done.then(markSettled), markPending()])
+    rs.releaseClose()
+    await expect(done).resolves.toEqual({ done: true, value: undefined })
+    expect(settledBeforeClose).toBe(false)
   })
 })
 

--- a/typescript/packages/node/src/core/ssh/stream.ts
+++ b/typescript/packages/node/src/core/ssh/stream.ts
@@ -12,10 +12,36 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { once } from 'node:events'
 import type { PathSpec } from '@struktoai/mirage-core'
 import { enoent } from '@struktoai/mirage-core'
+import type { ReadStream } from 'ssh2'
 import type { SSHAccessor } from '../../accessor/ssh.ts'
 import { isNoSuchFile, joinRoot, stripPrefix } from './utils.ts'
+
+async function waitForClose(rs: ReadStream): Promise<Error | null> {
+  try {
+    await once(rs, 'close')
+    return null
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error))
+  }
+}
+
+export async function* readChunks(rs: ReadStream): AsyncIterable<Uint8Array> {
+  const closed = waitForClose(rs)
+  let closeError: Error | null = null
+  try {
+    for await (const chunk of rs) {
+      const buf = chunk as Buffer
+      yield new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+    }
+  } finally {
+    if (!rs.destroyed) rs.destroy()
+    closeError = await closed
+  }
+  if (closeError !== null) throw closeError
+}
 
 export async function* stream(accessor: SSHAccessor, p: PathSpec): AsyncIterable<Uint8Array> {
   const sftp = await accessor.sftp()
@@ -23,10 +49,7 @@ export async function* stream(accessor: SSHAccessor, p: PathSpec): AsyncIterable
   const remote = joinRoot(accessor.config.root ?? '/', virtual)
   const rs = sftp.createReadStream(remote)
   try {
-    for await (const chunk of rs) {
-      const buf = chunk as Buffer
-      yield new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
-    }
+    yield* readChunks(rs)
   } catch (err) {
     if (isNoSuchFile(err)) throw enoent(p)
     throw err
@@ -46,9 +69,7 @@ export async function rangeRead(
   const chunks: Uint8Array[] = []
   let total = 0
   try {
-    for await (const chunk of rs) {
-      const buf = chunk as Buffer
-      const u8 = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+    for await (const u8 of readChunks(rs)) {
       chunks.push(u8)
       total += u8.byteLength
     }


### PR DESCRIPTION
## Summary

- make Python and TypeScript `comm --check-order` return a nonzero exit status for unsorted input
- make `paste`, `sort`, and `uniq` treat an absent operand as standard input, including empty input
- prevent `paste` from emitting a stray newline for empty sources
- reject malformed `uniq` numeric options instead of accepting numeric prefixes in TypeScript
- add mirrored regression coverage in both implementations

## Why

The Python and TypeScript implementations were mostly in parity, but several shared behaviors diverged from GNU Coreutils. `comm --check-order` emitted a diagnostic while still exiting successfully, and standard-input filters treated the lack of an explicit piped source as a missing operand. TypeScript also used `parseInt` for `uniq` counts, so values such as `2junk` were accepted while Python and GNU reject them.

These changes use GNU behavior as the tie-breaker and keep the two implementations aligned.

## Validation

- `./python/.venv/bin/pre-commit run --all-files`
- `pnpm build`
- `pnpm test` (all TypeScript package suites passed)
- focused Python parity suites: 122 passed before rebase; 20 focused generic tests passed after rebasing onto latest `main`
- full `uv run pytest`: 8,850 passed and 347 skipped; the remaining environment-dependent checks were five Redis setup errors from an empty `REDIS_URL` and one FUSE mount timeout
