### PR TITLE
test(integ): gapps target for native gdocs/gsheets/gslides, fix rm and clear_cache

### DIFF
--- a/integ/fixtures/google-apps/v1.json
+++ b/integ/fixtures/google-apps/v1.json
@@ -1,0 +1,5 @@
+[
+  {"kind": "doc", "name": "Q1 Plan", "text": "hello gdoc"},
+  {"kind": "sheet", "name": "Metrics", "rows": [["region", "revenue"], ["emea", "120"]]},
+  {"kind": "slide", "name": "Launch Deck"}
+]

--- a/integ/resources/google.json
+++ b/integ/resources/google.json
@@ -1,494 +1,746 @@
 {
-  "cases": [
-    {
-      "id": "g_doc_create",
-      "seq": 500000,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws docs documents create --json '{\"title\": \"Notes\"}'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"documentId\":\"doc0001\",\"title\":\"Notes\",\"body\":{\"content\":[{\"startIndex\":1,\"endIndex\":1,\"sectionBreak\":{\"sectionStyle\":{\"columnSeparatorStyle\":\"NONE\",\"contentDirection\":\"LEFT_TO_RIGHT\",\"sectionType\":\"CONTINUOUS\"}}},{\"startIndex\":1,\"endIndex\":2,\"paragraph\":{\"elements\":[{\"startIndex\":1,\"endIndex\":2,\"textRun\":{\"content\":\"\\n\",\"textStyle\":{}}}],\"paragraphStyle\":{\"namedStyleType\":\"NORMAL_TEXT\",\"direction\":\"LEFT_TO_RIGHT\"}}}]},\"revisionId\":\"rev-0\"}",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_doc_write",
-      "seq": 500001,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws docs +write --document doc0001 --text 'hello gdoc'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"documentId\":\"doc0001\",\"replies\":[{}]}",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_doc_get",
-      "seq": 500002,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws docs documents get --params '{\"documentId\": \"doc0001\"}'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"documentId\":\"doc0001\",\"title\":\"Notes\",\"body\":{\"content\":[{\"startIndex\":1,\"endIndex\":1,\"sectionBreak\":{\"sectionStyle\":{\"columnSeparatorStyle\":\"NONE\",\"contentDirection\":\"LEFT_TO_RIGHT\",\"sectionType\":\"CONTINUOUS\"}}},{\"startIndex\":1,\"endIndex\":12,\"paragraph\":{\"elements\":[{\"startIndex\":1,\"endIndex\":12,\"textRun\":{\"content\":\"hello gdoc\\n\",\"textStyle\":{}}}],\"paragraphStyle\":{\"namedStyleType\":\"NORMAL_TEXT\",\"direction\":\"LEFT_TO_RIGHT\"}}}]},\"revisionId\":\"rev-0\"}",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_doc_replace",
-      "seq": 500003,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws docs documents batchUpdate --params '{\"documentId\": \"doc0001\"}' --json '{\"requests\": [{\"replaceAllText\": {\"containsText\": {\"text\": \"hello\"}, \"replaceText\": \"HELLO\"}}]}'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"documentId\":\"doc0001\",\"replies\":[{\"replaceAllText\":{\"occurrencesChanged\":1}}]}",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_doc_export",
-      "seq": 500004,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws drive files export --params '{\"fileId\": \"doc0001\", \"mimeType\": \"text/plain\"}'",
-      "expect": {
-        "exit": 0,
-        "stdout": "HELLO gdoc",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_native_in_listing",
-      "seq": 500005,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws drive files create --json '{\"name\": \"Plan\", \"mimeType\": \"application/vnd.google-apps.document\", \"parents\": [\"f0001\"]}' > /dev/null && ls /data | grep gdoc",
-      "expect": {
-        "exit": 0,
-        "stdout": "Plan.gdoc.json\n",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_native_cat",
-      "seq": 500006,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "cat /data/Plan.gdoc.json | jq -c '{documentId: (.documentId | length > 0), title, body: (.body.content | length)}'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"documentId\":true,\"title\":\"Plan\",\"body\":2}\n",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_native_gws_parity",
-      "seq": 500007,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "D=$(cat /data/Plan.gdoc.json | jq -r .documentId) && gws docs +write --document $D --text 'from drive' | jq -c '.replies'",
-      "expect": {
-        "exit": 0,
-        "stdout": "[{}]\n",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_native_gws_readback",
-      "seq": 500008,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "cat /data/Plan.gdoc.json | jq -r '.body.content[1].paragraph.elements[0].textRun.content'",
-      "expect": {
-        "exit": 0,
-        "stdout": "from drive\n\n",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_sheet_create",
-      "seq": 500009,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws sheets spreadsheets create --json '{\"properties\": {\"title\": \"Data\"}}'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"spreadsheetId\":\"sheet0001\",\"properties\":{\"title\":\"Data\",\"locale\":\"en_US\",\"timeZone\":\"Etc/UTC\"},\"sheets\":[{\"properties\":{\"sheetId\":0,\"title\":\"Sheet1\",\"index\":0,\"sheetType\":\"GRID\",\"gridProperties\":{\"rowCount\":1000,\"columnCount\":26}}}],\"spreadsheetUrl\":\"https://docs.google.com/spreadsheets/d/sheet0001/edit\"}",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_sheet_append",
-      "seq": 500010,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws sheets +append --spreadsheet sheet0001 --range Sheet1 --values 'a,b,c'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"spreadsheetId\":\"sheet0001\",\"updates\":{\"spreadsheetId\":\"sheet0001\",\"updatedRange\":\"Sheet1!A1:C1\",\"updatedRows\":1,\"updatedColumns\":3,\"updatedCells\":3}}",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_sheet_read",
-      "seq": 500011,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws sheets +read --spreadsheet sheet0001 --range 'Sheet1!A1:C1'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"range\":\"Sheet1!A1:C1\",\"majorDimension\":\"ROWS\",\"values\":[[\"a\",\"b\",\"c\"]]}",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_sheet_get",
-      "seq": 500012,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws sheets spreadsheets get --params '{\"spreadsheetId\": \"sheet0001\"}'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"spreadsheetId\":\"sheet0001\",\"properties\":{\"title\":\"Data\",\"locale\":\"en_US\",\"timeZone\":\"Etc/UTC\"},\"sheets\":[{\"properties\":{\"sheetId\":0,\"title\":\"Sheet1\",\"index\":0,\"sheetType\":\"GRID\",\"gridProperties\":{\"rowCount\":1000,\"columnCount\":26}}}],\"spreadsheetUrl\":\"https://docs.google.com/spreadsheets/d/sheet0001/edit\"}",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_sheet_add_tab",
-      "seq": 500013,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws sheets spreadsheets batchUpdate --params '{\"spreadsheetId\": \"sheet0001\"}' --json '{\"requests\": [{\"addSheet\": {\"properties\": {\"title\": \"Extra\"}}}]}'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"spreadsheetId\":\"sheet0001\",\"replies\":[{\"addSheet\":{\"properties\":{\"sheetId\":1,\"title\":\"Extra\"}}}]}",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_slide_create",
-      "seq": 500014,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws slides presentations create --json '{\"title\": \"Deck\"}'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"presentationId\":\"pres0001\",\"title\":\"Deck\",\"pageSize\":{\"width\":{\"magnitude\":9144000,\"unit\":\"EMU\"},\"height\":{\"magnitude\":6858000,\"unit\":\"EMU\"}},\"slides\":[{\"objectId\":\"slide0001\",\"pageElements\":[]}],\"revisionId\":\"rev-1\"}",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_slide_add",
-      "seq": 500015,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws slides presentations batchUpdate --params '{\"presentationId\": \"pres0001\"}' --json '{\"requests\": [{\"createSlide\": {}}]}' | jq -c '.replies'",
-      "expect": {
-        "exit": 0,
-        "stdout": "[{\"createSlide\":{\"objectId\":\"slide0002\"}}]\n",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_slide_get",
-      "seq": 500016,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws slides presentations get --params '{\"presentationId\": \"pres0001\"}' | jq -c '{presentationId, title, slides: (.slides | length)}'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"presentationId\":\"pres0001\",\"title\":\"Deck\",\"slides\":2}\n",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_perm_create",
-      "seq": 500017,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws drive permissions create --params '{\"fileId\": \"doc0001\"}' --json '{\"role\": \"reader\", \"type\": \"anyone\"}'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"kind\":\"drive#permission\",\"id\":\"perm0001\",\"role\":\"reader\",\"type\":\"anyone\"}",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_perm_list",
-      "seq": 500018,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws drive permissions list --params '{\"fileId\": \"doc0001\"}'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"kind\":\"drive#permissionList\",\"permissions\":[{\"id\":\"perm0001\",\"role\":\"reader\",\"type\":\"anyone\"}]}",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_perm_delete",
-      "seq": 500019,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws drive permissions delete --params '{\"fileId\": \"doc0001\", \"permissionId\": \"perm0001\"}' && echo deleted",
-      "expect": {
-        "exit": 0,
-        "stdout": "deleted\n",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_files_list_q",
-      "seq": 500020,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws drive files list --params \"{\\\"q\\\": \\\"name = 'Notes'\\\"}\" | jq -c '[.files[] | {name, mimeType}]'",
-      "expect": {
-        "exit": 0,
-        "stdout": "{\"name\":\"Notes\",\"mimeType\":\"application/vnd.google-apps.document\"}\n",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_files_update",
-      "seq": 500021,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "F=$(cat /data/Plan.gdoc.json | jq -r .documentId) && gws drive files update --params \"{\\\"fileId\\\": \\\"$F\\\"}\" --json '{\"name\": \"Plan2\"}' > /dev/null && ls /data | grep gdoc",
-      "expect": {
-        "exit": 0,
-        "stdout": "Plan.gdoc.json\n",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_revisions_head",
-      "seq": 500022,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "printf v1 | tee /data/rev.txt > /dev/null && printf v2 | tee /data/rev.txt > /dev/null && F=$(gws drive files list --params \"{\\\"q\\\": \\\"name = 'rev.txt'\\\"}\" | jq -r '.files[0].id') && gws drive files list --params \"{\\\"q\\\": \\\"name = 'rev.txt'\\\"}\" | jq -r '.files[0].headRevisionId' | grep -c \"$F-r2\"",
-      "expect": {
-        "exit": 0,
-        "stdout": "1\n",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_files_delete",
-      "seq": 500023,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "F=$(cat /data/Plan2.gdoc.json | jq -r .documentId) && gws drive files delete --params \"{\\\"fileId\\\": \\\"$F\\\"}\" && ls /data | grep -c gdoc",
-      "expect": {
-        "exit": 0,
-        "stdout": "1\n",
-        "stderr": ""
-      }
-    },
-    {
-      "id": "g_files_get",
-      "seq": 500024,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws drive files get --params '{\"fileId\": \"doc0001\"}' | jq -c '{id, name, mimeType}'",
-      "expect": {
-        "exit": 0,
-        "stderr": "",
-        "stdout": "{\"id\":\"doc0001\",\"name\":\"Notes\",\"mimeType\":\"application/vnd.google-apps.document\"}\n"
-      }
-    },
-    {
-      "id": "g_files_copy",
-      "seq": 500025,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws drive files copy --params '{\"fileId\": \"doc0001\"}' --json '{\"name\": \"Notes copy\"}' | jq -c '{name, mimeType}' && gws drive files list --params \"{\\\"q\\\": \\\"name = 'Notes copy'\\\"}\" | jq -c '[.files[].name]'",
-      "expect": {
-        "exit": 0,
-        "stderr": "",
-        "stdout": "{\"name\":\"Notes copy\",\"mimeType\":\"application/vnd.google-apps.document\"}\n\"Notes copy\"\n"
-      }
-    },
-    {
-      "id": "g_sheet_write",
-      "seq": 500026,
-      "targets": [
-        "gdrive"
-      ],
-      "clear_cache": true,
-      "command": "gws sheets +write --spreadsheet sheet0001 --range 'Sheet1!A2:C2' --values 'x,y,z' > /dev/null && gws sheets +read --spreadsheet sheet0001 --range 'Sheet1!A2:C2'",
-      "expect": {
-        "exit": 0,
-        "stderr": "",
-        "stdout": "{\"range\":\"Sheet1!A2:C2\",\"majorDimension\":\"ROWS\",\"values\":[[\"x\",\"y\",\"z\"]]}"
-      }
-    },
-    {
-      "id": "gsh_seed",
-      "seq": 510000,
-      "targets": [
-        "gdrive-shared"
-      ],
-      "clear_cache": true,
-      "command": "printf 'inside shared drive' | tee /data/note.txt > /dev/null && echo seeded",
-      "expect": {
-        "exit": 0,
-        "stderr": "",
-        "stdout": "seeded\n"
-      }
-    },
-    {
-      "id": "gsh_ls_root",
-      "seq": 510001,
-      "targets": [
-        "gdrive-shared"
-      ],
-      "clear_cache": true,
-      "command": "ls /data",
-      "expect": {
-        "exit": 0,
-        "stderr": "",
-        "stdout": "note.txt\n"
-      }
-    },
-    {
-      "id": "gsh_cat",
-      "seq": 510002,
-      "targets": [
-        "gdrive-shared"
-      ],
-      "clear_cache": true,
-      "command": "cat /data/note.txt",
-      "expect": {
-        "exit": 0,
-        "stderr": "",
-        "stdout": "inside shared drive"
-      }
-    },
-    {
-      "id": "gsh_mkdir_nested",
-      "seq": 510003,
-      "targets": [
-        "gdrive-shared"
-      ],
-      "clear_cache": true,
-      "command": "mkdir -p /data/reports/q1 && printf 'q1 numbers' | tee /data/reports/q1/kpi.txt > /dev/null && find /data -type f | sort",
-      "expect": {
-        "exit": 0,
-        "stderr": "",
-        "stdout": "/data/note.txt\n/data/reports/q1/kpi.txt\n"
-      }
-    },
-    {
-      "id": "gsh_grep_r",
-      "seq": 510004,
-      "targets": [
-        "gdrive-shared"
-      ],
-      "clear_cache": true,
-      "command": "grep -r numbers /data",
-      "expect": {
-        "exit": 0,
-        "stderr": "",
-        "stdout": "/data/reports/q1/kpi.txt:q1 numbers\n"
-      }
-    },
-    {
-      "id": "gsh_mv_rm",
-      "seq": 510005,
-      "targets": [
-        "gdrive-shared"
-      ],
-      "clear_cache": true,
-      "command": "mv /data/note.txt /data/reports/note.txt && rm -r /data/reports && ls /data",
-      "expect": {
-        "exit": 0,
-        "stderr": "",
-        "stdout": ""
-      }
-    },
-    {
-      "id": "gsh_isolation",
-      "seq": 510006,
-      "targets": [
-        "gdrive-shared"
-      ],
-      "clear_cache": true,
-      "command": "printf 'two' | tee /data2/two.txt > /dev/null && ls /data | wc -l && ls /data2",
-      "expect": {
-        "exit": 0,
-        "stderr": "",
-        "stdout": "0\ntwo.txt\n"
-      }
-    },
-    {
-      "id": "gsh_native_create",
-      "seq": 510007,
-      "targets": [
-        "gdrive-shared"
-      ],
-      "clear_cache": true,
-      "command": "D=$(gws drive files create --json '{\"name\": \"Spec\", \"mimeType\": \"application/vnd.google-apps.document\"}' | jq -r .id) && gws docs +write --document $D --text 'shared doc' | jq -c '.replies | length'",
-      "expect": {
-        "exit": 0,
-        "stderr": "",
-        "stdout": "1\n"
-      }
-    }
-  ]
+ "cases": [
+  {
+   "id": "g_doc_create",
+   "seq": 500000,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws docs documents create --json '{\"title\": \"Notes\"}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"documentId\":\"doc0001\",\"title\":\"Notes\",\"body\":{\"content\":[{\"startIndex\":1,\"endIndex\":1,\"sectionBreak\":{\"sectionStyle\":{\"columnSeparatorStyle\":\"NONE\",\"contentDirection\":\"LEFT_TO_RIGHT\",\"sectionType\":\"CONTINUOUS\"}}},{\"startIndex\":1,\"endIndex\":2,\"paragraph\":{\"elements\":[{\"startIndex\":1,\"endIndex\":2,\"textRun\":{\"content\":\"\\n\",\"textStyle\":{}}}],\"paragraphStyle\":{\"namedStyleType\":\"NORMAL_TEXT\",\"direction\":\"LEFT_TO_RIGHT\"}}}]},\"revisionId\":\"rev-0\"}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_doc_write",
+   "seq": 500001,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws docs +write --document doc0001 --text 'hello gdoc'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"documentId\":\"doc0001\",\"replies\":[{}]}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_doc_get",
+   "seq": 500002,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws docs documents get --params '{\"documentId\": \"doc0001\"}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"documentId\":\"doc0001\",\"title\":\"Notes\",\"body\":{\"content\":[{\"startIndex\":1,\"endIndex\":1,\"sectionBreak\":{\"sectionStyle\":{\"columnSeparatorStyle\":\"NONE\",\"contentDirection\":\"LEFT_TO_RIGHT\",\"sectionType\":\"CONTINUOUS\"}}},{\"startIndex\":1,\"endIndex\":12,\"paragraph\":{\"elements\":[{\"startIndex\":1,\"endIndex\":12,\"textRun\":{\"content\":\"hello gdoc\\n\",\"textStyle\":{}}}],\"paragraphStyle\":{\"namedStyleType\":\"NORMAL_TEXT\",\"direction\":\"LEFT_TO_RIGHT\"}}}]},\"revisionId\":\"rev-0\"}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_doc_replace",
+   "seq": 500003,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws docs documents batchUpdate --params '{\"documentId\": \"doc0001\"}' --json '{\"requests\": [{\"replaceAllText\": {\"containsText\": {\"text\": \"hello\"}, \"replaceText\": \"HELLO\"}}]}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"documentId\":\"doc0001\",\"replies\":[{\"replaceAllText\":{\"occurrencesChanged\":1}}]}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_doc_export",
+   "seq": 500004,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws drive files export --params '{\"fileId\": \"doc0001\", \"mimeType\": \"text/plain\"}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "HELLO gdoc",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_native_in_listing",
+   "seq": 500005,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws drive files create --json '{\"name\": \"Plan\", \"mimeType\": \"application/vnd.google-apps.document\", \"parents\": [\"f0001\"]}' > /dev/null && ls /data | grep gdoc",
+   "expect": {
+    "exit": 0,
+    "stdout": "Plan.gdoc.json\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_native_cat",
+   "seq": 500006,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "cat /data/Plan.gdoc.json | jq -c '{documentId: (.documentId | length > 0), title, body: (.body.content | length)}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"documentId\":true,\"title\":\"Plan\",\"body\":2}\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_native_gws_parity",
+   "seq": 500007,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "D=$(cat /data/Plan.gdoc.json | jq -r .documentId) && gws docs +write --document $D --text 'from drive' | jq -c '.replies'",
+   "expect": {
+    "exit": 0,
+    "stdout": "[{}]\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_native_gws_readback",
+   "seq": 500008,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "cat /data/Plan.gdoc.json | jq -r '.body.content[1].paragraph.elements[0].textRun.content'",
+   "expect": {
+    "exit": 0,
+    "stdout": "from drive\n\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_sheet_create",
+   "seq": 500009,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws sheets spreadsheets create --json '{\"properties\": {\"title\": \"Data\"}}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"spreadsheetId\":\"sheet0001\",\"properties\":{\"title\":\"Data\",\"locale\":\"en_US\",\"timeZone\":\"Etc/UTC\"},\"sheets\":[{\"properties\":{\"sheetId\":0,\"title\":\"Sheet1\",\"index\":0,\"sheetType\":\"GRID\",\"gridProperties\":{\"rowCount\":1000,\"columnCount\":26}}}],\"spreadsheetUrl\":\"https://docs.google.com/spreadsheets/d/sheet0001/edit\"}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_sheet_append",
+   "seq": 500010,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws sheets +append --spreadsheet sheet0001 --range Sheet1 --values 'a,b,c'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"spreadsheetId\":\"sheet0001\",\"updates\":{\"spreadsheetId\":\"sheet0001\",\"updatedRange\":\"Sheet1!A1:C1\",\"updatedRows\":1,\"updatedColumns\":3,\"updatedCells\":3}}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_sheet_read",
+   "seq": 500011,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws sheets +read --spreadsheet sheet0001 --range 'Sheet1!A1:C1'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"range\":\"Sheet1!A1:C1\",\"majorDimension\":\"ROWS\",\"values\":[[\"a\",\"b\",\"c\"]]}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_sheet_get",
+   "seq": 500012,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws sheets spreadsheets get --params '{\"spreadsheetId\": \"sheet0001\"}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"spreadsheetId\":\"sheet0001\",\"properties\":{\"title\":\"Data\",\"locale\":\"en_US\",\"timeZone\":\"Etc/UTC\"},\"sheets\":[{\"properties\":{\"sheetId\":0,\"title\":\"Sheet1\",\"index\":0,\"sheetType\":\"GRID\",\"gridProperties\":{\"rowCount\":1000,\"columnCount\":26}}}],\"spreadsheetUrl\":\"https://docs.google.com/spreadsheets/d/sheet0001/edit\"}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_sheet_add_tab",
+   "seq": 500013,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws sheets spreadsheets batchUpdate --params '{\"spreadsheetId\": \"sheet0001\"}' --json '{\"requests\": [{\"addSheet\": {\"properties\": {\"title\": \"Extra\"}}}]}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"spreadsheetId\":\"sheet0001\",\"replies\":[{\"addSheet\":{\"properties\":{\"sheetId\":1,\"title\":\"Extra\"}}}]}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_slide_create",
+   "seq": 500014,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws slides presentations create --json '{\"title\": \"Deck\"}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"presentationId\":\"pres0001\",\"title\":\"Deck\",\"pageSize\":{\"width\":{\"magnitude\":9144000,\"unit\":\"EMU\"},\"height\":{\"magnitude\":6858000,\"unit\":\"EMU\"}},\"slides\":[{\"objectId\":\"slide0001\",\"pageElements\":[]}],\"revisionId\":\"rev-1\"}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_slide_add",
+   "seq": 500015,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws slides presentations batchUpdate --params '{\"presentationId\": \"pres0001\"}' --json '{\"requests\": [{\"createSlide\": {}}]}' | jq -c '.replies'",
+   "expect": {
+    "exit": 0,
+    "stdout": "[{\"createSlide\":{\"objectId\":\"slide0002\"}}]\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_slide_get",
+   "seq": 500016,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws slides presentations get --params '{\"presentationId\": \"pres0001\"}' | jq -c '{presentationId, title, slides: (.slides | length)}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"presentationId\":\"pres0001\",\"title\":\"Deck\",\"slides\":2}\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_perm_create",
+   "seq": 500017,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws drive permissions create --params '{\"fileId\": \"doc0001\"}' --json '{\"role\": \"reader\", \"type\": \"anyone\"}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"kind\":\"drive#permission\",\"id\":\"perm0001\",\"role\":\"reader\",\"type\":\"anyone\"}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_perm_list",
+   "seq": 500018,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws drive permissions list --params '{\"fileId\": \"doc0001\"}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"kind\":\"drive#permissionList\",\"permissions\":[{\"id\":\"perm0001\",\"role\":\"reader\",\"type\":\"anyone\"}]}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_perm_delete",
+   "seq": 500019,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws drive permissions delete --params '{\"fileId\": \"doc0001\", \"permissionId\": \"perm0001\"}' && echo deleted",
+   "expect": {
+    "exit": 0,
+    "stdout": "deleted\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_files_list_q",
+   "seq": 500020,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws drive files list --params \"{\\\"q\\\": \\\"name = 'Notes'\\\"}\" | jq -c '[.files[] | {name, mimeType}]'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"name\":\"Notes\",\"mimeType\":\"application/vnd.google-apps.document\"}\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_files_update",
+   "seq": 500021,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "F=$(cat /data/Plan.gdoc.json | jq -r .documentId) && gws drive files update --params \"{\\\"fileId\\\": \\\"$F\\\"}\" --json '{\"name\": \"Plan2\"}' > /dev/null && ls /data | grep gdoc",
+   "expect": {
+    "exit": 0,
+    "stdout": "Plan.gdoc.json\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_revisions_head",
+   "seq": 500022,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "printf v1 | tee /data/rev.txt > /dev/null && printf v2 | tee /data/rev.txt > /dev/null && F=$(gws drive files list --params \"{\\\"q\\\": \\\"name = 'rev.txt'\\\"}\" | jq -r '.files[0].id') && gws drive files list --params \"{\\\"q\\\": \\\"name = 'rev.txt'\\\"}\" | jq -r '.files[0].headRevisionId' | grep -c \"$F-r2\"",
+   "expect": {
+    "exit": 0,
+    "stdout": "1\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_files_delete",
+   "seq": 500023,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "F=$(cat /data/Plan2.gdoc.json | jq -r .documentId) && gws drive files delete --params \"{\\\"fileId\\\": \\\"$F\\\"}\" && ls /data | grep -c gdoc",
+   "expect": {
+    "exit": 0,
+    "stdout": "1\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_files_get",
+   "seq": 500024,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws drive files get --params '{\"fileId\": \"doc0001\"}' | jq -c '{id, name, mimeType}'",
+   "expect": {
+    "exit": 0,
+    "stderr": "",
+    "stdout": "{\"id\":\"doc0001\",\"name\":\"Notes\",\"mimeType\":\"application/vnd.google-apps.document\"}\n"
+   }
+  },
+  {
+   "id": "g_files_copy",
+   "seq": 500025,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws drive files copy --params '{\"fileId\": \"doc0001\"}' --json '{\"name\": \"Notes copy\"}' | jq -c '{name, mimeType}' && gws drive files list --params \"{\\\"q\\\": \\\"name = 'Notes copy'\\\"}\" | jq -c '[.files[].name]'",
+   "expect": {
+    "exit": 0,
+    "stderr": "",
+    "stdout": "{\"name\":\"Notes copy\",\"mimeType\":\"application/vnd.google-apps.document\"}\n\"Notes copy\"\n"
+   }
+  },
+  {
+   "id": "g_sheet_write",
+   "seq": 500026,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws sheets +write --spreadsheet sheet0001 --range 'Sheet1!A2:C2' --values 'x,y,z' > /dev/null && gws sheets +read --spreadsheet sheet0001 --range 'Sheet1!A2:C2'",
+   "expect": {
+    "exit": 0,
+    "stderr": "",
+    "stdout": "{\"range\":\"Sheet1!A2:C2\",\"majorDimension\":\"ROWS\",\"values\":[[\"x\",\"y\",\"z\"]]}"
+   }
+  },
+  {
+   "id": "gsh_seed",
+   "seq": 510000,
+   "targets": [
+    "gdrive-shared"
+   ],
+   "clear_cache": true,
+   "command": "printf 'inside shared drive' | tee /data/note.txt > /dev/null && echo seeded",
+   "expect": {
+    "exit": 0,
+    "stderr": "",
+    "stdout": "seeded\n"
+   }
+  },
+  {
+   "id": "gsh_ls_root",
+   "seq": 510001,
+   "targets": [
+    "gdrive-shared"
+   ],
+   "clear_cache": true,
+   "command": "ls /data",
+   "expect": {
+    "exit": 0,
+    "stderr": "",
+    "stdout": "note.txt\n"
+   }
+  },
+  {
+   "id": "gsh_cat",
+   "seq": 510002,
+   "targets": [
+    "gdrive-shared"
+   ],
+   "clear_cache": true,
+   "command": "cat /data/note.txt",
+   "expect": {
+    "exit": 0,
+    "stderr": "",
+    "stdout": "inside shared drive"
+   }
+  },
+  {
+   "id": "gsh_mkdir_nested",
+   "seq": 510003,
+   "targets": [
+    "gdrive-shared"
+   ],
+   "clear_cache": true,
+   "command": "mkdir -p /data/reports/q1 && printf 'q1 numbers' | tee /data/reports/q1/kpi.txt > /dev/null && find /data -type f | sort",
+   "expect": {
+    "exit": 0,
+    "stderr": "",
+    "stdout": "/data/note.txt\n/data/reports/q1/kpi.txt\n"
+   }
+  },
+  {
+   "id": "gsh_grep_r",
+   "seq": 510004,
+   "targets": [
+    "gdrive-shared"
+   ],
+   "clear_cache": true,
+   "command": "grep -r numbers /data",
+   "expect": {
+    "exit": 0,
+    "stderr": "",
+    "stdout": "/data/reports/q1/kpi.txt:q1 numbers\n"
+   }
+  },
+  {
+   "id": "gsh_mv_rm",
+   "seq": 510005,
+   "targets": [
+    "gdrive-shared"
+   ],
+   "clear_cache": true,
+   "command": "mv /data/note.txt /data/reports/note.txt && rm -r /data/reports && ls /data",
+   "expect": {
+    "exit": 0,
+    "stderr": "",
+    "stdout": ""
+   }
+  },
+  {
+   "id": "gsh_isolation",
+   "seq": 510006,
+   "targets": [
+    "gdrive-shared"
+   ],
+   "clear_cache": true,
+   "command": "printf 'two' | tee /data2/two.txt > /dev/null && ls /data | wc -l && ls /data2",
+   "expect": {
+    "exit": 0,
+    "stderr": "",
+    "stdout": "0\ntwo.txt\n"
+   }
+  },
+  {
+   "id": "gsh_native_create",
+   "seq": 510007,
+   "targets": [
+    "gdrive-shared"
+   ],
+   "clear_cache": true,
+   "command": "D=$(gws drive files create --json '{\"name\": \"Spec\", \"mimeType\": \"application/vnd.google-apps.document\"}' | jq -r .id) && gws docs +write --document $D --text 'shared doc' | jq -c '.replies | length'",
+   "expect": {
+    "exit": 0,
+    "stderr": "",
+    "stdout": "1\n"
+   }
+  },
+  {
+   "id": "g_native_sheet_in_listing",
+   "seq": 501000,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws drive files create --json '{\"name\": \"Board\", \"mimeType\": \"application/vnd.google-apps.spreadsheet\", \"parents\": [\"f0001\"]}' > /dev/null && ls /data | grep gsheet",
+   "expect": {
+    "exit": 0,
+    "stdout": "Board.gsheet.json\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_native_sheet_values",
+   "seq": 501001,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "S=$(cat /data/Board.gsheet.json | jq -r .spreadsheetId) && gws sheets +append --spreadsheet $S --range Sheet1 --values 'x,y' > /dev/null && gws sheets +read --spreadsheet $S --range 'Sheet1!A1:B1'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"range\":\"Sheet1!A1:B1\",\"majorDimension\":\"ROWS\",\"values\":[[\"x\",\"y\"]]}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_native_slide_in_listing",
+   "seq": 501002,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "gws drive files create --json '{\"name\": \"Deck\", \"mimeType\": \"application/vnd.google-apps.presentation\", \"parents\": [\"f0001\"]}' > /dev/null && ls /data | grep gslide",
+   "expect": {
+    "exit": 0,
+    "stdout": "Deck.gslide.json\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "g_native_slide_cat",
+   "seq": 501003,
+   "targets": [
+    "gdrive"
+   ],
+   "clear_cache": true,
+   "command": "cat /data/Deck.gslide.json | jq -c '{presentationId: (.presentationId | length > 0), title, slides: (.slides | length)}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"presentationId\":true,\"title\":\"Deck\",\"slides\":1}\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "gapp_docs_root",
+   "seq": 520000,
+   "targets": [
+    "gapps"
+   ],
+   "clear_cache": true,
+   "command": "ls /docs",
+   "expect": {
+    "exit": 0,
+    "stdout": "owned\nshared\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "gapp_docs_ls",
+   "seq": 520001,
+   "targets": [
+    "gapps"
+   ],
+   "clear_cache": true,
+   "command": "ls /docs/owned",
+   "expect": {
+    "exit": 0,
+    "stdout": "2026-01-01_Q1_Plan__doc0001.gdoc.json\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "gapp_docs_cat",
+   "seq": 520002,
+   "targets": [
+    "gapps"
+   ],
+   "clear_cache": true,
+   "command": "cat /docs/owned/2026-01-01_Q1_Plan__doc0001.gdoc.json | jq -c '{documentId, title}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"documentId\":\"doc0001\",\"title\":\"Q1 Plan\"}\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "gapp_docs_update",
+   "seq": 520003,
+   "targets": [
+    "gapps"
+   ],
+   "clear_cache": true,
+   "command": "D=$(cat /docs/owned/*.gdoc.json | jq -r .documentId) && gws docs documents batchUpdate --params \"{\\\"documentId\\\": \\\"$D\\\"}\" --json '{\"requests\": [{\"replaceAllText\": {\"containsText\": {\"text\": \"hello\"}, \"replaceText\": \"HELLO\"}}]}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"documentId\":\"doc0001\",\"replies\":[{\"replaceAllText\":{\"occurrencesChanged\":1}}]}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "gapp_docs_readback",
+   "seq": 520004,
+   "targets": [
+    "gapps"
+   ],
+   "clear_cache": true,
+   "command": "cat /docs/owned/*.gdoc.json | jq -r '.body.content[1].paragraph.elements[0].textRun.content'",
+   "expect": {
+    "exit": 0,
+    "stdout": "HELLO gdoc\n\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "gapp_sheets_ls",
+   "seq": 520005,
+   "targets": [
+    "gapps"
+   ],
+   "clear_cache": true,
+   "command": "ls /sheets/owned",
+   "expect": {
+    "exit": 0,
+    "stdout": "2026-01-01_Metrics__sheet0001.gsheet.json\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "gapp_sheets_cat",
+   "seq": 520006,
+   "targets": [
+    "gapps"
+   ],
+   "clear_cache": true,
+   "command": "cat /sheets/owned/*.gsheet.json | jq -c '{spreadsheetId, title: .properties.title}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"spreadsheetId\":\"sheet0001\",\"title\":\"Metrics\"}\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "gapp_sheets_read",
+   "seq": 520007,
+   "targets": [
+    "gapps"
+   ],
+   "clear_cache": true,
+   "command": "S=$(cat /sheets/owned/*.gsheet.json | jq -r .spreadsheetId) && gws sheets +read --spreadsheet $S --range 'Sheet1!A1:B2'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"range\":\"Sheet1!A1:B2\",\"majorDimension\":\"ROWS\",\"values\":[[\"region\",\"revenue\"],[\"emea\",\"120\"]]}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "gapp_sheets_append",
+   "seq": 520008,
+   "targets": [
+    "gapps"
+   ],
+   "clear_cache": true,
+   "command": "S=$(cat /sheets/owned/*.gsheet.json | jq -r .spreadsheetId) && gws sheets +append --spreadsheet $S --range Sheet1 --values 'apac,90' > /dev/null && gws sheets +read --spreadsheet $S --range 'Sheet1!A3:B3'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"range\":\"Sheet1!A3:B3\",\"majorDimension\":\"ROWS\",\"values\":[[\"apac\",\"90\"]]}",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "gapp_slides_ls",
+   "seq": 520009,
+   "targets": [
+    "gapps"
+   ],
+   "clear_cache": true,
+   "command": "ls /slides/owned",
+   "expect": {
+    "exit": 0,
+    "stdout": "2026-01-01_Launch_Deck__pres0001.gslide.json\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "gapp_slides_cat",
+   "seq": 520010,
+   "targets": [
+    "gapps"
+   ],
+   "clear_cache": true,
+   "command": "cat /slides/owned/*.gslide.json | jq -c '{presentationId, title, slides: (.slides | length)}'",
+   "expect": {
+    "exit": 0,
+    "stdout": "{\"presentationId\":\"pres0001\",\"title\":\"Launch Deck\",\"slides\":1}\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "gapp_slides_update",
+   "seq": 520011,
+   "targets": [
+    "gapps"
+   ],
+   "clear_cache": true,
+   "command": "P=$(cat /slides/owned/*.gslide.json | jq -r .presentationId) && gws slides presentations batchUpdate --params \"{\\\"presentationId\\\": \\\"$P\\\"}\" --json '{\"requests\": [{\"createSlide\": {}}]}' | jq -c .replies",
+   "expect": {
+    "exit": 0,
+    "stdout": "[{\"createSlide\":{\"objectId\":\"slide0002\"}}]\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "gapp_rm",
+   "seq": 520013,
+   "targets": [
+    "gapps"
+   ],
+   "clear_cache": true,
+   "command": "rm /slides/owned/*.gslide.json && ls /slides/owned | wc -l",
+   "expect": {
+    "exit": 0,
+    "stdout": "0\n",
+    "stderr": ""
+   }
+  },
+  {
+   "id": "gapp_slides_readback",
+   "seq": 520012,
+   "targets": [
+    "gapps"
+   ],
+   "clear_cache": true,
+   "command": "cat /slides/owned/*.gslide.json | jq -c '.slides | length'",
+   "expect": {
+    "exit": 0,
+    "stdout": "2\n",
+    "stderr": ""
+   }
+  }
+ ]
 }

--- a/integ/runners/parity.py
+++ b/integ/runners/parity.py
@@ -23,7 +23,7 @@ INTEG = Path(__file__).resolve().parents[1]
 SHARED_TARGETS = ["ram", "disk", "redis"]
 S3_TARGETS = ["s3", "s3-prefix"]
 SSH_TARGETS = ["ssh"]
-GDRIVE_TARGETS = ["gdrive", "gdrive-folder", "gdrive-shared"]
+GDRIVE_TARGETS = ["gdrive", "gdrive-folder", "gdrive-shared", "gapps"]
 
 
 def load(path: str) -> dict[tuple[str, str], dict]:

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import importlib.util
+import json
 import logging
 import os
 import shutil
@@ -31,8 +32,14 @@ from mirage.accessor.onedrive import OneDriveConfig
 from mirage.accessor.sharepoint import SharePointConfig
 from mirage.core.sharepoint import _resolver as sharepoint_resolver
 from mirage.resource.disk import DiskResource
+from mirage.resource.gdocs.config import GDocsConfig
+from mirage.resource.gdocs.gdocs import GDocsResource
 from mirage.resource.gdrive.config import GoogleDriveConfig
 from mirage.resource.gdrive.gdrive import GoogleDriveResource
+from mirage.resource.gsheets.config import GSheetsConfig
+from mirage.resource.gsheets.gsheets import GSheetsResource
+from mirage.resource.gslides.config import GSlidesConfig
+from mirage.resource.gslides.gslides import GSlidesResource
 from mirage.resource.hf_buckets import HfBucketsConfig, HfBucketsResource
 from mirage.resource.nextcloud import NextcloudConfig, NextcloudResource
 from mirage.resource.onedrive.onedrive import OneDriveResource
@@ -250,10 +257,16 @@ class GwsService:
         url = os.environ["GWS_URL"].rstrip("/")
         folder_ids: dict[str, str] = {}
         drive_ids: dict[str, str] = {}
+        # Native mounts (gdocs/gsheets/gslides) render the modified date
+        # into filenames, so those targets pin the server clock.
+        epoch = target.get("epoch")
+        reset_body = {"epoch": epoch} if epoch else {}
         async with aiohttp.ClientSession() as session:
-            async with session.post(f"{url}/reset") as resp:
+            async with session.post(f"{url}/reset", json=reset_body) as resp:
                 resp.raise_for_status()
             for mount in target["mounts"]:
+                if "root" not in mount:
+                    continue
                 # A mount may live inside a Shared Drive: the drive is
                 # created once per name and its id is the walk's start.
                 drive = mount.get("drive")
@@ -266,7 +279,57 @@ class GwsService:
                 for segment in str(mount["root"]).split("/"):
                     parent = await cls._folder(session, url, segment, parent)
                 folder_ids[mount["path"]] = parent
+            apps = target.get("apps")
+            if apps:
+                manifest = Path(__file__).resolve(
+                ).parents[2] / "fixtures" / f"{apps}.json"
+                await cls._seed_apps(session, url,
+                                     json.loads(manifest.read_text()))
         return cls(url, folder_ids)
+
+    @staticmethod
+    async def _seed_apps(session: aiohttp.ClientSession, url: str,
+                         entries: list[dict]) -> None:
+        # Native files are API objects, not byte blobs, so they seed through
+        # the same editor APIs the backends speak instead of fixture uploads.
+        for entry in entries:
+            kind = entry["kind"]
+            if kind == "doc":
+                async with session.post(f"{url}/v1/documents",
+                                        json={"title": entry["name"]}) as resp:
+                    resp.raise_for_status()
+                    doc_id = (await resp.json())["documentId"]
+                requests = [{
+                    "insertText": {
+                        "location": {
+                            "index": 1
+                        },
+                        "text": entry["text"],
+                    }
+                }]
+                async with session.post(
+                        f"{url}/v1/documents/{doc_id}:batchUpdate",
+                        json={"requests": requests}) as resp:
+                    resp.raise_for_status()
+            elif kind == "sheet":
+                async with session.post(
+                        f"{url}/v4/spreadsheets",
+                        json={"properties": {
+                            "title": entry["name"]
+                        }}) as resp:
+                    resp.raise_for_status()
+                    sheet_id = (await resp.json())["spreadsheetId"]
+                async with session.post(
+                        f"{url}/v4/spreadsheets/{sheet_id}"
+                        "/values/Sheet1:append",
+                        json={"values": entry["rows"]}) as resp:
+                    resp.raise_for_status()
+            elif kind == "slide":
+                async with session.post(f"{url}/v1/presentations",
+                                        json={"title": entry["name"]}) as resp:
+                    resp.raise_for_status()
+            else:
+                raise ValueError(f"unknown google-apps kind: {kind}")
 
     @staticmethod
     async def _folder(session: aiohttp.ClientSession, url: str, name: str,
@@ -294,6 +357,24 @@ class GwsService:
                               refresh_token="integ",
                               api_base=self.url,
                               folder_id=self.folder_ids[mount["path"]]))
+
+    def gdocs_resource(self) -> GDocsResource:
+        return GDocsResource(
+            GDocsConfig(client_id="integ",
+                        refresh_token="integ",
+                        api_base=self.url))
+
+    def gsheets_resource(self) -> GSheetsResource:
+        return GSheetsResource(
+            GSheetsConfig(client_id="integ",
+                          refresh_token="integ",
+                          api_base=self.url))
+
+    def gslides_resource(self) -> GSlidesResource:
+        return GSlidesResource(
+            GSlidesConfig(client_id="integ",
+                          refresh_token="integ",
+                          api_base=self.url))
 
     async def teardown(self) -> None:
         return None
@@ -450,6 +531,27 @@ def build_gdrive(
     return service.resource(mount), _noop
 
 
+def build_gdocs(
+        mount: dict, run_id: str, service: Service | None
+) -> tuple[object, Callable[[], Awaitable[None]]]:
+    assert isinstance(service, GwsService)
+    return service.gdocs_resource(), _noop
+
+
+def build_gsheets(
+        mount: dict, run_id: str, service: Service | None
+) -> tuple[object, Callable[[], Awaitable[None]]]:
+    assert isinstance(service, GwsService)
+    return service.gsheets_resource(), _noop
+
+
+def build_gslides(
+        mount: dict, run_id: str, service: Service | None
+) -> tuple[object, Callable[[], Awaitable[None]]]:
+    assert isinstance(service, GwsService)
+    return service.gslides_resource(), _noop
+
+
 def build_nextcloud(
         mount: dict, run_id: str, service: Service | None
 ) -> tuple[object, Callable[[], Awaitable[None]]]:
@@ -467,6 +569,9 @@ BUILDERS = {
     "ssh": build_ssh,
     "nextcloud": build_nextcloud,
     "gdrive": build_gdrive,
+    "gdocs": build_gdocs,
+    "gsheets": build_gsheets,
+    "gslides": build_gslides,
     "hf": build_hf,
 }
 

--- a/integ/runners/python/harness.py
+++ b/integ/runners/python/harness.py
@@ -96,7 +96,15 @@ def provision_line(result) -> str:
 
 async def run_case(ws, case: dict) -> tuple[int, str, str, float]:
     if case.get("clear_cache"):
+        # A full clear means the file cache AND every mount's index cache:
+        # remote listings live in the per-resource index, and a listing
+        # populated by an earlier case must not leak into this one.
+        # Resources without an index cache have nothing to clear.
         await ws.cache.clear()
+        for mount in ws.mounts():
+            store = getattr(mount.resource, "index", None)
+            if store is not None:
+                await store.clear()
     start = time.monotonic()
     if case.get("provision"):
         plan = await ws.execute(case["command"], provision=True)

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -25,7 +25,10 @@ import {
 import { OPFSResource, Workspace as BrowserWorkspace } from '@struktoai/mirage-browser'
 import {
   DiskResource,
+  GDocsResource,
   GDriveResource,
+  GSheetsResource,
+  GSlidesResource,
   HfBucketsResource,
   MountMode,
   RAMResource,
@@ -35,6 +38,7 @@ import {
   Workspace,
 } from '@struktoai/mirage-node'
 import { installFakeNavigator, makeMockRoot } from '../../../typescript/packages/browser/src/test-utils.ts'
+import { integRoot } from './harness.ts'
 import type { ExecWorkspace, Mount, Target } from './harness.ts'
 
 export interface Open {
@@ -232,14 +236,76 @@ async function gwsFolder(base: string, name: string, parent: string): Promise<st
 // The fake Google Workspace server is external and shared; /reset gives
 // each run a clean, deterministic state. Each mount is scoped to a
 // per-mount folder via GoogleConfig.folderId, the s3 key_prefix analog.
+interface GwsAppEntry {
+  kind: 'doc' | 'sheet' | 'slide'
+  name: string
+  text?: string
+  rows?: string[][]
+}
+
+// Native files are API objects, not byte blobs, so they seed through the
+// same editor APIs the backends speak instead of fixture uploads.
+async function seedGwsApps(base: string, entries: GwsAppEntry[]): Promise<void> {
+  for (const entry of entries) {
+    if (entry.kind === 'doc') {
+      const doc = await gwsJson(`${base}/v1/documents`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: entry.name }),
+      })
+      const requests = [{ insertText: { location: { index: 1 }, text: entry.text ?? '' } }]
+      await gwsJson(`${base}/v1/documents/${doc.documentId as string}:batchUpdate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requests }),
+      })
+    } else if (entry.kind === 'sheet') {
+      const sheet = await gwsJson(`${base}/v4/spreadsheets`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ properties: { title: entry.name } }),
+      })
+      const id = sheet.spreadsheetId as string
+      await gwsJson(`${base}/v4/spreadsheets/${id}/values/Sheet1:append`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ values: entry.rows ?? [] }),
+      })
+    } else {
+      await gwsJson(`${base}/v1/presentations`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: entry.name }),
+      })
+    }
+  }
+}
+
+function gwsNativeResource(base: string, resource: string): GDocsResource | GSheetsResource | GSlidesResource {
+  const config = { clientId: 'integ', clientSecret: 'integ', refreshToken: 'integ', apiBase: base }
+  if (resource === 'gdocs') return new GDocsResource(config)
+  if (resource === 'gsheets') return new GSheetsResource(config)
+  return new GSlidesResource(config)
+}
+
 async function openGws(target: Target): Promise<Open> {
   let base = process.env.GWS_URL ?? ''
   while (base.endsWith('/')) base = base.slice(0, -1)
   if (base === '') throw new Error('gdrive target requires GWS_URL')
-  await gwsJson(`${base}/reset`, { method: 'POST' })
-  const mounts: Record<string, GDriveResource> = {}
+  // Native mounts (gdocs/gsheets/gslides) render the modified date into
+  // filenames, so those targets pin the server clock.
+  await gwsJson(`${base}/reset`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(target.epoch !== undefined ? { epoch: target.epoch } : {}),
+  })
+  const mounts: Record<string, GDriveResource | GDocsResource | GSheetsResource | GSlidesResource> = {}
   const driveIds: Record<string, string> = {}
   for (const m of target.mounts) {
+    if (m.resource !== 'gdrive') {
+      mounts[m.path] = gwsNativeResource(base, m.resource)
+      continue
+    }
     // A mount may live inside a Shared Drive: the drive is created once
     // per name and its id is the walk's start.
     const drive = m.drive
@@ -263,6 +329,10 @@ async function openGws(target: Target): Promise<Open> {
       folderId: parent,
     })
   }
+  if (target.apps !== undefined) {
+    const manifest = join(integRoot(), 'fixtures', `${target.apps}.json`)
+    await seedGwsApps(base, JSON.parse(readFileSync(manifest, 'utf8')) as GwsAppEntry[])
+  }
   const ws = new Workspace(mounts, { mode: MountMode.WRITE })
   const cleanup = async (): Promise<void> => {
     await ws.close()
@@ -278,5 +348,8 @@ export const ADAPTERS: Record<string, (target: Target) => Promise<Open>> = {
   s3: openS3,
   ssh: openSsh,
   gdrive: openGws,
+  gdocs: openGws,
+  gsheets: openGws,
+  gslides: openGws,
   hf: openHf,
 }

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -35,6 +35,8 @@ export interface Target {
   id: string
   hosts: string[]
   service?: string
+  epoch?: string
+  apps?: string
   mounts: Mount[]
 }
 
@@ -93,6 +95,7 @@ export interface ExecWorkspace {
   execute(cmd: string, opts?: { stdin?: Uint8Array }): Promise<ExecResult>
   dispatch(opName: string, path: string): Promise<unknown>
   cache: { clear(): Promise<void> }
+  mounts(): readonly { resource: { index?: { clear(): Promise<void> } } }[]
   close(): Promise<void>
 }
 
@@ -196,7 +199,14 @@ export async function runCase(
   ws: ExecWorkspace,
   c: Case,
 ): Promise<{ exitCode: number; out: string; err: string; elapsed: number }> {
-  if (c.clear_cache === true) await ws.cache.clear()
+  if (c.clear_cache === true) {
+    // A full clear means the file cache AND every mount's index cache:
+    // remote listings live in the per-resource index, and a listing
+    // populated by an earlier case must not leak into this one. Resources
+    // without an index cache (e.g. opfs) have nothing to clear.
+    await ws.cache.clear()
+    for (const m of ws.mounts()) await m.resource.index?.clear()
+  }
   const start = performance.now()
   if (c.provision === true) {
     const plan = await (ws as unknown as ProvisionExec).execute(c.command, { provision: true })

--- a/integ/server/gws_server.ts
+++ b/integ/server/gws_server.ts
@@ -97,8 +97,14 @@ class GwsState {
   private ticks = 0
   // Frozen at construction (i.e. per /reset) so find -mtime windows
   // relative to "now" behave like a live backend, while the +1s tick per
-  // touch keeps ordering deterministic.
-  private readonly baseMs = Date.now()
+  // touch keeps ordering deterministic. /reset may pin an explicit epoch
+  // instead: mounts that render timestamps into filenames (gdocs/gsheets/
+  // gslides date prefixes) need fully baked-in listings.
+  private readonly baseMs: number
+
+  constructor(epoch?: string) {
+    this.baseMs = epoch === undefined ? Date.now() : Date.parse(epoch)
+  }
 
   nextId(kind: string): string {
     const n = (this.counters.get(kind) ?? 0) + 1
@@ -768,7 +774,8 @@ function route(ctx: Ctx): [number, object | Buffer | null, string?] {
     return [200, { access_token: 'gws-integ-token', expires_in: 3600, token_type: 'Bearer' }]
   }
   if (method === 'POST' && path === '/reset') {
-    state = new GwsState()
+    const body = ctx.body.length > 0 ? (json(ctx) as { epoch?: string }) : {}
+    state = new GwsState(body.epoch)
     return [200, { ok: true }]
   }
 

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -430,6 +430,33 @@
           "root": "team/data2"
         }
       ]
+    },
+    {
+      "id": "gapps",
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
+      "service": "gws",
+      "epoch": "2026-01-01T00:00:00Z",
+      "apps": "google-apps/v1",
+      "mounts": [
+        {
+          "path": "/docs",
+          "resource": "gdocs",
+          "backend": "gdocs"
+        },
+        {
+          "path": "/sheets",
+          "resource": "gsheets",
+          "backend": "gsheets"
+        },
+        {
+          "path": "/slides",
+          "resource": "gslides",
+          "backend": "gslides"
+        }
+      ]
     }
   ]
 }

--- a/python/mirage/commands/builtin/generic/rm_command.py
+++ b/python/mirage/commands/builtin/generic/rm_command.py
@@ -60,7 +60,7 @@ def make_rm(
         removed: dict[str, ByteSource] = {}
         for p in paths:
             try:
-                await unlink(p)
+                await unlink(accessor, p, index)
             except (FileNotFoundError, ValueError):
                 if f:
                     continue

--- a/python/tests/commands/builtin/generic/test_rm_command.py
+++ b/python/tests/commands/builtin/generic/test_rm_command.py
@@ -1,0 +1,90 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.cache.index import NULL_INDEX
+from mirage.commands.builtin.generic.rm_command import make_rm
+from mirage.types import PathSpec
+
+
+class FakeAccessor:
+    pass
+
+
+def _make_rm(files: set[str], calls: list[tuple]):
+
+    async def resolve_glob(accessor, paths, index):
+        return paths
+
+    async def unlink(accessor, path, index=NULL_INDEX):
+        calls.append((accessor, path, index))
+        if path.virtual not in files:
+            raise FileNotFoundError(path.virtual)
+        files.remove(path.virtual)
+
+    return make_rm(resource="gdocs", glob_fn=resolve_glob, unlink=unlink)
+
+
+@pytest.mark.asyncio
+async def test_rm_threads_accessor_and_index_into_unlink():
+    calls: list[tuple] = []
+    accessor = FakeAccessor()
+    rm = _make_rm({"/owned/a.gdoc.json"}, calls)
+    path = PathSpec.from_str_path("/owned/a.gdoc.json")
+    _, result = await rm(accessor, [path], index=NULL_INDEX)
+    assert result.exit_code == 0
+    assert calls == [(accessor, path, NULL_INDEX)]
+
+
+@pytest.mark.asyncio
+async def test_rm_missing_operand():
+    rm = _make_rm(set(), [])
+    with pytest.raises(ValueError, match="missing operand"):
+        await rm(FakeAccessor(), [])
+
+
+@pytest.mark.asyncio
+async def test_rm_enoent_propagates_without_force():
+    rm = _make_rm(set(), [])
+    with pytest.raises(FileNotFoundError):
+        await rm(FakeAccessor(), [PathSpec.from_str_path("/owned/x.json")])
+
+
+@pytest.mark.asyncio
+async def test_rm_force_swallows_enoent():
+    calls: list[tuple] = []
+    rm = _make_rm(set(), calls)
+    _, result = await rm(FakeAccessor(),
+                         [PathSpec.from_str_path("/owned/x.json")],
+                         f=True)
+    assert result.exit_code == 0
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_rm_verbose_reports_each_removal():
+    files = {"/owned/a.gdoc.json", "/owned/b.gdoc.json"}
+    rm = _make_rm(files, [])
+    paths = [
+        PathSpec.from_str_path("/owned/a.gdoc.json"),
+        PathSpec.from_str_path("/owned/b.gdoc.json"),
+    ]
+    output, result = await rm(FakeAccessor(), paths, v=True)
+    assert isinstance(output, bytes)
+    text = output.decode()
+    assert "removed '/owned/a.gdoc.json'" in text
+    assert "removed '/owned/b.gdoc.json'" in text
+    assert result.exit_code == 0
+    assert not files


### PR DESCRIPTION
Adds integ coverage for the native gdocs, gsheets, and gslides resources, which had none.

- New `gapps` target mounts the three native resources against the fake Workspace server. Native files seed through the server's editor APIs from a small manifest (`integ/fixtures/google-apps/v1.json`), since they are API objects rather than byte fixtures. The target pins the server clock (`epoch` on `/reset`) because native filenames embed the modified date.
- 14 `gapp_*` cases: ls owned/shared, cat the rendered JSON, jq the id out and chain it into gws commands, sheets read/append, docs and slides batchUpdate, rm. Plus 4 `g_native_sheet/slide_*` cases on the gdrive target covering the `.gsheet.json` and `.gslide.json` renders.

Two real bugs found by the new coverage, fixed here:

- Python `make_rm` called `unlink(p)` instead of `unlink(accessor, p, index)`, so `rm` was broken on its only three users (gdocs, gsheets, gslides). TypeScript was already correct. Added `test_rm_command.py`.
- The harness `clear_cache` cleared only the file cache, not the per-resource index, so remote listings leaked between cases and outcomes were ordering dependent. Both runners now clear every mount's index too (guarded, opfs has none).

Batteries: py and ts gws targets 1813/1813 each, py ram/disk/redis/s3 4937, py ssh/onedrive/sharepoint 2991, ts ram/disk/redis/opfs 3940.