### PR TITLE
chore(deps): bump pypdf to 6.14.2 to clear the uv audit job

### DIFF
--- a/python/uv.lock
+++ b/python/uv.lock
@@ -9735,11 +9735,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.13.3"
+version = "6.14.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/17/18/9947cc201af9ccf76720fd3347bf4f70eb882ce3fcf4cb05f7443e4cf871/pypdf-6.13.3.tar.gz", hash = "sha256:f3cb822769725f1bac658c406cfc9460399043f3750c2d3e4650e0a85eacabd7", size = 6484063, upload-time = "2026-06-17T15:22:00.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/56/2967e621598987905fb8cdfadd8f8de6b5c68c9351f0523c4df8409f28f1/pypdf-6.13.3-py3-none-any.whl", hash = "sha256:c6e3f86afb625791510b02ad5480e94b63970bb957df75d44657c282ecc52224", size = 347288, upload-time = "2026-06-17T15:21:59.512Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The `audit` job (`uv audit --preview-features audit --no-extra camel`) is failing on every branch, not just one: `pypdf 6.13.3` picked up four advisories.

| Advisory | Issue | Fixed in |
|---|---|---|
| CVE-2026-59937 | long runtimes for repeated malformed cross-reference entries | 6.14.0 |
| CVE-2026-59938 | large memory usage for wrong image dimensions | 6.14.0 |
| CVE-2026-59936 | infinite loop for unterminated inline images | 6.14.1 |
| CVE-2026-59935 | infinite loop for unterminated inline images (ASCII85 / ASCIIHex) | 6.14.2 |

`uv lock --upgrade-package pypdf` takes 6.13.3 to 6.14.2. The diff is one package, three lines.

`pypdf` is transitive via `browser-use`. Mirage reads PDFs through `pypdfium2` and never imports `pypdf` (no reference anywhere in `mirage/` or `tests/`), so this carries no behavior change.

Split out of #623, where it was noticed, because it fixes every branch rather than that one.

## Testing

Reproduced with the same uv CI installs (0.11.31; a local 0.11.0 exits 0 on these findings and hides the failure).

Before:

```
Found 4 known vulnerabilities and 1 adverse project status in 504 packages
EXIT=1
```

After:

```
Found no known vulnerabilities and 1 adverse project status in 504 packages
EXIT=0
```

Also: `uv sync --all-extras --no-extra camel` clean, `pypdf 6.14.2` installed, mirage imports fine, pdf/office tests pass, `pre-commit run --all-files` clean.

## Left alone

The remaining `socksio is archived` line is an *adverse project status*, not a vulnerability — `uv audit` exits 1 on vulnerabilities only, so it does not fail the job. It arrives via `httpx[socks]` from `openhands-sdk` and cannot be upgraded away; clearing it would mean dropping that dependency. Left visible rather than suppressed with `--ignore` or `|| true`, since the job is labelled informational and the line is accurate.