### PR TITLE
fix(shell): forward piped stdin through bash -c on the TypeScript host

### DIFF
--- a/integ/bash/control.json
+++ b/integ/bash/control.json
@@ -958,6 +958,37 @@
         "stdout": "apple\nbanana\ncherry\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "ctl_bash_c_stdin",
+      "seq": 502131,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "echo hi | bash -c 'cat'",
+      "expect": {
+        "exit": 0,
+        "stdout": "hi\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/typescript/packages/core/src/workspace/executor/builtins/script.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/script.ts
@@ -114,12 +114,13 @@ export async function handleBash(
     const data = await materialize(stdin)
     if (data.length > 0) {
       script = new TextDecoder().decode(data)
+      stdin = null
     }
   }
   if (script === null) {
     return [null, new IOResult(), new ExecutionNode({ command: 'bash', exitCode: 0 })]
   }
-  const io = await executeFn(script, { sessionId: session.sessionId })
+  const io = await executeFn(script, { sessionId: session.sessionId, stdin })
   return [io.stdout, io, new ExecutionNode({ command: `bash -c ${script}`, exitCode: io.exitCode })]
 }
 

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -1114,7 +1114,8 @@ export class Workspace {
       // the typed line's decision (runtime argument, route, or scripts).
       if (routingDecision !== null) innerOpts.routingDecision = routingDecision
       // `command NAME` re-runs the inner line and must forward the pipe
-      // stdin so `... | command cat` filters the upstream output.
+      // stdin so `... | command cat` filters the upstream output; the same
+      // path carries `echo hi | bash -c 'cat'` into the inner line.
       if (opts.stdin !== undefined && opts.stdin !== null) innerOpts.stdin = opts.stdin
       const res = await this.execute(cmd, innerOpts)
       return new IOResult({

--- a/typescript/packages/core/src/workspace/workspace_parity_general.test.ts
+++ b/typescript/packages/core/src/workspace/workspace_parity_general.test.ts
@@ -393,6 +393,14 @@ describe('workspace: for loop break / continue / test / arith / while', () => {
     await ws.close()
   })
 
+  it('bash -c forwards piped stdin to the inner line', async () => {
+    const { ws } = await makeWorkspace()
+    const io = await ws.execute("echo hi | bash -c 'cat'")
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toBe('hi\n')
+    await ws.close()
+  })
+
   it('bash -s reads script from stdin', async () => {
     const { ws } = await makeWorkspace()
     const io = await ws.execute('echo "echo from-stdin" | bash -s')


### PR DESCRIPTION
## Summary

TS `handleBash` called `executeFn(script, { sessionId })` without forwarding `stdin`, so `echo hi | bash -c 'cat'` dropped the piped input on the TypeScript host. Python's `handle_bash` already passes `stdin`, so this was a py/ts parity gap.

The `ExecuteFn` / `ExecuteStringFn` stdin plumbing and the inner `executeFn` threading already landed upstream with the `command` builtin (#595); this PR closes the one remaining gap in `handleBash` so `bash -c` rides that same path. (Rebased onto current `main`, so the diff is now just the `handleBash` fix + tests.)

## Changes

- `handleBash` (`script.ts`) forwards `stdin` to `executeFn`, and nulls it after consuming stdin as the script in the `-s` path (parity with Python's `stdin = None`) so `bash -s` does not re-feed the script bytes as the script's own stdin.
- Extend the threading comment in `workspace.ts` to note `bash -c` uses the same inner-stdin path as `command NAME`.
- Add integ case `ctl_bash_c_stdin` (`echo hi | bash -c 'cat'` → `hi`) in `integ/bash/control.json`, next to the existing `bash -c` family, and a matching core vitest. Python already had the mirror test (`test_bash_stdin_flows_into_script`).

## Test plan

- Core vitest: **4752 passed**, 7 skipped, 0 failures (on top of current `main`)
- Core typecheck: clean
- Python side unchanged (TS-only fix); the Python mirror test already passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
