### PR TITLE
Fix example command registrations

### DIFF
--- a/examples/python/demo/design_feedback.py
+++ b/examples/python/demo/design_feedback.py
@@ -86,7 +86,7 @@ async def main() -> None:
             "incident channel: read the message and any attached screenshot, "
             "find the relevant code in the Mirage GitHub repo, then file a "
             "design issue in the Strukto-ai team on Linear using "
-            "`linear-issue-create` with the feedback and code references.")
+            "`linear issue create` with the feedback and code references.")
 
     result = await Runner.run(
         agent,

--- a/examples/python/email/example_email.py
+++ b/examples/python/email/example_email.py
@@ -76,7 +76,10 @@ async def main() -> None:
     if not msg_files:
         print("No messages")
         return
-    first_msg = f"/email/{folder}/{first_date}/{msg_files[0]}"
+    first_filename = msg_files[0]
+    first_msg = f"/email/{folder}/{first_date}/{first_filename}"
+    uid = first_filename.rsplit("__",
+                                maxsplit=1)[-1].removesuffix(".email.json")
 
     print(f"=== cat {first_msg} ===")
     result = await ws.execute(f"cat {first_msg}")
@@ -123,9 +126,14 @@ async def main() -> None:
     print(f"  dispatch stat: mode={oct(meta_st.mode)[2:]} uid={meta_st.uid} "
           f"gid={meta_st.gid} mtime={meta_st.modified}")
 
-    print("=== email-triage --unseen --max 5 ===")
+    print("=== himalaya envelope list --unseen --max 5 ===")
     result = await ws.execute(
-        f'email-triage --folder {folder} --unseen --max 5')
+        f'himalaya envelope list --folder "{folder}" --unseen --max 5')
+    print((await result.stdout_str())[:500])
+
+    print(f"=== himalaya message read --uid {uid} ===")
+    result = await ws.execute(
+        f'himalaya message read --folder "{folder}" --uid {uid}')
     print((await result.stdout_str())[:500])
 
     print(f"\n=== tree -L 2 /email/{folder}/ ===")

--- a/examples/python/google/sheets.py
+++ b/examples/python/google/sheets.py
@@ -82,20 +82,15 @@ async def main():
     print(f"Created: {sheet_id}")
 
     print("\n=== gws sheets +write ===")
-    params = json.dumps({
-        "spreadsheetId": sheet_id,
-        "range": "Sheet1!A1",
-        "valueInputOption": "USER_ENTERED",
-    })
-    values = json.dumps({
-        "values": [
-            ["Name", "Age", "City"],
-            ["Alice", "30", "NYC"],
-            ["Bob", "25", "SF"],
-        ]
-    })
+    values = json.dumps([
+        ["Name", "Age", "City"],
+        ["Alice", "30", "NYC"],
+        ["Bob", "25", "SF"],
+    ])
     r = await ws.execute(f"gws sheets +write"
-                         f" --params '{params}' --json '{values}'")
+                         f" --spreadsheet {sheet_id}"
+                         f' --range "Sheet1!A1:C3"'
+                         f" --json-values '{values}'")
     print(f"Written: {(await r.stdout_str())[:80]}")
 
     print("\n=== gws sheets +read ===")

--- a/examples/python/gsheets/gsheets.py
+++ b/examples/python/gsheets/gsheets.py
@@ -137,20 +137,15 @@ async def main() -> None:
     print(f"Created: {sheet_id}")
 
     print("\n=== gws sheets +write ===")
-    params = json.dumps({
-        "spreadsheetId": sheet_id,
-        "range": "Sheet1!A1",
-        "valueInputOption": "USER_ENTERED",
-    })
-    values = json.dumps({
-        "values": [
-            ["Name", "Age", "City"],
-            ["Alice", "30", "NYC"],
-            ["Bob", "25", "SF"],
-        ]
-    })
+    values = json.dumps([
+        ["Name", "Age", "City"],
+        ["Alice", "30", "NYC"],
+        ["Bob", "25", "SF"],
+    ])
     r = await ws.execute(f"gws sheets +write"
-                         f" --params '{params}' --json '{values}'")
+                         f" --spreadsheet {sheet_id}"
+                         f' --range "Sheet1!A1:C3"'
+                         f" --json-values '{values}'")
     print(f"Written: {(await r.stdout_str())[:80]}")
 
     print("\n=== gws sheets +read ===")

--- a/examples/python/linear/linear.py
+++ b/examples/python/linear/linear.py
@@ -54,6 +54,16 @@ async def main() -> None:
         print("No teams available")
         return
 
+    team_key = first_team.split("__", 1)[0]
+
+    print("=== linear team list ===")
+    result = await ws.execute("linear team list")
+    print(await result.stdout_str())
+
+    print(f"=== linear team get {team_key} ===")
+    result = await ws.execute(f"linear team get {team_key}")
+    print(await result.stdout_str())
+
     print(f"=== cat /linear/teams/{first_team}/team.json ===")
     result = await ws.execute(f"cat /linear/teams/{first_team}/team.json")
     print(await result.stdout_str())
@@ -111,7 +121,16 @@ async def main() -> None:
         print("No issues available in first team")
         return
 
+    issue_key = first_issue.split("__", 1)[0]
     issue_path = f"/linear/teams/{first_team}/issues/{first_issue}"
+
+    print(f"=== linear issue list --team {team_key} ===")
+    result = await ws.execute(f"linear issue list --team {team_key}")
+    print(await result.stdout_str())
+
+    print(f"=== linear issue get {issue_key} ===")
+    result = await ws.execute(f"linear issue get {issue_key}")
+    print(await result.stdout_str())
 
     print("=== cat issue.json ===")
     result = await ws.execute(f"cat {issue_path}/issue.json")

--- a/examples/python/trello/trello.py
+++ b/examples/python/trello/trello.py
@@ -111,6 +111,16 @@ async def main() -> None:
     print(f"=== cat {board_path}/board.json ===")
     result = await ws.execute(f"cat {board_path}/board.json")
     print(await result.stdout_str())
+    board_payload = json.loads(await result.stdout_str())
+    board_id = board_payload.get("board_id", "")
+
+    print("=== trello board list ===")
+    result = await ws.execute("trello board list")
+    print(await result.stdout_str())
+
+    print(f"=== trello board show {board_id} ===")
+    result = await ws.execute(f"trello board show {board_id}")
+    print(await result.stdout_str())
 
     print(f"=== ls {board_path}/members/ ===")
     member_result = await ws.execute(f"ls {board_path}/members/")
@@ -247,8 +257,8 @@ async def main() -> None:
     result = await ws.execute(f"realpath {card_path}/card.json")
     print(await result.stdout_str())
 
-    print("=== trello-card-create ===")
-    result = await ws.execute(f'trello-card-create --list_id {list_id}'
+    print("=== trello card create ===")
+    result = await ws.execute(f'trello card create --list_id {list_id}'
                               ' --name "Test card from MIRAGE"'
                               ' --desc "Created by example script"')
     print(await result.stdout_str())
@@ -256,38 +266,37 @@ async def main() -> None:
     new_card = json.loads(await result.stdout_str())
     new_card_id = new_card.get("card_id", "")
 
-    print("=== trello-card-update ===")
+    print("=== trello card update ===")
     result = await ws.execute(
-        f'trello-card-update --card_id {new_card_id}'
+        f'trello card update --card_id {new_card_id}'
         ' --name "Updated test card" --desc "Updated description"')
     print(await result.stdout_str())
 
-    print("=== trello-card-move ===")
+    print("=== trello card move ===")
     result = await ws.execute(
-        f"trello-card-move --card_id {new_card_id} --list_id {list_id}")
+        f"trello card move --card_id {new_card_id} --list_id {list_id}")
     print(await result.stdout_str())
 
     members = (await member_result.stdout_str()).strip().splitlines()
     if members:
         first_member_name = members[0]
         member_id = first_member_name.rsplit("__", 1)[-1].replace(".json", "")
-        print("=== trello-card-assign ===")
-        result = await ws.execute(f"trello-card-assign --card_id {new_card_id}"
+        print("=== trello card assign ===")
+        result = await ws.execute(f"trello card assign --card_id {new_card_id}"
                                   f" --member_id {member_id}")
         print(await result.stdout_str())
 
-    print("=== trello-card-comment-add ===")
-    result = await ws.execute(
-        f'trello-card-comment-add --card_id {new_card_id}'
-        ' --text "Test comment from MIRAGE"')
+    print("=== trello card comment ===")
+    result = await ws.execute(f'trello card comment --card_id {new_card_id}'
+                              ' --text "Test comment from MIRAGE"')
     print(await result.stdout_str())
 
     comment_payload = json.loads(await result.stdout_str())
     comment_id = comment_payload.get("comment_id", "")
 
-    print("=== trello-card-comment-update ===")
+    print("=== trello card comment-update ===")
     result = await ws.execute(
-        f"trello-card-comment-update --comment_id {comment_id}"
+        f"trello card comment-update --comment_id {comment_id}"
         f' --card_id {new_card_id} --text "Updated comment"')
     print(await result.stdout_str())
 
@@ -295,21 +304,20 @@ async def main() -> None:
     if labels:
         first_label_name = labels[0]
         label_id = first_label_name.rsplit("__", 1)[-1].replace(".json", "")
-        print("=== trello-card-label-add ===")
+        print("=== trello card label ===")
+        result = await ws.execute(f"trello card label --card_id {new_card_id}"
+                                  f" --label_id {label_id}")
+        print(await result.stdout_str())
+
+        print("=== trello card unlabel ===")
         result = await ws.execute(
-            f"trello-card-label-add --card_id {new_card_id}"
+            f"trello card unlabel --card_id {new_card_id}"
             f" --label_id {label_id}")
         print(await result.stdout_str())
 
-        print("=== trello-card-label-remove ===")
-        result = await ws.execute(
-            f"trello-card-label-remove --card_id {new_card_id}"
-            f" --label_id {label_id}")
-        print(await result.stdout_str())
-
-    print("=== trello-card-update (archive) ===")
+    print("=== trello card update (archive) ===")
     result = await ws.execute(
-        f"trello-card-update --card_id {new_card_id} --closed true")
+        f"trello card update --card_id {new_card_id} --closed true")
     print(await result.stdout_str())
 
 

--- a/examples/typescript/email/email.ts
+++ b/examples/typescript/email/email.ts
@@ -25,7 +25,10 @@ import {
 } from '@struktoai/mirage-node'
 
 const __HERE = fileURLToPath(new URL('.', import.meta.url))
-dotenv.config({ path: resolve(__HERE, '../../../.env.development'), override: true })
+dotenv.config({
+  path: resolve(__HERE, '../../../.env.development'),
+  override: true,
+})
 
 function buildConfig(): EmailConfig {
   const imapHost = process.env.IMAP_HOST ?? ''
@@ -33,9 +36,7 @@ function buildConfig(): EmailConfig {
   const username = process.env.EMAIL_USERNAME ?? ''
   const password = process.env.EMAIL_PASSWORD ?? ''
   if (imapHost === '' || smtpHost === '' || username === '' || password === '') {
-    throw new Error(
-      'IMAP_HOST / SMTP_HOST / EMAIL_USERNAME / EMAIL_PASSWORD are required',
-    )
+    throw new Error('IMAP_HOST / SMTP_HOST / EMAIL_USERNAME / EMAIL_PASSWORD are required')
   }
   return buildEmailConfig({
     imapHost,
@@ -54,7 +55,11 @@ async function run(
     const r = await ws.execute(cmd)
     return { out: r.stdoutText, err: r.stderrText, code: r.exitCode }
   } catch (err) {
-    return { out: '', err: err instanceof Error ? err.message : String(err), code: 1 }
+    return {
+      out: '',
+      err: err instanceof Error ? err.message : String(err),
+      code: 1,
+    }
   }
 }
 
@@ -80,7 +85,10 @@ async function main(): Promise<void> {
     if (!folders.some((f) => f.includes('Inbox') || f.includes('INBOX'))) {
       folder = folders[0] ?? ''
     } else {
-      folder = folders.find((f) => f.includes('INBOX')) ?? folders.find((f) => f.includes('Inbox')) ?? folder
+      folder =
+        folders.find((f) => f.includes('INBOX')) ??
+        folders.find((f) => f.includes('Inbox')) ??
+        folder
     }
     if (folder === '') {
       console.log('No folders')
@@ -111,12 +119,13 @@ async function main(): Promise<void> {
       console.log('No messages')
       return
     }
-    const firstMsg = `/email/${folder}/${firstDate}/${messages[0] ?? ''}`
+    const firstFilename = messages[0] ?? ''
+    const firstMsg = `/email/${folder}/${firstDate}/${firstFilename}`
+    const uid = (firstFilename.split('__').at(-1) ?? '').replace(/\.email\.json$/, '')
 
     printSection(`cat ${firstMsg}`, (await run(ws, `cat ${firstMsg}`)).out, '')
     printSection(`jq .subject ${firstMsg}`, (await run(ws, `jq ".subject" ${firstMsg}`)).out, '')
     printSection(`jq .from ${firstMsg}`, (await run(ws, `jq ".from" ${firstMsg}`)).out, '')
-
 
     // chmod/chown/touch never hit the IMAP API: attrs land in the
     // workspace namespace (durable, snapshot-captured) and merge into
@@ -133,8 +142,14 @@ async function main(): Promise<void> {
     )
 
     printSection(
-      'email-triage --unseen --max 5',
-      (await run(ws, `email-triage --folder ${folder} --unseen --max 5`)).out,
+      'himalaya envelope list --unseen --max 5',
+      (await run(ws, `himalaya envelope list --folder "${folder}" --unseen --max 5`)).out,
+      '',
+    )
+
+    printSection(
+      `himalaya message read --uid ${uid}`,
+      (await run(ws, `himalaya message read --folder "${folder}" --uid ${uid}`)).out,
       '',
     )
 
@@ -145,10 +160,7 @@ async function main(): Promise<void> {
     )
 
     for (const [label, cmd] of [
-      [
-        `grep -r Hi /email/${folder}/ (folder scope, IMAP search)`,
-        `grep -r Hi /email/${folder}/`,
-      ],
+      [`grep -r Hi /email/${folder}/ (folder scope, IMAP search)`, `grep -r Hi /email/${folder}/`],
       [`rg Hi /email/${folder}/ (folder scope)`, `rg Hi /email/${folder}/`],
     ] as const) {
       console.log(`\n=== ${label} ===`)

--- a/examples/typescript/gsheets/gsheets.ts
+++ b/examples/typescript/gsheets/gsheets.ts
@@ -15,10 +15,19 @@
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import dotenv from 'dotenv'
-import { GSheetsResource, MountMode, Workspace, type FileStat, type GSheetsConfig } from '@struktoai/mirage-node'
+import {
+  GSheetsResource,
+  MountMode,
+  Workspace,
+  type FileStat,
+  type GSheetsConfig,
+} from '@struktoai/mirage-node'
 
 const __HERE = fileURLToPath(new URL('.', import.meta.url))
-dotenv.config({ path: resolve(__HERE, '../../../.env.development'), override: true })
+dotenv.config({
+  path: resolve(__HERE, '../../../.env.development'),
+  override: true,
+})
 
 function buildConfig(): GSheetsConfig {
   const clientId = process.env.GOOGLE_CLIENT_ID ?? ''
@@ -30,12 +39,19 @@ function buildConfig(): GSheetsConfig {
   return { clientId, clientSecret, refreshToken }
 }
 
-async function run(ws: Workspace, cmd: string): Promise<{ out: string; err: string; code: number }> {
+async function run(
+  ws: Workspace,
+  cmd: string,
+): Promise<{ out: string; err: string; code: number }> {
   try {
     const r = await ws.execute(cmd)
     return { out: r.stdoutText, err: r.stderrText, code: r.exitCode }
   } catch (err) {
-    return { out: '', err: err instanceof Error ? err.message : String(err), code: 1 }
+    return {
+      out: '',
+      err: err instanceof Error ? err.message : String(err),
+      code: 1,
+    }
   }
 }
 
@@ -67,7 +83,6 @@ async function main(): Promise<void> {
     console.log('=== stat ===')
     console.log(`  ${stat.out.trim()}`)
 
-
     // chmod/chown/touch never hit the Sheets API: attrs land in the
     // workspace namespace (durable, snapshot-captured) and merge into
     // dispatch-level stat.
@@ -95,7 +110,7 @@ async function main(): Promise<void> {
     console.log('\n=== gws sheets spreadsheets create ===')
     const create = await run(
       ws,
-      "gws sheets spreadsheets create --json '{\"properties\": {\"title\": \"MIRAGE TS Example Sheet\"}}'",
+      'gws sheets spreadsheets create --json \'{"properties": {"title": "MIRAGE TS Example Sheet"}}\'',
     )
     if (create.code !== 0) {
       printOut('create FAILED', create.out, create.err)
@@ -110,16 +125,13 @@ async function main(): Promise<void> {
     console.log(`Created: ${sheetId}`)
 
     console.log('\n=== gws sheets +write (A1:B2) ===')
-    const writeParams = JSON.stringify({ spreadsheetId: sheetId, range: 'A1:B2' })
-    const writeBody = JSON.stringify({
-      values: [
-        ['hello', 'world'],
-        ['foo', 'bar'],
-      ],
-    })
+    const writeValues = JSON.stringify([
+      ['hello', 'world'],
+      ['foo', 'bar'],
+    ])
     const write = await run(
       ws,
-      `gws sheets +write --params '${writeParams}' --json '${writeBody}'`,
+      `gws sheets +write --spreadsheet ${sheetId} --range "A1:B2" --json-values '${writeValues}'`,
     )
     console.log(`Written: ${write.out.slice(0, 80)}`)
 

--- a/examples/typescript/linear/linear.ts
+++ b/examples/typescript/linear/linear.ts
@@ -15,7 +15,13 @@
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import dotenv from 'dotenv'
-import { LinearResource, MountMode, Workspace, type FileStat, type LinearConfig } from '@struktoai/mirage-node'
+import {
+  LinearResource,
+  MountMode,
+  Workspace,
+  type FileStat,
+  type LinearConfig,
+} from '@struktoai/mirage-node'
 
 const __HERE = fileURLToPath(new URL('.', import.meta.url))
 dotenv.config({ path: resolve(__HERE, '../../../.env.development') })
@@ -56,7 +62,14 @@ async function main(): Promise<void> {
       console.log('no teams')
       return
     }
+    const teamKey = t0.split('__')[0] ?? ''
     const teamBase = `/linear/teams/${t0}`
+
+    console.log('\n=== linear team list ===')
+    await run(ws, 'linear team list')
+
+    console.log(`\n=== linear team get ${teamKey} ===`)
+    await run(ws, `linear team get ${teamKey}`)
 
     console.log(`\n=== tree -L 2 ${teamBase} ===`)
     await run(ws, `tree -L 2 "${teamBase}"`)
@@ -67,7 +80,14 @@ async function main(): Promise<void> {
     console.log(`\n=== ls ${teamBase}/issues/ ===`)
     const i0 = (await run(ws, `ls "${teamBase}/issues/" | head -n 1`)).trim()
     if (i0 === '') return
+    const issueKey = i0.split('__')[0] ?? ''
     const issuePath = `${teamBase}/issues/${i0}`
+
+    console.log(`\n=== linear issue list --team ${teamKey} ===`)
+    await run(ws, `linear issue list --team ${teamKey}`)
+
+    console.log(`\n=== linear issue get ${issueKey} ===`)
+    await run(ws, `linear issue get ${issueKey}`)
 
     console.log(`\n=== cat ${i0}/issue.json ===`)
     await run(ws, `cat "${issuePath}/issue.json"`)
@@ -98,7 +118,6 @@ async function main(): Promise<void> {
 
     console.log(`\n=== stat ${i0}/issue.json ===`)
     await run(ws, `stat "${issuePath}/issue.json"`)
-
 
     // chmod/chown/touch never hit the Linear API: attrs land in the
     // workspace namespace (durable, snapshot-captured) and merge into

--- a/examples/typescript/trello/trello.ts
+++ b/examples/typescript/trello/trello.ts
@@ -15,7 +15,13 @@
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import dotenv from 'dotenv'
-import { MountMode, TrelloResource, Workspace, type FileStat, type TrelloConfig } from '@struktoai/mirage-node'
+import {
+  MountMode,
+  TrelloResource,
+  Workspace,
+  type FileStat,
+  type TrelloConfig,
+} from '@struktoai/mirage-node'
 
 const __HERE = fileURLToPath(new URL('.', import.meta.url))
 dotenv.config({ path: resolve(__HERE, '../../../.env.development') })
@@ -105,7 +111,14 @@ async function main(): Promise<void> {
     console.log(`\n=== ls ${wsBase}/boards/ ===`)
     const b0 = (await run(ws, `ls "${wsBase}/boards/" | head -n 1`)).trim()
     if (b0 === '') return
+    const boardId = b0.split('__').pop() ?? ''
     const boardBase = `${wsBase}/boards/${b0}`
+
+    console.log('\n=== trello board list ===')
+    await run(ws, 'trello board list')
+
+    console.log(`\n=== trello board show ${boardId} ===`)
+    await run(ws, `trello board show ${boardId}`)
 
     console.log(`\n=== cat ${b0}/board.json ===`)
     await run(ws, `cat "${boardBase}/board.json"`)
@@ -146,7 +159,7 @@ async function main(): Promise<void> {
     if (listId !== '') {
       const created = await run(
         ws,
-        `trello-card-create --list_id ${listId} --name "mirage example card" --desc "created by examples/typescript/trello/trello.ts"`,
+        `trello card create --list_id ${listId} --name "mirage example card" --desc "created by examples/typescript/trello/trello.ts"`,
       )
       let cardId = ''
       try {
@@ -156,11 +169,14 @@ async function main(): Promise<void> {
         console.log('  could not parse created card payload, skipping write demos')
       }
       if (cardId !== '') {
-        await run(ws, `trello-card-update --card_id ${cardId} --name "mirage example card (updated)"`)
-        await run(ws, `trello-card-move --card_id ${cardId} --list_id ${listId}`)
+        await run(
+          ws,
+          `trello card update --card_id ${cardId} --name "mirage example card (updated)"`,
+        )
+        await run(ws, `trello card move --card_id ${cardId} --list_id ${listId}`)
         const comment = await run(
           ws,
-          `trello-card-comment-add --card_id ${cardId} --text "hello from mirage"`,
+          `trello card comment --card_id ${cardId} --text "hello from mirage"`,
         )
         let commentId = ''
         try {
@@ -172,7 +188,7 @@ async function main(): Promise<void> {
         if (commentId !== '') {
           await run(
             ws,
-            `trello-card-comment-update --comment_id ${commentId} --card_id ${cardId} --text "updated comment"`,
+            `trello card comment-update --comment_id ${commentId} --card_id ${cardId} --text "updated comment"`,
           )
         }
       }


### PR DESCRIPTION
## Summary

- update the Linear and Trello Python and TypeScript examples to use the registered nested command names
- replace the retired standalone email command with current `himalaya` envelope and message reads
- fix Google Sheets `+write` examples to use `--spreadsheet`, `--range`, and `--json-values`
- add representative read commands for Linear teams/issues and Trello boards

## Why

The command registry moved service actions to multi-word command names, but several examples still used retired hyphenated names. The Sheets examples had also adopted the new helper name while retaining passthrough-only `--params` and `--json` flags, so they still failed at dispatch.

## Impact

Examples for Linear, Trello, Google Sheets, and standalone email now match the commands and flags registered by both the Python and TypeScript implementations.

## Validation

- `./python/.venv/bin/pre-commit run --all-files`
- 50 targeted non-FUSE Python tests
- 22 targeted TypeScript tests
- focused TypeScript type-checks across Google, Email, Linear, and Trello examples
- static stale-command and registered-flag checks

No FUSE tests were run.
