### PR TITLE
feat(google): per-service API base URL overrides for `GoogleConfig`

### DIFF
--- a/python/mirage/core/google/_client.py
+++ b/python/mirage/core/google/_client.py
@@ -32,36 +32,56 @@ TOKEN_BUFFER_SECONDS = 300
 
 
 def token_url(config: GoogleConfig) -> str:
+    if config.token_url:
+        return config.token_url
     return f"{config.api_base}/token" if config.api_base else TOKEN_URL
 
 
 def drive_base(token_manager: "TokenManager") -> str:
-    base = token_manager.config.api_base
+    config = token_manager.config
+    if config.drive_api_base:
+        return config.drive_api_base
+    base = config.api_base
     return f"{base}/drive/v3" if base else DRIVE_API_BASE
 
 
 def drive_upload_base(token_manager: "TokenManager") -> str:
-    base = token_manager.config.api_base
+    config = token_manager.config
+    if config.drive_upload_api_base:
+        return config.drive_upload_api_base
+    base = config.api_base
     return f"{base}/upload/drive/v3" if base else DRIVE_UPLOAD_BASE
 
 
 def docs_base(token_manager: "TokenManager") -> str:
-    base = token_manager.config.api_base
+    config = token_manager.config
+    if config.docs_api_base:
+        return config.docs_api_base
+    base = config.api_base
     return f"{base}/v1" if base else DOCS_API_BASE
 
 
 def slides_base(token_manager: "TokenManager") -> str:
-    base = token_manager.config.api_base
+    config = token_manager.config
+    if config.slides_api_base:
+        return config.slides_api_base
+    base = config.api_base
     return f"{base}/v1" if base else SLIDES_API_BASE
 
 
 def sheets_base(token_manager: "TokenManager") -> str:
-    base = token_manager.config.api_base
+    config = token_manager.config
+    if config.sheets_api_base:
+        return config.sheets_api_base
+    base = config.api_base
     return f"{base}/v4" if base else SHEETS_API_BASE
 
 
 def gmail_base(token_manager: "TokenManager") -> str:
-    base = token_manager.config.api_base
+    config = token_manager.config
+    if config.gmail_api_base:
+        return config.gmail_api_base
+    base = config.api_base
     return f"{base}/gmail/v1" if base else GMAIL_API_BASE
 
 

--- a/python/mirage/core/google/config.py
+++ b/python/mirage/core/google/config.py
@@ -19,9 +19,19 @@ class GoogleConfig(BaseModel):
     client_id: str
     client_secret: SecretStr | None = None
     refresh_token: SecretStr
-    # Single-host override for every Google API (drive/docs/sheets/slides)
-    # plus the OAuth token endpoint; used to point backends at a fake server.
+    # Single-host override for every Google API
+    # (drive/docs/sheets/slides/gmail) plus the OAuth token endpoint; used to
+    # point backends at a fake server.
     api_base: str | None = None
+    # Per-service overrides; each wins over `api_base`, falling back to it then
+    # the real host.
+    token_url: str | None = None
+    drive_api_base: str | None = None
+    drive_upload_api_base: str | None = None
+    docs_api_base: str | None = None
+    sheets_api_base: str | None = None
+    slides_api_base: str | None = None
+    gmail_api_base: str | None = None
     # Drive-only: scope the mount to this folder ID instead of the Drive
     # root, the s3 key_prefix analog. Other Google backends ignore it.
     folder_id: str | None = None

--- a/python/tests/core/gmail/test_attachments.py
+++ b/python/tests/core/gmail/test_attachments.py
@@ -13,12 +13,13 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import base64
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from mirage.core.gmail.messages import _extract_attachments, get_attachment
+from mirage.core.google._client import TokenManager
+from mirage.core.google.config import GoogleConfig
 
 
 def test_extract_attachments_none():
@@ -79,7 +80,8 @@ def test_extract_attachments_nested():
 @pytest.mark.asyncio
 async def test_get_attachment():
     encoded = base64.urlsafe_b64encode(b"hello world").decode().rstrip("=")
-    token_manager = SimpleNamespace(config=SimpleNamespace(api_base=None))
+    token_manager = TokenManager(GoogleConfig(client_id="x",
+                                              refresh_token="y"))
     with patch(
             "mirage.core.gmail.messages.google_get",
             new_callable=AsyncMock,

--- a/python/tests/core/gmail/test_attachments.py
+++ b/python/tests/core/gmail/test_attachments.py
@@ -79,7 +79,8 @@ def test_extract_attachments_nested():
 @pytest.mark.asyncio
 async def test_get_attachment():
     encoded = base64.urlsafe_b64encode(b"hello world").decode().rstrip("=")
-    token_manager = SimpleNamespace(config=SimpleNamespace(api_base=None))
+    token_manager = SimpleNamespace(
+        config=SimpleNamespace(api_base=None, gmail_api_base=None))
     with patch(
             "mirage.core.gmail.messages.google_get",
             new_callable=AsyncMock,

--- a/python/tests/core/gmail/test_attachments.py
+++ b/python/tests/core/gmail/test_attachments.py
@@ -79,8 +79,7 @@ def test_extract_attachments_nested():
 @pytest.mark.asyncio
 async def test_get_attachment():
     encoded = base64.urlsafe_b64encode(b"hello world").decode().rstrip("=")
-    token_manager = SimpleNamespace(
-        config=SimpleNamespace(api_base=None, gmail_api_base=None))
+    token_manager = SimpleNamespace(config=SimpleNamespace(api_base=None))
     with patch(
             "mirage.core.gmail.messages.google_get",
             new_callable=AsyncMock,

--- a/python/tests/core/google/test_client.py
+++ b/python/tests/core/google/test_client.py
@@ -49,3 +49,41 @@ def test_api_base_override_rewrites_every_service():
     assert sheets_base(tm) == "http://127.0.0.1:19999/v4"
     assert gmail_base(tm) == "http://127.0.0.1:19999/gmail/v1"
     assert token_url(tm.config) == "http://127.0.0.1:19999/token"
+
+
+def test_per_service_base_overrides_take_precedence_over_api_base():
+    # each per-service base is the full service base and wins over api_base.
+    tm = TokenManager(
+        GoogleConfig(client_id="cid",
+                     refresh_token="rt",
+                     api_base="http://shared:9",
+                     token_url="http://oauth:1/oauth2/token",
+                     drive_api_base="http://drive:2/drive/v3",
+                     drive_upload_api_base="http://drive:2/upload/drive/v3",
+                     docs_api_base="http://docs:3/docs/v1",
+                     sheets_api_base="http://sheets:4/sheets/v4",
+                     slides_api_base="http://slides:5/slides/v1",
+                     gmail_api_base="http://gmail:6/gmail/v1"))
+    assert token_url(tm.config) == "http://oauth:1/oauth2/token"
+    assert drive_base(tm) == "http://drive:2/drive/v3"
+    assert drive_upload_base(tm) == "http://drive:2/upload/drive/v3"
+    assert docs_base(tm) == "http://docs:3/docs/v1"
+    assert sheets_base(tm) == "http://sheets:4/sheets/v4"
+    assert slides_base(tm) == "http://slides:5/slides/v1"
+    assert gmail_base(tm) == "http://gmail:6/gmail/v1"
+
+
+def test_per_service_base_falls_back_to_api_base_then_real_default():
+    # one per-service override set; the rest fall back to api_base, and with no
+    # api_base they fall back to the real Google hosts.
+    tm = TokenManager(
+        GoogleConfig(client_id="cid",
+                     refresh_token="rt",
+                     api_base="http://m",
+                     docs_api_base="http://docs-only/docs/v1"))
+    assert docs_base(tm) == "http://docs-only/docs/v1"  # explicit
+    assert sheets_base(tm) == "http://m/v4"  # api_base derived
+    assert gmail_base(tm) == "http://m/gmail/v1"  # api_base derived
+    bare = TokenManager(GoogleConfig(client_id="cid", refresh_token="rt"))
+    assert sheets_base(bare) == SHEETS_API_BASE  # real default
+    assert token_url(bare.config) == TOKEN_URL

--- a/typescript/packages/core/src/core/google/_client.test.ts
+++ b/typescript/packages/core/src/core/google/_client.test.ts
@@ -17,6 +17,7 @@ import {
   DOCS_API_BASE,
   DRIVE_API_BASE,
   DRIVE_UPLOAD_BASE,
+  GMAIL_API_BASE,
   SHEETS_API_BASE,
   SLIDES_API_BASE,
   TOKEN_URL,
@@ -24,6 +25,7 @@ import {
   docsBase,
   driveBase,
   driveUploadBase,
+  gmailBase,
   refreshAccessToken,
   sheetsBase,
   slidesBase,
@@ -145,6 +147,7 @@ describe('api base helpers', () => {
     expect(docsBase(tm)).toBe(DOCS_API_BASE)
     expect(slidesBase(tm)).toBe(SLIDES_API_BASE)
     expect(sheetsBase(tm)).toBe(SHEETS_API_BASE)
+    expect(gmailBase(tm)).toBe(GMAIL_API_BASE)
     expect(tokenUrl(tm.config)).toBe(TOKEN_URL)
   })
 
@@ -159,6 +162,44 @@ describe('api base helpers', () => {
     expect(docsBase(tm)).toBe('http://127.0.0.1:19999/v1')
     expect(slidesBase(tm)).toBe('http://127.0.0.1:19999/v1')
     expect(sheetsBase(tm)).toBe('http://127.0.0.1:19999/v4')
+    expect(gmailBase(tm)).toBe('http://127.0.0.1:19999/gmail/v1')
     expect(tokenUrl(tm.config)).toBe('http://127.0.0.1:19999/token')
+  })
+
+  it('per-service overrides take precedence over apiBase', () => {
+    const tm = new TokenManager({
+      clientId: 'cid',
+      refreshToken: 'rt',
+      apiBase: 'http://shared:9',
+      tokenUrl: 'http://oauth:1/oauth2/token',
+      driveApiBase: 'http://drive:2/drive/v3',
+      driveUploadApiBase: 'http://drive:2/upload/drive/v3',
+      docsApiBase: 'http://docs:3/docs/v1',
+      sheetsApiBase: 'http://sheets:4/sheets/v4',
+      slidesApiBase: 'http://slides:5/slides/v1',
+      gmailApiBase: 'http://gmail:6/gmail/v1',
+    })
+    expect(tokenUrl(tm.config)).toBe('http://oauth:1/oauth2/token')
+    expect(driveBase(tm)).toBe('http://drive:2/drive/v3')
+    expect(driveUploadBase(tm)).toBe('http://drive:2/upload/drive/v3')
+    expect(docsBase(tm)).toBe('http://docs:3/docs/v1')
+    expect(sheetsBase(tm)).toBe('http://sheets:4/sheets/v4')
+    expect(slidesBase(tm)).toBe('http://slides:5/slides/v1')
+    expect(gmailBase(tm)).toBe('http://gmail:6/gmail/v1')
+  })
+
+  it('per-service falls back to apiBase, then the real default', () => {
+    const tm = new TokenManager({
+      clientId: 'cid',
+      refreshToken: 'rt',
+      apiBase: 'http://m',
+      docsApiBase: 'http://docs-only/docs/v1',
+    })
+    expect(docsBase(tm)).toBe('http://docs-only/docs/v1') // explicit
+    expect(sheetsBase(tm)).toBe('http://m/v4') // apiBase derived
+    expect(gmailBase(tm)).toBe('http://m/gmail/v1') // apiBase derived
+    const bare = new TokenManager({ clientId: 'cid', refreshToken: 'rt' })
+    expect(sheetsBase(bare)).toBe(SHEETS_API_BASE) // real default
+    expect(tokenUrl(bare.config)).toBe(TOKEN_URL)
   })
 })

--- a/typescript/packages/core/src/core/google/_client.ts
+++ b/typescript/packages/core/src/core/google/_client.ts
@@ -24,36 +24,49 @@ export const DRIVE_UPLOAD_BASE = 'https://www.googleapis.com/upload/drive/v3'
 export const TOKEN_BUFFER_SECONDS = 300
 
 export function tokenUrl(config: GoogleConfig): string {
+  if (config.tokenUrl !== undefined) return config.tokenUrl
   return config.apiBase !== undefined ? `${config.apiBase}/token` : TOKEN_URL
 }
 
 export function driveBase(tokenManager: TokenManager): string {
-  const base = tokenManager.config.apiBase
+  const config = tokenManager.config
+  if (config.driveApiBase !== undefined) return config.driveApiBase
+  const base = config.apiBase
   return base !== undefined ? `${base}/drive/v3` : DRIVE_API_BASE
 }
 
 export function driveUploadBase(tokenManager: TokenManager): string {
-  const base = tokenManager.config.apiBase
+  const config = tokenManager.config
+  if (config.driveUploadApiBase !== undefined) return config.driveUploadApiBase
+  const base = config.apiBase
   return base !== undefined ? `${base}/upload/drive/v3` : DRIVE_UPLOAD_BASE
 }
 
 export function docsBase(tokenManager: TokenManager): string {
-  const base = tokenManager.config.apiBase
+  const config = tokenManager.config
+  if (config.docsApiBase !== undefined) return config.docsApiBase
+  const base = config.apiBase
   return base !== undefined ? `${base}/v1` : DOCS_API_BASE
 }
 
 export function slidesBase(tokenManager: TokenManager): string {
-  const base = tokenManager.config.apiBase
+  const config = tokenManager.config
+  if (config.slidesApiBase !== undefined) return config.slidesApiBase
+  const base = config.apiBase
   return base !== undefined ? `${base}/v1` : SLIDES_API_BASE
 }
 
 export function sheetsBase(tokenManager: TokenManager): string {
-  const base = tokenManager.config.apiBase
+  const config = tokenManager.config
+  if (config.sheetsApiBase !== undefined) return config.sheetsApiBase
+  const base = config.apiBase
   return base !== undefined ? `${base}/v4` : SHEETS_API_BASE
 }
 
 export function gmailBase(tokenManager: TokenManager): string {
-  const base = tokenManager.config.apiBase
+  const config = tokenManager.config
+  if (config.gmailApiBase !== undefined) return config.gmailApiBase
+  const base = config.apiBase
   return base !== undefined ? `${base}/gmail/v1` : GMAIL_API_BASE
 }
 

--- a/typescript/packages/core/src/core/google/config.ts
+++ b/typescript/packages/core/src/core/google/config.ts
@@ -27,9 +27,18 @@ export interface GoogleConfig {
   // token endpoint directly. Useful when the client_secret must stay on a
   // backend (e.g. a Vercel function proxy).
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-  // Single-host override for every Google API (drive/docs/sheets/slides)
+  // Single-host override for every Google API (drive/docs/sheets/slides/gmail)
   // plus the OAuth token endpoint; used to point backends at a fake server.
   apiBase?: string
+  // Per-service overrides; each wins over `apiBase`, falling back to it then
+  // the real host.
+  tokenUrl?: string
+  driveApiBase?: string
+  driveUploadApiBase?: string
+  docsApiBase?: string
+  sheetsApiBase?: string
+  slidesApiBase?: string
+  gmailApiBase?: string
   // Drive-only: scope the mount to this folder ID instead of the Drive
   // root, the s3 key_prefix analog. Other Google backends ignore it.
   folderId?: string
@@ -40,6 +49,13 @@ export interface GoogleConfigRedacted {
   clientSecret?: '<REDACTED>'
   refreshToken: '<REDACTED>'
   apiBase?: string
+  tokenUrl?: string
+  driveApiBase?: string
+  driveUploadApiBase?: string
+  docsApiBase?: string
+  sheetsApiBase?: string
+  slidesApiBase?: string
+  gmailApiBase?: string
   folderId?: string
 }
 
@@ -48,6 +64,13 @@ export const GoogleConfigSchema = z.object({
   clientSecret: secretStr().optional(),
   refreshToken: secretStr(),
   apiBase: z.string().optional(),
+  tokenUrl: z.string().optional(),
+  driveApiBase: z.string().optional(),
+  driveUploadApiBase: z.string().optional(),
+  docsApiBase: z.string().optional(),
+  sheetsApiBase: z.string().optional(),
+  slidesApiBase: z.string().optional(),
+  gmailApiBase: z.string().optional(),
   folderId: z.string().optional(),
 })
 
@@ -62,6 +85,13 @@ export function normalizeGoogleConfig(input: Record<string, unknown>): GoogleCon
       client_secret: 'clientSecret',
       refresh_token: 'refreshToken',
       api_base: 'apiBase',
+      token_url: 'tokenUrl',
+      drive_api_base: 'driveApiBase',
+      drive_upload_api_base: 'driveUploadApiBase',
+      docs_api_base: 'docsApiBase',
+      sheets_api_base: 'sheetsApiBase',
+      slides_api_base: 'slidesApiBase',
+      gmail_api_base: 'gmailApiBase',
       folder_id: 'folderId',
     },
   }) as unknown as GoogleConfig


### PR DESCRIPTION
## Background

`GoogleConfig` recently gained a single `api_base` field so that every Google backend
(drive/docs/sheets/slides/gmail + the OAuth token endpoint) can be pointed at a fake server for
testing. It rewrites the host for **all** services at once, deriving each service's URL by
appending that service's real path suffix to the one base.

## Problem

A single host only works when every service can be told apart by path. Google's real APIs live on
distinct hosts, so collapsing them onto one `api_base` produces paths that are ambiguous — or
outright colliding — at the subpath level:

| service | derived from `api_base` |
|---------|-------------------------|
| drive   | `{api_base}/drive/v3`   |
| docs    | `{api_base}/v1`         |
| slides  | `{api_base}/v1`  ← **identical to docs** |
| sheets  | `{api_base}/v4`         |
| gmail   | `{api_base}/gmail/v1`   |

`docs_base` and `slides_base` both resolve to `{api_base}/v1`, so a fake server hosting both under
one origin has **no way to distinguish a Docs request from a Slides request** — a concrete,
unavoidable collision. More broadly, `api_base` offers no subpath-level control: you can't point an
individual service somewhere else, and you can't line mirage up with a mock whose per-service paths
don't match the derived ones.

## Change

Add optional **per-service base-URL overrides** to `GoogleConfig`. Each takes precedence over
`api_base`, then falls back to the `api_base` derivation, then the real Google host — so nothing
changes unless you set them:

| field                    | overrides                 | fallback when unset                      |
|--------------------------|---------------------------|------------------------------------------|
| `token_url`              | OAuth token endpoint      | `{api_base}/token` → real `TOKEN_URL`    |
| `drive_api_base`         | Drive                     | `{api_base}/drive/v3` → real `DRIVE_API_BASE`        |
| `drive_upload_api_base`  | Drive upload              | `{api_base}/upload/drive/v3` → real `DRIVE_UPLOAD_BASE` |
| `docs_api_base`          | Docs                      | `{api_base}/v1` → real `DOCS_API_BASE`              |
| `sheets_api_base`        | Sheets                    | `{api_base}/v4` → real `SHEETS_API_BASE`              |
| `slides_api_base`        | Slides                    | `{api_base}/v1` → real `SLIDES_API_BASE`              |
| `gmail_api_base`         | Gmail                     | `{api_base}/gmail/v1` → real `GMAIL_API_BASE`        |

Resolution order in every base helper is:
`service-specific override → api_base-derived → real default`.

With these, Docs and Slides can resolve to genuinely different bases (e.g. `…/docs/v1` and
`…/slides/v1`), which removes the collision, and a mock whose paths differ from the derived ones
can be matched exactly.

### Notes

- `token_url` is the **full** token endpoint URL and is used verbatim (it replaces the whole
  `TOKEN_URL`; no `/token` is appended) — the OAuth endpoint is a single URL, not a base. The
  remaining fields are service bases that callers append paths to.
- `api_base` behavior is unchanged, and with nothing set every service still points at its real
  Google host. Fully backward compatible.

## Tests

- Per-service overrides take precedence over `api_base` for every service.
- Fallback chain: explicit override → `api_base` derivation → real default.
- Existing default-host and single-`api_base` tests remain unchanged and green.
