### PR TITLE
feat(commands): auto-inject --version for registered commands

### DIFF
--- a/integ/crossmount/version/basic.json
+++ b/integ/crossmount/version/basic.json
@@ -1,0 +1,66 @@
+{
+  "cases": [
+    {
+      "id": "xm_version_spans_mounts",
+      "seq": 782,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "cat --version /data/a.txt /data2/xm.txt | cut -d' ' -f1,2",
+      "expect": {
+        "exit": 0,
+        "stdout": "cat (Mirage)\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "xro_version_on_read_only_mount",
+      "seq": 783,
+      "targets": [
+        "ram",
+        "disk"
+      ],
+      "command": "rm --version /ro/xro.txt | cut -d' ' -f1,2",
+      "expect": {
+        "exit": 0,
+        "stdout": "rm (Mirage)\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "xro_help_on_read_only_mount",
+      "seq": 784,
+      "targets": [
+        "ram",
+        "disk"
+      ],
+      "command": "rm --help /ro/xro.txt | grep -c -F -- 'Usage: rm'",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/unix/version/basic.json
+++ b/integ/unix/version/basic.json
@@ -1,0 +1,232 @@
+{
+  "cases": [
+    {
+      "id": "version_cat",
+      "seq": 790,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "cat --version | cut -d' ' -f1,2",
+      "expect": {
+        "exit": 0,
+        "stdout": "cat (Mirage)\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "version_tsort",
+      "seq": 791,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "tsort --version | cut -d' ' -f1,2",
+      "expect": {
+        "exit": 0,
+        "stdout": "tsort (Mirage)\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "version_listed_in_help",
+      "seq": 792,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "cat --help | grep -c -F -- '--version'",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "version_after_end_of_options",
+      "seq": 793,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "grep -- --version /data/a.txt; echo code=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "code=1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "version_unknown_command_still_127",
+      "seq": 794,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "nosuchcmd --version 2>&1; echo code=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "nosuchcmd: command not found\ncode=127\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "version_write_command_not_run",
+      "seq": 795,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mkdir -p /data/pver && printf 'keep' > /data/pver/f.txt && rm --version /data/pver/f.txt | cut -d' ' -f1,2",
+      "expect": {
+        "exit": 0,
+        "stdout": "rm (Mirage)\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "version_write_target_survives",
+      "seq": 796,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "cat /data/pver/f.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "keep",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/python/mirage/commands/config.py
+++ b/python/mirage/commands/config.py
@@ -37,6 +37,37 @@ _VERSION_OPTION = Option(
 )
 
 
+def _version_line(name: str) -> bytes:
+    """Render the GNU-style version line for a command.
+
+    Args:
+        name (str): command name as invoked.
+    """
+    return f"{name} (Mirage) {__version__}\n".encode()
+
+
+def version_request(name: str, spec: CommandSpec | None,
+                    argv: list[str]) -> bytes | None:
+    """Version output when argv asks a command for the injected --version.
+
+    None when the command declares its own --version, when the flag is
+    absent, or when it sits after the `--` end-of-options marker.
+
+    Args:
+        name (str): command name as invoked.
+        spec (CommandSpec | None): the command's registered spec.
+        argv (list[str]): the words after the command name.
+    """
+    if spec is None or not any(o is _VERSION_OPTION for o in spec.options):
+        return None
+    for arg in argv:
+        if arg == "--":
+            return None
+        if arg == "--version":
+            return _version_line(name)
+    return None
+
+
 def _with_help_support(
         name: str, spec: CommandSpec,
         fn: Callable[..., Any]) -> tuple[CommandSpec, Callable[..., Any]]:
@@ -53,7 +84,7 @@ def _with_help_support(
     new_spec = (spec if not extras else replace(
         spec, options=spec.options + tuple(extras)))
     help_text = render_help(name, new_spec).encode()
-    version_text = f"{name} (Mirage) {__version__}\n".encode()
+    version_text = _version_line(name)
 
     @functools.wraps(fn)
     async def wrapper(accessor, paths, *texts, **kwargs):

--- a/python/mirage/commands/config.py
+++ b/python/mirage/commands/config.py
@@ -22,6 +22,7 @@ from mirage.commands.spec.help import render_help
 from mirage.commands.spec.types import OperandKind, Option
 from mirage.io.stream import yield_bytes
 from mirage.io.types import IOResult
+from mirage.version import __version__
 
 _HELP_OPTION = Option(
     long="--help",
@@ -29,19 +30,37 @@ _HELP_OPTION = Option(
     description="Show this help and exit",
 )
 
+_VERSION_OPTION = Option(
+    long="--version",
+    value_kind=OperandKind.NONE,
+    description="Show version information and exit",
+)
+
 
 def _with_help_support(
         name: str, spec: CommandSpec,
         fn: Callable[..., Any]) -> tuple[CommandSpec, Callable[..., Any]]:
-    has_help = any(o.long == "--help" for o in spec.options)
-    new_spec = spec if has_help else replace(
-        spec, options=spec.options + (_HELP_OPTION, ))
+    """Inject --help / --version and short-circuit them before the handler.
+
+    Mirrors GNU coreutils: every registered command accepts both flags,
+    prints to stdout, and exits 0 without running the command body.
+    """
+    extras: list[Option] = []
+    if not any(o.long == "--help" for o in spec.options):
+        extras.append(_HELP_OPTION)
+    if not any(o.long == "--version" for o in spec.options):
+        extras.append(_VERSION_OPTION)
+    new_spec = (spec if not extras else replace(
+        spec, options=spec.options + tuple(extras)))
     help_text = render_help(name, new_spec).encode()
+    version_text = f"{name} (Mirage) {__version__}\n".encode()
 
     @functools.wraps(fn)
     async def wrapper(accessor, paths, *texts, **kwargs):
         if kwargs.get("help") is True:
             return yield_bytes(help_text), IOResult()
+        if kwargs.get("version") is True:
+            return yield_bytes(version_text), IOResult()
         return await fn(accessor, paths, *texts, **kwargs)
 
     return new_spec, wrapper

--- a/python/mirage/workspace/executor/command.py
+++ b/python/mirage/workspace/executor/command.py
@@ -24,6 +24,7 @@ from mirage.commands.builtin.generic.crossmount.detect import strategy_for
 from mirage.commands.builtin.generic.crossmount.types import Strategy
 from mirage.commands.builtin.utils.safeguard import (CommandTimeoutError,
                                                      maybe_with_timeout)
+from mirage.commands.config import version_request
 from mirage.commands.errors import UsageError
 from mirage.commands.safeguard import resolve_across_mounts, resolve_safeguard
 from mirage.commands.spec import (SPECS, CommandSpec, OperandKind,
@@ -629,6 +630,19 @@ async def handle_command(
                               stderr=err), ExecutionNode(command=cmd_str,
                                                          exit_code=127,
                                                          stderr=err)
+
+    # --version answers from the package, never from a backend, so it is
+    # served before mount permission checks and cross-mount routing:
+    # otherwise `rm --version /ro/x` hits the read-only refusal and
+    # `cat --version /ram/a /disk/b` parses against the shared spec, which
+    # carries no injected --version, and fails as an unknown option.
+    cmd_mount = registry.mount_for_command(cmd_name)
+    version_out = version_request(
+        cmd_name,
+        cmd_mount.spec_for(cmd_name) if cmd_mount else None, raw_argv)
+    if version_out is not None:
+        return version_out, IOResult(), ExecutionNode(command=cmd_str,
+                                                      exit_code=0)
 
     # Path-valued flags (e.g. shuf --output=/dst/out) own a mount just like
     # positional operands, so they join routing and mount validation instead

--- a/python/mirage/workspace/mount/mount.py
+++ b/python/mirage/workspace/mount/mount.py
@@ -524,8 +524,13 @@ class MountEntry:
         revs_token = push_revisions(self.revisions or None)
         prev_manager = push_cache_manager(self.cache_manager)
         try:
+            # --help / --version short-circuit inside the handler wrapper
+            # and never touch the backend, so a read-only mount answers
+            # them like GNU instead of refusing them as writes.
+            info_only = (kw.get("help") is True or kw.get("version") is True)
             for cmd in handlers:
-                if cmd.write and self.effective_mode() == MountMode.READ:
+                if (cmd.write and not info_only
+                        and self.effective_mode() == MountMode.READ):
                     return None, IOResult(
                         exit_code=1,
                         stderr=(f"{cmd_name}: read-only mount "

--- a/python/tests/commands/test_config.py
+++ b/python/tests/commands/test_config.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
+
 from mirage.commands.config import RegisteredCommand, command, cross_command
 from mirage.commands.spec import CommandSpec, Operand, OperandKind
+from mirage.version import __version__
 
 
 class TestRegisteredCommand:
@@ -129,3 +132,42 @@ class TestCrossCommandDecorator:
         assert rc.src == "s3"
         assert rc.dst == "disk"
         assert rc.resource == "s3->disk"
+
+
+class TestVersionSupport:
+
+    def test_auto_injects_version_option(self):
+        spec = CommandSpec()
+
+        @command("foo", resource="disk", spec=spec)
+        async def my_fn(backend, paths, *texts, **kw):
+            pass
+
+        longs = [o.long for o in my_fn._registered_commands[0].spec.options]
+        assert "--version" in longs
+        assert "--help" in longs
+
+    def test_version_short_circuits_handler(self):
+        called = False
+
+        @command("tsort", resource="disk", spec=CommandSpec())
+        async def my_fn(backend, paths, *texts, **kw):
+            nonlocal called
+            called = True
+            return None, None
+
+        stdout, result = asyncio.run(my_fn._registered_commands[0].fn(
+            None, [], version=True))
+        assert called is False
+        chunks = asyncio.run(_collect(stdout))
+        assert chunks == f"tsort (Mirage) {__version__}\n".encode()
+        assert result.exit_code == 0
+
+
+async def _collect(source):
+    if isinstance(source, (bytes, bytearray)):
+        return bytes(source)
+    parts = []
+    async for chunk in source:
+        parts.append(chunk)
+    return b"".join(parts)

--- a/python/tests/commands/test_config.py
+++ b/python/tests/commands/test_config.py
@@ -14,9 +14,30 @@
 
 import asyncio
 
-from mirage.commands.config import RegisteredCommand, command, cross_command
-from mirage.commands.spec import CommandSpec, Operand, OperandKind
+from mirage.commands.config import (RegisteredCommand, command, cross_command,
+                                    version_request)
+from mirage.commands.spec import CommandSpec, Operand, OperandKind, Option
 from mirage.version import __version__
+
+_HANDLER_CALLS: list[str] = []
+
+
+async def _noop_handler(backend, paths, *texts, **kw):
+    return None, None
+
+
+async def _recording_handler(backend, paths, *texts, **kw):
+    _HANDLER_CALLS.append("called")
+    return None, None
+
+
+async def _collect(source):
+    if isinstance(source, (bytes, bytearray)):
+        return bytes(source)
+    parts = []
+    async for chunk in source:
+        parts.append(chunk)
+    return b"".join(parts)
 
 
 class TestRegisteredCommand:
@@ -137,37 +158,55 @@ class TestCrossCommandDecorator:
 class TestVersionSupport:
 
     def test_auto_injects_version_option(self):
-        spec = CommandSpec()
-
-        @command("foo", resource="disk", spec=spec)
-        async def my_fn(backend, paths, *texts, **kw):
-            pass
-
-        longs = [o.long for o in my_fn._registered_commands[0].spec.options]
+        registered = command("foo", resource="disk",
+                             spec=CommandSpec())(_noop_handler)
+        longs = [
+            o.long for o in registered._registered_commands[0].spec.options
+        ]
         assert "--version" in longs
         assert "--help" in longs
 
     def test_version_short_circuits_handler(self):
-        called = False
-
-        @command("tsort", resource="disk", spec=CommandSpec())
-        async def my_fn(backend, paths, *texts, **kw):
-            nonlocal called
-            called = True
-            return None, None
-
-        stdout, result = asyncio.run(my_fn._registered_commands[0].fn(
+        _HANDLER_CALLS.clear()
+        registered = command("tsort", resource="disk",
+                             spec=CommandSpec())(_recording_handler)
+        stdout, result = asyncio.run(registered._registered_commands[0].fn(
             None, [], version=True))
-        assert called is False
-        chunks = asyncio.run(_collect(stdout))
-        assert chunks == f"tsort (Mirage) {__version__}\n".encode()
+        assert _HANDLER_CALLS == []
+        assert asyncio.run(
+            _collect(stdout)) == f"tsort (Mirage) {__version__}\n".encode()
         assert result.exit_code == 0
 
 
-async def _collect(source):
-    if isinstance(source, (bytes, bytearray)):
-        return bytes(source)
-    parts = []
-    async for chunk in source:
-        parts.append(chunk)
-    return b"".join(parts)
+class TestVersionRequest:
+
+    def test_matches_injected_option(self):
+        registered = command("tsort", resource="disk",
+                             spec=CommandSpec())(_noop_handler)
+        spec = registered._registered_commands[0].spec
+        assert version_request(
+            "tsort", spec,
+            ["--version"]) == f"tsort (Mirage) {__version__}\n".encode()
+
+    def test_none_without_the_flag(self):
+        registered = command("tsort", resource="disk",
+                             spec=CommandSpec())(_noop_handler)
+        spec = registered._registered_commands[0].spec
+        assert version_request("tsort", spec, ["/data/a.txt"]) is None
+
+    def test_none_after_end_of_options(self):
+        registered = command("grep", resource="disk",
+                             spec=CommandSpec())(_noop_handler)
+        spec = registered._registered_commands[0].spec
+        assert version_request("grep", spec, ["--", "--version"]) is None
+
+    def test_none_for_unregistered_command(self):
+        assert version_request("nope", None, ["--version"]) is None
+
+    def test_none_when_command_declares_its_own_version(self):
+        spec = CommandSpec(options=(Option(long="--version"), ))
+        registered = command("custom", resource="disk",
+                             spec=spec)(_noop_handler)
+        assert version_request("custom",
+                               registered._registered_commands[0].spec,
+                               ["--version"]) is None

--- a/python/tests/workspace/test_help_man_integration.py
+++ b/python/tests/workspace/test_help_man_integration.py
@@ -41,6 +41,17 @@ def test_help_flag_renders_help_through_executor():
         _materialize(io.stdout))
     assert "Usage: cat" in out
     assert "--help" in out
+    assert "--version" in out
+
+
+def test_version_flag_prints_mirage_package_version():
+    ws = _ws()
+    io = _exec(ws, "tsort --version")
+    assert io.exit_code == 0
+    out = io.stdout.decode() if isinstance(io.stdout, bytes) else _run(
+        _materialize(io.stdout))
+    assert out.startswith("tsort (Mirage) ")
+    assert out.endswith("\n")
 
 
 def test_man_renders_help_for_known_command():

--- a/python/tests/workspace/test_help_man_integration.py
+++ b/python/tests/workspace/test_help_man_integration.py
@@ -29,8 +29,28 @@ def _ws():
     return Workspace(resources={"/ram/": (ram, MountMode.EXEC)}, )
 
 
+def _multi_ws():
+    ram = RAMResource()
+    ram._store.files["/a.txt"] = b"a\n"
+    other = RAMResource()
+    other._store.files["/b.txt"] = b"b\n"
+    ro = RAMResource()
+    ro._store.files["/c.txt"] = b"c\n"
+    return Workspace(
+        resources={
+            "/ram/": (ram, MountMode.EXEC),
+            "/other/": (other, MountMode.EXEC),
+            "/ro/": (ro, MountMode.READ),
+        })
+
+
 def _exec(ws, cmd):
     return _run(ws.execute(cmd))
+
+
+def _out(io):
+    return io.stdout.decode() if isinstance(io.stdout, bytes) else _run(
+        _materialize(io.stdout))
 
 
 def test_help_flag_renders_help_through_executor():
@@ -52,6 +72,41 @@ def test_version_flag_prints_mirage_package_version():
         _materialize(io.stdout))
     assert out.startswith("tsort (Mirage) ")
     assert out.endswith("\n")
+
+
+def test_version_beats_the_read_only_mount_refusal():
+    ws = _multi_ws()
+    io = _exec(ws, "rm --version /ro/c.txt")
+    assert io.exit_code == 0
+    assert _out(io).startswith("rm (Mirage) ")
+
+
+def test_help_beats_the_read_only_mount_refusal():
+    ws = _multi_ws()
+    io = _exec(ws, "rm --help /ro/c.txt")
+    assert io.exit_code == 0
+    assert "Usage: rm" in _out(io)
+
+
+def test_version_beats_cross_mount_routing():
+    ws = _multi_ws()
+    io = _exec(ws, "cat --version /ram/a.txt /other/b.txt")
+    assert io.exit_code == 0
+    assert _out(io).startswith("cat (Mirage) ")
+
+
+def test_version_does_not_run_a_write_command():
+    ws = _multi_ws()
+    io = _exec(ws, "rm --version /ram/a.txt")
+    assert io.exit_code == 0
+    assert _out(_exec(ws, "cat /ram/a.txt")) == "a\n"
+
+
+def test_version_after_end_of_options_stays_an_operand():
+    ws = _multi_ws()
+    io = _exec(ws, "grep -- --version /ram/a.txt")
+    assert io.exit_code == 1
+    assert _out(io) == ""
 
 
 def test_man_renders_help_for_known_command():

--- a/typescript/packages/core/src/commands/config.ts
+++ b/typescript/packages/core/src/commands/config.ts
@@ -19,6 +19,7 @@ import type { Resource } from '../resource/base.ts'
 import type { CommandSafeguard, PathSpec } from '../types.ts'
 import type { Runtime } from '../workspace/executor/runtime.ts'
 import type { StatOverlay } from '../ops/config.ts'
+import { VERSION } from '../version.ts'
 import type { AggregateResult } from './builtin/aggregators.ts'
 import { renderHelp } from './spec/help.ts'
 import { CommandSpec, OperandKind, Option } from './spec/types.ts'
@@ -142,26 +143,45 @@ const HELP_OPTION = new Option({
   description: 'Show this help and exit',
 })
 
+const VERSION_OPTION = new Option({
+  long: '--version',
+  valueKind: OperandKind.NONE,
+  description: 'Show version information and exit',
+})
+
 const HELP_ENC = new TextEncoder()
 
+/**
+ * Inject --help / --version and short-circuit them before the handler.
+ * Mirrors GNU coreutils: every registered command accepts both flags,
+ * prints to stdout, and exits 0 without running the command body.
+ */
 function withHelpSupport(
   name: string,
   spec: CommandSpec,
   fn: CommandFn,
 ): { spec: CommandSpec; fn: CommandFn } {
   const hasHelp = spec.options.some((o) => o.long === '--help')
+  const hasVersion = spec.options.some((o) => o.long === '--version')
+  const extras: Option[] = []
+  if (!hasHelp) extras.push(HELP_OPTION)
+  if (!hasVersion) extras.push(VERSION_OPTION)
   const init: ConstructorParameters<typeof CommandSpec>[0] = {
-    options: hasHelp ? spec.options : [...spec.options, HELP_OPTION],
+    options: extras.length === 0 ? spec.options : [...spec.options, ...extras],
     positional: spec.positional,
     rest: spec.rest,
     ignoreTokens: [...spec.ignoreTokens],
   }
   if (spec.description !== null) init.description = spec.description
-  const newSpec = hasHelp ? spec : new CommandSpec(init)
+  const newSpec = extras.length === 0 ? spec : new CommandSpec(init)
   const helpText = renderHelp(name, newSpec)
+  const versionText = `${name} (Mirage) ${VERSION}\n`
   const wrappedFn: CommandFn = async (accessor, paths, texts, opts) => {
     if (opts.flags.help === true) {
       return [HELP_ENC.encode(helpText), new IOResult()]
+    }
+    if (opts.flags.version === true) {
+      return [HELP_ENC.encode(versionText), new IOResult()]
     }
     return fn(accessor, paths, texts, opts)
   }

--- a/typescript/packages/core/src/commands/config.ts
+++ b/typescript/packages/core/src/commands/config.ts
@@ -151,6 +151,29 @@ const VERSION_OPTION = new Option({
 
 const HELP_ENC = new TextEncoder()
 
+/** Render the GNU-style version line for a command. */
+function versionLine(name: string): string {
+  return `${name} (Mirage) ${VERSION}\n`
+}
+
+/**
+ * Version output when argv asks a command for the injected --version.
+ * Null when the command declares its own --version, when the flag is
+ * absent, or when it sits after the `--` end-of-options marker.
+ */
+export function versionRequest(
+  name: string,
+  spec: CommandSpec | null,
+  argv: string[],
+): Uint8Array | null {
+  if (!spec?.options.some((o) => o === VERSION_OPTION)) return null
+  for (const arg of argv) {
+    if (arg === '--') return null
+    if (arg === '--version') return HELP_ENC.encode(versionLine(name))
+  }
+  return null
+}
+
 /**
  * Inject --help / --version and short-circuit them before the handler.
  * Mirrors GNU coreutils: every registered command accepts both flags,
@@ -175,7 +198,7 @@ function withHelpSupport(
   if (spec.description !== null) init.description = spec.description
   const newSpec = extras.length === 0 ? spec : new CommandSpec(init)
   const helpText = renderHelp(name, newSpec)
-  const versionText = `${name} (Mirage) ${VERSION}\n`
+  const versionText = versionLine(name)
   const wrappedFn: CommandFn = async (accessor, paths, texts, opts) => {
     if (opts.flags.help === true) {
       return [HELP_ENC.encode(helpText), new IOResult()]

--- a/typescript/packages/core/src/commands/multi_provider.test.ts
+++ b/typescript/packages/core/src/commands/multi_provider.test.ts
@@ -13,14 +13,22 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { command, RegisteredCommand } from './config.ts'
-import { CommandSpec } from './spec/types.ts'
+import { command, RegisteredCommand, versionRequest } from './config.ts'
+import { CommandSpec, Option } from './spec/types.ts'
 import { IOResult } from '../io/types.ts'
 
-describe('command() registers multiple resources', () => {
-  const noopFn = (): Promise<[Uint8Array, IOResult]> =>
-    Promise.resolve([new Uint8Array(), new IOResult()])
+const noopFn = (): Promise<[Uint8Array, IOResult]> =>
+  Promise.resolve([new Uint8Array(), new IOResult()])
 
+function specFor(name: string, spec = new CommandSpec()): CommandSpec | null {
+  return command({ name, resource: 'disk', spec, fn: noopFn })[0]?.spec ?? null
+}
+
+function decode(out: Uint8Array | null): string | null {
+  return out === null ? null : new TextDecoder().decode(out)
+}
+
+describe('command() registers multiple resources', () => {
   it('returns one RegisteredCommand per resource when passed an array', () => {
     const cmds = command({
       name: 'cat',
@@ -135,5 +143,29 @@ describe('command() registers multiple resources', () => {
     expect(stdout).toBeDefined()
     const text = new TextDecoder().decode(stdout as Uint8Array)
     expect(text).toMatch(/^tsort \(Mirage\) \d+\.\d+\.\d+\n$/)
+  })
+})
+
+describe('versionRequest', () => {
+  it('matches the injected option', () => {
+    const out = versionRequest('tsort', specFor('tsort'), ['--version'])
+    expect(decode(out)).toMatch(/^tsort \(Mirage\) \d+\.\d+\.\d+\n$/)
+  })
+
+  it('is null without the flag', () => {
+    expect(versionRequest('tsort', specFor('tsort'), ['/data/a.txt'])).toBeNull()
+  })
+
+  it('is null after the end-of-options marker', () => {
+    expect(versionRequest('grep', specFor('grep'), ['--', '--version'])).toBeNull()
+  })
+
+  it('is null for an unregistered command', () => {
+    expect(versionRequest('nope', null, ['--version'])).toBeNull()
+  })
+
+  it('is null when the command declares its own --version', () => {
+    const own = new CommandSpec({ options: [new Option({ long: '--version' })] })
+    expect(versionRequest('custom', specFor('custom', own), ['--version'])).toBeNull()
   })
 })

--- a/typescript/packages/core/src/commands/multi_provider.test.ts
+++ b/typescript/packages/core/src/commands/multi_provider.test.ts
@@ -99,4 +99,41 @@ describe('command() registers multiple resources', () => {
     expect(text).toContain('bar: do bar')
     expect(text).toContain('--help')
   })
+
+  it('auto-injects --version into spec.options', () => {
+    const cmds = command({
+      name: 'foo',
+      resource: 'disk',
+      spec: new CommandSpec(),
+      fn: noopFn,
+    })
+    const versionOpt = cmds[0]?.spec.options.find((o) => o.long === '--version')
+    expect(versionOpt).toBeDefined()
+  })
+
+  it('--version short-circuits the handler and returns package version', async () => {
+    let handlerCalled = false
+    const cmds = command({
+      name: 'tsort',
+      resource: 'disk',
+      spec: new CommandSpec(),
+      fn: () => {
+        handlerCalled = true
+        return Promise.resolve([new Uint8Array(), new IOResult()])
+      },
+    })
+    const opts = {
+      stdin: null,
+      flags: { version: true },
+      filetypeFns: null,
+      cwd: '/',
+      resource: {} as never,
+    }
+    const result = await cmds[0]?.fn({} as never, [], [], opts)
+    expect(handlerCalled).toBe(false)
+    const stdout = result?.[0]
+    expect(stdout).toBeDefined()
+    const text = new TextDecoder().decode(stdout as Uint8Array)
+    expect(text).toMatch(/^tsort \(Mirage\) \d+\.\d+\.\d+\n$/)
+  })
 })

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -55,6 +55,7 @@ import { resolveAcrossMounts, resolveSafeguard } from '../../commands/safeguard.
 import type { ExecuteNodeFn } from './jobs.ts'
 import { handleFg, handleJobs, handleKill, handlePs, handleWait } from './jobs.ts'
 import { UsageError } from '../../commands/errors.ts'
+import { versionRequest } from '../../commands/config.ts'
 import { formatFsError } from '../../utils/errors.ts'
 import { rstripSlash, stripSlash } from '../../utils/slash.ts'
 
@@ -383,6 +384,17 @@ export async function handleCommand(
       new IOResult({ exitCode: 127, stderr: errBytes }),
       new ExecutionNode({ command: cmdStr, exitCode: 127, stderr: errBytes }),
     ]
+  }
+
+  // --version answers from the package, never from a backend, so it is
+  // served before mount permission checks and cross-mount routing:
+  // otherwise `rm --version /ro/x` hits the read-only refusal and
+  // `cat --version /ram/a /disk/b` parses against the shared spec, which
+  // carries no injected --version, and fails as an unknown option.
+  const cmdMount = registry.mountForCommand(cmdName)
+  const versionOut = versionRequest(cmdName, cmdMount?.specFor(cmdName) ?? null, rawArgv)
+  if (versionOut !== null) {
+    return [versionOut, new IOResult(), new ExecutionNode({ command: cmdStr, exitCode: 0 })]
   }
 
   // Path-valued flags (e.g. shuf --output=/dst/out) own a mount just like

--- a/typescript/packages/core/src/workspace/help_man_integration.test.ts
+++ b/typescript/packages/core/src/workspace/help_man_integration.test.ts
@@ -31,6 +31,31 @@ async function makeWs(): Promise<Workspace> {
   )
 }
 
+async function makeMultiWs(): Promise<Workspace> {
+  const parser = await getTestParser()
+  const ram = new RAMResource()
+  ram.store.dirs.add('/')
+  ram.store.files.set('/a.txt', new TextEncoder().encode('a\n'))
+  const other = new RAMResource()
+  other.store.dirs.add('/')
+  other.store.files.set('/b.txt', new TextEncoder().encode('b\n'))
+  const ro = new RAMResource()
+  ro.store.dirs.add('/')
+  ro.store.files.set('/c.txt', new TextEncoder().encode('c\n'))
+  const registry = new OpsRegistry()
+  registry.registerResource(ram)
+  registry.registerResource(other)
+  registry.registerResource(ro)
+  return new Workspace(
+    {
+      '/ram/': [ram, MountMode.EXEC],
+      '/other/': [other, MountMode.EXEC],
+      '/ro/': [ro, MountMode.READ],
+    },
+    { mode: MountMode.WRITE, ops: registry, shellParser: parser },
+  )
+}
+
 describe('--help and man through the executor', () => {
   it('--help on a builtin renders help text without invoking the handler', async () => {
     const ws = await makeWs()
@@ -53,6 +78,41 @@ describe('--help and man through the executor', () => {
     const ws = await makeWs()
     const io = await ws.execute('cat --help')
     expect(stdoutStr(io)).toContain('--version')
+  })
+
+  it('--version beats the read-only mount refusal', async () => {
+    const ws = await makeMultiWs()
+    const io = await ws.execute('rm --version /ro/c.txt')
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toMatch(/^rm \(Mirage\) \d+\.\d+\.\d+\n$/)
+  })
+
+  it('--help beats the read-only mount refusal', async () => {
+    const ws = await makeMultiWs()
+    const io = await ws.execute('rm --help /ro/c.txt')
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toContain('Usage: rm')
+  })
+
+  it('--version beats cross-mount routing', async () => {
+    const ws = await makeMultiWs()
+    const io = await ws.execute('cat --version /ram/a.txt /other/b.txt')
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(io)).toMatch(/^cat \(Mirage\) \d+\.\d+\.\d+\n$/)
+  })
+
+  it('--version does not run a write command', async () => {
+    const ws = await makeMultiWs()
+    const io = await ws.execute('rm --version /ram/a.txt')
+    expect(io.exitCode).toBe(0)
+    expect(stdoutStr(await ws.execute('cat /ram/a.txt'))).toBe('a\n')
+  })
+
+  it('--version after the end-of-options marker stays an operand', async () => {
+    const ws = await makeMultiWs()
+    const io = await ws.execute('grep -- --version /ram/a.txt')
+    expect(io.exitCode).toBe(1)
+    expect(stdoutStr(io)).toBe('')
   })
 
   it('man <cmd> prints help from the existing handleMan', async () => {

--- a/typescript/packages/core/src/workspace/help_man_integration.test.ts
+++ b/typescript/packages/core/src/workspace/help_man_integration.test.ts
@@ -41,6 +41,20 @@ describe('--help and man through the executor', () => {
     expect(out).toContain('--help')
   })
 
+  it('--version on a builtin prints Mirage package version', async () => {
+    const ws = await makeWs()
+    const io = await ws.execute('tsort --version')
+    const out = stdoutStr(io)
+    expect(io.exitCode).toBe(0)
+    expect(out).toMatch(/^tsort \(Mirage\) \d+\.\d+\.\d+\n$/)
+  })
+
+  it('--version is listed in --help for registered commands', async () => {
+    const ws = await makeWs()
+    const io = await ws.execute('cat --help')
+    expect(stdoutStr(io)).toContain('--version')
+  })
+
   it('man <cmd> prints help from the existing handleMan', async () => {
     const ws = await makeWs()
     const io = await ws.execute('man cat')

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -446,8 +446,12 @@ export class MountEntry {
         runWithRevisions(
           this.revisions.size > 0 ? this.revisions : null,
           async (): Promise<[ByteSource | null, IOResult]> => {
+            // --help / --version short-circuit inside the handler
+            // wrapper and never touch the backend, so a read-only mount
+            // answers them like GNU instead of refusing them as writes.
+            const infoOnly = flags.help === true || flags.version === true
             for (const cmd of handlers) {
-              if (cmd.write && this.effectiveMode() === MountMode.READ) {
+              if (cmd.write && !infoOnly && this.effectiveMode() === MountMode.READ) {
                 return [
                   null,
                   new IOResult({


### PR DESCRIPTION
Fixes #610 (Tier 3 `--version` sweep).

Registered commands already get `--help` injected by `command()` and short-circuit to rendered help. This does the same for `--version`: the flag is added to the command spec, the handler is not called, and stdout prints:

```
<name> (Mirage) <package version>
```

with exit code 0. Package version comes from the existing Python `mirage.version` / TypeScript `VERSION` sources so both implementations stay aligned.

This covers the remaining Tier 3 item on #610, including `tsort --version`, without repeating the option in every command. Sort's `-V` / `--version-sort` stays a separate flag.

## Testing

- `pre-commit run` on the touched files (yapf, flake8, ruff, prettier, eslint, knip, mypy)
- Python: `pytest tests/commands/test_config.py tests/workspace/test_help_man_integration.py`
- TypeScript: vitest on `multi_provider.test.ts` and `help_man_integration.test.ts`
- Manual: `cat --version`, `tsort --version`, and `sort --version-sort` through a RAM workspace