### PR TITLE
Remove Delivery column from watch matrix

### DIFF
--- a/docs/python/watch-matrix.mdx
+++ b/docs/python/watch-matrix.mdx
@@ -18,17 +18,17 @@ Watching splits into two halves, and they have different support stories:
   would subscribe to; mapping its payload to a `FileEvent` is consumer code,
   and Mirage ships a sample where marked.
 
-| Resource | Delivery | Pull (`delta_hook`) | Push signal (provider-side) | Sample |
-| --- | --- | --- | --- | --- |
-| Nextcloud | ✓ | ✓ ETag walk diff | `webhook_listeners` app (Nextcloud 30+) | [example](https://github.com/strukto-ai/mirage/blob/main/examples/python/nextcloud/watch.py) + integ receiver |
-| S3 / S3-compatible | ✓ | planned | S3 Event Notifications (SQS/EventBridge) | — |
-| Google Drive | ✓ | planned | `changes.watch` push channels | — |
-| Dropbox | ✓ | planned | Dropbox webhooks + cursor delta | — |
-| OneDrive / SharePoint | ✓ | planned | Graph change notifications + delta API | — |
-| GitHub | ✓ | planned | repository webhooks (push events) | — |
-| Slack | ✓ | planned | Events API (`message`, `file_shared`, ...) | — |
-| Disk | ✓ | planned | local inotify / FSEvents / watchdog | — |
-| RAM, Redis, others | ✓ | — | (no external writers to observe) | — |
+| Resource | Pull (`delta_hook`) | Push signal (provider-side) | Sample |
+| --- | --- | --- | --- |
+| Nextcloud | ✓ ETag walk diff | `webhook_listeners` app (Nextcloud 30+) | [example](https://github.com/strukto-ai/mirage/blob/main/examples/python/nextcloud/watch.py) + integ receiver |
+| S3 / S3-compatible | planned | S3 Event Notifications (SQS/EventBridge) | — |
+| Google Drive | planned | `changes.watch` push channels | — |
+| Dropbox | planned | Dropbox webhooks + cursor delta | — |
+| OneDrive / SharePoint | planned | Graph change notifications + delta API | — |
+| GitHub | planned | repository webhooks (push events) | — |
+| Slack | planned | Events API (`message`, `file_shared`, ...) | — |
+| Disk | planned | local inotify / FSEvents / watchdog | — |
+| RAM, Redis, others | — | (no external writers to observe) | — |
 
 ## What "Delivery ✓" buys you without a hook
 


### PR DESCRIPTION
## Summary

Remove the redundant **Delivery** column from the Python watch matrix table while preserving the pull detection, provider push signal, and sample information.

## Why

Delivery support is already explained immediately above the table as available for every mount, so repeating the same checkmark in every resource row adds noise without conveying additional differences.

## Impact

The published watch matrix is narrower and focuses on the resource-specific detection capabilities that vary between backends. Runtime behavior is unchanged.

## Validation

- `SKIP=no-commit-to-branch ./python/.venv/bin/pre-commit run --all-files` — passed
- `uv run pytest` — 9,822 passed, 347 skipped, 5 Redis setup errors because `REDIS_URL` is unset
- `git diff --check` — passed
