### PR TITLE
fix(examples): use real gws command names

### DIFF
--- a/examples/python/gdocs/gdocs.py
+++ b/examples/python/gdocs/gdocs.py
@@ -123,14 +123,14 @@ async def main() -> None:
     r = await ws.execute(f"realpath /gdocs/owned/{first}")
     print(await r.stdout_str())
 
-    print("=== gws-docs-documents-create ===")
-    r = await ws.execute('gws-docs-documents-create'
+    print("=== gws docs documents create ===")
+    r = await ws.execute('gws docs documents create'
                          ' --json \'{"title": "MIRAGE Example Doc"}\'')
     doc = json.loads(await r.stdout_str())
     doc_id = doc["documentId"]
     print(f"Created: {doc_id}")
 
-    print("\n=== gws-docs-documents-batchUpdate ===")
+    print("\n=== gws docs documents batchUpdate ===")
     body = json.dumps({
         "requests": [{
             "insertText": {
@@ -142,14 +142,14 @@ async def main() -> None:
         }]
     })
     params = json.dumps({"documentId": doc_id})
-    r = await ws.execute(f"gws-docs-documents-batchUpdate"
+    r = await ws.execute(f"gws docs documents batchUpdate"
                          f" --params '{params}' --json '{body}'")
     print(f"Updated: {(await r.stdout_str())[:80]}")
 
-    print("\n=== gws-docs-write ===")
-    r = await ws.execute(f'gws-docs-write'
+    print("\n=== gws docs +write ===")
+    r = await ws.execute(f'gws docs +write'
                          f' --document {doc_id}'
-                         f' --text "Appended via gws-docs-write."')
+                         f' --text "Appended via gws docs +write."')
     print(f"Written: {(await r.stdout_str())[:80]}")
 
     url = f"https://docs.google.com/document/d/{doc_id}/edit"

--- a/examples/python/gdrive/gdrive.py
+++ b/examples/python/gdrive/gdrive.py
@@ -145,15 +145,15 @@ async def main() -> None:
         result = await ws.execute(f'realpath "{gdoc}"')
         print(await result.stdout_str())
 
-    print("=== gws-docs-documents-create ===")
+    print("=== gws docs documents create ===")
     result = await ws.execute(
-        'gws-docs-documents-create'
+        'gws docs documents create'
         ' --json \'{"title": "Test from MIRAGE gdrive"}\'')
     print((await result.stdout_str())[:300])
 
-    print("=== gws-sheets-spreadsheets-create ===")
+    print("=== gws sheets spreadsheets create ===")
     result = await ws.execute(
-        'gws-sheets-spreadsheets-create'
+        'gws sheets spreadsheets create'
         ' --json \'{"properties": {"title": "Test Sheet from gdrive"}}\'')
     print((await result.stdout_str())[:300])
 

--- a/examples/python/gmail/gmail.py
+++ b/examples/python/gmail/gmail.py
@@ -212,9 +212,9 @@ async def main() -> None:
 
     # Resource-specific commands
 
-    # gws-gmail-triage
-    print("=== gws-gmail-triage ===")
-    result = await ws.execute('gws-gmail-triage --query "is:unread" --max 3')
+    # gws gmail +triage
+    print("=== gws gmail +triage ===")
+    result = await ws.execute('gws gmail +triage --query "is:unread" --max 3')
     print((await result.stdout_str())[:500])
 
     # ── glob expansion (exercises resolve_glob → readdir)
@@ -232,15 +232,15 @@ async def main() -> None:
     for line in out.splitlines():
         print(f"  {line[:120]}")
 
-    # gws-gmail-read (use message_id from filename)
+    # gws gmail +read (use message_id from filename)
     msg_id = first_msg.rsplit("__", 1)[-1].replace(".gmail.json", "")
-    print(f"=== gws-gmail-read --id {msg_id} ===")
-    result = await ws.execute(f"gws-gmail-read --id {msg_id}")
+    print(f"=== gws gmail +read --id {msg_id} ===")
+    result = await ws.execute(f"gws gmail +read --id {msg_id}")
     print((await result.stdout_str())[:500])
 
-    # gws-gmail-send
-    print("=== gws-gmail-send ===")
-    result = await ws.execute('gws-gmail-send --to "zechengzhang97@gmail.com"'
+    # gws gmail +send
+    print("=== gws gmail +send ===")
+    result = await ws.execute('gws gmail +send --to "zechengzhang97@gmail.com"'
                               ' --subject "Test from MIRAGE"'
                               ' --body "Sent by gmail.py example"')
     out = await result.stdout_str()
@@ -251,24 +251,25 @@ async def main() -> None:
         sent = json.loads(out)
         sent_id = sent.get("id", "")
 
-    # gws-gmail-reply
+    # gws gmail +reply
     if sent_id:
-        print("=== gws-gmail-reply ===")
-        result = await ws.execute(f'gws-gmail-reply --message-id {sent_id}'
+        print("=== gws gmail +reply ===")
+        result = await ws.execute(f'gws gmail +reply --message-id {sent_id}'
                                   ' --body "Reply from MIRAGE"')
         print((await result.stdout_str())[:200])
 
-    # gws-gmail-reply-all
+    # gws gmail +reply-all
     if sent_id:
-        print("=== gws-gmail-reply-all ===")
-        result = await ws.execute(f'gws-gmail-reply-all --message-id {sent_id}'
-                                  ' --body "Reply-all from MIRAGE"')
+        print("=== gws gmail +reply-all ===")
+        result = await ws.execute(
+            f'gws gmail +reply-all --message-id {sent_id}'
+            ' --body "Reply-all from MIRAGE"')
         print((await result.stdout_str())[:200])
 
-    # gws-gmail-forward
+    # gws gmail +forward
     if sent_id:
-        print("=== gws-gmail-forward ===")
-        result = await ws.execute(f'gws-gmail-forward --message-id {sent_id}'
+        print("=== gws gmail +forward ===")
+        result = await ws.execute(f'gws gmail +forward --message-id {sent_id}'
                                   ' --to "zechengzhang97@gmail.com"')
         print((await result.stdout_str())[:200])
 

--- a/examples/python/google/docs.py
+++ b/examples/python/google/docs.py
@@ -64,14 +64,14 @@ async def main():
     r = await ws.execute(f"tail -c 200 /gdocs/owned/{first}")
     print(await r.stdout_str())
 
-    print("=== gws-docs-documents-create ===")
-    r = await ws.execute('gws-docs-documents-create'
+    print("=== gws docs documents create ===")
+    r = await ws.execute('gws docs documents create'
                          ' --json \'{"title": "MIRAGE Example Doc"}\'')
     doc = json.loads(await r.stdout_str())
     doc_id = doc["documentId"]
     print(f"Created: {doc_id}")
 
-    print("\n=== gws-docs-documents-batchUpdate ===")
+    print("\n=== gws docs documents batchUpdate ===")
     body = json.dumps({
         "requests": [{
             "insertText": {
@@ -83,14 +83,14 @@ async def main():
         }]
     })
     params = json.dumps({"documentId": doc_id})
-    r = await ws.execute(f"gws-docs-documents-batchUpdate"
+    r = await ws.execute(f"gws docs documents batchUpdate"
                          f" --params '{params}' --json '{body}'")
     print(f"Updated: {(await r.stdout_str())[:80]}")
 
-    print("\n=== gws-docs-write ===")
-    r = await ws.execute(f'gws-docs-write'
+    print("\n=== gws docs +write ===")
+    r = await ws.execute(f'gws docs +write'
                          f' --document {doc_id}'
-                         f' --text "Appended via gws-docs-write."')
+                         f' --text "Appended via gws docs +write."')
     print(f"Written: {(await r.stdout_str())[:80]}")
 
     url = f"https://docs.google.com/document/d/{doc_id}/edit"

--- a/examples/python/google/gmail.py
+++ b/examples/python/google/gmail.py
@@ -55,13 +55,13 @@ async def main():
     r = await ws.execute(f'jq ".subject" /gmail/INBOX/{first}')
     print(await r.stdout_str())
 
-    print("=== gws-gmail-triage ===")
-    r = await ws.execute('gws-gmail-triage --query "is:unread" --max 5')
+    print("=== gws gmail +triage ===")
+    r = await ws.execute('gws gmail +triage --query "is:unread" --max 5')
     print((await r.stdout_str())[:500])
 
-    print("=== gws-gmail-send ===")
+    print("=== gws gmail +send ===")
     r = await ws.execute(
-        'gws-gmail-send --to "zechengzhang97@gmail.com"'
+        'gws gmail +send --to "zechengzhang97@gmail.com"'
         ' --subject "Hello from MIRAGE"'
         ' --body "This email was sent via the MIRAGE Gmail resource."')
     print((await r.stdout_str())[:200])

--- a/examples/python/google/sheets.py
+++ b/examples/python/google/sheets.py
@@ -68,9 +68,9 @@ async def main():
     r = await ws.execute(f"tail -c 200 /gsheets/owned/{first}")
     print(await r.stdout_str())
 
-    print("=== gws-sheets-spreadsheets-create ===")
+    print("=== gws sheets spreadsheets create ===")
     body = json.dumps({"properties": {"title": "MIRAGE Sheets Test"}})
-    r = await ws.execute("gws-sheets-spreadsheets-create"
+    r = await ws.execute("gws sheets spreadsheets create"
                          f" --json '{body}'")
     out = await r.stdout_str()
     if r.exit_code != 0 or not out.strip():
@@ -81,7 +81,7 @@ async def main():
     sheet_id = sheet["spreadsheetId"]
     print(f"Created: {sheet_id}")
 
-    print("\n=== gws-sheets-write ===")
+    print("\n=== gws sheets +write ===")
     params = json.dumps({
         "spreadsheetId": sheet_id,
         "range": "Sheet1!A1",
@@ -94,24 +94,24 @@ async def main():
             ["Bob", "25", "SF"],
         ]
     })
-    r = await ws.execute(f"gws-sheets-write"
+    r = await ws.execute(f"gws sheets +write"
                          f" --params '{params}' --json '{values}'")
     print(f"Written: {(await r.stdout_str())[:80]}")
 
-    print("\n=== gws-sheets-read ===")
-    r = await ws.execute(f'gws-sheets-read'
+    print("\n=== gws sheets +read ===")
+    r = await ws.execute(f'gws sheets +read'
                          f' --spreadsheet {sheet_id}'
                          f' --range "Sheet1!A1:C3"')
     print(f"Values: {await r.stdout_str()}")
 
-    print("=== gws-sheets-append ===")
-    r = await ws.execute(f"gws-sheets-append"
+    print("=== gws sheets +append ===")
+    r = await ws.execute(f"gws sheets +append"
                          f" --spreadsheet {sheet_id}"
                          f" --values Diana,28,Chicago")
     print(f"Appended: {(await r.stdout_str())[:80]}")
 
-    print("\n=== gws-sheets-read (all) ===")
-    r = await ws.execute(f'gws-sheets-read'
+    print("\n=== gws sheets +read (all) ===")
+    r = await ws.execute(f'gws sheets +read'
                          f' --spreadsheet {sheet_id}'
                          f' --range Sheet1')
     print(f"All: {await r.stdout_str()}")

--- a/examples/python/google/slides.py
+++ b/examples/python/google/slides.py
@@ -69,14 +69,14 @@ async def main():
     r = await ws.execute(f"tail -c 200 /gslides/owned/{first}")
     print(await r.stdout_str())
 
-    print("=== gws-slides-presentations-create ===")
-    r = await ws.execute('gws-slides-presentations-create'
+    print("=== gws slides presentations create ===")
+    r = await ws.execute('gws slides presentations create'
                          ' --json \'{"title": "MIRAGE Slides Test"}\'')
     pres = json.loads(await r.stdout_str())
     pres_id = pres["presentationId"]
     print(f"Created: {pres_id}")
 
-    print("\n=== gws-slides-presentations-batchUpdate ===")
+    print("\n=== gws slides presentations batchUpdate ===")
     body = json.dumps({
         "requests": [{
             "createSlide": {
@@ -88,7 +88,7 @@ async def main():
         }]
     })
     params = json.dumps({"presentationId": pres_id})
-    r = await ws.execute("gws-slides-presentations-batchUpdate"
+    r = await ws.execute("gws slides presentations batchUpdate"
                          f" --params '{params}' --json '{body}'")
     update = json.loads(await r.stdout_str())
     slide_id = update["replies"][0]["createSlide"]["objectId"]

--- a/examples/python/gsheets/gsheets.py
+++ b/examples/python/gsheets/gsheets.py
@@ -128,15 +128,15 @@ async def main() -> None:
     r = await ws.execute(f"realpath /gsheets/owned/{first}")
     print(await r.stdout_str())
 
-    print("=== gws-sheets-spreadsheets-create ===")
+    print("=== gws sheets spreadsheets create ===")
     body = json.dumps({"properties": {"title": "MIRAGE Sheets Test"}})
-    r = await ws.execute("gws-sheets-spreadsheets-create"
+    r = await ws.execute("gws sheets spreadsheets create"
                          f" --json '{body}'")
     sheet = json.loads(await r.stdout_str())
     sheet_id = sheet["spreadsheetId"]
     print(f"Created: {sheet_id}")
 
-    print("\n=== gws-sheets-write ===")
+    print("\n=== gws sheets +write ===")
     params = json.dumps({
         "spreadsheetId": sheet_id,
         "range": "Sheet1!A1",
@@ -149,29 +149,29 @@ async def main() -> None:
             ["Bob", "25", "SF"],
         ]
     })
-    r = await ws.execute(f"gws-sheets-write"
+    r = await ws.execute(f"gws sheets +write"
                          f" --params '{params}' --json '{values}'")
     print(f"Written: {(await r.stdout_str())[:80]}")
 
-    print("\n=== gws-sheets-read ===")
-    r = await ws.execute(f'gws-sheets-read'
+    print("\n=== gws sheets +read ===")
+    r = await ws.execute(f'gws sheets +read'
                          f' --spreadsheet {sheet_id}'
                          f' --range "Sheet1!A1:C3"')
     print(f"Values: {await r.stdout_str()}")
 
-    print("=== gws-sheets-append ===")
-    r = await ws.execute(f"gws-sheets-append"
+    print("=== gws sheets +append ===")
+    r = await ws.execute(f"gws sheets +append"
                          f" --spreadsheet {sheet_id}"
                          f" --values Diana,28,Chicago")
     print(f"Appended: {(await r.stdout_str())[:80]}")
 
-    print("\n=== gws-sheets-read (all) ===")
-    r = await ws.execute(f'gws-sheets-read'
+    print("\n=== gws sheets +read (all) ===")
+    r = await ws.execute(f'gws sheets +read'
                          f' --spreadsheet {sheet_id}'
                          f' --range Sheet1')
     print(f"All: {await r.stdout_str()}")
 
-    print("\n=== gws-sheets-spreadsheets-batchUpdate ===")
+    print("\n=== gws sheets spreadsheets batchUpdate ===")
     batch_body = json.dumps({
         "requests": [{
             "updateSpreadsheetProperties": {
@@ -183,7 +183,7 @@ async def main() -> None:
         }]
     })
     batch_params = json.dumps({"spreadsheetId": sheet_id})
-    r = await ws.execute("gws-sheets-spreadsheets-batchUpdate"
+    r = await ws.execute("gws sheets spreadsheets batchUpdate"
                          f" --params '{batch_params}' --json '{batch_body}'")
     print(f"BatchUpdate: {(await r.stdout_str())[:80]}")
 

--- a/examples/python/gslides/gslides.py
+++ b/examples/python/gslides/gslides.py
@@ -128,14 +128,14 @@ async def main() -> None:
     r = await ws.execute(f"realpath /gslides/owned/{first}")
     print(await r.stdout_str())
 
-    print("=== gws-slides-presentations-create ===")
-    r = await ws.execute('gws-slides-presentations-create'
+    print("=== gws slides presentations create ===")
+    r = await ws.execute('gws slides presentations create'
                          ' --json \'{"title": "MIRAGE Slides Test"}\'')
     pres = json.loads(await r.stdout_str())
     pres_id = pres["presentationId"]
     print(f"Created: {pres_id}")
 
-    print("\n=== gws-slides-presentations-batchUpdate ===")
+    print("\n=== gws slides presentations batchUpdate ===")
     body = json.dumps({
         "requests": [{
             "createSlide": {
@@ -147,7 +147,7 @@ async def main() -> None:
         }]
     })
     params = json.dumps({"presentationId": pres_id})
-    r = await ws.execute("gws-slides-presentations-batchUpdate"
+    r = await ws.execute("gws slides presentations batchUpdate"
                          f" --params '{params}' --json '{body}'")
     update = json.loads(await r.stdout_str())
     slide_id = update["replies"][0]["createSlide"]["objectId"]

--- a/examples/typescript/browser/src/main.ts
+++ b/examples/typescript/browser/src/main.ts
@@ -245,7 +245,7 @@ async function demoGslides(ws: Workspace): Promise<void> {
 
 async function demoGdrive(ws: Workspace): Promise<void> {
   line('')
-  line('━━━ Google Drive (/gdrive/) — folder tree + gws-* reused via multi-resource ━━━', 'prompt')
+  line('━━━ Google Drive (/gdrive/) — folder tree + gws commands reused via multi-resource ━━━', 'prompt')
   await run(ws, 'ls /gdrive/')
   await run(ws, 'tree -L 1 /gdrive/')
   await run(ws, "find /gdrive/ -name '*.gdoc.json' | head -n 3")

--- a/examples/typescript/gdocs/gdocs.ts
+++ b/examples/typescript/gdocs/gdocs.ts
@@ -123,10 +123,10 @@ async function main(): Promise<void> {
     console.log('=== realpath ===')
     console.log(`  ${realpath.out.trim()}`)
 
-    console.log('\n=== gws-docs-documents-create ===')
+    console.log('\n=== gws docs documents create ===')
     const create = await run(
       ws,
-      "gws-docs-documents-create --json '{\"title\": \"MIRAGE TS Example Doc\"}'",
+      "gws docs documents create --json '{\"title\": \"MIRAGE TS Example Doc\"}'",
     )
     if (create.code !== 0) {
       printOut('create FAILED', create.out, create.err)
@@ -140,21 +140,21 @@ async function main(): Promise<void> {
     }
     console.log(`Created: ${docId}`)
 
-    console.log('\n=== gws-docs-documents-batchUpdate ===')
+    console.log('\n=== gws docs documents batchUpdate ===')
     const body = JSON.stringify({
       requests: [{ insertText: { location: { index: 1 }, text: 'Hello from MIRAGE TS!\n' } }],
     })
     const params = JSON.stringify({ documentId: docId })
     const update = await run(
       ws,
-      `gws-docs-documents-batchUpdate --params '${params}' --json '${body}'`,
+      `gws docs documents batchUpdate --params '${params}' --json '${body}'`,
     )
     console.log(`Updated: ${update.out.slice(0, 80)}`)
 
-    console.log('\n=== gws-docs-write ===')
+    console.log('\n=== gws docs +write ===')
     const write = await run(
       ws,
-      `gws-docs-write --document ${docId} --text "Appended via gws-docs-write."`,
+      `gws docs +write --document ${docId} --text "Appended via gws docs +write."`,
     )
     console.log(`Written: ${write.out.slice(0, 80)}`)
 

--- a/examples/typescript/gdrive/gdrive.ts
+++ b/examples/typescript/gdrive/gdrive.ts
@@ -139,19 +139,19 @@ async function main(): Promise<void> {
       printOut(`realpath ${firstDoc}`, realpath.out, realpath.err)
     }
 
-    console.log('\n=== gws-docs-documents-create ===')
+    console.log('\n=== gws docs documents create ===')
     const create = await run(
       ws,
-      "gws-docs-documents-create --json '{\"title\": \"Test from MIRAGE gdrive\"}'",
+      "gws docs documents create --json '{\"title\": \"Test from MIRAGE gdrive\"}'",
     )
-    printOut('gws-docs-documents-create', create.out, create.err, 300)
+    printOut('gws docs documents create', create.out, create.err, 300)
 
-    console.log('\n=== gws-sheets-spreadsheets-create ===')
+    console.log('\n=== gws sheets spreadsheets create ===')
     const createSheet = await run(
       ws,
-      "gws-sheets-spreadsheets-create --json '{\"properties\": {\"title\": \"Test Sheet from gdrive\"}}'",
+      "gws sheets spreadsheets create --json '{\"properties\": {\"title\": \"Test Sheet from gdrive\"}}'",
     )
-    printOut('gws-sheets-spreadsheets-create', createSheet.out, createSheet.err, 300)
+    printOut('gws sheets spreadsheets create', createSheet.out, createSheet.err, 300)
   } finally {
     await ws.close()
   }

--- a/examples/typescript/gmail/gmail.ts
+++ b/examples/typescript/gmail/gmail.ts
@@ -166,8 +166,8 @@ async function main(): Promise<void> {
     printSection('realpath', (await run(ws, `realpath ${msgPath}`)).out, '')
 
     printSection(
-      'gws-gmail-triage',
-      (await run(ws, 'gws-gmail-triage --query "is:unread" --max 3')).out,
+      'gws gmail +triage',
+      (await run(ws, 'gws gmail +triage --query "is:unread" --max 3')).out,
       '',
     )
 
@@ -184,16 +184,16 @@ async function main(): Promise<void> {
 
     const msgId = (firstMsg.split('__').pop() ?? '').replace('.gmail.json', '')
     printSection(
-      `gws-gmail-read --id ${msgId}`,
-      (await run(ws, `gws-gmail-read --id ${msgId}`)).out,
+      `gws gmail +read --id ${msgId}`,
+      (await run(ws, `gws gmail +read --id ${msgId}`)).out,
       '',
     )
 
     const sendOut = await run(
       ws,
-      'gws-gmail-send --to "zechengzhang97@gmail.com" --subject "Test from MIRAGE TS" --body "Sent by gmail.ts example"',
+      'gws gmail +send --to "zechengzhang97@gmail.com" --subject "Test from MIRAGE TS" --body "Sent by gmail.ts example"',
     )
-    printSection('gws-gmail-send', sendOut.out, sendOut.err, 200)
+    printSection('gws gmail +send', sendOut.out, sendOut.err, 200)
 
     let sentId = ''
     if (sendOut.out.trim() !== '') {
@@ -207,33 +207,33 @@ async function main(): Promise<void> {
 
     if (sentId !== '') {
       printSection(
-        'gws-gmail-reply',
+        'gws gmail +reply',
         (
           await run(
             ws,
-            `gws-gmail-reply --message-id ${sentId} --body "Reply from MIRAGE TS"`,
+            `gws gmail +reply --message-id ${sentId} --body "Reply from MIRAGE TS"`,
           )
         ).out,
         '',
         200,
       )
       printSection(
-        'gws-gmail-reply-all',
+        'gws gmail +reply-all',
         (
           await run(
             ws,
-            `gws-gmail-reply-all --message-id ${sentId} --body "Reply-all from MIRAGE TS"`,
+            `gws gmail +reply-all --message-id ${sentId} --body "Reply-all from MIRAGE TS"`,
           )
         ).out,
         '',
         200,
       )
       printSection(
-        'gws-gmail-forward',
+        'gws gmail +forward',
         (
           await run(
             ws,
-            `gws-gmail-forward --message-id ${sentId} --to "zechengzhang97@gmail.com"`,
+            `gws gmail +forward --message-id ${sentId} --to "zechengzhang97@gmail.com"`,
           )
         ).out,
         '',

--- a/examples/typescript/gmail/gmail_browser/main.ts
+++ b/examples/typescript/gmail/gmail_browser/main.ts
@@ -78,7 +78,7 @@ async function main(): Promise<void> {
     }
 
     console.log('')
-    await run(ws, 'gws-gmail-triage --query "is:unread" --max 3')
+    await run(ws, 'gws gmail +triage --query "is:unread" --max 3')
 
     console.log('')
     await run(ws, 'tree -L 1 /gmail/INBOX/')

--- a/examples/typescript/gsheets/gsheets.ts
+++ b/examples/typescript/gsheets/gsheets.ts
@@ -92,10 +92,10 @@ async function main(): Promise<void> {
     const findOwned = await run(ws, "find /gsheets/owned/ -name '*.gsheet.json' | head -n 5")
     printOut('find /gsheets/owned/', findOwned.out, findOwned.err, 2000)
 
-    console.log('\n=== gws-sheets-spreadsheets-create ===')
+    console.log('\n=== gws sheets spreadsheets create ===')
     const create = await run(
       ws,
-      "gws-sheets-spreadsheets-create --json '{\"properties\": {\"title\": \"MIRAGE TS Example Sheet\"}}'",
+      "gws sheets spreadsheets create --json '{\"properties\": {\"title\": \"MIRAGE TS Example Sheet\"}}'",
     )
     if (create.code !== 0) {
       printOut('create FAILED', create.out, create.err)
@@ -109,7 +109,7 @@ async function main(): Promise<void> {
     }
     console.log(`Created: ${sheetId}`)
 
-    console.log('\n=== gws-sheets-write (A1:B2) ===')
+    console.log('\n=== gws sheets +write (A1:B2) ===')
     const writeParams = JSON.stringify({ spreadsheetId: sheetId, range: 'A1:B2' })
     const writeBody = JSON.stringify({
       values: [
@@ -119,19 +119,19 @@ async function main(): Promise<void> {
     })
     const write = await run(
       ws,
-      `gws-sheets-write --params '${writeParams}' --json '${writeBody}'`,
+      `gws sheets +write --params '${writeParams}' --json '${writeBody}'`,
     )
     console.log(`Written: ${write.out.slice(0, 80)}`)
 
-    console.log('\n=== gws-sheets-append (A:B) ===')
+    console.log('\n=== gws sheets +append (A:B) ===')
     const append = await run(
       ws,
-      `gws-sheets-append --spreadsheet ${sheetId} --range "A:B" --json-values '[["appended", "row"]]'`,
+      `gws sheets +append --spreadsheet ${sheetId} --range "A:B" --json-values '[["appended", "row"]]'`,
     )
     console.log(`Appended: ${append.out.slice(0, 80)}`)
 
-    console.log('\n=== gws-sheets-read (A1:B3) ===')
-    const read = await run(ws, `gws-sheets-read --spreadsheet ${sheetId} --range "A1:B3"`)
+    console.log('\n=== gws sheets +read (A1:B3) ===')
+    const read = await run(ws, `gws sheets +read --spreadsheet ${sheetId} --range "A1:B3"`)
     console.log(read.out.trim())
 
     console.log(`\nOpen: https://docs.google.com/spreadsheets/d/${sheetId}/edit`)

--- a/examples/typescript/gslides/gslides.ts
+++ b/examples/typescript/gslides/gslides.ts
@@ -92,10 +92,10 @@ async function main(): Promise<void> {
     const findOwned = await run(ws, "find /gslides/owned/ -name '*.gslide.json' | head -n 5")
     printOut('find /gslides/owned/', findOwned.out, findOwned.err, 2000)
 
-    console.log('\n=== gws-slides-presentations-create ===')
+    console.log('\n=== gws slides presentations create ===')
     const create = await run(
       ws,
-      "gws-slides-presentations-create --json '{\"title\": \"MIRAGE TS Example Deck\"}'",
+      "gws slides presentations create --json '{\"title\": \"MIRAGE TS Example Deck\"}'",
     )
     if (create.code !== 0) {
       printOut('create FAILED', create.out, create.err)
@@ -109,7 +109,7 @@ async function main(): Promise<void> {
     }
     console.log(`Created: ${presId}`)
 
-    console.log('\n=== gws-slides-presentations-batchUpdate (insert text on first slide) ===')
+    console.log('\n=== gws slides presentations batchUpdate (insert text on first slide) ===')
     const slideId = deck.slides?.[0]?.objectId ?? ''
     if (slideId !== '') {
       const params = JSON.stringify({ presentationId: presId })
@@ -145,7 +145,7 @@ async function main(): Promise<void> {
       })
       const batch = await run(
         ws,
-        `gws-slides-presentations-batchUpdate --params '${params}' --json '${body}'`,
+        `gws slides presentations batchUpdate --params '${params}' --json '${body}'`,
       )
       console.log(`Updated: ${batch.out.slice(0, 80)}`)
     }

--- a/examples/typescript/man/man.ts
+++ b/examples/typescript/man/man.ts
@@ -42,7 +42,7 @@ async function main(): Promise<void> {
   await show('man cat', 'man cat')
   await show('man find', 'man find')
   await show('man grep', 'man grep')
-  await show('man gws-gmail-send (gmail-only)', 'man gws-gmail-send')
+  await show('man gws gmail +send (gmail-only)', 'man "gws gmail +send"')
   await show('man date (general only)', 'man date')
 
   await ws.close()


### PR DESCRIPTION
Every `gws` invocation in the Google examples used a hyphenated name that is not registered, so each one exited 127. The examples print only `stdout` and never check the exit code, so the failures rendered as empty sections and went unnoticed.

## Two naming families

The registry has two conventions, and Python and TypeScript register identical names:

| kind | shape | example |
| --- | --- | --- |
| generated passthrough | `gws <service> <resource> <method>` | `gws docs documents create` |
| hand-written helper | `gws <service> +<verb>` | `gws sheets +read` |

So `gws-docs-documents-create` becomes `gws docs documents create`, but `gws-sheets-read` becomes `gws sheets +read`, not `gws sheets read`. A plain dehyphenation would have produced 10 more broken commands that still looked plausible.

Two special cases:

- `man` reads only `argv[0]`, so it now passes the multiword name quoted: `man "gws gmail +send"`. Unquoted would have silently looked up bare `gws`.
- `gws-integ-token` in `integ/server/gws_server.ts` is an OAuth access token string, not a command, and is untouched.

## Verification

- All 16 distinct `gws` references in `examples/` resolve against the real registry, zero unresolvable.
- Zero residual `gws-` hyphens in examples.
- Live read-only check against the real Google API: `gws drive files list` exit 0, `gws docs documents get` exit 0.
- `pre-commit` green on the changed files.

The `create`, `batchUpdate`, and `+send` paths are name-correct and dispatch-verified but were not executed live, since they write to Drive and send mail.

## Follow-up not included here

The examples still print only `stdout` and never surface `stderr` or check exit codes, which is why this bug stayed hidden. Fixing that touches every example's result handling and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)