### PR TITLE
Improve Pi agent integration with native UI and stale-write protection

### DIFF
--- a/docs/typescript/agents/pi.mdx
+++ b/docs/typescript/agents/pi.mdx
@@ -4,10 +4,11 @@ description: Run @earendil-works/pi-coding-agent with all 7 built-in tools wired
 icon: /images/pi-logo.svg
 ---
 
-[Pi Coding Agent](https://github.com/earendil-works/pi) is a TypeScript coding agent with seven built-in tools (read, write, edit, bash, grep, find, ls). Mirage provides an extension factory that swaps Pi's host-backed operations for `Workspace` operations.
+[Pi Coding Agent](https://github.com/earendil-works/pi) is a TypeScript coding agent with seven built-in tools (`read`, `write`, `edit`, `bash`, `grep`, `find`, and `ls`). Mirage provides a native Pi inline extension that replaces their host-filesystem operations with a `Workspace`.
 
 <Note>
-  Node 22.19 or newer only. Pi is a CLI agent; it uses `process.cwd()`, agent directories, and other Node-only APIs.
+  Node 22.19 or newer only. Pi is a CLI agent; it uses `process.cwd()`, agent directories, and other
+  Node-only APIs.
 </Note>
 
 ## Install
@@ -16,61 +17,71 @@ icon: /images/pi-logo.svg
 pnpm add @struktoai/mirage-agents @struktoai/mirage-node @earendil-works/pi-coding-agent
 ```
 
-## Usage
+## Native Pi UI
+
+Pass the Mirage extension to Pi's regular entry point. Pi continues to own its CLI/TUI, model selection, sessions, themes, commands, and authentication.
 
 ```ts
 import { MountMode, OpsRegistry, RAMResource, Workspace } from '@struktoai/mirage-node'
-import {
-  createAgentSession,
-  DefaultResourceLoader,
-  getAgentDir,
-  ModelRuntime,
-  SessionManager,
-  SettingsManager,
-} from '@earendil-works/pi-coding-agent'
-import { buildSystemPrompt, mirageExtension } from '@struktoai/mirage-agents/pi'
+import { main } from '@earendil-works/pi-coding-agent'
+import { mirageExtension } from '@struktoai/mirage-agents/pi'
 
 const ram = new RAMResource()
 const ops = new OpsRegistry()
 for (const op of ram.ops()) ops.register(op)
 const ws = new Workspace({ '/': ram }, { mode: MountMode.WRITE, ops })
 
-const resourceLoader = new DefaultResourceLoader({
-  cwd: process.cwd(),
-  agentDir: getAgentDir(),
-  settingsManager: SettingsManager.create(process.cwd(), getAgentDir()),
-  systemPrompt: buildSystemPrompt({
-    mountInfo: { '/': 'In-memory filesystem (read/write)' },
-  }),
+await main(process.argv.slice(2), {
   extensionFactories: [mirageExtension(ws)],
-  noExtensions: true,
-  noSkills: true,
 })
-await resourceLoader.reload()
-
-const modelRuntime = await ModelRuntime.create()
-const { session } = await createAgentSession({
-  modelRuntime,
-  resourceLoader,
-  sessionManager: SessionManager.inMemory(),
-})
-
-await session.prompt("Create /hello.txt with 'hi' and ls /.")
 ```
 
-The examples also accept `PI_PROVIDER`, `PI_MODEL`, `PI_BASE_URL`, and `PI_API_KEY`. This lets a built-in Pi provider and model run through a compatible gateway without writing credentials to Pi's configuration files.
+Running this script in a terminal opens Pi's existing UI. The extension also routes interactive `!` and `!!` shell commands through Mirage at the virtual working directory.
+
+For an isolated Mirage session, prevent Pi from loading `AGENTS.md` and `CLAUDE.md` files from the host project:
+
+```bash
+pnpm exec tsx agents/pi/ui_pi.ts --no-context-files
+```
+
+After asking Pi to create a file, you can verify that the native UI is using Mirage:
+
+```text
+!ls /
+!cat /hello.txt
+```
+
+Omit `--no-context-files` when you intentionally want Pi to combine host-project instructions with the mounted Mirage workspace.
+
+The one-shot examples use Pi's lower-level session API and accept `PI_PROVIDER`, `PI_MODEL`, `PI_BASE_URL`, and `PI_API_KEY`. This lets a built-in Pi provider and model run through a compatible gateway without writing credentials to Pi's configuration files.
+
+## Stale-write protection
+
+Pi serializes its own mutations and its `edit` tool checks that the requested old text still exists in the current file. It does not, however, retain a file revision from an earlier agent read.
+
+The Mirage extension records a content fingerprint whenever Pi reads or greps a file. A later `edit` or full-file `write` fails with `StaleMirageFileError` if that content changed in the meantime. Reading the file again refreshes the fingerprint, so the agent can reconsider the new content and retry. The `edit` adapter also checks again immediately before writing.
+
+This protection is enabled by default. It observes the content returned by the mounted resource, so a remote backend's cache and invalidation policy still determines when an external change becomes visible to Mirage.
 
 ## Exports
 
-| Symbol | Purpose |
-| --- | --- |
-| `mirageExtension(ws, opts?)` | Returns an `ExtensionFactory` that registers all 7 Pi tools against `ws`. |
-| `mirageOperations(ws)` | Lower-level: returns the `{ read, write, edit, bash, grep, find, ls }` operation bundle if you want to register tools manually. |
-| `buildSystemPrompt` | Generates a system prompt that describes mounted paths to the model. |
+| Symbol                        | Purpose                                                                           |
+| ----------------------------- | --------------------------------------------------------------------------------- |
+| `mirageExtension(ws, opts?)`  | Returns a named Pi `InlineExtension` that registers all seven tools against `ws`. |
+| `mirageOperations(ws, opts?)` | Lower-level `{ read, write, edit, bash, grep, find, ls }` operation bundle.       |
+| `StaleMirageFileError`        | Error raised when a mutation targets content that changed after an agent read.    |
+| `buildSystemPrompt`           | Generates a system prompt that describes mounted paths to the model.              |
 
-`mirageExtension` accepts `{ cwd?: string }`, defaults to `'/'`, which tells Pi the working directory inside the mounted workspace.
+`mirageExtension` accepts:
+
+| Option                 | Default             | Purpose                                                                                                         |
+| ---------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `cwd`                  | `'/'`               | Working directory inside the mounted workspace.                                                                 |
+| `staleWriteProtection` | `true`              | Reject mutations when the file changed after Pi read it.                                                        |
+| `systemPrompt`         | Mirage mount prompt | Extra instructions appended to Pi's prompt. Pass a string to replace the Mirage text, or `false` to disable it. |
 
 ## Examples
 
+- [`examples/typescript/agents/pi/ui_pi.ts`](https://github.com/strukto-ai/mirage/blob/main/examples/typescript/agents/pi/ui_pi.ts), Mirage inside Pi's native CLI/TUI.
 - [`examples/typescript/agents/pi/ram_pi.ts`](https://github.com/strukto-ai/mirage/blob/main/examples/typescript/agents/pi/ram_pi.ts), RAM-only sandbox.
 - [`examples/typescript/agents/pi/s3_pi.ts`](https://github.com/strukto-ai/mirage/blob/main/examples/typescript/agents/pi/s3_pi.ts), Pi exploring an S3 bucket through Mirage.

--- a/examples/typescript/agents/pi/ram_pi.ts
+++ b/examples/typescript/agents/pi/ram_pi.ts
@@ -24,7 +24,7 @@ import {
   SessionManager,
   SettingsManager,
 } from '@earendil-works/pi-coding-agent'
-import { buildSystemPrompt, mirageExtension } from '@struktoai/mirage-agents/pi'
+import { mirageExtension } from '@struktoai/mirage-agents/pi'
 import { configurePiModel } from './config.ts'
 
 loadEnv({
@@ -40,9 +40,6 @@ const resourceLoader = new DefaultResourceLoader({
   cwd: process.cwd(),
   agentDir: getAgentDir(),
   settingsManager: SettingsManager.create(process.cwd(), getAgentDir()),
-  systemPrompt: buildSystemPrompt({
-    mountInfo: { '/': 'In-memory filesystem (read/write)' },
-  }),
   extensionFactories: [mirageExtension(ws)],
   noExtensions: true,
   noSkills: true,
@@ -62,10 +59,7 @@ const { session } = await createAgentSession({
 })
 
 session.subscribe((event) => {
-  if (
-    event.type === 'message_update' &&
-    event.assistantMessageEvent.type === 'text_delta'
-  ) {
+  if (event.type === 'message_update' && event.assistantMessageEvent.type === 'text_delta') {
     process.stdout.write(event.assistantMessageEvent.delta)
   }
 })

--- a/examples/typescript/agents/pi/s3_pi.ts
+++ b/examples/typescript/agents/pi/s3_pi.ts
@@ -30,7 +30,7 @@ import {
   SessionManager,
   SettingsManager,
 } from '@earendil-works/pi-coding-agent'
-import { buildSystemPrompt, mirageExtension } from '@struktoai/mirage-agents/pi'
+import { mirageExtension } from '@struktoai/mirage-agents/pi'
 import { configurePiModel } from './config.ts'
 
 loadEnv({
@@ -60,9 +60,6 @@ const resourceLoader = new DefaultResourceLoader({
   cwd: process.cwd(),
   agentDir: getAgentDir(),
   settingsManager: SettingsManager.create(process.cwd(), getAgentDir()),
-  systemPrompt: buildSystemPrompt({
-    mountInfo: { '/s3/': 'S3 bucket (CSV, Parquet, JSONL)' },
-  }),
   extensionFactories: [mirageExtension(ws)],
   noExtensions: true,
   noSkills: true,
@@ -82,10 +79,7 @@ const { session } = await createAgentSession({
 })
 
 session.subscribe((event) => {
-  if (
-    event.type === 'message_update' &&
-    event.assistantMessageEvent.type === 'text_delta'
-  ) {
+  if (event.type === 'message_update' && event.assistantMessageEvent.type === 'text_delta') {
     process.stdout.write(event.assistantMessageEvent.delta)
   }
 })
@@ -95,9 +89,7 @@ await session.prompt(
 )
 console.log()
 
-await session.prompt(
-  'How many rows are in the parquet, orc, and h5 files under /s3/data/?',
-)
+await session.prompt('How many rows are in the parquet, orc, and h5 files under /s3/data/?')
 console.log()
 
 const records = ws.records

--- a/examples/typescript/agents/pi/ui_pi.ts
+++ b/examples/typescript/agents/pi/ui_pi.ts
@@ -12,12 +12,15 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export { mirageExtension, type MirageExtensionOptions } from './extension.ts'
-export {
-  mirageOperations,
-  StaleMirageFileError,
-  type MirageOperationsBundle,
-  type MirageOperationsOptions,
-} from './operations.ts'
-export { MIRAGE_SYSTEM_PROMPT, buildSystemPrompt } from '../prompt.ts'
-export type { BuildSystemPromptOptions } from '../prompt.ts'
+import { MountMode, OpsRegistry, RAMResource, Workspace } from '@struktoai/mirage-node'
+import { main } from '@earendil-works/pi-coding-agent'
+import { mirageExtension } from '@struktoai/mirage-agents/pi'
+
+const ram = new RAMResource()
+const ops = new OpsRegistry()
+for (const op of ram.ops()) ops.register(op)
+const ws = new Workspace({ '/': ram }, { mode: MountMode.WRITE, ops })
+
+await main(process.argv.slice(2), {
+  extensionFactories: [mirageExtension(ws)],
+})

--- a/typescript/packages/agents/src/pi/extension.test.ts
+++ b/typescript/packages/agents/src/pi/extension.test.ts
@@ -14,8 +14,21 @@
 
 import { describe, expect, it } from 'vitest'
 import { MountMode, OpsRegistry, RAMResource, Workspace } from '@struktoai/mirage-node'
-import type { ExtensionAPI, ToolDefinition } from '@earendil-works/pi-coding-agent'
+import type {
+  BeforeAgentStartEvent,
+  BeforeAgentStartEventResult,
+  ExtensionAPI,
+  ToolDefinition,
+  UserBashEvent,
+  UserBashEventResult,
+} from '@earendil-works/pi-coding-agent'
 import { mirageExtension } from './extension.ts'
+
+function extensionFactory(ws: Workspace, opts?: Parameters<typeof mirageExtension>[1]) {
+  const extension = mirageExtension(ws, opts)
+  if (typeof extension === 'function') return extension
+  return extension.factory
+}
 
 function mkWs(): Workspace {
   const ram = new RAMResource()
@@ -27,22 +40,52 @@ function mkWs(): Workspace {
 interface FakePi {
   api: ExtensionAPI
   tools: ToolDefinition[]
+  beforeAgentStart:
+    | ((
+        event: BeforeAgentStartEvent,
+      ) =>
+        | Promise<BeforeAgentStartEventResult | undefined>
+        | BeforeAgentStartEventResult
+        | undefined)
+    | undefined
+  userBash:
+    | ((
+        event: UserBashEvent,
+      ) => Promise<UserBashEventResult | undefined> | UserBashEventResult | undefined)
+    | undefined
 }
 
 function fakePi(): FakePi {
   const tools: ToolDefinition[] = []
+  const pi: FakePi = {
+    api: undefined as unknown as ExtensionAPI,
+    tools,
+    beforeAgentStart: undefined,
+    userBash: undefined,
+  }
   const stub = {
     registerTool: (tool: ToolDefinition) => {
       tools.push(tool)
     },
+    on: (event: string, handler: FakePi['userBash'] | FakePi['beforeAgentStart']) => {
+      if (event === 'user_bash') pi.userBash = handler as FakePi['userBash']
+      if (event === 'before_agent_start') {
+        pi.beforeAgentStart = handler as FakePi['beforeAgentStart']
+      }
+    },
   }
-  return { api: stub as unknown as ExtensionAPI, tools }
+  pi.api = stub as unknown as ExtensionAPI
+  return pi
 }
 
 describe('mirageExtension', () => {
   it('registers all 7 built-in tools by name', async () => {
     const pi = fakePi()
-    const factory = mirageExtension(mkWs())
+    const extension = mirageExtension(mkWs())
+    expect(typeof extension).not.toBe('function')
+    if (typeof extension === 'function') throw new Error('unreachable')
+    expect(extension.name).toBe('mirage')
+    const factory = extension.factory
     await factory(pi.api)
     const names = pi.tools.map((t) => t.name).sort()
     expect(names).toEqual(['bash', 'edit', 'find', 'grep', 'ls', 'read', 'write'])
@@ -50,7 +93,7 @@ describe('mirageExtension', () => {
 
   it('preserves pi tool schemas (read has path/offset/limit)', async () => {
     const pi = fakePi()
-    await mirageExtension(mkWs())(pi.api)
+    await extensionFactory(mkWs())(pi.api)
     const read = pi.tools.find((t) => t.name === 'read')
     expect(read).toBeDefined()
     if (read === undefined) throw new Error('unreachable')
@@ -60,13 +103,54 @@ describe('mirageExtension', () => {
 
   it('uses /-rooted cwd by default (pi factories accept it)', async () => {
     const pi = fakePi()
-    await mirageExtension(mkWs())(pi.api)
+    await extensionFactory(mkWs())(pi.api)
     expect(pi.tools.length).toBe(7)
   })
 
   it('honors custom cwd', async () => {
     const pi = fakePi()
-    await mirageExtension(mkWs(), { cwd: '/data' })(pi.api)
+    await extensionFactory(mkWs(), { cwd: '/data' })(pi.api)
     expect(pi.tools.length).toBe(7)
+  })
+
+  it('adds Mirage instructions without replacing Pi system prompt', async () => {
+    const pi = fakePi()
+    await extensionFactory(mkWs())(pi.api)
+    expect(pi.beforeAgentStart).toBeDefined()
+    if (pi.beforeAgentStart === undefined) throw new Error('unreachable')
+    const result = await pi.beforeAgentStart({
+      systemPrompt: 'Pi base prompt',
+    } as BeforeAgentStartEvent)
+    expect(result?.systemPrompt).toContain('Pi base prompt')
+    expect(result?.systemPrompt).toContain('Your filesystem is powered by Mirage')
+  })
+
+  it('can leave the Pi system prompt unchanged', async () => {
+    const pi = fakePi()
+    await extensionFactory(mkWs(), { systemPrompt: false })(pi.api)
+    expect(pi.beforeAgentStart).toBeUndefined()
+  })
+
+  it('routes interactive ! commands through Mirage at the virtual cwd', async () => {
+    const ws = mkWs()
+    await ws.fs.mkdir('/data')
+    const pi = fakePi()
+    await extensionFactory(ws, { cwd: '/data' })(pi.api)
+    expect(pi.userBash).toBeDefined()
+    if (pi.userBash === undefined) throw new Error('unreachable')
+    const event: UserBashEvent = {
+      type: 'user_bash',
+      command: 'pwd',
+      excludeFromContext: false,
+      cwd: process.cwd(),
+    }
+    const routed = await pi.userBash(event)
+    expect(routed?.operations).toBeDefined()
+    if (routed?.operations === undefined) throw new Error('unreachable')
+    const chunks: Buffer[] = []
+    await routed.operations.exec('pwd', process.cwd(), {
+      onData: (chunk) => chunks.push(chunk),
+    })
+    expect(Buffer.concat(chunks).toString()).toBe('/data\n')
   })
 })

--- a/typescript/packages/agents/src/pi/extension.ts
+++ b/typescript/packages/agents/src/pi/extension.ts
@@ -21,27 +21,47 @@ import {
   createLsToolDefinition,
   createReadToolDefinition,
   createWriteToolDefinition,
-  type ExtensionFactory,
+  type BashOperations,
+  type InlineExtension,
 } from '@earendil-works/pi-coding-agent'
-import { mirageOperations } from './operations.ts'
+import { buildSystemPrompt } from '../prompt.ts'
+import { mirageOperations, type MirageOperationsOptions } from './operations.ts'
 
-export interface MirageExtensionOptions {
+export interface MirageExtensionOptions extends MirageOperationsOptions {
   cwd?: string
+  systemPrompt?: string | false
 }
 
-export function mirageExtension(
-  ws: Workspace,
-  opts: MirageExtensionOptions = {},
-): ExtensionFactory {
+function bashAtCwd(operations: BashOperations, cwd: string): BashOperations {
+  return {
+    exec: (command, _hostCwd, options) => operations.exec(command, cwd, options),
+  }
+}
+
+export function mirageExtension(ws: Workspace, opts: MirageExtensionOptions = {}): InlineExtension {
   const cwd = opts.cwd ?? '/'
-  const ops = mirageOperations(ws)
-  return (pi) => {
-    pi.registerTool(createReadToolDefinition(cwd, { operations: ops.read }))
-    pi.registerTool(createWriteToolDefinition(cwd, { operations: ops.write }))
-    pi.registerTool(createEditToolDefinition(cwd, { operations: ops.edit }))
-    pi.registerTool(createBashToolDefinition(cwd, { operations: ops.bash }))
-    pi.registerTool(createGrepToolDefinition(cwd, { operations: ops.grep }))
-    pi.registerTool(createFindToolDefinition(cwd, { operations: ops.find }))
-    pi.registerTool(createLsToolDefinition(cwd, { operations: ops.ls }))
+  const ops = mirageOperations(ws, opts)
+  const userBash = bashAtCwd(ops.bash, cwd)
+  const systemPrompt =
+    opts.systemPrompt === false
+      ? undefined
+      : (opts.systemPrompt ?? buildSystemPrompt({ workspace: ws }))
+  return {
+    name: 'mirage',
+    factory: (pi) => {
+      pi.registerTool(createReadToolDefinition(cwd, { operations: ops.read }))
+      pi.registerTool(createWriteToolDefinition(cwd, { operations: ops.write }))
+      pi.registerTool(createEditToolDefinition(cwd, { operations: ops.edit }))
+      pi.registerTool(createBashToolDefinition(cwd, { operations: ops.bash }))
+      pi.registerTool(createGrepToolDefinition(cwd, { operations: ops.grep }))
+      pi.registerTool(createFindToolDefinition(cwd, { operations: ops.find }))
+      pi.registerTool(createLsToolDefinition(cwd, { operations: ops.ls }))
+      pi.on('user_bash', () => ({ operations: userBash }))
+      if (systemPrompt !== undefined) {
+        pi.on('before_agent_start', (event) => ({
+          systemPrompt: `${event.systemPrompt}\n\n${systemPrompt}`,
+        }))
+      }
+    },
   }
 }

--- a/typescript/packages/agents/src/pi/operations.test.ts
+++ b/typescript/packages/agents/src/pi/operations.test.ts
@@ -72,6 +72,59 @@ describe('mirageOperations.edit', () => {
     await ops.edit.writeFile('/f.txt', `${buf.toString()} + new`)
     expect(await ws.fs.readFileText('/f.txt')).toBe('old + new')
   })
+
+  it('rejects an edit after the file changed since the agent read it', async () => {
+    const ws = mkWs()
+    await ws.fs.writeFile('/f.txt', 'original')
+    const ops = mirageOperations(ws)
+    await ops.read.readFile('/f.txt')
+    await ws.fs.writeFile('/f.txt', 'changed elsewhere')
+
+    await expect(ops.edit.readFile('/f.txt')).rejects.toThrow(
+      'File changed since it was last read: /f.txt',
+    )
+
+    await ops.read.readFile('/f.txt')
+    expect((await ops.edit.readFile('/f.txt')).toString()).toBe('changed elsewhere')
+  })
+
+  it('rejects a write when the file changes while an edit is in progress', async () => {
+    const ws = mkWs()
+    await ws.fs.writeFile('/f.txt', 'original')
+    const ops = mirageOperations(ws)
+    await ops.edit.readFile('/f.txt')
+    await ws.fs.writeFile('/f.txt', 'changed elsewhere')
+
+    await expect(ops.edit.writeFile('/f.txt', 'replacement')).rejects.toThrow(
+      'Read the file again before modifying it',
+    )
+    expect(await ws.fs.readFileText('/f.txt')).toBe('changed elsewhere')
+  })
+})
+
+describe('mirageOperations stale write protection', () => {
+  it('rejects an overwrite after the file changed since the agent read it', async () => {
+    const ws = mkWs()
+    await ws.fs.writeFile('/f.txt', 'original')
+    const ops = mirageOperations(ws)
+    await ops.read.readFile('/f.txt')
+    await ws.fs.writeFile('/f.txt', 'changed elsewhere')
+
+    await expect(ops.write.writeFile('/f.txt', 'replacement')).rejects.toThrow(
+      'Read the file again before modifying it',
+    )
+    expect(await ws.fs.readFileText('/f.txt')).toBe('changed elsewhere')
+  })
+
+  it('can disable stale write protection', async () => {
+    const ws = mkWs()
+    await ws.fs.writeFile('/f.txt', 'original')
+    const ops = mirageOperations(ws, { staleWriteProtection: false })
+    await ops.read.readFile('/f.txt')
+    await ws.fs.writeFile('/f.txt', 'changed elsewhere')
+    await ops.write.writeFile('/f.txt', 'replacement')
+    expect(await ws.fs.readFileText('/f.txt')).toBe('replacement')
+  })
 })
 
 describe('mirageOperations.bash', () => {

--- a/typescript/packages/agents/src/pi/operations.ts
+++ b/typescript/packages/agents/src/pi/operations.ts
@@ -12,7 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { ExecuteResult, Workspace } from '@struktoai/mirage-core'
+import { createHash } from 'node:crypto'
+import { rstripSlash, type ExecuteResult, type Workspace } from '@struktoai/mirage-core'
 import type {
   BashOperations,
   EditOperations,
@@ -23,7 +24,20 @@ import type {
   WriteOperations,
 } from '@earendil-works/pi-coding-agent'
 import picomatch from 'picomatch'
-import { rstripSlash } from '@struktoai/mirage-core'
+
+export interface MirageOperationsOptions {
+  staleWriteProtection?: boolean
+}
+
+export class StaleMirageFileError extends Error {
+  readonly path: string
+
+  constructor(path: string) {
+    super(`File changed since it was last read: ${path}. Read the file again before modifying it.`)
+    this.name = 'StaleMirageFileError'
+    this.path = path
+  }
+}
 
 export interface MirageOperationsBundle {
   read: ReadOperations
@@ -33,6 +47,78 @@ export interface MirageOperationsBundle {
   grep: GrepOperations
   find: FindOperations
   ls: LsOperations
+}
+
+function fingerprint(content: Uint8Array | string): string {
+  return createHash('sha256').update(content).digest('base64url')
+}
+
+async function readBuffer(ws: Workspace, path: string): Promise<Buffer> {
+  const bytes = await ws.fs.readFile(path, { raw: true })
+  return Buffer.from(bytes)
+}
+
+class FileVersionTracker {
+  private readonly readVersions = new Map<string, string>()
+  private readonly editVersions = new Map<string, string>()
+
+  constructor(
+    private readonly ws: Workspace,
+    private readonly enabled: boolean,
+  ) {}
+
+  private async currentVersion(path: string): Promise<string | null> {
+    if (!(await this.ws.fs.exists(path))) return null
+    return fingerprint(await readBuffer(this.ws, path))
+  }
+
+  private async assertVersion(path: string, expected: string): Promise<void> {
+    if ((await this.currentVersion(path)) !== expected) {
+      throw new StaleMirageFileError(path)
+    }
+  }
+
+  private recordWrite(path: string, content: string): void {
+    if (!this.enabled) return
+    this.readVersions.set(path, fingerprint(content))
+    this.editVersions.delete(path)
+  }
+
+  async read(path: string): Promise<Buffer> {
+    const content = await readBuffer(this.ws, path)
+    if (this.enabled) this.readVersions.set(path, fingerprint(content))
+    return content
+  }
+
+  async readForEdit(path: string): Promise<Buffer> {
+    const content = await readBuffer(this.ws, path)
+    if (!this.enabled) return content
+    const version = fingerprint(content)
+    const readVersion = this.readVersions.get(path)
+    if (readVersion !== undefined && readVersion !== version) {
+      throw new StaleMirageFileError(path)
+    }
+    this.editVersions.set(path, version)
+    return content
+  }
+
+  async write(path: string, content: string): Promise<void> {
+    if (this.enabled) {
+      const readVersion = this.readVersions.get(path)
+      if (readVersion !== undefined) await this.assertVersion(path, readVersion)
+    }
+    await this.ws.fs.writeFile(path, content)
+    this.recordWrite(path, content)
+  }
+
+  async writeEdit(path: string, content: string): Promise<void> {
+    if (this.enabled) {
+      const editVersion = this.editVersions.get(path)
+      if (editVersion !== undefined) await this.assertVersion(path, editVersion)
+    }
+    await this.ws.fs.writeFile(path, content)
+    this.recordWrite(path, content)
+  }
 }
 
 async function ensureParent(ws: Workspace, dir: string): Promise<void> {
@@ -62,12 +148,7 @@ async function walkDirectory(
   results: string[],
 ): Promise<void> {
   if (results.length >= opts.limit) return
-  let entries: string[]
-  try {
-    entries = await ws.fs.readdir(dir)
-  } catch {
-    return
-  }
+  const entries = await ws.fs.readdir(dir)
   for (const full of entries) {
     if (results.length >= opts.limit) return
     const rel = full.startsWith(cwdPrefix) ? full.slice(cwdPrefix.length) : full
@@ -78,21 +159,20 @@ async function walkDirectory(
   }
 }
 
-export function mirageOperations(ws: Workspace): MirageOperationsBundle {
+export function mirageOperations(
+  ws: Workspace,
+  options: MirageOperationsOptions = {},
+): MirageOperationsBundle {
+  const versions = new FileVersionTracker(ws, options.staleWriteProtection ?? true)
   const read: ReadOperations = {
-    readFile: async (absolutePath: string) => {
-      const bytes = await ws.fs.readFile(absolutePath, { raw: true })
-      return Buffer.from(bytes)
-    },
+    readFile: (absolutePath: string) => versions.read(absolutePath),
     access: async (absolutePath: string) => {
       await ws.fs.stat(absolutePath)
     },
   }
 
   const write: WriteOperations = {
-    writeFile: async (absolutePath: string, content: string) => {
-      await ws.fs.writeFile(absolutePath, content)
-    },
+    writeFile: (absolutePath: string, content: string) => versions.write(absolutePath, content),
     mkdir: async (dir: string) => {
       await ensureParent(ws, dir)
       if (!(await ws.fs.exists(dir))) {
@@ -102,8 +182,8 @@ export function mirageOperations(ws: Workspace): MirageOperationsBundle {
   }
 
   const edit: EditOperations = {
-    readFile: read.readFile,
-    writeFile: write.writeFile,
+    readFile: (absolutePath: string) => versions.readForEdit(absolutePath),
+    writeFile: (absolutePath: string, content: string) => versions.writeEdit(absolutePath, content),
     access: read.access,
   }
 
@@ -144,7 +224,7 @@ export function mirageOperations(ws: Workspace): MirageOperationsBundle {
 
   const grep: GrepOperations = {
     isDirectory: async (absolutePath: string) => ws.fs.isDir(absolutePath),
-    readFile: async (absolutePath: string) => ws.fs.readFileText(absolutePath),
+    readFile: async (absolutePath: string) => (await versions.read(absolutePath)).toString('utf-8'),
   }
 
   const find: FindOperations = {


### PR DESCRIPTION
## Summary

- return Mirage's Pi integration as a named native `InlineExtension`
- register all seven Pi filesystem tools against the Mirage workspace and route interactive `!`/`!!` commands through its virtual cwd
- append Mirage mount guidance to Pi's existing system prompt instead of replacing it
- add content-fingerprint stale-write protection for `edit` and `write`, with reread recovery and an opt-out
- add a native Pi CLI/TUI example and update the RAM, S3, and integration documentation

## Why

Pi 0.80.10 serializes its own mutations and verifies exact edit text against the current file, but it does not retain a revision from an earlier agent read. A full-file write can therefore overwrite content changed outside Pi after the agent inspected it.

The previous examples also replaced Pi's system prompt and did not demonstrate using Mirage through Pi's existing CLI/TUI. Keeping Mirage as an inline extension preserves Pi's model selection, authentication, sessions, themes, commands, and UI.

## Impact

A file read or grepped through the Mirage extension now records a SHA-256 content fingerprint. A later edit or overwrite fails with `StaleMirageFileError` if the content changed. Reading again refreshes the fingerprint so the agent can reconsider and retry. The edit adapter also checks immediately before writing.

The protection defaults on and can be disabled with `staleWriteProtection: false`. Remote changes remain subject to the mounted backend's cache/invalidation policy.

## Validation

- `pnpm build`
- `pre-commit run --all-files`
- `@struktoai/mirage-agents` build and typecheck
- agent package tests: 168 passed
- native Pi UI example compiles and reaches Pi's CLI entry point
- full Python suite: 9,217 passed, 347 skipped; five Redis tests could not start without `REDIS_URL`, and one FUSE test could not mount because macFUSE is unavailable in this environment
