### PR TITLE
feat(runtime): run_line, runtimes that run whole lines

### DIFF
--- a/integ/runtime.py
+++ b/integ/runtime.py
@@ -33,6 +33,8 @@ from mirage.resource.mongodb import MongoDBResource  # noqa: E402
 from mirage.resource.ram import RAMResource  # noqa: E402
 from mirage.resource.redis import RedisResource  # noqa: E402
 from mirage.resource.s3 import S3Config, S3Resource  # noqa: E402
+from mirage.runtime.base import RunArgs  # noqa: E402
+from mirage.runtime.base import RunResult, Runtime  # noqa: E402
 from mirage.runtime.python.monty import MontyRuntime  # noqa: E402
 from mirage.runtime.route import ScriptSource  # noqa: E402
 from mirage.runtime.table import VfsRuntime  # noqa: E402
@@ -193,6 +195,21 @@ async def _run_error(ws: Workspace, name: str, cmd: str) -> None:
     result = await ws.execute(cmd)
     print(f"=== {name} ===")
     print(f"exit_code={result.exit_code}")
+
+
+class EchoBox(Runtime):
+    name = "sandbox"
+    captures = ("nvidia-smi", )
+    runs_lines = True
+
+    async def run(self, args: RunArgs) -> RunResult:
+        raise AssertionError("whole-line runtimes take lines")
+
+    async def run_line(self, line: str, stdin: bytes | None,
+                       env: dict[str, str], cwd: str) -> RunResult:
+        return RunResult(stdout=f"box:{line}\n".encode(),
+                         stderr=None,
+                         exit_code=0)
 
 
 async def main() -> None:
@@ -444,6 +461,34 @@ async def main() -> None:
         print("=== py3_safeguard_timeout ===")
         print(f"exit_code={result.exit_code}")
         await ws_sg.close()
+
+        # A runtime that runs whole lines: the raw line lands there
+        # wholesale when it captures one of the line's commands or "*";
+        # a refused line falls back to the workspace shell.
+        ws_line = Workspace({"/ram": RAMResource()},
+                            mode=MountMode.EXEC,
+                            runtimes=[EchoBox(), "vfs"])
+        result = await ws_line.execute("nvidia-smi -L | grep GPU")
+        print("=== whole_line_capture ===")
+        print(await result.stdout_str(), end="")
+        result = await ws_line.execute("echo still-the-workspace")
+        print("=== whole_line_uncaptured ===")
+        print(await result.stdout_str(), end="")
+        await ws_line.close()
+
+        star = EchoBox()
+        star.captures = ("*", )
+        star.script = ScriptSource("'keep-out' not in ctx['line']")
+        ws_star = Workspace({"/ram": RAMResource()},
+                            mode=MountMode.EXEC,
+                            runtimes=[star, "vfs"])
+        result = await ws_star.execute("ls /ram && echo done")
+        print("=== whole_line_star ===")
+        print(await result.stdout_str(), end="")
+        result = await ws_star.execute("echo keep-out")
+        print("=== whole_line_refused ===")
+        print(await result.stdout_str(), end="")
+        await ws_star.close()
         await ws.close()
     finally:
         server.stop()

--- a/integ/runtime.ts
+++ b/integ/runtime.ts
@@ -26,6 +26,9 @@ import {
   ScriptSource,
   VfsRuntime,
   Workspace,
+  type RouteScript,
+  type Runtime,
+  type RunResult,
 } from "@struktoai/mirage-node";
 
 const REDIS_URL = process.env.REDIS_URL ?? "redis://localhost:6379/0";
@@ -178,6 +181,28 @@ function buildWorkspace(runId: string): Workspace {
     { "/ram": ram, "/redis": redis, "/s3": s3, "/mongodb": mongodb },
     { mode: MountMode.EXEC, runtimes: ["monty", "quickjs", "vfs"] },
   );
+}
+
+class EchoBox implements Runtime {
+  readonly name = "sandbox";
+  captures: readonly string[] = ["nvidia-smi"];
+  readonly runsLines = true;
+  script?: RouteScript;
+  attach(): void {}
+  run(): Promise<RunResult> {
+    return Promise.reject(new Error("whole-line runtimes take lines"));
+  }
+  runLine(
+    line: string,
+    _stdin: Uint8Array | null,
+    _env: Record<string, string>,
+    _cwd: string,
+  ): Promise<RunResult> {
+    return Promise.resolve({ stdout: ENC.encode(`box:${line}\n`), stderr: null, exitCode: 0 });
+  }
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 async function run(ws: Workspace, name: string, cmd: string): Promise<void> {
@@ -347,6 +372,28 @@ async function main(): Promise<void> {
   console.log("=== add_runtime_arg_after ===");
   process.stdout.write(DEC.decode(added.stdout));
   await wsAdd.close();
+
+  // A runtime that runs whole lines: the raw line lands there
+  // wholesale when it captures one of the line's commands or "*";
+  // a refused line falls back to the workspace shell.
+  const wsLine = new Workspace(
+    { "/ram": new RAMResource() },
+    { mode: MountMode.EXEC, runtimes: [new EchoBox(), "vfs"] },
+  );
+  await run(wsLine, "whole_line_capture", "nvidia-smi -L | grep GPU");
+  await run(wsLine, "whole_line_uncaptured", "echo still-the-workspace");
+  await wsLine.close();
+
+  const star = new EchoBox();
+  star.captures = ["*"];
+  star.script = new ScriptSource("'keep-out' not in ctx['line']");
+  const wsStar = new Workspace(
+    { "/ram": new RAMResource() },
+    { mode: MountMode.EXEC, runtimes: [star, "vfs"] },
+  );
+  await run(wsStar, "whole_line_star", "ls /ram && echo done");
+  await run(wsStar, "whole_line_refused", "echo keep-out");
+  await wsStar.close();
   await ws.close();
 }
 

--- a/integ/truth_runtime.txt
+++ b/integ/truth_runtime.txt
@@ -75,3 +75,11 @@ exit_code=126
 unknown-runtime-rejected
 === add_runtime_arg_after ===
 42
+=== whole_line_capture ===
+box:nvidia-smi -L | grep GPU
+=== whole_line_uncaptured ===
+still-the-workspace
+=== whole_line_star ===
+box:ls /ram && echo done
+=== whole_line_refused ===
+keep-out

--- a/integ/truth_runtime_py.txt
+++ b/integ/truth_runtime_py.txt
@@ -95,3 +95,11 @@ exit_code=126
 mirage: cat: no runtime accepted this line
 === py3_safeguard_timeout ===
 exit_code=124
+=== whole_line_capture ===
+box:nvidia-smi -L | grep GPU
+=== whole_line_uncaptured ===
+still-the-workspace
+=== whole_line_star ===
+box:ls /ram && echo done
+=== whole_line_refused ===
+keep-out

--- a/python/mirage/runtime/base.py
+++ b/python/mirage/runtime/base.py
@@ -25,7 +25,7 @@ class ScriptSource:
     value references a ``.py`` file whose content is embedded here at
     load. The source sees ctx as a dict and its LAST EXPRESSION is the
     verdict. It runs on the routing interpreter (monty today; a
-    sandbox runtime is a candidate door later).
+    sandbox runtime may take this over later).
 
     Args:
         source (str): the script program.
@@ -93,6 +93,10 @@ class Runtime(ABC):
     # config-borne ScriptSource. None = always willing. Policy, not
     # capability: it can only refuse lines the captures already allow.
     script: Callable[..., Any] | ScriptSource | None = None
+    # A runtime that runs whole lines sets this True and implements
+    # run_line. Interpreter runtimes leave it False: they are the
+    # engine inside one command (python3, node), never the line.
+    runs_lines: bool = False
 
     def attach(self, dispatch: Callable[..., Any],
                mount_prefixes: Callable[[], list[str]]) -> None:
@@ -117,6 +121,25 @@ class Runtime(ABC):
         Args:
             args (RunArgs): the execution request.
         """
+
+    async def run_line(self, line: str, stdin: bytes | None,
+                       env: dict[str, str], cwd: str) -> RunResult:
+        """Execute one raw command line wholesale.
+
+        Only runtimes with ``runs_lines`` implement this. The runtime
+        owns the entire line: pipes, redirects, and every command in
+        it run inside the runtime's world (its own cat, its own grep),
+        the workspace shell never splits the line. A line lands here
+        when this runtime captures one of the line's commands or "*".
+
+        Args:
+            line (str): the raw typed line.
+            stdin (bytes | None): bytes piped into the line.
+            env (dict[str, str]): the session environment.
+            cwd (str): the session working directory.
+        """
+        raise NotImplementedError(
+            f"runtime {self.name!r} runs single commands, not whole lines")
 
     async def close(self) -> None:
         """Release interpreter resources. Default: nothing held."""

--- a/python/mirage/runtime/table.py
+++ b/python/mirage/runtime/table.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, Callable
 
 from mirage.runtime.base import Runtime, ScriptSource
@@ -37,9 +37,9 @@ class VfsRuntime(Runtime):
     capturer: the workspace serves exactly those commands and anything
     unclaimed exits 126. Required: every workspace world contains
     exactly one, appended automatically when the runtimes list omits
-    it; pass your own instance to customize it. run() stays
-    unimplemented until the line-door contract exists; the workspace
-    executor serves its commands internally.
+    it; pass your own instance to customize it. Its run_line is the
+    workspace executor itself, wired in at construction; run() stays
+    unimplemented because vfs has no single-command interpreter.
 
     Args:
         script (Callable | ScriptSource | None): per-line admission
@@ -52,9 +52,10 @@ class VfsRuntime(Runtime):
 
     name = "vfs"
     captures: tuple[str, ...] = ()
+    runs_lines = True
 
     def __init__(self,
-                 script: "Callable[..., Any] | ScriptSource | None" = None,
+                 script: Callable[..., Any] | ScriptSource | None = None,
                  captures: Sequence[str] | None = None) -> None:
         self.script = script
         # Declaring captures (even empty) turns the catch-all off; the
@@ -62,10 +63,28 @@ class VfsRuntime(Runtime):
         self.restricted = captures is not None
         if captures is not None:
             self.captures = tuple(captures)
+        self._execute_line: Callable[..., Any] | None = None
+
+    def bind_line_executor(self, execute: Callable[..., Any]) -> None:
+        """Wire the workspace executor in as this runtime's run_line.
+
+        Args:
+            execute (Callable): async (line, stdin, env, cwd) ->
+                RunResult, provided by the owning workspace.
+        """
+        self._execute_line = execute
 
     async def run(self, args: Any) -> Any:
-        raise RuntimeError("the vfs runtime has no interpreter door; the "
-                           "workspace executor runs its commands")
+        raise RuntimeError("the vfs runtime runs whole lines through the "
+                           "workspace executor; it has no single-command "
+                           "interpreter")
+
+    async def run_line(self, line: str, stdin: bytes | None,
+                       env: dict[str, str], cwd: str) -> Any:
+        if self._execute_line is None:
+            raise RuntimeError(
+                "the vfs runtime is not attached to a workspace")
+        return await self._execute_line(line, stdin, env, cwd)
 
 
 NAMED: dict[str, type[Runtime]] = {cls.name: cls for cls in RUNTIMES}
@@ -162,6 +181,33 @@ def bind_commands(entries: list[Runtime]) -> dict[str, Runtime]:
             if command not in bindings:
                 bindings[command] = entry
     return bindings
+
+
+def whole_line_runtime(bindings: Mapping[str, Runtime | None],
+                       commands: Sequence[str]) -> Runtime | None:
+    """The runtime that runs this entire line, if any.
+
+    A runtime with ``runs_lines`` takes the raw line when it captures
+    one of the line's commands; a "*" capture claims any line. A
+    specific capture beats "*". The vfs runtime never matches here:
+    the workspace executor IS its run_line, the path the line takes
+    anyway when nothing else claims it.
+
+    Args:
+        bindings (Mapping[str, Runtime | None]): the line's resolved
+            command bindings (a RoutingDecision's or the registry's).
+        commands (Sequence[str]): the line's stage command names.
+    """
+    for command in commands:
+        runtime = bindings.get(command)
+        if (runtime is not None and runtime.runs_lines
+                and not isinstance(runtime, VfsRuntime)):
+            return runtime
+    star = bindings.get("*")
+    if (star is not None and star.runs_lines
+            and not isinstance(star, VfsRuntime)):
+        return star
+    return None
 
 
 def catch_all(entries: list[Runtime]) -> Runtime | None:

--- a/python/mirage/workspace/workspace.py
+++ b/python/mirage/workspace/workspace.py
@@ -31,7 +31,7 @@ from mirage.commands.builtin.utils.safeguard import (CommandTimeoutError,
 from mirage.commands.errors import FindParseError, UsageError
 from mirage.commands.safeguard import CommandSafeguard, resolve_safeguard
 from mirage.io import IOResult
-from mirage.io.types import ByteSource
+from mirage.io.types import ByteSource, materialize
 from mirage.observe.context import RecordingScope
 from mirage.observe.observer import Observer
 from mirage.observe.record import OpRecord
@@ -43,13 +43,13 @@ from mirage.provision import ProvisionResult
 from mirage.resource.base import BaseResource
 from mirage.resource.history import HISTORY_PREFIX, HistoryViewResource
 from mirage.resource.ram import RAMResource
-from mirage.runtime.base import Runtime
+from mirage.runtime.base import RunResult, Runtime
 from mirage.runtime.route import (RouteContext, RouteFn, RoutingDecision,
                                   RoutingDecisionError, command_facts,
                                   decide_line)
 from mirage.runtime.table import (DEFAULT_ENTRIES, VfsRuntime, bind_commands,
                                   build_runtime, catch_all,
-                                  runtime_bindings_for)
+                                  runtime_bindings_for, whole_line_runtime)
 from mirage.shell.job_table import JobTable
 from mirage.shell.parse import find_syntax_error, parse
 from mirage.types import (ConsistencyPolicy, DriftPolicy, FileStat, MountMode,
@@ -270,6 +270,9 @@ class Workspace:
         self._registry.vfs_runtime = next(
             (entry for entry in self._runtime_entries
              if isinstance(entry, VfsRuntime)), None)
+        if isinstance(self._registry.vfs_runtime, VfsRuntime):
+            self._registry.vfs_runtime.bind_line_executor(
+                self._execute_line_for_vfs)
         _reject_config_script("route", route)
         self._route = route
 
@@ -482,6 +485,48 @@ class Workspace:
         self._runtime_entries = candidate
         self._registry.runtime_bindings = bindings
         return entry
+
+    def _whole_line_runtime(
+            self, ast: Any,
+            decision: RoutingDecision | None) -> Runtime | None:
+        """The runtime taking this whole line, None for the executor.
+
+        A runtime with ``runs_lines`` takes the raw line when the
+        line's resolved bindings place one of its commands (or "*") on
+        it; everything else walks the executor's tree as today. The
+        common world has no such runtime, so this is a cheap scan.
+
+        Args:
+            ast: the parsed tree-sitter root node.
+            decision (RoutingDecision | None): the line's decision,
+                None when only static bindings apply.
+        """
+        if not any(entry.runs_lines and not isinstance(entry, VfsRuntime)
+                   for entry in self._runtime_entries):
+            return None
+        bindings: Mapping[str, Runtime
+                          | None] = (decision.bindings if decision is not None
+                                     else self._registry.runtime_bindings)
+        facts = command_facts(ast)
+        return whole_line_runtime(bindings, [fact.command for fact in facts])
+
+    async def _execute_line_for_vfs(self, line: str, stdin: bytes | None,
+                                    env: dict[str,
+                                              str], cwd: str) -> RunResult:
+        """The workspace executor as the vfs runtime's run_line.
+
+        Args:
+            line (str): the raw command line.
+            stdin (bytes | None): bytes piped into the line.
+            env (dict[str, str]): environment overrides for the line.
+            cwd (str): working directory for the line.
+        """
+        io = await self.execute(line, stdin=stdin, cwd=cwd, env=env)
+        stdout = (await materialize(io.stdout)
+                  if io.stdout is not None else b"")
+        stderr = (await materialize(io.stderr)
+                  if io.stderr is not None else None)
+        return RunResult(stdout=stdout, stderr=stderr, exit_code=io.exit_code)
 
     async def _resolve_routing_decision(
             self, ast: Any, command: str, runtime: str | None, provision: bool,
@@ -1143,6 +1188,18 @@ class Workspace:
                                    self._plan_eval_stub, self._namespace, ast,
                                    effective_session), prov_timeout, prov_name
                     or "")
+            line_runtime = self._whole_line_runtime(ast, decision)
+            if line_runtime is not None:
+                data = (await materialize(stdin)
+                        if stdin is not None else None)
+                result = await line_runtime.run_line(
+                    command, data, dict(effective_session.env),
+                    effective_session.cwd)
+                io = IOResult(exit_code=result.exit_code,
+                              stdout=result.stdout,
+                              stderr=result.stderr)
+                session.last_exit_code = io.exit_code
+                return io
             io, _ = await run_command_tree(
                 self.dispatch,
                 self._registry,

--- a/python/tests/runtime/test_table.py
+++ b/python/tests/runtime/test_table.py
@@ -12,13 +12,15 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
+
 import pytest
 
 from mirage.runtime.base import RunArgs, RunResult, Runtime
 from mirage.runtime.python import LocalRuntime
 from mirage.runtime.table import (DEFAULT_ENTRIES, RUNTIMES, VfsRuntime,
                                   bind_commands, build_runtime,
-                                  runtime_bindings_for)
+                                  runtime_bindings_for, whole_line_runtime)
 
 
 class FakeRuntime(Runtime):
@@ -90,3 +92,42 @@ def test_runtime_bindings_for_rejects_vfs():
 def test_runtime_bindings_for_unknown_name_lists_entries():
     with pytest.raises(ValueError, match="'fake', 'vfs'"):
         runtime_bindings_for([FakeRuntime(), VfsRuntime()], "nope")
+
+
+class _LineRuntime(Runtime):
+    name = "boxy"
+    captures = ("nvidia-smi", )
+    runs_lines = True
+
+    async def run(self, args: RunArgs) -> RunResult:
+        raise AssertionError
+
+    async def run_line(self, line: str, stdin: bytes | None,
+                       env: dict[str, str], cwd: str) -> RunResult:
+        return RunResult(stdout=b"", stderr=None, exit_code=0)
+
+
+def test_whole_line_runtime_matches_a_captured_command():
+    box = _LineRuntime()
+    assert whole_line_runtime({"nvidia-smi": box},
+                              ["cat", "nvidia-smi"]) is box
+
+
+def test_whole_line_runtime_specific_beats_star():
+    box, star = _LineRuntime(), _LineRuntime()
+    bindings = {"nvidia-smi": box, "*": star}
+    assert whole_line_runtime(bindings, ["nvidia-smi"]) is box
+    assert whole_line_runtime(bindings, ["ls"]) is star
+
+
+def test_whole_line_runtime_skips_stage_engines_and_vfs():
+    vfs = VfsRuntime(captures=["grep"])
+    monty_like = _LineRuntime()
+    monty_like.runs_lines = False
+    bindings = {"grep": vfs, "python3": monty_like}
+    assert whole_line_runtime(bindings, ["grep", "python3"]) is None
+
+
+def test_vfs_run_line_requires_a_workspace():
+    with pytest.raises(RuntimeError, match="not attached"):
+        asyncio.run(VfsRuntime().run_line("echo x", None, {}, "/"))

--- a/python/tests/workspace/test_runtime_binding.py
+++ b/python/tests/workspace/test_runtime_binding.py
@@ -392,3 +392,96 @@ def test_config_script_path_form_missing_file_fails_loud(tmp_path):
             "name": "local",
             "script": str(tmp_path / "nope.py")
         }])
+
+
+class LineBox(Runtime):
+    name = "sandbox"
+    captures = ("nvidia-smi", )
+    runs_lines = True
+
+    def __init__(self) -> None:
+        self.lines: list[tuple[str, bytes | None, str]] = []
+
+    async def run(self, args: RunArgs) -> RunResult:
+        raise AssertionError("run_line runtimes never get single stages")
+
+    async def run_line(self, line: str, stdin: bytes | None,
+                       env: dict[str, str], cwd: str) -> RunResult:
+        self.lines.append((line, stdin, cwd))
+        return RunResult(stdout=b"box:" + line.encode(),
+                         stderr=None,
+                         exit_code=0)
+
+
+@pytest.mark.asyncio
+async def test_whole_line_goes_to_the_capturing_runtime():
+    box = LineBox()
+    ws = Workspace({"/ram": RAMResource()},
+                   mode=MountMode.EXEC,
+                   runtimes=[box, "vfs"])
+    io = await ws.execute("nvidia-smi -L | grep GPU > /out.txt")
+    assert await materialize(io.stdout
+                             ) == b"box:nvidia-smi -L | grep GPU > /out.txt"
+    assert box.lines[0][0] == "nvidia-smi -L | grep GPU > /out.txt"
+    await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_star_captures_any_line_and_stdin_arrives():
+    box = LineBox()
+    box.captures = ("*", )
+    ws = Workspace({"/ram": RAMResource()},
+                   mode=MountMode.EXEC,
+                   runtimes=[box, "vfs"])
+    io = await ws.execute("ls /ram && echo done", stdin=b"fed")
+    assert (await materialize(io.stdout)).startswith(b"box:")
+    assert box.lines[0][1] == b"fed"
+    await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_refused_line_runtime_falls_to_the_workspace():
+    box = LineBox()
+    box.captures = ("*", )
+    box.script = lambda ctx: "keep-out" not in ctx.line
+    ws = Workspace({"/ram": RAMResource()},
+                   mode=MountMode.EXEC,
+                   runtimes=[box, "vfs"])
+    taken = await ws.execute("echo captured")
+    kept = await ws.execute("echo keep-out")
+    assert (await materialize(taken.stdout)).startswith(b"box:")
+    assert await materialize(kept.stdout) == b"keep-out\n"
+    assert kept.exit_code == 0
+    await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_argument_places_the_whole_line():
+    box = LineBox()
+    box.captures = ("*", )
+    box.script = lambda ctx: False
+    ws = Workspace({"/ram": RAMResource()},
+                   mode=MountMode.EXEC,
+                   runtimes=[box, "vfs"])
+    refused = await ws.execute("echo hi")
+    forced = await ws.execute("echo hi", runtime="sandbox")
+    assert await materialize(refused.stdout) == b"hi\n"
+    assert (await materialize(forced.stdout)).startswith(b"box:")
+    await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_vfs_run_line_is_the_workspace_executor():
+    ws = Workspace({"/ram": RAMResource()}, mode=MountMode.EXEC)
+    vfs = ws._registry.vfs_runtime
+    assert vfs is not None
+    result = await vfs.run_line("echo through-vfs", None, {}, "/")
+    assert result.stdout == b"through-vfs\n"
+    assert result.exit_code == 0
+    await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_run_line_default_is_not_implemented():
+    with pytest.raises(NotImplementedError, match="whole lines"):
+        await MontyRuntime().run_line("echo x", None, {}, "/")

--- a/typescript/packages/core/src/workspace/executor/runtime.ts
+++ b/typescript/packages/core/src/workspace/executor/runtime.ts
@@ -56,12 +56,31 @@ export interface Runtime {
    */
   script?: RouteScript
   /**
+   * A runtime that runs whole lines sets this true and implements
+   * runLine. Interpreter runtimes leave it unset: they are the engine
+   * inside one command (python3, node), never the line.
+   */
+  readonly runsLines?: boolean
+  /**
    * Late-wire workspace I/O into a user-constructed instance. The
    * workspace attaches its dispatch bridge at construction; runtimes
    * that never touch workspace files keep this a no-op.
    */
   attach(dispatch: BridgeDispatchFn, listMounts: () => string[]): void
   run(args: RunArgs): Promise<RunResult>
+  /**
+   * Execute one raw command line wholesale. Only runtimes with
+   * runsLines implement this: the runtime owns the entire line
+   * (pipes, redirects, its own cat), the workspace shell never
+   * splits it. A line lands here when this runtime captures one of
+   * the line's commands or "*".
+   */
+  runLine?(
+    line: string,
+    stdin: Uint8Array | null,
+    env: Record<string, string>,
+    cwd: string,
+  ): Promise<RunResult>
   close(): Promise<void>
 }
 
@@ -85,9 +104,9 @@ export function scriptStringError(kind = 'a script'): Error {
  * capturer: the workspace serves exactly those commands and anything
  * unclaimed exits 126. Required: every workspace world contains
  * exactly one, appended automatically when the runtimes list omits it;
- * pass your own instance to customize it. run() stays unimplemented
- * until the line-door contract exists; the workspace executor serves
- * its commands internally.
+ * pass your own instance to customize it. Its runLine is the workspace
+ * executor itself, wired in at construction; run() stays unimplemented
+ * because vfs has no single-command interpreter.
  */
 export class VfsRuntime implements Runtime {
   readonly name = 'vfs'
@@ -95,7 +114,16 @@ export class VfsRuntime implements Runtime {
   // Declaring captures (even empty) turns the catch-all off; the
   // dispatcher reads this bit, not the array's length.
   readonly restricted: boolean = false
+  readonly runsLines = true
   script?: RouteScript
+  private executeLine:
+    | ((
+        line: string,
+        stdin: Uint8Array | null,
+        env: Record<string, string>,
+        cwd: string,
+      ) => Promise<RunResult>)
+    | null = null
 
   // The record form exists for the shared buildRuntime path, which
   // hands every runtime its options object ({script?, captures?}).
@@ -124,9 +152,34 @@ export class VfsRuntime implements Runtime {
   run(): Promise<never> {
     return Promise.reject(
       new Error(
-        'the vfs runtime has no interpreter door; the workspace executor runs its commands',
+        'the vfs runtime runs whole lines through the workspace executor; ' +
+          'it has no single-command interpreter',
       ),
     )
+  }
+
+  /** Wire the workspace executor in as this runtime's runLine. */
+  bindLineExecutor(
+    execute: (
+      line: string,
+      stdin: Uint8Array | null,
+      env: Record<string, string>,
+      cwd: string,
+    ) => Promise<RunResult>,
+  ): void {
+    this.executeLine = execute
+  }
+
+  runLine(
+    line: string,
+    stdin: Uint8Array | null,
+    env: Record<string, string>,
+    cwd: string,
+  ): Promise<RunResult> {
+    if (this.executeLine === null) {
+      return Promise.reject(new Error('the vfs runtime is not attached to a workspace'))
+    }
+    return this.executeLine(line, stdin, env, cwd)
   }
 
   close(): Promise<void> {
@@ -201,6 +254,32 @@ export function bindCommands(entries: readonly Runtime[]): Record<string, Runtim
     }
   }
   return bindings
+}
+
+/**
+ * The runtime that runs this entire line, if any.
+ *
+ * A runtime with runsLines takes the raw line when it captures one of
+ * the line's commands; a "*" capture claims any line. A specific
+ * capture beats "*". The vfs runtime never matches here: the
+ * workspace executor IS its runLine, the path the line takes anyway
+ * when nothing else claims it.
+ */
+export function wholeLineRuntime(
+  bindings: Record<string, Runtime | null>,
+  commands: readonly string[],
+): Runtime | null {
+  for (const command of commands) {
+    const runtime = Object.hasOwn(bindings, command) ? bindings[command] : null
+    if (runtime?.runsLines === true) {
+      if (!(runtime instanceof VfsRuntime)) return runtime
+    }
+  }
+  const star = Object.hasOwn(bindings, '*') ? bindings['*'] : null
+  if (star?.runsLines === true) {
+    if (!(star instanceof VfsRuntime)) return star
+  }
+  return null
 }
 
 /**

--- a/typescript/packages/core/src/workspace/runtime_routing.test.ts
+++ b/typescript/packages/core/src/workspace/runtime_routing.test.ts
@@ -343,3 +343,119 @@ describe('script context', () => {
     }
   })
 })
+
+class LineBox implements Runtime {
+  readonly name = 'sandbox'
+  captures: readonly string[] = ['nvidia-smi']
+  readonly runsLines = true
+  script?: RouteScript
+  lines: [string, Uint8Array | null, string][] = []
+  attach(): void {
+    // wiring is a no-op for the fake
+  }
+  run(_args: RunArgs): Promise<RunResult> {
+    return Promise.reject(new Error('runLine runtimes never get single stages'))
+  }
+  runLine(
+    line: string,
+    stdin: Uint8Array | null,
+    _env: Record<string, string>,
+    cwd: string,
+  ): Promise<RunResult> {
+    this.lines.push([line, stdin, cwd])
+    return Promise.resolve({ stdout: ENC.encode(`box:${line}`), stderr: null, exitCode: 0 })
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+describe('whole-line runtimes', () => {
+  it('a captured command sends the raw line wholesale', async () => {
+    const parser = await getTestParser()
+    const box = new LineBox()
+    const ws = new Workspace(
+      { '/': new RAMResource() },
+      { mode: MountMode.EXEC, shellParser: parser, runtimes: [box, 'vfs'] },
+    )
+    try {
+      const result = await ws.execute('nvidia-smi -L | grep GPU > /out.txt')
+      expect(DEC.decode(result.stdout)).toBe('box:nvidia-smi -L | grep GPU > /out.txt')
+      expect(box.lines[0]?.[0]).toBe('nvidia-smi -L | grep GPU > /out.txt')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('a "*" capture claims any line and stdin arrives', async () => {
+    const parser = await getTestParser()
+    const box = new LineBox()
+    box.captures = ['*']
+    const ws = new Workspace(
+      { '/': new RAMResource() },
+      { mode: MountMode.EXEC, shellParser: parser, runtimes: [box, 'vfs'] },
+    )
+    try {
+      const result = await ws.execute('ls / && echo done', { stdin: ENC.encode('fed') })
+      expect(DEC.decode(result.stdout)).toBe('box:ls / && echo done')
+      expect(DEC.decode(box.lines[0]?.[1] ?? new Uint8Array())).toBe('fed')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('a refused line falls to the workspace, never 126', async () => {
+    const parser = await getTestParser()
+    const box = new LineBox()
+    box.captures = ['*']
+    box.script = (ctx) => !ctx.line.includes('keep-out')
+    const ws = new Workspace(
+      { '/': new RAMResource() },
+      { mode: MountMode.EXEC, shellParser: parser, runtimes: [box, 'vfs'] },
+    )
+    try {
+      const taken = await ws.execute('echo captured')
+      const kept = await ws.execute('echo keep-out')
+      expect(DEC.decode(taken.stdout)).toBe('box:echo captured')
+      expect(DEC.decode(kept.stdout)).toBe('keep-out\n')
+      expect(kept.exitCode).toBe(0)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('the runtime argument places the whole line', async () => {
+    const parser = await getTestParser()
+    const box = new LineBox()
+    box.captures = ['*']
+    box.script = () => false
+    const ws = new Workspace(
+      { '/': new RAMResource() },
+      { mode: MountMode.EXEC, shellParser: parser, runtimes: [box, 'vfs'] },
+    )
+    try {
+      const refused = await ws.execute('echo hi')
+      const forced = await ws.execute('echo hi', { runtime: 'sandbox' })
+      expect(DEC.decode(refused.stdout)).toBe('hi\n')
+      expect(DEC.decode(forced.stdout)).toBe('box:echo hi')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it("the vfs runtime's runLine is the workspace executor", async () => {
+    const parser = await getTestParser()
+    const vfs = new VfsRuntime()
+    const ws = new Workspace(
+      { '/': new RAMResource() },
+      { mode: MountMode.EXEC, shellParser: parser, runtimes: ['pyodide', vfs] },
+    )
+    try {
+      const result = await vfs.runLine('echo through-vfs', null, {}, '/')
+      expect(DEC.decode(result.stdout)).toBe('through-vfs\n')
+      expect(result.exitCode).toBe(0)
+    } finally {
+      await ws.close()
+    }
+  })
+})

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -74,10 +74,12 @@ import {
   catchAll,
   runtimeBindingsFor,
   scriptStringError,
+  wholeLineRuntime,
   DEFAULT_ENTRIES,
   VfsRuntime,
   type Runtime,
   type RuntimeEntry,
+  type RunResult,
 } from './executor/runtime.ts'
 import { buildRuntime } from './executor/runtime_table.ts'
 import type { PythonReplRunResult } from './executor/python/types.ts'
@@ -345,6 +347,11 @@ export class Workspace {
     }
     this.registry.vfsRuntime =
       this.runtimeEntries.find((entry) => entry instanceof VfsRuntime) ?? null
+    if (this.registry.vfsRuntime instanceof VfsRuntime) {
+      this.registry.vfsRuntime.bindLineExecutor((line, lineStdin, env, cwd) =>
+        this.executeLineForVfs(line, lineStdin, env, cwd),
+      )
+    }
     for (const entry of this.runtimeEntries) {
       if (typeof entry.script === 'string')
         throw scriptStringError(`runtime '${entry.name}' script`)
@@ -464,6 +471,46 @@ export class Workspace {
    * so dispatch falls to the static bindings; a nested eval inherits
    * the typed line's decision and never re-routes.
    */
+  /**
+   * The runtime taking this whole line, null for the executor.
+   *
+   * A runtime with runsLines takes the raw line when the line's
+   * resolved bindings place one of its commands (or "*") on it;
+   * everything else walks the executor's tree as today. The common
+   * world has no such runtime, so this is a cheap scan.
+   */
+  private wholeLineRuntimeFor(
+    rootNode: TSNodeLike,
+    decision: RoutingDecision | null,
+  ): Runtime | null {
+    const candidates = this.runtimeEntries.some(
+      (entry) => entry.runsLines === true && !(entry instanceof VfsRuntime),
+    )
+    if (!candidates) return null
+    const bindings: Record<string, Runtime | null> =
+      decision !== null ? decision.bindings : this.runtimeBindings
+    const facts = commandFacts(rootNode)
+    return wholeLineRuntime(
+      bindings,
+      facts.map((fact) => fact.command),
+    )
+  }
+
+  /** The workspace executor as the vfs runtime's runLine. */
+  private async executeLineForVfs(
+    line: string,
+    stdin: Uint8Array | null,
+    env: Record<string, string>,
+    cwd: string,
+  ): Promise<RunResult> {
+    const result = await this.execute(line, { stdin, cwd, env })
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr.length > 0 ? result.stderr : null,
+      exitCode: result.exitCode,
+    }
+  }
+
   private async resolveRoutingDecision(
     root: TSNodeLike,
     command: string,
@@ -1131,6 +1178,33 @@ export class Workspace {
     // with record:false: no new recording scope, so their ops land in the
     // caller's recorder, and no command entry is logged for them.
     const isLine = options.record !== false
+    const lineRuntime = this.wholeLineRuntimeFor(rootNode, deps.routingDecision ?? null)
+    if (lineRuntime?.runLine !== undefined) {
+      const data = stdin !== null ? await materialize(stdin) : null
+      const result = await lineRuntime.runLine(
+        command,
+        data,
+        { ...effectiveSession.env },
+        effectiveSession.cwd,
+      )
+      targetSession.lastExitCode = result.exitCode
+      if (isLine) {
+        const lineIo = new IOResult({
+          exitCode: result.exitCode,
+          stdout: result.stdout,
+          ...(result.stderr !== null ? { stderr: result.stderr } : {}),
+        })
+        await this.observer.logExecution(
+          command,
+          lineIo,
+          [],
+          callAgentId,
+          targetSession.sessionId,
+          effectiveSession.cwd,
+        )
+      }
+      return new ExecuteResult(result.stdout, result.stderr ?? new Uint8Array(), result.exitCode)
+    }
     const runBody = (): Promise<[ByteSource | null, IOResult, ExecutionNode]> =>
       runWithSession(effectiveSession, () =>
         runCommandTree(deps, rootNode, effectiveSession, stdin),


### PR DESCRIPTION
Both languages, the next leg after #547.

**run_line.** `Runtime.run_line(line, stdin, env, cwd)` plus a `runs_lines` flag. A runtime with it executes whole lines: the raw typed line lands there wholesale and the runtime owns pipes, redirects, and every command in it (its own cat, its own grep); the workspace shell never splits the line. Interpreter runtimes (monty, pyodide, quickjs) are untouched: they stay the per-stage engine inside python3/node on workspace-run lines.

**Placement.** A line goes to a runs_lines runtime when the line's resolved bindings place one of its commands there, or the runtime captures `"*"` (any line). Specific captures beat `"*"`. The whole ladder composes unchanged: a script refusal falls back to the workspace shell (never a spurious 126), `runtime=` forces placement, route verdicts overlay. `execute` short-circuits before the tree walk; history still records the command event.

**Vfs closes the loop.** `VfsRuntime.run_line` is now real, wired to the workspace executor at construction: every line runs on exactly one runtime's run_line, and the workspace shell is what the vfs runtime's happens to be. `run()` still raises: vfs has no single-command interpreter.

Verified: python full suite green, mypy clean; TS typecheck all packages, core/node/server suites green; integ battery gains whole_line capture / uncaptured / star / refused cases in both languages; pre-commit clean.
