### PR TITLE
test(integ): grep/find/rg/zgrep flag coverage

### DIFF
--- a/integ/unix/find.json
+++ b/integ/unix/find.json
@@ -887,6 +887,270 @@
         "stdout": "",
         "stderr": "find: unknown predicate '-boguspredicate'\n"
       }
+    },
+    {
+      "id": "find_flags_provision",
+      "seq": 500300,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "mkdir -p /data/f4/sub1/skipme /data/f4/del && printf 'alpha inner\\n' > /data/f4/sub1/inner.txt && printf 'alpha skip\\n' > /data/f4/sub1/skipme/deep.txt && printf 'x\\n' > /data/f4/del/f1.tmp && printf 'y\\n' > /data/f4/del/f2.tmp && printf 'keep\\n' > /data/f4/del/keep.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "find_print_trailing",
+      "seq": 500301,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "find /data/f4/sub1 -name \"*.txt\" -print",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/f4/sub1/inner.txt\n/data/f4/sub1/skipme/deep.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "find_print0",
+      "seq": 500302,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "find /data/f4/sub1 -print0",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/f4/sub1\u0000/data/f4/sub1/inner.txt\u0000/data/f4/sub1/skipme\u0000/data/f4/sub1/skipme/deep.txt\u0000",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "find_print0_name",
+      "seq": 500303,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "find /data/f4/sub1 -name \"*.txt\" -print0",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/f4/sub1/inner.txt\u0000/data/f4/sub1/skipme/deep.txt\u0000",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "find_a_alias",
+      "seq": 500304,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "find /data/f4/sub1 -name \"*.txt\" -a -name \"inner*\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/f4/sub1/inner.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "find_and_alias",
+      "seq": 500305,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "find /data/f4/sub1 -name inner.txt -and -name \"*.txt\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/f4/sub1/inner.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "find_parens_or",
+      "seq": 500306,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "find /data/f4/sub1 \\( -name inner.txt -o -name deep.txt \\)",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/f4/sub1/inner.txt\n/data/f4/sub1/skipme/deep.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "find_ls_paths",
+      "seq": 500307,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "find /data/f4/sub1 -name \"*.txt\" -ls | awk '{print $NF}'",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/f4/sub1/inner.txt\n/data/f4/sub1/skipme/deep.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "find_delete_by_name",
+      "seq": 500308,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "find /data/f4/del -name \"*.tmp\" -delete && ls /data/f4/del",
+      "expect": {
+        "exit": 0,
+        "stdout": "keep.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "find_delete_with_print",
+      "seq": 500309,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "mkdir -p /data/f4/del2 && printf 'x\\n' > /data/f4/del2/g.tmp && find /data/f4/del2 -name \"*.tmp\" -delete -print && ls /data/f4/del2",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/f4/del2/g.tmp\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "find_delete_tree",
+      "seq": 500310,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "mkdir -p /data/f4/del3 && printf 'z\\n' > /data/f4/del3/h.txt && find /data/f4/del3 -delete && find /data/f4 -name del3",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "find_delete_mount_root_noop",
+      "seq": 500311,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "find /data -maxdepth 0 -delete; echo rc=$?; ls /data/f4/sub1",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=0\ninner.txt\nskipme\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/unix/grep.json
+++ b/integ/unix/grep.json
@@ -1151,6 +1151,424 @@
         "stdout": "/data/a.txt:hello\n",
         "stderr": "grep: /data/sub: Is a directory\n"
       }
+    },
+    {
+      "id": "grep_flags_provision",
+      "seq": 500200,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "mkdir -p /data/g4/sub && printf 'error: disk full\\nwarning: low memory\\ninfo: all good\\nerror: timeout\\nnote: done\\n' > /data/g4/app.log && printf 'alpha\\nbeta\\ngamma\\nALPHA\\n' > /data/g4/notes.txt && printf 'alpha inner\\n' > /data/g4/sub/inner.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_q_match",
+      "seq": 500201,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -q alpha /data/g4/notes.txt; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_q_no_match",
+      "seq": 500202,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -q zzz /data/g4/notes.txt; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_q_multi_file",
+      "seq": 500203,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -q alpha /data/g4/notes.txt /data/g4/app.log; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_q_multi_file_no_match",
+      "seq": 500204,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -q zzz /data/g4/notes.txt /data/g4/app.log; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_q_recursive",
+      "seq": 500205,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -qR alpha /data/g4; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_q_files_only",
+      "seq": 500206,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -ql alpha /data/g4/notes.txt /data/g4/app.log; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_q_count_all_zero",
+      "seq": 500207,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -qc zzz /data/g4/notes.txt /data/g4/app.log; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_H_single_file",
+      "seq": 500208,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -H alpha /data/g4/notes.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/g4/notes.txt:alpha\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_Hn_single_file",
+      "seq": 500209,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -Hn alpha /data/g4/notes.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/g4/notes.txt:1:alpha\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_Hc_single_file",
+      "seq": 500210,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -Hc alpha /data/g4/notes.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/g4/notes.txt:1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_C1_context",
+      "seq": 500211,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -C1 warning /data/g4/app.log",
+      "expect": {
+        "exit": 0,
+        "stdout": "error: disk full\nwarning: low memory\ninfo: all good\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_C1_merges_groups",
+      "seq": 500212,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -C1 error /data/g4/app.log",
+      "expect": {
+        "exit": 0,
+        "stdout": "error: disk full\nwarning: low memory\ninfo: all good\nerror: timeout\nnote: done\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_A_B_combined",
+      "seq": 500213,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -A1 -B2 timeout /data/g4/app.log",
+      "expect": {
+        "exit": 0,
+        "stdout": "warning: low memory\ninfo: all good\nerror: timeout\nnote: done\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_nC1_dash_context",
+      "seq": 500214,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -nC1 warning /data/g4/app.log",
+      "expect": {
+        "exit": 0,
+        "stdout": "1-error: disk full\n2:warning: low memory\n3-info: all good\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_R_recursive",
+      "seq": 500215,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -R alpha /data/g4 | sort",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/g4/notes.txt:alpha\n/data/g4/sub/inner.txt:alpha inner\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_Rl_recursive",
+      "seq": 500216,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep -Rl alpha /data/g4 | sort",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/g4/notes.txt\n/data/g4/sub/inner.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_colour_noop",
+      "seq": 500217,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep --colour=auto alpha /data/g4/notes.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "alpha\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "grep_color_never_noop",
+      "seq": 500218,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "grep --color=never alpha /data/g4/notes.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "alpha\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/unix/rg.json
+++ b/integ/unix/rg.json
@@ -395,6 +395,446 @@
         "stdout": "",
         "stderr": "rg: usage: rg [flags] pattern [path]\n"
       }
+    },
+    {
+      "id": "rg_flags_provision",
+      "seq": 500400,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "mkdir -p /data/r4/sub && printf 'error: disk full\\nwarning: low memory\\ninfo: all good\\nerror: timeout\\nnote: done\\n' > /data/r4/app.log && printf 'alpha\\nbeta\\ngamma\\nALPHA\\n' > /data/r4/notes.txt && printf 'def main():\\n    return 42\\n' > /data/r4/code.py && printf 'function main() { return 42; }\\n' > /data/r4/code.js && printf 'secret alpha\\n' > /data/r4/.hidden.txt && printf 'alpha inner\\n' > /data/r4/sub/inner.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_v_invert",
+      "seq": 500401,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg -v error /data/r4/app.log",
+      "expect": {
+        "exit": 0,
+        "stdout": "warning: low memory\ninfo: all good\nnote: done\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_n_line_numbers",
+      "seq": 500402,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg -n alpha /data/r4/notes.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "1:alpha\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_w_word",
+      "seq": 500403,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg -w alpha /data/r4/notes.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "alpha\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_w_word_no_partial",
+      "seq": 500404,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg -w alph /data/r4/notes.txt; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_F_fixed",
+      "seq": 500405,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg -F \"main()\" /data/r4/code.py",
+      "expect": {
+        "exit": 0,
+        "stdout": "def main():\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_o_only_matching",
+      "seq": 500406,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg -o \"err[a-z]*\" /data/r4/app.log",
+      "expect": {
+        "exit": 0,
+        "stdout": "error\nerror\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_H_single_file",
+      "seq": 500407,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg -H alpha /data/r4/notes.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/r4/notes.txt:alpha\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_I_no_filename_dir",
+      "seq": 500408,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg -I alpha /data/r4/sub",
+      "expect": {
+        "exit": 0,
+        "stdout": "alpha inner\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_m_max_count",
+      "seq": 500409,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg -m1 error /data/r4/app.log",
+      "expect": {
+        "exit": 0,
+        "stdout": "error: disk full\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_A1_after",
+      "seq": 500410,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg -A1 warning /data/r4/app.log",
+      "expect": {
+        "exit": 0,
+        "stdout": "warning: low memory\ninfo: all good\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_B1_before",
+      "seq": 500411,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg -B1 info /data/r4/app.log",
+      "expect": {
+        "exit": 0,
+        "stdout": "warning: low memory\ninfo: all good\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_C1_context",
+      "seq": 500412,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg -C1 warning /data/r4/app.log",
+      "expect": {
+        "exit": 0,
+        "stdout": "error: disk full\nwarning: low memory\ninfo: all good\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_C1_merges_groups",
+      "seq": 500413,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg -C1 error /data/r4/app.log",
+      "expect": {
+        "exit": 0,
+        "stdout": "error: disk full\nwarning: low memory\ninfo: all good\nerror: timeout\nnote: done\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_nA1_dash_context",
+      "seq": 500414,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg -nA1 warning /data/r4/app.log",
+      "expect": {
+        "exit": 0,
+        "stdout": "2:warning: low memory\n3-info: all good\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_hidden_skipped_by_default",
+      "seq": 500415,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg alpha /data/r4 | sort",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/r4/notes.txt:alpha\n/data/r4/sub/inner.txt:alpha inner\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_hidden_flag",
+      "seq": 500416,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg --hidden alpha /data/r4 | sort",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/r4/.hidden.txt:secret alpha\n/data/r4/notes.txt:alpha\n/data/r4/sub/inner.txt:alpha inner\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_type_py",
+      "seq": 500417,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg --type py \"return\" /data/r4",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/r4/code.py:    return 42\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_glob_log",
+      "seq": 500418,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg --glob \"*.log\" error /data/r4",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/r4/app.log:error: disk full\n/data/r4/app.log:error: timeout\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "rg_color_noop",
+      "seq": 500419,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "rg --color=never alpha /data/r4/notes.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "alpha\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/unix/zgrep.json
+++ b/integ/unix/zgrep.json
@@ -191,6 +191,402 @@
         "stdout": "",
         "stderr": "zgrep: usage: zgrep [flags] pattern [path]\n"
       }
+    },
+    {
+      "id": "zgrep_flags_provision",
+      "seq": 500500,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "mkdir -p /data/z4 && printf 'error: disk full\\nwarning: low memory\\ninfo: all good\\nerror: timeout\\nnote: done\\n' > /data/z4/app.log && printf 'alpha\\nbeta\\ngamma\\nALPHA\\n' > /data/z4/notes.txt && gzip /data/z4/app.log /data/z4/notes.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_i_ignore_case",
+      "seq": 500501,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -i ALPHA /data/z4/notes.txt.gz",
+      "expect": {
+        "exit": 0,
+        "stdout": "alpha\nALPHA\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_l_files_only",
+      "seq": 500502,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -l alpha /data/z4/notes.txt.gz /data/z4/app.log.gz",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/z4/notes.txt.gz\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_n_line_numbers",
+      "seq": 500503,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -n error /data/z4/app.log.gz",
+      "expect": {
+        "exit": 0,
+        "stdout": "1:error: disk full\n4:error: timeout\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_v_invert",
+      "seq": 500504,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -v error /data/z4/app.log.gz",
+      "expect": {
+        "exit": 0,
+        "stdout": "warning: low memory\ninfo: all good\nnote: done\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_E_extended",
+      "seq": 500505,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -E \"err(or|ata)\" /data/z4/app.log.gz",
+      "expect": {
+        "exit": 0,
+        "stdout": "error: disk full\nerror: timeout\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_F_fixed",
+      "seq": 500506,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -F \"info: all good\" /data/z4/app.log.gz",
+      "expect": {
+        "exit": 0,
+        "stdout": "info: all good\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_H_filename",
+      "seq": 500507,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -H error /data/z4/app.log.gz",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/z4/app.log.gz:error: disk full\n/data/z4/app.log.gz:error: timeout\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_multi_auto_prefix",
+      "seq": 500508,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep error /data/z4/app.log.gz /data/z4/notes.txt.gz",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/z4/app.log.gz:error: disk full\n/data/z4/app.log.gz:error: timeout\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_h_suppress_prefix",
+      "seq": 500509,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -h error /data/z4/app.log.gz /data/z4/notes.txt.gz",
+      "expect": {
+        "exit": 0,
+        "stdout": "error: disk full\nerror: timeout\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_m_max_count",
+      "seq": 500510,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -m2 o /data/z4/app.log.gz",
+      "expect": {
+        "exit": 0,
+        "stdout": "error: disk full\nwarning: low memory\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_o_only_matching",
+      "seq": 500511,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -o \"err[a-z]*\" /data/z4/app.log.gz",
+      "expect": {
+        "exit": 0,
+        "stdout": "error\nerror\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_q_match",
+      "seq": 500512,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -q error /data/z4/app.log.gz; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_q_no_match",
+      "seq": 500513,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -q zzz /data/z4/app.log.gz; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_w_word",
+      "seq": 500514,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -w alpha /data/z4/notes.txt.gz",
+      "expect": {
+        "exit": 0,
+        "stdout": "alpha\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_w_no_partial",
+      "seq": 500515,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -w alph /data/z4/notes.txt.gz; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_c_multi_includes_zero",
+      "seq": 500516,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "zgrep -c error /data/z4/app.log.gz /data/z4/notes.txt.gz",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/z4/app.log.gz:2\n/data/z4/notes.txt.gz:0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "zgrep_H_stdin_label",
+      "seq": 500517,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "s3-prefix",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "echo hi | gzip | zgrep -H hi",
+      "expect": {
+        "exit": 0,
+        "stdout": "(standard input):hi\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/python/mirage/commands/builtin/generic/grep.py
+++ b/python/mirage/commands/builtin/generic/grep.py
@@ -147,6 +147,9 @@ async def grep(
                 )
                 results.extend(rebase_raw(hits, p.virtual, p.raw_path))
             stderr = format_optional_records(warnings)
+            if f.quiet:
+                return b"", IOResult(exit_code=0 if results else 1,
+                                     stderr=stderr)
             if not results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
             return format_records(results), IOResult(stderr=stderr)
@@ -196,9 +199,14 @@ async def grep(
                     else:
                         all_results.extend(f"{label}{rl}" for rl in hits)
             stderr = format_optional_records(warnings)
+            matched = bool(all_results) and (
+                not f.count_only or count_records_have_matches(all_results))
+            if f.quiet:
+                return b"", IOResult(exit_code=0 if matched else 1,
+                                     stderr=stderr)
             if not all_results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            if f.count_only and not count_records_have_matches(all_results):
+            if not matched:
                 return format_records(all_results), IOResult(exit_code=1,
                                                              stderr=stderr)
             return format_records(all_results), IOResult(stderr=stderr)
@@ -234,9 +242,14 @@ async def grep(
                 else:
                     all_results.extend(f"{label}{r}" for r in hits)
             stderr = format_optional_records(multi_warnings)
+            matched = bool(all_results) and (
+                not f.count_only or count_records_have_matches(all_results))
+            if f.quiet:
+                return b"", IOResult(exit_code=0 if matched else 1,
+                                     stderr=stderr)
             if not all_results:
                 return b"", IOResult(exit_code=1, stderr=stderr)
-            if f.count_only and not count_records_have_matches(all_results):
+            if not matched:
                 return format_records(all_results), IOResult(exit_code=1,
                                                              stderr=stderr)
             return format_records(all_results), IOResult(stderr=stderr)

--- a/python/mirage/commands/builtin/generic/rg.py
+++ b/python/mirage/commands/builtin/generic/rg.py
@@ -177,6 +177,7 @@ async def rg(
                     hidden=f.hidden,
                     warnings=warnings_f,
                     file_prefix=p.raw_path if label else None,
+                    no_filename=f.no_filename,
                 )
                 results.extend(rebase_raw(hits_full, p.virtual, p.raw_path))
             stderr = format_optional_records(warnings_f)

--- a/python/mirage/commands/builtin/generic/zgrep.py
+++ b/python/mirage/commands/builtin/generic/zgrep.py
@@ -169,9 +169,11 @@ async def zgrep(
                 all_results.append("(standard input)")
                 any_match = True
         else:
+            # GNU zgrep labels stdin "(standard input)" under -H.
+            stdin_name = "(standard input)" if f.force_filename else None
             result, had_match = _zgrep_search(data, compiled, f.ignore_case,
                                               f.invert, f.count,
-                                              f.line_numbers, None,
+                                              f.line_numbers, stdin_name,
                                               f.only_matching, f.max_count)
             if had_match:
                 any_match = True

--- a/python/mirage/commands/builtin/rg_helper.py
+++ b/python/mirage/commands/builtin/rg_helper.py
@@ -15,6 +15,7 @@
 import fnmatch
 import posixpath
 
+from mirage.commands.builtin.grep_context import grep_context_lines
 from mirage.commands.builtin.grep_helper import (BINARY_EXTENSIONS,
                                                  compile_pattern,
                                                  get_extension)
@@ -187,6 +188,7 @@ async def rg_full(
     hidden: bool,
     warnings: list[str] | None,
     file_prefix: str | None = None,
+    no_filename: bool = False,
 ) -> list[str]:
     compiled = compile_pattern(pattern, ignore_case, fixed_string, whole_word)
 
@@ -212,6 +214,17 @@ async def rg_full(
             if warnings is not None:
                 warnings.append(f"rg: {path}: {exc}")
             return []
+        if ((context_before or context_after) and not files_only
+                and not count_only and not only_matching
+                and file_prefix is None):
+            # Single-file context rides the shared grep renderer (match
+            # lines `N:`, context lines `N-`, `--` between groups).
+            # Directory search and filename-prefixed fanout skip context,
+            # mirroring grep's -H divergence.
+            rendered = grep_context_lines(data, compiled, invert, line_numbers,
+                                          max_count, context_after,
+                                          context_before)
+            return [b.decode().rstrip("\n") for b in rendered]
         results: list[str] = []
         count = 0
         for i_ln, line in enumerate(data, 1):
@@ -280,6 +293,7 @@ async def rg_full(
                 glob_pattern,
                 hidden,
                 warnings,
+                no_filename=no_filename,
             ))
         else:
             if get_extension(entry) in BINARY_EXTENSIONS:
@@ -308,9 +322,12 @@ async def rg_full(
                     else:
                         text = line
                     pfx = f"{i_ln}:{text}" if line_numbers else text
-                    results.append(f"{entry}:{pfx}")
+                    # ripgrep -I drops per-file labels in directory walks.
+                    results.append(pfx if no_filename else f"{entry}:{pfx}")
                 if count_only and file_count > 0:
-                    results.append(f"{entry}:{file_count}")
+                    results.append(
+                        str(file_count
+                            ) if no_filename else f"{entry}:{file_count}")
             except Exception as exc:
                 if warnings is not None:
                     warnings.append(f"rg: {entry}: {exc}")

--- a/python/mirage/workspace/executor/find_action_dispatch.py
+++ b/python/mirage/workspace/executor/find_action_dispatch.py
@@ -71,7 +71,9 @@ async def _apply_find_actions(
                 resolved=True,
             )
             try:
-                _, rm_io = await mount.execute_cmd("rm", [ps], [], {},
+                # -d so directories emptied by the deepest-first pass are
+                # removable, matching GNU -delete's rmdir behavior.
+                _, rm_io = await mount.execute_cmd("rm", [ps], [], {"d": True},
                                                    stdin=None,
                                                    cwd=cwd)
             except (FileNotFoundError, NotADirectoryError, PermissionError,

--- a/python/tests/commands/builtin/generic/test_grep.py
+++ b/python/tests/commands/builtin/generic/test_grep.py
@@ -513,3 +513,107 @@ async def test_grep_multi_file_no_filename_suppresses_prefix():
     )
     decoded = (await _drain_async(output)).decode()
     assert decoded == "apple\napricot\n"
+
+
+@pytest.mark.asyncio
+async def test_grep_quiet_multi_file_suppresses_output():
+    readdir, stat, rb, rs = _make_backend({
+        "/a.txt": b"apple\n",
+        "/b.txt": b"banana\n",
+    })
+    output, io = await grep(
+        [_spec("/a.txt"), _spec("/b.txt")],
+        ["apple"],
+        {"q": True},
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+    )
+    assert await _drain_async(output) == b""
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_grep_quiet_multi_file_no_match_exits_1():
+    readdir, stat, rb, rs = _make_backend({
+        "/a.txt": b"apple\n",
+        "/b.txt": b"banana\n",
+    })
+    output, io = await grep(
+        [_spec("/a.txt"), _spec("/b.txt")],
+        ["zzz"],
+        {"q": True},
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+    )
+    assert await _drain_async(output) == b""
+    assert io.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_grep_quiet_recursive_suppresses_output():
+    readdir, stat, rb, rs = _make_backend({
+        "/dir/a.txt": b"apple\n",
+        "/dir/sub/b.txt": b"apricot\n",
+    })
+    output, io = await grep(
+        [_spec("/dir")],
+        ["ap"],
+        {
+            "q": True,
+            "r": True
+        },
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+    )
+    assert await _drain_async(output) == b""
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_grep_quiet_files_only_suppresses_output():
+    readdir, stat, rb, rs = _make_backend({
+        "/a.txt": b"apple\n",
+        "/b.txt": b"banana\n",
+    })
+    output, io = await grep(
+        [_spec("/a.txt"), _spec("/b.txt")],
+        ["apple"],
+        {
+            "q": True,
+            "args_l": True
+        },
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+    )
+    assert await _drain_async(output) == b""
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_grep_quiet_count_zero_counts_exits_1():
+    readdir, stat, rb, rs = _make_backend({
+        "/a.txt": b"apple\n",
+        "/b.txt": b"banana\n",
+    })
+    output, io = await grep(
+        [_spec("/a.txt"), _spec("/b.txt")],
+        ["zzz"],
+        {
+            "q": True,
+            "c": True
+        },
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+    )
+    assert await _drain_async(output) == b""
+    assert io.exit_code == 1

--- a/python/tests/commands/builtin/generic/test_rg.py
+++ b/python/tests/commands/builtin/generic/test_rg.py
@@ -514,3 +514,132 @@ async def test_rg_no_filename_suppresses_multi_file_labels():
         read_stream=rs,
     )
     assert (await _drain_async(output)).decode() == "apple\napricot\n"
+
+
+LOG = (b"error: disk full\nwarning: low memory\ninfo: all good\n"
+       b"error: timeout\nnote: done\n")
+
+
+@pytest.mark.asyncio
+async def test_rg_context_after_single_file():
+    readdir, stat, rb, rs = _make_backend({"/app.log": LOG})
+    output, io = await rg(
+        [_spec("/app.log")],
+        ["warning"],
+        {"A": "1"},
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+    )
+    decoded = (await _drain_async(output)).decode()
+    assert decoded == "warning: low memory\ninfo: all good\n"
+    assert io.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_rg_context_c_merges_adjacent_groups():
+    readdir, stat, rb, rs = _make_backend({"/app.log": LOG})
+    output, _ = await rg(
+        [_spec("/app.log")],
+        ["error"],
+        {"C": "1"},
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+    )
+    decoded = (await _drain_async(output)).decode()
+    assert decoded == ("error: disk full\nwarning: low memory\n"
+                       "info: all good\nerror: timeout\nnote: done\n")
+
+
+@pytest.mark.asyncio
+async def test_rg_context_line_numbers_use_dash_separator():
+    readdir, stat, rb, rs = _make_backend({"/app.log": LOG})
+    output, _ = await rg(
+        [_spec("/app.log")],
+        ["warning"],
+        {
+            "n": True,
+            "A": "1"
+        },
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+    )
+    decoded = (await _drain_async(output)).decode()
+    assert decoded == "2:warning: low memory\n3-info: all good\n"
+
+
+@pytest.mark.asyncio
+async def test_rg_context_respects_max_count():
+    readdir, stat, rb, rs = _make_backend({"/app.log": LOG})
+    output, _ = await rg(
+        [_spec("/app.log")],
+        ["error"],
+        {
+            "m": "1",
+            "C": "1"
+        },
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+    )
+    decoded = (await _drain_async(output)).decode()
+    assert decoded == "error: disk full\nwarning: low memory\n"
+
+
+@pytest.mark.asyncio
+async def test_rg_context_separates_distant_groups():
+    readdir, stat, rb, rs = _make_backend({"/f.txt": b"hit\na\nb\nc\nhit\n"})
+    output, _ = await rg(
+        [_spec("/f.txt")],
+        ["hit"],
+        {"A": "1"},
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+    )
+    decoded = (await _drain_async(output)).decode()
+    assert decoded == "hit\na\n--\nhit\n"
+
+
+@pytest.mark.asyncio
+async def test_rg_dir_search_ignores_context():
+    # Deliberate divergence: directory search skips context lines,
+    # mirroring grep's -H divergence.
+    readdir, stat, rb, rs = _make_backend({"/dir/app.log": LOG})
+    output, _ = await rg(
+        [_spec("/dir")],
+        ["warning"],
+        {"A": "1"},
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+    )
+    decoded = (await _drain_async(output)).decode()
+    assert decoded == "/dir/app.log:warning: low memory\n"
+
+
+@pytest.mark.asyncio
+async def test_rg_no_filename_dir_walk():
+    readdir, stat, rb, rs = _make_backend({
+        "/dir/a.txt": b"alpha one\n",
+        "/dir/b.txt": b"alpha two\n",
+    })
+    output, _ = await rg(
+        [_spec("/dir")],
+        ["alpha"],
+        {"args_I": True},
+        readdir=readdir,
+        stat=stat,
+        read_bytes=rb,
+        read_stream=rs,
+    )
+    decoded = (await _drain_async(output)).decode()
+    assert decoded == "alpha one\nalpha two\n"

--- a/python/tests/commands/builtin/test_zgrep.py
+++ b/python/tests/commands/builtin/test_zgrep.py
@@ -79,3 +79,11 @@ def test_zgrep_dash_e_and_dash_f_union():
     stdout, io = _run_raw(ws, "zgrep -e foo -f /data/pats.txt /data/f.gz")
     assert io.exit_code == 0
     assert _bytes(stdout) == b"foo\nbaz\n"
+
+
+def test_zgrep_stdin_h_labels_standard_input():
+    ws, _ = _ws()
+    compressed = gzip.compress(b"foo\nbar\n")
+    stdout, io = _run_raw(ws, "zgrep -H bar", stdin=compressed)
+    assert _bytes(stdout) == b"(standard input):bar\n"
+    assert io.exit_code == 0

--- a/python/tests/workspace/test_find_action_dispatch.py
+++ b/python/tests/workspace/test_find_action_dispatch.py
@@ -199,3 +199,20 @@ def test_mount_entries_filtered_by_name() -> None:
         assert "/b" not in lines
 
     _run(_go())
+
+
+def test_delete_removes_emptied_directories() -> None:
+
+    async def _go():
+        ws = _ws()
+        ws.create_session("s")
+        await ws.execute("mkdir -p /tree/deep", session_id="s")
+        await ws.execute("touch /tree/deep/f.txt", session_id="s")
+        r = await ws.execute("find /tree -delete", session_id="s")
+        assert r.exit_code == 0
+        assert await r.stderr_str() == ""
+        check = await ws.execute("find / -name tree", session_id="s")
+        assert await check.stdout_str() == ""
+        await ws.close()
+
+    _run(_go())

--- a/typescript/packages/core/src/commands/builtin/generic/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/grep.ts
@@ -167,6 +167,14 @@ export async function grepGeneric(
         for (const h of rebaseRaw(hits, p.virtual, p.rawPath)) results.push(h)
       }
       const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n') + '\n') : undefined
+      if (f.quiet)
+        return [
+          new Uint8Array(0),
+          new IOResult({
+            exitCode: results.length > 0 ? 0 : 1,
+            ...(stderr !== undefined ? { stderr } : {}),
+          }),
+        ]
       if (results.length === 0)
         return [
           new Uint8Array(0),
@@ -215,15 +223,23 @@ export async function grepGeneric(
         }
       }
       const stderr = warnings.length > 0 ? ENC.encode(warnings.join('\n') + '\n') : undefined
+      const matched = allResults.length > 0 && (!f.countOnly || countRecordsHaveMatches(allResults))
+      if (f.quiet)
+        return [
+          new Uint8Array(0),
+          new IOResult({
+            exitCode: matched ? 0 : 1,
+            ...(stderr !== undefined ? { stderr } : {}),
+          }),
+        ]
       if (allResults.length === 0)
         return [
           new Uint8Array(0),
           new IOResult({ exitCode: 1, ...(stderr !== undefined ? { stderr } : {}) }),
         ]
-      const exitCode = f.countOnly && !countRecordsHaveMatches(allResults) ? 1 : 0
       return [
         ENC.encode(allResults.join('\n') + '\n'),
-        new IOResult({ exitCode, ...(stderr !== undefined ? { stderr } : {}) }),
+        new IOResult({ exitCode: matched ? 0 : 1, ...(stderr !== undefined ? { stderr } : {}) }),
       ]
     }
 
@@ -256,6 +272,16 @@ export async function grepGeneric(
       }
       const multiStderr =
         multiWarnings.length > 0 ? ENC.encode(multiWarnings.join('\n') + '\n') : undefined
+      const multiMatched =
+        allResults.length > 0 && (!f.countOnly || countRecordsHaveMatches(allResults))
+      if (f.quiet)
+        return [
+          new Uint8Array(0),
+          new IOResult({
+            exitCode: multiMatched ? 0 : 1,
+            ...(multiStderr !== undefined ? { stderr: multiStderr } : {}),
+          }),
+        ]
       if (allResults.length === 0)
         return [
           new Uint8Array(0),
@@ -264,12 +290,11 @@ export async function grepGeneric(
             ...(multiStderr !== undefined ? { stderr: multiStderr } : {}),
           }),
         ]
-      const multiExit = f.countOnly && !countRecordsHaveMatches(allResults) ? 1 : 0
       const out: ByteSource = ENC.encode(allResults.join('\n') + '\n')
       return [
         out,
         new IOResult({
-          exitCode: multiExit,
+          exitCode: multiMatched ? 0 : 1,
           ...(multiStderr !== undefined ? { stderr: multiStderr } : {}),
         }),
       ]

--- a/typescript/packages/core/src/commands/builtin/generic/grep_count.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/grep_count.test.ts
@@ -127,3 +127,41 @@ describe('grepGeneric count-only exit codes', () => {
     expect(io.exitCode).toBe(1)
   })
 })
+
+describe('grepGeneric quiet mode', () => {
+  it('grep -q on multiple files suppresses output and exits 0 on match', async () => {
+    const [out, io] = await runGrep([spec('/a.txt'), spec('/b.txt')], 'hello', { q: true })
+    expect(out).toBe('')
+    expect(io.exitCode).toBe(0)
+  })
+
+  it('grep -q on multiple files exits 1 with no match', async () => {
+    const [out, io] = await runGrep([spec('/a.txt'), spec('/b.txt')], 'zzz', { q: true })
+    expect(out).toBe('')
+    expect(io.exitCode).toBe(1)
+  })
+
+  it('grep -qr suppresses output and exits 0 on match', async () => {
+    const [out, io] = await runGrep([spec('/d')], 'hello', { q: true, r: true })
+    expect(out).toBe('')
+    expect(io.exitCode).toBe(0)
+  })
+
+  it('grep -ql suppresses the file list', async () => {
+    const [out, io] = await runGrep([spec('/a.txt'), spec('/b.txt')], 'hello', {
+      q: true,
+      args_l: true,
+    })
+    expect(out).toBe('')
+    expect(io.exitCode).toBe(0)
+  })
+
+  it('grep -qc exits 1 when every count is zero', async () => {
+    const [out, io] = await runGrep([spec('/a.txt'), spec('/b.txt')], 'zzz', {
+      q: true,
+      c: true,
+    })
+    expect(out).toBe('')
+    expect(io.exitCode).toBe(1)
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/generic/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/rg.ts
@@ -228,6 +228,7 @@ export async function rgGeneric(
       fileType: flags.fileType,
       globPattern: flags.globPattern,
       hidden: flags.hidden,
+      noFilename: flags.noFilename,
     }
     const results: string[] = []
     for (const p of paths) {

--- a/typescript/packages/core/src/commands/builtin/generic/zgrep.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/zgrep.ts
@@ -187,11 +187,12 @@ export async function zgrepGeneric(
         }
       }
     } else {
+      // GNU zgrep labels stdin "(standard input)" under -H.
       const [result, hadMatch] = zgrepSearch(
         data,
         pattern,
         { ignoreCase, invert, count: countOnly, lineNumbers, onlyMatching, maxCount },
-        null,
+        forceH ? '(standard input)' : null,
       )
       if (hadMatch) anyMatch = true
       for (const r of result) allResults.push(r)

--- a/typescript/packages/core/src/commands/builtin/ram/zgrep.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/zgrep.test.ts
@@ -72,4 +72,12 @@ describe('zgrep', () => {
     const r = await runZgrep(resource, [PathSpec.fromStrPath('/f.gz')], ['xyz'])
     expect(r.exitCode).toBe(1)
   })
+
+  it('labels stdin "(standard input)" under -H', async () => {
+    const resource = new RAMResource()
+    const compressed = await gzip(ENC.encode('foo\nbar\n'))
+    const r = await runZgrep(resource, [], ['bar'], { H: true }, compressed)
+    expect(r.exitCode).toBe(0)
+    expect(r.out).toBe('(standard input):bar\n')
+  })
 })

--- a/typescript/packages/core/src/commands/builtin/rg_helper.test.ts
+++ b/typescript/packages/core/src/commands/builtin/rg_helper.test.ts
@@ -109,3 +109,144 @@ describe('rgFull countOnly', () => {
     expect(out).toEqual(['/db/a.txt:Graph', '/db/a.txt:Graph again'])
   })
 })
+
+const LOG_FILES: Record<string, string> = {
+  '/log/app.log':
+    'error: disk full\nwarning: low memory\ninfo: all good\nerror: timeout\nnote: done\n',
+  '/log/far.txt': 'hit\na\nb\nc\nhit\n',
+}
+
+function logReaddirFn(path: string): Promise<string[]> {
+  if (path === '/log') return Promise.resolve(['/log/app.log', '/log/far.txt'])
+  return Promise.reject(new Error(`not a dir: ${path}`))
+}
+
+function logStatFn(path: string): Promise<FileStat> {
+  if (path === '/log') {
+    return Promise.resolve(new FileStat({ name: 'log', type: FileType.DIRECTORY }))
+  }
+  const content = LOG_FILES[path]
+  if (content === undefined) return Promise.reject(new Error(`ENOENT: ${path}`))
+  const name = path.split('/').pop() ?? ''
+  return Promise.resolve(new FileStat({ name, type: FileType.TEXT, size: content.length }))
+}
+
+function logReadBytesFn(path: string): Promise<Uint8Array> {
+  const content = LOG_FILES[path]
+  if (content === undefined) return Promise.reject(new Error(`ENOENT: ${path}`))
+  return Promise.resolve(ENC.encode(content))
+}
+
+describe('rgFull single-file context', () => {
+  it('renders after-context lines', async () => {
+    const out = await rgFull(
+      logReaddirFn,
+      logStatFn,
+      logReadBytesFn,
+      '/log/app.log',
+      'warning',
+      opts({ contextAfter: 1 }),
+      null,
+    )
+    expect(out).toEqual(['warning: low memory', 'info: all good'])
+  })
+
+  it('merges adjacent context groups without a separator', async () => {
+    const out = await rgFull(
+      logReaddirFn,
+      logStatFn,
+      logReadBytesFn,
+      '/log/app.log',
+      'error',
+      opts({ contextBefore: 1, contextAfter: 1 }),
+      null,
+    )
+    expect(out).toEqual([
+      'error: disk full',
+      'warning: low memory',
+      'info: all good',
+      'error: timeout',
+      'note: done',
+    ])
+  })
+
+  it('labels context lines with a dash under -n', async () => {
+    const out = await rgFull(
+      logReaddirFn,
+      logStatFn,
+      logReadBytesFn,
+      '/log/app.log',
+      'warning',
+      opts({ lineNumbers: true, contextAfter: 1 }),
+      null,
+    )
+    expect(out).toEqual(['2:warning: low memory', '3-info: all good'])
+  })
+
+  it('separates distant groups with --', async () => {
+    const out = await rgFull(
+      logReaddirFn,
+      logStatFn,
+      logReadBytesFn,
+      '/log/far.txt',
+      'hit',
+      opts({ contextAfter: 1 }),
+      null,
+    )
+    expect(out).toEqual(['hit', 'a', '--', 'hit'])
+  })
+
+  it('respects maxCount with context', async () => {
+    const out = await rgFull(
+      logReaddirFn,
+      logStatFn,
+      logReadBytesFn,
+      '/log/app.log',
+      'error',
+      opts({ maxCount: 1, contextBefore: 1, contextAfter: 1 }),
+      null,
+    )
+    expect(out).toEqual(['error: disk full', 'warning: low memory'])
+  })
+
+  it('skips context on directory walks (documented divergence)', async () => {
+    const out = await rgFull(
+      logReaddirFn,
+      logStatFn,
+      logReadBytesFn,
+      '/log',
+      'warning',
+      opts({ contextAfter: 1 }),
+      null,
+    )
+    expect(out).toEqual(['/log/app.log:warning: low memory'])
+  })
+})
+
+describe('rgFull -I in directory walks', () => {
+  it('drops per-file labels', async () => {
+    const out = await rgFull(
+      logReaddirFn,
+      logStatFn,
+      logReadBytesFn,
+      '/log',
+      'warning',
+      opts({ noFilename: true }),
+      null,
+    )
+    expect(out).toEqual(['warning: low memory'])
+  })
+
+  it('keeps paths for -l', async () => {
+    const out = await rgFull(
+      logReaddirFn,
+      logStatFn,
+      logReadBytesFn,
+      '/log',
+      'warning',
+      opts({ noFilename: true, filesOnly: true }),
+      null,
+    )
+    expect(out).toEqual(['/log/app.log'])
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/rg_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/rg_helper.ts
@@ -18,6 +18,7 @@ import { rstripSlash } from '../../utils/slash.ts'
 import { gnuBasename } from '../../utils/path.ts'
 import { getExtension } from '../resolve.ts'
 import { BINARY_EXTENSIONS, compilePattern, grepLines } from './grep_helper.ts'
+import { grepContextLines } from './grep_context.ts'
 import { fnmatch } from '../../utils/fnmatch.ts'
 import type { AsyncReadBytesFn, AsyncReaddirFn, AsyncStatFn } from './utils/types.ts'
 
@@ -75,6 +76,7 @@ export interface RgFullOptions {
   fileType: string | null
   globPattern: string | null
   hidden: boolean
+  noFilename?: boolean
 }
 
 function searchFile(
@@ -158,6 +160,28 @@ export async function rgFull(
       if (warnings !== null) warnings.push(`rg: ${path}: ${String(err)}`)
       return []
     }
+    if (
+      (opts.contextBefore > 0 || opts.contextAfter > 0) &&
+      !opts.filesOnly &&
+      !opts.countOnly &&
+      !opts.onlyMatching &&
+      filePrefix === null
+    ) {
+      // Single-file context rides the shared grep renderer (match lines
+      // `N:`, context lines `N-`, `--` between groups). Directory search
+      // and filename-prefixed fanout skip context, mirroring grep's -H
+      // divergence.
+      const rendered = grepContextLines(
+        data,
+        compiled,
+        opts.invert,
+        opts.lineNumbers,
+        opts.maxCount,
+        opts.contextAfter,
+        opts.contextBefore,
+      )
+      return rendered.map((chunk) => DEC.decode(chunk).replace(/\n$/, ''))
+    }
     return searchFile(data, compiled, opts, filePrefix)
   }
 
@@ -202,7 +226,10 @@ export async function rgFull(
       if (warnings !== null) warnings.push(`rg: ${entry}: ${String(err)}`)
       continue
     }
-    const fileResults = searchFile(data, compiled, opts, entry)
+    // ripgrep -I drops per-file labels in directory walks; -l keeps
+    // paths (they are the output).
+    const walkPrefix = opts.noFilename === true && !opts.filesOnly ? null : entry
+    const fileResults = searchFile(data, compiled, opts, walkPrefix)
     results.push(...fileResults)
   }
 

--- a/typescript/packages/core/src/workspace/executor/find_action_dispatch.ts
+++ b/typescript/packages/core/src/workspace/executor/find_action_dispatch.ts
@@ -58,7 +58,9 @@ export async function applyFindActions(
         resolved: true,
       })
       try {
-        const [, rmIo] = await mount.executeCmd('rm', [ps], [], {}, { stdin: null, cwd })
+        // -d so directories emptied by the deepest-first pass are removable,
+        // matching GNU -delete's rmdir behavior.
+        const [, rmIo] = await mount.executeCmd('rm', [ps], [], { d: true }, { stdin: null, cwd })
         if (rmIo.exitCode !== 0) {
           const errBytes = await materialize(rmIo.stderr)
           if (errBytes.length > 0) errors.push(errBytes)

--- a/typescript/packages/core/src/workspace/find_actions.test.ts
+++ b/typescript/packages/core/src/workspace/find_actions.test.ts
@@ -103,6 +103,18 @@ describe('find action layer', () => {
       })
       expect(r.exitCode).toBe(0)
     })
+
+    it('removes directories emptied by the deepest-first pass', async () => {
+      const ws = await singleMountWs()
+      ws.createSession('s')
+      await ws.execute('mkdir -p /tree/deep', { sessionId: 's' })
+      await ws.execute('touch /tree/deep/f.txt', { sessionId: 's' })
+      const r = await ws.execute('find /tree -delete', { sessionId: 's' })
+      expect(r.exitCode).toBe(0)
+      expect(r.stderrText).toBe('')
+      const after = await ws.execute('find / -name tree', { sessionId: 's' })
+      expect(after.stdoutText).toBe('')
+    })
   })
 
   describe('-print0', () => {


### PR DESCRIPTION
## Summary

PR 4 of the integ coverage plan (follows #546): closes the search-family flag gaps in the JSON integ suites, plus five product fixes the pinning flushed out.

**69 new cases** in `integ/unix/{grep,find,rg,zgrep}.json` (seq 500200–500517):
- grep `-q` (single/multi-file/`-R`/`-l`/`-qc`), `-H`/`-Hn`/`-Hc`, `-A/-B/-C` incl. group merging and `-n` dash-context, `-R`/`-Rl`, `--colour`/`--color` no-op pins
- find `-print` (trailing), `-print0` (NUL-terminated), `-delete` (by name, with `-print`, whole tree, mount-root noop guard), `-ls` (path column via awk — timestamps are nondeterministic), `-a`/`-and` aliases, escaped-paren `\( -o \)` grouping
- rg `-v -n -w -F -o -H -I -m -A -B -C --hidden --type --glob --color=never` + no-match exit pin
- zgrep all 12 previously untested flags (`-i -l -n -v -E -F -H -h -m -o -q -w`) + multi-file `-c` zero-count row + `(standard input)` stdin label

Every expectation pinned in docker against GNU coreutils (`debian:stable-slim`) and ripgrep 14.1.1. Cases self-provision `/data/{g4,f4,r4,z4}` subtrees so they stay independent of what earlier suites leave in the persistent workspace.

## Product fixes (Python + TypeScript, with unit tests)

- **rg `-A/-B/-C` never rendered context** — parsed and forwarded, then silently dropped in both languages. Single-file search now reuses the shared grep context renderer (`N:` match / `N-` context / `--` between groups, matching ripgrep). Directory walks still skip context, mirroring grep's documented `-H` divergence.
- **grep `-q` leaked output on multi-file / `-R` / `-l` paths** — only the single-file stream path was quiet. Now quiet everywhere with exit 0/1 by match, including `-qc` all-zero → 1.
- **rg `-I` kept per-file labels in directory walks** — now dropped (ripgrep semantics); `-l` keeps paths.
- **find `-delete` could not remove directories** emptied by its deepest-first pass (the action dispatcher issued a bare `rm`); now `rm -d`, so `find dir -delete` removes the whole tree like GNU.
- **zgrep `-H` on stdin** now labels `(standard input):`.

## Deliberately not covered (follow-ups)

- find `-prune` — still a loud `find: unknown predicate` error; GNU-correct prune needs action-position semantics (own PR).
- grep `-I` — accepted no-op; needs content-based binary detection (mirage only has extension-based skip).
- rg directory-walk context rendering.

## Verification

- JSON harness: **981/981** on python host (ram + disk pre-rebase, ram post-rebase) and typescript-node host (ram)
- `pytest`: green except known environmental failures (no `tac` binary on macOS, no local Redis)
- TS: `tsc --noEmit` clean, vitest 4117 passed, `pre-commit run --all-files` fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)