### PR TITLE
feat: coreutils Tier 3 — df capacity command + statfs model (#609)

### DIFF
--- a/integ/unix/df/basic.json
+++ b/integ/unix/df/basic.json
@@ -1,0 +1,78 @@
+{
+  "cases": [
+    {
+      "id": "df_unknown",
+      "seq": 612001,
+      "targets": [
+        "ram"
+      ],
+      "command": "df /data",
+      "expect": {
+        "exit": 0,
+        "stdout": "Filesystem     1K-blocks Used Available Use% Mounted on\nram                    -    -         -    - /data\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "df_type",
+      "seq": 612002,
+      "targets": [
+        "ram"
+      ],
+      "command": "df -T /data",
+      "expect": {
+        "exit": 0,
+        "stdout": "Filesystem     Type 1K-blocks Used Available Use% Mounted on\nram            ram          -    -         -    - /data\n",
+        "stderr": ""
+      },
+      "flags": [
+        "T"
+      ]
+    },
+    {
+      "id": "df_inodes",
+      "seq": 612003,
+      "targets": [
+        "ram"
+      ],
+      "command": "df -i /data",
+      "expect": {
+        "exit": 0,
+        "stdout": "Filesystem     Inodes IUsed IFree IUse% Mounted on\nram                 -     -     -     - /data\n",
+        "stderr": ""
+      },
+      "flags": [
+        "i"
+      ]
+    },
+    {
+      "id": "df_posix",
+      "seq": 612004,
+      "targets": [
+        "ram"
+      ],
+      "command": "df -P /data",
+      "expect": {
+        "exit": 0,
+        "stdout": "Filesystem     1024-blocks Used Available Capacity Mounted on\nram                      -    -         -        - /data\n",
+        "stderr": ""
+      },
+      "flags": [
+        "P"
+      ]
+    },
+    {
+      "id": "df_invalid_option",
+      "seq": 612005,
+      "targets": [
+        "ram"
+      ],
+      "command": "df -z /data 2>&1",
+      "expect": {
+        "exit": 2,
+        "stdout": "df: invalid option -- 'z'\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/unix/df/basic.json
+++ b/integ/unix/df/basic.json
@@ -73,6 +73,71 @@
         "stdout": "df: invalid option -- 'z'\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "df_existing_file",
+      "seq": 612006,
+      "targets": [
+        "ram"
+      ],
+      "command": "df /data/one_byte.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "Filesystem     1K-blocks Used Available Use% Mounted on\nram                    -    -         -    - /data\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "df_missing_file",
+      "seq": 612007,
+      "targets": [
+        "ram"
+      ],
+      "command": "df /data/nonexistent 2>&1",
+      "expect": {
+        "exit": 1,
+        "stdout": "df: /data/nonexistent: No such file or directory\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "df_block_zero",
+      "seq": 612008,
+      "targets": [
+        "ram"
+      ],
+      "command": "df -B0 /data 2>&1",
+      "expect": {
+        "exit": 1,
+        "stdout": "df: invalid -B argument '0'\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "df_format_block_last",
+      "seq": 612009,
+      "targets": [
+        "ram"
+      ],
+      "command": "df -h -B1M /data",
+      "expect": {
+        "exit": 0,
+        "stdout": "Filesystem     1M-blocks Used Available Use% Mounted on\nram                    -    -         -    - /data\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "df_format_human_last",
+      "seq": 612010,
+      "targets": [
+        "ram"
+      ],
+      "command": "df -B1M -h /data",
+      "expect": {
+        "exit": 0,
+        "stdout": "Filesystem     Size Used Avail Use% Mounted on\nram               -    -     -    - /data\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/unix/numfmt/tier2.json
+++ b/integ/unix/numfmt/tier2.json
@@ -46,7 +46,7 @@
       "command": "printf '1000 foo\\n2000   bar baz\\n' | numfmt --to=si",
       "expect": {
         "exit": 0,
-        "stdout": "1K foo\n2K   bar baz\n",
+        "stdout": "1.0k foo\n2.0k   bar baz\n",
         "stderr": ""
       },
       "flags": [

--- a/python/mirage/commands/builtin/generic/numfmt.py
+++ b/python/mirage/commands/builtin/generic/numfmt.py
@@ -7,7 +7,7 @@ from mirage.io.types import ByteSource, IOResult
 
 _SUFFIX_ORDER = ("", "K", "M", "G", "T", "P", "E", "Z", "Y", "R", "Q")
 # SI spells kilo lowercase; every larger unit and all of IEC stay uppercase.
-_SI_DISPLAY = ("", "k", "M", "G", "T", "P", "E", "Z", "Y", "R", "Q")
+_SI_DISPLAY = ("", "k", *_SUFFIX_ORDER[2:])
 _FIRST_FIELD_RE = re.compile(r"(\s*)(\S+)([\s\S]*)")
 
 

--- a/python/mirage/commands/builtin/generic/numfmt.py
+++ b/python/mirage/commands/builtin/generic/numfmt.py
@@ -1,11 +1,13 @@
 import re
-from decimal import Decimal, InvalidOperation
+from decimal import ROUND_HALF_EVEN, ROUND_UP, Decimal, InvalidOperation
 
 from mirage.commands.builtin.utils.lines import split_lines
 from mirage.commands.builtin.utils.stream import _read_stdin_async
 from mirage.io.types import ByteSource, IOResult
 
-_SI_SUFFIXES = ("", "K", "M", "G", "T", "P", "E", "Z", "Y", "R", "Q")
+_SUFFIX_ORDER = ("", "K", "M", "G", "T", "P", "E", "Z", "Y", "R", "Q")
+# SI spells kilo lowercase; every larger unit and all of IEC stay uppercase.
+_SI_DISPLAY = ("", "k", "M", "G", "T", "P", "E", "Z", "Y", "R", "Q")
 _FIRST_FIELD_RE = re.compile(r"(\s*)(\S+)([\s\S]*)")
 
 
@@ -17,30 +19,49 @@ def _parse_number(value: str, from_mode: str) -> Decimal:
     suffix = match.group(2)
     if not suffix or from_mode == "none":
         return number
-    normalized = suffix.removesuffix("i").removesuffix("B")
-    if normalized not in _SI_SUFFIXES:
+    normalized = suffix.removesuffix("i").removesuffix("B").upper()
+    if normalized not in _SUFFIX_ORDER:
         raise InvalidOperation(value)
-    exponent = _SI_SUFFIXES.index(normalized)
+    exponent = _SUFFIX_ORDER.index(normalized)
     base = 1000 if from_mode == "si" else 1024
     return number * (Decimal(base)**exponent)
 
 
 def _format_number(number: Decimal, to_mode: str, grouping: bool) -> str:
-    suffix = ""
-    if to_mode != "none":
-        base = Decimal(1000 if to_mode == "si" else 1024)
-        exponent = 0
-        while abs(number) >= base and exponent < len(_SI_SUFFIXES) - 1:
-            number /= base
-            exponent += 1
-        suffix = _SI_SUFFIXES[exponent]
-        if to_mode == "iec-i" and exponent:
-            suffix += "i"
-    rounded = number.quantize(
-        Decimal("1")) if number == number.to_integral() else number.quantize(
-            Decimal("0.1"))
-    text = format(rounded, ",f" if grouping else "f")
-    return text + suffix
+    """Render a value the way GNU numfmt does for the given --to mode.
+
+    GNU rounds away from zero, keeping one decimal only while the scaled
+    value is below 10. That rounding can push a value back over the base
+    (999.4 -> 1000 -> 1.0k), so the unit is re-checked afterwards. The final
+    render goes through printf, which rounds half-even, which is why an
+    unscaled 2.5 prints as 2.
+
+    Args:
+        number (Decimal): Value to render, already --from scaled.
+        to_mode (str): One of ``none``, ``si``, ``iec`` or ``iec-i``.
+        grouping (bool): Whether to group thousands.
+    """
+    if to_mode == "none":
+        return format(number.normalize(), ",f" if grouping else "f")
+    base = Decimal(1000 if to_mode == "si" else 1024)
+    display = _SI_DISPLAY if to_mode == "si" else _SUFFIX_ORDER
+    power = 0
+    while abs(number) >= base and power < len(display) - 1:
+        number /= base
+        power += 1
+    step = Decimal("0.1") if abs(number) < 10 else Decimal(1)
+    number = number.quantize(step, rounding=ROUND_UP)
+    if abs(number) >= base and power < len(display) - 1:
+        number /= base
+        power += 1
+    places = 1 if power and abs(number) < 10 else 0
+    number = number.quantize(Decimal(1).scaleb(-places),
+                             rounding=ROUND_HALF_EVEN)
+    suffix = display[power]
+    if to_mode == "iec-i" and power:
+        suffix += "i"
+    spec = f",.{places}f" if grouping else f".{places}f"
+    return format(number, spec) + suffix
 
 
 def _convert_field(value: str, to_mode: str, from_mode: str, suffix: str,

--- a/python/mirage/commands/spec/builtin_specs/listing.py
+++ b/python/mirage/commands/spec/builtin_specs/listing.py
@@ -120,6 +120,20 @@ SPECS: dict[str,
                     ),
                     rest=Operand(kind=OperandKind.PATH),
                 ),
+                'df':
+                CommandSpec(
+                    options=(
+                        Option(short="-h"),
+                        Option(short="-H"),
+                        Option(short="-k"),
+                        Option(short="-i"),
+                        Option(short="-a"),
+                        Option(short="-T"),
+                        Option(short="-P"),
+                        Option(short="-B", value_kind=OperandKind.TEXT),
+                    ),
+                    rest=Operand(kind=OperandKind.PATH),
+                ),
                 'file':
                 CommandSpec(
                     options=(

--- a/python/mirage/commands/spec/builtin_specs/viewing.py
+++ b/python/mirage/commands/spec/builtin_specs/viewing.py
@@ -183,6 +183,6 @@ SPECS: dict[str, CommandSpec] = {
                    value_kind=OperandKind.TEXT,
                    repeatable=True),
         ),
-        positional=(Operand(kind=OperandKind.PATH), ),
+        rest=Operand(kind=OperandKind.PATH),
     ),
 }

--- a/python/mirage/resource/base.py
+++ b/python/mirage/resource/base.py
@@ -23,7 +23,7 @@ from mirage.cache.index import (IndexCacheStore, IndexConfig,
 from mirage.commands.config import RegisteredCommand
 from mirage.ops.registry import RegisteredOp
 from mirage.resource.secrets import redacted_config_dump
-from mirage.types import PathSpec
+from mirage.types import CapacityResult, CapacityState, PathSpec
 
 try:
     from mirage.cache.index import RedisIndexCacheStore
@@ -87,6 +87,15 @@ class BaseResource:
                            paths: list[str | PathSpec],
                            prefix: str = "") -> list[PathSpec]:
         raise NotImplementedError
+
+    async def statfs(self) -> CapacityResult:
+        """Capacity of this backend for df. Default: UNKNOWN (rendered as
+        ``-``). Backends that can report truthfully — a real filesystem, or
+        a provider that exposes a storage quota — override this. Never
+        fabricate a number: report QUOTA only with real values, else
+        ELASTIC/NA/UNKNOWN.
+        """
+        return CapacityResult(state=CapacityState.UNKNOWN)
 
     def __getattr__(self, name: str) -> Any:
         fn = type(self)._ops.get(name)

--- a/python/mirage/resource/disk/disk.py
+++ b/python/mirage/resource/disk/disk.py
@@ -37,7 +37,7 @@ from mirage.core.disk.write import write_bytes
 from mirage.ops.disk import OPS as DISK_OPS
 from mirage.resource.base import BaseResource
 from mirage.resource.disk.prompt import PROMPT
-from mirage.types import PathSpec, ResourceName
+from mirage.types import CapacityResult, CapacityState, PathSpec, ResourceName
 from mirage.utils.glob_walk import make_resolve_glob
 from mirage.utils.key_prefix import mount_key
 
@@ -86,6 +86,22 @@ class DiskResource(BaseResource):
                 if isinstance(p, PathSpec) else p for p in paths
             ]
         return await _resolve_glob(self.accessor, paths, self._index)
+
+    async def statfs(self) -> CapacityResult:
+        # A real filesystem reports real numbers (QUOTA). GNU df: used counts
+        # reserved blocks (f_blocks - f_bfree), available excludes them
+        # (f_bavail); both scaled by the fundamental block size.
+        st = os.statvfs(self.root)
+        frsize = st.f_frsize or st.f_bsize
+        return CapacityResult(
+            state=CapacityState.QUOTA,
+            total=st.f_blocks * frsize,
+            used=(st.f_blocks - st.f_bfree) * frsize,
+            available=st.f_bavail * frsize,
+            inodes=st.f_files,
+            inodes_used=st.f_files - st.f_ffree,
+            inodes_free=st.f_favail,
+        )
 
     def get_state(self) -> dict[str, Any]:
         files: dict[str, bytes] = {}

--- a/python/mirage/types.py
+++ b/python/mirage/types.py
@@ -104,6 +104,46 @@ ReaddirFn: TypeAlias = Callable[..., Awaitable[list[str]]]
 StatFn: TypeAlias = Callable[..., Awaitable["FileStat"]]
 
 
+class CapacityState(StrEnum):
+    """How a mount's capacity relates to a df-style report.
+
+    QUOTA: real total/used/available numbers are known (a real disk, or a
+    provider that exposes a storage quota). ELASTIC: the backend has no
+    fixed size (object stores like S3 grow without a quota). NA: the
+    backend has no filesystem-capacity concept (a message/table surface
+    like Slack or Postgres). UNKNOWN: bounded but not cheaply measurable,
+    or simply not reported yet. df renders real numbers for QUOTA and a
+    literal ``-`` for the rest — never a fabricated total.
+    """
+    QUOTA = "quota"
+    ELASTIC = "elastic"
+    NA = "na"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class CapacityResult:
+    """One mount's capacity for df. All byte counts are None unless the
+    state is QUOTA.
+
+    Args:
+        state (CapacityState): how to interpret the numbers.
+        total (int | None): total bytes.
+        used (int | None): used bytes.
+        available (int | None): bytes available to the workspace user.
+        inodes (int | None): total inodes.
+        inodes_used (int | None): used inodes.
+        inodes_free (int | None): free inodes.
+    """
+    state: CapacityState
+    total: int | None = None
+    used: int | None = None
+    available: int | None = None
+    inodes: int | None = None
+    inodes_used: int | None = None
+    inodes_free: int | None = None
+
+
 @dataclass(frozen=True, slots=True)
 class NativeCopy:
     copy: CopyFn

--- a/python/mirage/workspace/executor/builtins/__init__.py
+++ b/python/mirage/workspace/executor/builtins/__init__.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from mirage.workspace.executor.builtins.capacity import handle_df
 from mirage.workspace.executor.builtins.command import (handle_command_builtin,
                                                         handle_type)
 from mirage.workspace.executor.builtins.condition import handle_test
@@ -67,6 +68,7 @@ __all__ = [
     'handle_readlink',
     'link_flags',
     'follow_paths',
+    'handle_df',
     'handle_chgrp',
     'handle_chmod',
     'handle_chown',

--- a/python/mirage/workspace/executor/builtins/capacity.py
+++ b/python/mirage/workspace/executor/builtins/capacity.py
@@ -13,11 +13,13 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import math
+from typing import Any, Callable
 
 from mirage.commands.builtin.utils.formatting import _human_size
 from mirage.types import CapacityResult, CapacityState, PathSpec
 from mirage.utils.path import resolve_path
 from mirage.workspace.executor.builtins.shared import (Result, fail, ok,
+                                                       operand_text,
                                                        split_value_flags)
 from mirage.workspace.mount.mount import MountEntry
 from mirage.workspace.mount.registry import MountRegistry
@@ -44,10 +46,44 @@ def _parse_block(text: str) -> tuple[int, str] | None:
         head = t[:-1] or "1"
         if not head.isdigit():
             return None
-        return int(head) * _BLOCK_SUFFIX[suffix], t
-    if not t.isdigit():
+        value = int(head) * _BLOCK_SUFFIX[suffix]
+    elif t.isdigit():
+        value = int(t)
+    else:
         return None
-    return int(t), t
+    # GNU rejects a zero (or non-positive) block size rather than scaling.
+    if value <= 0:
+        return None
+    return value, t
+
+
+def _last_format(args: list[str | PathSpec]) -> str | None:
+    """The last size-format flag (-h/-H/-k/-B) in the leading option run.
+
+    GNU df lets a later size flag override the earlier ones (``df -h -B1M``
+    prints a block header, ``df -B1M -h`` prints ``Size``), so the display
+    format is whichever of these appears last rather than a fixed
+    precedence. Returns the flag letter, or None when none are present.
+
+    Args:
+        args (list[str | PathSpec]): args after the command name.
+    """
+    last: str | None = None
+    i = 0
+    while i < len(args):
+        s = operand_text(args[i])
+        if s == "--" or not (len(s) >= 2 and s[0] == "-" and s[1] != "-"):
+            break
+        body = s[1:]
+        for j, c in enumerate(body):
+            if c in "hHkB":
+                last = c
+            if c == "B":
+                if not body[j + 1:]:
+                    i += 1
+                break
+        i += 1
+    return last
 
 
 def _human_si(n: int) -> str:
@@ -143,16 +179,36 @@ def _pct_cell(cap: CapacityResult, inodes: bool) -> str:
     return _use_pct(cap.used or 0, cap.available or 0)
 
 
-def _target_mounts(registry: MountRegistry, session: Session,
-                   operands: list[str | PathSpec]) -> list[MountEntry]:
+async def _path_exists(dispatch: Callable[..., Any], spec: PathSpec) -> bool:
+    """Whether a path resolves to an existing entry.
+
+    GNU df errors on a missing FILE operand, so a deeper path is statted
+    before its mount is accepted; a missing entry maps to False.
+
+    Args:
+        dispatch (Callable): op dispatcher.
+        spec (PathSpec): the operand to stat.
+    """
+    try:
+        await dispatch("stat", spec)
+    except FileNotFoundError:
+        return False
+    return True
+
+
+async def _target_mounts(registry: MountRegistry, dispatch: Callable[..., Any],
+                         session: Session,
+                         operands: list[str | PathSpec]) -> list[MountEntry]:
     """Resolve df operands to the mounts to report, deduped and ordered.
 
     No operand (or the workspace root ``/``) reports every mount; a path
-    operand reports the mount that contains it. Mirrors GNU df, which maps
-    each FILE to its filesystem and lists all filesystems with no args.
+    operand reports the mount that contains it, and a missing FILE raises
+    ``FileNotFoundError`` carrying the operand as typed. Mirrors GNU df,
+    which maps each FILE to its filesystem and lists all with no args.
 
     Args:
         registry (MountRegistry): mount registry.
+        dispatch (Callable): op dispatcher (FILE existence check).
         session (Session): session providing cwd for relative operands.
         operands (list[str | PathSpec]): path operands.
     """
@@ -162,15 +218,28 @@ def _target_mounts(registry: MountRegistry, session: Session,
     seen: set[str] = set()
     out: list[MountEntry] = []
     for op in operands:
-        virtual = (op.virtual if isinstance(op, PathSpec) else resolve_path(
-            str(op), session.cwd))
+        if isinstance(op, PathSpec):
+            virtual, label, spec = op.virtual, op.raw_path, op
+        else:
+            virtual = resolve_path(str(op), session.cwd)
+            label, spec = str(op), PathSpec.from_str_path(virtual)
         if virtual in ("", "/"):
             for m in ordered:
                 if m.prefix not in seen:
                     seen.add(m.prefix)
                     out.append(m)
             continue
-        mount = registry.mount_for(virtual)
+        try:
+            mount = registry.mount_for(virtual)
+        except (KeyError, ValueError, FileNotFoundError):
+            raise FileNotFoundError(label) from None
+        # GNU df maps each FILE to its filesystem and errors on a missing
+        # one. The mount root is the filesystem itself (always present); a
+        # deeper path must exist, so stat it before accepting the mount.
+        root = mount.prefix.rstrip("/") or "/"
+        if virtual.rstrip("/") != root and not await _path_exists(
+                dispatch, spec):
+            raise FileNotFoundError(label)
         if mount.prefix not in seen:
             seen.add(mount.prefix)
             out.append(mount)
@@ -214,6 +283,7 @@ def _render_table(header: list[str], rows: list[list[str]],
 async def handle_df(
     registry: MountRegistry,
     session: Session,
+    dispatch: Callable[..., Any],
     args: list[str | PathSpec],
 ) -> Result:
     """df [OPTION]... [FILE]...: report per-mount capacity.
@@ -227,6 +297,7 @@ async def handle_df(
     Args:
         registry (MountRegistry): mount registry (mount enumeration).
         session (Session): session providing cwd for relative operands.
+        dispatch (Callable): op dispatcher (FILE existence check).
         args (list[str | PathSpec]): args after the command name.
     """
     flags, values, operands, bad = split_value_flags(args, "hHkiaTP", "B")
@@ -234,28 +305,30 @@ async def handle_df(
         return fail("df", f"df: invalid option -- '{bad}'\n", 2)
 
     posix = "P" in flags
-    block = 1024
-    block_label = "1024-blocks" if posix else "1K-blocks"
+    b_parsed = None
     if "B" in values:
-        parsed = _parse_block(values["B"])
-        if parsed is None:
-            return fail(
-                "df", f"df: invalid --block-size argument '{values['B']}'\n",
-                1)
-        block, block_label = parsed[0], f"{parsed[1]}-blocks"
+        b_parsed = _parse_block(values["B"])
+        if b_parsed is None:
+            return fail("df", f"df: invalid -B argument '{values['B']}'\n", 1)
 
-    si = "H" in flags
-    human = si or "h" in flags
+    # GNU resolves the mutually overriding size flags last-wins, so -h/-H
+    # (human) or -k/-B (block) is chosen by whichever appears last.
+    last_fmt = _last_format(args)
+    si = last_fmt == "H"
+    human = last_fmt in ("h", "H")
+    if last_fmt == "B" and b_parsed is not None:
+        block, block_label = b_parsed[0], f"{b_parsed[1]}-blocks"
+    else:
+        block = 1024
+        block_label = "1024-blocks" if posix else "1K-blocks"
+
     inodes = "i" in flags
     show_type = "T" in flags
 
     try:
-        mounts = _target_mounts(registry, session, operands)
-    except (FileNotFoundError, KeyError, ValueError):
-        target = operands[0] if operands else ""
-        label = target.raw_path if isinstance(target,
-                                              PathSpec) else str(target)
-        return fail("df", f"df: {label}: No such file or directory\n", 1)
+        mounts = await _target_mounts(registry, dispatch, session, operands)
+    except FileNotFoundError as exc:
+        return fail("df", f"df: {exc}: No such file or directory\n", 1)
 
     if inodes:
         num_headers = ["Inodes", "IUsed", "IFree"]

--- a/python/mirage/workspace/executor/builtins/capacity.py
+++ b/python/mirage/workspace/executor/builtins/capacity.py
@@ -1,0 +1,289 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import math
+
+from mirage.commands.builtin.utils.formatting import _human_size
+from mirage.types import CapacityResult, CapacityState, PathSpec
+from mirage.utils.path import resolve_path
+from mirage.workspace.executor.builtins.shared import (Result, fail, ok,
+                                                       split_value_flags)
+from mirage.workspace.mount.mount import MountEntry
+from mirage.workspace.mount.registry import MountRegistry
+from mirage.workspace.session import Session
+
+_BLOCK_SUFFIX = {"K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
+_SI_UNITS = ("B", "K", "M", "G", "T")
+
+
+def _parse_block(text: str) -> tuple[int, str] | None:
+    """Parse a -B/--block-size argument into (bytes, header-label).
+
+    Accepts a plain byte count or a 1024-based suffix (K/M/G/T), the way
+    GNU labels the column after the raw argument (``-B1M`` -> ``1M-blocks``).
+
+    Args:
+        text (str): the -B argument as typed.
+    """
+    t = text.strip()
+    if not t:
+        return None
+    suffix = t[-1].upper()
+    if suffix in _BLOCK_SUFFIX:
+        head = t[:-1] or "1"
+        if not head.isdigit():
+            return None
+        return int(head) * _BLOCK_SUFFIX[suffix], t
+    if not t.isdigit():
+        return None
+    return int(t), t
+
+
+def _human_si(n: int) -> str:
+    """Human-readable size in powers of 1000 (df -H), mirroring the 1024
+    ``_human_size`` shape used by df -h / du -h.
+
+    Args:
+        n (int): byte count.
+    """
+    value = float(n)
+    i = 0
+    while value >= 1000 and i < len(_SI_UNITS) - 1:
+        value /= 1000
+        i += 1
+    text = str(round(value)) if i == 0 else f"{value:.1f}"
+    return f"{text}{_SI_UNITS[i]}"
+
+
+def _scale(nbytes: int, block: int) -> str:
+    """Bytes as a count of ``block``-byte units, rounded up like GNU df.
+
+    Args:
+        nbytes (int): byte count.
+        block (int): block size in bytes.
+    """
+    return str(-(-nbytes // block))
+
+
+def _use_pct(used: int, avail: int) -> str:
+    """GNU df use-percent: ceil(used / (used + avail) * 100), or ``-`` when
+    the denominator is zero.
+
+    Args:
+        used (int): used bytes.
+        avail (int): available bytes.
+    """
+    denom = used + avail
+    if denom <= 0:
+        return "-"
+    return f"{math.ceil(used * 100 / denom)}%"
+
+
+def _num_cells(cap: CapacityResult, human: bool, si: bool, block: int,
+               inodes: bool) -> list[str]:
+    """The three numeric cells (block or inode) for one mount, or three
+    ``-`` when capacity is not a known quota (never a fabricated 0).
+
+    Args:
+        cap (CapacityResult): the mount's capacity.
+        human (bool): -h/-H human-readable sizes.
+        si (bool): -H (powers of 1000) rather than -h (1024).
+        block (int): block size in bytes for the non-human form.
+        inodes (bool): -i inode columns instead of block columns.
+    """
+    quota = cap.state == CapacityState.QUOTA
+    if inodes:
+        if quota and cap.inodes is not None:
+            return [
+                str(cap.inodes),
+                str(cap.inodes_used if cap.inodes_used is not None else 0),
+                str(cap.inodes_free if cap.inodes_free is not None else 0),
+            ]
+        return ["-", "-", "-"]
+    if quota and cap.total is not None:
+        used = cap.used or 0
+        avail = cap.available or 0
+        if human:
+            fmt = _human_si if si else _human_size
+            return [fmt(cap.total), fmt(used), fmt(avail)]
+        return [
+            _scale(cap.total, block),
+            _scale(used, block),
+            _scale(avail, block)
+        ]
+    return ["-", "-", "-"]
+
+
+def _pct_cell(cap: CapacityResult, inodes: bool) -> str:
+    """The Use%/IUse% cell for one mount, or ``-`` outside a known quota.
+
+    Args:
+        cap (CapacityResult): the mount's capacity.
+        inodes (bool): -i inode mode (percent over inodes).
+    """
+    if cap.state != CapacityState.QUOTA:
+        return "-"
+    if inodes:
+        if cap.inodes is None:
+            return "-"
+        return _use_pct(cap.inodes_used or 0, cap.inodes_free or 0)
+    if cap.total is None:
+        return "-"
+    return _use_pct(cap.used or 0, cap.available or 0)
+
+
+def _target_mounts(registry: MountRegistry, session: Session,
+                   operands: list[str | PathSpec]) -> list[MountEntry]:
+    """Resolve df operands to the mounts to report, deduped and ordered.
+
+    No operand (or the workspace root ``/``) reports every mount; a path
+    operand reports the mount that contains it. Mirrors GNU df, which maps
+    each FILE to its filesystem and lists all filesystems with no args.
+
+    Args:
+        registry (MountRegistry): mount registry.
+        session (Session): session providing cwd for relative operands.
+        operands (list[str | PathSpec]): path operands.
+    """
+    ordered = sorted(registry.mounts(), key=lambda m: m.prefix)
+    if not operands:
+        return ordered
+    seen: set[str] = set()
+    out: list[MountEntry] = []
+    for op in operands:
+        virtual = (op.virtual if isinstance(op, PathSpec) else resolve_path(
+            str(op), session.cwd))
+        if virtual in ("", "/"):
+            for m in ordered:
+                if m.prefix not in seen:
+                    seen.add(m.prefix)
+                    out.append(m)
+            continue
+        mount = registry.mount_for(virtual)
+        if mount.prefix not in seen:
+            seen.add(mount.prefix)
+            out.append(mount)
+    return out
+
+
+def _render_table(header: list[str], rows: list[list[str]],
+                  show_type: bool) -> str:
+    """GNU df column layout: Filesystem left-justified (min width 14), Type
+    (when present) left, numeric columns right-justified, Mounted on left
+    with no trailing pad, single-space separators.
+
+    Args:
+        header (list[str]): column headers.
+        rows (list[list[str]]): one list of cells per mount.
+        show_type (bool): whether column 1 is the Type column (left).
+    """
+    ncols = len(header)
+    left = {0, ncols - 1}
+    if show_type:
+        left.add(1)
+    widths = [
+        max(len(header[c]), max((len(r[c]) for r in rows), default=0))
+        for c in range(ncols)
+    ]
+    widths[0] = max(widths[0], 14)
+    lines: list[str] = []
+    for cells in [header, *rows]:
+        parts: list[str] = []
+        for c in range(ncols):
+            if c == ncols - 1:
+                parts.append(cells[c])
+            elif c in left:
+                parts.append(cells[c].ljust(widths[c]))
+            else:
+                parts.append(cells[c].rjust(widths[c]))
+        lines.append(" ".join(parts))
+    return "\n".join(lines) + "\n"
+
+
+async def handle_df(
+    registry: MountRegistry,
+    session: Session,
+    args: list[str | PathSpec],
+) -> Result:
+    """df [OPTION]... [FILE]...: report per-mount capacity.
+
+    A mount reports real numbers only when its backend can (a real
+    filesystem, or a provider exposing a quota); every other backend shows
+    ``-`` rather than a fabricated total. Flags: -h/-H human sizes, -k/-B
+    block size, -T backend type column, -i inodes, -P POSIX header, -a
+    accepted no-op (mirage has no pseudo/duplicate mounts to hide).
+
+    Args:
+        registry (MountRegistry): mount registry (mount enumeration).
+        session (Session): session providing cwd for relative operands.
+        args (list[str | PathSpec]): args after the command name.
+    """
+    flags, values, operands, bad = split_value_flags(args, "hHkiaTP", "B")
+    if bad is not None:
+        return fail("df", f"df: invalid option -- '{bad}'\n", 2)
+
+    posix = "P" in flags
+    block = 1024
+    block_label = "1024-blocks" if posix else "1K-blocks"
+    if "B" in values:
+        parsed = _parse_block(values["B"])
+        if parsed is None:
+            return fail(
+                "df", f"df: invalid --block-size argument '{values['B']}'\n",
+                1)
+        block, block_label = parsed[0], f"{parsed[1]}-blocks"
+
+    si = "H" in flags
+    human = si or "h" in flags
+    inodes = "i" in flags
+    show_type = "T" in flags
+
+    try:
+        mounts = _target_mounts(registry, session, operands)
+    except (FileNotFoundError, KeyError, ValueError):
+        target = operands[0] if operands else ""
+        label = target.raw_path if isinstance(target,
+                                              PathSpec) else str(target)
+        return fail("df", f"df: {label}: No such file or directory\n", 1)
+
+    if inodes:
+        num_headers = ["Inodes", "IUsed", "IFree"]
+        pct_header = "IUse%"
+    elif human:
+        num_headers = ["Size", "Used", "Avail"]
+        pct_header = "Use%"
+    else:
+        num_headers = [block_label, "Used", "Available"]
+        pct_header = "Capacity" if posix else "Use%"
+
+    header = ["Filesystem"]
+    if show_type:
+        header.append("Type")
+    header += num_headers + [pct_header, "Mounted on"]
+
+    data: list[list[str]] = []
+    for mount in mounts:
+        cap = await mount.resource.statfs()
+        cells = [mount.resource.name]
+        if show_type:
+            cells.append(mount.resource.name)
+        cells += _num_cells(cap, human, si, block, inodes)
+        cells.append(_pct_cell(cap, inodes))
+        cells.append(mount.prefix.rstrip("/") or "/")
+        data.append(cells)
+
+    return ok("df", _render_table(header, data, show_type).encode())
+
+
+__all__ = ["handle_df"]

--- a/python/mirage/workspace/node/command_dispatch.py
+++ b/python/mirage/workspace/node/command_dispatch.py
@@ -39,13 +39,13 @@ from mirage.shell.helpers import (  # isort: skip
     get_process_sub_direction, get_text, split_env_prefix)
 from mirage.workspace.executor.builtins import (  # isort: skip
     follow_paths, handle_bash, handle_cd, handle_chgrp, handle_chmod,
-    handle_chown, handle_command_builtin, handle_echo, handle_env, handle_eval,
-    handle_exit, handle_export, handle_getopts, handle_history, handle_ln,
-    handle_local, handle_man, handle_printenv, handle_printf, handle_read,
-    handle_readlink, handle_return, handle_set, handle_shift, handle_sleep,
-    handle_source, handle_test, handle_timeout, handle_touch, handle_trap,
-    handle_type, handle_unset, handle_whoami, handle_xargs, link_flags,
-    prepare_mv, strip_link_operands)
+    handle_chown, handle_command_builtin, handle_df, handle_echo, handle_env,
+    handle_eval, handle_exit, handle_export, handle_getopts, handle_history,
+    handle_ln, handle_local, handle_man, handle_printenv, handle_printf,
+    handle_read, handle_readlink, handle_return, handle_set, handle_shift,
+    handle_sleep, handle_source, handle_test, handle_timeout, handle_touch,
+    handle_trap, handle_type, handle_unset, handle_whoami, handle_xargs,
+    link_flags, prepare_mv, strip_link_operands)
 
 _CdArgs = list[str | PathSpec]
 
@@ -470,6 +470,11 @@ async def _run_argv(
         return await handle_chgrp(namespace, dispatch, operands)
     if name == "touch":
         return await handle_touch(namespace, dispatch, session, operands)
+
+    # ── capacity (registry-routed: enumerates mounts, reports per-mount
+    #    statfs; never fabricates numbers) ──
+    if name == "df":
+        return await handle_df(registry, session, operands)
 
     # ── symlink-aware dispatch: reads follow links (open(2)); rm/mv act
     #    on the link entry itself (lstat semantics) ──

--- a/python/mirage/workspace/node/command_dispatch.py
+++ b/python/mirage/workspace/node/command_dispatch.py
@@ -474,7 +474,17 @@ async def _run_argv(
     # ── capacity (registry-routed: enumerates mounts, reports per-mount
     #    statfs; never fabricates numbers) ──
     if name == "df":
-        return await handle_df(registry, session, operands)
+        if namespace.nodes:
+            try:
+                operands = follow_paths(namespace, operands)
+            except CycleError as exc:
+                err = (f"df: {exc}: "
+                       f"Too many levels of symbolic links\n").encode()
+                return None, IOResult(exit_code=1,
+                                      stderr=err), ExecutionNode(command="df",
+                                                                 exit_code=1,
+                                                                 stderr=err)
+        return await handle_df(registry, session, dispatch, operands)
 
     # ── symlink-aware dispatch: reads follow links (open(2)); rm/mv act
     #    on the link entry itself (lstat semantics) ──

--- a/python/tests/commands/native/test_numfmt.py
+++ b/python/tests/commands/native/test_numfmt.py
@@ -14,7 +14,7 @@
 
 
 def test_numfmt_scales_to_and_from_units(env):
-    assert env.mirage("numfmt --to=si 1000") == "1K\n"
+    assert env.mirage("numfmt --to=si 1000") == "1.0k\n"
     assert env.mirage("numfmt --from=iec-i 1Ki") == "1024\n"
 
 

--- a/python/tests/commands/test_spec.py
+++ b/python/tests/commands/test_spec.py
@@ -205,6 +205,7 @@ def test_all_commands_have_specs():
         "find",
         "tree",
         "du",
+        "df",
         "cat",
         "head",
         "tail",

--- a/python/tests/workspace/executor/builtins/test_capacity.py
+++ b/python/tests/workspace/executor/builtins/test_capacity.py
@@ -159,3 +159,55 @@ async def test_disk_statfs_real_quota(tmp_path):
     assert cap.total and cap.total > 0
     assert cap.available is not None and cap.available >= 0
     assert cap.inodes and cap.inodes > 0
+
+
+@pytest.mark.asyncio
+async def test_df_rejects_zero_block_size():
+    # GNU df rejects -B0 with a CLI error rather than dividing by zero.
+    ws = _ws()
+    code, out = await _run(ws, "df -B0 /q")
+    assert code == 1
+    assert out == ""
+    err = await (await ws.execute("df -B0 /q")).stderr_str()
+    assert err == "df: invalid -B argument '0'\n"
+
+
+@pytest.mark.asyncio
+async def test_df_last_size_format_wins():
+    # -h/-H/-k/-B are mutually overriding; GNU lets the last one win.
+    ws = _ws()
+    _, hb = await _run(ws, "df -h -B1M /q")
+    assert hb.splitlines()[0].split()[1] == "1M-blocks"
+    _, bh = await _run(ws, "df -B1M -h /q")
+    assert bh.splitlines()[0].split()[1] == "Size"
+    _, hk = await _run(ws, "df -h -k /q")
+    assert hk.splitlines()[0].split()[1] == "1K-blocks"
+    _, kh = await _run(ws, "df -k -h /q")
+    assert kh.splitlines()[0].split()[1] == "Size"
+
+
+@pytest.mark.asyncio
+async def test_df_missing_file_operand_errors():
+    # GNU df errors on a missing FILE; an existing path (and the mount root)
+    # report normally.
+    ws = _ws()
+    await ws.execute("mkdir -p /mem/sub")
+    await ws.execute("sh -c 'echo hi > /mem/sub/f.txt'")
+    assert (await _run(ws, "df /mem/sub/f.txt"))[0] == 0
+    assert (await _run(ws, "df /mem"))[0] == 0
+    code, out = await _run(ws, "df /mem/missing")
+    assert code == 1
+    assert out == ""
+    err = await (await ws.execute("df /mem/missing")).stderr_str()
+    assert err == "df: /mem/missing: No such file or directory\n"
+
+
+@pytest.mark.asyncio
+async def test_df_follows_symlink_to_target_mount():
+    # GNU df follows a FILE operand, so a symlink reports the mount of its
+    # target, not the mount holding the link.
+    ws = _ws()
+    await ws.execute("ln -s /q /mem/link")
+    code, out = await _run(ws, "df /mem/link")
+    assert code == 0
+    assert out.splitlines()[-1].split()[-1] == "/q"

--- a/python/tests/workspace/executor/builtins/test_capacity.py
+++ b/python/tests/workspace/executor/builtins/test_capacity.py
@@ -1,0 +1,161 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+"""df coverage: honest per-mount capacity.
+
+A backend reports real numbers only when it can (disk statvfs, or a
+provider quota); everything else renders ``-`` rather than a fabricated
+total. Numbers here come from a fixed-quota stub so the output is
+deterministic (real disk free space is machine-specific).
+"""
+import pytest
+
+from mirage.resource.disk import DiskResource
+from mirage.resource.ram import RAMResource
+from mirage.types import CapacityResult, CapacityState, MountMode
+from mirage.workspace import Workspace
+
+
+class _QuotaResource(RAMResource):
+    """RAM backend that reports a fixed quota, standing in for a real
+    filesystem / a provider that exposes storage numbers."""
+
+    name = "quota"
+
+    async def statfs(self) -> CapacityResult:
+        return CapacityResult(
+            state=CapacityState.QUOTA,
+            total=1024000,
+            used=409600,
+            available=614400,
+            inodes=1000,
+            inodes_used=100,
+            inodes_free=900,
+        )
+
+
+def _ws() -> Workspace:
+    return Workspace(
+        {
+            "/mem": (RAMResource(), MountMode.WRITE),
+            "/q": (_QuotaResource(), MountMode.WRITE),
+        },
+        mode=MountMode.WRITE,
+    )
+
+
+async def _run(ws: Workspace, cmd: str) -> tuple[int, str]:
+    r = await ws.execute(cmd)
+    return r.exit_code, await r.stdout_str()
+
+
+def test_capacity_default_state_is_unknown():
+    import asyncio
+    cap = asyncio.run(RAMResource().statfs())
+    assert cap.state == CapacityState.UNKNOWN
+    assert cap.total is None
+
+
+@pytest.mark.asyncio
+async def test_df_unknown_backend_renders_dashes():
+    ws = _ws()
+    code, out = await _run(ws, "df /mem")
+    assert code == 0
+    assert out == ("Filesystem     1K-blocks Used Available Use% Mounted on\n"
+                   "ram                    -    -         -    - /mem\n")
+
+
+@pytest.mark.asyncio
+async def test_df_quota_backend_reports_real_numbers():
+    ws = _ws()
+    code, out = await _run(ws, "df /q")
+    assert code == 0
+    lines = out.splitlines()
+    assert lines[0].split() == [
+        "Filesystem", "1K-blocks", "Used", "Available", "Use%", "Mounted", "on"
+    ]
+    assert lines[1].split() == ["quota", "1000", "400", "600", "40%", "/q"]
+
+
+@pytest.mark.asyncio
+async def test_df_type_column():
+    ws = _ws()
+    code, out = await _run(ws, "df -T /q")
+    assert code == 0
+    assert out.splitlines()[0].split()[:2] == ["Filesystem", "Type"]
+    assert out.splitlines()[1].split()[:2] == ["quota", "quota"]
+
+
+@pytest.mark.asyncio
+async def test_df_inodes():
+    ws = _ws()
+    code, out = await _run(ws, "df -i /q")
+    assert code == 0
+    assert out.splitlines()[0].split() == [
+        "Filesystem", "Inodes", "IUsed", "IFree", "IUse%", "Mounted", "on"
+    ]
+    assert out.splitlines()[1].split() == [
+        "quota", "1000", "100", "900", "10%", "/q"
+    ]
+    # unknown backend: inode columns are dashes too
+    _, out2 = await _run(ws, "df -i /mem")
+    assert out2.splitlines()[1].split() == ["ram", "-", "-", "-", "-", "/mem"]
+
+
+@pytest.mark.asyncio
+async def test_df_posix_and_block_size_headers():
+    ws = _ws()
+    _, posix = await _run(ws, "df -P /q")
+    assert posix.splitlines()[0].split()[1:] == [
+        "1024-blocks", "Used", "Available", "Capacity", "Mounted", "on"
+    ]
+    _, block = await _run(ws, "df -B 1M /q")
+    assert block.splitlines()[0].split()[1] == "1M-blocks"
+    # 1024000 bytes -> ceil to 1 MiB block
+    assert block.splitlines()[1].split()[1] == "1"
+
+
+@pytest.mark.asyncio
+async def test_df_human_readable():
+    ws = _ws()
+    _, out = await _run(ws, "df -h /q")
+    assert out.splitlines()[0].split()[1:4] == ["Size", "Used", "Avail"]
+    # 1024000 bytes -> 1000.0K
+    assert out.splitlines()[1].split()[1].endswith("K")
+
+
+@pytest.mark.asyncio
+async def test_df_no_args_lists_all_mounts():
+    ws = _ws()
+    code, out = await _run(ws, "df")
+    assert code == 0
+    mounted_on = [ln.split()[-1] for ln in out.splitlines()[1:]]
+    assert "/mem" in mounted_on
+    assert "/q" in mounted_on
+
+
+@pytest.mark.asyncio
+async def test_df_invalid_option():
+    ws = _ws()
+    code, _ = await _run(ws, "df -z /mem")
+    assert code == 2
+
+
+@pytest.mark.asyncio
+async def test_disk_statfs_real_quota(tmp_path):
+    # The real disk backend reports real numbers (QUOTA), not fabricated.
+    cap = await DiskResource(root=str(tmp_path)).statfs()
+    assert cap.state == CapacityState.QUOTA
+    assert cap.total and cap.total > 0
+    assert cap.available is not None and cap.available >= 0
+    assert cap.inodes and cap.inodes > 0

--- a/spec/python/general/df.json
+++ b/spec/python/general/df.json
@@ -1,0 +1,90 @@
+{
+  "_meta": {
+    "filetypes": [],
+    "has_aggregate": false,
+    "has_provision": false,
+    "has_write": false,
+    "resources": []
+  },
+  "description": null,
+  "ignore_tokens": [],
+  "options": [
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-h",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-H",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-k",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-i",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-a",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-T",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-P",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-B",
+      "value_kind": "text",
+      "value_optional": false
+    }
+  ],
+  "positional": [],
+  "rest": {
+    "kind": "path",
+    "provided_by": []
+  }
+}

--- a/spec/python/general/od.json
+++ b/spec/python/general/od.json
@@ -81,11 +81,9 @@
       "value_optional": false
     }
   ],
-  "positional": [
-    {
-      "kind": "path",
-      "provided_by": []
-    }
-  ],
-  "rest": null
+  "positional": [],
+  "rest": {
+    "kind": "path",
+    "provided_by": []
+  }
 }

--- a/spec/typescript/browser/general/df.json
+++ b/spec/typescript/browser/general/df.json
@@ -1,0 +1,90 @@
+{
+  "_meta": {
+    "filetypes": [],
+    "has_aggregate": false,
+    "has_provision": false,
+    "has_write": false,
+    "resources": []
+  },
+  "description": null,
+  "ignore_tokens": [],
+  "options": [
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-h",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-H",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-k",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-i",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-a",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-T",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-P",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-B",
+      "value_kind": "text",
+      "value_optional": false
+    }
+  ],
+  "positional": [],
+  "rest": {
+    "kind": "path",
+    "provided_by": []
+  }
+}

--- a/spec/typescript/browser/general/od.json
+++ b/spec/typescript/browser/general/od.json
@@ -71,11 +71,9 @@
       "value_optional": false
     }
   ],
-  "positional": [
-    {
-      "kind": "path",
-      "provided_by": []
-    }
-  ],
-  "rest": null
+  "positional": [],
+  "rest": {
+    "kind": "path",
+    "provided_by": []
+  }
 }

--- a/spec/typescript/node/general/df.json
+++ b/spec/typescript/node/general/df.json
@@ -1,0 +1,90 @@
+{
+  "_meta": {
+    "filetypes": [],
+    "has_aggregate": false,
+    "has_provision": false,
+    "has_write": false,
+    "resources": []
+  },
+  "description": null,
+  "ignore_tokens": [],
+  "options": [
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-h",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-H",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-k",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-i",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-a",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-T",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-P",
+      "value_kind": "none",
+      "value_optional": false
+    },
+    {
+      "description": null,
+      "long": null,
+      "numeric_shorthand": false,
+      "repeatable": false,
+      "short": "-B",
+      "value_kind": "text",
+      "value_optional": false
+    }
+  ],
+  "positional": [],
+  "rest": {
+    "kind": "path",
+    "provided_by": []
+  }
+}

--- a/spec/typescript/node/general/od.json
+++ b/spec/typescript/node/general/od.json
@@ -80,11 +80,9 @@
       "value_optional": false
     }
   ],
-  "positional": [
-    {
-      "kind": "path",
-      "provided_by": []
-    }
-  ],
-  "rest": null
+  "positional": [],
+  "rest": {
+    "kind": "path",
+    "provided_by": []
+  }
 }

--- a/typescript/packages/core/src/commands/builtin/generic/numfmt.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/numfmt.ts
@@ -6,7 +6,7 @@ const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
 const SUFFIXES = ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'R', 'Q'] as const
 // SI spells kilo lowercase; every larger unit and all of IEC stay uppercase.
-const SI_DISPLAY = ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'R', 'Q'] as const
+const SI_DISPLAY: readonly string[] = ['', 'k', ...SUFFIXES.slice(2)]
 
 function parseNumber(value: string, fromMode: string): number {
   const match = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+))([A-Za-z]*)$/.exec(value)

--- a/typescript/packages/core/src/commands/builtin/generic/numfmt.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/numfmt.ts
@@ -5,32 +5,68 @@ import { resolveSource } from '../utils/stream.ts'
 const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
 const SUFFIXES = ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'R', 'Q'] as const
+// SI spells kilo lowercase; every larger unit and all of IEC stay uppercase.
+const SI_DISPLAY = ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'R', 'Q'] as const
 
 function parseNumber(value: string, fromMode: string): number {
   const match = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+))([A-Za-z]*)$/.exec(value)
   if (match === null) throw new Error(`numfmt: invalid number: '${value}'`)
   const number = Number(match[1])
-  const suffix = (match[2] ?? '').replace(/i?B$/, '').replace(/i$/, '')
+  const suffix = (match[2] ?? '').replace(/i?B$/, '').replace(/i$/, '').toUpperCase()
   if (suffix === '' || fromMode === 'none') return number
   const exponent = SUFFIXES.indexOf(suffix as (typeof SUFFIXES)[number])
   if (exponent < 0) throw new Error(`numfmt: invalid suffix in input: '${value}'`)
   return number * (fromMode === 'si' ? 1000 : 1024) ** exponent
 }
 
+// Round away from zero at `places` decimals. The epsilon absorbs binary
+// representation error so 1.5 * 10 does not creep above 15 and round to 16.
+function roundAwayFromZero(value: number, places: number): number {
+  const factor = 10 ** places
+  const scaled = Math.abs(value) * factor
+  return Math.sign(value) * (Math.ceil(scaled - 1e-9) / factor)
+}
+
+// printf("%.*f") rounds half to even, which is why an unscaled 2.5 prints 2.
+function toFixedHalfEven(value: number, places: number): string {
+  const factor = 10 ** places
+  const scaled = value * factor
+  const floor = Math.floor(scaled)
+  const diff = scaled - floor
+  let unit: number
+  if (diff > 0.5 + 1e-9) unit = floor + 1
+  else if (diff < 0.5 - 1e-9) unit = floor
+  else unit = floor % 2 === 0 ? floor : floor + 1
+  return (unit / factor).toFixed(places)
+}
+
+// GNU rounds away from zero, keeping one decimal only while the scaled value
+// is below 10. That rounding can push a value back over the base
+// (999.4 -> 1000 -> 1.0k), so the unit is re-checked afterwards.
 function formatNumber(value: number, toMode: string, grouping: boolean): string {
-  let number = value
-  let exponent = 0
-  if (toMode !== 'none') {
-    const base = toMode === 'si' ? 1000 : 1024
-    while (Math.abs(number) >= base && exponent < SUFFIXES.length - 1) {
-      number /= base
-      exponent += 1
-    }
+  if (toMode === 'none') {
+    return grouping ? value.toLocaleString('en-US', { maximumFractionDigits: 20 }) : String(value)
   }
-  const rounded = Number.isInteger(number) ? number.toFixed(0) : number.toFixed(1)
-  const body = grouping ? Number(rounded).toLocaleString('en-US') : rounded
-  const suffix = `${SUFFIXES[exponent] ?? ''}${toMode === 'iec-i' && exponent > 0 ? 'i' : ''}`
-  return body + suffix
+  const base = toMode === 'si' ? 1000 : 1024
+  const display = toMode === 'si' ? SI_DISPLAY : SUFFIXES
+  let number = value
+  let power = 0
+  while (Math.abs(number) >= base && power < display.length - 1) {
+    number /= base
+    power += 1
+  }
+  number = roundAwayFromZero(number, Math.abs(number) < 10 ? 1 : 0)
+  if (Math.abs(number) >= base && power < display.length - 1) {
+    number /= base
+    power += 1
+  }
+  const places = power > 0 && Math.abs(number) < 10 ? 1 : 0
+  const body = toFixedHalfEven(number, places)
+  const grouped = grouping
+    ? Number(body).toLocaleString('en-US', { minimumFractionDigits: places })
+    : body
+  const suffix = `${display[power] ?? ''}${toMode === 'iec-i' && power > 0 ? 'i' : ''}`
+  return grouped + suffix
 }
 
 function convertField(

--- a/typescript/packages/core/src/commands/spec/builtins.test.ts
+++ b/typescript/packages/core/src/commands/spec/builtins.test.ts
@@ -62,6 +62,6 @@ describe('BUILTIN_SPECS', () => {
   })
 
   it('covers the full python set size', () => {
-    expect(Object.keys(BUILTIN_SPECS).length).toBe(92)
+    expect(Object.keys(BUILTIN_SPECS).length).toBe(93)
   })
 })

--- a/typescript/packages/core/src/commands/spec/builtins.ts
+++ b/typescript/packages/core/src/commands/spec/builtins.ts
@@ -96,6 +96,19 @@ export const BUILTIN_SPECS: Readonly<Record<string, CommandSpec>> = Object.freez
     ],
     rest: new Operand({ kind: OperandKind.PATH }),
   }),
+  df: new CommandSpec({
+    options: [
+      new Option({ short: '-h' }),
+      new Option({ short: '-H' }),
+      new Option({ short: '-k' }),
+      new Option({ short: '-i' }),
+      new Option({ short: '-a' }),
+      new Option({ short: '-T' }),
+      new Option({ short: '-P' }),
+      new Option({ short: '-B', valueKind: OperandKind.TEXT }),
+    ],
+    rest: new Operand({ kind: OperandKind.PATH }),
+  }),
   cat: new CommandSpec({
     options: [
       new Option({ short: '-n', long: '--number' }),

--- a/typescript/packages/core/src/commands/spec/builtins.ts
+++ b/typescript/packages/core/src/commands/spec/builtins.ts
@@ -1083,6 +1083,6 @@ export const BUILTIN_SPECS: Readonly<Record<string, CommandSpec>> = Object.freez
       new Option({ short: '-N', long: '--read-bytes', valueKind: OperandKind.TEXT }),
       new Option({ short: '-t', long: '--format', valueKind: OperandKind.TEXT, repeatable: true }),
     ],
-    positional: [new Operand({ kind: OperandKind.PATH })],
+    rest: new Operand({ kind: OperandKind.PATH }),
   }),
 })

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -17,6 +17,8 @@ export {
   CommandSafeguard,
   type CommandSafeguardInit,
   ConsistencyPolicy,
+  CapacityState,
+  type CapacityResult,
   type CopyFn,
   type CopyStrategy,
   DriftPolicy,

--- a/typescript/packages/core/src/resource/base.ts
+++ b/typescript/packages/core/src/resource/base.ts
@@ -20,7 +20,8 @@ import type { IndexCacheStore } from '../cache/index/store.ts'
 import type { PredNode } from '../commands/builtin/findEval.ts'
 import type { RegisteredCommand } from '../commands/config.ts'
 import type { RegisteredOp } from '../ops/registry.ts'
-import type { FileStat, PathSpec } from '../types.ts'
+import type { CapacityResult, FileStat, PathSpec } from '../types.ts'
+import { CapacityState } from '../types.ts'
 
 export interface FindOptions {
   name?: string | null
@@ -89,6 +90,10 @@ export interface Resource {
   du?(path: PathSpec): Promise<number>
   find?(path: PathSpec, options?: FindOptions): Promise<string[]>
   glob?(paths: readonly PathSpec[], prefix?: string): Promise<PathSpec[]>
+  // Capacity for df. Absent -> treated as UNKNOWN (rendered `-`). Implement
+  // only where a truthful number exists (a real filesystem, or a provider
+  // quota); never fabricate a total.
+  statfs?(): Promise<CapacityResult>
 }
 
 export function throwUnsupported(op: string): never {
@@ -127,5 +132,11 @@ export abstract class BaseResource {
     }
     const ttl = config === undefined ? this.indexTtl : (config.ttl ?? 600)
     return new RAMIndexCacheStore({ ttl })
+  }
+
+  // Default df capacity: UNKNOWN (rendered `-`). Backends that can report
+  // truthfully — a real filesystem, or a provider quota — override this.
+  statfs(): Promise<CapacityResult> {
+    return Promise.resolve({ state: CapacityState.UNKNOWN })
   }
 }

--- a/typescript/packages/core/src/types.ts
+++ b/typescript/packages/core/src/types.ts
@@ -258,6 +258,33 @@ export class FileStat {
   }
 }
 
+// How a mount's capacity relates to a df-style report. QUOTA: real
+// total/used/available are known (a real filesystem, or a provider that
+// exposes a storage quota). ELASTIC: no fixed size (object stores that grow
+// without a quota). NA: no filesystem-capacity concept (message/table
+// surfaces). UNKNOWN: bounded but not cheaply measurable / not reported yet.
+// df renders real numbers for QUOTA and a literal `-` for the rest — never a
+// fabricated total.
+export const CapacityState = {
+  QUOTA: 'quota',
+  ELASTIC: 'elastic',
+  NA: 'na',
+  UNKNOWN: 'unknown',
+} as const
+export type CapacityState = (typeof CapacityState)[keyof typeof CapacityState]
+
+// One mount's capacity for df. Byte counts are null/undefined unless the
+// state is QUOTA.
+export interface CapacityResult {
+  state: CapacityState
+  total?: number | null
+  used?: number | null
+  available?: number | null
+  inodes?: number | null
+  inodesUsed?: number | null
+  inodesFree?: number | null
+}
+
 export type ReadBytesFn<Args extends unknown[] = [path: PathSpec]> = (
   ...args: Args
 ) => Promise<Uint8Array>

--- a/typescript/packages/core/src/workspace/executor/builtins/capacity.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/capacity.test.ts
@@ -1,0 +1,155 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { RAMResource } from '../../../resource/ram/ram.ts'
+import { CapacityState, MountMode } from '../../../types.ts'
+import type { CapacityResult } from '../../../types.ts'
+import { getTestParser } from '../../fixtures/workspace_fixture.ts'
+import { Workspace } from '../../workspace.ts'
+
+// RAM backend that reports a fixed quota, standing in for a real filesystem
+// / a provider that exposes storage numbers (real disk free space is
+// machine-specific, so this keeps the output deterministic).
+class QuotaResource extends RAMResource {
+  override statfs(): Promise<CapacityResult> {
+    return Promise.resolve({
+      state: CapacityState.QUOTA,
+      total: 1024000,
+      used: 409600,
+      available: 614400,
+      inodes: 1000,
+      inodesUsed: 100,
+      inodesFree: 900,
+    })
+  }
+}
+
+async function makeWs(): Promise<Workspace> {
+  const parser = await getTestParser()
+  return new Workspace(
+    { '/mem': new RAMResource(), '/q': new QuotaResource() },
+    { mode: MountMode.WRITE, shellParser: parser },
+  )
+}
+
+async function run(ws: Workspace, cmd: string): Promise<[number, string]> {
+  const r = await ws.execute(cmd)
+  return [r.exitCode, r.stdoutText]
+}
+
+// Whitespace-split fields of output line `i` (0 = header).
+function cols(out: string, i: number): string[] {
+  return (out.trimEnd().split('\n')[i] ?? '').split(/\s+/)
+}
+
+describe('df', () => {
+  it('default statfs state is UNKNOWN', async () => {
+    const cap = await new RAMResource().statfs()
+    expect(cap.state).toBe(CapacityState.UNKNOWN)
+    expect(cap.total).toBeUndefined()
+  })
+
+  it('unknown backend renders dashes', async () => {
+    const ws = await makeWs()
+    const [code, out] = await run(ws, 'df /mem')
+    expect(code).toBe(0)
+    expect(out).toBe(
+      'Filesystem     1K-blocks Used Available Use% Mounted on\n' +
+        'ram                    -    -         -    - /mem\n',
+    )
+    await ws.close()
+  })
+
+  it('quota backend reports real numbers', async () => {
+    const ws = await makeWs()
+    const [code, out] = await run(ws, 'df /q')
+    expect(code).toBe(0)
+    expect(cols(out, 0)).toEqual([
+      'Filesystem',
+      '1K-blocks',
+      'Used',
+      'Available',
+      'Use%',
+      'Mounted',
+      'on',
+    ])
+    expect(cols(out, 1)).toEqual(['ram', '1000', '400', '600', '40%', '/q'])
+    await ws.close()
+  })
+
+  it('type column', async () => {
+    const ws = await makeWs()
+    const [, out] = await run(ws, 'df -T /q')
+    expect(cols(out, 0).slice(0, 2)).toEqual(['Filesystem', 'Type'])
+    expect(cols(out, 1).slice(0, 2)).toEqual(['ram', 'ram'])
+    await ws.close()
+  })
+
+  it('inode columns; unknown -> dashes', async () => {
+    const ws = await makeWs()
+    const [, q] = await run(ws, 'df -i /q')
+    expect(cols(q, 0)).toEqual(['Filesystem', 'Inodes', 'IUsed', 'IFree', 'IUse%', 'Mounted', 'on'])
+    expect(cols(q, 1)).toEqual(['ram', '1000', '100', '900', '10%', '/q'])
+    const [, m] = await run(ws, 'df -i /mem')
+    expect(cols(m, 1)).toEqual(['ram', '-', '-', '-', '-', '/mem'])
+    await ws.close()
+  })
+
+  it('posix and block-size headers', async () => {
+    const ws = await makeWs()
+    const [, posix] = await run(ws, 'df -P /q')
+    expect(cols(posix, 0).slice(1)).toEqual([
+      '1024-blocks',
+      'Used',
+      'Available',
+      'Capacity',
+      'Mounted',
+      'on',
+    ])
+    const [, block] = await run(ws, 'df -B 1M /q')
+    expect(cols(block, 0)[1]).toBe('1M-blocks')
+    expect(cols(block, 1)[1]).toBe('1')
+    await ws.close()
+  })
+
+  it('human-readable', async () => {
+    const ws = await makeWs()
+    const [, out] = await run(ws, 'df -h /q')
+    expect(cols(out, 0).slice(1, 4)).toEqual(['Size', 'Used', 'Avail'])
+    expect((cols(out, 1)[1] ?? '').endsWith('K')).toBe(true)
+    await ws.close()
+  })
+
+  it('no args lists all mounts', async () => {
+    const ws = await makeWs()
+    const [code, out] = await run(ws, 'df')
+    expect(code).toBe(0)
+    const mountedOn = out
+      .trimEnd()
+      .split('\n')
+      .slice(1)
+      .map((ln) => ln.split(/\s+/).pop())
+    expect(mountedOn).toContain('/mem')
+    expect(mountedOn).toContain('/q')
+    await ws.close()
+  })
+
+  it('invalid option', async () => {
+    const ws = await makeWs()
+    const [code] = await run(ws, 'df -z /mem')
+    expect(code).toBe(2)
+    await ws.close()
+  })
+})

--- a/typescript/packages/core/src/workspace/executor/builtins/capacity.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/capacity.test.ts
@@ -152,4 +152,47 @@ describe('df', () => {
     expect(code).toBe(2)
     await ws.close()
   })
+
+  it('rejects a zero block size', async () => {
+    const ws = await makeWs()
+    const r = await ws.execute('df -B0 /q')
+    expect(r.exitCode).toBe(1)
+    expect(r.stderrText).toBe("df: invalid -B argument '0'\n")
+    await ws.close()
+  })
+
+  it('last size-format flag wins', async () => {
+    const ws = await makeWs()
+    const [, hb] = await run(ws, 'df -h -B1M /q')
+    expect(cols(hb, 0)[1]).toBe('1M-blocks')
+    const [, bh] = await run(ws, 'df -B1M -h /q')
+    expect(cols(bh, 0)[1]).toBe('Size')
+    const [, hk] = await run(ws, 'df -h -k /q')
+    expect(cols(hk, 0)[1]).toBe('1K-blocks')
+    const [, kh] = await run(ws, 'df -k -h /q')
+    expect(cols(kh, 0)[1]).toBe('Size')
+    await ws.close()
+  })
+
+  it('errors on a missing FILE operand', async () => {
+    const ws = await makeWs()
+    await ws.execute('mkdir -p /mem/sub')
+    await ws.execute("sh -c 'echo hi > /mem/sub/f.txt'")
+    expect((await run(ws, 'df /mem/sub/f.txt'))[0]).toBe(0)
+    expect((await run(ws, 'df /mem'))[0]).toBe(0)
+    const r = await ws.execute('df /mem/missing')
+    expect(r.exitCode).toBe(1)
+    expect(r.stderrText).toBe('df: /mem/missing: No such file or directory\n')
+    await ws.close()
+  })
+
+  it('follows a symlink to the target mount', async () => {
+    const ws = await makeWs()
+    await ws.execute('ln -s /q /mem/link')
+    const [code, out] = await run(ws, 'df /mem/link')
+    expect(code).toBe(0)
+    const last = out.trimEnd().split('\n').pop() ?? ''
+    expect(last.split(/\s+/).pop()).toBe('/q')
+    await ws.close()
+  })
 })

--- a/typescript/packages/core/src/workspace/executor/builtins/capacity.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/capacity.ts
@@ -14,9 +14,11 @@
 
 import { humanSize } from '../../../commands/builtin/utils/formatting.ts'
 import { IOResult } from '../../../io/types.ts'
-import { CapacityState, PathSpec } from '../../../types.ts'
+import { CapacityState, FileStat, PathSpec } from '../../../types.ts'
 import type { CapacityResult } from '../../../types.ts'
 import { resolvePath } from '../../../utils/path.ts'
+import { rstripSlash } from '../../../utils/slash.ts'
+import type { DispatchFn } from '../cross_mount.ts'
 import type { MountEntry } from '../../mount/mount.ts'
 import type { MountRegistry } from '../../mount/registry.ts'
 import type { Session } from '../../session/session.ts'
@@ -55,13 +57,55 @@ function parseBlock(text: string): [number, string] | null {
   const t = text.trim()
   if (t.length === 0) return null
   const suffix = t.slice(-1).toUpperCase()
+  let value: number
   if (suffix in BLOCK_SUFFIX) {
     const head = t.slice(0, -1) || '1'
     if (!/^\d+$/.test(head)) return null
-    return [parseInt(head, 10) * (BLOCK_SUFFIX[suffix] ?? 1), t]
+    value = parseInt(head, 10) * (BLOCK_SUFFIX[suffix] ?? 1)
+  } else if (/^\d+$/.test(t)) {
+    value = parseInt(t, 10)
+  } else {
+    return null
   }
-  if (!/^\d+$/.test(t)) return null
-  return [parseInt(t, 10), t]
+  // GNU rejects a zero (or non-positive) block size rather than scaling.
+  if (value <= 0) return null
+  return [value, t]
+}
+
+// The last size-format flag (-h/-H/-k/-B) in the leading option run. GNU df
+// lets a later size flag override the earlier ones (`df -h -B1M` prints a
+// block header, `df -B1M -h` prints `Size`), so the display format is
+// whichever appears last. Returns the flag letter, or null when none appear.
+function lastFormat(args: (string | PathSpec)[]): string | null {
+  let last: string | null = null
+  let i = 0
+  while (i < args.length) {
+    const arg = args[i]
+    const s = typeof arg === 'string' ? arg : ''
+    if (s === '--' || !(s.length >= 2 && s.startsWith('-') && s[1] !== '-')) break
+    const body = s.slice(1)
+    for (let j = 0; j < body.length; j++) {
+      const c = body[j]
+      if (c === 'h' || c === 'H' || c === 'k' || c === 'B') last = c
+      if (c === 'B') {
+        if (body.slice(j + 1).length === 0) i += 1
+        break
+      }
+    }
+    i += 1
+  }
+  return last
+}
+
+// Whether a path resolves to an existing entry; GNU df errors on a missing
+// FILE operand, so a deeper path is statted before its mount is accepted.
+async function pathExists(dispatch: DispatchFn, spec: PathSpec): Promise<boolean> {
+  try {
+    const [stat] = await dispatch('stat', spec)
+    return stat instanceof FileStat
+  } catch {
+    return false
+  }
 }
 
 // Human-readable size in powers of 1000 (df -H), mirroring the 1024
@@ -132,17 +176,20 @@ function pctCell(cap: CapacityResult, inodes: boolean): string {
 // Resolve df operands to the mounts to report, deduped and ordered. No
 // operand (or the workspace root `/`) reports every mount; a path operand
 // reports the mount containing it. Null when an operand maps to no mount.
-function targetMounts(
+async function targetMounts(
   registry: MountRegistry,
+  dispatch: DispatchFn,
   session: Session,
   operands: (string | PathSpec)[],
-): MountEntry[] | { missing: string } {
+): Promise<MountEntry[] | { missing: string }> {
   const ordered = [...registry.allMounts()].sort((a, b) => a.prefix.localeCompare(b.prefix))
   if (operands.length === 0) return ordered
   const seen = new Set<string>()
   const out: MountEntry[] = []
   for (const op of operands) {
     const virtual = op instanceof PathSpec ? op.virtual : resolvePath(op, session.cwd)
+    const label = op instanceof PathSpec ? op.rawPath : op
+    const spec = op instanceof PathSpec ? op : PathSpec.fromStrPath(virtual)
     if (virtual === '' || virtual === '/') {
       for (const m of ordered) {
         if (!seen.has(m.prefix)) {
@@ -154,7 +201,13 @@ function targetMounts(
     }
     const mount = registry.mountFor(virtual)
     if (mount === null) {
-      return { missing: op instanceof PathSpec ? op.rawPath : op }
+      return { missing: label }
+    }
+    // The mount root is the filesystem itself (always present); a deeper
+    // path must exist, matching GNU df's per-FILE check.
+    const root = rstripSlash(mount.prefix) || '/'
+    if (rstripSlash(virtual) !== root && !(await pathExists(dispatch, spec))) {
+      return { missing: label }
     }
     if (!seen.has(mount.prefix)) {
       seen.add(mount.prefix)
@@ -196,28 +249,36 @@ function renderTable(header: string[], rows: string[][], showType: boolean): str
 export async function handleDf(
   registry: MountRegistry,
   session: Session,
+  dispatch: DispatchFn,
   args: (string | PathSpec)[],
 ): Promise<Result> {
   const { flags, values, operands, bad } = splitValueFlags(args, 'hHkiaTP', 'B')
   if (bad !== null) return errorResult(`df: invalid option -- '${bad}'\n`, 2)
 
   const posix = flags.has('P')
-  let block = 1024
-  let blockLabel = posix ? '1024-blocks' : '1K-blocks'
   const bArg = values.get('B')
+  let bParsed: [number, string] | null = null
   if (bArg !== undefined) {
-    const parsed = parseBlock(bArg)
-    if (parsed === null) return errorResult(`df: invalid --block-size argument '${bArg}'\n`, 1)
-    block = parsed[0]
-    blockLabel = `${parsed[1]}-blocks`
+    bParsed = parseBlock(bArg)
+    if (bParsed === null) return errorResult(`df: invalid -B argument '${bArg}'\n`, 1)
   }
 
-  const si = flags.has('H')
-  const human = si || flags.has('h')
+  // GNU resolves the mutually overriding size flags last-wins, so -h/-H
+  // (human) or -k/-B (block) is chosen by whichever appears last.
+  const lf = lastFormat(args)
+  const si = lf === 'H'
+  const human = lf === 'h' || lf === 'H'
+  let block = 1024
+  let blockLabel = posix ? '1024-blocks' : '1K-blocks'
+  if (lf === 'B' && bParsed !== null) {
+    block = bParsed[0]
+    blockLabel = `${bParsed[1]}-blocks`
+  }
+
   const inodes = flags.has('i')
   const showType = flags.has('T')
 
-  const mounts = targetMounts(registry, session, operands)
+  const mounts = await targetMounts(registry, dispatch, session, operands)
   if (!Array.isArray(mounts)) {
     return errorResult(`df: ${mounts.missing}: No such file or directory\n`, 1)
   }

--- a/typescript/packages/core/src/workspace/executor/builtins/capacity.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/capacity.ts
@@ -1,0 +1,256 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { humanSize } from '../../../commands/builtin/utils/formatting.ts'
+import { IOResult } from '../../../io/types.ts'
+import { CapacityState, PathSpec } from '../../../types.ts'
+import type { CapacityResult } from '../../../types.ts'
+import { resolvePath } from '../../../utils/path.ts'
+import type { MountEntry } from '../../mount/mount.ts'
+import type { MountRegistry } from '../../mount/registry.ts'
+import type { Session } from '../../session/session.ts'
+import { ExecutionNode } from '../../types.ts'
+import { splitValueFlags } from './metadata.ts'
+import type { Result } from './scope.ts'
+
+const SI_UNITS = ['B', 'K', 'M', 'G', 'T']
+const BLOCK_SUFFIX: Record<string, number> = {
+  K: 1024,
+  M: 1024 ** 2,
+  G: 1024 ** 3,
+  T: 1024 ** 4,
+}
+
+function errorResult(message: string, exitCode: number): Result {
+  const err = new TextEncoder().encode(message)
+  return [
+    null,
+    new IOResult({ exitCode, stderr: err }),
+    new ExecutionNode({ command: 'df', exitCode, stderr: err }),
+  ]
+}
+
+function textResult(out: string): Result {
+  return [
+    new TextEncoder().encode(out),
+    new IOResult(),
+    new ExecutionNode({ command: 'df', exitCode: 0 }),
+  ]
+}
+
+// Parse a -B/--block-size argument into [bytes, header-label]; a plain byte
+// count or a 1024-based suffix (K/M/G/T), labelled after the raw argument.
+function parseBlock(text: string): [number, string] | null {
+  const t = text.trim()
+  if (t.length === 0) return null
+  const suffix = t.slice(-1).toUpperCase()
+  if (suffix in BLOCK_SUFFIX) {
+    const head = t.slice(0, -1) || '1'
+    if (!/^\d+$/.test(head)) return null
+    return [parseInt(head, 10) * (BLOCK_SUFFIX[suffix] ?? 1), t]
+  }
+  if (!/^\d+$/.test(t)) return null
+  return [parseInt(t, 10), t]
+}
+
+// Human-readable size in powers of 1000 (df -H), mirroring the 1024
+// `humanSize` shape used by df -h / du -h.
+function humanSi(n: number): string {
+  let value = n
+  let i = 0
+  while (value >= 1000 && i < SI_UNITS.length - 1) {
+    value /= 1000
+    i += 1
+  }
+  const text = i === 0 ? String(Math.round(value)) : value.toFixed(1)
+  return `${text}${SI_UNITS[i] ?? ''}`
+}
+
+// Bytes as a count of `block`-byte units, rounded up like GNU df.
+function scale(nbytes: number, block: number): string {
+  return String(Math.ceil(nbytes / block))
+}
+
+// GNU df use-percent: ceil(used / (used + avail) * 100), or `-` when the
+// denominator is zero.
+function usePct(used: number, avail: number): string {
+  const denom = used + avail
+  if (denom <= 0) return '-'
+  return `${String(Math.ceil((used * 100) / denom))}%`
+}
+
+// The three numeric cells (block or inode) for one mount, or three `-` when
+// capacity is not a known quota (never a fabricated 0).
+function numCells(
+  cap: CapacityResult,
+  human: boolean,
+  si: boolean,
+  block: number,
+  inodes: boolean,
+): string[] {
+  const quota = cap.state === CapacityState.QUOTA
+  if (inodes) {
+    if (quota && cap.inodes != null) {
+      return [String(cap.inodes), String(cap.inodesUsed ?? 0), String(cap.inodesFree ?? 0)]
+    }
+    return ['-', '-', '-']
+  }
+  if (quota && cap.total != null) {
+    const used = cap.used ?? 0
+    const avail = cap.available ?? 0
+    if (human) {
+      const fmt = si ? humanSi : humanSize
+      return [fmt(cap.total), fmt(used), fmt(avail)]
+    }
+    return [scale(cap.total, block), scale(used, block), scale(avail, block)]
+  }
+  return ['-', '-', '-']
+}
+
+// The Use%/IUse% cell for one mount, or `-` outside a known quota.
+function pctCell(cap: CapacityResult, inodes: boolean): string {
+  if (cap.state !== CapacityState.QUOTA) return '-'
+  if (inodes) {
+    if (cap.inodes == null) return '-'
+    return usePct(cap.inodesUsed ?? 0, cap.inodesFree ?? 0)
+  }
+  if (cap.total == null) return '-'
+  return usePct(cap.used ?? 0, cap.available ?? 0)
+}
+
+// Resolve df operands to the mounts to report, deduped and ordered. No
+// operand (or the workspace root `/`) reports every mount; a path operand
+// reports the mount containing it. Null when an operand maps to no mount.
+function targetMounts(
+  registry: MountRegistry,
+  session: Session,
+  operands: (string | PathSpec)[],
+): MountEntry[] | { missing: string } {
+  const ordered = [...registry.allMounts()].sort((a, b) => a.prefix.localeCompare(b.prefix))
+  if (operands.length === 0) return ordered
+  const seen = new Set<string>()
+  const out: MountEntry[] = []
+  for (const op of operands) {
+    const virtual = op instanceof PathSpec ? op.virtual : resolvePath(op, session.cwd)
+    if (virtual === '' || virtual === '/') {
+      for (const m of ordered) {
+        if (!seen.has(m.prefix)) {
+          seen.add(m.prefix)
+          out.push(m)
+        }
+      }
+      continue
+    }
+    const mount = registry.mountFor(virtual)
+    if (mount === null) {
+      return { missing: op instanceof PathSpec ? op.rawPath : op }
+    }
+    if (!seen.has(mount.prefix)) {
+      seen.add(mount.prefix)
+      out.push(mount)
+    }
+  }
+  return out
+}
+
+// GNU df column layout: Filesystem left-justified (min width 14), Type (when
+// present) left, numeric columns right-justified, Mounted on left with no
+// trailing pad, single-space separators.
+function renderTable(header: string[], rows: string[][], showType: boolean): string {
+  const ncols = header.length
+  const left = new Set<number>([0, ncols - 1])
+  if (showType) left.add(1)
+  const widths = header.map((h, c) =>
+    Math.max(h.length, ...rows.map((r) => (r[c] ?? '').length), 0),
+  )
+  widths[0] = Math.max(widths[0] ?? 0, 14)
+  const lines: string[] = []
+  for (const cells of [header, ...rows]) {
+    const parts: string[] = []
+    for (let c = 0; c < ncols; c++) {
+      const cell = cells[c] ?? ''
+      const w = widths[c] ?? 0
+      if (c === ncols - 1) parts.push(cell)
+      else if (left.has(c)) parts.push(cell.padEnd(w))
+      else parts.push(cell.padStart(w))
+    }
+    lines.push(parts.join(' '))
+  }
+  return lines.join('\n') + '\n'
+}
+
+// df [OPTION]... [FILE]...: report per-mount capacity. A mount reports real
+// numbers only when its backend can; every other backend shows `-` rather
+// than a fabricated total.
+export async function handleDf(
+  registry: MountRegistry,
+  session: Session,
+  args: (string | PathSpec)[],
+): Promise<Result> {
+  const { flags, values, operands, bad } = splitValueFlags(args, 'hHkiaTP', 'B')
+  if (bad !== null) return errorResult(`df: invalid option -- '${bad}'\n`, 2)
+
+  const posix = flags.has('P')
+  let block = 1024
+  let blockLabel = posix ? '1024-blocks' : '1K-blocks'
+  const bArg = values.get('B')
+  if (bArg !== undefined) {
+    const parsed = parseBlock(bArg)
+    if (parsed === null) return errorResult(`df: invalid --block-size argument '${bArg}'\n`, 1)
+    block = parsed[0]
+    blockLabel = `${parsed[1]}-blocks`
+  }
+
+  const si = flags.has('H')
+  const human = si || flags.has('h')
+  const inodes = flags.has('i')
+  const showType = flags.has('T')
+
+  const mounts = targetMounts(registry, session, operands)
+  if (!Array.isArray(mounts)) {
+    return errorResult(`df: ${mounts.missing}: No such file or directory\n`, 1)
+  }
+
+  let numHeaders: string[]
+  let pctHeader: string
+  if (inodes) {
+    numHeaders = ['Inodes', 'IUsed', 'IFree']
+    pctHeader = 'IUse%'
+  } else if (human) {
+    numHeaders = ['Size', 'Used', 'Avail']
+    pctHeader = 'Use%'
+  } else {
+    numHeaders = [blockLabel, 'Used', 'Available']
+    pctHeader = posix ? 'Capacity' : 'Use%'
+  }
+
+  const header = ['Filesystem']
+  if (showType) header.push('Type')
+  header.push(...numHeaders, pctHeader, 'Mounted on')
+
+  const data: string[][] = []
+  for (const mount of mounts) {
+    const cap = mount.resource.statfs
+      ? await mount.resource.statfs()
+      : { state: CapacityState.UNKNOWN }
+    const cells = [mount.resource.kind]
+    if (showType) cells.push(mount.resource.kind)
+    cells.push(...numCells(cap, human, si, block, inodes))
+    cells.push(pctCell(cap, inodes))
+    cells.push(mount.prefix.replace(/\/+$/, '') || '/')
+    data.push(cells)
+  }
+
+  return textResult(renderTable(header, data, showType))
+}

--- a/typescript/packages/core/src/workspace/executor/builtins/index.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/index.ts
@@ -23,6 +23,7 @@ export {
   prepareMv,
   stripLinkOperands,
 } from './links.ts'
+export { handleDf } from './capacity.ts'
 export { handleChgrp, handleChmod, handleChown, handleTouch } from './metadata.ts'
 export {
   handleEnv,

--- a/typescript/packages/core/src/workspace/executor/builtins/metadata.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/metadata.ts
@@ -123,7 +123,7 @@ function nowIso(): string {
   return isoNoMs(new Date())
 }
 
-interface SplitValueFlags {
+export interface SplitValueFlags {
   flags: Set<string>
   values: Map<string, string>
   operands: (string | PathSpec)[]
@@ -131,7 +131,7 @@ interface SplitValueFlags {
 }
 
 // Split leading flags where some take a value (`-t STAMP`).
-function splitValueFlags(
+export function splitValueFlags(
   args: readonly (string | PathSpec)[],
   boolean: string,
   valued: string,

--- a/typescript/packages/core/src/workspace/executor/builtins/metadata.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/metadata.ts
@@ -152,19 +152,17 @@ export function splitValueFlags(
     }
     if (parsing && s !== '-' && s.length >= 2 && s.startsWith('-') && !s.startsWith('--')) {
       const body = s.slice(1)
-      let bad: string | null = null
-      for (const c of body) {
-        if (!boolean.includes(c) && !valued.includes(c)) {
-          bad = c
-          break
-        }
-      }
-      if (bad !== null) return { flags, values, operands, bad }
       for (let j = 0; j < body.length; j++) {
         const c = body.charAt(j)
         if (boolean.includes(c)) {
           flags.add(c)
           continue
+        }
+        // A valued flag consumes the rest of the token (-tSTAMP) or the next
+        // argument (-t STAMP); those trailing chars are its value, not flags,
+        // so validation must stop here rather than pre-scanning the token.
+        if (!valued.includes(c)) {
+          return { flags, values, operands, bad: c }
         }
         const rest = body.slice(j + 1)
         if (rest.length > 0) {

--- a/typescript/packages/core/src/workspace/node/command_dispatch.ts
+++ b/typescript/packages/core/src/workspace/node/command_dispatch.ts
@@ -618,7 +618,24 @@ async function runArgv(
   // Capacity (registry-routed: enumerates mounts, reports per-mount statfs;
   // never fabricates numbers).
   if (name === 'df') {
-    return handleDf(registry, session, operands)
+    if (namespace.nodes.size > 0) {
+      try {
+        operands = followPaths(namespace, operands)
+      } catch (err) {
+        if (err instanceof CycleError) {
+          const errBytes = new TextEncoder().encode(
+            `df: ${err.path}: Too many levels of symbolic links\n`,
+          )
+          return [
+            null,
+            new IOResult({ exitCode: 1, stderr: errBytes }),
+            new ExecutionNode({ command: 'df', exitCode: 1, stderr: errBytes }),
+          ]
+        }
+        throw err
+      }
+    }
+    return handleDf(registry, session, dispatch, operands)
   }
 
   // Symlink-aware dispatch: reads follow links (open(2)); rm/mv act on

--- a/typescript/packages/core/src/workspace/node/command_dispatch.ts
+++ b/typescript/packages/core/src/workspace/node/command_dispatch.ts
@@ -52,6 +52,7 @@ import {
   handleExport,
   handleHistory,
   handleChgrp,
+  handleDf,
   handleChmod,
   handleChown,
   handleLn,
@@ -612,6 +613,12 @@ async function runArgv(
   }
   if (name === 'touch') {
     return handleTouch(namespace, dispatch, session, operands)
+  }
+
+  // Capacity (registry-routed: enumerates mounts, reports per-mount statfs;
+  // never fabricates numbers).
+  if (name === 'df') {
+    return handleDf(registry, session, operands)
   }
 
   // Symlink-aware dispatch: reads follow links (open(2)); rm/mv act on

--- a/typescript/packages/node/src/commands/native_numfmt.test.ts
+++ b/typescript/packages/node/src/commands/native_numfmt.test.ts
@@ -19,7 +19,7 @@ describe.each(NATIVE_BACKENDS)('native numfmt (%s backend)', (kind) => {
   it('scales units and supports suffix grouping', async () => {
     const env = makeEnv(kind)
     try {
-      expect(await env.mirage('numfmt --to=si 1000')).toBe('1K\n')
+      expect(await env.mirage('numfmt --to=si 1000')).toBe('1.0k\n')
       expect(await env.mirage('numfmt --from=iec-i 1Ki')).toBe('1024\n')
       expect(await env.mirage('numfmt --grouping --suffix=B 1234B')).toBe('1,234B\n')
     } finally {

--- a/typescript/packages/node/src/resource/disk/disk.test.ts
+++ b/typescript/packages/node/src/resource/disk/disk.test.ts
@@ -15,7 +15,7 @@
 import { chmodSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { FileType, ResourceName } from '@struktoai/mirage-core'
+import { CapacityState, FileType, ResourceName } from '@struktoai/mirage-core'
 import { spec, tmpRoot } from '../../test-utils.ts'
 import { DiskResource } from './disk.ts'
 
@@ -46,6 +46,14 @@ describe('DiskResource — identity', () => {
 
   it('commands() returns RAM_COMMANDS', () => {
     expect(res.commands().length).toBeGreaterThan(0)
+  })
+
+  it('statfs reports a real quota (df numbers, not fabricated)', async () => {
+    const cap = await res.statfs()
+    expect(cap.state).toBe(CapacityState.QUOTA)
+    expect(cap.total ?? 0).toBeGreaterThan(0)
+    expect(cap.available ?? -1).toBeGreaterThanOrEqual(0)
+    expect(cap.inodes ?? 0).toBeGreaterThan(0)
   })
 })
 

--- a/typescript/packages/node/src/resource/disk/disk.ts
+++ b/typescript/packages/node/src/resource/disk/disk.ts
@@ -12,15 +12,25 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { chmod, mkdir, readdir, readFile, stat as fsStat, writeFile } from 'node:fs/promises'
+import {
+  chmod,
+  mkdir,
+  readdir,
+  readFile,
+  stat as fsStat,
+  statfs as fsStatfs,
+  writeFile,
+} from 'node:fs/promises'
 import path from 'node:path'
 import {
   BaseResource,
+  CapacityState,
   PathSpec,
   ResourceName,
   makeResolveGlob,
   mountKey,
   mountPrefixOf,
+  type CapacityResult,
   type FileStat,
   type FindOptions,
   type RegisteredCommand,
@@ -114,6 +124,22 @@ export class DiskResource extends BaseResource implements Resource {
 
   close(): Promise<void> {
     return Promise.resolve()
+  }
+
+  // A real filesystem reports real numbers (QUOTA). GNU df: used counts
+  // reserved blocks (blocks - bfree), available excludes them (bavail).
+  override async statfs(): Promise<CapacityResult> {
+    const st = await fsStatfs(this.root)
+    const bsize = st.bsize
+    return {
+      state: CapacityState.QUOTA,
+      total: st.blocks * bsize,
+      used: (st.blocks - st.bfree) * bsize,
+      available: st.bavail * bsize,
+      inodes: st.files,
+      inodesUsed: st.files - st.ffree,
+      inodesFree: st.ffree,
+    }
   }
 
   ops(): readonly RegisteredOp[] {


### PR DESCRIPTION
## Summary

Tier 3 of #609: adds **`df`** with an honest, per-provider capacity model. mirage spans heterogeneous backends, so `df` reports real numbers only where a backend can truthfully provide them and a literal `-` everywhere else — **never a fabricated total** (the #609 mandate). Python ≡ TypeScript.

Scoped as **PR-A** (the framework + disk + the command); the per-provider quota APIs, the FUSE hookup, and the long-tail flags are **PR-B** (below).

## Capacity model

`CapacityResult` + a four-state `CapacityState` (`quota | elastic | na | unknown`), in `types.py` / `types.ts`. `Resource.statfs()` defaults to `unknown`; the **disk** backend overrides it with a real `os.statvfs` / `fs.statfs` → `quota`. Every other backend inherits `unknown` and renders `-`.

## The `df` command

A registry-aware executor handler (not a per-backend generic — `df` reports *mount-level* facts): it enumerates the target mounts (all, or the mount containing each `FILE`; `/` or no-arg → all), reads each mount's prefix + backend kind + `statfs`, and renders **one GNU-byte-exact table**.

- Columns: Filesystem (left, min width 14), optional Type (`-T`), right-justified numeric columns, Use%/Capacity, Mounted on (no trailing slash).
- Flags: `-h`/`-H` human sizes, `-k`/`-B` block size, `-T` type, `-i` inodes, `-P` POSIX; `-a` and `--sync` accepted no-ops. `Use% = ceil(used/(used+avail)·100)`.
- **Honest rendering:** `quota` → real numbers; `elastic`/`na`/`unknown` → `-` in every numeric column. GNU never emits `-` for blocks (it only sees real filesystems) — the deliberate, more-truthful divergence for a VFS.

```
Filesystem     1K-blocks Used Available Use% Mounted on
ram                    -    -         -    - /mem          # unknown backend
disk           482797652 306837348 175960304  64% /disk    # real statvfs
```

## Testing

- **Unit:** py 10 + ts 9 df tests (fixed-quota stub for deterministic numbers + a **real-disk `statfs`** assertion on both). Spec keyset/count tests updated (89 → 90).
- **Integ:** `integ/unix/df/basic.json` (5 cases), verified **byte-identical 1736/1736 on both hosts** (ram target → deterministic `-` output → confirms py ≡ ts).
- Full Python suite green (bar the pre-existing macOS-`tac` env failures), TS core vitest 4857, node resource tests + disk `statfs`, `pre-commit` clean (yapf/isort/prettier/eslint/knip/mypy), specs regenerated for all three surfaces.

## Deferred to PR-B

- Promote `statfs` to a dispatch `RegisteredOp` and wire the FUSE `statfs` off its current hardcoded fake (`fuse/fs.py` `f_blocks=1024*1024`; node `fuse.ts`) with a kernel-vs-agent sentinel split (kernel gets a large value so writes aren't blocked; `df` stays honest `-`). Untestable here (no macFUSE).
- Per-provider quota APIs (Drive `about.get`, Dropbox `get_space_usage`, OneDrive/SharePoint Graph, Gmail, Box, Nextcloud) + explicit `elastic` (S3/GridFS) / `na` (Slack/Postgres) states.
- Long-tail flags: `-l` (local vs network), `--output`, `-t`/`-x` type filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
