### PR TITLE
Add native OpenCode plugin and stale-write protection

### DIFF
--- a/docs/home/resource-matrix.mdx
+++ b/docs/home/resource-matrix.mdx
@@ -130,6 +130,7 @@ Mirage drops into the major agent application frameworks. Each adapter exposes a
 | Vercel AI SDK | [<Icon icon="node-js" />](/typescript/agents/vercel) [<Icon icon="globe" />](/typescript/agents/vercel) | `mirageTools()` returns five typed tools for `generateText` / `streamText`. |
 | LangChain (Deep Agents) | [<Icon icon="python" />](/python/agents/langchain) [<Icon icon="node-js" />](/typescript/agents/langchain) | `LangchainWorkspace` backend for Python and Node Deep Agents. |
 | Pi Coding Agent | [<Icon icon="node-js" />](/typescript/agents/pi) | Mirage extension for `@earendil-works/pi-coding-agent`. Node only. |
+| OpenCode | [<Icon icon="node-js" />](/typescript/agents/opencode) | Native installable plugin with Mirage tools and per-session stale-write protection. Node only. |
 | Mastra | [<Icon icon="node-js" />](/typescript/agents/mastra) | `mirageTools()` for Mastra `Agent` definitions. Node only. |
 | Pydantic AI | [<Icon icon="python" />](/python/agents/pydantic-ai) | For pydantic-ai and pydantic-deepagents. |
 | CAMEL-AI | [<Icon icon="python" />](/python/agents/camel) | For CAMEL `ChatAgent`. |

--- a/docs/typescript/agents/index.mdx
+++ b/docs/typescript/agents/index.mdx
@@ -29,7 +29,7 @@ For browser apps, swap `@struktoai/mirage-node` for `@struktoai/mirage-browser`.
     For [Mastra](https://mastra.ai) `Agent` definitions.
   </Card>
   <Card title="OpenCode" icon="/images/opencode-logo.svg" href="/typescript/agents/opencode">
-    Plugin tools for [OpenCode](https://opencode.ai) that swap `read`, `write`, `edit`, and `bash`.
+    Native installable plugin for [OpenCode](https://opencode.ai), with Mirage tools and per-session stale-write protection.
   </Card>
   <Card title="Claude Code" icon="/images/claude-logo.svg" href="/typescript/agents/claude-code">
     Mount a workspace via FUSE and run `claude` against it.

--- a/docs/typescript/agents/opencode.mdx
+++ b/docs/typescript/agents/opencode.mdx
@@ -1,24 +1,65 @@
 ---
 title: OpenCode
-description: Hand a Mirage workspace to OpenCode as a plugin via the @struktoai/mirage-agents/opencode adapter.
+description: Install native Mirage filesystem tools in OpenCode, with stale-write protection and no MCP server.
 icon: /images/opencode-logo.svg
 ---
 
-[OpenCode](https://opencode.ai) is an open-source coding agent that runs in your terminal, IDE, or desktop. Its plugin API lets you register tools that take precedence over the built-ins by name, so a Mirage plugin can swap OpenCode's `read`, `write`, `edit`, `ls`, `bash`, `glob`, and `grep` to operate on a `Workspace` instead of the local disk. Once installed, anything OpenCode reads or writes flows through Mirage and reaches every mounted resource (S3, GCS, Postgres, Linear, Slack, ...) as files.
+[OpenCode](https://opencode.ai) can use Mirage through a native plugin, without MCP. The plugin replaces its filesystem and shell tools with Mirage-backed versions.
 
 ## Install
 
-`@struktoai/mirage-agents/opencode` is a tool factory plus a thin plugin shim, typed against OpenCode's official plugin package. Pair it with `@struktoai/mirage-node` for any Node or Bun project.
+Create a `mirage.yaml` in your project:
+
+```yaml mirage.yaml
+mounts:
+  /:
+    resource: ram
+```
+
+Add the plugin to `opencode.json`:
+
+```json opencode.json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@struktoai/mirage-opencode"]
+}
+```
+
+Run `opencode` normally. Mirage searches the project and parent directories for `mirage.yaml`, `workspace.yaml`, `.mirage/workspace.yaml`, and their `.yml` variants.
+
+To select another config or disable stale-write protection, pass plugin options:
+
+```json opencode.json
+{
+  "plugin": [
+    [
+      "@struktoai/mirage-opencode",
+      {
+        "config": "config/agent-workspace.yaml",
+        "staleWriteProtection": true
+      }
+    ]
+  ]
+}
+```
+
+You can also set `MIRAGE_OPENCODE_CONFIG` or `MIRAGE_CONFIG` to the workspace config path.
+
+## Stale writes
+
+Stale-write protection is enabled by default and isolated per OpenCode session. `read` records a content fingerprint; `write` and `edit` verify it immediately before changing the file. If the file changed, OpenCode must reread it before retrying.
+
+`bash` commands are not tracked because they can read or mutate arbitrary paths. Use the structured `read`, `write`, and `edit` tools when stale-write protection is required.
+
+## Custom plugin
+
+Use `@struktoai/mirage-agents/opencode` directly when the workspace is constructed in code rather than YAML:
 
 ```bash
 bun add @struktoai/mirage-agents @struktoai/mirage-node @opencode-ai/plugin
 ```
 
-OpenCode runs `bun install` on startup against `.opencode/package.json`, so this works whether you use bun, pnpm, or npm in the host project.
-
-## Usage
-
-Drop a plugin file into `.opencode/plugins/` (project-local) or `~/.config/opencode/plugins/` (global). OpenCode auto-discovers it and merges the returned `tool` dict over its built-ins.
+Create `.opencode/plugins/mirage.ts`:
 
 ```ts .opencode/plugins/mirage.ts
 import { MountMode, OpsRegistry, RAMResource, Workspace } from '@struktoai/mirage-node'
@@ -32,7 +73,7 @@ const ws = new Workspace({ '/': ram }, { mode: MountMode.WRITE, ops })
 export default miragePlugin(ws)
 ```
 
-Add the dependencies to `.opencode/package.json` so OpenCode resolves them on startup:
+Add the dependencies to `.opencode/package.json`:
 
 ```json .opencode/package.json
 {
@@ -44,30 +85,30 @@ Add the dependencies to `.opencode/package.json` so OpenCode resolves them on st
 }
 ```
 
-Then run `opencode` in that directory. The agent's `read /hello.txt`, `bash 'find /'`, `grep foo /`, etc. now all flow through the Mirage workspace.
-
 ## Exports
 
 | Symbol | Purpose |
 | --- | --- |
-| `mirageTools(ws)` | Returns `{ read, write, edit, ls, bash, glob, grep }`, each shaped as an OpenCode `ToolDefinition`. Use this if you want to compose with other plugin hooks. |
-| `miragePlugin(ws)` | Returns a `Plugin` function for default-exporting from a plugin file. Wraps `mirageTools` under the `tool` hook. |
+| `mirageTools(ws, options?)` | Returns OpenCode tool definitions for `read`, `write`, `edit`, `ls`, `bash`, `glob`, and `grep`. |
+| `miragePlugin(ws, options?)` | Returns a native OpenCode plugin backed by `ws`. |
+| `MirageOpenCodeOptions` | Supports `staleWriteProtection` (default `true`). |
+| `StaleMirageFileError` | Indicates that a tracked file changed after it was read. |
 
 ### Tool reference
 
-Tools return plain text except multimodal reads, which use OpenCode's official attachment result.
+Tools return text except PDF and image reads, which return OpenCode attachments.
 
 | Tool | Input | Output |
 | --- | --- | --- |
 | `read` | `{ filePath }` | UTF-8 text; a PDF/image attachment; or metadata for other binaries |
-| `write` | `{ filePath, content }` | Confirmation line (auto-mkdirs parent) |
-| `edit` | `{ filePath, oldString, newString, replaceAll? }` | Confirmation line with occurrence count |
-| `ls` | `{ path }` | Newline-separated entries, dirs suffixed with `/` |
-| `bash` | `{ command }` | Merged stdout/stderr (routes through Mirage shell) |
+| `write` | `{ filePath, content }` | Confirmation; creates parent directories |
+| `edit` | `{ filePath, oldString, newString, replaceAll? }` | Confirmation with replacement count |
+| `ls` | `{ path }` | Entries, with `/` after directories |
+| `bash` | `{ command }` | Merged stdout and stderr |
 | `glob` | `{ pattern, path? }` | `find -name` results |
 | `grep` | `{ pattern, path? }` | `grep -rn` results |
 
-`bash`, `glob`, and `grep` go through `ws.execute()`, so they pick up every Mirage shell builtin (resource-aware `head`, `tail`, `find`, `grep`, etc.) across mounts.
+`bash`, `glob`, and `grep` run through the Mirage shell across all mounts.
 
 ## Examples
 

--- a/plugins/mirage/skills/mirage-filesystem/SKILL.md
+++ b/plugins/mirage/skills/mirage-filesystem/SKILL.md
@@ -10,9 +10,9 @@ Use the Mirage tools for virtual paths. Host filesystem tools cannot access thos
 ## Workflow
 
 1. Use the Mirage `ls`, `grep`, or `execute_command` tool to discover mounted data.
-2. Use the Mirage `read` tool before modifying an existing file.
-3. Use `edit` for an existing file and `write` only for a new file.
-4. If an edit reports that the file changed since it was read, read the file again, reconsider the edit against the new content, and retry.
-5. Use `execute_command` for pipelines and structured-file commands that need Mirage shell semantics.
+1. Use the Mirage `read` tool before modifying an existing file.
+1. Use `edit` for an existing file and `write` only for a new file.
+1. If an edit reports that the file changed since it was read, read the file again, reconsider the edit against the new content, and retry.
+1. Use `execute_command` for pipelines and structured-file commands that need Mirage shell semantics.
 
 Do not fall back to a host filesystem tool when a Mirage tool fails on a virtual path. Report the Mirage error or fix the Mirage configuration.

--- a/typescript/packages/agents/src/opencode/index.test.ts
+++ b/typescript/packages/agents/src/opencode/index.test.ts
@@ -86,6 +86,31 @@ describe('opencode mirageTools.write', () => {
     await callTool(mirageTools(ws).write, { filePath: '/a/b/c.txt', content: 'x' })
     expect(await ws.fs.readFileText('/a/b/c.txt')).toBe('x')
   })
+
+  it('rejects an overwrite after the file changed since the session read it', async () => {
+    const ws = mkWs()
+    await ws.fs.writeFile('/out.txt', 'original')
+    const tools = mirageTools(ws)
+    await callTool(tools.read, { filePath: '/out.txt' })
+    await ws.fs.writeFile('/out.txt', 'changed elsewhere')
+
+    const out = await callTool(tools.write, { filePath: '/out.txt', content: 'replacement' })
+
+    expect(out).toContain('File changed since it was last read')
+    expect(await ws.fs.readFileText('/out.txt')).toBe('changed elsewhere')
+  })
+
+  it('can disable stale write protection', async () => {
+    const ws = mkWs()
+    await ws.fs.writeFile('/out.txt', 'original')
+    const tools = mirageTools(ws, { staleWriteProtection: false })
+    await callTool(tools.read, { filePath: '/out.txt' })
+    await ws.fs.writeFile('/out.txt', 'changed elsewhere')
+
+    await callTool(tools.write, { filePath: '/out.txt', content: 'replacement' })
+
+    expect(await ws.fs.readFileText('/out.txt')).toBe('replacement')
+  })
 })
 
 describe('opencode mirageTools.edit', () => {
@@ -134,6 +159,23 @@ describe('opencode mirageTools.edit', () => {
       newString: 'X',
     })
     expect(out).toContain('string not found')
+  })
+
+  it('rejects an edit after the file changed since the session read it', async () => {
+    const ws = mkWs()
+    await ws.fs.writeFile('/f.txt', 'original')
+    const tools = mirageTools(ws)
+    await callTool(tools.read, { filePath: '/f.txt' })
+    await ws.fs.writeFile('/f.txt', 'changed elsewhere')
+
+    const out = await callTool(tools.edit, {
+      filePath: '/f.txt',
+      oldString: 'changed',
+      newString: 'updated',
+    })
+
+    expect(out).toContain('File changed since it was last read')
+    expect(await ws.fs.readFileText('/f.txt')).toBe('changed elsewhere')
   })
 })
 
@@ -220,5 +262,22 @@ describe('opencode resolver (per-session workspace)', () => {
 
     expect(await exec(tools.read)({ filePath: '/note.txt' }, ctxA)).toBe('alice')
     expect(await exec(tools.read)({ filePath: '/note.txt' }, ctxB)).toBe('bob')
+  })
+
+  it('keeps stale-read state isolated between sessions sharing a workspace', async () => {
+    const ws = mkWs()
+    await ws.fs.writeFile('/note.txt', 'one')
+    const tools = mirageTools(ws)
+    const exec = (t: unknown) =>
+      (t as { execute: (a: unknown, c: unknown) => Promise<string> }).execute
+    const ctxA = { sessionID: 'a', messageID: 'm', agent: '', abort: new AbortController().signal }
+    const ctxB = { sessionID: 'b', messageID: 'm', agent: '', abort: new AbortController().signal }
+
+    await exec(tools.read)({ filePath: '/note.txt' }, ctxA)
+    await exec(tools.write)({ filePath: '/note.txt', content: 'two' }, ctxB)
+    const out = await exec(tools.write)({ filePath: '/note.txt', content: 'three' }, ctxA)
+
+    expect(out).toContain('File changed since it was last read')
+    expect(await ws.fs.readFileText('/note.txt')).toBe('two')
   })
 })

--- a/typescript/packages/agents/src/opencode/index.ts
+++ b/typescript/packages/agents/src/opencode/index.ts
@@ -15,12 +15,19 @@
 import { tool, type Plugin, type ToolContext, type ToolDefinition } from '@opencode-ai/plugin'
 import type { Workspace } from '@struktoai/mirage-node'
 import { encodeBase64, gnuDirname } from '@struktoai/mirage-core'
+import { FileVersionTracker } from '../file-version.ts'
 import { readWorkspaceFile } from '../read-file.ts'
 
 const z = tool.schema
 
 export type WsResolver = (ctx: ToolContext) => Workspace | Promise<Workspace>
 export type WsLike = Workspace | WsResolver
+
+export interface MirageOpenCodeOptions {
+  staleWriteProtection?: boolean
+}
+
+type SessionTrackers = Map<string, FileVersionTracker>
 
 function isResolver(ws: WsLike): ws is WsResolver {
   return typeof ws === 'function'
@@ -46,7 +53,31 @@ function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
-export function mirageTools(ws: WsLike): Record<string, ToolDefinition> {
+function trackerFor(
+  trackers: WeakMap<Workspace, SessionTrackers>,
+  ws: Workspace,
+  ctx: ToolContext,
+  enabled: boolean,
+): FileVersionTracker {
+  let sessions = trackers.get(ws)
+  if (sessions === undefined) {
+    sessions = new Map<string, FileVersionTracker>()
+    trackers.set(ws, sessions)
+  }
+  let tracker = sessions.get(ctx.sessionID)
+  if (tracker === undefined) {
+    tracker = new FileVersionTracker(ws, enabled)
+    sessions.set(ctx.sessionID, tracker)
+  }
+  return tracker
+}
+
+export function mirageTools(
+  ws: WsLike,
+  options: MirageOpenCodeOptions = {},
+): Record<string, ToolDefinition> {
+  const trackers = new WeakMap<Workspace, SessionTrackers>()
+  const staleWriteProtection = options.staleWriteProtection ?? true
   const read = tool({
     description:
       'Read a file. Returns UTF-8 text for source/data files, attaches PDFs and images for multimodal models, and returns metadata for other binary files.',
@@ -55,8 +86,9 @@ export function mirageTools(ws: WsLike): Record<string, ToolDefinition> {
     },
     execute: async ({ filePath }, ctx) => {
       const w = await resolveWs(ws, ctx)
+      const versions = trackerFor(trackers, w, ctx, staleWriteProtection)
       try {
-        const result = await readWorkspaceFile(w, filePath)
+        const result = await readWorkspaceFile(w, filePath, versions.read.bind(versions))
         if (result.kind === 'text') return result.content
         if (result.kind === 'image' || result.kind === 'file') {
           const filename = result.path.split('/').pop() ?? result.path
@@ -87,9 +119,14 @@ export function mirageTools(ws: WsLike): Record<string, ToolDefinition> {
     },
     execute: async ({ filePath, content }, ctx) => {
       const w = await resolveWs(ws, ctx)
-      await ensureParent(w, filePath)
-      await w.fs.writeFile(filePath, content)
-      return `Wrote ${String(content.length)} bytes to ${filePath}`
+      const versions = trackerFor(trackers, w, ctx, staleWriteProtection)
+      try {
+        await ensureParent(w, filePath)
+        await versions.write(filePath, content)
+        return `Wrote ${String(content.length)} bytes to ${filePath}`
+      } catch (err) {
+        return `Error: ${errMsg(err)}`
+      }
     },
   })
 
@@ -107,10 +144,12 @@ export function mirageTools(ws: WsLike): Record<string, ToolDefinition> {
     },
     execute: async ({ filePath, oldString, newString, replaceAll }, ctx) => {
       const w = await resolveWs(ws, ctx)
+      const versions = trackerFor(trackers, w, ctx, staleWriteProtection)
       let current: string
       try {
-        current = await w.fs.readFileText(filePath)
-      } catch {
+        current = (await versions.readForEdit(filePath)).toString('utf8')
+      } catch (err) {
+        if (await w.fs.exists(filePath)) return `Error: ${errMsg(err)}`
         return `Error: file '${filePath}' not found`
       }
       const count = current.split(oldString).length - 1
@@ -124,7 +163,11 @@ export function mirageTools(ws: WsLike): Record<string, ToolDefinition> {
         replaceAll === true
           ? current.split(oldString).join(newString)
           : current.replace(oldString, newString)
-      await w.fs.writeFile(filePath, next)
+      try {
+        await versions.writeEdit(filePath, next)
+      } catch (err) {
+        return `Error: ${errMsg(err)}`
+      }
       const occurrences = replaceAll === true ? count : 1
       return `Edited ${filePath} (${String(occurrences)} occurrence${occurrences === 1 ? '' : 's'})`
     },
@@ -199,6 +242,8 @@ export function mirageTools(ws: WsLike): Record<string, ToolDefinition> {
   return { read, write, edit, ls, bash, glob, grep }
 }
 
-export function miragePlugin(ws: WsLike): Plugin {
-  return () => Promise.resolve({ tool: mirageTools(ws) })
+export function miragePlugin(ws: WsLike, options: MirageOpenCodeOptions = {}): Plugin {
+  return () => Promise.resolve({ tool: mirageTools(ws, options) })
 }
+
+export { StaleMirageFileError } from '../file-version.ts'

--- a/typescript/packages/agents/src/read-file.ts
+++ b/typescript/packages/agents/src/read-file.ts
@@ -20,6 +20,8 @@ export type WorkspaceFileReadResult =
   | (WorkspaceFileBase & { kind: 'file'; data: Uint8Array; filename: string })
   | (WorkspaceFileBase & { kind: 'binary'; note: string })
 
+export type WorkspaceFileReader = (path: string) => Promise<Uint8Array>
+
 function extOf(path: string): string {
   const dot = path.lastIndexOf('.')
   const slash = path.lastIndexOf('/')
@@ -63,12 +65,13 @@ function isTextMime(mimeType: ReadFileMime): boolean {
 export async function readWorkspaceFile(
   ws: Workspace,
   path: string,
+  reader?: WorkspaceFileReader,
 ): Promise<WorkspaceFileReadResult> {
   const stat = await ws.fs.stat(path)
   if (stat.type === FileType.DIRECTORY) {
     throw new Error(`Cannot read directory as a file: ${path}`)
   }
-  const data = await ws.fs.readFile(path, { raw: true })
+  const data = reader === undefined ? await ws.fs.readFile(path, { raw: true }) : await reader(path)
   const mimeType = mimeFor(path, data, stat)
   const base = { path, mimeType, bytes: data.byteLength }
 

--- a/typescript/packages/cli/src/mcp.ts
+++ b/typescript/packages/cli/src/mcp.ts
@@ -12,22 +12,10 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { existsSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
 import { serveMirageMcp } from '@struktoai/mirage-agents/mcp'
-import type { CommandSafeguard, MountSpec } from '@struktoai/mirage-node'
-import { Workspace, newWorkspaceId } from '@struktoai/mirage-node'
-import { configToWorkspaceArgs, loadWorkspaceConfigFile } from '@struktoai/mirage-server'
+import type { Workspace } from '@struktoai/mirage-node'
+import { buildWorkspaceFromConfig, resolveWorkspaceConfig } from '@struktoai/mirage-server'
 import type { Command } from 'commander'
-
-const CONFIG_CANDIDATES = [
-  '.mirage/workspace.yaml',
-  '.mirage/workspace.yml',
-  'workspace.yaml',
-  'workspace.yml',
-  'mirage.yaml',
-  'mirage.yml',
-]
 
 export interface McpConfigResolutionOptions {
   cwd?: string
@@ -38,74 +26,22 @@ interface McpCommandOptions {
   staleWriteProtection: boolean
 }
 
-function requireConfig(path: string): string {
-  if (!existsSync(path)) throw new Error(`Mirage workspace config not found: ${path}`)
-  return path
-}
-
 export function resolveMcpConfig(
   config: string | undefined,
   options: McpConfigResolutionOptions = {},
 ): string {
-  const cwd = resolve(options.cwd ?? process.cwd())
-  const env = options.env ?? process.env
-  if (config !== undefined) return requireConfig(resolve(cwd, config))
-  if (env.MIRAGE_MCP_CONFIG !== undefined) {
-    return requireConfig(resolve(cwd, env.MIRAGE_MCP_CONFIG))
-  }
-
-  let dir: string | undefined = cwd
-  while (dir !== undefined) {
-    for (const candidate of CONFIG_CANDIDATES) {
-      const path = resolve(dir, candidate)
-      if (existsSync(path)) return path
-    }
-    const parent = dirname(dir)
-    dir = parent === dir ? undefined : parent
-  }
-  throw new Error(
-    'No Mirage workspace config found. Pass one to `mirage mcp <config>` or set MIRAGE_MCP_CONFIG.',
-  )
+  return resolveWorkspaceConfig(config, {
+    ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+    ...(options.env !== undefined ? { env: options.env } : {}),
+    envNames: ['MIRAGE_MCP_CONFIG', 'MIRAGE_CONFIG'],
+  })
 }
 
 export async function buildMcpWorkspace(configPath: string): Promise<Workspace> {
-  const config = loadWorkspaceConfigFile(configPath)
-  const args = await configToWorkspaceArgs(config)
-  const resources: Record<string, MountSpec> = {}
-  const commandSafeguards: Record<string, Record<string, CommandSafeguard>> = {}
-  for (const [prefix, [resource, mode, safeguards]] of Object.entries(args.resources)) {
-    resources[prefix] = [resource, mode]
-    if (Object.keys(safeguards).length > 0) commandSafeguards[prefix] = safeguards
-  }
-  const workspace = new Workspace(resources, {
-    mode: args.options.mode,
-    consistency: args.options.consistency,
-    ...(args.options.sessionId !== undefined ? { sessionId: args.options.sessionId } : {}),
-    ...(args.options.agentId !== undefined ? { agentId: args.options.agentId } : {}),
-    workspaceId: args.options.workspaceId ?? newWorkspaceId(),
-    ...(args.options.store !== undefined ? { store: args.options.store } : {}),
-    ...(Object.keys(commandSafeguards).length > 0 ? { commandSafeguards } : {}),
-    ...(args.options.cache !== undefined ? { cache: args.options.cache } : {}),
-    ...(args.options.index !== undefined ? { index: args.options.index } : {}),
-    ...(args.options.runtimes !== undefined ? { runtimes: args.options.runtimes } : {}),
-    ...(args.options.route !== undefined ? { route: args.options.route } : {}),
-  })
-  try {
-    for (const [prefix, target] of Object.entries(args.fuseMounts)) {
-      const mountpoint = typeof target === 'string' ? target : undefined
-      await workspace.addFuseMount(prefix, mountpoint)
-    }
-  } catch (error) {
-    await workspace.close()
-    throw error
-  }
-  return workspace
+  return buildWorkspaceFromConfig(configPath)
 }
 
-async function runMcpServer(
-  config: string | undefined,
-  options: McpCommandOptions,
-): Promise<void> {
+async function runMcpServer(config: string | undefined, options: McpCommandOptions): Promise<void> {
   const configPath = resolveMcpConfig(config)
   const workspace = await buildMcpWorkspace(configPath)
   try {

--- a/typescript/packages/opencode/package.json
+++ b/typescript/packages/opencode/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@struktoai/mirage-opencode",
+  "version": "0.0.0",
+  "description": "Native Mirage filesystem tools for OpenCode",
+  "keywords": [
+    "mirage",
+    "opencode",
+    "ai-agents",
+    "virtual-filesystem"
+  ],
+  "homepage": "https://github.com/strukto-ai/mirage#readme",
+  "bugs": {
+    "url": "https://github.com/strukto-ai/mirage/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/strukto-ai/mirage.git",
+    "directory": "typescript/packages/opencode"
+  },
+  "license": "Apache-2.0",
+  "author": "Zecheng Zhang <zecheng@strukto.ai>",
+  "engines": {
+    "opencode": ">=1.18.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./dist/server.js",
+  "types": "./dist/server.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.js"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@struktoai/mirage-agents": "workspace:*",
+    "@struktoai/mirage-server": "workspace:*"
+  },
+  "peerDependencies": {
+    "@opencode-ai/plugin": "^1.18.3"
+  },
+  "devDependencies": {
+    "@opencode-ai/plugin": "^1.18.3",
+    "@types/node": "^22.0.0",
+    "tsup": "^8.5.0",
+    "typescript": "^6.0.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/typescript/packages/opencode/src/server.test.ts
+++ b/typescript/packages/opencode/src/server.test.ts
@@ -1,0 +1,61 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { PluginInput } from '@opencode-ai/plugin'
+import { afterEach, describe, expect, it } from 'vitest'
+import plugin, { MirageOpenCodePlugin } from './server.ts'
+
+const tempDirs: string[] = []
+
+function mkTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'mirage-opencode-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+function pluginInput(directory: string): PluginInput {
+  return { directory } as PluginInput
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('MirageOpenCodePlugin', () => {
+  it('loads a workspace config and registers native tools', async () => {
+    const dir = mkTempDir()
+    writeFileSync(join(dir, 'mirage.yaml'), 'mounts:\n  /:\n    resource: ram\n')
+
+    const hooks = await MirageOpenCodePlugin(pluginInput(dir))
+
+    expect(Object.keys(hooks.tool ?? {}).sort()).toEqual([
+      'bash',
+      'edit',
+      'glob',
+      'grep',
+      'ls',
+      'read',
+      'write',
+    ])
+    await hooks.dispose?.()
+  })
+
+  it('exports an OpenCode server plugin module', () => {
+    expect(plugin.id).toBe('@struktoai/mirage-opencode')
+    expect(plugin.server).toBe(MirageOpenCodePlugin)
+  })
+})

--- a/typescript/packages/opencode/src/server.ts
+++ b/typescript/packages/opencode/src/server.ts
@@ -1,0 +1,59 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { Plugin, PluginModule, PluginOptions } from '@opencode-ai/plugin'
+import { mirageTools } from '@struktoai/mirage-agents/opencode'
+import { buildWorkspaceFromConfig, resolveWorkspaceConfig } from '@struktoai/mirage-server'
+
+export interface MirageOpenCodePluginOptions {
+  config?: string
+  staleWriteProtection?: boolean
+}
+
+function parseOptions(options: PluginOptions): MirageOpenCodePluginOptions {
+  const config = options.config
+  const staleWriteProtection = options.staleWriteProtection
+  if (config !== undefined && typeof config !== 'string') {
+    throw new TypeError('Mirage OpenCode plugin option "config" must be a string')
+  }
+  if (staleWriteProtection !== undefined && typeof staleWriteProtection !== 'boolean') {
+    throw new TypeError('Mirage OpenCode plugin option "staleWriteProtection" must be a boolean')
+  }
+  return {
+    ...(config !== undefined ? { config } : {}),
+    ...(staleWriteProtection !== undefined ? { staleWriteProtection } : {}),
+  }
+}
+
+export const MirageOpenCodePlugin: Plugin = async (input, rawOptions = {}) => {
+  const options = parseOptions(rawOptions)
+  const configPath = resolveWorkspaceConfig(options.config, {
+    cwd: input.directory,
+    envNames: ['MIRAGE_OPENCODE_CONFIG', 'MIRAGE_CONFIG'],
+  })
+  const workspace = await buildWorkspaceFromConfig(configPath)
+  return {
+    tool: mirageTools(workspace, {
+      staleWriteProtection: options.staleWriteProtection ?? true,
+    }),
+    dispose: () => workspace.close(),
+  }
+}
+
+const plugin: PluginModule = {
+  id: '@struktoai/mirage-opencode',
+  server: MirageOpenCodePlugin,
+}
+
+export default plugin

--- a/typescript/packages/opencode/tsconfig.json
+++ b/typescript/packages/opencode/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/typescript/packages/opencode/tsup.config.ts
+++ b/typescript/packages/opencode/tsup.config.ts
@@ -1,0 +1,29 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/server.ts'],
+  format: ['esm'],
+  dts: {
+    compilerOptions: {
+      ignoreDeprecations: '6.0',
+    },
+  },
+  sourcemap: true,
+  clean: true,
+  target: 'es2022',
+  platform: 'node',
+})

--- a/typescript/packages/server/src/index.ts
+++ b/typescript/packages/server/src/index.ts
@@ -23,6 +23,12 @@ export {
   type WorkspaceConfigRaw,
 } from './config.ts'
 export {
+  buildWorkspaceFromConfig,
+  resolveWorkspaceConfig,
+  WORKSPACE_CONFIG_CANDIDATES,
+  type WorkspaceConfigResolutionOptions,
+} from './workspace_config.ts'
+export {
   AuthMode,
   ENV_AUTH_MODE,
   ENV_AUTH_TOKEN,

--- a/typescript/packages/server/src/workspace_config.test.ts
+++ b/typescript/packages/server/src/workspace_config.test.ts
@@ -1,0 +1,71 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { buildWorkspaceFromConfig, resolveWorkspaceConfig } from './workspace_config.ts'
+
+const tempDirs: string[] = []
+
+function mkTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'mirage-workspace-config-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('resolveWorkspaceConfig', () => {
+  it('resolves a named environment variable', () => {
+    const dir = mkTempDir()
+    const path = join(dir, 'custom.yaml')
+    writeFileSync(path, 'mounts: {}\n')
+
+    expect(
+      resolveWorkspaceConfig(undefined, {
+        cwd: dir,
+        env: { MIRAGE_OPENCODE_CONFIG: path },
+        envNames: ['MIRAGE_OPENCODE_CONFIG'],
+      }),
+    ).toBe(path)
+  })
+
+  it('searches parent directories for standard config names', () => {
+    const dir = mkTempDir()
+    const child = join(dir, 'src', 'nested')
+    mkdirSync(child, { recursive: true })
+    const path = join(dir, 'mirage.yaml')
+    writeFileSync(path, 'mounts: {}\n')
+
+    expect(resolveWorkspaceConfig(undefined, { cwd: child, env: {} })).toBe(path)
+  })
+})
+
+describe('buildWorkspaceFromConfig', () => {
+  it('builds a workspace from YAML', async () => {
+    const dir = mkTempDir()
+    const path = join(dir, 'workspace.yaml')
+    writeFileSync(path, 'mounts:\n  /:\n    resource: ram\n')
+
+    const workspace = await buildWorkspaceFromConfig(path)
+    await workspace.fs.writeFile('/hello.txt', 'hello')
+
+    expect(await workspace.fs.readFileText('/hello.txt')).toBe('hello')
+    await workspace.close()
+  })
+})

--- a/typescript/packages/server/src/workspace_config.ts
+++ b/typescript/packages/server/src/workspace_config.ts
@@ -1,0 +1,101 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import type { CommandSafeguard, MountSpec } from '@struktoai/mirage-node'
+import { Workspace, newWorkspaceId } from '@struktoai/mirage-node'
+import { configToWorkspaceArgs, loadWorkspaceConfigFile } from './config.ts'
+
+export const WORKSPACE_CONFIG_CANDIDATES = [
+  '.mirage/workspace.yaml',
+  '.mirage/workspace.yml',
+  'workspace.yaml',
+  'workspace.yml',
+  'mirage.yaml',
+  'mirage.yml',
+]
+
+export interface WorkspaceConfigResolutionOptions {
+  cwd?: string
+  env?: Record<string, string | undefined>
+  envNames?: string[]
+}
+
+function requireConfig(path: string): string {
+  if (!existsSync(path)) throw new Error(`Mirage workspace config not found: ${path}`)
+  return path
+}
+
+export function resolveWorkspaceConfig(
+  config: string | undefined,
+  options: WorkspaceConfigResolutionOptions = {},
+): string {
+  const cwd = resolve(options.cwd ?? process.cwd())
+  const env = options.env ?? process.env
+  if (config !== undefined) return requireConfig(resolve(cwd, config))
+
+  for (const name of options.envNames ?? ['MIRAGE_CONFIG']) {
+    const value = env[name]
+    if (value !== undefined) return requireConfig(resolve(cwd, value))
+  }
+
+  let dir: string | undefined = cwd
+  while (dir !== undefined) {
+    for (const candidate of WORKSPACE_CONFIG_CANDIDATES) {
+      const path = resolve(dir, candidate)
+      if (existsSync(path)) return path
+    }
+    const parent = dirname(dir)
+    dir = parent === dir ? undefined : parent
+  }
+  const envNames = options.envNames ?? ['MIRAGE_CONFIG']
+  throw new Error(
+    `No Mirage workspace config found. Pass a config path or set ${envNames.join(' or ')}.`,
+  )
+}
+
+export async function buildWorkspaceFromConfig(configPath: string): Promise<Workspace> {
+  const config = loadWorkspaceConfigFile(configPath)
+  const args = await configToWorkspaceArgs(config)
+  const resources: Record<string, MountSpec> = {}
+  const commandSafeguards: Record<string, Record<string, CommandSafeguard>> = {}
+  for (const [prefix, [resource, mode, safeguards]] of Object.entries(args.resources)) {
+    resources[prefix] = [resource, mode]
+    if (Object.keys(safeguards).length > 0) commandSafeguards[prefix] = safeguards
+  }
+  const workspace = new Workspace(resources, {
+    mode: args.options.mode,
+    consistency: args.options.consistency,
+    ...(args.options.sessionId !== undefined ? { sessionId: args.options.sessionId } : {}),
+    ...(args.options.agentId !== undefined ? { agentId: args.options.agentId } : {}),
+    workspaceId: args.options.workspaceId ?? newWorkspaceId(),
+    ...(args.options.store !== undefined ? { store: args.options.store } : {}),
+    ...(Object.keys(commandSafeguards).length > 0 ? { commandSafeguards } : {}),
+    ...(args.options.cache !== undefined ? { cache: args.options.cache } : {}),
+    ...(args.options.index !== undefined ? { index: args.options.index } : {}),
+    ...(args.options.runtimes !== undefined ? { runtimes: args.options.runtimes } : {}),
+    ...(args.options.route !== undefined ? { route: args.options.route } : {}),
+  })
+  try {
+    for (const [prefix, target] of Object.entries(args.fuseMounts)) {
+      const mountpoint = typeof target === 'string' ? target : undefined
+      await workspace.addFuseMount(prefix, mountpoint)
+    }
+  } catch (error) {
+    await workspace.close()
+    throw error
+  }
+  return workspace
+}

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -542,6 +542,31 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/debug@4.1.13)(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  packages/opencode:
+    dependencies:
+      '@struktoai/mirage-agents':
+        specifier: workspace:*
+        version: link:../agents
+      '@struktoai/mirage-server':
+        specifier: workspace:*
+        version: link:../server
+    devDependencies:
+      '@opencode-ai/plugin':
+        specifier: ^1.18.3
+        version: 1.18.3
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+
   packages/server:
     dependencies:
       '@fastify/multipart':


### PR DESCRIPTION
## Summary

- add @struktoai/mirage-opencode, an installable native OpenCode plugin that discovers Mirage workspace YAML and preserves the OpenCode UI
- add per-session stale-write protection to OpenCode read, write, and edit tools using the shared FileVersionTracker
- extract reusable TypeScript workspace-config loading from the MCP CLI for native integrations
- document native OpenCode setup, shell-command tracking limits, and the OpenHands Python follow-up

## Why

OpenCode exposes a public native plugin API, so Mirage can integrate directly instead of requiring MCP or a hand-written local plugin. The existing adapter reread files while editing but did not enforce that the agent had observed external changes made after its earlier read.

## Behavior

A structured read records the content fingerprint. A later structured write or edit fails with a reread instruction if the file changed. Tracking is isolated by OpenCode session and can be disabled through plugin options. Shell commands remain opaque and are intentionally not treated as structured reads or writes.

Issue #572 tracks replacing fallback hashing with backend-native versions where available and adding Python/OpenHands parity.

## Validation

- full pre-commit suite
- full TypeScript monorepo build
- full TypeScript package tests
- TypeScript type checks for agents, server, CLI, and OpenCode packages
- pnpm pack --dry-run for the new package
- focused post-rebase tests: OpenCode adapter 21 passed, OpenCode package 2 passed, workspace config 3 passed
- full Python suite was otherwise green apart from existing environment-dependent Redis and macFUSE tests; the non-Redis namespace suite passed separately