### PR TITLE
Release 0.0.4

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mirage-ai"
-version = "0.0.3"
+version = "0.0.4"
 description = "A unified virtual filesystem for AI agents. Mount S3, Google Drive, Slack, Gmail, GitHub, Linear, Notion, Postgres, MongoDB, SSH, and more behind one filesystem so agents read, write, and pipe across services with familiar shell commands."
 readme = "README.md"
 license = "Apache-2.0"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -4116,7 +4116,7 @@ wheels = [
 
 [[package]]
 name = "mirage-ai"
-version = "0.0.3"
+version = "0.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/typescript/packages/agents/package.json
+++ b/typescript/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-agents",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/browser/package.json
+++ b/typescript/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-browser",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/cli/package.json
+++ b/typescript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-cli",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-core",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/node/package.json
+++ b/typescript/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-node",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",

--- a/typescript/packages/server/package.json
+++ b/typescript/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@struktoai/mirage-server",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A Unified Virtual Filesystem For AI Agents",
   "keywords": [
     "bash",


### PR DESCRIPTION
Cut 0.0.4, mirroring the 0.0.3 release.

- Python: `python/pyproject.toml` 0.0.3 -> 0.0.4 (plus `uv.lock`). `mirage.__version__` reads package metadata, so no source edit is needed.
- TypeScript: agents, browser, cli, core, node, server package.json 0.0.3 -> 0.0.4. `opencode` stays at 0.0.0, as in the 0.0.3 cut.

`pre-commit run --all-files` passes.