### PR TITLE
fix(google): keep API endpoints fixed

### DIFF
--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -36,6 +36,7 @@ from pymongo import AsyncMongoClient
 from mirage import MountMode, Workspace
 from mirage.accessor.onedrive import OneDriveConfig
 from mirage.accessor.sharepoint import SharePointConfig
+from mirage.core.google import _client as google_client
 from mirage.core.sharepoint import _resolver as sharepoint_resolver
 from mirage.resource.box import BoxConfig, BoxResource
 from mirage.resource.disk import DiskResource
@@ -320,6 +321,16 @@ class NextcloudService:
 FOLDER_MIME = "application/vnd.google-apps.folder"
 
 
+def _use_fake_google_endpoints(url: str) -> None:
+    google_client.TOKEN_URL = f"{url}/token"
+    google_client.DRIVE_API_BASE = f"{url}/drive/v3"
+    google_client.DRIVE_UPLOAD_BASE = f"{url}/upload/drive/v3"
+    google_client.DOCS_API_BASE = f"{url}/v1"
+    google_client.SLIDES_API_BASE = f"{url}/v1"
+    google_client.SHEETS_API_BASE = f"{url}/v4"
+    google_client.GMAIL_API_BASE = f"{url}/gmail/v1"
+
+
 class GwsService:
     """Points gdrive mounts at the fake Google Workspace server.
 
@@ -336,6 +347,7 @@ class GwsService:
     @classmethod
     async def create(cls, run_id: str, target: dict) -> "GwsService":
         url = os.environ["GWS_URL"].rstrip("/")
+        _use_fake_google_endpoints(url)
         folder_ids: dict[str, str] = {}
         drive_ids: dict[str, str] = {}
         # Native mounts (gdocs/gsheets/gslides) render the modified date
@@ -461,32 +473,23 @@ class GwsService:
         return GoogleDriveResource(
             GoogleDriveConfig(client_id="integ",
                               refresh_token="integ",
-                              api_base=self.url,
                               folder_id=self.folder_ids[mount["path"]]))
 
     def gdocs_resource(self) -> GDocsResource:
         return GDocsResource(
-            GDocsConfig(client_id="integ",
-                        refresh_token="integ",
-                        api_base=self.url))
+            GDocsConfig(client_id="integ", refresh_token="integ"))
 
     def gsheets_resource(self) -> GSheetsResource:
         return GSheetsResource(
-            GSheetsConfig(client_id="integ",
-                          refresh_token="integ",
-                          api_base=self.url))
+            GSheetsConfig(client_id="integ", refresh_token="integ"))
 
     def gslides_resource(self) -> GSlidesResource:
         return GSlidesResource(
-            GSlidesConfig(client_id="integ",
-                          refresh_token="integ",
-                          api_base=self.url))
+            GSlidesConfig(client_id="integ", refresh_token="integ"))
 
     def gmail_resource(self) -> GmailResource:
         return GmailResource(
-            GmailConfig(client_id="integ",
-                        refresh_token="integ",
-                        api_base=self.url))
+            GmailConfig(client_id="integ", refresh_token="integ"))
 
     async def teardown(self) -> None:
         return None

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -63,6 +63,41 @@ const S3_SECRET = process.env.AWS_SECRET_ACCESS_KEY ?? 'testing'
 const NEXTCLOUD_URL = process.env.NEXTCLOUD_URL
 const NEXTCLOUD_USERNAME = process.env.NEXTCLOUD_USERNAME ?? 'admin'
 const NEXTCLOUD_PASSWORD = process.env.NEXTCLOUD_PASSWORD ?? 'admin123'
+const GOOGLE_API_HOSTS = new Set([
+  'oauth2.googleapis.com',
+  'www.googleapis.com',
+  'docs.googleapis.com',
+  'slides.googleapis.com',
+  'sheets.googleapis.com',
+  'gmail.googleapis.com',
+])
+
+type FetchInput = Parameters<typeof globalThis.fetch>[0]
+type FetchInit = Parameters<typeof globalThis.fetch>[1]
+
+let realFetch: typeof globalThis.fetch | null = null
+let fakeGoogleBase = ''
+
+function redirectGoogleUrl(input: FetchInput): FetchInput {
+  if (typeof input !== 'string' && !(input instanceof URL)) return input
+  const raw = input instanceof URL ? input.href : input
+  if (!raw.startsWith('http://') && !raw.startsWith('https://')) return input
+  const url = new URL(raw)
+  if (!GOOGLE_API_HOSTS.has(url.hostname)) return input
+  return `${fakeGoogleBase}${url.pathname}${url.search}`
+}
+
+function fakeGoogleFetch(input: FetchInput, init?: FetchInit): Promise<Response> {
+  if (realFetch === null) throw new Error('fake Google fetch is not installed')
+  return realFetch(redirectGoogleUrl(input), init)
+}
+
+function useFakeGoogleEndpoints(base: string): void {
+  fakeGoogleBase = base
+  if (realFetch !== null) return
+  realFetch = globalThis.fetch
+  globalThis.fetch = fakeGoogleFetch
+}
 
 function runId(): string {
   return `${String(process.pid)}-${String(Date.now())}`
@@ -592,10 +627,9 @@ async function seedGwsMail(base: string, entries: MailEntry[]): Promise<void> {
 }
 
 function gwsNativeResource(
-  base: string,
   resource: string,
 ): GDocsResource | GSheetsResource | GSlidesResource | GmailResource {
-  const config = { clientId: 'integ', clientSecret: 'integ', refreshToken: 'integ', apiBase: base }
+  const config = { clientId: 'integ', clientSecret: 'integ', refreshToken: 'integ' }
   if (resource === 'gdocs') return new GDocsResource(config)
   if (resource === 'gsheets') return new GSheetsResource(config)
   if (resource === 'gmail') return new GmailResource(config)
@@ -606,6 +640,7 @@ async function openGws(target: Target): Promise<Open> {
   let base = process.env.GWS_URL ?? ''
   while (base.endsWith('/')) base = base.slice(0, -1)
   if (base === '') throw new Error('gdrive target requires GWS_URL')
+  useFakeGoogleEndpoints(base)
   // Native mounts (gdocs/gsheets/gslides) render the modified date into
   // filenames, so those targets pin the server clock.
   await gwsJson(`${base}/reset`, {
@@ -624,7 +659,7 @@ async function openGws(target: Target): Promise<Open> {
       continue
     }
     if (m.resource !== 'gdrive') {
-      mounts[m.path] = gwsNativeResource(base, m.resource)
+      mounts[m.path] = gwsNativeResource(m.resource)
       continue
     }
     // A mount may live inside a Shared Drive: the drive is created once
@@ -646,7 +681,6 @@ async function openGws(target: Target): Promise<Open> {
       clientId: 'integ',
       clientSecret: 'integ',
       refreshToken: 'integ',
-      apiBase: base,
       folderId: parent,
     })
   }

--- a/integ/server/gws_server.ts
+++ b/integ/server/gws_server.ts
@@ -16,7 +16,8 @@
 // Slides v1 + Gmail v1 on one in-memory host, plus a fake OAuth /token and
 // a /reset for per-run isolation. Mirrors the real REST surface closely
 // enough that mirage's google backends and the gws passthrough commands run
-// unmodified against it (GoogleConfig.api_base points here). Deliberate
+// unmodified against it; the integration runners redirect Google's fixed
+// production origins to this server. Deliberate
 // simplifications, all deterministic so both language runners see
 // byte-identical responses:
 //   - ids and timestamps are counters over a fixed clock, not random

--- a/python/mirage/core/google/_client.py
+++ b/python/mirage/core/google/_client.py
@@ -32,36 +32,56 @@ TOKEN_BUFFER_SECONDS = 300
 
 
 def token_url(config: GoogleConfig) -> str:
+    if config.token_url:
+        return config.token_url
     return f"{config.api_base}/token" if config.api_base else TOKEN_URL
 
 
 def drive_base(token_manager: "TokenManager") -> str:
-    base = token_manager.config.api_base
+    config = token_manager.config
+    if config.drive_api_base:
+        return config.drive_api_base
+    base = config.api_base
     return f"{base}/drive/v3" if base else DRIVE_API_BASE
 
 
 def drive_upload_base(token_manager: "TokenManager") -> str:
-    base = token_manager.config.api_base
+    config = token_manager.config
+    if config.drive_upload_api_base:
+        return config.drive_upload_api_base
+    base = config.api_base
     return f"{base}/upload/drive/v3" if base else DRIVE_UPLOAD_BASE
 
 
 def docs_base(token_manager: "TokenManager") -> str:
-    base = token_manager.config.api_base
+    config = token_manager.config
+    if config.docs_api_base:
+        return config.docs_api_base
+    base = config.api_base
     return f"{base}/v1" if base else DOCS_API_BASE
 
 
 def slides_base(token_manager: "TokenManager") -> str:
-    base = token_manager.config.api_base
+    config = token_manager.config
+    if config.slides_api_base:
+        return config.slides_api_base
+    base = config.api_base
     return f"{base}/v1" if base else SLIDES_API_BASE
 
 
 def sheets_base(token_manager: "TokenManager") -> str:
-    base = token_manager.config.api_base
+    config = token_manager.config
+    if config.sheets_api_base:
+        return config.sheets_api_base
+    base = config.api_base
     return f"{base}/v4" if base else SHEETS_API_BASE
 
 
 def gmail_base(token_manager: "TokenManager") -> str:
-    base = token_manager.config.api_base
+    config = token_manager.config
+    if config.gmail_api_base:
+        return config.gmail_api_base
+    base = config.api_base
     return f"{base}/gmail/v1" if base else GMAIL_API_BASE
 
 

--- a/python/mirage/core/google/_client.py
+++ b/python/mirage/core/google/_client.py
@@ -31,58 +31,32 @@ DRIVE_UPLOAD_BASE = "https://www.googleapis.com/upload/drive/v3"
 TOKEN_BUFFER_SECONDS = 300
 
 
-def token_url(config: GoogleConfig) -> str:
-    if config.token_url:
-        return config.token_url
-    return f"{config.api_base}/token" if config.api_base else TOKEN_URL
+def token_url() -> str:
+    return TOKEN_URL
 
 
-def drive_base(token_manager: "TokenManager") -> str:
-    config = token_manager.config
-    if config.drive_api_base:
-        return config.drive_api_base
-    base = config.api_base
-    return f"{base}/drive/v3" if base else DRIVE_API_BASE
+def drive_base(_token_manager: "TokenManager") -> str:
+    return DRIVE_API_BASE
 
 
-def drive_upload_base(token_manager: "TokenManager") -> str:
-    config = token_manager.config
-    if config.drive_upload_api_base:
-        return config.drive_upload_api_base
-    base = config.api_base
-    return f"{base}/upload/drive/v3" if base else DRIVE_UPLOAD_BASE
+def drive_upload_base(_token_manager: "TokenManager") -> str:
+    return DRIVE_UPLOAD_BASE
 
 
-def docs_base(token_manager: "TokenManager") -> str:
-    config = token_manager.config
-    if config.docs_api_base:
-        return config.docs_api_base
-    base = config.api_base
-    return f"{base}/v1" if base else DOCS_API_BASE
+def docs_base(_token_manager: "TokenManager") -> str:
+    return DOCS_API_BASE
 
 
-def slides_base(token_manager: "TokenManager") -> str:
-    config = token_manager.config
-    if config.slides_api_base:
-        return config.slides_api_base
-    base = config.api_base
-    return f"{base}/v1" if base else SLIDES_API_BASE
+def slides_base(_token_manager: "TokenManager") -> str:
+    return SLIDES_API_BASE
 
 
-def sheets_base(token_manager: "TokenManager") -> str:
-    config = token_manager.config
-    if config.sheets_api_base:
-        return config.sheets_api_base
-    base = config.api_base
-    return f"{base}/v4" if base else SHEETS_API_BASE
+def sheets_base(_token_manager: "TokenManager") -> str:
+    return SHEETS_API_BASE
 
 
-def gmail_base(token_manager: "TokenManager") -> str:
-    config = token_manager.config
-    if config.gmail_api_base:
-        return config.gmail_api_base
-    base = config.api_base
-    return f"{base}/gmail/v1" if base else GMAIL_API_BASE
+def gmail_base(_token_manager: "TokenManager") -> str:
+    return GMAIL_API_BASE
 
 
 async def refresh_access_token(config: GoogleConfig, ) -> tuple[str, int]:
@@ -103,7 +77,7 @@ async def refresh_access_token(config: GoogleConfig, ) -> tuple[str, int]:
     if client_secret:
         data["client_secret"] = client_secret
     async with aiohttp.ClientSession() as session:
-        async with session.post(token_url(config), data=data) as resp:
+        async with session.post(token_url(), data=data) as resp:
             resp.raise_for_status()
             body = await resp.json()
             return body["access_token"], body["expires_in"]

--- a/python/mirage/core/google/config.py
+++ b/python/mirage/core/google/config.py
@@ -19,9 +19,19 @@ class GoogleConfig(BaseModel):
     client_id: str
     client_secret: SecretStr | None = None
     refresh_token: SecretStr
-    # Single-host override for every Google API (drive/docs/sheets/slides)
-    # plus the OAuth token endpoint; used to point backends at a fake server.
+    # Single-host override for every Google API
+    # (drive/docs/sheets/slides/gmail) plus the OAuth token endpoint; used to
+    # point backends at a fake server.
     api_base: str | None = None
+    # Per-service overrides; each wins over `api_base`, falling back to it then
+    # the real host.
+    token_url: str | None = None
+    drive_api_base: str | None = None
+    drive_upload_api_base: str | None = None
+    docs_api_base: str | None = None
+    sheets_api_base: str | None = None
+    slides_api_base: str | None = None
+    gmail_api_base: str | None = None
     # Drive-only: scope the mount to this folder ID instead of the Drive
     # root, the s3 key_prefix analog. Other Google backends ignore it.
     folder_id: str | None = None

--- a/python/mirage/core/google/config.py
+++ b/python/mirage/core/google/config.py
@@ -19,19 +19,6 @@ class GoogleConfig(BaseModel):
     client_id: str
     client_secret: SecretStr | None = None
     refresh_token: SecretStr
-    # Single-host override for every Google API
-    # (drive/docs/sheets/slides/gmail) plus the OAuth token endpoint; used to
-    # point backends at a fake server.
-    api_base: str | None = None
-    # Per-service overrides; each wins over `api_base`, falling back to it then
-    # the real host.
-    token_url: str | None = None
-    drive_api_base: str | None = None
-    drive_upload_api_base: str | None = None
-    docs_api_base: str | None = None
-    sheets_api_base: str | None = None
-    slides_api_base: str | None = None
-    gmail_api_base: str | None = None
     # Drive-only: scope the mount to this folder ID instead of the Drive
     # root, the s3 key_prefix analog. Other Google backends ignore it.
     folder_id: str | None = None

--- a/python/tests/core/gmail/test_attachments.py
+++ b/python/tests/core/gmail/test_attachments.py
@@ -13,12 +13,13 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import base64
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from mirage.core.gmail.messages import _extract_attachments, get_attachment
+from mirage.core.google._client import TokenManager
+from mirage.core.google.config import GoogleConfig
 
 
 def test_extract_attachments_none():
@@ -79,7 +80,8 @@ def test_extract_attachments_nested():
 @pytest.mark.asyncio
 async def test_get_attachment():
     encoded = base64.urlsafe_b64encode(b"hello world").decode().rstrip("=")
-    token_manager = SimpleNamespace(config=SimpleNamespace(api_base=None))
+    token_manager = TokenManager(GoogleConfig(client_id="x",
+                                              refresh_token="y"))
     with patch(
             "mirage.core.gmail.messages.google_get",
             new_callable=AsyncMock,

--- a/python/tests/core/gmail/test_attachments.py
+++ b/python/tests/core/gmail/test_attachments.py
@@ -79,7 +79,8 @@ def test_extract_attachments_nested():
 @pytest.mark.asyncio
 async def test_get_attachment():
     encoded = base64.urlsafe_b64encode(b"hello world").decode().rstrip("=")
-    token_manager = SimpleNamespace(config=SimpleNamespace(api_base=None))
+    token_manager = SimpleNamespace(
+        config=SimpleNamespace(api_base=None, gmail_api_base=None))
     with patch(
             "mirage.core.gmail.messages.google_get",
             new_callable=AsyncMock,

--- a/python/tests/core/gmail/test_attachments.py
+++ b/python/tests/core/gmail/test_attachments.py
@@ -79,8 +79,7 @@ def test_extract_attachments_nested():
 @pytest.mark.asyncio
 async def test_get_attachment():
     encoded = base64.urlsafe_b64encode(b"hello world").decode().rstrip("=")
-    token_manager = SimpleNamespace(
-        config=SimpleNamespace(api_base=None, gmail_api_base=None))
+    token_manager = SimpleNamespace(config=SimpleNamespace(api_base=None))
     with patch(
             "mirage.core.gmail.messages.google_get",
             new_callable=AsyncMock,

--- a/python/tests/core/google/test_client.py
+++ b/python/tests/core/google/test_client.py
@@ -24,9 +24,8 @@ from mirage.core.google._client import (DOCS_API_BASE, DRIVE_API_BASE,
 from mirage.core.google.config import GoogleConfig
 
 
-def _manager(api_base: str | None = None) -> TokenManager:
-    return TokenManager(
-        GoogleConfig(client_id="cid", refresh_token="rt", api_base=api_base))
+def _manager() -> TokenManager:
+    return TokenManager(GoogleConfig(client_id="cid", refresh_token="rt"))
 
 
 def test_bases_default_to_real_google_hosts():
@@ -37,53 +36,4 @@ def test_bases_default_to_real_google_hosts():
     assert slides_base(tm) == SLIDES_API_BASE
     assert sheets_base(tm) == SHEETS_API_BASE
     assert gmail_base(tm) == GMAIL_API_BASE
-    assert token_url(tm.config) == TOKEN_URL
-
-
-def test_api_base_override_rewrites_every_service():
-    tm = _manager("http://127.0.0.1:19999")
-    assert drive_base(tm) == "http://127.0.0.1:19999/drive/v3"
-    assert drive_upload_base(tm) == "http://127.0.0.1:19999/upload/drive/v3"
-    assert docs_base(tm) == "http://127.0.0.1:19999/v1"
-    assert slides_base(tm) == "http://127.0.0.1:19999/v1"
-    assert sheets_base(tm) == "http://127.0.0.1:19999/v4"
-    assert gmail_base(tm) == "http://127.0.0.1:19999/gmail/v1"
-    assert token_url(tm.config) == "http://127.0.0.1:19999/token"
-
-
-def test_per_service_base_overrides_take_precedence_over_api_base():
-    # each per-service base is the full service base and wins over api_base.
-    tm = TokenManager(
-        GoogleConfig(client_id="cid",
-                     refresh_token="rt",
-                     api_base="http://shared:9",
-                     token_url="http://oauth:1/oauth2/token",
-                     drive_api_base="http://drive:2/drive/v3",
-                     drive_upload_api_base="http://drive:2/upload/drive/v3",
-                     docs_api_base="http://docs:3/docs/v1",
-                     sheets_api_base="http://sheets:4/sheets/v4",
-                     slides_api_base="http://slides:5/slides/v1",
-                     gmail_api_base="http://gmail:6/gmail/v1"))
-    assert token_url(tm.config) == "http://oauth:1/oauth2/token"
-    assert drive_base(tm) == "http://drive:2/drive/v3"
-    assert drive_upload_base(tm) == "http://drive:2/upload/drive/v3"
-    assert docs_base(tm) == "http://docs:3/docs/v1"
-    assert sheets_base(tm) == "http://sheets:4/sheets/v4"
-    assert slides_base(tm) == "http://slides:5/slides/v1"
-    assert gmail_base(tm) == "http://gmail:6/gmail/v1"
-
-
-def test_per_service_base_falls_back_to_api_base_then_real_default():
-    # one per-service override set; the rest fall back to api_base, and with no
-    # api_base they fall back to the real Google hosts.
-    tm = TokenManager(
-        GoogleConfig(client_id="cid",
-                     refresh_token="rt",
-                     api_base="http://m",
-                     docs_api_base="http://docs-only/docs/v1"))
-    assert docs_base(tm) == "http://docs-only/docs/v1"  # explicit
-    assert sheets_base(tm) == "http://m/v4"  # api_base derived
-    assert gmail_base(tm) == "http://m/gmail/v1"  # api_base derived
-    bare = TokenManager(GoogleConfig(client_id="cid", refresh_token="rt"))
-    assert sheets_base(bare) == SHEETS_API_BASE  # real default
-    assert token_url(bare.config) == TOKEN_URL
+    assert token_url() == TOKEN_URL

--- a/python/tests/core/google/test_client.py
+++ b/python/tests/core/google/test_client.py
@@ -49,3 +49,41 @@ def test_api_base_override_rewrites_every_service():
     assert sheets_base(tm) == "http://127.0.0.1:19999/v4"
     assert gmail_base(tm) == "http://127.0.0.1:19999/gmail/v1"
     assert token_url(tm.config) == "http://127.0.0.1:19999/token"
+
+
+def test_per_service_base_overrides_take_precedence_over_api_base():
+    # each per-service base is the full service base and wins over api_base.
+    tm = TokenManager(
+        GoogleConfig(client_id="cid",
+                     refresh_token="rt",
+                     api_base="http://shared:9",
+                     token_url="http://oauth:1/oauth2/token",
+                     drive_api_base="http://drive:2/drive/v3",
+                     drive_upload_api_base="http://drive:2/upload/drive/v3",
+                     docs_api_base="http://docs:3/docs/v1",
+                     sheets_api_base="http://sheets:4/sheets/v4",
+                     slides_api_base="http://slides:5/slides/v1",
+                     gmail_api_base="http://gmail:6/gmail/v1"))
+    assert token_url(tm.config) == "http://oauth:1/oauth2/token"
+    assert drive_base(tm) == "http://drive:2/drive/v3"
+    assert drive_upload_base(tm) == "http://drive:2/upload/drive/v3"
+    assert docs_base(tm) == "http://docs:3/docs/v1"
+    assert sheets_base(tm) == "http://sheets:4/sheets/v4"
+    assert slides_base(tm) == "http://slides:5/slides/v1"
+    assert gmail_base(tm) == "http://gmail:6/gmail/v1"
+
+
+def test_per_service_base_falls_back_to_api_base_then_real_default():
+    # one per-service override set; the rest fall back to api_base, and with no
+    # api_base they fall back to the real Google hosts.
+    tm = TokenManager(
+        GoogleConfig(client_id="cid",
+                     refresh_token="rt",
+                     api_base="http://m",
+                     docs_api_base="http://docs-only/docs/v1"))
+    assert docs_base(tm) == "http://docs-only/docs/v1"  # explicit
+    assert sheets_base(tm) == "http://m/v4"  # api_base derived
+    assert gmail_base(tm) == "http://m/gmail/v1"  # api_base derived
+    bare = TokenManager(GoogleConfig(client_id="cid", refresh_token="rt"))
+    assert sheets_base(bare) == SHEETS_API_BASE  # real default
+    assert token_url(bare.config) == TOKEN_URL

--- a/typescript/packages/browser/src/resource/gdocs/config.ts
+++ b/typescript/packages/browser/src/resource/gdocs/config.ts
@@ -19,7 +19,6 @@ export interface GDocsConfig {
   clientSecret?: string
   refreshToken: string
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-  apiBase?: string
 }
 
 export interface GDocsConfigRedacted {
@@ -32,7 +31,6 @@ const GDocsConfigSchema = z.object({
   clientId: z.string(),
   clientSecret: secretStr().optional(),
   refreshToken: secretStr(),
-  apiBase: z.string().optional(),
 })
 
 export function redactGDocsConfig(config: GDocsConfig): GDocsConfigRedacted {
@@ -45,7 +43,6 @@ export function normalizeGDocsConfig(input: Record<string, unknown>): GDocsConfi
       client_id: 'clientId',
       client_secret: 'clientSecret',
       refresh_token: 'refreshToken',
-      api_base: 'apiBase',
     },
   }) as unknown as GDocsConfig
 }

--- a/typescript/packages/browser/src/resource/gdocs/gdocs.ts
+++ b/typescript/packages/browser/src/resource/gdocs/gdocs.ts
@@ -59,7 +59,6 @@ export class GDocsResource implements Resource {
       ...(config.clientSecret !== undefined ? { clientSecret: config.clientSecret } : {}),
       refreshToken: config.refreshToken,
       ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-      ...(config.apiBase !== undefined ? { apiBase: config.apiBase } : {}),
     })
     this.accessor = new GDocsAccessor({ tokenManager: tm })
     this.index = new RAMIndexCacheStore({ ttl: 86_400 })

--- a/typescript/packages/browser/src/resource/gdrive/config.ts
+++ b/typescript/packages/browser/src/resource/gdrive/config.ts
@@ -19,7 +19,6 @@ export interface GDriveConfig {
   clientSecret?: string
   refreshToken: string
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-  apiBase?: string
   folderId?: string
 }
 
@@ -33,7 +32,6 @@ const GDriveConfigSchema = z.object({
   clientId: z.string(),
   clientSecret: secretStr().optional(),
   refreshToken: secretStr(),
-  apiBase: z.string().optional(),
   folderId: z.string().optional(),
 })
 
@@ -47,7 +45,6 @@ export function normalizeGDriveConfig(input: Record<string, unknown>): GDriveCon
       client_id: 'clientId',
       client_secret: 'clientSecret',
       refresh_token: 'refreshToken',
-      api_base: 'apiBase',
       folder_id: 'folderId',
     },
   }) as unknown as GDriveConfig

--- a/typescript/packages/browser/src/resource/gdrive/gdrive.ts
+++ b/typescript/packages/browser/src/resource/gdrive/gdrive.ts
@@ -58,7 +58,6 @@ export class GDriveResource implements Resource {
       ...(config.clientSecret !== undefined ? { clientSecret: config.clientSecret } : {}),
       refreshToken: config.refreshToken,
       ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-      ...(config.apiBase !== undefined ? { apiBase: config.apiBase } : {}),
       ...(config.folderId !== undefined ? { folderId: config.folderId } : {}),
     })
     this.accessor = new GDriveAccessor({ tokenManager: tm })

--- a/typescript/packages/browser/src/resource/gsheets/config.ts
+++ b/typescript/packages/browser/src/resource/gsheets/config.ts
@@ -19,7 +19,6 @@ export interface GSheetsConfig {
   clientSecret?: string
   refreshToken: string
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-  apiBase?: string
 }
 
 export interface GSheetsConfigRedacted {
@@ -32,7 +31,6 @@ const GSheetsConfigSchema = z.object({
   clientId: z.string(),
   clientSecret: secretStr().optional(),
   refreshToken: secretStr(),
-  apiBase: z.string().optional(),
 })
 
 export function redactGSheetsConfig(config: GSheetsConfig): GSheetsConfigRedacted {
@@ -45,7 +43,6 @@ export function normalizeGSheetsConfig(input: Record<string, unknown>): GSheetsC
       client_id: 'clientId',
       client_secret: 'clientSecret',
       refresh_token: 'refreshToken',
-      api_base: 'apiBase',
     },
   }) as unknown as GSheetsConfig
 }

--- a/typescript/packages/browser/src/resource/gsheets/gsheets.ts
+++ b/typescript/packages/browser/src/resource/gsheets/gsheets.ts
@@ -59,7 +59,6 @@ export class GSheetsResource implements Resource {
       ...(config.clientSecret !== undefined ? { clientSecret: config.clientSecret } : {}),
       refreshToken: config.refreshToken,
       ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-      ...(config.apiBase !== undefined ? { apiBase: config.apiBase } : {}),
     })
     this.accessor = new GSheetsAccessor({ tokenManager: tm })
     this.index = new RAMIndexCacheStore({ ttl: 86_400 })

--- a/typescript/packages/browser/src/resource/gslides/config.ts
+++ b/typescript/packages/browser/src/resource/gslides/config.ts
@@ -19,7 +19,6 @@ export interface GSlidesConfig {
   clientSecret?: string
   refreshToken: string
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-  apiBase?: string
 }
 
 export interface GSlidesConfigRedacted {
@@ -32,7 +31,6 @@ const GSlidesConfigSchema = z.object({
   clientId: z.string(),
   clientSecret: secretStr().optional(),
   refreshToken: secretStr(),
-  apiBase: z.string().optional(),
 })
 
 export function redactGSlidesConfig(config: GSlidesConfig): GSlidesConfigRedacted {
@@ -45,7 +43,6 @@ export function normalizeGSlidesConfig(input: Record<string, unknown>): GSlidesC
       client_id: 'clientId',
       client_secret: 'clientSecret',
       refresh_token: 'refreshToken',
-      api_base: 'apiBase',
     },
   }) as unknown as GSlidesConfig
 }

--- a/typescript/packages/browser/src/resource/gslides/gslides.ts
+++ b/typescript/packages/browser/src/resource/gslides/gslides.ts
@@ -59,7 +59,6 @@ export class GSlidesResource implements Resource {
       ...(config.clientSecret !== undefined ? { clientSecret: config.clientSecret } : {}),
       refreshToken: config.refreshToken,
       ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-      ...(config.apiBase !== undefined ? { apiBase: config.apiBase } : {}),
     })
     this.accessor = new GSlidesAccessor({ tokenManager: tm })
     this.index = new RAMIndexCacheStore({ ttl: 86_400 })

--- a/typescript/packages/core/src/core/google/_client.test.ts
+++ b/typescript/packages/core/src/core/google/_client.test.ts
@@ -148,58 +148,6 @@ describe('api base helpers', () => {
     expect(slidesBase(tm)).toBe(SLIDES_API_BASE)
     expect(sheetsBase(tm)).toBe(SHEETS_API_BASE)
     expect(gmailBase(tm)).toBe(GMAIL_API_BASE)
-    expect(tokenUrl(tm.config)).toBe(TOKEN_URL)
-  })
-
-  it('apiBase override rewrites every service', () => {
-    const tm = new TokenManager({
-      clientId: 'cid',
-      refreshToken: 'rt',
-      apiBase: 'http://127.0.0.1:19999',
-    })
-    expect(driveBase(tm)).toBe('http://127.0.0.1:19999/drive/v3')
-    expect(driveUploadBase(tm)).toBe('http://127.0.0.1:19999/upload/drive/v3')
-    expect(docsBase(tm)).toBe('http://127.0.0.1:19999/v1')
-    expect(slidesBase(tm)).toBe('http://127.0.0.1:19999/v1')
-    expect(sheetsBase(tm)).toBe('http://127.0.0.1:19999/v4')
-    expect(gmailBase(tm)).toBe('http://127.0.0.1:19999/gmail/v1')
-    expect(tokenUrl(tm.config)).toBe('http://127.0.0.1:19999/token')
-  })
-
-  it('per-service overrides take precedence over apiBase', () => {
-    const tm = new TokenManager({
-      clientId: 'cid',
-      refreshToken: 'rt',
-      apiBase: 'http://shared:9',
-      tokenUrl: 'http://oauth:1/oauth2/token',
-      driveApiBase: 'http://drive:2/drive/v3',
-      driveUploadApiBase: 'http://drive:2/upload/drive/v3',
-      docsApiBase: 'http://docs:3/docs/v1',
-      sheetsApiBase: 'http://sheets:4/sheets/v4',
-      slidesApiBase: 'http://slides:5/slides/v1',
-      gmailApiBase: 'http://gmail:6/gmail/v1',
-    })
-    expect(tokenUrl(tm.config)).toBe('http://oauth:1/oauth2/token')
-    expect(driveBase(tm)).toBe('http://drive:2/drive/v3')
-    expect(driveUploadBase(tm)).toBe('http://drive:2/upload/drive/v3')
-    expect(docsBase(tm)).toBe('http://docs:3/docs/v1')
-    expect(sheetsBase(tm)).toBe('http://sheets:4/sheets/v4')
-    expect(slidesBase(tm)).toBe('http://slides:5/slides/v1')
-    expect(gmailBase(tm)).toBe('http://gmail:6/gmail/v1')
-  })
-
-  it('per-service falls back to apiBase, then the real default', () => {
-    const tm = new TokenManager({
-      clientId: 'cid',
-      refreshToken: 'rt',
-      apiBase: 'http://m',
-      docsApiBase: 'http://docs-only/docs/v1',
-    })
-    expect(docsBase(tm)).toBe('http://docs-only/docs/v1') // explicit
-    expect(sheetsBase(tm)).toBe('http://m/v4') // apiBase derived
-    expect(gmailBase(tm)).toBe('http://m/gmail/v1') // apiBase derived
-    const bare = new TokenManager({ clientId: 'cid', refreshToken: 'rt' })
-    expect(sheetsBase(bare)).toBe(SHEETS_API_BASE) // real default
-    expect(tokenUrl(bare.config)).toBe(TOKEN_URL)
+    expect(tokenUrl()).toBe(TOKEN_URL)
   })
 })

--- a/typescript/packages/core/src/core/google/_client.test.ts
+++ b/typescript/packages/core/src/core/google/_client.test.ts
@@ -17,6 +17,7 @@ import {
   DOCS_API_BASE,
   DRIVE_API_BASE,
   DRIVE_UPLOAD_BASE,
+  GMAIL_API_BASE,
   SHEETS_API_BASE,
   SLIDES_API_BASE,
   TOKEN_URL,
@@ -24,6 +25,7 @@ import {
   docsBase,
   driveBase,
   driveUploadBase,
+  gmailBase,
   refreshAccessToken,
   sheetsBase,
   slidesBase,
@@ -145,6 +147,7 @@ describe('api base helpers', () => {
     expect(docsBase(tm)).toBe(DOCS_API_BASE)
     expect(slidesBase(tm)).toBe(SLIDES_API_BASE)
     expect(sheetsBase(tm)).toBe(SHEETS_API_BASE)
+    expect(gmailBase(tm)).toBe(GMAIL_API_BASE)
     expect(tokenUrl(tm.config)).toBe(TOKEN_URL)
   })
 
@@ -159,6 +162,44 @@ describe('api base helpers', () => {
     expect(docsBase(tm)).toBe('http://127.0.0.1:19999/v1')
     expect(slidesBase(tm)).toBe('http://127.0.0.1:19999/v1')
     expect(sheetsBase(tm)).toBe('http://127.0.0.1:19999/v4')
+    expect(gmailBase(tm)).toBe('http://127.0.0.1:19999/gmail/v1')
     expect(tokenUrl(tm.config)).toBe('http://127.0.0.1:19999/token')
+  })
+
+  it('per-service overrides take precedence over apiBase', () => {
+    const tm = new TokenManager({
+      clientId: 'cid',
+      refreshToken: 'rt',
+      apiBase: 'http://shared:9',
+      tokenUrl: 'http://oauth:1/oauth2/token',
+      driveApiBase: 'http://drive:2/drive/v3',
+      driveUploadApiBase: 'http://drive:2/upload/drive/v3',
+      docsApiBase: 'http://docs:3/docs/v1',
+      sheetsApiBase: 'http://sheets:4/sheets/v4',
+      slidesApiBase: 'http://slides:5/slides/v1',
+      gmailApiBase: 'http://gmail:6/gmail/v1',
+    })
+    expect(tokenUrl(tm.config)).toBe('http://oauth:1/oauth2/token')
+    expect(driveBase(tm)).toBe('http://drive:2/drive/v3')
+    expect(driveUploadBase(tm)).toBe('http://drive:2/upload/drive/v3')
+    expect(docsBase(tm)).toBe('http://docs:3/docs/v1')
+    expect(sheetsBase(tm)).toBe('http://sheets:4/sheets/v4')
+    expect(slidesBase(tm)).toBe('http://slides:5/slides/v1')
+    expect(gmailBase(tm)).toBe('http://gmail:6/gmail/v1')
+  })
+
+  it('per-service falls back to apiBase, then the real default', () => {
+    const tm = new TokenManager({
+      clientId: 'cid',
+      refreshToken: 'rt',
+      apiBase: 'http://m',
+      docsApiBase: 'http://docs-only/docs/v1',
+    })
+    expect(docsBase(tm)).toBe('http://docs-only/docs/v1') // explicit
+    expect(sheetsBase(tm)).toBe('http://m/v4') // apiBase derived
+    expect(gmailBase(tm)).toBe('http://m/gmail/v1') // apiBase derived
+    const bare = new TokenManager({ clientId: 'cid', refreshToken: 'rt' })
+    expect(sheetsBase(bare)).toBe(SHEETS_API_BASE) // real default
+    expect(tokenUrl(bare.config)).toBe(TOKEN_URL)
   })
 })

--- a/typescript/packages/core/src/core/google/_client.ts
+++ b/typescript/packages/core/src/core/google/_client.ts
@@ -24,36 +24,49 @@ export const DRIVE_UPLOAD_BASE = 'https://www.googleapis.com/upload/drive/v3'
 export const TOKEN_BUFFER_SECONDS = 300
 
 export function tokenUrl(config: GoogleConfig): string {
+  if (config.tokenUrl !== undefined) return config.tokenUrl
   return config.apiBase !== undefined ? `${config.apiBase}/token` : TOKEN_URL
 }
 
 export function driveBase(tokenManager: TokenManager): string {
-  const base = tokenManager.config.apiBase
+  const config = tokenManager.config
+  if (config.driveApiBase !== undefined) return config.driveApiBase
+  const base = config.apiBase
   return base !== undefined ? `${base}/drive/v3` : DRIVE_API_BASE
 }
 
 export function driveUploadBase(tokenManager: TokenManager): string {
-  const base = tokenManager.config.apiBase
+  const config = tokenManager.config
+  if (config.driveUploadApiBase !== undefined) return config.driveUploadApiBase
+  const base = config.apiBase
   return base !== undefined ? `${base}/upload/drive/v3` : DRIVE_UPLOAD_BASE
 }
 
 export function docsBase(tokenManager: TokenManager): string {
-  const base = tokenManager.config.apiBase
+  const config = tokenManager.config
+  if (config.docsApiBase !== undefined) return config.docsApiBase
+  const base = config.apiBase
   return base !== undefined ? `${base}/v1` : DOCS_API_BASE
 }
 
 export function slidesBase(tokenManager: TokenManager): string {
-  const base = tokenManager.config.apiBase
+  const config = tokenManager.config
+  if (config.slidesApiBase !== undefined) return config.slidesApiBase
+  const base = config.apiBase
   return base !== undefined ? `${base}/v1` : SLIDES_API_BASE
 }
 
 export function sheetsBase(tokenManager: TokenManager): string {
-  const base = tokenManager.config.apiBase
+  const config = tokenManager.config
+  if (config.sheetsApiBase !== undefined) return config.sheetsApiBase
+  const base = config.apiBase
   return base !== undefined ? `${base}/v4` : SHEETS_API_BASE
 }
 
 export function gmailBase(tokenManager: TokenManager): string {
-  const base = tokenManager.config.apiBase
+  const config = tokenManager.config
+  if (config.gmailApiBase !== undefined) return config.gmailApiBase
+  const base = config.apiBase
   return base !== undefined ? `${base}/gmail/v1` : GMAIL_API_BASE
 }
 

--- a/typescript/packages/core/src/core/google/_client.ts
+++ b/typescript/packages/core/src/core/google/_client.ts
@@ -23,51 +23,32 @@ export const GMAIL_API_BASE = 'https://gmail.googleapis.com/gmail/v1'
 export const DRIVE_UPLOAD_BASE = 'https://www.googleapis.com/upload/drive/v3'
 export const TOKEN_BUFFER_SECONDS = 300
 
-export function tokenUrl(config: GoogleConfig): string {
-  if (config.tokenUrl !== undefined) return config.tokenUrl
-  return config.apiBase !== undefined ? `${config.apiBase}/token` : TOKEN_URL
+export function tokenUrl(): string {
+  return TOKEN_URL
 }
 
-export function driveBase(tokenManager: TokenManager): string {
-  const config = tokenManager.config
-  if (config.driveApiBase !== undefined) return config.driveApiBase
-  const base = config.apiBase
-  return base !== undefined ? `${base}/drive/v3` : DRIVE_API_BASE
+export function driveBase(_tokenManager: TokenManager): string {
+  return DRIVE_API_BASE
 }
 
-export function driveUploadBase(tokenManager: TokenManager): string {
-  const config = tokenManager.config
-  if (config.driveUploadApiBase !== undefined) return config.driveUploadApiBase
-  const base = config.apiBase
-  return base !== undefined ? `${base}/upload/drive/v3` : DRIVE_UPLOAD_BASE
+export function driveUploadBase(_tokenManager: TokenManager): string {
+  return DRIVE_UPLOAD_BASE
 }
 
-export function docsBase(tokenManager: TokenManager): string {
-  const config = tokenManager.config
-  if (config.docsApiBase !== undefined) return config.docsApiBase
-  const base = config.apiBase
-  return base !== undefined ? `${base}/v1` : DOCS_API_BASE
+export function docsBase(_tokenManager: TokenManager): string {
+  return DOCS_API_BASE
 }
 
-export function slidesBase(tokenManager: TokenManager): string {
-  const config = tokenManager.config
-  if (config.slidesApiBase !== undefined) return config.slidesApiBase
-  const base = config.apiBase
-  return base !== undefined ? `${base}/v1` : SLIDES_API_BASE
+export function slidesBase(_tokenManager: TokenManager): string {
+  return SLIDES_API_BASE
 }
 
-export function sheetsBase(tokenManager: TokenManager): string {
-  const config = tokenManager.config
-  if (config.sheetsApiBase !== undefined) return config.sheetsApiBase
-  const base = config.apiBase
-  return base !== undefined ? `${base}/v4` : SHEETS_API_BASE
+export function sheetsBase(_tokenManager: TokenManager): string {
+  return SHEETS_API_BASE
 }
 
-export function gmailBase(tokenManager: TokenManager): string {
-  const config = tokenManager.config
-  if (config.gmailApiBase !== undefined) return config.gmailApiBase
-  const base = config.apiBase
-  return base !== undefined ? `${base}/gmail/v1` : GMAIL_API_BASE
+export function gmailBase(_tokenManager: TokenManager): string {
+  return GMAIL_API_BASE
 }
 
 export class GoogleApiError extends Error {
@@ -88,7 +69,7 @@ export async function refreshAccessToken(config: GoogleConfig): Promise<[string,
   if (config.clientSecret !== undefined && config.clientSecret !== '') {
     body.set('client_secret', config.clientSecret)
   }
-  const r = await fetch(tokenUrl(config), {
+  const r = await fetch(tokenUrl(), {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),

--- a/typescript/packages/core/src/core/google/config.ts
+++ b/typescript/packages/core/src/core/google/config.ts
@@ -27,18 +27,6 @@ export interface GoogleConfig {
   // token endpoint directly. Useful when the client_secret must stay on a
   // backend (e.g. a Vercel function proxy).
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-  // Single-host override for every Google API (drive/docs/sheets/slides/gmail)
-  // plus the OAuth token endpoint; used to point backends at a fake server.
-  apiBase?: string
-  // Per-service overrides; each wins over `apiBase`, falling back to it then
-  // the real host.
-  tokenUrl?: string
-  driveApiBase?: string
-  driveUploadApiBase?: string
-  docsApiBase?: string
-  sheetsApiBase?: string
-  slidesApiBase?: string
-  gmailApiBase?: string
   // Drive-only: scope the mount to this folder ID instead of the Drive
   // root, the s3 key_prefix analog. Other Google backends ignore it.
   folderId?: string
@@ -48,14 +36,6 @@ export interface GoogleConfigRedacted {
   clientId: string
   clientSecret?: '<REDACTED>'
   refreshToken: '<REDACTED>'
-  apiBase?: string
-  tokenUrl?: string
-  driveApiBase?: string
-  driveUploadApiBase?: string
-  docsApiBase?: string
-  sheetsApiBase?: string
-  slidesApiBase?: string
-  gmailApiBase?: string
   folderId?: string
 }
 
@@ -63,14 +43,6 @@ export const GoogleConfigSchema = z.object({
   clientId: z.string(),
   clientSecret: secretStr().optional(),
   refreshToken: secretStr(),
-  apiBase: z.string().optional(),
-  tokenUrl: z.string().optional(),
-  driveApiBase: z.string().optional(),
-  driveUploadApiBase: z.string().optional(),
-  docsApiBase: z.string().optional(),
-  sheetsApiBase: z.string().optional(),
-  slidesApiBase: z.string().optional(),
-  gmailApiBase: z.string().optional(),
   folderId: z.string().optional(),
 })
 
@@ -84,14 +56,6 @@ export function normalizeGoogleConfig(input: Record<string, unknown>): GoogleCon
       client_id: 'clientId',
       client_secret: 'clientSecret',
       refresh_token: 'refreshToken',
-      api_base: 'apiBase',
-      token_url: 'tokenUrl',
-      drive_api_base: 'driveApiBase',
-      drive_upload_api_base: 'driveUploadApiBase',
-      docs_api_base: 'docsApiBase',
-      sheets_api_base: 'sheetsApiBase',
-      slides_api_base: 'slidesApiBase',
-      gmail_api_base: 'gmailApiBase',
       folder_id: 'folderId',
     },
   }) as unknown as GoogleConfig

--- a/typescript/packages/core/src/core/google/config.ts
+++ b/typescript/packages/core/src/core/google/config.ts
@@ -27,9 +27,18 @@ export interface GoogleConfig {
   // token endpoint directly. Useful when the client_secret must stay on a
   // backend (e.g. a Vercel function proxy).
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-  // Single-host override for every Google API (drive/docs/sheets/slides)
+  // Single-host override for every Google API (drive/docs/sheets/slides/gmail)
   // plus the OAuth token endpoint; used to point backends at a fake server.
   apiBase?: string
+  // Per-service overrides; each wins over `apiBase`, falling back to it then
+  // the real host.
+  tokenUrl?: string
+  driveApiBase?: string
+  driveUploadApiBase?: string
+  docsApiBase?: string
+  sheetsApiBase?: string
+  slidesApiBase?: string
+  gmailApiBase?: string
   // Drive-only: scope the mount to this folder ID instead of the Drive
   // root, the s3 key_prefix analog. Other Google backends ignore it.
   folderId?: string
@@ -40,6 +49,13 @@ export interface GoogleConfigRedacted {
   clientSecret?: '<REDACTED>'
   refreshToken: '<REDACTED>'
   apiBase?: string
+  tokenUrl?: string
+  driveApiBase?: string
+  driveUploadApiBase?: string
+  docsApiBase?: string
+  sheetsApiBase?: string
+  slidesApiBase?: string
+  gmailApiBase?: string
   folderId?: string
 }
 
@@ -48,6 +64,13 @@ export const GoogleConfigSchema = z.object({
   clientSecret: secretStr().optional(),
   refreshToken: secretStr(),
   apiBase: z.string().optional(),
+  tokenUrl: z.string().optional(),
+  driveApiBase: z.string().optional(),
+  driveUploadApiBase: z.string().optional(),
+  docsApiBase: z.string().optional(),
+  sheetsApiBase: z.string().optional(),
+  slidesApiBase: z.string().optional(),
+  gmailApiBase: z.string().optional(),
   folderId: z.string().optional(),
 })
 
@@ -62,6 +85,13 @@ export function normalizeGoogleConfig(input: Record<string, unknown>): GoogleCon
       client_secret: 'clientSecret',
       refresh_token: 'refreshToken',
       api_base: 'apiBase',
+      token_url: 'tokenUrl',
+      drive_api_base: 'driveApiBase',
+      drive_upload_api_base: 'driveUploadApiBase',
+      docs_api_base: 'docsApiBase',
+      sheets_api_base: 'sheetsApiBase',
+      slides_api_base: 'slidesApiBase',
+      gmail_api_base: 'gmailApiBase',
       folder_id: 'folderId',
     },
   }) as unknown as GoogleConfig

--- a/typescript/packages/node/src/resource/gdocs/config.ts
+++ b/typescript/packages/node/src/resource/gdocs/config.ts
@@ -19,7 +19,6 @@ export interface GDocsConfig {
   clientSecret: string
   refreshToken: string
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-  apiBase?: string
 }
 
 export interface GDocsConfigRedacted {
@@ -32,7 +31,6 @@ const GDocsConfigSchema = z.object({
   clientId: z.string(),
   clientSecret: secretStr(),
   refreshToken: secretStr(),
-  apiBase: z.string().optional(),
 })
 
 export function redactGDocsConfig(config: GDocsConfig): GDocsConfigRedacted {
@@ -45,7 +43,6 @@ export function normalizeGDocsConfig(input: Record<string, unknown>): GDocsConfi
       client_id: 'clientId',
       client_secret: 'clientSecret',
       refresh_token: 'refreshToken',
-      api_base: 'apiBase',
     },
   }) as unknown as GDocsConfig
 }

--- a/typescript/packages/node/src/resource/gdocs/gdocs.ts
+++ b/typescript/packages/node/src/resource/gdocs/gdocs.ts
@@ -59,7 +59,6 @@ export class GDocsResource extends BaseResource implements Resource {
       clientSecret: config.clientSecret,
       refreshToken: config.refreshToken,
       ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-      ...(config.apiBase !== undefined ? { apiBase: config.apiBase } : {}),
     })
     this.accessor = new GDocsAccessor({ tokenManager: tm })
   }

--- a/typescript/packages/node/src/resource/gdrive/config.ts
+++ b/typescript/packages/node/src/resource/gdrive/config.ts
@@ -19,7 +19,6 @@ export interface GDriveConfig {
   clientSecret: string
   refreshToken: string
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-  apiBase?: string
   folderId?: string
 }
 
@@ -33,7 +32,6 @@ const GDriveConfigSchema = z.object({
   clientId: z.string(),
   clientSecret: secretStr(),
   refreshToken: secretStr(),
-  apiBase: z.string().optional(),
   folderId: z.string().optional(),
 })
 
@@ -47,7 +45,6 @@ export function normalizeGDriveConfig(input: Record<string, unknown>): GDriveCon
       client_id: 'clientId',
       client_secret: 'clientSecret',
       refresh_token: 'refreshToken',
-      api_base: 'apiBase',
       folder_id: 'folderId',
     },
   }) as unknown as GDriveConfig

--- a/typescript/packages/node/src/resource/gdrive/gdrive.ts
+++ b/typescript/packages/node/src/resource/gdrive/gdrive.ts
@@ -58,7 +58,6 @@ export class GDriveResource extends BaseResource implements Resource {
       clientSecret: config.clientSecret,
       refreshToken: config.refreshToken,
       ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-      ...(config.apiBase !== undefined ? { apiBase: config.apiBase } : {}),
       ...(config.folderId !== undefined ? { folderId: config.folderId } : {}),
     })
     this.accessor = new GDriveAccessor({ tokenManager: tm })

--- a/typescript/packages/node/src/resource/gsheets/config.ts
+++ b/typescript/packages/node/src/resource/gsheets/config.ts
@@ -19,7 +19,6 @@ export interface GSheetsConfig {
   clientSecret: string
   refreshToken: string
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-  apiBase?: string
 }
 
 export interface GSheetsConfigRedacted {
@@ -32,7 +31,6 @@ const GSheetsConfigSchema = z.object({
   clientId: z.string(),
   clientSecret: secretStr(),
   refreshToken: secretStr(),
-  apiBase: z.string().optional(),
 })
 
 export function redactGSheetsConfig(config: GSheetsConfig): GSheetsConfigRedacted {
@@ -45,7 +43,6 @@ export function normalizeGSheetsConfig(input: Record<string, unknown>): GSheetsC
       client_id: 'clientId',
       client_secret: 'clientSecret',
       refresh_token: 'refreshToken',
-      api_base: 'apiBase',
     },
   }) as unknown as GSheetsConfig
 }

--- a/typescript/packages/node/src/resource/gsheets/gsheets.ts
+++ b/typescript/packages/node/src/resource/gsheets/gsheets.ts
@@ -59,7 +59,6 @@ export class GSheetsResource extends BaseResource implements Resource {
       clientSecret: config.clientSecret,
       refreshToken: config.refreshToken,
       ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-      ...(config.apiBase !== undefined ? { apiBase: config.apiBase } : {}),
     })
     this.accessor = new GSheetsAccessor({ tokenManager: tm })
   }

--- a/typescript/packages/node/src/resource/gslides/config.ts
+++ b/typescript/packages/node/src/resource/gslides/config.ts
@@ -19,7 +19,6 @@ export interface GSlidesConfig {
   clientSecret: string
   refreshToken: string
   refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-  apiBase?: string
 }
 
 export interface GSlidesConfigRedacted {
@@ -32,7 +31,6 @@ const GSlidesConfigSchema = z.object({
   clientId: z.string(),
   clientSecret: secretStr(),
   refreshToken: secretStr(),
-  apiBase: z.string().optional(),
 })
 
 export function redactGSlidesConfig(config: GSlidesConfig): GSlidesConfigRedacted {
@@ -45,7 +43,6 @@ export function normalizeGSlidesConfig(input: Record<string, unknown>): GSlidesC
       client_id: 'clientId',
       client_secret: 'clientSecret',
       refresh_token: 'refreshToken',
-      api_base: 'apiBase',
     },
   }) as unknown as GSlidesConfig
 }

--- a/typescript/packages/node/src/resource/gslides/gslides.ts
+++ b/typescript/packages/node/src/resource/gslides/gslides.ts
@@ -59,7 +59,6 @@ export class GSlidesResource extends BaseResource implements Resource {
       clientSecret: config.clientSecret,
       refreshToken: config.refreshToken,
       ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-      ...(config.apiBase !== undefined ? { apiBase: config.apiBase } : {}),
     })
     this.accessor = new GSlidesAccessor({ tokenManager: tm })
   }


### PR DESCRIPTION
Supersedes #583 by @khj809. That PR added per-service API base URL overrides to `GoogleConfig`. This one keeps its first three commits and reverts the override surface, because production endpoints should not be configurable just so tests can reach a fake server.

## What changed

Dropped from `GoogleConfig` in both languages: `api_base`, `token_url`, `drive_api_base`, `drive_upload_api_base`, `docs_api_base`, `sheets_api_base`, `slides_api_base`, `gmail_api_base`. Also removed from the TS redacted type, the zod schema, the snake to camel normalizer, and the per-backend config files for gdocs/gdrive/gsheets/gslides.

The base functions now return the fixed production constants. The integ suites reach the fake Google Workspace server without touching config:

- Python rebinds the module level constants in `integ/runners/python/adapters.py`.
- TypeScript installs a `globalThis.fetch` shim in `integ/runners/typescript/adapters.ts` that rewrites the six Google API hostnames. `export const` cannot be rebound, so the shim is the equivalent seam.

Both redirect to identical paths. `storage.googleapis.com` is deliberately excluded, GCS is a separate backend and is unaffected.

## Verification

- Python google/gmail/gdocs/gsheets/gslides/gdrive tests: 273 passed
- TS core google tests: 56 passed
- `pnpm -r run typecheck`: clean across all 7 packages
- `pre-commit run --all-files`: green

## Why a new PR

#583 comes from `brekkylab`, an organization owned fork. GitHub does not offer "Allow edits by maintainers" for PRs from org owned forks, so the commit could not be pushed onto that branch and the checkbox is not available to the author either. Opening this from origin was the only way to land it without adding a collaborator to their fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)