### PR TITLE
feat(dropbox): grep/rg search push-down via files/search_v2

### DIFF
--- a/docs/home/resource-matrix.mdx
+++ b/docs/home/resource-matrix.mdx
@@ -70,7 +70,7 @@ No external setup, these run locally or against a connection string you already 
 | Resource | Access | Setup | Docs | Notes |
 | --- | --- | --- | --- | --- |
 | Databricks Volume | read, write | [Databricks Volume](/home/setup/databricks) | [<Icon icon="python" />](/python/resource/databricks_volume) [<Icon icon="node-js" />](/typescript/setup/databricks_volume) | Unity Catalog volume subtree; mv/cp are non-atomic copies |
-| Dropbox | read, write | [Dropbox](/home/setup/dropbox) | [<Icon icon="python" />](/python/resource/dropbox) [<Icon icon="node-js" />](/typescript/dropbox) [<Icon icon="globe" />](/typescript/dropbox) | OAuth2 + PKCE; Python, Node, and browser; `root_path` mounts a subfolder |
+| Dropbox | read, write | [Dropbox](/home/setup/dropbox) | [<Icon icon="python" />](/python/resource/dropbox) [<Icon icon="node-js" />](/typescript/dropbox) [<Icon icon="globe" />](/typescript/dropbox) | OAuth2 + PKCE; Python, Node, and browser; `root_path` mounts a subfolder; `content_search` narrows grep/rg via the search API |
 | Box | read, write | [Box](/home/setup/box) | [<Icon icon="python" />](/python/resource/box) [<Icon icon="node-js" />](/typescript/box) [<Icon icon="globe" />](/typescript/box) | OAuth2 + PKCE or developer token; Python, Node, and browser; `root_folder_id` mounts a subfolder; `.boxnote.json` / `.boxcanvas.json` / `.gdoc.json` decoded |
 | Nextcloud | read, write | [Nextcloud](/home/setup/nextcloud) | [<Icon icon="python" />](/python/resource/nextcloud) | Self-hosted Nextcloud / ownCloud / WebDAV; HTTP Basic auth with app password |
 

--- a/docs/python/resource/dropbox.mdx
+++ b/docs/python/resource/dropbox.mdx
@@ -43,13 +43,14 @@ memory, refreshing ~5 minutes before expiry.
 
 ### Config Reference
 
-| Field           | Required | Description                                                             |
-| --------------- | -------- | ----------------------------------------------------------------------- |
-| `client_id`     | Yes      | Dropbox app key                                                         |
-| `client_secret` | Yes      | Dropbox app secret                                                      |
-| `refresh_token` | Yes      | Long-lived OAuth2 refresh token                                         |
-| `root_path`     | No       | Mount a sub-folder of the account as the root (default `/`, the account root) |
-| `endpoint`      | No       | Base URL overriding the real Dropbox hosts (test fakes)                 |
+| Field            | Required | Description                                                             |
+| ---------------- | -------- | ----------------------------------------------------------------------- |
+| `client_id`      | Yes      | Dropbox app key                                                         |
+| `client_secret`  | Yes      | Dropbox app secret                                                      |
+| `refresh_token`  | Yes      | Long-lived OAuth2 refresh token                                         |
+| `root_path`      | No       | Mount a sub-folder of the account as the root (default `/`, the account root) |
+| `content_search` | No       | Let `grep`/`rg` narrow recursive scans via `/2/files/search_v2` (default `False`; see below) |
+| `endpoint`       | No       | Base URL overriding the real Dropbox hosts (test fakes)                 |
 
 ## Mount a subfolder
 
@@ -68,6 +69,36 @@ config = DropboxConfig(
 
 `root_path` accepts `Team/data`, `/Team/data`, or `/Team/data/` (all
 normalized the same way); `..` segments are rejected.
+
+## Search push-down
+
+By default a recursive `grep`/`rg` walks the tree and downloads every file.
+With `content_search=True`, both commands first ask
+[`/2/files/search_v2`](https://www.dropbox.com/developers/documentation/http/documentation#files-search)
+which files contain the pattern's literal, then download and scan only those
+candidates — the output stays exactly GNU because the local scan still decides
+every match. Regex patterns narrow on an extracted required literal; flags
+whose output must see every file in scope (`grep -v`, `grep -c`, `rg -v`,
+`rg --type/--glob`) always take the full walk, as do file operands and
+multi-pattern (`-e`/`-f`) runs. An empty or failed search also falls back to
+the full walk.
+
+```python
+config = DropboxConfig(
+    client_id=os.environ["DROPBOX_APP_KEY"],
+    client_secret=os.environ["DROPBOX_APP_SECRET"],
+    refresh_token=os.environ["DROPBOX_REFRESH_TOKEN"],
+    content_search=True,
+)
+```
+
+The knob is off by default for two reasons: full-text content search is
+plan-gated (Dropbox Professional/Essentials/Business and up — on other plans
+`search_v2` silently matches file names only, so a narrowed scan would miss
+content matches), and Dropbox's search index lags recent writes by a short
+delay, so a push-down may miss files written moments earlier. Only enable it
+when the account's plan includes full-text search and slightly stale results
+are acceptable.
 
 ## Cache
 

--- a/docs/typescript/dropbox.mdx
+++ b/docs/typescript/dropbox.mdx
@@ -62,6 +62,36 @@ await ws.execute('ls /dropbox/') // lists the contents of /Team/data
 `..` segments are rejected. Config dictionaries (e.g. via the resource registry) may spell it
 `root_path`. Omitting it (or passing `/`) mounts the account root as before.
 
+## Search push-down
+
+By default a recursive `grep`/`rg` walks the tree and downloads every file. With
+`contentSearch: true` (config dictionaries may spell it `content_search`), both commands
+first ask [`/2/files/search_v2`](https://www.dropbox.com/developers/documentation/http/documentation#files-search)
+which files contain the pattern's literal, then download and scan only those candidates —
+the output stays exactly GNU/ripgrep because the local scan still decides every match.
+Regex patterns narrow on an extracted required literal; flags whose output must see every
+file in scope (`grep -v`, `grep -c`, `rg -v`, `rg --type/--glob`) always take the full
+walk, as do file operands and multi-pattern (`-e`/`-f`) runs. An empty or failed search
+also falls back to the full walk.
+
+```ts
+const dropbox = new DropboxResource({
+  clientId: process.env.DROPBOX_APP_KEY!,
+  clientSecret: process.env.DROPBOX_APP_SECRET!,
+  refreshToken: process.env.DROPBOX_REFRESH_TOKEN!,
+  contentSearch: true,
+})
+```
+
+The knob is off by default for two reasons: full-text content search is plan-gated
+(Dropbox Professional/Essentials/Business and up — on other plans `search_v2` silently
+matches file names only, so a narrowed scan would miss content matches), and Dropbox's
+search index lags recent writes by a short delay, so a push-down may miss files written
+moments earlier. Only enable it when the account's plan includes full-text search and
+slightly stale results are acceptable. See
+[Dropbox (Python) — Search push-down](/python/resource/dropbox#search-push-down) for the
+mirrored Python knob.
+
 ## Browser (PKCE, no client secret)
 
 ```bash

--- a/examples/python/dropbox/dropbox.py
+++ b/examples/python/dropbox/dropbox.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import os
+import uuid
 
 from dotenv import load_dotenv
 
@@ -29,9 +30,13 @@ config = DropboxConfig(
     # Mount a subfolder instead of the account root by setting
     # DROPBOX_ROOT_PATH, e.g. "/Team/data".
     root_path=os.environ.get("DROPBOX_ROOT_PATH") or "/",
+    # Set DROPBOX_CONTENT_SEARCH=1 to let grep/rg narrow recursive scans
+    # via /2/files/search_v2 instead of downloading every file. Needs a
+    # plan with full-text search (Professional/Essentials/Business+).
+    content_search=os.environ.get("DROPBOX_CONTENT_SEARCH") == "1",
 )
 backend = DropboxResource(config)
-ws = Workspace({"/dropbox": backend}, mode=MountMode.READ)
+ws = Workspace({"/dropbox": backend}, mode=MountMode.WRITE)
 
 
 async def show(cmd: str, max_chars: int = 600) -> None:
@@ -46,6 +51,7 @@ async def show(cmd: str, max_chars: int = 600) -> None:
 
 
 async def main() -> None:
+    # ── read-only tour ──
     await show("ls /dropbox/")
     await show("tree /dropbox/")
     await show("find /dropbox -name '*.txt' | head -n 5")
@@ -54,6 +60,25 @@ async def main() -> None:
     result = await ws.execute("cat /dropbox/__nf_missing__.txt")
     print(f"exit={result.exit_code}  "
           f"{(await result.stderr_str()).strip()}")
+
+    # ── write roundtrip (scoped to a unique folder, cleaned up) ──
+    scratch = f"/dropbox/_mirage_example/{uuid.uuid4().hex[:8]}"
+    print(f"\n=== write roundtrip under {scratch} ===")
+    try:
+        await show(f"mkdir -p {scratch}/sub")
+        await show(f"echo 'alpha beta' | tee {scratch}/notes.txt")
+        await show(f"echo 'beta gamma' | tee {scratch}/sub/inner.txt")
+        await show(f"mv {scratch}/notes.txt {scratch}/renamed.txt")
+        await show(f"cat {scratch}/renamed.txt")
+
+        # ── recursive search; with content_search=True the candidates
+        # come from /2/files/search_v2 and only matches are downloaded ──
+        await show(f"grep -rn beta {scratch}")
+        await show(f"rg -l gamma {scratch}")
+    finally:
+        await show(f"rm -r {scratch}")
+        await show("rm -d /dropbox/_mirage_example")
+
     await ws.close()
 
 

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -465,10 +465,13 @@ class DropboxService:
         account = mount.get("bucket") or mount["path"]
         fake = self.accounts[account]
         return DropboxResource(
+            # The fake supports full-text search_v2, so exercise grep/rg
+            # narrowing in the battery.
             DropboxConfig(client_id="integ-client",
                           client_secret="integ-secret",
                           refresh_token="integ-refresh",
                           endpoint=fake.endpoint,
+                          content_search=True,
                           root_path=mount.get("root") or "/"))
 
     async def teardown(self) -> None:

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -302,6 +302,9 @@ async function openDropbox(target: Target): Promise<Open> {
       clientId: 'integ-client',
       clientSecret: 'integ-secret',
       refreshToken: 'integ-refresh',
+      // The fake supports full-text search_v2, so exercise grep/rg
+      // narrowing in the battery.
+      contentSearch: true,
       endpoint: fake.endpoint,
       ...(m.root !== undefined ? { rootPath: m.root } : {}),
     })

--- a/integ/server/dropbox.ts
+++ b/integ/server/dropbox.ts
@@ -40,11 +40,19 @@ interface DropboxEntryJson {
   server_modified?: string
 }
 
+interface SearchMatchJson {
+  match_type: { '.tag': string }
+  metadata: { '.tag': 'metadata'; metadata: DropboxEntryJson }
+}
+
+const DEC = new TextDecoder()
+
 // One fake Dropbox account with explicit folder objects. Serves every
 // endpoint the backend calls — /oauth2/token plus the /2/files RPCs
 // (list_folder, get_metadata, download, upload, create_folder_v2,
-// delete_v2, move_v2, copy_v2) — on a single origin, matching the
-// DropboxConfig `endpoint` override. Mirrors integ/server/dropbox_server.py.
+// delete_v2, move_v2, copy_v2, search_v2 and search/continue_v2) — on a
+// single origin, matching the DropboxConfig `endpoint` override. Mirrors
+// integ/server/dropbox_server.py.
 export interface FakeDropbox {
   endpoint: string
   close: () => void
@@ -82,6 +90,7 @@ function malformed(res: ServerResponse): void {
 class Account {
   readonly folders = new Set<string>()
   readonly files = new Map<string, StoredFile>()
+  readonly searchCursors = new Map<string, { matches: SearchMatchJson[]; start: number; limit: number }>()
 
   addAncestors(path: string): void {
     const parts = path.split('/').slice(1, -1)
@@ -144,6 +153,32 @@ class Account {
       if (file.startsWith(prefix)) this.files.delete(file)
     }
     return true
+  }
+
+  // Case-insensitive substring over names and content: a superset of the
+  // real token-based matching, which is what grep/rg narrowing needs (the
+  // client still scans the candidates exactly).
+  searchMatches(query: string, scope: string, filenameOnly: boolean): SearchMatchJson[] | null {
+    if (scope !== '' && this.entryFor(scope) === null) return null
+    const q = query.toLowerCase()
+    const scopeLower = scope.toLowerCase()
+    const prefix = scopeLower === '' ? '/' : `${scopeLower}/`
+    const out: SearchMatchJson[] = []
+    for (const path of [...this.folders, ...this.files.keys()].sort()) {
+      const lower = path.toLowerCase()
+      if (scopeLower !== '' && lower !== scopeLower && !lower.startsWith(prefix)) continue
+      const nameHit = path.slice(path.lastIndexOf('/') + 1).toLowerCase().includes(q)
+      const stored = this.files.get(path)
+      const contentHit =
+        !filenameOnly && stored !== undefined && DEC.decode(stored.data).toLowerCase().includes(q)
+      if (!nameHit && !contentHit) continue
+      const tag = nameHit && contentHit ? 'filename_and_content' : nameHit ? 'filename' : 'file_content'
+      out.push({
+        match_type: { '.tag': tag },
+        metadata: { '.tag': 'metadata', metadata: this.entryFor(path) as DropboxEntryJson },
+      })
+    }
+    return out
   }
 
   // Copies a file or a folder subtree; returns false if src is missing.
@@ -279,8 +314,60 @@ function handle(
     json(res, { metadata: account.entryFor(to_path) })
     return
   }
+  if (url === '/2/files/search_v2') {
+    const parsed = JSON.parse(body.toString('utf8') || '{}') as {
+      query?: string
+      options?: { path?: string; max_results?: number; filename_only?: boolean }
+    }
+    const query = parsed.query ?? ''
+    if (query === '') {
+      res.writeHead(400, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error_summary: 'invalid_argument' }))
+      return
+    }
+    const options = parsed.options ?? {}
+    const matches = account.searchMatches(
+      query,
+      options.path ?? '',
+      options.filename_only === true,
+    )
+    if (matches === null) {
+      jsonError(res, 'path/not_found/...')
+      return
+    }
+    searchPage(account, res, matches, 0, options.max_results ?? 100)
+    return
+  }
+  if (url === '/2/files/search/continue_v2') {
+    const { cursor = '' } = JSON.parse(body.toString('utf8') || '{}') as { cursor?: string }
+    const state = account.searchCursors.get(cursor)
+    if (state === undefined) {
+      jsonError(res, 'reset/...')
+      return
+    }
+    searchPage(account, res, state.matches, state.start, state.limit)
+    return
+  }
   res.writeHead(404, { 'Content-Type': 'application/json' })
   res.end(JSON.stringify({ error_summary: `unknown endpoint ${url}` }))
+}
+
+function searchPage(
+  account: Account,
+  res: ServerResponse,
+  matches: SearchMatchJson[],
+  start: number,
+  limit: number,
+): void {
+  const page = matches.slice(start, start + limit)
+  const hasMore = start + limit < matches.length
+  const resp: Record<string, unknown> = { matches: page, has_more: hasMore }
+  if (hasMore) {
+    const token = `search-${String(account.searchCursors.size)}`
+    account.searchCursors.set(token, { matches, start: start + limit, limit })
+    resp.cursor = token
+  }
+  json(res, resp)
 }
 
 export function startFakeDropbox(): Promise<FakeDropbox> {

--- a/integ/server/dropbox_server.py
+++ b/integ/server/dropbox_server.py
@@ -29,14 +29,16 @@ class FakeDropbox:
 
     Serves every endpoint the backend calls — /oauth2/token plus the
     /2/files RPCs (list_folder, get_metadata, download, upload,
-    create_folder_v2, delete_v2, move_v2, copy_v2) — on a single
-    origin, matching the DropboxConfig ``endpoint`` override. Mirrors
-    the TS fake in integ/server/dropbox.ts.
+    create_folder_v2, delete_v2, move_v2, copy_v2, search_v2 and
+    search/continue_v2) — on a single origin, matching the
+    DropboxConfig ``endpoint`` override. Mirrors the TS fake in
+    integ/server/dropbox.ts.
     """
 
     def __init__(self) -> None:
         self.folders: set[str] = set()
         self.files: dict[str, tuple[bytes, str]] = {}
+        self.search_cursors: dict[str, tuple[list, int, int]] = {}
         self.endpoint = ""
 
     def _add_ancestors(self, path: str) -> None:
@@ -215,6 +217,78 @@ class FakeDropbox:
     async def handle_copy(self, request: web.Request) -> web.Response:
         return await self._handle_relocate(request, move=False)
 
+    def _search_matches(self, query: str, scope: str,
+                        filename_only: bool) -> list[dict] | None:
+        # Case-insensitive substring over names and content: a superset of
+        # the real token-based matching, which is what grep/rg narrowing
+        # needs (the client still scans the candidates exactly).
+        if scope and self._entry_for(scope) is None:
+            return None
+        q = query.lower()
+        scope_lower = scope.lower()
+        prefix = f"{scope_lower}/" if scope_lower else "/"
+        out: list[dict] = []
+        for path in sorted(self.folders | set(self.files)):
+            lower = path.lower()
+            if scope_lower and lower != scope_lower and not lower.startswith(
+                    prefix):
+                continue
+            name_hit = q in path.rsplit("/", 1)[1].lower()
+            stored = self.files.get(path)
+            content_hit = (not filename_only and stored is not None
+                           and q in stored[0].decode(errors="replace").lower())
+            if not name_hit and not content_hit:
+                continue
+            tag = ("filename_and_content" if name_hit and content_hit else
+                   "filename" if name_hit else "file_content")
+            out.append({
+                "match_type": {
+                    ".tag": tag
+                },
+                "metadata": {
+                    ".tag": "metadata",
+                    "metadata": self._entry_for(path),
+                },
+            })
+        return out
+
+    def _search_page(self, matches: list, start: int,
+                     limit: int) -> web.Response:
+        page = matches[start:start + limit]
+        has_more = start + limit < len(matches)
+        resp: dict = {"matches": page, "has_more": has_more}
+        if has_more:
+            token = f"search-{len(self.search_cursors)}"
+            self.search_cursors[token] = (matches, start + limit, limit)
+            resp["cursor"] = token
+        return web.json_response(resp)
+
+    async def handle_search(self, request: web.Request) -> web.Response:
+        body = await request.json()
+        query = body.get("query") or ""
+        if not query:
+            return web.json_response({"error_summary": "invalid_argument"},
+                                     status=400)
+        options = body.get("options") or {}
+        matches = self._search_matches(query,
+                                       options.get("path") or "",
+                                       bool(options.get("filename_only")))
+        if matches is None:
+            return web.json_response({"error_summary": "path/not_found/..."},
+                                     status=409)
+        return self._search_page(matches, 0,
+                                 int(options.get("max_results") or 100))
+
+    async def handle_search_continue(self,
+                                     request: web.Request) -> web.Response:
+        body = await request.json()
+        state = self.search_cursors.get(body.get("cursor") or "")
+        if state is None:
+            return web.json_response({"error_summary": "reset/..."},
+                                     status=409)
+        matches, start, limit = state
+        return self._search_page(matches, start, limit)
+
 
 async def start_fake_dropbox() -> tuple[FakeDropbox, web.AppRunner]:
     fake = FakeDropbox()
@@ -230,6 +304,9 @@ async def start_fake_dropbox() -> tuple[FakeDropbox, web.AppRunner]:
     app.router.add_post("/2/files/delete_v2", fake.handle_delete)
     app.router.add_post("/2/files/move_v2", fake.handle_move)
     app.router.add_post("/2/files/copy_v2", fake.handle_copy)
+    app.router.add_post("/2/files/search_v2", fake.handle_search)
+    app.router.add_post("/2/files/search/continue_v2",
+                        fake.handle_search_continue)
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, "127.0.0.1", 0)

--- a/python/mirage/commands/builtin/dropbox/__init__.py
+++ b/python/mirage/commands/builtin/dropbox/__init__.py
@@ -12,12 +12,16 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from mirage.commands.builtin.dropbox.grep import grep
 from mirage.commands.builtin.dropbox.io import IO as _IO
+from mirage.commands.builtin.dropbox.rg import rg
 from mirage.commands.builtin.filetype_factory import make_filetype_commands
 from mirage.commands.builtin.generic_bind import (make_file_read_provision,
                                                   make_generic_commands)
 from mirage.core.dropbox.read import read as _read
 from mirage.core.dropbox.stat import stat as _stat
+
+_DROPBOX_OVERRIDES = {"grep", "rg"}
 
 COMMANDS = [
     *make_filetype_commands("dropbox",
@@ -25,5 +29,7 @@ COMMANDS = [
                             _read,
                             read_takes_index=True,
                             provision=make_file_read_provision(_stat)),
-    *make_generic_commands("dropbox", _IO),
+    *make_generic_commands("dropbox", _IO, overrides=_DROPBOX_OVERRIDES),
+    grep,
+    rg,
 ]

--- a/python/mirage/commands/builtin/dropbox/grep.py
+++ b/python/mirage/commands/builtin/dropbox/grep.py
@@ -1,0 +1,80 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.dropbox import DropboxAccessor
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.commands.builtin.dropbox.io import IO as _IO
+from mirage.commands.builtin.dropbox.narrow import narrow_scope
+from mirage.commands.builtin.generic.grep import grep as generic_grep
+from mirage.commands.builtin.generic_bind import default_provision
+from mirage.commands.builtin.generic_bind.adapter import bound_op
+from mirage.commands.builtin.grep_helper import pattern_arg
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.commands.spec.types import FlagView
+from mirage.core.dropbox.read import read as _read
+from mirage.core.dropbox.read import stream as _stream
+from mirage.core.dropbox.readdir import readdir as _readdir
+from mirage.core.dropbox.stat import stat as _stat
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+@command("grep",
+         resource="dropbox",
+         spec=SPECS["grep"],
+         provision=default_provision("grep",
+                                     _IO.stat,
+                                     resolve_glob=_IO.resolve_glob,
+                                     readdir=_IO.readdir))
+async def grep(
+    accessor: DropboxAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: ByteSource | None = None,
+    prefix: str = "",
+    index: IndexCacheStore = NULL_INDEX,
+    **flags: object,
+) -> tuple[ByteSource | None, IOResult]:
+    fl = FlagView(flags, spec=SPECS["grep"])
+    pattern = pattern_arg(texts, fl)
+
+    resolved: list[PathSpec] = []
+    used_search = False
+    if paths:
+        # -v and -c need the walk: GNU prints non-matching lines (-v) and
+        # zero counts (-c) from files a narrowed superset would never
+        # visit.
+        resolved, used_search = await narrow_scope(
+            accessor,
+            index,
+            paths,
+            pattern,
+            fixed_string=fl.as_bool("F"),
+            recursive=fl.as_bool("r") or fl.as_bool("R"),
+            exact_file_set=fl.as_bool("v") or fl.as_bool("c"),
+        )
+        if used_search and not resolved:
+            return b"", IOResult(exit_code=1)
+
+    return await generic_grep(
+        resolved,
+        texts,
+        flags,
+        readdir=bound_op(_readdir, accessor, index),
+        stat=bound_op(_stat, accessor, index),
+        read_bytes=bound_op(_read, accessor, index),
+        read_stream=bound_op(_stream, accessor, index),
+        stdin=stdin,
+    )

--- a/python/mirage/commands/builtin/dropbox/narrow.py
+++ b/python/mirage/commands/builtin/dropbox/narrow.py
@@ -1,0 +1,108 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.accessor.dropbox import DropboxAccessor
+from mirage.cache.index import IndexCacheStore
+from mirage.commands.builtin.dropbox.io import resolve_glob
+from mirage.commands.builtin.grep_helper import (BINARY_EXTENSIONS,
+                                                 get_extension, search_query)
+from mirage.core.dropbox.search import narrow_paths
+from mirage.core.dropbox.stat import stat as dropbox_stat
+from mirage.types import FileType, PathSpec
+
+
+async def _all_directories(
+    accessor: DropboxAccessor,
+    index: IndexCacheStore,
+    paths: list[PathSpec],
+) -> bool:
+    """Whether every scope operand stats as a directory.
+
+    File operands keep the exact single-file output shape (no walk-style
+    labels), and missing operands must surface the walk's error message,
+    so both fall back to the generic scan.
+
+    Args:
+        accessor (DropboxAccessor): backend handle.
+        index (IndexCacheStore): index consulted before the metadata API.
+        paths (list[PathSpec]): scope paths, possibly mount-prefixed.
+    """
+    for p in paths:
+        try:
+            s = await dropbox_stat(accessor, p, index)
+        except (OSError, ValueError):
+            return False
+        if s.type != FileType.DIRECTORY:
+            return False
+    return True
+
+
+async def narrow_scope(
+    accessor: DropboxAccessor,
+    index: IndexCacheStore,
+    paths: list[PathSpec],
+    pattern: str | None,
+    *,
+    fixed_string: bool,
+    recursive: bool,
+    exact_file_set: bool,
+) -> tuple[list[PathSpec], bool]:
+    """Resolve grep/rg scope paths, narrowing via Dropbox file search.
+
+    Push-down needs every gate to hold: the mount opted in via
+    ``content_search``, the scan is recursive, a single-line literal can be
+    pushed down (regex patterns narrow on an extracted required literal and
+    stay exact because the caller still scans the regex locally), and the
+    output mode tolerates a narrowed-superset file set (``exact_file_set``
+    covers flags like -v that must see every file). Unlike the GitHub
+    narrow there is no scope-size gate: one search call plus targeted
+    downloads beats a readdir-walk-plus-download-everything scan at every
+    scope size, and Dropbox search has no code-search-style rate ceiling.
+    An empty search result still falls back to the full scan (GitHub
+    parity) because search indexing lags recent writes.
+
+    Binary-extension candidates are dropped from the narrowed set because
+    the recursive walk it replaces skips them.
+
+    Args:
+        accessor (DropboxAccessor): backend handle.
+        index (IndexCacheStore): index for the glob-resolution fallback.
+        paths (list[PathSpec]): scope paths, possibly mount-prefixed.
+        pattern (str | None): the search pattern, or None for -f-only runs.
+        fixed_string (bool): True if -F is set.
+        recursive (bool): True if the scan walks directories.
+        exact_file_set (bool): True when the output mode must see every
+            file in scope, forcing the full walk.
+
+    Returns:
+        tuple[list[PathSpec], bool]: resolved paths and whether search
+            narrowed the set. A narrowed set may be empty (every candidate
+            was binary); callers must not treat that as a stdin run.
+    """
+    query = (search_query(pattern, fixed_string)
+             if pattern is not None and "\n" not in pattern else None)
+    use_search = (query is not None and recursive and not exact_file_set
+                  and accessor.config.content_search
+                  and await _all_directories(accessor, index, paths))
+    if use_search:
+        assert query is not None
+        narrowed = await narrow_paths(accessor, query, paths)
+        if narrowed:
+            kept = [
+                p for p in narrowed
+                if get_extension(p.virtual) not in BINARY_EXTENSIONS
+            ]
+            return kept, True
+    resolved = await resolve_glob(accessor, paths, index)
+    return resolved, False

--- a/python/mirage/commands/builtin/dropbox/rg.py
+++ b/python/mirage/commands/builtin/dropbox/rg.py
@@ -1,0 +1,123 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from collections.abc import Mapping
+
+from mirage.accessor.dropbox import DropboxAccessor
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
+from mirage.commands.builtin.dropbox.io import IO as _IO
+from mirage.commands.builtin.dropbox.narrow import narrow_scope
+from mirage.commands.builtin.generic.rg import rg as generic_rg
+from mirage.commands.builtin.generic_bind import default_provision
+from mirage.commands.builtin.generic_bind.adapter import bound_op
+from mirage.commands.builtin.grep_helper import pattern_arg
+from mirage.commands.registry import command
+from mirage.commands.spec import SPECS
+from mirage.commands.spec.types import FlagView
+from mirage.core.dropbox.read import read as _read
+from mirage.core.dropbox.read import stream as _stream
+from mirage.core.dropbox.readdir import readdir as _readdir
+from mirage.core.dropbox.stat import stat as _stat
+from mirage.io.types import ByteSource, IOResult
+from mirage.types import PathSpec
+
+
+def _keep_visible(
+    narrowed: list[PathSpec],
+    scopes: list[PathSpec],
+    hidden: bool,
+) -> list[PathSpec]:
+    """Reproduce rg's dotfile pruning for search-narrowed candidates.
+
+    The generic rg walk skips hidden files and never descends into hidden
+    directories, but explicit file operands bypass that pruning, so
+    narrowed candidates are filtered on every path segment below their
+    (longest-matching) scope.
+
+    Args:
+        narrowed (list[PathSpec]): search-narrowed candidate files.
+        scopes (list[PathSpec]): the original scope operands.
+        hidden (bool): True if --hidden is set (no pruning).
+    """
+    if hidden:
+        return narrowed
+    kept: list[PathSpec] = []
+    for p in narrowed:
+        rel = p.virtual
+        best = -1
+        for scope in scopes:
+            base = scope.virtual.rstrip("/")
+            if len(base) > best and (p.virtual == base
+                                     or p.virtual.startswith(base + "/")):
+                rel = p.virtual[len(base):]
+                best = len(base)
+        if any(seg.startswith(".") for seg in rel.split("/") if seg):
+            continue
+        kept.append(p)
+    return kept
+
+
+@command("rg",
+         resource="dropbox",
+         spec=SPECS["rg"],
+         provision=default_provision("rg",
+                                     _IO.stat,
+                                     resolve_glob=_IO.resolve_glob,
+                                     readdir=_IO.readdir))
+async def rg(
+    accessor: DropboxAccessor,
+    paths: list[PathSpec],
+    *texts: str,
+    stdin: ByteSource | None = None,
+    prefix: str = "",
+    index: IndexCacheStore = NULL_INDEX,
+    **flags: object,
+) -> tuple[ByteSource | None, IOResult]:
+    fl = FlagView(flags, spec=SPECS["rg"])
+    pattern_str = pattern_arg(texts, fl)
+
+    run_flags: Mapping[str, object] = flags
+    if paths:
+        # -v needs the walk (a narrowed superset hides fully non-matching
+        # files whose every line matches inverted); --type/--glob keep the
+        # walk so their file filtering stays in one place.
+        narrowed, used_search = await narrow_scope(
+            accessor,
+            index,
+            paths,
+            pattern_str,
+            fixed_string=fl.as_bool("F"),
+            recursive=True,
+            exact_file_set=(fl.as_bool("v") or fl.as_str("type") is not None
+                            or fl.as_str("glob") is not None),
+        )
+        if used_search:
+            narrowed = _keep_visible(narrowed, paths, fl.as_bool("hidden"))
+            if not narrowed:
+                return b"", IOResult(exit_code=1)
+            # ripgrep labels every file a walk finds; narrowed candidates
+            # arrive as explicit operands, so force the label flag.
+            run_flags = {**flags, "H": True}
+        paths = narrowed
+
+    return await generic_rg(
+        paths,
+        texts,
+        run_flags,
+        readdir=bound_op(_readdir, accessor, index),
+        stat=bound_op(_stat, accessor, index),
+        read_bytes=bound_op(_read, accessor, index),
+        read_stream=bound_op(_stream, accessor, index),
+        stdin=stdin,
+    )

--- a/python/mirage/commands/builtin/dropbox/rg.py
+++ b/python/mirage/commands/builtin/dropbox/rg.py
@@ -107,8 +107,10 @@ async def rg(
             if not narrowed:
                 return b"", IOResult(exit_code=1)
             # ripgrep labels every file a walk finds; narrowed candidates
-            # arrive as explicit operands, so force the label flag.
-            run_flags = {**flags, "H": True}
+            # arrive as explicit operands, so force the label flag —
+            # unless -I suppresses labels.
+            if not fl.as_bool("args_I"):
+                run_flags = {**flags, "H": True}
         paths = narrowed
 
     return await generic_rg(

--- a/python/mirage/commands/builtin/grep_helper.py
+++ b/python/mirage/commands/builtin/grep_helper.py
@@ -590,21 +590,31 @@ async def grep_files_only(
     compiled = compile_pattern(pattern, ignore_case, fixed_string, whole_word)
 
     if recursive:
-        return await grep_recursive(
-            readdir_fn,
-            stat_fn,
-            read_bytes_fn,
-            path,
-            compiled,
-            invert,
-            line_numbers,
-            count_only,
-            True,
-            only_matching,
-            max_count,
-            warnings,
-            read_stream_fn,
-        )
+        # GNU only walks directory operands; a file operand under -r takes
+        # the plain single-file scan (TS grepGeneric parity). Stat failures
+        # keep the walk so missing operands surface its error shape.
+        operand_is_file = False
+        try:
+            s = await stat_fn(path)
+            operand_is_file = s.type != FileType.DIRECTORY
+        except (FileNotFoundError, ValueError):
+            operand_is_file = False
+        if not operand_is_file:
+            return await grep_recursive(
+                readdir_fn,
+                stat_fn,
+                read_bytes_fn,
+                path,
+                compiled,
+                invert,
+                line_numbers,
+                count_only,
+                True,
+                only_matching,
+                max_count,
+                warnings,
+                read_stream_fn,
+            )
 
     try:
         data = await read_bytes_fn(path)

--- a/python/mirage/core/dropbox/api.py
+++ b/python/mirage/core/dropbox/api.py
@@ -16,6 +16,12 @@ from typing import Any
 
 from mirage.core.dropbox._client import DropboxTokenManager, dropbox_rpc
 
+SEARCH_PAGE = 1000
+# search_v2 + search/continue_v2 serve at most 10,000 matches total; a
+# result set that hits the ceiling may be incomplete and must not be used
+# to narrow a scan.
+MAX_SEARCH_MATCHES = 10_000
+
 
 async def get_metadata(tm: DropboxTokenManager, path: str) -> dict[str, Any]:
     return await dropbox_rpc(tm, "/files/get_metadata", {"path": path})
@@ -48,6 +54,61 @@ async def copy_path(tm: DropboxTokenManager, from_path: str,
         "to_path": to_path,
         "autorename": False,
     })
+
+
+async def search_files(
+    tm: DropboxTokenManager,
+    query: str,
+    path: str = "",
+    filename_only: bool = False,
+) -> tuple[list[tuple[str, str]], bool]:
+    """Collect (path_lower, path_display) file matches for a search query.
+
+    Pages through ``/files/search_v2`` and ``/files/search/continue_v2``,
+    deduplicating across pages (the API may repeat results between pages).
+
+    Args:
+        tm (DropboxTokenManager): token manager for the account.
+        query (str): literal search query.
+        path (str): Dropbox API path scoping the search; ``""`` searches
+            the whole account.
+        filename_only (bool): restrict matching to file names.
+
+    Returns:
+        tuple[list[tuple[str, str]], bool]: matched file paths and whether
+            the result hit the API's 10,000-match ceiling (truncated
+            results are not a trustworthy superset).
+    """
+    options: dict[str, Any] = {
+        "max_results": SEARCH_PAGE,
+        "file_status": "active",
+        "filename_only": filename_only,
+    }
+    if path:
+        options["path"] = path
+    resp = await dropbox_rpc(tm, "/files/search_v2", {
+        "query": query,
+        "options": options,
+    })
+    seen: set[str] = set()
+    out: list[tuple[str, str]] = []
+    while True:
+        for match in resp.get("matches", []):
+            meta = match.get("metadata", {}).get("metadata", {})
+            if meta.get(".tag") != "file":
+                continue
+            lower = meta.get("path_lower") or ""
+            display = meta.get("path_display") or lower
+            if not lower or lower in seen:
+                continue
+            seen.add(lower)
+            out.append((lower, display))
+        if len(out) >= MAX_SEARCH_MATCHES:
+            return out, True
+        if not resp.get("has_more"):
+            return out, False
+        resp = await dropbox_rpc(tm, "/files/search/continue_v2",
+                                 {"cursor": resp["cursor"]})
 
 
 async def list_folder(

--- a/python/mirage/core/dropbox/search.py
+++ b/python/mirage/core/dropbox/search.py
@@ -81,8 +81,8 @@ async def narrow_paths(
             if lower != scope_lower and not lower.startswith(scope_prefix):
                 continue
             key = display[len(root):].strip("/")
-            scoped.append(f"{mount_prefix}/{key}" if key else mount_prefix
-                          or "/")
+            scoped.append(
+                f"{mount_prefix}/{key}" if key else mount_prefix or "/")
         scoped.sort(key=_path_components)
         for virtual in scoped:
             narrowed.append(

--- a/python/mirage/core/dropbox/search.py
+++ b/python/mirage/core/dropbox/search.py
@@ -1,0 +1,95 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import logging
+
+from mirage.accessor.dropbox import DropboxAccessor
+from mirage.core.dropbox._client import DropboxApiError
+from mirage.core.dropbox.api import search_files
+from mirage.core.dropbox.paths import dropbox_path_of
+from mirage.types import PathSpec
+from mirage.utils.key_prefix import mount_key, mount_prefix_of
+from mirage.utils.path import rebase_raw
+
+logger = logging.getLogger(__name__)
+
+
+def _path_components(virtual: str) -> list[str]:
+    return virtual.split("/")
+
+
+async def narrow_paths(
+    accessor: DropboxAccessor,
+    query: str,
+    paths: list[PathSpec],
+) -> list[PathSpec] | None:
+    """Use Dropbox file search to narrow grep/rg scopes to candidate files.
+
+    Search results are compared against each scope on ``path_lower``
+    (Dropbox paths are case-insensitive) and mapped back to mount paths
+    from ``path_display``. Per-scope results are sorted component-wise so
+    they line up with the order a sorted readdir walk would visit, and
+    each ``raw_path`` is rebased onto the scope's as-typed spelling so
+    output labels match a walk's.
+
+    Returns None whenever the narrowed set cannot be trusted as a superset
+    of what a full scan would read (API failure, or the 10,000-match
+    search ceiling), so the caller falls back to the full scan.
+
+    Args:
+        accessor (DropboxAccessor): backend handle carrying the root path.
+        query (str): literal search query.
+        paths (list[PathSpec]): scope paths, possibly mount-prefixed.
+
+    Returns:
+        list[PathSpec] | None: one PathSpec per matching file under the
+            scopes, or None when narrowing is unusable.
+    """
+    if not paths:
+        return []
+    mount_prefix = mount_prefix_of(paths[0].virtual, paths[0].resource_path)
+    root = accessor.root_path
+    narrowed: list[PathSpec] = []
+    for p in paths:
+        scope_api = dropbox_path_of(accessor, p)
+        try:
+            results, truncated = await search_files(accessor.token_manager,
+                                                    query,
+                                                    path=scope_api)
+        except DropboxApiError as exc:
+            logger.warning(
+                "dropbox search push-down failed (%s); "
+                "falling back to per-file scan", exc)
+            return None
+        if truncated:
+            return None
+        scope_lower = scope_api.lower()
+        scope_prefix = scope_lower.rstrip("/") + "/"
+        scoped: list[str] = []
+        for lower, display in results:
+            if lower != scope_lower and not lower.startswith(scope_prefix):
+                continue
+            key = display[len(root):].strip("/")
+            scoped.append(f"{mount_prefix}/{key}" if key else mount_prefix
+                          or "/")
+        scoped.sort(key=_path_components)
+        for virtual in scoped:
+            narrowed.append(
+                PathSpec(virtual=virtual,
+                         directory="",
+                         resource_path=mount_key(virtual, mount_prefix),
+                         resolved=True,
+                         raw_path=rebase_raw([virtual], p.virtual,
+                                             p.raw_path)[0]))
+    return narrowed

--- a/python/mirage/resource/dropbox/config.py
+++ b/python/mirage/resource/dropbox/config.py
@@ -20,6 +20,13 @@ class DropboxConfig(BaseModel):
     client_secret: SecretStr
     refresh_token: SecretStr
     root_path: str = "/"
+    # Opt-in for grep/rg to narrow recursive scans via /files/search_v2
+    # instead of downloading every file. Full-text content search is
+    # plan-gated (Dropbox Professional/Essentials/Business and up); on other
+    # plans search_v2 silently matches file names only, which would make a
+    # narrowed scan miss content matches — so this stays off by default.
+    # Search indexing also lags recent writes by a short delay.
+    content_search: bool = False
     # Base URL overriding the real Dropbox hosts (integ fakes): one origin
     # serving /oauth2/token, the RPC API under /2, and content downloads
     # under /2. None means the production oauth/api/content hosts.

--- a/python/tests/commands/builtin/dropbox/test_grep_search.py
+++ b/python/tests/commands/builtin/dropbox/test_grep_search.py
@@ -1,0 +1,112 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mirage.accessor.dropbox import DropboxAccessor
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.commands.builtin.dropbox.grep import grep
+from mirage.core.dropbox._client import DropboxTokenManager
+from mirage.io.types import IOResult
+from mirage.resource.dropbox.config import DropboxConfig
+from mirage.types import PathSpec
+
+_GLOBALS = grep.__wrapped__.__globals__
+
+
+def make_accessor() -> DropboxAccessor:
+    config = DropboxConfig(client_id="c",
+                           client_secret="s",
+                           refresh_token="r",
+                           content_search=True)
+    return DropboxAccessor(config, DropboxTokenManager(config))
+
+
+def scope() -> PathSpec:
+    return PathSpec(resource_path="", virtual="/data", directory="/data")
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+@pytest.fixture
+def harness(monkeypatch):
+    narrow = AsyncMock(return_value=([], False))
+    generic = AsyncMock(return_value=(b"", IOResult()))
+    monkeypatch.setitem(_GLOBALS, "narrow_scope", narrow)
+    monkeypatch.setitem(_GLOBALS, "generic_grep", generic)
+    return narrow, generic
+
+
+@pytest.mark.asyncio
+async def test_plain_recursive_grep_allows_narrowing(harness, index):
+    narrow, _ = harness
+    await grep(make_accessor(), [scope()], "needle", r=True, index=index)
+    kwargs = narrow.await_args.kwargs
+    assert kwargs["recursive"]
+    assert not kwargs["exact_file_set"]
+    assert not kwargs["fixed_string"]
+
+
+@pytest.mark.asyncio
+async def test_invert_forces_the_full_walk(harness, index):
+    narrow, _ = harness
+    await grep(make_accessor(), [scope()],
+               "needle",
+               r=True,
+               v=True,
+               index=index)
+    assert narrow.await_args.kwargs["exact_file_set"]
+
+
+@pytest.mark.asyncio
+async def test_count_forces_the_full_walk(harness, index):
+    narrow, _ = harness
+    await grep(make_accessor(), [scope()],
+               "needle",
+               r=True,
+               c=True,
+               index=index)
+    assert narrow.await_args.kwargs["exact_file_set"]
+
+
+@pytest.mark.asyncio
+async def test_narrowed_files_reach_the_generic_grep(harness, index):
+    narrow, generic = harness
+    hits = [
+        PathSpec(resource_path="a.txt",
+                 virtual="/data/a.txt",
+                 directory="",
+                 resolved=True)
+    ]
+    narrow.return_value = (hits, True)
+    await grep(make_accessor(), [scope()], "needle", r=True, index=index)
+    assert generic.await_args.args[0] == hits
+
+
+@pytest.mark.asyncio
+async def test_empty_narrowed_set_exits_one_without_reading(harness, index):
+    narrow, generic = harness
+    narrow.return_value = ([], True)
+    stdout, io = await grep(make_accessor(), [scope()],
+                            "needle",
+                            r=True,
+                            index=index)
+    assert stdout == b""
+    assert io.exit_code == 1
+    generic.assert_not_awaited()

--- a/python/tests/commands/builtin/dropbox/test_narrow.py
+++ b/python/tests/commands/builtin/dropbox/test_narrow.py
@@ -1,0 +1,210 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mirage.accessor.dropbox import DropboxAccessor
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.commands.builtin.dropbox.narrow import narrow_scope
+from mirage.core.dropbox._client import DropboxTokenManager
+from mirage.resource.dropbox.config import DropboxConfig
+from mirage.types import FileStat, FileType, PathSpec
+
+_NGLOBALS = narrow_scope.__globals__
+
+DIR_STAT = FileStat(name="data", type=FileType.DIRECTORY)
+FILE_STAT = FileStat(name="x.txt", type=FileType.TEXT)
+
+
+def make_accessor(content_search: bool = True) -> DropboxAccessor:
+    config = DropboxConfig(client_id="c",
+                           client_secret="s",
+                           refresh_token="r",
+                           content_search=content_search)
+    return DropboxAccessor(config, DropboxTokenManager(config))
+
+
+def scope() -> PathSpec:
+    return PathSpec(resource_path="", virtual="/data", directory="/data")
+
+
+def spec(virtual: str) -> PathSpec:
+    return PathSpec(resource_path=virtual.removeprefix("/data/"),
+                    virtual=virtual,
+                    directory="",
+                    resolved=True)
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+@pytest.fixture
+def harness(monkeypatch):
+    stat = AsyncMock(return_value=DIR_STAT)
+    narrow = AsyncMock(return_value=[spec("/data/a.txt")])
+    glob = AsyncMock(return_value=[scope()])
+    monkeypatch.setitem(_NGLOBALS, "dropbox_stat", stat)
+    monkeypatch.setitem(_NGLOBALS, "narrow_paths", narrow)
+    monkeypatch.setitem(_NGLOBALS, "resolve_glob", glob)
+    return stat, narrow, glob
+
+
+async def run(index, **kwargs):
+    defaults = {
+        "fixed_string": False,
+        "recursive": True,
+        "exact_file_set": False,
+    }
+    defaults.update(kwargs)
+    return await narrow_scope(make_accessor(), index, [scope()], "needle",
+                              **defaults)
+
+
+@pytest.mark.asyncio
+async def test_narrows_recursive_literal_scans(harness, index):
+    _, narrow, glob = harness
+    resolved, used = await run(index)
+    assert used
+    assert [p.virtual for p in resolved] == ["/data/a.txt"]
+    narrow.assert_awaited_once()
+    glob.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_knob_off_skips_search(harness, index):
+    _, narrow, glob = harness
+    resolved, used = await narrow_scope(make_accessor(content_search=False),
+                                        index, [scope()],
+                                        "needle",
+                                        fixed_string=False,
+                                        recursive=True,
+                                        exact_file_set=False)
+    assert not used
+    narrow.assert_not_awaited()
+    glob.assert_awaited_once()
+    assert resolved == [scope()]
+
+
+@pytest.mark.asyncio
+async def test_non_recursive_skips_search(harness, index):
+    _, narrow, _ = harness
+    _, used = await run(index, recursive=False)
+    assert not used
+    narrow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_exact_file_set_skips_search(harness, index):
+    _, narrow, _ = harness
+    _, used = await run(index, exact_file_set=True)
+    assert not used
+    narrow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_multiline_pattern_skips_search(harness, index):
+    _, narrow, _ = harness
+    _, used = await narrow_scope(make_accessor(),
+                                 index, [scope()],
+                                 "foo\nbar",
+                                 fixed_string=False,
+                                 recursive=True,
+                                 exact_file_set=False)
+    assert not used
+    narrow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_regex_without_literal_skips_search(harness, index):
+    _, narrow, _ = harness
+    _, used = await narrow_scope(make_accessor(),
+                                 index, [scope()],
+                                 "foo|bar",
+                                 fixed_string=False,
+                                 recursive=True,
+                                 exact_file_set=False)
+    assert not used
+    narrow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_regex_narrows_on_required_literal(harness, index):
+    _, narrow, _ = harness
+    _, used = await narrow_scope(make_accessor(),
+                                 index, [scope()],
+                                 "import.*os",
+                                 fixed_string=False,
+                                 recursive=True,
+                                 exact_file_set=False)
+    assert used
+    assert narrow.await_args.args[1] == "import"
+
+
+@pytest.mark.asyncio
+async def test_file_scope_skips_search(harness, index):
+    stat, narrow, _ = harness
+    stat.return_value = FILE_STAT
+    _, used = await run(index)
+    assert not used
+    narrow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_scope_skips_search(harness, index):
+    stat, narrow, _ = harness
+    stat.side_effect = FileNotFoundError("/data")
+    _, used = await run(index)
+    assert not used
+    narrow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unusable_narrow_falls_back_to_glob(harness, index):
+    _, narrow, glob = harness
+    narrow.return_value = None
+    _, used = await run(index)
+    assert not used
+    glob.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_empty_narrow_falls_back_to_glob(harness, index):
+    _, narrow, glob = harness
+    narrow.return_value = []
+    _, used = await run(index)
+    assert not used
+    glob.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_binary_candidates_are_dropped(harness, index):
+    _, narrow, _ = harness
+    narrow.return_value = [spec("/data/a.parquet"), spec("/data/a.txt")]
+    resolved, used = await run(index)
+    assert used
+    assert [p.virtual for p in resolved] == ["/data/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_all_binary_narrow_stays_used_and_empty(harness, index):
+    _, narrow, glob = harness
+    narrow.return_value = [spec("/data/a.parquet")]
+    resolved, used = await run(index)
+    assert used
+    assert resolved == []
+    glob.assert_not_awaited()

--- a/python/tests/commands/builtin/dropbox/test_rg_search.py
+++ b/python/tests/commands/builtin/dropbox/test_rg_search.py
@@ -1,0 +1,137 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mirage.accessor.dropbox import DropboxAccessor
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.commands.builtin.dropbox.rg import _keep_visible, rg
+from mirage.core.dropbox._client import DropboxTokenManager
+from mirage.io.types import IOResult
+from mirage.resource.dropbox.config import DropboxConfig
+from mirage.types import PathSpec
+
+_GLOBALS = rg.__wrapped__.__globals__
+
+
+def make_accessor() -> DropboxAccessor:
+    config = DropboxConfig(client_id="c",
+                           client_secret="s",
+                           refresh_token="r",
+                           content_search=True)
+    return DropboxAccessor(config, DropboxTokenManager(config))
+
+
+def scope() -> PathSpec:
+    return PathSpec(resource_path="", virtual="/data", directory="/data")
+
+
+def spec(virtual: str) -> PathSpec:
+    return PathSpec(resource_path=virtual.removeprefix("/data/"),
+                    virtual=virtual,
+                    directory="",
+                    resolved=True)
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+@pytest.fixture
+def harness(monkeypatch):
+    narrow = AsyncMock(return_value=([], False))
+    generic = AsyncMock(return_value=(b"", IOResult()))
+    monkeypatch.setitem(_GLOBALS, "narrow_scope", narrow)
+    monkeypatch.setitem(_GLOBALS, "generic_rg", generic)
+    return narrow, generic
+
+
+def test_keep_visible_drops_dotfiles_below_the_scope():
+    kept = _keep_visible(
+        [spec("/data/.env"),
+         spec("/data/.git/config"),
+         spec("/data/a.txt")], [scope()],
+        hidden=False)
+    assert [p.virtual for p in kept] == ["/data/a.txt"]
+
+
+def test_keep_visible_hidden_flag_keeps_everything():
+    paths = [spec("/data/.env"), spec("/data/a.txt")]
+    assert _keep_visible(paths, [scope()], hidden=True) == paths
+
+
+def test_keep_visible_ignores_dots_in_the_scope_itself():
+    hidden_scope = PathSpec(resource_path=".cfg",
+                            virtual="/data/.cfg",
+                            directory="/data/.cfg")
+    kept = _keep_visible([spec("/data/.cfg/a.txt")], [hidden_scope],
+                         hidden=False)
+    assert [p.virtual for p in kept] == ["/data/.cfg/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_plain_rg_allows_narrowing(harness, index):
+    narrow, _ = harness
+    await rg(make_accessor(), [scope()], "needle", index=index)
+    kwargs = narrow.await_args.kwargs
+    assert kwargs["recursive"]
+    assert not kwargs["exact_file_set"]
+
+
+@pytest.mark.asyncio
+async def test_invert_type_and_glob_force_the_full_walk(harness, index):
+    narrow, _ = harness
+    await rg(make_accessor(), [scope()], "needle", v=True, index=index)
+    assert narrow.await_args.kwargs["exact_file_set"]
+    await rg(make_accessor(), [scope()], "needle", type="py", index=index)
+    assert narrow.await_args.kwargs["exact_file_set"]
+    await rg(make_accessor(), [scope()], "needle", glob="*.py", index=index)
+    assert narrow.await_args.kwargs["exact_file_set"]
+
+
+@pytest.mark.asyncio
+async def test_narrowed_run_forces_filename_labels(harness, index):
+    narrow, generic = harness
+    narrow.return_value = ([spec("/data/a.txt")], True)
+    await rg(make_accessor(), [scope()], "needle", index=index)
+    assert generic.await_args.args[2].get("H") is True
+
+
+@pytest.mark.asyncio
+async def test_walk_fallback_leaves_flags_alone(harness, index):
+    narrow, generic = harness
+    narrow.return_value = ([scope()], False)
+    await rg(make_accessor(), [scope()], "needle", index=index)
+    assert "H" not in generic.await_args.args[2]
+
+
+@pytest.mark.asyncio
+async def test_hidden_candidates_are_pruned(harness, index):
+    narrow, generic = harness
+    narrow.return_value = ([spec("/data/.env"), spec("/data/a.txt")], True)
+    await rg(make_accessor(), [scope()], "needle", index=index)
+    assert [p.virtual for p in generic.await_args.args[0]] == ["/data/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_all_hidden_narrowed_set_exits_one(harness, index):
+    narrow, generic = harness
+    narrow.return_value = ([spec("/data/.env")], True)
+    stdout, io = await rg(make_accessor(), [scope()], "needle", index=index)
+    assert stdout == b""
+    assert io.exit_code == 1
+    generic.assert_not_awaited()

--- a/python/tests/commands/builtin/dropbox/test_rg_search.py
+++ b/python/tests/commands/builtin/dropbox/test_rg_search.py
@@ -112,6 +112,14 @@ async def test_narrowed_run_forces_filename_labels(harness, index):
 
 
 @pytest.mark.asyncio
+async def test_dash_upper_i_suppression_survives_narrowing(harness, index):
+    narrow, generic = harness
+    narrow.return_value = ([spec("/data/a.txt")], True)
+    await rg(make_accessor(), [scope()], "needle", args_I=True, index=index)
+    assert "H" not in generic.await_args.args[2]
+
+
+@pytest.mark.asyncio
 async def test_walk_fallback_leaves_flags_alone(harness, index):
     narrow, generic = harness
     narrow.return_value = ([scope()], False)

--- a/python/tests/commands/builtin/test_grep_helper.py
+++ b/python/tests/commands/builtin/test_grep_helper.py
@@ -16,12 +16,14 @@ import re
 
 import pytest
 
+from mirage.commands.builtin import grep_helper
 from mirage.commands.builtin.constants import PatternType
 from mirage.commands.builtin.grep_helper import (NEVER_MATCH, classify_pattern,
                                                  compile_pattern,
                                                  extract_required_literal,
                                                  merge_pattern_list,
                                                  search_query)
+from mirage.types import FileStat, FileType
 
 
 def test_single_pattern_keeps_regex_semantics():
@@ -141,3 +143,36 @@ def test_search_query_regex_extracts_literal():
 
 def test_search_query_regex_no_literal_is_none():
     assert search_query("foo|bar", False) is None
+
+
+@pytest.mark.asyncio
+async def test_grep_files_only_recursive_scans_file_operands():
+    # GNU: `grep -rl pat file` treats the operand as a file; only directory
+    # operands are walked (search-narrowed candidates arrive as files).
+    async def readdir_fn(path):
+        raise FileNotFoundError(path)
+
+    async def stat_fn(path):
+        return FileStat(name=path, type=FileType.TEXT)
+
+    async def read_bytes_fn(path):
+        return b"alpha beta\n"
+
+    hits = await grep_helper.grep_files_only(
+        readdir_fn,
+        stat_fn,
+        read_bytes_fn,
+        "/data/notes.txt",
+        "alpha",
+        recursive=True,
+        ignore_case=False,
+        invert=False,
+        line_numbers=False,
+        count_only=False,
+        fixed_string=False,
+        only_matching=False,
+        max_count=None,
+        whole_word=False,
+        warnings=[],
+    )
+    assert hits == ["/data/notes.txt"]

--- a/python/tests/core/dropbox/test_api.py
+++ b/python/tests/core/dropbox/test_api.py
@@ -16,8 +16,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from mirage.core.dropbox import api
 from mirage.core.dropbox._client import DropboxTokenManager
-from mirage.core.dropbox.api import list_folder
+from mirage.core.dropbox.api import list_folder, search_files
 from mirage.resource.dropbox.config import DropboxConfig
 
 TM = DropboxTokenManager(
@@ -63,3 +64,92 @@ async def test_list_folder_pages_through_continue():
     continue_call = rpc.await_args_list[1]
     assert continue_call.args[1] == "/files/list_folder/continue"
     assert continue_call.args[2] == {"cursor": "c1"}
+
+
+def _search_match(tag: str, lower: str, display: str) -> dict:
+    return {
+        "match_type": {
+            ".tag": "filename"
+        },
+        "metadata": {
+            ".tag": "metadata",
+            "metadata": {
+                ".tag": tag,
+                "path_lower": lower,
+                "path_display": display,
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_search_files_pages_dedups_and_skips_folders():
+    pages = [
+        {
+            "matches": [
+                _search_match("file", "/a.txt", "/A.txt"),
+                _search_match("folder", "/dir", "/Dir"),
+            ],
+            "has_more":
+            True,
+            "cursor":
+            "c1",
+        },
+        {
+            "matches": [
+                _search_match("file", "/a.txt", "/A.txt"),
+                _search_match("file", "/b.txt", "/B.txt"),
+            ],
+            "has_more":
+            False,
+        },
+    ]
+    with patch("mirage.core.dropbox.api.dropbox_rpc",
+               new_callable=AsyncMock,
+               side_effect=pages) as rpc:
+        out, truncated = await search_files(TM, "needle", path="/docs")
+    assert out == [("/a.txt", "/A.txt"), ("/b.txt", "/B.txt")]
+    assert not truncated
+    first_call = rpc.await_args_list[0]
+    assert first_call.args[1] == "/files/search_v2"
+    assert first_call.args[2]["query"] == "needle"
+    assert first_call.args[2]["options"] == {
+        "max_results": api.SEARCH_PAGE,
+        "file_status": "active",
+        "filename_only": False,
+        "path": "/docs",
+    }
+    continue_call = rpc.await_args_list[1]
+    assert continue_call.args[1] == "/files/search/continue_v2"
+    assert continue_call.args[2] == {"cursor": "c1"}
+
+
+@pytest.mark.asyncio
+async def test_search_files_account_root_omits_path():
+    with patch("mirage.core.dropbox.api.dropbox_rpc",
+               new_callable=AsyncMock,
+               return_value={
+                   "matches": [],
+                   "has_more": False
+               }) as rpc:
+        out, truncated = await search_files(TM, "needle")
+    assert out == []
+    assert not truncated
+    assert "path" not in rpc.await_args.args[2]["options"]
+
+
+@pytest.mark.asyncio
+async def test_search_files_flags_the_match_ceiling(monkeypatch):
+    monkeypatch.setattr(api, "MAX_SEARCH_MATCHES", 1)
+    page = {
+        "matches": [_search_match("file", "/a.txt", "/A.txt")],
+        "has_more": True,
+        "cursor": "c1",
+    }
+    with patch("mirage.core.dropbox.api.dropbox_rpc",
+               new_callable=AsyncMock,
+               return_value=page) as rpc:
+        out, truncated = await search_files(TM, "needle")
+    assert out == [("/a.txt", "/A.txt")]
+    assert truncated
+    assert rpc.await_count == 1

--- a/python/tests/core/dropbox/test_search.py
+++ b/python/tests/core/dropbox/test_search.py
@@ -1,0 +1,128 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mirage.accessor.dropbox import DropboxAccessor
+from mirage.core.dropbox._client import DropboxApiError, DropboxTokenManager
+from mirage.core.dropbox.search import narrow_paths
+from mirage.resource.dropbox.config import DropboxConfig
+from mirage.types import PathSpec
+
+
+def make_accessor(root_path: str = "/") -> DropboxAccessor:
+    config = DropboxConfig(client_id="c",
+                           client_secret="s",
+                           refresh_token="r",
+                           root_path=root_path)
+    return DropboxAccessor(config, DropboxTokenManager(config))
+
+
+def mount_root() -> PathSpec:
+    return PathSpec(resource_path="", virtual="/data", directory="/data")
+
+
+def subdir() -> PathSpec:
+    return PathSpec(resource_path="docs",
+                    virtual="/data/docs",
+                    directory="/data/docs")
+
+
+@pytest.mark.asyncio
+async def test_narrow_maps_api_paths_to_mount_paths():
+    results = [("/x.txt", "/x.txt"), ("/sub/y.txt", "/Sub/Y.txt")]
+    with patch("mirage.core.dropbox.search.search_files",
+               new_callable=AsyncMock,
+               return_value=(results, False)) as spy:
+        out = await narrow_paths(make_accessor(), "needle", [mount_root()])
+    assert spy.await_args.kwargs["path"] == ""
+    assert out is not None
+    assert [p.virtual for p in out] == ["/data/Sub/Y.txt", "/data/x.txt"]
+    assert out[1].resource_path == "x.txt"
+    assert out[1].resolved
+
+
+@pytest.mark.asyncio
+async def test_narrow_strips_root_path_case_insensitively():
+    results = [("/team/sub/a.txt", "/Team/Sub/A.txt")]
+    with patch("mirage.core.dropbox.search.search_files",
+               new_callable=AsyncMock,
+               return_value=(results, False)) as spy:
+        out = await narrow_paths(make_accessor("/Team"), "needle",
+                                 [mount_root()])
+    assert spy.await_args.kwargs["path"] == "/Team"
+    assert out is not None
+    assert [p.virtual for p in out] == ["/data/Sub/A.txt"]
+
+
+@pytest.mark.asyncio
+async def test_narrow_filters_results_outside_the_scope():
+    results = [("/docs/in.txt", "/docs/in.txt"),
+               ("/other/out.txt", "/other/out.txt")]
+    with patch("mirage.core.dropbox.search.search_files",
+               new_callable=AsyncMock,
+               return_value=(results, False)) as spy:
+        out = await narrow_paths(make_accessor(), "needle", [subdir()])
+    assert spy.await_args.kwargs["path"] == "/docs"
+    assert out is not None
+    assert [p.virtual for p in out] == ["/data/docs/in.txt"]
+
+
+@pytest.mark.asyncio
+async def test_narrow_sorts_results_in_walk_order():
+    # A sorted readdir walk descends into foo/ before visiting foo.txt;
+    # plain lexicographic path order would put foo.txt first ('.' < '/').
+    results = [("/foo.txt", "/foo.txt"), ("/foo/inner.txt", "/foo/inner.txt")]
+    with patch("mirage.core.dropbox.search.search_files",
+               new_callable=AsyncMock,
+               return_value=(results, False)):
+        out = await narrow_paths(make_accessor(), "needle", [mount_root()])
+    assert out is not None
+    assert [p.virtual for p in out] == ["/data/foo/inner.txt", "/data/foo.txt"]
+
+
+@pytest.mark.asyncio
+async def test_narrow_rebases_raw_onto_the_scope_spelling():
+    scope = PathSpec(resource_path="",
+                     virtual="/data",
+                     directory="/data",
+                     raw_path=".")
+    results = [("/x.txt", "/x.txt")]
+    with patch("mirage.core.dropbox.search.search_files",
+               new_callable=AsyncMock,
+               return_value=(results, False)):
+        out = await narrow_paths(make_accessor(), "needle", [scope])
+    assert out is not None
+    assert out[0].raw_path == "./x.txt"
+
+
+@pytest.mark.asyncio
+async def test_narrow_api_error_returns_none():
+    with patch("mirage.core.dropbox.search.search_files",
+               new_callable=AsyncMock,
+               side_effect=DropboxApiError("boom", 500)):
+        out = await narrow_paths(make_accessor(), "needle", [mount_root()])
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_narrow_truncated_results_return_none():
+    results = [("/x.txt", "/x.txt")]
+    with patch("mirage.core.dropbox.search.search_files",
+               new_callable=AsyncMock,
+               return_value=(results, True)):
+        out = await narrow_paths(make_accessor(), "needle", [mount_root()])
+    assert out is None

--- a/typescript/packages/browser/src/resource/dropbox/config.ts
+++ b/typescript/packages/browser/src/resource/dropbox/config.ts
@@ -19,6 +19,7 @@ export interface DropboxConfig {
   clientSecret?: string
   refreshToken: string
   rootPath?: string
+  contentSearch?: boolean
   endpoint?: string
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
 }
@@ -28,6 +29,7 @@ export interface DropboxConfigRedacted {
   clientSecret?: '<REDACTED>'
   refreshToken: '<REDACTED>'
   rootPath?: string
+  contentSearch?: boolean
   endpoint?: string
 }
 
@@ -36,6 +38,7 @@ const DropboxConfigSchema = z.object({
   clientSecret: secretStr().optional(),
   refreshToken: secretStr(),
   rootPath: z.string().optional(),
+  contentSearch: z.boolean().optional(),
   endpoint: z.string().optional(),
 })
 
@@ -50,6 +53,7 @@ export function normalizeDropboxConfig(input: Record<string, unknown>): DropboxC
       client_secret: 'clientSecret',
       refresh_token: 'refreshToken',
       root_path: 'rootPath',
+      content_search: 'contentSearch',
     },
   }) as unknown as DropboxConfig
 }

--- a/typescript/packages/browser/src/resource/dropbox/dropbox.ts
+++ b/typescript/packages/browser/src/resource/dropbox/dropbox.ts
@@ -62,6 +62,7 @@ export class DropboxResource implements Resource {
     this.accessor = new DropboxAccessor({
       tokenManager: tm,
       ...(config.rootPath !== undefined ? { rootPath: config.rootPath } : {}),
+      ...(config.contentSearch !== undefined ? { contentSearch: config.contentSearch } : {}),
     })
     this.index = new RAMIndexCacheStore({ ttl: 86_400 })
   }

--- a/typescript/packages/core/src/accessor/dropbox.ts
+++ b/typescript/packages/core/src/accessor/dropbox.ts
@@ -31,10 +31,18 @@ export function normalizeDropboxRootPath(value: string | undefined): string {
 export class DropboxAccessor extends Accessor {
   readonly tokenManager: DropboxTokenManager
   readonly rootPath: string
+  // Opt-in for grep/rg search push-down; full-text content search is
+  // plan-gated on Dropbox, so this must mirror the account's plan.
+  readonly contentSearch: boolean
 
-  constructor(opts: { tokenManager: DropboxTokenManager; rootPath?: string }) {
+  constructor(opts: {
+    tokenManager: DropboxTokenManager
+    rootPath?: string
+    contentSearch?: boolean
+  }) {
     super()
     this.tokenManager = opts.tokenManager
     this.rootPath = normalizeDropboxRootPath(opts.rootPath)
+    this.contentSearch = opts.contentSearch === true
   }
 }

--- a/typescript/packages/core/src/commands/builtin/dropbox/grep.test.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/grep.test.ts
@@ -1,0 +1,108 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+// Mirror of python/tests/commands/builtin/dropbox/test_grep_search.py.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./narrow.ts', () => ({ narrowScope: vi.fn() }))
+vi.mock('../generic/grep.ts', () => ({ grepGeneric: vi.fn() }))
+
+import { DropboxAccessor } from '../../../accessor/dropbox.ts'
+import type { DropboxTokenManager } from '../../../core/dropbox/_client.ts'
+import { IOResult } from '../../../io/types.ts'
+import type { Resource } from '../../../resource/base.ts'
+import { PathSpec } from '../../../types.ts'
+import type { CommandFnResult, CommandOpts } from '../../config.ts'
+import { grepGeneric } from '../generic/grep.ts'
+import { DROPBOX_GREP } from './grep.ts'
+import { narrowScope } from './narrow.ts'
+
+const STUB_TM = {} as DropboxTokenManager
+const narrow = vi.mocked(narrowScope)
+const generic = vi.mocked(grepGeneric)
+
+function makeAccessor(): DropboxAccessor {
+  return new DropboxAccessor({ tokenManager: STUB_TM, contentSearch: true })
+}
+
+function scope(): PathSpec {
+  return new PathSpec({ virtual: '/data', directory: '/data', resourcePath: '' })
+}
+
+async function runGrep(
+  flags: Record<string, string | boolean | string[]>,
+): Promise<CommandFnResult> {
+  const cmd = DROPBOX_GREP[0]
+  if (cmd === undefined) throw new Error('grep not registered')
+  const opts: CommandOpts = {
+    stdin: null,
+    flags,
+    filetypeFns: null,
+    cwd: '/',
+    resource: null as unknown as Resource,
+  }
+  return cmd.fn(makeAccessor(), [scope()], ['needle'], opts)
+}
+
+beforeEach(() => {
+  narrow.mockReset()
+  generic.mockReset()
+  narrow.mockResolvedValue({ resolved: [], usedSearch: false })
+  generic.mockResolvedValue([new Uint8Array(), new IOResult()])
+})
+
+describe('dropbox grep push-down', () => {
+  it('allows narrowing for a plain recursive grep', async () => {
+    await runGrep({ r: true })
+    const opts = narrow.mock.calls[0]?.[3]
+    expect(opts?.recursive).toBe(true)
+    expect(opts?.exactFileSet).toBe(false)
+    expect(opts?.fixedString).toBe(false)
+  })
+
+  it('forces the full walk for -v', async () => {
+    await runGrep({ r: true, v: true })
+    expect(narrow.mock.calls[0]?.[3]?.exactFileSet).toBe(true)
+  })
+
+  it('forces the full walk for -c', async () => {
+    await runGrep({ r: true, c: true })
+    expect(narrow.mock.calls[0]?.[3]?.exactFileSet).toBe(true)
+  })
+
+  it('hands narrowed files to the generic grep', async () => {
+    const hits = [
+      new PathSpec({
+        virtual: '/data/a.txt',
+        directory: '',
+        resourcePath: 'a.txt',
+        resolved: true,
+      }),
+    ]
+    narrow.mockResolvedValue({ resolved: hits, usedSearch: true })
+    await runGrep({ r: true })
+    expect(generic.mock.calls[0]?.[1]).toEqual(hits)
+  })
+
+  it('exits 1 without reading when the narrowed set is empty', async () => {
+    narrow.mockResolvedValue({ resolved: [], usedSearch: true })
+    const result = await runGrep({ r: true })
+    expect(result).not.toBeNull()
+    const [out, io] = result as [Uint8Array, IOResult]
+    expect(out).toEqual(new Uint8Array())
+    expect(io.exitCode).toBe(1)
+    expect(generic).not.toHaveBeenCalled()
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/dropbox/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/grep.ts
@@ -27,6 +27,8 @@ import { grepGeneric } from '../generic/grep.ts'
 import { DROPBOX_IO } from './io.ts'
 import { narrowScope } from './narrow.ts'
 
+const dropboxResolveGlob = resolveGlobOf(DROPBOX_IO)
+
 async function grepCommand(
   accessor: DropboxAccessor,
   paths: PathSpec[],
@@ -49,8 +51,7 @@ async function grepCommand(
       return [new Uint8Array(), new IOResult({ exitCode: 1 })]
     }
   }
-  const stat = (p: PathSpec): Promise<FileStat> =>
-    dropboxStat(accessor, p, opts.index ?? undefined)
+  const stat = (p: PathSpec): Promise<FileStat> => dropboxStat(accessor, p, opts.index ?? undefined)
   const readdir = (p: PathSpec): Promise<string[]> =>
     dropboxReaddir(accessor, p, opts.index ?? undefined)
   const stream = (p: PathSpec): AsyncIterable<Uint8Array> =>
@@ -65,5 +66,5 @@ export const DROPBOX_GREP = command({
   fn: grepCommand,
   // Same cost estimate the generic-bound grep carried; narrowing only
   // ever lowers the real cost below it.
-  provision: defaultProvision('grep', DROPBOX_IO.stat, resolveGlobOf(DROPBOX_IO), DROPBOX_IO.readdir),
+  provision: defaultProvision('grep', DROPBOX_IO.stat, dropboxResolveGlob, DROPBOX_IO.readdir),
 })

--- a/typescript/packages/core/src/commands/builtin/dropbox/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/grep.ts
@@ -1,0 +1,69 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DropboxAccessor } from '../../../accessor/dropbox.ts'
+import { stream as dropboxStream } from '../../../core/dropbox/read.ts'
+import { readdir as dropboxReaddir } from '../../../core/dropbox/readdir.ts'
+import { stat as dropboxStat } from '../../../core/dropbox/stat.ts'
+import { IOResult } from '../../../io/types.ts'
+import { type FileStat, ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { resolveGlobOf } from '../generic_bind/index.ts'
+import { defaultProvision } from '../generic_bind/provision.ts'
+import { patternArg } from '../grep_helper.ts'
+import { grepGeneric } from '../generic/grep.ts'
+import { DROPBOX_IO } from './io.ts'
+import { narrowScope } from './narrow.ts'
+
+async function grepCommand(
+  accessor: DropboxAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  let resolved: PathSpec[] = []
+  if (paths.length > 0) {
+    const pattern = patternArg(texts, opts.flags)
+    // -v and -c need the walk: GNU prints non-matching lines (-v) and zero
+    // counts (-c) from files a narrowed superset would never visit.
+    const narrowed = await narrowScope(accessor, paths, pattern, {
+      fixedString: opts.flags.F === true,
+      recursive: opts.flags.r === true || opts.flags.R === true,
+      exactFileSet: opts.flags.v === true || opts.flags.c === true,
+      ...(opts.index !== null ? { index: opts.index } : {}),
+    })
+    resolved = narrowed.resolved
+    if (narrowed.usedSearch && resolved.length === 0) {
+      return [new Uint8Array(), new IOResult({ exitCode: 1 })]
+    }
+  }
+  const stat = (p: PathSpec): Promise<FileStat> =>
+    dropboxStat(accessor, p, opts.index ?? undefined)
+  const readdir = (p: PathSpec): Promise<string[]> =>
+    dropboxReaddir(accessor, p, opts.index ?? undefined)
+  const stream = (p: PathSpec): AsyncIterable<Uint8Array> =>
+    dropboxStream(accessor, p, opts.index ?? undefined)
+  return grepGeneric('grep', resolved, texts, opts, stat, readdir, stream)
+}
+
+export const DROPBOX_GREP = command({
+  name: 'grep',
+  resource: ResourceName.DROPBOX,
+  spec: specOf('grep'),
+  fn: grepCommand,
+  // Same cost estimate the generic-bound grep carried; narrowing only
+  // ever lowers the real cost below it.
+  provision: defaultProvision('grep', DROPBOX_IO.stat, resolveGlobOf(DROPBOX_IO), DROPBOX_IO.readdir),
+})

--- a/typescript/packages/core/src/commands/builtin/dropbox/index.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/index.ts
@@ -19,7 +19,11 @@ import { ResourceName } from '../../../types.ts'
 import type { RegisteredCommand } from '../../config.ts'
 import { makeFiletypeCommands } from '../filetype_factory/factory.ts'
 import { makeGenericCommands } from '../generic_bind/index.ts'
+import { DROPBOX_GREP } from './grep.ts'
 import { DROPBOX_IO } from './io.ts'
+import { DROPBOX_RG } from './rg.ts'
+
+const DROPBOX_OVERRIDES = new Set(['grep', 'rg'])
 
 export const DROPBOX_COMMANDS: readonly RegisteredCommand[] = [
   ...makeFiletypeCommands<DropboxAccessor>({
@@ -27,5 +31,9 @@ export const DROPBOX_COMMANDS: readonly RegisteredCommand[] = [
     readBytes: dropboxRead,
     statEntry: dropboxStat,
   }),
-  ...makeGenericCommands<DropboxAccessor>(ResourceName.DROPBOX, DROPBOX_IO),
+  ...makeGenericCommands<DropboxAccessor>(ResourceName.DROPBOX, DROPBOX_IO, {
+    overrides: DROPBOX_OVERRIDES,
+  }),
+  ...DROPBOX_GREP,
+  ...DROPBOX_RG,
 ]

--- a/typescript/packages/core/src/commands/builtin/dropbox/narrow.test.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/narrow.test.ts
@@ -1,0 +1,169 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+// Mirror of python/tests/commands/builtin/dropbox/test_narrow.py.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as GenericBindModule from '../generic_bind/index.ts'
+
+const { resolveGlobSpy } = vi.hoisted(() => ({ resolveGlobSpy: vi.fn() }))
+
+vi.mock('../generic_bind/index.ts', async () => {
+  const actual = await vi.importActual<typeof GenericBindModule>('../generic_bind/index.ts')
+  return { ...actual, resolveGlobOf: () => resolveGlobSpy }
+})
+
+vi.mock('../../../core/dropbox/search.ts', () => ({ narrowPaths: vi.fn() }))
+vi.mock('../../../core/dropbox/stat.ts', () => ({ stat: vi.fn() }))
+
+import { DropboxAccessor } from '../../../accessor/dropbox.ts'
+import type { DropboxTokenManager } from '../../../core/dropbox/_client.ts'
+import * as searchModule from '../../../core/dropbox/search.ts'
+import * as statModule from '../../../core/dropbox/stat.ts'
+import { FileStat, FileType, PathSpec } from '../../../types.ts'
+import { narrowScope } from './narrow.ts'
+
+const STUB_TM = {} as DropboxTokenManager
+const narrow = vi.mocked(searchModule.narrowPaths)
+const stat = vi.mocked(statModule.stat)
+
+const DIR_STAT = new FileStat({ name: 'data', type: FileType.DIRECTORY })
+const FILE_STAT = new FileStat({ name: 'x.txt', type: FileType.TEXT })
+
+function makeAccessor(contentSearch = true): DropboxAccessor {
+  return new DropboxAccessor({ tokenManager: STUB_TM, contentSearch })
+}
+
+function scope(): PathSpec {
+  return new PathSpec({ virtual: '/data', directory: '/data', resourcePath: '' })
+}
+
+function spec(virtual: string): PathSpec {
+  return new PathSpec({
+    virtual,
+    directory: '',
+    resourcePath: virtual.replace(/^\/data\//, ''),
+    resolved: true,
+  })
+}
+
+async function run(
+  overrides: { pattern?: string | null; recursive?: boolean; exactFileSet?: boolean } = {},
+  accessor = makeAccessor(),
+): Promise<{ resolved: PathSpec[]; usedSearch: boolean }> {
+  return narrowScope(accessor, [scope()], overrides.pattern ?? 'needle', {
+    fixedString: false,
+    recursive: overrides.recursive ?? true,
+    exactFileSet: overrides.exactFileSet ?? false,
+  })
+}
+
+beforeEach(() => {
+  narrow.mockReset()
+  stat.mockReset()
+  resolveGlobSpy.mockReset()
+  stat.mockResolvedValue(DIR_STAT)
+  narrow.mockResolvedValue([spec('/data/a.txt')])
+  resolveGlobSpy.mockResolvedValue([scope()])
+})
+
+describe('narrowScope', () => {
+  it('narrows recursive literal scans', async () => {
+    const out = await run()
+    expect(out.usedSearch).toBe(true)
+    expect(out.resolved.map((p) => p.virtual)).toEqual(['/data/a.txt'])
+    expect(narrow).toHaveBeenCalledTimes(1)
+    expect(resolveGlobSpy).not.toHaveBeenCalled()
+  })
+
+  it('skips search when the knob is off', async () => {
+    const out = await run({}, makeAccessor(false))
+    expect(out.usedSearch).toBe(false)
+    expect(narrow).not.toHaveBeenCalled()
+    expect(resolveGlobSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips search for non-recursive scans', async () => {
+    const out = await run({ recursive: false })
+    expect(out.usedSearch).toBe(false)
+    expect(narrow).not.toHaveBeenCalled()
+  })
+
+  it('skips search when the output needs the exact file set', async () => {
+    const out = await run({ exactFileSet: true })
+    expect(out.usedSearch).toBe(false)
+    expect(narrow).not.toHaveBeenCalled()
+  })
+
+  it('skips search for multi-line pattern lists', async () => {
+    const out = await run({ pattern: 'foo\nbar' })
+    expect(out.usedSearch).toBe(false)
+    expect(narrow).not.toHaveBeenCalled()
+  })
+
+  it('skips search for regexes without a required literal', async () => {
+    const out = await run({ pattern: 'foo|bar' })
+    expect(out.usedSearch).toBe(false)
+    expect(narrow).not.toHaveBeenCalled()
+  })
+
+  it('narrows regexes on their required literal', async () => {
+    const out = await run({ pattern: 'import.*os' })
+    expect(out.usedSearch).toBe(true)
+    expect(narrow.mock.calls[0]?.[1]).toBe('import')
+  })
+
+  it('skips search for file scopes', async () => {
+    stat.mockResolvedValue(FILE_STAT)
+    const out = await run()
+    expect(out.usedSearch).toBe(false)
+    expect(narrow).not.toHaveBeenCalled()
+  })
+
+  it('skips search for missing scopes', async () => {
+    stat.mockRejectedValue(new Error('enoent'))
+    const out = await run()
+    expect(out.usedSearch).toBe(false)
+    expect(narrow).not.toHaveBeenCalled()
+  })
+
+  it('falls back to glob when narrowing is unusable', async () => {
+    narrow.mockResolvedValue(null)
+    const out = await run()
+    expect(out.usedSearch).toBe(false)
+    expect(resolveGlobSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to glob for an empty narrow', async () => {
+    narrow.mockResolvedValue([])
+    const out = await run()
+    expect(out.usedSearch).toBe(false)
+    expect(resolveGlobSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops binary candidates', async () => {
+    narrow.mockResolvedValue([spec('/data/a.parquet'), spec('/data/a.txt')])
+    const out = await run()
+    expect(out.usedSearch).toBe(true)
+    expect(out.resolved.map((p) => p.virtual)).toEqual(['/data/a.txt'])
+  })
+
+  it('keeps usedSearch for an all-binary narrow', async () => {
+    narrow.mockResolvedValue([spec('/data/a.parquet')])
+    const out = await run()
+    expect(out.usedSearch).toBe(true)
+    expect(out.resolved).toEqual([])
+    expect(resolveGlobSpy).not.toHaveBeenCalled()
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/dropbox/narrow.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/narrow.ts
@@ -1,0 +1,92 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DropboxAccessor } from '../../../accessor/dropbox.ts'
+import type { IndexCacheStore } from '../../../cache/index/store.ts'
+import { narrowPaths } from '../../../core/dropbox/search.ts'
+import { stat as dropboxStat } from '../../../core/dropbox/stat.ts'
+import { FileType, type PathSpec } from '../../../types.ts'
+import { getExtension } from '../../resolve.ts'
+import { resolveGlobOf } from '../generic_bind/index.ts'
+import { BINARY_EXTENSIONS, searchQuery } from '../grep_helper.ts'
+import { DROPBOX_IO } from './io.ts'
+
+const resolveGlob = resolveGlobOf(DROPBOX_IO)
+
+export interface NarrowResult {
+  resolved: PathSpec[]
+  usedSearch: boolean
+}
+
+async function allDirectories(
+  accessor: DropboxAccessor,
+  paths: readonly PathSpec[],
+  index?: IndexCacheStore,
+): Promise<boolean> {
+  for (const p of paths) {
+    try {
+      const s = await dropboxStat(accessor, p, index)
+      if (s.type !== FileType.DIRECTORY) return false
+    } catch {
+      // File operands keep the exact single-file output shape and missing
+      // operands must surface the walk's error message; both fall back.
+      return false
+    }
+  }
+  return true
+}
+
+// Resolve grep/rg scope paths, narrowing via Dropbox file search. Push-down
+// needs every gate to hold: the mount opted in via contentSearch, the scan
+// is recursive, a single-line literal can be pushed down (regex patterns
+// narrow on an extracted required literal and stay exact because the caller
+// still scans the regex locally), the output mode tolerates a
+// narrowed-superset file set (exactFileSet covers flags like -v that must
+// see every file), and every scope operand is a directory. Unlike the
+// GitHub narrow there is no scope-size gate: one search call plus targeted
+// downloads beats a readdir-walk-plus-download-everything scan at every
+// scope size. An empty search result still falls back to the full scan
+// (GitHub parity) because search indexing lags recent writes.
+// Binary-extension candidates are dropped from the narrowed set because the
+// recursive walk it replaces skips them; a narrowed set may therefore be
+// empty, which callers must not treat as a stdin run.
+export async function narrowScope(
+  accessor: DropboxAccessor,
+  paths: PathSpec[],
+  pattern: string | null,
+  opts: {
+    fixedString: boolean
+    recursive: boolean
+    exactFileSet: boolean
+    index?: IndexCacheStore
+  },
+): Promise<NarrowResult> {
+  const query =
+    pattern !== null && !pattern.includes('\n') ? searchQuery(pattern, opts.fixedString) : null
+  const useSearch =
+    query !== null &&
+    opts.recursive &&
+    !opts.exactFileSet &&
+    accessor.contentSearch &&
+    (await allDirectories(accessor, paths, opts.index))
+  if (useSearch) {
+    const narrowed = await narrowPaths(accessor, query, paths)
+    if (narrowed !== null && narrowed.length > 0) {
+      const kept = narrowed.filter((p) => !BINARY_EXTENSIONS.has(getExtension(p.virtual) ?? ''))
+      return { resolved: kept, usedSearch: true }
+    }
+  }
+  const resolved = await resolveGlob(accessor, paths, opts.index)
+  return { resolved, usedSearch: false }
+}

--- a/typescript/packages/core/src/commands/builtin/dropbox/rg.test.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/rg.test.ts
@@ -119,6 +119,12 @@ describe('dropbox rg push-down', () => {
     expect(generic.mock.calls[0]?.[2]?.flags.H).toBe(true)
   })
 
+  it('keeps -I suppression instead of forcing labels', async () => {
+    narrow.mockResolvedValue({ resolved: [spec('/data/a.txt')], usedSearch: true })
+    await runRg({ args_I: true })
+    expect('H' in (generic.mock.calls[0]?.[2]?.flags ?? {})).toBe(false)
+  })
+
   it('leaves flags alone on the walk fallback', async () => {
     narrow.mockResolvedValue({ resolved: [scope()], usedSearch: false })
     await runRg({})

--- a/typescript/packages/core/src/commands/builtin/dropbox/rg.test.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/rg.test.ts
@@ -1,0 +1,146 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+// Mirror of python/tests/commands/builtin/dropbox/test_rg_search.py.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./narrow.ts', () => ({ narrowScope: vi.fn() }))
+vi.mock('../generic/rg.ts', () => ({ rgGeneric: vi.fn() }))
+
+import { DropboxAccessor } from '../../../accessor/dropbox.ts'
+import type { DropboxTokenManager } from '../../../core/dropbox/_client.ts'
+import { IOResult } from '../../../io/types.ts'
+import type { Resource } from '../../../resource/base.ts'
+import { PathSpec } from '../../../types.ts'
+import type { CommandFnResult, CommandOpts } from '../../config.ts'
+import { rgGeneric } from '../generic/rg.ts'
+import { narrowScope } from './narrow.ts'
+import { DROPBOX_RG, keepVisible } from './rg.ts'
+
+const STUB_TM = {} as DropboxTokenManager
+const narrow = vi.mocked(narrowScope)
+const generic = vi.mocked(rgGeneric)
+
+function makeAccessor(): DropboxAccessor {
+  return new DropboxAccessor({ tokenManager: STUB_TM, contentSearch: true })
+}
+
+function scope(): PathSpec {
+  return new PathSpec({ virtual: '/data', directory: '/data', resourcePath: '' })
+}
+
+function spec(virtual: string): PathSpec {
+  return new PathSpec({
+    virtual,
+    directory: '',
+    resourcePath: virtual.replace(/^\/data\//, ''),
+    resolved: true,
+  })
+}
+
+async function runRg(flags: Record<string, string | boolean | string[]>): Promise<CommandFnResult> {
+  const cmd = DROPBOX_RG[0]
+  if (cmd === undefined) throw new Error('rg not registered')
+  const opts: CommandOpts = {
+    stdin: null,
+    flags,
+    filetypeFns: null,
+    cwd: '/',
+    resource: null as unknown as Resource,
+  }
+  return cmd.fn(makeAccessor(), [scope()], ['needle'], opts)
+}
+
+beforeEach(() => {
+  narrow.mockReset()
+  generic.mockReset()
+  narrow.mockResolvedValue({ resolved: [], usedSearch: false })
+  generic.mockResolvedValue([new Uint8Array(), new IOResult()])
+})
+
+describe('keepVisible', () => {
+  it('drops dotfiles below the scope', () => {
+    const kept = keepVisible(
+      [spec('/data/.env'), spec('/data/.git/config'), spec('/data/a.txt')],
+      [scope()],
+      false,
+    )
+    expect(kept.map((p) => p.virtual)).toEqual(['/data/a.txt'])
+  })
+
+  it('keeps everything under --hidden', () => {
+    const paths = [spec('/data/.env'), spec('/data/a.txt')]
+    expect(keepVisible(paths, [scope()], true)).toEqual(paths)
+  })
+
+  it('ignores dots in the scope itself', () => {
+    const hiddenScope = new PathSpec({
+      virtual: '/data/.cfg',
+      directory: '/data/.cfg',
+      resourcePath: '.cfg',
+    })
+    const kept = keepVisible([spec('/data/.cfg/a.txt')], [hiddenScope], false)
+    expect(kept.map((p) => p.virtual)).toEqual(['/data/.cfg/a.txt'])
+  })
+})
+
+describe('dropbox rg push-down', () => {
+  it('allows narrowing for a plain rg', async () => {
+    await runRg({})
+    const opts = narrow.mock.calls[0]?.[3]
+    expect(opts?.recursive).toBe(true)
+    expect(opts?.exactFileSet).toBe(false)
+  })
+
+  it('forces the full walk for -v, --type, and --glob', async () => {
+    await runRg({ v: true })
+    expect(narrow.mock.calls[0]?.[3]?.exactFileSet).toBe(true)
+    await runRg({ type: 'py' })
+    expect(narrow.mock.calls[1]?.[3]?.exactFileSet).toBe(true)
+    await runRg({ glob: '*.py' })
+    expect(narrow.mock.calls[2]?.[3]?.exactFileSet).toBe(true)
+  })
+
+  it('forces filename labels for a narrowed run', async () => {
+    narrow.mockResolvedValue({ resolved: [spec('/data/a.txt')], usedSearch: true })
+    await runRg({})
+    expect(generic.mock.calls[0]?.[2]?.flags.H).toBe(true)
+  })
+
+  it('leaves flags alone on the walk fallback', async () => {
+    narrow.mockResolvedValue({ resolved: [scope()], usedSearch: false })
+    await runRg({})
+    expect('H' in (generic.mock.calls[0]?.[2]?.flags ?? {})).toBe(false)
+  })
+
+  it('prunes hidden candidates', async () => {
+    narrow.mockResolvedValue({
+      resolved: [spec('/data/.env'), spec('/data/a.txt')],
+      usedSearch: true,
+    })
+    await runRg({})
+    expect((generic.mock.calls[0]?.[0] ?? []).map((p) => p.virtual)).toEqual(['/data/a.txt'])
+  })
+
+  it('exits 1 when every narrowed candidate is hidden', async () => {
+    narrow.mockResolvedValue({ resolved: [spec('/data/.env')], usedSearch: true })
+    const result = await runRg({})
+    expect(result).not.toBeNull()
+    const [out, io] = result as [Uint8Array, IOResult]
+    expect(out).toEqual(new Uint8Array())
+    expect(io.exitCode).toBe(1)
+    expect(generic).not.toHaveBeenCalled()
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/dropbox/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/rg.ts
@@ -1,0 +1,109 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { DropboxAccessor } from '../../../accessor/dropbox.ts'
+import { stream as dropboxStream } from '../../../core/dropbox/read.ts'
+import { readdir as dropboxReaddir } from '../../../core/dropbox/readdir.ts'
+import { stat as dropboxStat } from '../../../core/dropbox/stat.ts'
+import { IOResult } from '../../../io/types.ts'
+import { type FileStat, ResourceName, type PathSpec } from '../../../types.ts'
+import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { resolveGlobOf } from '../generic_bind/index.ts'
+import { defaultProvision } from '../generic_bind/provision.ts'
+import { patternArg } from '../grep_helper.ts'
+import { rgGeneric } from '../generic/rg.ts'
+import { DROPBOX_IO } from './io.ts'
+import { narrowScope } from './narrow.ts'
+
+// Reproduce rg's dotfile pruning for search-narrowed candidates: the
+// generic rg walk skips hidden files and never descends into hidden
+// directories, but explicit file operands bypass that pruning, so narrowed
+// candidates are filtered on every path segment below their
+// (longest-matching) scope.
+export function keepVisible(
+  narrowed: PathSpec[],
+  scopes: readonly PathSpec[],
+  hidden: boolean,
+): PathSpec[] {
+  if (hidden) return narrowed
+  const kept: PathSpec[] = []
+  for (const p of narrowed) {
+    let rel = p.virtual
+    let best = -1
+    for (const scope of scopes) {
+      const base = scope.virtual.replace(/\/+$/, '')
+      if (base.length > best && (p.virtual === base || p.virtual.startsWith(base + '/'))) {
+        rel = p.virtual.slice(base.length)
+        best = base.length
+      }
+    }
+    const segments = rel.split('/').filter((s) => s !== '')
+    if (segments.some((s) => s.startsWith('.'))) continue
+    kept.push(p)
+  }
+  return kept
+}
+
+async function rgCommand(
+  accessor: DropboxAccessor,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+): Promise<CommandFnResult> {
+  let resolved = paths
+  let runOpts = opts
+  if (paths.length > 0) {
+    const pattern = patternArg(texts, opts.flags)
+    // -v needs the walk (a narrowed superset hides fully non-matching
+    // files whose every line matches inverted); --type/--glob keep the
+    // walk so their file filtering stays in one place.
+    const narrowed = await narrowScope(accessor, paths, pattern, {
+      fixedString: opts.flags.F === true,
+      recursive: true,
+      exactFileSet:
+        opts.flags.v === true ||
+        typeof opts.flags.type === 'string' ||
+        typeof opts.flags.glob === 'string',
+      ...(opts.index !== null ? { index: opts.index } : {}),
+    })
+    if (narrowed.usedSearch) {
+      const visible = keepVisible(narrowed.resolved, paths, opts.flags.hidden === true)
+      if (visible.length === 0) return [new Uint8Array(), new IOResult({ exitCode: 1 })]
+      resolved = visible
+      // ripgrep labels every file a walk finds; narrowed candidates
+      // arrive as explicit operands, so force the label flag.
+      runOpts = { ...opts, flags: { ...opts.flags, H: true } }
+    } else {
+      resolved = narrowed.resolved
+    }
+  }
+  const stat = (p: PathSpec): Promise<FileStat> =>
+    dropboxStat(accessor, p, opts.index ?? undefined)
+  const readdir = (p: PathSpec): Promise<string[]> =>
+    dropboxReaddir(accessor, p, opts.index ?? undefined)
+  const stream = (p: PathSpec): AsyncIterable<Uint8Array> =>
+    dropboxStream(accessor, p, opts.index ?? undefined)
+  return rgGeneric(resolved, texts, runOpts, stat, readdir, stream)
+}
+
+export const DROPBOX_RG = command({
+  name: 'rg',
+  resource: ResourceName.DROPBOX,
+  spec: specOf('rg'),
+  fn: rgCommand,
+  // Same cost estimate the generic-bound rg carried; narrowing only ever
+  // lowers the real cost below it.
+  provision: defaultProvision('rg', DROPBOX_IO.stat, resolveGlobOf(DROPBOX_IO), DROPBOX_IO.readdir),
+})

--- a/typescript/packages/core/src/commands/builtin/dropbox/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/rg.ts
@@ -27,6 +27,8 @@ import { rgGeneric } from '../generic/rg.ts'
 import { DROPBOX_IO } from './io.ts'
 import { narrowScope } from './narrow.ts'
 
+const dropboxResolveGlob = resolveGlobOf(DROPBOX_IO)
+
 // Reproduce rg's dotfile pruning for search-narrowed candidates: the
 // generic rg walk skips hidden files and never descends into hidden
 // directories, but explicit file operands bypass that pruning, so narrowed
@@ -83,14 +85,17 @@ async function rgCommand(
       if (visible.length === 0) return [new Uint8Array(), new IOResult({ exitCode: 1 })]
       resolved = visible
       // ripgrep labels every file a walk finds; narrowed candidates
-      // arrive as explicit operands, so force the label flag.
-      runOpts = { ...opts, flags: { ...opts.flags, H: true } }
+      // arrive as explicit operands, so force the label flag — unless -I
+      // suppresses labels (forcing H would defeat it in the delegated
+      // grepGeneric body).
+      if (opts.flags.args_I !== true) {
+        runOpts = { ...opts, flags: { ...opts.flags, H: true } }
+      }
     } else {
       resolved = narrowed.resolved
     }
   }
-  const stat = (p: PathSpec): Promise<FileStat> =>
-    dropboxStat(accessor, p, opts.index ?? undefined)
+  const stat = (p: PathSpec): Promise<FileStat> => dropboxStat(accessor, p, opts.index ?? undefined)
   const readdir = (p: PathSpec): Promise<string[]> =>
     dropboxReaddir(accessor, p, opts.index ?? undefined)
   const stream = (p: PathSpec): AsyncIterable<Uint8Array> =>
@@ -105,5 +110,5 @@ export const DROPBOX_RG = command({
   fn: rgCommand,
   // Same cost estimate the generic-bound rg carried; narrowing only ever
   // lowers the real cost below it.
-  provision: defaultProvision('rg', DROPBOX_IO.stat, resolveGlobOf(DROPBOX_IO), DROPBOX_IO.readdir),
+  provision: defaultProvision('rg', DROPBOX_IO.stat, dropboxResolveGlob, DROPBOX_IO.readdir),
 })

--- a/typescript/packages/core/src/commands/builtin/grep_helper.test.ts
+++ b/typescript/packages/core/src/commands/builtin/grep_helper.test.ts
@@ -13,11 +13,13 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
+import { FileStat, FileType } from '../../types.ts'
 import { PatternType } from './constants.ts'
 import {
   classifyPattern,
   compilePattern,
   extractRequiredLiteral,
+  grepFilesOnly,
   isRegexPattern,
   mergePatternList,
   NEVER_MATCH,
@@ -172,5 +174,28 @@ describe('searchQuery', () => {
   })
   it('returns null when no literal can be proven', () => {
     expect(searchQuery('foo|bar', false)).toBeNull()
+  })
+})
+
+describe('grepFilesOnly', () => {
+  it('scans file operands under recursive instead of walking them', async () => {
+    // GNU: `grep -rl pat file` treats the operand as a file; only directory
+    // operands are walked (search-narrowed candidates arrive as files).
+    const readdirFn = (path: string): Promise<string[]> => Promise.reject(new Error(path))
+    const statFn = (path: string): Promise<FileStat> =>
+      Promise.resolve(new FileStat({ name: path, type: FileType.TEXT }))
+    const readBytesFn = (): Promise<Uint8Array> => Promise.resolve(ENC.encode('alpha beta\n'))
+    const hits = await grepFilesOnly(readdirFn, statFn, readBytesFn, '/data/notes.txt', 'alpha', {
+      recursive: true,
+      ignoreCase: false,
+      invert: false,
+      lineNumbers: false,
+      countOnly: false,
+      fixedString: false,
+      onlyMatching: false,
+      maxCount: null,
+      wholeWord: false,
+    })
+    expect(hits).toEqual(['/data/notes.txt'])
   })
 })

--- a/typescript/packages/core/src/commands/builtin/grep_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/grep_helper.ts
@@ -462,7 +462,19 @@ export async function grepFilesOnly(
 ): Promise<string[]> {
   const compiled = compilePattern(pattern, opts.ignoreCase, opts.fixedString, opts.wholeWord)
   if (opts.recursive) {
-    return grepRecursive(readdirFn, statFn, readBytesFn, path, compiled, opts, warnings)
+    // GNU only walks directory operands; a file operand under -r takes the
+    // plain single-file scan (python grep_files_only parity). Stat failures
+    // keep the walk so missing operands surface its error shape.
+    let operandIsFile = false
+    try {
+      const s = await statFn(path)
+      operandIsFile = s.type !== FileType.DIRECTORY
+    } catch {
+      operandIsFile = false
+    }
+    if (!operandIsFile) {
+      return grepRecursive(readdirFn, statFn, readBytesFn, path, compiled, opts, warnings)
+    }
   }
   try {
     const data = await readBytesFn(path)

--- a/typescript/packages/core/src/core/dropbox/api.test.ts
+++ b/typescript/packages/core/src/core/dropbox/api.test.ts
@@ -1,0 +1,96 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+// Mirror of the search_files cases in python/tests/core/dropbox/test_api.py.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ClientModule from './_client.ts'
+
+vi.mock('./_client.ts', async () => {
+  const actual = await vi.importActual<typeof ClientModule>('./_client.ts')
+  return { ...actual, dropboxRpc: vi.fn() }
+})
+
+import * as client from './_client.ts'
+import type { DropboxTokenManager } from './_client.ts'
+import { MAX_SEARCH_MATCHES, SEARCH_PAGE, searchFiles } from './api.ts'
+
+const TM = {} as DropboxTokenManager
+const rpc = vi.mocked(client.dropboxRpc)
+
+function searchMatch(tag: string, lower: string, display: string): Record<string, unknown> {
+  return {
+    match_type: { '.tag': 'filename' },
+    metadata: {
+      '.tag': 'metadata',
+      metadata: { '.tag': tag, path_lower: lower, path_display: display },
+    },
+  }
+}
+
+beforeEach(() => {
+  rpc.mockReset()
+})
+
+describe('searchFiles', () => {
+  it('pages, dedups across pages, and skips folders', async () => {
+    rpc
+      .mockResolvedValueOnce({
+        matches: [searchMatch('file', '/a.txt', '/A.txt'), searchMatch('folder', '/dir', '/Dir')],
+        has_more: true,
+        cursor: 'c1',
+      })
+      .mockResolvedValueOnce({
+        matches: [searchMatch('file', '/a.txt', '/A.txt'), searchMatch('file', '/b.txt', '/B.txt')],
+        has_more: false,
+      })
+    const out = await searchFiles(TM, 'needle', { path: '/docs' })
+    expect(out.paths).toEqual([
+      ['/a.txt', '/A.txt'],
+      ['/b.txt', '/B.txt'],
+    ])
+    expect(out.truncated).toBe(false)
+    expect(rpc.mock.calls[0]?.[1]).toBe('/files/search_v2')
+    expect(rpc.mock.calls[0]?.[2]).toEqual({
+      query: 'needle',
+      options: {
+        max_results: SEARCH_PAGE,
+        file_status: 'active',
+        filename_only: false,
+        path: '/docs',
+      },
+    })
+    expect(rpc.mock.calls[1]?.[1]).toBe('/files/search/continue_v2')
+    expect(rpc.mock.calls[1]?.[2]).toEqual({ cursor: 'c1' })
+  })
+
+  it('omits the path option for the account root', async () => {
+    rpc.mockResolvedValueOnce({ matches: [], has_more: false })
+    const out = await searchFiles(TM, 'needle')
+    expect(out).toEqual({ paths: [], truncated: false })
+    const options = (rpc.mock.calls[0]?.[2] as { options: Record<string, unknown> }).options
+    expect('path' in options).toBe(false)
+  })
+
+  it('flags the 10,000-match ceiling as truncated', async () => {
+    const matches = Array.from({ length: MAX_SEARCH_MATCHES }, (_, i) =>
+      searchMatch('file', `/f${String(i)}.txt`, `/f${String(i)}.txt`),
+    )
+    rpc.mockResolvedValueOnce({ matches, has_more: true, cursor: 'c1' })
+    const out = await searchFiles(TM, 'needle')
+    expect(out.paths).toHaveLength(MAX_SEARCH_MATCHES)
+    expect(out.truncated).toBe(true)
+    expect(rpc).toHaveBeenCalledTimes(1)
+  })
+})

--- a/typescript/packages/core/src/core/dropbox/api.ts
+++ b/typescript/packages/core/src/core/dropbox/api.ts
@@ -92,29 +92,54 @@ export async function copyPath(tm: DropboxTokenManager, from: string, to: string
   await dropboxRpc(tm, '/files/copy_v2', { from_path: from, to_path: to, autorename: false })
 }
 
+export const SEARCH_PAGE = 1000
+// search_v2 + search/continue_v2 serve at most 10,000 matches total; a
+// result set that hits the ceiling may be incomplete and must not be used
+// to narrow a scan.
+export const MAX_SEARCH_MATCHES = 10_000
+
+export interface SearchFilesResult {
+  paths: [string, string][]
+  truncated: boolean
+}
+
+/**
+ * Collect `[path_lower, path_display]` file matches for a search query.
+ *
+ * Pages through `/files/search_v2` and `/files/search/continue_v2`,
+ * deduplicating across pages (the API may repeat results between pages).
+ * `path: ''` searches the whole account. `truncated` reports whether the
+ * result hit the API's 10,000-match ceiling (a truncated set is not a
+ * trustworthy superset).
+ */
 export async function searchFiles(
   tm: DropboxTokenManager,
   query: string,
-  opts: { path?: string; maxResults?: number; fileStatus?: 'active' | 'deleted' } = {},
-): Promise<DropboxEntry[]> {
-  const max = opts.maxResults ?? 100
-  const body: Record<string, unknown> = {
-    query,
-    options: {
-      max_results: max,
-      file_status: opts.fileStatus ?? 'active',
-    },
+  opts: { path?: string; filenameOnly?: boolean } = {},
+): Promise<SearchFilesResult> {
+  const options: Record<string, unknown> = {
+    max_results: SEARCH_PAGE,
+    file_status: 'active',
+    filename_only: opts.filenameOnly === true,
   }
-  if (opts.path !== undefined && opts.path !== '' && opts.path !== '/') {
-    ;(body.options as Record<string, unknown>).path = opts.path
+  if (opts.path !== undefined && opts.path !== '') options.path = opts.path
+  let resp = (await dropboxRpc(tm, '/files/search_v2', { query, options })) as SearchResponseV2
+  const seen = new Set<string>()
+  const paths: [string, string][] = []
+  for (;;) {
+    for (const m of resp.matches ?? []) {
+      const entry = m.metadata?.metadata
+      if (entry?.['.tag'] !== 'file') continue
+      const lower = entry.path_lower ?? ''
+      const display = entry.path_display ?? lower
+      if (lower === '' || seen.has(lower)) continue
+      seen.add(lower)
+      paths.push([lower, display])
+    }
+    if (paths.length >= MAX_SEARCH_MATCHES) return { paths, truncated: true }
+    if (resp.has_more !== true || resp.cursor === undefined) return { paths, truncated: false }
+    resp = (await dropboxRpc(tm, '/files/search/continue_v2', {
+      cursor: resp.cursor,
+    })) as SearchResponseV2
   }
-  const resp = (await dropboxRpc(tm, '/files/search_v2', body)) as SearchResponseV2
-  const matches = resp.matches ?? []
-  const entries: DropboxEntry[] = []
-  for (const m of matches) {
-    const entry = m.metadata?.metadata
-    if (entry === undefined) continue
-    if (entry['.tag'] !== 'deleted') entries.push(entry)
-  }
-  return entries
 }

--- a/typescript/packages/core/src/core/dropbox/search.test.ts
+++ b/typescript/packages/core/src/core/dropbox/search.test.ts
@@ -1,0 +1,129 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+// Mirror of python/tests/core/dropbox/test_search.py.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ApiModule from './api.ts'
+
+vi.mock('./api.ts', async () => {
+  const actual = await vi.importActual<typeof ApiModule>('./api.ts')
+  return { ...actual, searchFiles: vi.fn() }
+})
+
+import { DropboxAccessor } from '../../accessor/dropbox.ts'
+import { PathSpec } from '../../types.ts'
+import { DropboxApiError, type DropboxTokenManager } from './_client.ts'
+import * as api from './api.ts'
+import { narrowPaths } from './search.ts'
+
+const STUB_TM = {} as DropboxTokenManager
+const search = vi.mocked(api.searchFiles)
+
+function makeAccessor(rootPath?: string): DropboxAccessor {
+  return new DropboxAccessor({
+    tokenManager: STUB_TM,
+    ...(rootPath !== undefined ? { rootPath } : {}),
+  })
+}
+
+function mountRoot(): PathSpec {
+  return new PathSpec({ virtual: '/data', directory: '/data', resourcePath: '' })
+}
+
+function subdir(): PathSpec {
+  return new PathSpec({ virtual: '/data/docs', directory: '/data/docs', resourcePath: 'docs' })
+}
+
+beforeEach(() => {
+  search.mockReset()
+})
+
+describe('narrowPaths', () => {
+  it('maps API paths back to mount paths', async () => {
+    search.mockResolvedValueOnce({
+      paths: [
+        ['/x.txt', '/x.txt'],
+        ['/sub/y.txt', '/Sub/Y.txt'],
+      ],
+      truncated: false,
+    })
+    const out = await narrowPaths(makeAccessor(), 'needle', [mountRoot()])
+    expect(search.mock.calls[0]?.[2]).toEqual({ path: '' })
+    expect(out?.map((p) => p.virtual)).toEqual(['/data/Sub/Y.txt', '/data/x.txt'])
+    expect(out?.[1]?.resourcePath).toBe('x.txt')
+    expect(out?.[1]?.resolved).toBe(true)
+  })
+
+  it('strips the configured root path case-insensitively', async () => {
+    search.mockResolvedValueOnce({
+      paths: [['/team/sub/a.txt', '/Team/Sub/A.txt']],
+      truncated: false,
+    })
+    const out = await narrowPaths(makeAccessor('/Team'), 'needle', [mountRoot()])
+    expect(search.mock.calls[0]?.[2]).toEqual({ path: '/Team' })
+    expect(out?.map((p) => p.virtual)).toEqual(['/data/Sub/A.txt'])
+  })
+
+  it('filters results outside the scope', async () => {
+    search.mockResolvedValueOnce({
+      paths: [
+        ['/docs/in.txt', '/docs/in.txt'],
+        ['/other/out.txt', '/other/out.txt'],
+      ],
+      truncated: false,
+    })
+    const out = await narrowPaths(makeAccessor(), 'needle', [subdir()])
+    expect(search.mock.calls[0]?.[2]).toEqual({ path: '/docs' })
+    expect(out?.map((p) => p.virtual)).toEqual(['/data/docs/in.txt'])
+  })
+
+  it('sorts results in sorted-readdir walk order', async () => {
+    // A sorted readdir walk descends into foo/ before visiting foo.txt;
+    // plain lexicographic path order would put foo.txt first ('.' < '/').
+    search.mockResolvedValueOnce({
+      paths: [
+        ['/foo.txt', '/foo.txt'],
+        ['/foo/inner.txt', '/foo/inner.txt'],
+      ],
+      truncated: false,
+    })
+    const out = await narrowPaths(makeAccessor(), 'needle', [mountRoot()])
+    expect(out?.map((p) => p.virtual)).toEqual(['/data/foo/inner.txt', '/data/foo.txt'])
+  })
+
+  it('rebases rawPath onto the scope spelling', async () => {
+    const scope = new PathSpec({
+      virtual: '/data',
+      directory: '/data',
+      resourcePath: '',
+      rawPath: '.',
+    })
+    search.mockResolvedValueOnce({ paths: [['/x.txt', '/x.txt']], truncated: false })
+    const out = await narrowPaths(makeAccessor(), 'needle', [scope])
+    expect(out?.[0]?.rawPath).toBe('./x.txt')
+  })
+
+  it('returns null on an API failure', async () => {
+    search.mockRejectedValueOnce(new DropboxApiError('boom', 500))
+    const out = await narrowPaths(makeAccessor(), 'needle', [mountRoot()])
+    expect(out).toBeNull()
+  })
+
+  it('returns null for truncated results', async () => {
+    search.mockResolvedValueOnce({ paths: [['/x.txt', '/x.txt']], truncated: true })
+    const out = await narrowPaths(makeAccessor(), 'needle', [mountRoot()])
+    expect(out).toBeNull()
+  })
+})

--- a/typescript/packages/core/src/core/dropbox/search.ts
+++ b/typescript/packages/core/src/core/dropbox/search.ts
@@ -1,0 +1,92 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { mountKey, mountPrefixOf } from '../../utils/key_prefix.ts'
+import type { DropboxAccessor } from '../../accessor/dropbox.ts'
+import { PathSpec } from '../../types.ts'
+import { rebaseRaw } from '../../utils/path.ts'
+import { searchFiles } from './api.ts'
+import { dropboxPathOf } from './paths.ts'
+
+function compareComponents(a: string, b: string): number {
+  const ca = a.split('/')
+  const cb = b.split('/')
+  const n = Math.min(ca.length, cb.length)
+  for (let i = 0; i < n; i += 1) {
+    const x = ca[i] ?? ''
+    const y = cb[i] ?? ''
+    if (x < y) return -1
+    if (x > y) return 1
+  }
+  return ca.length - cb.length
+}
+
+/**
+ * Use Dropbox file search to narrow grep/rg scopes to candidate files.
+ *
+ * Search results are compared against each scope on `path_lower` (Dropbox
+ * paths are case-insensitive) and mapped back to mount paths from
+ * `path_display`. Per-scope results are sorted component-wise so they line
+ * up with the order a sorted readdir walk would visit, and each `rawPath`
+ * is rebased onto the scope's as-typed spelling so output labels match a
+ * walk's.
+ *
+ * Returns null whenever the narrowed set cannot be trusted as a superset
+ * of what a full scan would read (API failure, or the 10,000-match search
+ * ceiling), so the caller falls back to the full scan.
+ */
+export async function narrowPaths(
+  accessor: DropboxAccessor,
+  query: string,
+  paths: readonly PathSpec[],
+): Promise<PathSpec[] | null> {
+  const first = paths[0]
+  if (first === undefined) return []
+  const mountPrefix = mountPrefixOf(first.virtual, first.resourcePath)
+  const root = accessor.rootPath
+  const narrowed: PathSpec[] = []
+  for (const p of paths) {
+    const scopeApi = dropboxPathOf(accessor, p)
+    let results: [string, string][]
+    try {
+      const out = await searchFiles(accessor.tokenManager, query, { path: scopeApi })
+      if (out.truncated) return null
+      results = out.paths
+    } catch {
+      // Search is best-effort; an API failure falls back to the full scan.
+      return null
+    }
+    const scopeLower = scopeApi.toLowerCase()
+    const scopePrefix = scopeLower.replace(/\/+$/, '') + '/'
+    const scoped: string[] = []
+    for (const [lower, display] of results) {
+      if (lower !== scopeLower && !lower.startsWith(scopePrefix)) continue
+      const key = display.slice(root.length).replace(/^\/+|\/+$/g, '')
+      scoped.push(key === '' ? mountPrefix || '/' : `${mountPrefix}/${key}`)
+    }
+    scoped.sort(compareComponents)
+    for (const virtual of scoped) {
+      narrowed.push(
+        new PathSpec({
+          virtual,
+          directory: '',
+          resourcePath: mountKey(virtual, mountPrefix),
+          resolved: true,
+          rawPath: rebaseRaw([virtual], p.virtual, p.rawPath)[0] ?? virtual,
+        }),
+      )
+    }
+  }
+  return narrowed
+}

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -901,6 +901,7 @@ export { DROPBOX_OPS } from './ops/dropbox/index.ts'
 export { read as dropboxRead, stream as dropboxStream } from './core/dropbox/read.ts'
 export { readdir as dropboxReaddir } from './core/dropbox/readdir.ts'
 export { stat as dropboxStat } from './core/dropbox/stat.ts'
+export { narrowPaths as dropboxNarrowPaths } from './core/dropbox/search.ts'
 export { DROPBOX_PROMPT } from './resource/dropbox/prompt.ts'
 export {
   BOX_API_BASE,

--- a/typescript/packages/node/src/resource/dropbox/config.ts
+++ b/typescript/packages/node/src/resource/dropbox/config.ts
@@ -19,6 +19,7 @@ export interface DropboxConfig {
   clientSecret: string
   refreshToken: string
   rootPath?: string
+  contentSearch?: boolean
   endpoint?: string
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
 }
@@ -28,6 +29,7 @@ export interface DropboxConfigRedacted {
   clientSecret: '<REDACTED>'
   refreshToken: '<REDACTED>'
   rootPath?: string
+  contentSearch?: boolean
   endpoint?: string
 }
 
@@ -36,6 +38,7 @@ const DropboxConfigSchema = z.object({
   clientSecret: secretStr(),
   refreshToken: secretStr(),
   rootPath: z.string().optional(),
+  contentSearch: z.boolean().optional(),
   endpoint: z.string().optional(),
 })
 
@@ -50,6 +53,7 @@ export function normalizeDropboxConfig(input: Record<string, unknown>): DropboxC
       client_secret: 'clientSecret',
       refresh_token: 'refreshToken',
       root_path: 'rootPath',
+      content_search: 'contentSearch',
     },
   }) as unknown as DropboxConfig
 }

--- a/typescript/packages/node/src/resource/dropbox/dropbox.ts
+++ b/typescript/packages/node/src/resource/dropbox/dropbox.ts
@@ -62,6 +62,7 @@ export class DropboxResource extends BaseResource implements Resource {
     this.accessor = new DropboxAccessor({
       tokenManager: tm,
       ...(config.rootPath !== undefined ? { rootPath: config.rootPath } : {}),
+      ...(config.contentSearch !== undefined ? { contentSearch: config.contentSearch } : {}),
     })
   }
 


### PR DESCRIPTION
## What

Recursive `grep`/`rg` on a Dropbox mount previously walked the tree and downloaded every file. This adds an opt-in search push-down: with `content_search=True` (TS `contentSearch: true`), both commands first ask [`/2/files/search_v2`](https://www.dropbox.com/developers/documentation/http/documentation#files-search) which files contain the pattern's literal, then download and scan only those candidates. **Output stays exactly GNU/ripgrep** because the local scan still decides every match — search only narrows the candidate set.

Follows the GitHub backend's narrow-then-scan blueprint and the Slack backend's availability-gate pattern, with three deliberate hardenings the GitHub narrow doesn't have:

- `-v` / `-c` (grep) and `-v` / `--type` / `--glob` (rg) force the full walk — a narrowed superset would hide files those output modes must see.
- No `-l` short-circuit: Dropbox search is case-insensitive, so narrowed candidates are always re-scanned locally.
- Binary-extension candidates are dropped (the walk skips them), rg prunes hidden candidates segment-wise, and narrowed rg runs force walk-style filename labels.

## Why the knob is off by default

Full-text content search is plan-gated (Professional/Essentials/Business+); on other plans `search_v2` silently matches file names only, which would make a narrowed scan miss content matches. Dropbox's search index also lags recent writes. Docs spell out both caveats.

## Details

- **Core (both languages)**: `search_files`/`searchFiles` pages `search_v2` + `search/continue_v2`, dedups across pages (API may repeat results), and flags the 10,000-match ceiling; `narrow_paths`/`narrowPaths` maps `path_lower`/`path_display` back to mount paths under `root_path` (case-insensitive scope filter, display-cased output), sorts candidates into sorted-readdir **walk order** (component-wise, not lexicographic), and rebases `raw_path` onto the scope's as-typed spelling so labels match a walk. Failed/empty/truncated searches fall back to the full walk.
- **Gating** (`narrow_scope`/`narrowScope`): knob on + recursive + single-line literal (regexes narrow on an extracted required literal) + all scope operands stat as directories. Unlike GitHub there is no scope-size gate: one search call plus targeted downloads beats a full walk at every scope size.
- **Provision**: bespoke wrappers re-attach the factory's `default_provision`, so cost estimates are byte-identical to before (`prov_*` battery cases).
- **GNU fix (python generic)**: `grep -Rl` with a *file* operand now stats first and scans the file instead of readdir-walking it — GNU behavior and TS parity; narrowed candidates exercised this latent gap.
- **Fakes**: `integ/server/dropbox.ts` + `dropbox_server.py` implement `search_v2`/`search/continue_v2` with cursor paging; matching is case-insensitive substring over names and content — a superset of real token matching, which is exactly the contract narrowing needs.
- **Battery**: adapters enable the knob, so every dropbox/dropbox-root grep/rg case now exercises the push-down live.

## Verification

- Battery: `dropbox` + `dropbox-root` **988/988 on both hosts** (push-down active); ram/disk/s3 regression targets clean on both hosts (python 3271/0 incl. s3; TS 2170/0, s3 skipped locally).
- Python: full suite green (only known env failures: native tac, fuse, redis); mypy 1435 files clean.
- TS: core 4304 / browser 165 / node 1540 (+4 known native_tac env); typecheck, eslint, knip, pre-commit clean.
- `spec/` regenerated — no drift (registered command names unchanged).
- Docs: search push-down sections in `docs/python/resource/dropbox.mdx` + `docs/typescript/dropbox.mdx`, resource-matrix note; python example extended with a write roundtrip + search demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)