### PR TITLE
fix(shell): ${v:$o} loud error + quoted array-@ slice/op/indices multi-word (PR 8)

### DIFF
--- a/integ/bash/array.json
+++ b/integ/bash/array.json
@@ -960,6 +960,192 @@
         "stdout": "rc=1\n",
         "stderr": "bash: ar28[-5]: bad array subscript\n"
       }
+    },
+    {
+      "id": "array_at_slice_quoted",
+      "seq": 603000,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "box",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "q1a=(w x y z); printf \"<%s>\" \"${q1a[@]:1:2}\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "<x><y>",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "array_at_slice_quoted_wordcount",
+      "seq": 603001,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "box",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "q2a=(w x y z); set -- \"${q2a[@]:1:2}\"; echo \"$#\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "2\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "array_at_slice_prefix_suffix",
+      "seq": 603002,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "box",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "q3a=(w x y z); printf \"<%s>\" \"p${q3a[@]:1:2}s\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "<px><ys>",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "array_at_op_quoted_multiword",
+      "seq": 603003,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "box",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "q4a=(cat car cow); printf \"<%s>\" \"${q4a[@]/c/K}\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "<Kat><Kar><Kow>",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "array_at_indices_quoted_multiword",
+      "seq": 603004,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "box",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "q5a=(w x y z); printf \"<%s>\" \"${!q5a[@]}\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "<0><1><2><3>",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "array_star_slice_single_word",
+      "seq": 603005,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "box",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "q6a=(w x y z); printf \"<%s>\" \"${q6a[*]:1:2}\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "<x y>",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/bash/param.json
+++ b/integ/bash/param.json
@@ -1642,6 +1642,99 @@
         "stdout": "inner\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "substr_dollar_offset_bad_subst",
+      "seq": 603100,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "box",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "pv1=hello; po1=2; echo \"X${pv1:$po1}Y\"",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "bash: ${pv1}: bad substitution\n"
+      }
+    },
+    {
+      "id": "substr_dollar_offset_len_bad_subst",
+      "seq": 603101,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "box",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "pw1=hello; pn1=1; echo \"${pw1:$pn1:2}\"",
+      "expect": {
+        "exit": 2,
+        "stdout": "",
+        "stderr": "bash: ${pw1}: bad substitution\n"
+      }
+    },
+    {
+      "id": "substr_offset_arith_alternatives_ok",
+      "seq": 603102,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "box",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "pz1=hello; pk1=2; echo \"${pz1:pk1}:${pz1:$((pk1))}\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "llo:llo\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/python/mirage/workspace/expand/parts.py
+++ b/python/mirage/workspace/expand/parts.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from collections.abc import Callable
+from functools import partial
 from typing import Any
 
 import tree_sitter
@@ -28,7 +29,7 @@ from mirage.workspace.expand.classify import classify_word
 from mirage.workspace.expand.constants import (BRACE_LITERAL_TYPES,
                                                BRACE_WORD_TYPES, SPLIT_TYPES)
 from mirage.workspace.expand.node import _unescape_unquoted, expand_node
-from mirage.workspace.expand.variable import _PARAM_OPS
+from mirage.workspace.expand.variable import expand_array_at, is_multiword_at
 from mirage.workspace.mount import MountRegistry
 from mirage.workspace.session import Session
 from mirage.workspace.session.shell_dirs import home_dir
@@ -41,33 +42,8 @@ def _has_at_expansion(node: tree_sitter.Node) -> bool:
     return False
 
 
-def _array_at_name(child: tree_sitter.Node) -> str | None:
-    if child.type != NT.EXPANSION:
-        return None
-    # Any operator (length #, slice :, strip/replace, indirection !)
-    # disqualifies the plain-splat fast path; expand_braces owns those.
-    has_op = any(c.type in _PARAM_OPS and not c.is_named
-                 for c in child.children)
-    if has_op:
-        return None
-    sub = next((c for c in child.named_children if c.type == "subscript"),
-               None)
-    if sub is None:
-        return None
-    idx_text = ""
-    var_name = None
-    for sc in sub.named_children:
-        if sc.type == NT.VARIABLE_NAME:
-            var_name = get_text(sc)
-        else:
-            idx_text = get_text(sc)
-    if var_name and idx_text == "@":
-        return var_name
-    return None
-
-
 def _string_has_array_at(node: tree_sitter.Node) -> bool:
-    return any(_array_at_name(c) is not None for c in node.children)
+    return any(is_multiword_at(c) for c in node.children)
 
 
 async def _expand_string_with_array(
@@ -76,28 +52,33 @@ async def _expand_string_with_array(
     execute_fn: Callable[..., Any],
     call_stack: CallStack | None,
 ) -> list[str]:
-    """Expand a string containing one or more "${a[@]}" into multiple words.
+    """Expand a string containing one or more "${a[@]...}" into words.
 
     Bash semantics: "prefix${a[@]}suffix" with a=(1 2 3) produces three
-    words: "prefix1", "2", "3suffix". Single-element arrays merge prefix
-    and suffix into one word; empty arrays still produce prefix+suffix.
+    words: "prefix1", "2", "3suffix". Slices ("${a[@]:o:l}"), per-element
+    ops ("${a[@]/x/y}"), and indices ("${!a[@]}") word-split the same
+    way. A single-element result merges prefix and suffix into one word;
+    an empty result still yields prefix+suffix.
     """
-    arrays = getattr(session, "arrays", {})
+    expand_child = partial(expand_node,
+                           session=session,
+                           execute_fn=execute_fn,
+                           call_stack=call_stack)
     fragments: list[str] = [""]
     for child in node.children:
         if child.type == NT.DQUOTE:
             continue
-        arr_name = _array_at_name(child)
-        if arr_name is not None:
-            arr = arrays.get(arr_name)
-            if not arr:
+        if is_multiword_at(child):
+            words = await expand_array_at(child, session, call_stack,
+                                          expand_child)
+            if not words:
                 continue
-            if len(arr) == 1:
-                fragments[-1] = fragments[-1] + arr[0]
+            if len(words) == 1:
+                fragments[-1] = fragments[-1] + words[0]
             else:
-                fragments[-1] = fragments[-1] + arr[0]
-                fragments.extend(arr[1:-1])
-                fragments.append(arr[-1])
+                fragments[-1] = fragments[-1] + words[0]
+                fragments.extend(words[1:-1])
+                fragments.append(words[-1])
             continue
         text = await expand_node(child, session, execute_fn, call_stack)
         fragments[-1] = fragments[-1] + text

--- a/python/mirage/workspace/expand/variable.py
+++ b/python/mirage/workspace/expand/variable.py
@@ -44,6 +44,11 @@ _CASE_OPS = frozenset({"^", "^^", ",", ",,"})
 # spelling (no unescaping) while still expanding nested $-expansions.
 _PATTERN_OPS = _REPLACE_OPS | _STRIP_OPS | _CASE_OPS
 
+# Ops on a "${a[@]...}" splat that act per element, so a quoted splat
+# still splits into one word per element; every other op acts on the
+# space-joined value and stays a single word.
+_MULTIWORD_AT_OPS = frozenset({":"}) | _STRIP_OPS | _REPLACE_OPS | _CASE_OPS
+
 _LITERAL_ARG_TYPES = frozenset({NT.WORD, NT.NUMBER, "regex"})
 
 # Operators that handle unset themselves, so `set -u` must not fire
@@ -440,6 +445,15 @@ async def expand_braces(node: tree_sitter.Node, session: Session,
             (dependency-injected to avoid a cycle with ``expand_node``).
     """
     p = _parse_braces(node)
+    if any(c.type == "}" and c.is_missing for c in node.children):
+        # tree-sitter-bash cannot parse a $-spelled substring offset
+        # (${v:$o}, ${v:$o:n}): it truncates the expansion with a
+        # zero-width `}` and reparses the tail as stray siblings. bash
+        # accepts the form, so emitting the mis-parse would corrupt the
+        # value silently; fail loudly instead. Spell it ${v:o} or
+        # ${v:$((o))}.
+        msg = f"bash: ${{{p.var_name or ''}}}: bad substitution\n"
+        raise ExitSignal(2, stderr=msg.encode(), contained_code=2)
     env = session.env
     arrays = getattr(session, "arrays", {})
 
@@ -565,3 +579,60 @@ def _slice_array(arr: list[str], groups: list[str],
     if length < 0:
         return arr[offset:max(offset, len(arr) + length)]
     return arr[offset:offset + length]
+
+
+def is_multiword_at(node: tree_sitter.Node) -> bool:
+    """Report whether a "${a[@]...}" splat word-splits when quoted.
+
+    True for the ``@``-subscript forms bash keeps as one word per
+    element: plain ``${a[@]}``, slice ``${a[@]:o:l}``, per-element
+    strip/replace/case ops, and ``${!a[@]}`` indices. False for
+    single-word forms (``${a[*]}``, ``${#a[@]}``, non-``@`` subscript,
+    or a default/alternate op that acts on the joined value).
+
+    Args:
+        node (tree_sitter.Node): the ``expansion`` node.
+    """
+    if node.type != NT.EXPANSION:
+        return False
+    p = _parse_braces(node)
+    if p.subscript != "@" or p.length_op:
+        return False
+    if p.indirect_op or p.op is None:
+        return True
+    return p.op in _MULTIWORD_AT_OPS
+
+
+async def expand_array_at(node: tree_sitter.Node, session: Session,
+                          call_stack: CallStack | None,
+                          expand_child: ExpandChild) -> list[str]:
+    """Resolve a multi-word "${a[@]...}" splat to its word list.
+
+    Only call when ``is_multiword_at`` is True; the caller word-splits
+    (or stitches prefix/suffix onto) the returned words, matching bash's
+    quoted-splat semantics.
+
+    Args:
+        node (tree_sitter.Node): the ``expansion`` node.
+        session (Session): shell session (arrays, env).
+        call_stack (CallStack | None): function-call scope, if any.
+        expand_child (ExpandChild): nested-node expander for op operands.
+    """
+    p = _parse_braces(node)
+    arrays = getattr(session, "arrays", {})
+    arr = arrays.get(p.var_name)
+    if arr is None:
+        scalar = session.env.get(p.var_name or "", "")
+        arr = [scalar] if scalar else []
+    if p.indirect_op:
+        return [str(i) for i in range(len(arr))]
+    if p.op is None:
+        return list(arr)
+    groups: list[str] = []
+    for gi, group in enumerate(p.groups):
+        pattern_mode = gi == 0 and p.op in _PATTERN_OPS
+        groups.append(await _expand_group(group, expand_child, pattern_mode,
+                                          session, call_stack))
+    if p.op == ":":
+        return _slice_array(arr, groups, session.env)
+    return [_value_op(p.op, el, groups, session.env) for el in arr]

--- a/python/tests/shell/test_arrays.py
+++ b/python/tests/shell/test_arrays.py
@@ -44,6 +44,12 @@ CASES = [
     ('v=ab; v+=cd; echo "$v"', "abcd\n"),
     ('unset_append_zz+=x; echo "$unset_append_zz"', "x\n"),
     ('a=(one two); echo "pre${a[@]}post"', "preone twopost\n"),
+    ('a=(w x y z); printf "<%s>" "${a[@]:1:2}"; echo', "<x><y>\n"),
+    ('a=(w x y z); set -- "${a[@]:1:2}"; echo "$#"', "2\n"),
+    ('a=(w x y z); printf "<%s>" "p${a[@]:1:2}s"; echo', "<px><ys>\n"),
+    ('a=(cat car cow); printf "<%s>" "${a[@]/c/K}"; echo',
+     "<Kat><Kar><Kow>\n"),
+    ('a=(w x y z); printf "<%s>" "${!a[@]}"; echo', "<0><1><2><3>\n"),
 ]
 
 

--- a/python/tests/shell/test_param_expansion.py
+++ b/python/tests/shell/test_param_expansion.py
@@ -115,3 +115,19 @@ def test_assign_op_inside_function_local(shell):
         'f(){ local v=; echo "${v:=zz}"; echo "inner=$v"; }; f; '
         'echo "outer=[$v]"')
     assert out == "zz\ninner=zz\nouter=[]\n"
+
+
+def test_dollar_spelled_substring_offset_is_bad_substitution(shell):
+    # tree-sitter-bash cannot parse a $-spelled offset (${v:$o}); mirage
+    # fails loudly (exit 2) instead of emitting the mis-parse. bash
+    # accepts it, so spell it ${v:o} or ${v:$((o))} (both supported).
+    code, out, err = shell.mirage_result('v=hello; o=2; echo "X${v:$o}Y"')
+    assert code == 2
+    assert out == ""
+    assert err == "bash: ${v}: bad substitution\n"
+
+
+def test_dollar_spelled_substring_offset_with_length(shell):
+    code, _, err = shell.mirage_result('v=hello; o=2; echo "${v:$o:2}"')
+    assert code == 2
+    assert "bad substitution" in err

--- a/typescript/packages/core/src/workspace/expand/parts.ts
+++ b/typescript/packages/core/src/workspace/expand/parts.ts
@@ -23,7 +23,7 @@ import { expandTemplate, makeInert, substitute } from './brace.ts'
 import { classifyWord } from './classify/index.ts'
 import { BRACE_LITERAL_TYPES, BRACE_WORD_TYPES, SPLIT_TYPES } from './constants.ts'
 import { expandNode, unescapeUnquoted, type ExecuteFn } from './node.ts'
-import { PARAM_OPS, type TSNodeLike } from './variable.ts'
+import { expandArrayAt, isMultiwordAt, type TSNodeLike } from './variable.ts'
 
 // Brace-expand a concatenation or brace_expression into words. Literal
 // word tokens form the brace template; every other child (expansions,
@@ -69,34 +69,9 @@ function getPositionalArgs(session: Session, callStack: CallStack | null): strin
   return session.positionalArgs
 }
 
-function arrayAtName(child: TSNodeLike): string | null {
-  if (child.type !== NT.EXPANSION) return null
-  // Any operator (length #, slice :, strip/replace, indirection !)
-  // disqualifies the plain-splat fast path; expandBraces owns those.
-  for (const c of child.children) {
-    if (PARAM_OPS.has(c.type) && c.isNamed !== true) return null
-  }
-  let subscript: TSNodeLike | null = null
-  for (const c of child.namedChildren) {
-    if (c.type === 'subscript') {
-      subscript = c
-      break
-    }
-  }
-  if (subscript === null) return null
-  let varName: string | null = null
-  let idxText = ''
-  for (const sc of subscript.namedChildren) {
-    if (sc.type === NT.VARIABLE_NAME) varName = sc.text
-    else idxText = sc.text
-  }
-  if (varName !== null && idxText === '@') return varName
-  return null
-}
-
 function stringHasArrayAt(node: TSNodeLike): boolean {
   for (const c of node.children) {
-    if (arrayAtName(c) !== null) return true
+    if (isMultiwordAt(c)) return true
   }
   return false
 }
@@ -107,21 +82,20 @@ async function expandStringWithArray(
   executeFn: ExecuteFn,
   callStack: CallStack | null,
 ): Promise<string[]> {
-  const arrays = session.arrays
+  const expandChild = (n: TSNodeLike) => expandNode(n, session, executeFn, callStack)
   const fragments: string[] = ['']
   for (const child of node.children) {
     if (child.type === NT.DQUOTE) continue
-    const arrName = arrayAtName(child)
-    if (arrName !== null) {
-      const arr = arrays[arrName]
-      if (arr === undefined || arr.length === 0) continue
+    if (isMultiwordAt(child)) {
+      const words = await expandArrayAt(child, session, callStack, expandChild)
+      if (words.length === 0) continue
       const last = fragments.length - 1
-      if (arr.length === 1) {
-        fragments[last] = (fragments[last] ?? '') + (arr[0] ?? '')
+      if (words.length === 1) {
+        fragments[last] = (fragments[last] ?? '') + (words[0] ?? '')
       } else {
-        fragments[last] = (fragments[last] ?? '') + (arr[0] ?? '')
-        for (let i = 1; i < arr.length - 1; i++) fragments.push(arr[i] ?? '')
-        fragments.push(arr[arr.length - 1] ?? '')
+        fragments[last] = (fragments[last] ?? '') + (words[0] ?? '')
+        for (let i = 1; i < words.length - 1; i++) fragments.push(words[i] ?? '')
+        fragments.push(words[words.length - 1] ?? '')
       }
       continue
     }

--- a/typescript/packages/core/src/workspace/expand/variable.ts
+++ b/typescript/packages/core/src/workspace/expand/variable.ts
@@ -31,13 +31,14 @@ export interface TSNodeLike {
   namedChildren: TSNodeLike[]
   parent?: TSNodeLike | null
   isNamed?: boolean
+  isMissing?: boolean
   startIndex?: number
   endIndex?: number
 }
 
 export type ExpandChild = (node: TSNodeLike) => Promise<string>
 
-export const PARAM_OPS: ReadonlySet<string> = new Set([
+const PARAM_OPS: ReadonlySet<string> = new Set([
   ':-',
   '-',
   ':+',
@@ -71,6 +72,16 @@ const CASE_OPS: ReadonlySet<string> = new Set(['^', '^^', ',', ',,'])
 // Ops whose first operand is a glob pattern that must keep its literal
 // spelling (no unescaping) while still expanding nested $-expansions.
 const PATTERN_OPS: ReadonlySet<string> = new Set([...REPLACE_OPS, ...STRIP_OPS, ...CASE_OPS])
+
+// Ops on a "${a[@]...}" splat that act per element, so a quoted splat
+// still splits into one word per element; every other op acts on the
+// space-joined value and stays a single word.
+const MULTIWORD_AT_OPS: ReadonlySet<string> = new Set([
+  ':',
+  ...STRIP_OPS,
+  ...REPLACE_OPS,
+  ...CASE_OPS,
+])
 
 const LITERAL_ARG_TYPES: ReadonlySet<string> = new Set([NT.WORD, NT.NUMBER, 'regex'])
 
@@ -425,6 +436,46 @@ function sliceArray(arr: string[], groups: string[], env: Record<string, string>
   return arr.slice(offset, offset + length)
 }
 
+// True for the "${a[@]...}" forms bash keeps as one word per element:
+// plain, slice, per-element strip/replace/case ops, and ${!a[@]}
+// indices. False for single-word forms (${a[*]}, ${#a[@]}, non-@
+// subscript, or a default/alternate op acting on the joined value).
+export function isMultiwordAt(node: TSNodeLike): boolean {
+  if (node.type !== NT.EXPANSION) return false
+  const p = parseBraces(node)
+  if (p.subscript !== '@' || p.lengthOp) return false
+  if (p.indirectOp || p.op === null) return true
+  return MULTIWORD_AT_OPS.has(p.op)
+}
+
+// Resolve a multi-word "${a[@]...}" splat to its word list. Only call
+// when isMultiwordAt is true; the caller word-splits (or stitches
+// prefix/suffix onto) the words, matching bash's quoted-splat rule.
+export async function expandArrayAt(
+  node: TSNodeLike,
+  session: Session,
+  callStack: CallStack | null,
+  expandChild: ExpandChild,
+): Promise<string[]> {
+  const p = parseBraces(node)
+  const env = session.env
+  let arr = session.arrays[p.varName ?? '']
+  if (arr === undefined) {
+    const scalar = env[p.varName ?? ''] ?? ''
+    arr = scalar !== '' ? [scalar] : []
+  }
+  if (p.indirectOp) return arr.map((_, i) => String(i))
+  if (p.op === null) return [...arr]
+  const op = p.op
+  const groups: string[] = []
+  for (let gi = 0; gi < p.groups.length; gi++) {
+    const patternMode = gi === 0 && PATTERN_OPS.has(op)
+    groups.push(await expandGroup(p.groups[gi] ?? [], expandChild, patternMode, session, callStack))
+  }
+  if (op === ':') return sliceArray(arr, groups, env)
+  return arr.map((el) => valueOp(op, el, groups, env))
+}
+
 // bash evaluates subscripts in arithmetic context (${a[i+1]});
 // unresolvable expressions index element 0, mirroring bash's
 // unset-name-is-zero arithmetic rule.
@@ -461,6 +512,20 @@ export async function expandBraces(
   expandChild: ExpandChild,
 ): Promise<string> {
   const p = parseBraces(node)
+  if (node.children.some((c) => c.type === '}' && c.isMissing)) {
+    // tree-sitter-bash cannot parse a $-spelled substring offset
+    // (${v:$o}, ${v:$o:n}): it truncates the expansion with a
+    // zero-width `}` and reparses the tail as stray siblings. bash
+    // accepts the form, so emitting the mis-parse would corrupt the
+    // value silently; fail loudly instead. Spell it ${v:o} or
+    // ${v:$((o))}.
+    throw new ExitSignal(
+      2,
+      new TextEncoder().encode(`bash: \${${p.varName ?? ''}}: bad substitution\n`),
+      null,
+      2,
+    )
+  }
   const env = session.env
   const arrays = session.arrays
 

--- a/typescript/packages/core/src/workspace/shell_arrays.test.ts
+++ b/typescript/packages/core/src/workspace/shell_arrays.test.ts
@@ -45,6 +45,11 @@ const CASES: [string, string][] = [
   ['v=ab; v+=cd; echo "$v"', 'abcd\n'],
   ['unset_append_zz+=x; echo "$unset_append_zz"', 'x\n'],
   ['a=(one two); echo "pre${a[@]}post"', 'preone twopost\n'],
+  ['a=(w x y z); printf "<%s>" "${a[@]:1:2}"; echo', '<x><y>\n'],
+  ['a=(w x y z); set -- "${a[@]:1:2}"; echo "$#"', '2\n'],
+  ['a=(w x y z); printf "<%s>" "p${a[@]:1:2}s"; echo', '<px><ys>\n'],
+  ['a=(cat car cow); printf "<%s>" "${a[@]/c/K}"; echo', '<Kat><Kar><Kow>\n'],
+  ['a=(w x y z); printf "<%s>" "${!a[@]}"; echo', '<0><1><2><3>\n'],
 ]
 
 describe('shell arrays', () => {

--- a/typescript/packages/core/src/workspace/shell_param_expansion.test.ts
+++ b/typescript/packages/core/src/workspace/shell_param_expansion.test.ts
@@ -89,6 +89,11 @@ const ERROR_CASES: [string, number, string, string][] = [
     'after code=0\n',
     'bash: UNSET: parameter null or not set\n',
   ],
+  // tree-sitter-bash cannot parse a $-spelled offset (${v:$o}); mirage
+  // fails loudly (exit 2) rather than emit the mis-parse. Spell it
+  // ${v:o} or ${v:$((o))}, both supported.
+  ['v=hello; o=2; echo "X${v:$o}Y"', 2, '', 'bash: ${v}: bad substitution\n'],
+  ['v=hello; o=2; echo "${v:$o:2}"', 2, '', 'bash: ${v}: bad substitution\n'],
 ]
 
 describe('parameter expansion error operators', () => {


### PR DESCRIPTION
## What

The **PR 8 deferred-expansion trio** from `bash_gap.md` — items 1 and 3. Item 2 is deferred (see below). Both Python and TypeScript; every behavior GNU-pinned against docker `bash 5.2`.

## Item 1 — `${v:$o}` → loud error

tree-sitter-bash cannot parse a `$`-spelled substring offset: `${v:$o}` / `${v:$o:n}` is truncated into a brace-less expansion (a zero-width `}`) plus stray sibling nodes, so mirage silently emitted corrupted text (`${v:$o}` with `o=2` gave `hello2}` instead of `llo`).

`expand_braces` now detects the missing brace and fails loudly:

```
$ v=hello; o=2; echo "${v:$o}"
bash: ${v}: bad substitution     # exit 2
```

**Deliberate divergence:** bash *accepts* `${v:$o}` (→ `llo`). Turning silent corruption into a clear error is the safe fix; the supported spellings `${v:o}` and `${v:$((o))}` work and are regression-pinned.

## Item 3 — quoted `"${a[@]...}"` multi-word

A quoted array-`@` splat with an operator was collapsing to a single word. Now it word-splits into N words like bash, for every multi-word form:

| form | before | after / bash |
|---|---|---|
| `"${a[@]:1:2}"` | `<x y>` (1) | `<x><y>` (2) |
| `"${a[@]/x/K}"` | 1 word | `<w><K><y><z>` |
| `"${!a[@]}"` | 1 word | `<0><1><2><3>` |
| `"p${a[@]:1:2}s"` | 1 word | `<px><ys>` |

Single-word forms are unchanged: `"${a[*]}"` / `"${a[*]:1:2}"` (IFS-join) and `"${#a[@]}"` (count) stay one word. New `expand_array_at` / `is_multiword_at` in the shared variable module, wired through the parts multi-word splat path (which already handled plain `"${a[@]}"`).

## Item 2 — DEFERRED (documented divergence)

`${a[-9]}` (a negative subscript past the start) expands to empty — **the behavior is already GNU-correct**; only bash's cosmetic, non-fatal `bash: a: bad array subscript` stderr line is missing. Emitting it requires a non-fatal warning channel threaded through every expansion call site (`expand_argv` + `expand_and_classify`) — a high-blast-radius change for near-zero value. Left as a documented divergence.

## Tests

- Python: `test_arrays.py` +5, `test_param_expansion.py` +2.
- TypeScript: `shell_arrays.test.ts` +5, `shell_param_expansion.test.ts` +2.
- Integration: `integ/bash/array.json` +6 (seq 603000–603005), `integ/bash/param.json` +3 (seq 603100–603102).
- Both hosts (python, typescript-node) pass **1575/1575** on `ram`.
