### PR TITLE
feat(agents): canonical ops layer + stream background job output

### DIFF
--- a/python/mirage/agents/background.py
+++ b/python/mirage/agents/background.py
@@ -1,0 +1,161 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from dataclasses import dataclass
+
+from mirage.agents.io_text import decode
+from mirage.shell.job_table import Job, JobStatus
+from mirage.workspace.workspace import Workspace
+
+
+@dataclass(frozen=True, slots=True)
+class BackgroundJob:
+    """Status of one long-lived command.
+
+    Args:
+        shell_id (str): identifier used to read from or kill the job.
+        command (str): the command line that was started.
+        pid (int): the workspace's job number. Mirage runs background
+            commands as tasks in-process, so there is no OS process id;
+            this is the same number the ``jobs`` builtin reports.
+        running (bool): whether the job is still executing.
+        exit_code (int | None): exit status, or None while running.
+    """
+
+    shell_id: str
+    command: str
+    pid: int
+    running: bool
+    exit_code: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BackgroundChunk:
+    """Output produced since the previous read of a job.
+
+    Args:
+        shell_id (str): the job this output came from.
+        stdout (str): new stdout since the last read.
+        stderr (str): new stderr since the last read.
+        running (bool): whether the job is still executing.
+        exit_code (int | None): exit status, or None while running.
+    """
+
+    shell_id: str
+    stdout: str
+    stderr: str
+    running: bool
+    exit_code: int | None = None
+
+
+def _to_job(job: Job) -> BackgroundJob:
+    running = job.status == JobStatus.RUNNING
+    return BackgroundJob(
+        shell_id=str(job.id),
+        command=job.command,
+        pid=job.id,
+        running=running,
+        exit_code=None if running else job.exit_code,
+    )
+
+
+class BackgroundJobs:
+    """Incremental view over a workspace's background jobs.
+
+    Wraps the job table that backs the shell's ``&`` operator and the
+    ``jobs`` builtin, adding the per-reader cursor that agent harnesses
+    expect: each :meth:`output` call returns only what is new since the
+    previous one for that job.
+
+    Output arrives in one piece when a job finishes rather than streaming
+    while it runs, because the job table materializes a job's streams on
+    completion. Reads before then are empty, not lost.
+    """
+
+    def __init__(self,
+                 workspace: Workspace,
+                 session_id: str | None = None) -> None:
+        self._ws = workspace
+        self._session_id = session_id
+        self._drained: dict[str, tuple[int, int]] = {}
+
+    def _job(self, shell_id: str) -> Job:
+        try:
+            job_id = int(shell_id)
+        except ValueError:
+            raise KeyError(shell_id) from None
+        job = self._ws.job_table.get(job_id)
+        if job is None:
+            raise KeyError(shell_id)
+        return job
+
+    async def start(self, command: str) -> BackgroundJob:
+        """Run a command detached and return its handle immediately.
+
+        Args:
+            command (str): the command line to run.
+        """
+        before = {job.id for job in self._ws.job_table.list_jobs()}
+        await self._ws.execute(f"{command} &", session_id=self._session_id)
+        started = [
+            job for job in self._ws.job_table.list_jobs()
+            if job.id not in before
+        ]
+        if not started:
+            raise RuntimeError(f"background command did not start: {command}")
+        return _to_job(max(started, key=lambda job: job.id))
+
+    def output(self, shell_id: str) -> BackgroundChunk:
+        """Drain the output a job has produced since the previous call.
+
+        Args:
+            shell_id (str): the job to read from.
+        """
+        job = self._job(shell_id)
+        seen_out, seen_err = self._drained.get(shell_id, (0, 0))
+        stdout = job.stdout[seen_out:]
+        stderr = job.stderr[seen_err:]
+        self._drained[shell_id] = (len(job.stdout), len(job.stderr))
+        running = job.status == JobStatus.RUNNING
+        return BackgroundChunk(
+            shell_id=shell_id,
+            stdout=decode(stdout),
+            stderr=decode(stderr),
+            running=running,
+            exit_code=None if running else job.exit_code,
+        )
+
+    def info(self) -> list[BackgroundJob]:
+        """Return the status of every tracked job."""
+        return [_to_job(job) for job in self._ws.job_table.list_jobs()]
+
+    def kill(self, shell_id: str) -> bool:
+        """Stop a job, reporting whether it was still running.
+
+        Args:
+            shell_id (str): the job to stop.
+        """
+        try:
+            job = self._job(shell_id)
+        except KeyError:
+            return False
+        if job.status != JobStatus.RUNNING:
+            return False
+        return self._ws.job_table.kill(job.id)
+
+    def kill_all(self) -> None:
+        """Stop every running job and forget its read cursor."""
+        for job in self._ws.job_table.running_jobs():
+            self._ws.job_table.kill(job.id)
+        self._drained.clear()

--- a/python/mirage/agents/langchain/_convert.py
+++ b/python/mirage/agents/langchain/_convert.py
@@ -14,47 +14,39 @@
 
 from deepagents.backends.protocol import ExecuteResponse, FileInfo, GrepMatch
 
-from mirage.agents.io_text import decode
+from mirage.agents import ops
 from mirage.io.types import IOResult
 
 
 def io_to_execute_response(io: IOResult) -> ExecuteResponse:
-    stdout = decode(io.stdout if isinstance(io.stdout, bytes) else None)
-    stderr = decode(io.stderr if isinstance(io.stderr, bytes) else None)
-    output = stdout
-    if stderr:
-        output = f"{stdout}\n{stderr}" if stdout else stderr
-    return ExecuteResponse(output=output, exit_code=io.exit_code)
+    """Map a command outcome onto the deepagents response type.
+
+    Args:
+        io (IOResult): the executed command's result.
+    """
+    result = ops.io_to_exec_result(io)
+    return ExecuteResponse(output=result.output, exit_code=result.exit_code)
 
 
 def io_to_grep_matches(io: IOResult) -> list[GrepMatch]:
-    stdout = decode(
-        io.stdout if isinstance(io.stdout, bytes) else None).strip()
-    if not stdout:
-        return []
-    matches: list[GrepMatch] = []
-    for line in stdout.split("\n"):
-        parts = line.split(":", 2)
-        if len(parts) >= 3:
-            try:
-                line_num = int(parts[1])
-            except ValueError:
-                continue
-            matches.append(
-                GrepMatch(path=parts[0], line=line_num, text=parts[2]))
-    return matches
+    """Map grep matches onto the deepagents match type.
+
+    Args:
+        io (IOResult): result of a ``grep -n`` run.
+    """
+    return [
+        GrepMatch(path=m.path, line=m.line, text=m.text)
+        for m in ops.io_to_grep_matches(io)
+    ]
 
 
 def io_to_file_infos(io: IOResult) -> list[FileInfo]:
-    stdout = decode(
-        io.stdout if isinstance(io.stdout, bytes) else None).strip()
-    if not stdout:
-        return []
-    infos: list[FileInfo] = []
-    for entry in stdout.split("\n"):
-        entry = entry.strip()
-        if not entry:
-            continue
-        is_dir = entry.endswith("/")
-        infos.append(FileInfo(path=entry.rstrip("/"), is_dir=is_dir))
-    return infos
+    """Map directory entries onto the deepagents file-info type.
+
+    Args:
+        io (IOResult): result of an ``ls`` run.
+    """
+    return [
+        FileInfo(path=i.path, is_dir=i.is_dir)
+        for i in ops.io_to_file_infos(io)
+    ]

--- a/python/mirage/agents/langchain/backend.py
+++ b/python/mirage/agents/langchain/backend.py
@@ -19,9 +19,9 @@ from pathlib import PurePosixPath
 from deepagents.backends.protocol import (EditResult, ExecuteResponse,
                                           FileData, FileDownloadResponse,
                                           FileInfo, FileUploadResponse,
-                                          GlobResult, GrepResult, LsResult,
-                                          ReadResult, SandboxBackendProtocol,
-                                          WriteResult)
+                                          GlobResult, GrepMatch, GrepResult,
+                                          LsResult, ReadResult,
+                                          SandboxBackendProtocol, WriteResult)
 
 from mirage.agents.langchain._convert import (io_to_execute_response,
                                               io_to_file_infos,
@@ -296,6 +296,64 @@ class LangchainWorkspace(SandboxBackendProtocol):
         if error:
             return GlobResult(error=error)
         return GlobResult(matches=io_to_file_infos(io))
+
+    # ── info projections ─────────────────────────────────────
+
+    def ls_info(self, path: str) -> list[FileInfo]:
+        return self._run(self.als_info(path))
+
+    async def als_info(self, path: str) -> list[FileInfo]:
+        """Entries of a directory, unwrapped.
+
+        The error channel of :meth:`als` collapses to an empty list, which
+        is what the protocol's bare-list return leaves room for.
+
+        Args:
+            path (str): directory to list.
+        """
+        result = await self.als(path)
+        return result.entries or []
+
+    def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+        return self._run(self.aglob_info(pattern, path))
+
+    async def aglob_info(self,
+                         pattern: str,
+                         path: str = "/") -> list[FileInfo]:
+        """Glob matches, unwrapped.
+
+        Args:
+            pattern (str): glob pattern.
+            path (str): directory to search under.
+        """
+        result = await self.aglob(pattern, path)
+        return result.matches or []
+
+    def grep_raw(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+    ) -> list[GrepMatch] | str:
+        return self._run(self.agrep_raw(pattern, path, glob))
+
+    async def agrep_raw(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+    ) -> list[GrepMatch] | str:
+        """Grep matches, or the error text when the search failed.
+
+        Args:
+            pattern (str): search pattern.
+            path (str | None): directory to search under.
+            glob (str | None): restrict to files matching this glob.
+        """
+        result = await self.agrep(pattern, path, glob)
+        if result.error is not None:
+            return result.error
+        return result.matches or []
 
     # ── upload / download ────────────────────────────────────
 

--- a/python/mirage/agents/ops.py
+++ b/python/mirage/agents/ops.py
@@ -1,0 +1,109 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.agents.io_text import decode
+from mirage.agents.types import ExecResult, FileInfo, GrepMatch
+from mirage.io.types import IOResult
+
+
+def parse_grep(stdout: str) -> list[GrepMatch]:
+    """Parse ``grep -n`` output into matches.
+
+    Lines that are not ``path:line:text`` with a numeric line are skipped,
+    which is how grep reports binary-file notices and similar asides.
+
+    Args:
+        stdout (str): raw grep output.
+    """
+    text = stdout.strip()
+    if not text:
+        return []
+    matches: list[GrepMatch] = []
+    for line in text.split("\n"):
+        parts = line.split(":", 2)
+        if len(parts) < 3:
+            continue
+        try:
+            line_num = int(parts[1])
+        except ValueError:
+            continue
+        matches.append(GrepMatch(path=parts[0], line=line_num, text=parts[2]))
+    return matches
+
+
+def parse_ls(stdout: str, base: str | None = None) -> list[FileInfo]:
+    """Parse ``ls`` output into directory entries.
+
+    A trailing ``/`` marks a directory and is stripped from the path.
+
+    Args:
+        stdout (str): raw ls output.
+        base (str | None): when given, entries are joined onto this
+            directory so paths are absolute; otherwise the entry is used
+            as-is.
+    """
+    text = stdout.strip()
+    if not text:
+        return []
+    prefix = base.rstrip("/") if base is not None else None
+    infos: list[FileInfo] = []
+    for entry in text.split("\n"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        is_dir = entry.endswith("/")
+        clean = entry.rstrip("/")
+        path = f"{prefix}/{clean}" if prefix is not None else clean
+        infos.append(
+            FileInfo(path=path, name=clean.rsplit("/", 1)[-1], is_dir=is_dir))
+    return infos
+
+
+def io_to_exec_result(io: IOResult) -> ExecResult:
+    """Fold an IOResult into an agent-facing command outcome.
+
+    stderr is appended to stdout so a harness that shows one text blob
+    still surfaces errors.
+
+    Args:
+        io (IOResult): the executed command's result.
+    """
+    stdout = decode(io.stdout if isinstance(io.stdout, bytes) else None)
+    stderr = decode(io.stderr if isinstance(io.stderr, bytes) else None)
+    output = stdout
+    if stderr:
+        output = f"{stdout}\n{stderr}" if stdout else stderr
+    return ExecResult(output=output, exit_code=io.exit_code)
+
+
+def io_to_grep_matches(io: IOResult) -> list[GrepMatch]:
+    """Parse grep matches from an IOResult.
+
+    Args:
+        io (IOResult): result of a ``grep -n`` run.
+    """
+    return parse_grep(
+        decode(io.stdout if isinstance(io.stdout, bytes) else None))
+
+
+def io_to_file_infos(io: IOResult, base: str | None = None) -> list[FileInfo]:
+    """Parse directory entries from an IOResult.
+
+    Args:
+        io (IOResult): result of an ``ls`` run.
+        base (str | None): directory to join entries onto, when absolute
+            paths are wanted.
+    """
+    return parse_ls(
+        decode(io.stdout if isinstance(io.stdout, bytes) else None), base)

--- a/python/mirage/agents/pydantic_ai/_convert.py
+++ b/python/mirage/agents/pydantic_ai/_convert.py
@@ -14,49 +14,39 @@
 
 from pydantic_ai_backends.types import ExecuteResponse, FileInfo, GrepMatch
 
-from mirage.agents.io_text import decode
+from mirage.agents import ops
 from mirage.io.types import IOResult
 
 
 def io_to_execute_response(io: IOResult) -> ExecuteResponse:
-    stdout = decode(io.stdout if isinstance(io.stdout, bytes) else None)
-    stderr = decode(io.stderr if isinstance(io.stderr, bytes) else None)
-    output = stdout
-    if stderr:
-        output = f"{stdout}\n{stderr}" if stdout else stderr
-    return ExecuteResponse(output=output, exit_code=io.exit_code)
+    """Map a command outcome onto the pydantic-ai response type.
+
+    Args:
+        io (IOResult): the executed command's result.
+    """
+    result = ops.io_to_exec_result(io)
+    return ExecuteResponse(output=result.output, exit_code=result.exit_code)
 
 
 def io_to_grep_matches(io: IOResult) -> list[GrepMatch]:
-    stdout = decode(
-        io.stdout if isinstance(io.stdout, bytes) else None).strip()
-    if not stdout:
-        return []
-    matches: list[GrepMatch] = []
-    for line in stdout.split("\n"):
-        parts = line.split(":", 2)
-        if len(parts) >= 3:
-            try:
-                line_num = int(parts[1])
-            except ValueError:
-                continue
-            matches.append(
-                GrepMatch(path=parts[0], line_number=line_num, line=parts[2]))
-    return matches
+    """Map grep matches onto the pydantic-ai match type.
+
+    Args:
+        io (IOResult): result of a ``grep -n`` run.
+    """
+    return [
+        GrepMatch(path=m.path, line_number=m.line, line=m.text)
+        for m in ops.io_to_grep_matches(io)
+    ]
 
 
 def io_to_file_infos(io: IOResult) -> list[FileInfo]:
-    stdout = decode(
-        io.stdout if isinstance(io.stdout, bytes) else None).strip()
-    if not stdout:
-        return []
-    infos: list[FileInfo] = []
-    for entry in stdout.split("\n"):
-        entry = entry.strip()
-        if not entry:
-            continue
-        is_dir = entry.endswith("/")
-        clean = entry.rstrip("/")
-        name = clean.rsplit("/", 1)[-1] if "/" in clean else clean
-        infos.append(FileInfo(name=name, path=clean, is_dir=is_dir, size=None))
-    return infos
+    """Map directory entries onto the pydantic-ai file-info type.
+
+    Args:
+        io (IOResult): result of an ``ls`` run.
+    """
+    return [
+        FileInfo(name=i.name, path=i.path, is_dir=i.is_dir, size=i.size)
+        for i in ops.io_to_file_infos(io)
+    ]

--- a/python/mirage/agents/pydantic_ai/backend.py
+++ b/python/mirage/agents/pydantic_ai/backend.py
@@ -14,10 +14,13 @@
 
 import shlex
 
-from pydantic_ai_backends.protocol import SandboxProtocol
-from pydantic_ai_backends.types import (EditResult, ExecuteResponse, FileInfo,
-                                        GrepMatch, WriteResult)
+from pydantic_ai_backends.protocol import BackgroundSandboxProtocol
+from pydantic_ai_backends.types import (BackgroundHandle, BackgroundOutput,
+                                        BackgroundProcessInfo, EditResult,
+                                        ExecuteResponse, FileInfo, GrepMatch,
+                                        WriteResult)
 
+from mirage.agents.background import BackgroundJobs
 from mirage.agents.pydantic_ai._convert import (io_to_execute_response,
                                                 io_to_file_infos,
                                                 io_to_grep_matches)
@@ -26,12 +29,13 @@ from mirage.io.types import IOResult
 from mirage.workspace.workspace import Workspace
 
 
-class PydanticAIWorkspace(SandboxProtocol):
+class PydanticAIWorkspace(BackgroundSandboxProtocol):
     """Pydantic AI backend backed by a Mirage Workspace.
 
     File operations (read, write, edit, ls) go through the Ops layer directly.
     Shell operations (execute, grep, glob) go through Workspace.execute()
-    for pipe and flag support.
+    for pipe and flag support. Background processes are the workspace's own
+    job table, the one behind the shell's ``&`` operator.
     """
 
     def __init__(
@@ -43,6 +47,7 @@ class PydanticAIWorkspace(SandboxProtocol):
         self._ws = workspace
         self._id = sandbox_id
         self._session_id = session_id
+        self._bg = BackgroundJobs(workspace, session_id=session_id)
 
     def _run(self, coro):
         return run_async_from_sync(coro)
@@ -239,3 +244,38 @@ class PydanticAIWorkspace(SandboxProtocol):
         io = await self._exec(
             f"find {shlex.quote(path)} -name {shlex.quote(name)}")
         return io_to_file_infos(io)
+
+    # -- background ----------------------------------------------------
+
+    def execute_background(self, command: str) -> BackgroundHandle:
+        return self._run(self.aexecute_background(command))
+
+    async def aexecute_background(self, command: str) -> BackgroundHandle:
+        job = await self._bg.start(command)
+        return BackgroundHandle(shell_id=job.shell_id,
+                                pid=job.pid,
+                                command=job.command)
+
+    def read_background(self, shell_id: str) -> BackgroundOutput:
+        chunk = self._bg.output(shell_id)
+        return BackgroundOutput(shell_id=chunk.shell_id,
+                                stdout=chunk.stdout,
+                                stderr=chunk.stderr,
+                                running=chunk.running,
+                                exit_code=chunk.exit_code)
+
+    def kill_background(self, shell_id: str) -> bool:
+        return self._bg.kill(shell_id)
+
+    def list_background(self) -> list[BackgroundProcessInfo]:
+        return [
+            BackgroundProcessInfo(shell_id=job.shell_id,
+                                  command=job.command,
+                                  pid=job.pid,
+                                  running=job.running,
+                                  exit_code=job.exit_code)
+            for job in self._bg.info()
+        ]
+
+    def kill_all_background(self) -> None:
+        self._bg.kill_all()

--- a/python/mirage/agents/types.py
+++ b/python/mirage/agents/types.py
@@ -1,0 +1,64 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ExecResult:
+    """Outcome of a shell command run for an agent harness.
+
+    Args:
+        output (str): stdout, with stderr appended when both are present.
+        exit_code (int): the command's exit status.
+    """
+
+    output: str
+    exit_code: int
+
+
+@dataclass(frozen=True, slots=True)
+class GrepMatch:
+    """One `grep -n` hit.
+
+    Args:
+        path (str): file the match was found in.
+        line (int): 1-based line number.
+        text (str): the matching line's text.
+    """
+
+    path: str
+    line: int
+    text: str
+
+
+@dataclass(frozen=True, slots=True)
+class FileInfo:
+    """A directory entry in its richest form.
+
+    Carries every field any supported harness needs, so adapters project
+    down rather than re-deriving. ``size`` is None when the listing did not
+    report one.
+
+    Args:
+        path (str): full path of the entry.
+        name (str): final path segment.
+        is_dir (bool): whether the entry is a directory.
+        size (int | None): byte size when known.
+    """
+
+    path: str
+    name: str
+    is_dir: bool
+    size: int | None = None

--- a/python/mirage/shell/job_table.py
+++ b/python/mirage/shell/job_table.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import time
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -30,6 +31,13 @@ class JobStatus(str, Enum):
 
 @dataclass
 class Job:
+    """One background command and the output it has produced so far.
+
+    ``stdout`` and ``stderr`` grow while the job runs: the runner appends
+    to them as chunks arrive, so a reader can watch a long job instead of
+    waiting for it to finish.
+    """
+
     id: int
     command: str
     task: asyncio.Task[Any] | None
@@ -45,6 +53,21 @@ class Job:
     session_id: str = ""
 
 
+JobRunner = Callable[[Job], Coroutine[Any, Any, tuple[IOResult,
+                                                      ExecutionNode]]]
+
+
+def _note_killed(job: Job) -> None:
+    """Record that a job was killed, keeping what it already printed.
+
+    Args:
+        job (Job): the job being stopped.
+    """
+    if job.stderr and not job.stderr.endswith(b"\n"):
+        job.stderr += b"\n"
+    job.stderr += b"Killed"
+
+
 class JobTable:
 
     def __init__(self) -> None:
@@ -54,19 +77,33 @@ class JobTable:
     def submit(
         self,
         command: str,
-        task: asyncio.Task[Any],
+        run: JobRunner,
         cwd: str,
         agent: str = "unknown",
         session_id: str = "",
     ) -> Job:
+        """Register a job and start it.
+
+        The table creates the task itself so the runner is handed the job
+        it writes into. Building the task first would leave a window in
+        which output could arrive with nowhere to go.
+
+        Args:
+            command (str): the command line being run.
+            run (JobRunner): coroutine factory taking the job to fill.
+            cwd (str): working directory the job was started from.
+            agent (str): agent that started the job.
+            session_id (str): session the job belongs to.
+        """
         job = Job(id=self._next_id,
                   command=command,
-                  task=task,
+                  task=None,
                   cwd=cwd,
                   agent=agent,
                   session_id=session_id)
         self._jobs[job.id] = job
         self._next_id += 1
+        job.task = asyncio.create_task(run(job))
         return job
 
     def get(self, job_id: int) -> Job | None:
@@ -92,11 +129,10 @@ class JobTable:
         """Sync status from the underlying asyncio task without awaiting.
 
         When the bg task has finished (normally, raised, or was cancelled)
-        but no one has called ``wait``, this updates the job's status,
-        exit_code, and captured streams from the task result. Lets
-        ``list_jobs`` / ``running_jobs`` / ``get`` report fresh state.
-        Requires ``_run_bg`` to have already materialized stdout/stderr,
-        so reading the result is purely synchronous.
+        but no one has called ``wait``, this settles the job's status and
+        exit_code. Lets ``list_jobs`` / ``running_jobs`` / ``get`` report
+        fresh state. Output is not read from the task result: the runner
+        has been appending it to the job all along.
         """
         if job.status != JobStatus.RUNNING:
             return
@@ -106,24 +142,19 @@ class JobTable:
         if job.task.cancelled():
             job.status = JobStatus.KILLED
             job.exit_code = 137
-            job.stderr = b"Killed"
+            _note_killed(job)
             return
         exc = job.task.exception()
         if exc is not None:
             job.status = JobStatus.COMPLETED
             job.exit_code = 1
-            job.stderr = str(exc).encode()
+            job.stderr += str(exc).encode()
             return
-        stdout, io_result, exec_node = job.task.result()
-        job.stdout = stdout if isinstance(stdout, bytes) else b""
+        io_result, exec_node = job.task.result()
         job.io_result = io_result
         job.execution_node = exec_node
         io_result.sync_exit_code()
         job.exit_code = io_result.exit_code
-        if isinstance(io_result.stderr, bytes):
-            job.stderr = io_result.stderr
-        elif io_result.stderr is None:
-            job.stderr = b""
         job.status = JobStatus.COMPLETED
 
     def kill(self, job_id: int) -> bool:
@@ -132,9 +163,10 @@ class JobTable:
             return False
         if job.task is not None:
             job.task.cancel()
+        if job.status != JobStatus.KILLED:
+            _note_killed(job)
         job.status = JobStatus.KILLED
         job.exit_code = 137
-        job.stderr = b"Killed"
         return True
 
     async def wait(self, job_id: int) -> Job:
@@ -143,22 +175,20 @@ class JobTable:
             return job
         assert job.task is not None
         try:
-            stdout, io_result, exec_node = await job.task
-            job.stdout = stdout if isinstance(stdout, bytes) else b""
+            io_result, exec_node = await job.task
             job.io_result = io_result
             job.execution_node = exec_node
             io_result.sync_exit_code()
             job.exit_code = io_result.exit_code
-            job.stderr = await io_result.materialize_stderr()
             job.status = JobStatus.COMPLETED
         except asyncio.CancelledError:
             job.status = JobStatus.KILLED
             job.exit_code = 137
-            job.stderr = b"Killed"
+            _note_killed(job)
         except Exception as exc:
             job.status = JobStatus.COMPLETED
             job.exit_code = 1
-            job.stderr = str(exc).encode()
+            job.stderr += str(exc).encode()
         return job
 
     async def wait_all(self) -> list[Job]:

--- a/python/mirage/workspace/executor/jobs.py
+++ b/python/mirage/workspace/executor/jobs.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+from typing import Any
 
 import tree_sitter
 
@@ -21,9 +22,35 @@ from mirage.io import IOResult
 from mirage.io.types import ByteSource, materialize
 from mirage.shell.errors import ExitSignal
 from mirage.shell.helpers import get_text
-from mirage.shell.job_table import JobTable
+from mirage.shell.job_table import Job, JobTable
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
+
+_DETACHED: set[asyncio.Task[Any]] = set()
+
+
+async def _drain_into(job: Job | None, stream: ByteSource | None) -> None:
+    """Append a command's stdout to its job as chunks arrive.
+
+    Consuming the stream chunk by chunk rather than materializing it whole
+    is what lets a reader see a running job's output before it finishes.
+    A command that computes its output eagerly still yields everything at
+    once, because there is nothing to observe before it is done.
+
+    Args:
+        job (Job | None): job to append to, or None when nothing is
+            tracking this command.
+        stream (ByteSource | None): the command's stdout.
+    """
+    if stream is None:
+        return
+    if isinstance(stream, bytes):
+        if job is not None:
+            job.stdout += stream
+        return
+    async for chunk in stream:
+        if job is not None:
+            job.stdout += chunk
 
 
 async def handle_background(
@@ -39,7 +66,7 @@ async def handle_background(
     """Run left side in background."""
     bg_session = session.fork()
 
-    async def _run_bg():
+    async def _run_bg(job: Job | None) -> tuple[IOResult, ExecutionNode]:
         # Background jobs don't receive stdin, matching real shell
         # behavior where bg processes get /dev/null. This prevents
         # race conditions when stdin is an async iterator.
@@ -49,38 +76,44 @@ async def handle_background(
                                                        call_stack)
         except CommandTimeoutError as exc:
             msg = (str(exc) + "\n").encode()
+            stdout = b""
             io = IOResult(exit_code=124, stderr=msg)
             exec_node = ExecutionNode(command=cmd_str_inner,
                                       stderr=msg,
                                       exit_code=124)
-            return b"", io, exec_node
         except ExitSignal as sig:
             # A background job is its own shell: exit ends the job only.
+            stdout = sig.stdout or b""
             io = IOResult(exit_code=sig.contained_code,
                           stderr=sig.stderr or None)
             exec_node = ExecutionNode(command=cmd_str_inner,
                                       stderr=sig.stderr,
                                       exit_code=sig.contained_code)
-            return sig.stdout or b"", io, exec_node
-        stdout = await materialize(stdout)
-        # Eagerly materialize stderr too so JobTable._refresh can read
-        # the task result synchronously without an async hop.
-        await io.materialize_stderr()
+        await _drain_into(job, stdout)
+        # Eagerly materialize stderr too so JobTable._refresh can settle
+        # the job synchronously without an async hop.
+        stderr = await io.materialize_stderr()
+        if job is not None:
+            job.stderr += stderr
         io.sync_exit_code()
-        return stdout, io, exec_node
+        return io, exec_node
 
-    task = asyncio.create_task(_run_bg())
     cmd_str = get_text(left) if hasattr(left, 'text') else str(left)
 
     if job_table is not None:
         job = job_table.submit(command=cmd_str,
-                               task=task,
+                               run=_run_bg,
                                cwd=bg_session.cwd,
                                agent=agent_id or "",
                                session_id=session.session_id)
         session.last_bg_job_id = job.id
         job_line = f"[{job.id}]\n".encode()
     else:
+        # No table is tracking this job, so hold the task here: the event
+        # loop keeps only a weak reference and would let it be collected.
+        task = asyncio.create_task(_run_bg(None))
+        _DETACHED.add(task)
+        task.add_done_callback(_DETACHED.discard)
         job_line = b"[bg]\n"
 
     if right is None:

--- a/python/tests/agents/langchain/test_backend.py
+++ b/python/tests/agents/langchain/test_backend.py
@@ -192,3 +192,53 @@ async def test_upload_and_download(backend):
     down_results = await backend.adownload_files(["/up1.txt", "/up2.txt"])
     assert down_results[0].content == b"content1"
     assert down_results[1].content == b"content2"
+
+
+@pytest.mark.asyncio
+async def test_als_info_returns_bare_entries(backend):
+    await backend.awrite("/d/a.txt", "x")
+    infos = await backend.als_info("/d")
+    assert [i["path"] for i in infos] == ["/d/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_als_info_empty_on_error(backend):
+    assert await backend.als_info("/missing") == []
+
+
+@pytest.mark.asyncio
+async def test_aglob_info_returns_bare_matches(backend):
+    await backend.awrite("/g/one.txt", "x")
+    infos = await backend.aglob_info("*.txt", path="/g")
+    assert any(i["path"].endswith("one.txt") for i in infos)
+
+
+@pytest.mark.asyncio
+async def test_aglob_info_empty_on_error(backend):
+    assert await backend.aglob_info("*.txt", path="/missing") == []
+
+
+@pytest.mark.asyncio
+async def test_agrep_raw_returns_matches(backend):
+    await backend.awrite("/r/f.txt", "alpha\nbeta\n")
+    result = await backend.agrep_raw("beta", path="/r")
+    assert isinstance(result, list)
+    assert result[0]["line"] == 2
+    assert result[0]["text"] == "beta"
+
+
+@pytest.mark.asyncio
+async def test_agrep_raw_projects_error_to_string(backend):
+    from deepagents.backends.protocol import GrepResult
+
+    async def failing(*args, **kwargs):
+        return GrepResult(error="boom")
+
+    backend.agrep = failing
+    assert await backend.agrep_raw("x") == "boom"
+
+
+def test_sync_info_projections(backend):
+    backend.write("/s/a.txt", "x")
+    assert [i["path"] for i in backend.ls_info("/s")] == ["/s/a.txt"]
+    assert isinstance(backend.grep_raw("nope", path="/s"), list)

--- a/python/tests/agents/pydantic_ai/test_backend.py
+++ b/python/tests/agents/pydantic_ai/test_backend.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
+
 import pytest
 
 from mirage import MountMode, RAMResource, Workspace
@@ -124,3 +126,60 @@ async def test_exists(backend):
     assert not await backend.aexists("/missing.txt")
     await backend.awrite("/exists.txt", "content")
     assert await backend.aexists("/exists.txt")
+
+
+async def _settle_background(backend, shell_id, tries=50):
+    for _ in range(tries):
+        output = backend.read_background(shell_id)
+        if not output.running:
+            return output
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"background job {shell_id} never finished")
+
+
+@pytest.mark.asyncio
+async def test_execute_background_returns_a_handle(backend):
+    handle = await backend.aexecute_background("echo bg")
+
+    assert handle.command == "echo bg"
+    assert handle.shell_id
+    assert handle.pid
+
+
+@pytest.mark.asyncio
+async def test_read_background_drains_output(backend):
+    handle = await backend.aexecute_background("echo streamed")
+
+    output = await _settle_background(backend, handle.shell_id)
+
+    assert output.stdout == "streamed\n"
+    assert output.exit_code == 0
+    assert backend.read_background(handle.shell_id).stdout == ""
+
+
+@pytest.mark.asyncio
+async def test_list_background_reports_started_jobs(backend):
+    handle = await backend.aexecute_background("sleep 30")
+
+    listed = backend.list_background()
+
+    assert [p.shell_id for p in listed] == [handle.shell_id]
+    assert listed[0].running
+
+
+@pytest.mark.asyncio
+async def test_kill_background_stops_a_job(backend):
+    handle = await backend.aexecute_background("sleep 30")
+
+    assert backend.kill_background(handle.shell_id)
+    assert not backend.kill_background(handle.shell_id)
+
+
+@pytest.mark.asyncio
+async def test_kill_all_background_clears_running_jobs(backend):
+    await backend.aexecute_background("sleep 30")
+    await backend.aexecute_background("sleep 30")
+
+    backend.kill_all_background()
+
+    assert not any(p.running for p in backend.list_background())

--- a/python/tests/agents/test_background.py
+++ b/python/tests/agents/test_background.py
@@ -1,0 +1,118 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+import pytest
+
+from mirage import MountMode, RAMResource, Workspace
+from mirage.agents.background import BackgroundJobs
+
+
+@pytest.fixture
+def workspace():
+    return Workspace({"/": RAMResource()}, mode=MountMode.WRITE)
+
+
+@pytest.fixture
+def jobs(workspace):
+    return BackgroundJobs(workspace)
+
+
+async def _settle(jobs, shell_id, tries=50):
+    for _ in range(tries):
+        chunk = jobs.output(shell_id)
+        if not chunk.running:
+            return chunk
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"job {shell_id} never finished")
+
+
+@pytest.mark.asyncio
+async def test_start_returns_running_handle(jobs):
+    job = await jobs.start("echo hi")
+
+    assert job.shell_id == "1"
+    assert job.command == "echo hi"
+    assert job.running
+    assert job.exit_code is None
+
+
+@pytest.mark.asyncio
+async def test_output_reports_completion(jobs):
+    job = await jobs.start("echo hello")
+
+    chunk = await _settle(jobs, job.shell_id)
+
+    assert chunk.stdout == "hello\n"
+    assert chunk.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_output_is_incremental(jobs):
+    job = await jobs.start("echo once")
+    await _settle(jobs, job.shell_id)
+
+    again = jobs.output(job.shell_id)
+
+    assert again.stdout == ""
+    assert again.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_output_rejects_unknown_shell(jobs):
+    with pytest.raises(KeyError):
+        jobs.output("404")
+    with pytest.raises(KeyError):
+        jobs.output("not-a-number")
+
+
+@pytest.mark.asyncio
+async def test_info_lists_every_job(jobs):
+    first = await jobs.start("echo a")
+    second = await jobs.start("echo b")
+
+    listed = {job.shell_id: job.command for job in jobs.info()}
+
+    assert listed == {first.shell_id: "echo a", second.shell_id: "echo b"}
+
+
+@pytest.mark.asyncio
+async def test_kill_stops_a_running_job(jobs):
+    job = await jobs.start("sleep 30")
+
+    assert jobs.kill(job.shell_id)
+
+    chunk = jobs.output(job.shell_id)
+    assert not chunk.running
+    assert chunk.exit_code == 137
+
+
+@pytest.mark.asyncio
+async def test_kill_is_false_for_finished_and_unknown_jobs(jobs):
+    job = await jobs.start("echo done")
+    await _settle(jobs, job.shell_id)
+
+    assert not jobs.kill(job.shell_id)
+    assert not jobs.kill("404")
+
+
+@pytest.mark.asyncio
+async def test_kill_all_stops_every_running_job(jobs):
+    await jobs.start("sleep 30")
+    await jobs.start("sleep 30")
+
+    jobs.kill_all()
+
+    assert not any(job.running for job in jobs.info())

--- a/python/tests/agents/test_ops.py
+++ b/python/tests/agents/test_ops.py
@@ -1,0 +1,80 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.agents.ops import (io_to_exec_result, io_to_file_infos,
+                               io_to_grep_matches, parse_grep, parse_ls)
+from mirage.io.types import IOResult
+
+
+def _io(stdout: bytes = b"", stderr: bytes = b"", exit_code: int = 0):
+    return IOResult(stdout=stdout, stderr=stderr, exit_code=exit_code)
+
+
+def test_parse_grep_reads_path_line_text():
+    matches = parse_grep("a.py:12:hello\nb/c.py:3:world\n")
+    assert [(m.path, m.line, m.text) for m in matches] == [
+        ("a.py", 12, "hello"),
+        ("b/c.py", 3, "world"),
+    ]
+
+
+def test_parse_grep_skips_non_numeric_and_short_lines():
+    matches = parse_grep("Binary file x matches\na.py:notanum:t\na.py:1:ok")
+    assert [(m.path, m.line, m.text) for m in matches] == [("a.py", 1, "ok")]
+
+
+def test_parse_grep_empty():
+    assert parse_grep("") == []
+    assert parse_grep("   \n ") == []
+
+
+def test_parse_ls_marks_dirs_and_derives_name():
+    infos = parse_ls("src/\nREADME.md\n")
+    assert [(i.path, i.name, i.is_dir) for i in infos] == [
+        ("src", "src", True),
+        ("README.md", "README.md", False),
+    ]
+
+
+def test_parse_ls_joins_base_when_given():
+    infos = parse_ls("a\nsub/\n", base="/repo/")
+    assert [(i.path, i.name, i.is_dir) for i in infos] == [
+        ("/repo/a", "a", False),
+        ("/repo/sub", "sub", True),
+    ]
+
+
+def test_parse_ls_empty():
+    assert parse_ls("") == []
+
+
+def test_exec_result_appends_stderr_to_stdout():
+    r = io_to_exec_result(_io(b"out", b"bad", 1))
+    assert r.output == "out\nbad"
+    assert r.exit_code == 1
+
+
+def test_exec_result_stderr_only():
+    assert io_to_exec_result(_io(b"", b"bad", 2)).output == "bad"
+
+
+def test_exec_result_stdout_only():
+    r = io_to_exec_result(_io(b"fine", b"", 0))
+    assert r.output == "fine"
+    assert r.exit_code == 0
+
+
+def test_io_helpers_delegate_to_parsers():
+    assert io_to_grep_matches(_io(b"a.py:1:x"))[0].path == "a.py"
+    assert io_to_file_infos(_io(b"d/"), base="/b")[0].path == "/b/d"

--- a/python/tests/shell/test_background_jobs.py
+++ b/python/tests/shell/test_background_jobs.py
@@ -22,21 +22,27 @@ from mirage.workspace import Workspace
 from mirage.workspace.types import ExecutionNode
 
 
-async def _make_failing_task():
+async def _failing_run(job):
     raise RuntimeError("resource API error")
 
 
-async def _make_successful_task():
-    return b"hello", IOResult(exit_code=0), ExecutionNode(command="echo hello",
-                                                          exit_code=0)
+async def _never_ending_run(job):
+    job.stdout += b"partial"
+    await asyncio.sleep(30)
+    return IOResult(exit_code=0), ExecutionNode(command="noisy", exit_code=0)
+
+
+async def _successful_run(job):
+    job.stdout += b"hello"
+    return IOResult(exit_code=0), ExecutionNode(command="echo hello",
+                                                exit_code=0)
 
 
 def test_wait_handles_task_exception():
 
     async def _run():
         table = JobTable()
-        task = asyncio.create_task(_make_failing_task())
-        table.submit(command="bad_cmd", task=task, cwd="/")
+        table.submit(command="bad_cmd", run=_failing_run, cwd="/")
         job = await table.wait(1)
         assert job.status == JobStatus.COMPLETED
         assert job.exit_code == 1
@@ -49,10 +55,8 @@ def test_wait_all_survives_failing_task():
 
     async def _run():
         table = JobTable()
-        task1 = asyncio.create_task(_make_failing_task())
-        task2 = asyncio.create_task(_make_successful_task())
-        table.submit(command="bad", task=task1, cwd="/")
-        table.submit(command="good", task=task2, cwd="/")
+        table.submit(command="bad", run=_failing_run, cwd="/")
+        table.submit(command="good", run=_successful_run, cwd="/")
         jobs = await table.wait_all()
         assert len(jobs) == 2
         bad = table.get(1)
@@ -68,12 +72,29 @@ def test_wait_successful_task():
 
     async def _run():
         table = JobTable()
-        task = asyncio.create_task(_make_successful_task())
-        table.submit(command="echo hello", task=task, cwd="/")
+        table.submit(command="echo hello", run=_successful_run, cwd="/")
         job = await table.wait(1)
         assert job.status == JobStatus.COMPLETED
         assert job.exit_code == 0
         assert job.stdout == b"hello"
+
+    asyncio.run(_run())
+
+
+def test_kill_keeps_output_produced_before_the_kill():
+
+    async def _run():
+        table = JobTable()
+        table.submit(command="noisy", run=_never_ending_run, cwd="/")
+        job = table.get(1)
+        while not job.stdout:
+            await asyncio.sleep(0.01)
+
+        table.kill(1)
+
+        assert job.status == JobStatus.KILLED
+        assert job.stdout == b"partial"
+        assert job.stderr == b"Killed"
 
     asyncio.run(_run())
 

--- a/python/tests/workspace/executor/test_jobs.py
+++ b/python/tests/workspace/executor/test_jobs.py
@@ -1,0 +1,94 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+import pytest
+
+from mirage.io.cachable_iterator import CachableAsyncIterator
+from mirage.shell.job_table import Job
+from mirage.workspace.executor.jobs import _drain_into
+
+
+def _job() -> Job:
+    return Job(id=1, command="stream", task=None, cwd="/")
+
+
+async def _yield_on_demand(gate: asyncio.Event):
+    yield b"first\n"
+    await gate.wait()
+    yield b"second\n"
+
+
+@pytest.mark.asyncio
+async def test_drain_into_appends_bytes():
+    job = _job()
+
+    await _drain_into(job, b"done\n")
+
+    assert job.stdout == b"done\n"
+
+
+@pytest.mark.asyncio
+async def test_drain_into_tolerates_no_output():
+    job = _job()
+
+    await _drain_into(job, None)
+
+    assert job.stdout == b""
+
+
+@pytest.mark.asyncio
+async def test_drain_into_appends_before_the_stream_ends():
+    """The point of the whole exercise: output is visible while running."""
+    job = _job()
+    gate = asyncio.Event()
+
+    task = asyncio.create_task(_drain_into(job, _yield_on_demand(gate)))
+    while not job.stdout:
+        await asyncio.sleep(0)
+
+    assert job.stdout == b"first\n"
+    assert not task.done()
+
+    gate.set()
+    await task
+    assert job.stdout == b"first\nsecond\n"
+
+
+@pytest.mark.asyncio
+async def test_drain_into_buffers_a_cachable_iterator():
+    """Iterating must drain the cache wrapper as materialize would."""
+    job = _job()
+    gate = asyncio.Event()
+    gate.set()
+    stream = CachableAsyncIterator(_yield_on_demand(gate))
+
+    await _drain_into(job, stream)
+
+    assert job.stdout == b"first\nsecond\n"
+    assert stream.exhausted
+    assert b"".join(stream.buffered_chunks) == b"first\nsecond\n"
+
+
+@pytest.mark.asyncio
+async def test_drain_into_consumes_the_stream_without_a_job():
+    """A command with no job table still runs for its side effects."""
+    gate = asyncio.Event()
+    gate.set()
+    stream = CachableAsyncIterator(_yield_on_demand(gate))
+
+    await _drain_into(None, stream)
+
+    assert stream.exhausted


### PR DESCRIPTION
Two independent changes to the agent-facing job and backend layers.

## 1. Canonical ops layer for agent backends

`mirage/agents/types.py` and `ops.py` hold one set of result types and one set of parsers. Each harness adapter becomes a thin field-mapper over them rather than carrying its own copy of the parsing (the two `_convert.py` files shrink by 70 lines).

Two protocols were only partly implemented and are now complete:

- **deepagents** `SandboxBackendProtocol` was missing `ls_info`, `glob_info` and `grep_raw` plus async variants. They are now projections of the existing Result-returning ops.
- **pydantic-ai** `BackgroundSandboxProtocol` was not implemented at all. `mirage/agents/background.py` wraps the workspace job table and adds the per-reader cursor the protocol requires, so `read_background` returns only what is new since the last call.

## 2. Background job output streams instead of arriving at exit

A background job materialized its whole stdout inside the task and returned it as the task result, which `JobTable._refresh` could only read through `task.result()`. That value does not exist until the task is done, so output was invisible for the entire run. Measured, for a job printing one line per second:

```
0.5s  running=True   new_stdout=''
2.5s  running=True   new_stdout=''
3.0s  running=False  new_stdout='tick-1\ntick-2\ntick-3\n'
```

The runner now drains the stream chunk by chunk into the job, so any command that streams is observable while it runs.

Known limitation, deliberately not addressed here: compound constructs (`for`, `while`, `;` lists) still batch, because they compute their output eagerly inside `execute_node` before yielding any of it. That is an executor-level change.

Three related fixes fall out:

- `JobTable.submit` takes a runner factory and creates the task itself, so the job exists before output can arrive. Creating the task first left a window where output had nowhere to go.
- `kill` appends its notice to stderr instead of overwriting it, which previously discarded everything the job had already printed.
- Detached tasks (no job table) are held in a set, since the event loop keeps only a weak reference and could otherwise collect them.

## Tests

New: `tests/agents/test_ops.py`, `tests/agents/test_background.py`, `tests/workspace/executor/test_jobs.py` (including a gate-based test that output is visible before the stream ends). Updated: the deepagents and pydantic-ai backend tests, and `tests/shell/test_background_jobs.py` for the runner-factory signature.

Python only; no TypeScript behavior changes.
