### PR TITLE
Add S3 proxy support to TypeScript and align proxy handling with Python

### DIFF
--- a/docs/typescript/setup/s3.mdx
+++ b/docs/typescript/setup/s3.mdx
@@ -26,6 +26,11 @@ const s3 = new S3Resource({
   region: process.env.AWS_DEFAULT_REGION ?? 'us-east-1',
   accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  // Optional:
+  // endpoint: 'http://localhost:9000',  // MinIO
+  // forcePathStyle: true,               // For MinIO/R2
+  // timeoutMs: 30_000,
+  // proxy: 'http://proxy:8080',
 })
 
 const ws = new Workspace({ '/bucket/': s3 }, { mode: MountMode.READ })

--- a/python/mirage/accessor/s3.py
+++ b/python/mirage/accessor/s3.py
@@ -30,7 +30,7 @@ class S3Config(BaseModel):
     aws_profile: str | None = None
     path_style: bool = False
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
     key_prefix: str | None = None
 
     @field_validator("key_prefix")

--- a/python/mirage/core/s3/_client.py
+++ b/python/mirage/core/s3/_client.py
@@ -43,6 +43,7 @@ def _client_kwargs(config: S3Config) -> dict[str, Any]:
     access_key_id = reveal_secret(config.aws_access_key_id)
     secret_access_key = reveal_secret(config.aws_secret_access_key)
     session_token = reveal_secret(config.aws_session_token)
+    proxy = reveal_secret(config.proxy)
     if access_key_id and secret_access_key:
         kwargs["aws_access_key_id"] = access_key_id
         kwargs["aws_secret_access_key"] = secret_access_key
@@ -52,8 +53,8 @@ def _client_kwargs(config: S3Config) -> dict[str, Any]:
         "connect_timeout": config.timeout,
         "read_timeout": config.timeout,
     }
-    if config.proxy:
-        cfg_kwargs["proxies"] = {"https": config.proxy, "http": config.proxy}
+    if proxy:
+        cfg_kwargs["proxies"] = {"https": proxy, "http": proxy}
     if config.path_style:
         cfg_kwargs["s3"] = {"addressing_style": "path"}
     kwargs["config"] = Config(**cfg_kwargs)

--- a/python/mirage/resource/aliyun/config.py
+++ b/python/mirage/resource/aliyun/config.py
@@ -28,7 +28,7 @@ class AliyunConfig(BaseModel):
     path_style: bool = False
     key_prefix: str | None = None
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
 
     def resolved_endpoint_url(self) -> str:
         if self.endpoint_url:

--- a/python/mirage/resource/backblaze/config.py
+++ b/python/mirage/resource/backblaze/config.py
@@ -28,7 +28,7 @@ class BackblazeConfig(BaseModel):
     path_style: bool = False
     key_prefix: str | None = None
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
 
     def resolved_endpoint_url(self) -> str:
         if self.endpoint_url:

--- a/python/mirage/resource/ceph/config.py
+++ b/python/mirage/resource/ceph/config.py
@@ -28,7 +28,7 @@ class CephConfig(BaseModel):
     path_style: bool = True
     key_prefix: str | None = None
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
 
     def to_s3_config(self) -> S3Config:
         return S3Config(

--- a/python/mirage/resource/digitalocean/config.py
+++ b/python/mirage/resource/digitalocean/config.py
@@ -28,7 +28,7 @@ class DigitalOceanConfig(BaseModel):
     path_style: bool = False
     key_prefix: str | None = None
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
 
     def resolved_endpoint_url(self) -> str:
         if self.endpoint_url:

--- a/python/mirage/resource/gcs/config.py
+++ b/python/mirage/resource/gcs/config.py
@@ -30,7 +30,7 @@ class GCSConfig(BaseModel):
     path_style: bool = False
     key_prefix: str | None = None
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
 
     def to_s3_config(self) -> S3Config:
         return S3Config(

--- a/python/mirage/resource/minio/config.py
+++ b/python/mirage/resource/minio/config.py
@@ -28,7 +28,7 @@ class MinIOConfig(BaseModel):
     path_style: bool = True
     key_prefix: str | None = None
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
 
     def to_s3_config(self) -> S3Config:
         return S3Config(

--- a/python/mirage/resource/oci/config.py
+++ b/python/mirage/resource/oci/config.py
@@ -28,7 +28,7 @@ class OCIConfig(BaseModel):
     secret_access_key: SecretStr
     key_prefix: str | None = None
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
 
     def resolved_endpoint_url(self) -> str:
         if self.endpoint_url:

--- a/python/mirage/resource/qingstor/config.py
+++ b/python/mirage/resource/qingstor/config.py
@@ -28,7 +28,7 @@ class QingStorConfig(BaseModel):
     path_style: bool = False
     key_prefix: str | None = None
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
 
     def resolved_endpoint_url(self) -> str:
         if self.endpoint_url:

--- a/python/mirage/resource/r2/config.py
+++ b/python/mirage/resource/r2/config.py
@@ -30,7 +30,7 @@ class R2Config(BaseModel):
     path_style: bool = False
     key_prefix: str | None = None
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
 
     def resolved_endpoint_url(self) -> str:
         if self.endpoint_url:

--- a/python/mirage/resource/scaleway/config.py
+++ b/python/mirage/resource/scaleway/config.py
@@ -28,7 +28,7 @@ class ScalewayConfig(BaseModel):
     path_style: bool = False
     key_prefix: str | None = None
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
 
     def resolved_endpoint_url(self) -> str:
         if self.endpoint_url:

--- a/python/mirage/resource/seaweedfs/config.py
+++ b/python/mirage/resource/seaweedfs/config.py
@@ -28,7 +28,7 @@ class SeaweedFSConfig(BaseModel):
     path_style: bool = True
     key_prefix: str | None = None
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
 
     def to_s3_config(self) -> S3Config:
         return S3Config(

--- a/python/mirage/resource/supabase/config.py
+++ b/python/mirage/resource/supabase/config.py
@@ -29,7 +29,7 @@ class SupabaseConfig(BaseModel):
     session_token: SecretStr | None = None
     key_prefix: str | None = None
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
 
     def resolved_endpoint_url(self) -> str:
         if self.endpoint_url:

--- a/python/mirage/resource/tencent/config.py
+++ b/python/mirage/resource/tencent/config.py
@@ -28,7 +28,7 @@ class TencentConfig(BaseModel):
     path_style: bool = False
     key_prefix: str | None = None
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
 
     def resolved_endpoint_url(self) -> str:
         if self.endpoint_url:

--- a/python/mirage/resource/wasabi/config.py
+++ b/python/mirage/resource/wasabi/config.py
@@ -28,7 +28,7 @@ class WasabiConfig(BaseModel):
     path_style: bool = False
     key_prefix: str | None = None
     timeout: int = 30
-    proxy: str | None = None
+    proxy: SecretStr | None = None
 
     def resolved_endpoint_url(self) -> str:
         if self.endpoint_url:

--- a/python/tests/resource/object_storage/test_minio.py
+++ b/python/tests/resource/object_storage/test_minio.py
@@ -59,7 +59,8 @@ def test_minio_config_to_s3_config():
     assert s3.path_style is True
     assert reveal_secret(s3.aws_access_key_id) == "minioadmin"
     assert reveal_secret(s3.aws_secret_access_key) == "minioadmin"
-    assert s3.proxy == "http://localhost:8080"
+    assert s3.proxy is not None
+    assert s3.proxy.get_secret_value() == "http://localhost:8080"
 
 
 def test_minio_config_path_style_override():

--- a/python/tests/resource/object_storage/test_oci.py
+++ b/python/tests/resource/object_storage/test_oci.py
@@ -66,7 +66,8 @@ def test_oci_config_to_s3_config():
     assert reveal_secret(s3_config.aws_access_key_id) == "access-key"
     assert reveal_secret(s3_config.aws_secret_access_key) == "secret-key"
     assert s3_config.path_style is True
-    assert s3_config.proxy == "http://localhost:8080"
+    assert s3_config.proxy is not None
+    assert s3_config.proxy.get_secret_value() == "http://localhost:8080"
 
 
 def test_oci_config_custom_endpoint():

--- a/python/tests/resource/object_storage/test_r2.py
+++ b/python/tests/resource/object_storage/test_r2.py
@@ -51,7 +51,8 @@ def test_r2config_to_s3_config():
         "https://account-123.r2.cloudflarestorage.com")
     assert reveal_secret(s3_config.aws_access_key_id) == "access-key"
     assert reveal_secret(s3_config.aws_secret_access_key) == "secret-key"
-    assert s3_config.proxy == "http://localhost:8080"
+    assert s3_config.proxy is not None
+    assert s3_config.proxy.get_secret_value() == "http://localhost:8080"
 
 
 def test_r2config_custom_endpoint():

--- a/python/tests/resource/object_storage/test_s3.py
+++ b/python/tests/resource/object_storage/test_s3.py
@@ -15,13 +15,39 @@
 import pytest
 from pydantic import ValidationError
 
-from mirage.resource.s3 import S3Config
+from mirage.core.s3._client import _client_kwargs
+from mirage.resource.s3 import S3Config, S3Resource
 
 
 def test_s3config_defaults():
     c = S3Config(bucket="my-bucket")
     assert c.region is None
     assert c.timeout == 30
+    assert c.proxy is None
+
+
+def test_s3_client_kwargs_route_through_proxy():
+    config = S3Config(bucket="b",
+                      proxy="http://proxy-user:proxy-secret@localhost:8080")
+    proxies = _client_kwargs(config)["config"].proxies
+    assert proxies == {
+        "http": "http://proxy-user:proxy-secret@localhost:8080",
+        "https": "http://proxy-user:proxy-secret@localhost:8080",
+    }
+
+
+def test_s3_client_kwargs_treat_empty_proxy_as_disabled():
+    config = S3Config(bucket="b", proxy="")
+    assert _client_kwargs(config)["config"].proxies is None
+
+
+def test_s3_state_redacts_proxy_credentials():
+    resource = S3Resource(
+        S3Config(bucket="b", proxy="http://proxy-user:proxy-secret@host:8080"))
+    blob = repr(resource.get_state())
+    assert "proxy-user" not in blob
+    assert "proxy-secret" not in blob
+    assert "<REDACTED>" in blob
 
 
 def test_s3config_immutable():

--- a/python/tests/resource/object_storage/test_seaweedfs.py
+++ b/python/tests/resource/object_storage/test_seaweedfs.py
@@ -59,7 +59,8 @@ def test_seaweedfs_config_to_s3_config():
     assert s3.path_style is True
     assert reveal_secret(s3.aws_access_key_id) == "weed"
     assert reveal_secret(s3.aws_secret_access_key) == "weed"
-    assert s3.proxy == "http://localhost:8080"
+    assert s3.proxy is not None
+    assert s3.proxy.get_secret_value() == "http://localhost:8080"
 
 
 def test_seaweedfs_config_path_style_override():

--- a/python/tests/resource/object_storage/test_supabase.py
+++ b/python/tests/resource/object_storage/test_supabase.py
@@ -67,7 +67,8 @@ def test_supabase_config_to_s3_config():
     assert reveal_secret(s3_config.aws_secret_access_key) == "secret-key"
     assert reveal_secret(s3_config.aws_session_token) == "session-token"
     assert s3_config.path_style is True
-    assert s3_config.proxy == "http://localhost:8080"
+    assert s3_config.proxy is not None
+    assert s3_config.proxy.get_secret_value() == "http://localhost:8080"
 
 
 def test_supabase_config_requires_project_ref_or_endpoint():

--- a/typescript/.changeset/quiet-proxies-decode.md
+++ b/typescript/.changeset/quiet-proxies-decode.md
@@ -1,6 +1,0 @@
----
-'@struktoai/mirage-core': patch
-'@struktoai/mirage-node': patch
----
-
-Add proxy support for Node S3-compatible resources and decode LanceDB blobs without relying on Node's `Buffer` global.

--- a/typescript/.changeset/quiet-proxies-decode.md
+++ b/typescript/.changeset/quiet-proxies-decode.md
@@ -1,0 +1,6 @@
+---
+'@struktoai/mirage-core': patch
+'@struktoai/mirage-node': patch
+---
+
+Add proxy support for Node S3-compatible resources and decode LanceDB blobs without relying on Node's `Buffer` global.

--- a/typescript/packages/core/src/accessor/s3.ts
+++ b/typescript/packages/core/src/accessor/s3.ts
@@ -16,14 +16,10 @@ import { Accessor } from './base.ts'
 import type { Resource } from '../resource/base.ts'
 import type { S3Config } from '../resource/s3/config.ts'
 
-export interface S3RuntimeConfig extends S3Config {
-  requestHandler?: unknown
-}
-
 export class S3Accessor extends Accessor {
-  readonly config: S3RuntimeConfig
+  readonly config: S3Config
 
-  constructor(config: S3RuntimeConfig) {
+  constructor(config: S3Config) {
     super()
     this.config = config
   }

--- a/typescript/packages/core/src/accessor/s3.ts
+++ b/typescript/packages/core/src/accessor/s3.ts
@@ -16,10 +16,14 @@ import { Accessor } from './base.ts'
 import type { Resource } from '../resource/base.ts'
 import type { S3Config } from '../resource/s3/config.ts'
 
-export class S3Accessor extends Accessor {
-  readonly config: S3Config
+export interface S3RuntimeConfig extends S3Config {
+  requestHandler?: unknown
+}
 
-  constructor(config: S3Config) {
+export class S3Accessor extends Accessor {
+  readonly config: S3RuntimeConfig
+
+  constructor(config: S3RuntimeConfig) {
     super()
     this.config = config
   }

--- a/typescript/packages/core/src/core/lancedb/read.test.ts
+++ b/typescript/packages/core/src/core/lancedb/read.test.ts
@@ -1,0 +1,59 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { LanceDBAccessor } from '../../accessor/lancedb.ts'
+import { resolveLanceDBConfig } from '../../resource/lancedb/config.ts'
+import { PathSpec } from '../../types.ts'
+import type { LanceDriver } from './_driver.ts'
+import { read } from './read.ts'
+
+const BLOB_PATH = new PathSpec({ resourcePath: '1.bin', virtual: '/1.bin', directory: '/1.bin' })
+
+function makeAccessor(blob: unknown): LanceDBAccessor {
+  const driver = {
+    rowRecord: vi.fn().mockResolvedValue({ id: '1', blob }),
+  } as unknown as LanceDriver
+  const config = resolveLanceDBConfig({
+    uri: '/tmp/db',
+    table: 'items',
+    idColumn: 'id',
+    blobColumn: 'blob',
+    blobExt: 'bin',
+  })
+  return new LanceDBAccessor(driver, config)
+}
+
+describe('lancedb core read', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('decodes base64 without the Node Buffer global', async () => {
+    vi.stubGlobal('Buffer', undefined)
+    const bytes = await read(makeAccessor('AAEC/w=='), BLOB_PATH)
+    expect([...bytes]).toEqual([0, 1, 2, 255])
+  })
+
+  it('returns Uint8Array blobs unchanged', async () => {
+    const blob = new Uint8Array([3, 2, 1])
+    expect(await read(makeAccessor(blob), BLOB_PATH)).toBe(blob)
+  })
+
+  it('rejects values that are neither bytes nor base64 strings', async () => {
+    await expect(read(makeAccessor(42), BLOB_PATH)).rejects.toThrow(
+      'blob column is not bytes or base64 string',
+    )
+  })
+})

--- a/typescript/packages/core/src/core/lancedb/read.ts
+++ b/typescript/packages/core/src/core/lancedb/read.ts
@@ -16,6 +16,7 @@ import type { LanceDBAccessor } from '../../accessor/lancedb.ts'
 import type { IndexCacheStore } from '../../cache/index/store.ts'
 import type { LanceRow } from './_driver.ts'
 import { PathSpec } from '../../types.ts'
+import { decodeBase64 } from '../../utils/base64.ts'
 import { renderCard } from './render.ts'
 import { type LanceDBScope, ScopeLevel, detectScope } from './scope.ts'
 
@@ -35,7 +36,7 @@ async function resolveRow(accessor: LanceDBAccessor, scope: LanceDBScope): Promi
 
 function blobBytes(value: unknown): Uint8Array {
   if (value instanceof Uint8Array) return value
-  if (typeof value === 'string') return Uint8Array.from(Buffer.from(value, 'base64'))
+  if (typeof value === 'string') return decodeBase64(value)
   throw new Error('blob column is not bytes or base64 string')
 }
 

--- a/typescript/packages/core/src/core/s3/_client.test.ts
+++ b/typescript/packages/core/src/core/s3/_client.test.ts
@@ -1,0 +1,25 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it, vi } from 'vitest'
+import { createS3Client } from './_client.ts'
+
+describe('S3 client', () => {
+  it('forwards an injected request handler', async () => {
+    const requestHandler = { handle: vi.fn() }
+    const client = await createS3Client({ bucket: 'b', requestHandler })
+    expect(client.config.requestHandler).toBe(requestHandler)
+    client.destroy()
+  })
+})

--- a/typescript/packages/core/src/core/s3/_client.test.ts
+++ b/typescript/packages/core/src/core/s3/_client.test.ts
@@ -12,14 +12,74 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { describe, expect, it, vi } from 'vitest'
+import type { S3Client } from '@aws-sdk/client-s3'
+import { describe, expect, it } from 'vitest'
+import type { S3HttpAgents } from '../../resource/s3/config.ts'
 import { createS3Client } from './_client.ts'
 
+interface ResolvedHandlerConfig {
+  connectionTimeout?: number
+  requestTimeout?: number
+  httpAgent?: unknown
+  httpAgentProvider?: () => Promise<unknown>
+  httpsAgent?: unknown
+}
+
+function makeAgents(): S3HttpAgents {
+  return { httpAgent: { destroy: () => undefined }, httpsAgent: { destroy: () => undefined } }
+}
+
+// The SDK builds the NodeHttpHandler itself from the options object we hand it
+// and resolves that config lazily, so read it back through `configProvider`.
+function resolvedHandlerConfig(client: S3Client): Promise<ResolvedHandlerConfig> {
+  const handler = client.config.requestHandler as unknown as {
+    configProvider: Promise<ResolvedHandlerConfig>
+  }
+  return handler.configProvider
+}
+
 describe('S3 client', () => {
-  it('forwards an injected request handler', async () => {
-    const requestHandler = { handle: vi.fn() }
-    const client = await createS3Client({ bucket: 'b', requestHandler })
-    expect(client.config.requestHandler).toBe(requestHandler)
+  it('forwards runtime-provided agents into the request handler', async () => {
+    const agents = makeAgents()
+    const client = await createS3Client({ bucket: 'b', httpAgentProvider: () => agents })
+    const resolved = await resolvedHandlerConfig(client)
+    const httpAgent = (await resolved.httpAgentProvider?.()) ?? resolved.httpAgent
+    expect(httpAgent).toBe(agents.httpAgent)
+    expect(resolved.httpsAgent).toBe(agents.httpsAgent)
+    client.destroy()
+  })
+
+  // Every S3 op destroys its own client when it finishes. Agents must therefore
+  // be per-client: a shared pair would let one op's cleanup tear down sockets a
+  // concurrent op is still using (e.g. `ls -l`, which stats entries in parallel).
+  it('asks the provider for fresh agents per client so destroy() stays scoped', async () => {
+    const seen: unknown[] = []
+    const provider = (): S3HttpAgents => {
+      const agents = makeAgents()
+      seen.push(agents.httpsAgent)
+      return agents
+    }
+    const config = { bucket: 'b', httpAgentProvider: provider }
+    const a = await createS3Client(config)
+    const b = await createS3Client(config)
+    expect(seen).toHaveLength(2)
+    expect(seen[0]).not.toBe(seen[1])
+    expect(await resolvedHandlerConfig(a)).not.toBe(await resolvedHandlerConfig(b))
+    a.destroy()
+    b.destroy()
+  })
+
+  it('keeps timeouts alongside provided agents', async () => {
+    const agents = makeAgents()
+    const client = await createS3Client({
+      bucket: 'b',
+      timeoutMs: 1234,
+      httpAgentProvider: () => agents,
+    })
+    const resolved = await resolvedHandlerConfig(client)
+    expect(resolved.requestTimeout).toBe(1234)
+    expect(resolved.connectionTimeout).toBe(1234)
+    expect(resolved.httpsAgent).toBe(agents.httpsAgent)
     client.destroy()
   })
 })

--- a/typescript/packages/core/src/core/s3/_client.ts
+++ b/typescript/packages/core/src/core/s3/_client.ts
@@ -15,7 +15,6 @@
 import { mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { S3Client } from '@aws-sdk/client-s3'
 import type { PathSpec } from '../../types.ts'
-import type { S3RuntimeConfig } from '../../accessor/s3.ts'
 import { loadOptionalPeer } from '../../utils/optional_peer.ts'
 import * as kp from '../../utils/key_prefix.ts'
 import type { S3Config } from '../../resource/s3/config.ts'
@@ -45,7 +44,7 @@ export interface S3SendClient {
 }
 
 export async function withClient<T>(
-  config: S3RuntimeConfig,
+  config: S3Config,
   fn: (client: S3SendClient) => Promise<T>,
 ): Promise<T> {
   const client = (await createS3Client(config)) as unknown as S3SendClient
@@ -94,7 +93,7 @@ export async function loadS3Module(config?: S3Config): Promise<S3Module> {
   return cachedModule
 }
 
-export async function createS3Client(config: S3RuntimeConfig): Promise<S3Client> {
+export async function createS3Client(config: S3Config): Promise<S3Client> {
   if (config.presignedUrlProvider !== undefined) {
     const { createBrowserS3Client } = await import('./_client_browser.ts')
     return createBrowserS3Client(config) as unknown as S3Client
@@ -111,13 +110,14 @@ export async function createS3Client(config: S3RuntimeConfig): Promise<S3Client>
       ...(config.sessionToken !== undefined ? { sessionToken: config.sessionToken } : {}),
     }
   }
-  if (config.requestHandler !== undefined) {
-    options.requestHandler = config.requestHandler
-  } else if (config.timeoutMs !== undefined) {
-    options.requestHandler = {
-      connectionTimeout: config.timeoutMs,
-      requestTimeout: config.timeoutMs,
-    }
+  const requestHandler: Record<string, unknown> = {
+    ...(config.timeoutMs !== undefined
+      ? { connectionTimeout: config.timeoutMs, requestTimeout: config.timeoutMs }
+      : {}),
+    ...(config.httpAgentProvider !== undefined ? config.httpAgentProvider() : {}),
+  }
+  if (Object.keys(requestHandler).length > 0) {
+    options.requestHandler = requestHandler
   }
   return new mod.S3Client(options)
 }

--- a/typescript/packages/core/src/core/s3/_client.ts
+++ b/typescript/packages/core/src/core/s3/_client.ts
@@ -110,7 +110,9 @@ export async function createS3Client(config: S3Config): Promise<S3Client> {
       ...(config.sessionToken !== undefined ? { sessionToken: config.sessionToken } : {}),
     }
   }
-  if (config.timeoutMs !== undefined) {
+  if (config.requestHandler !== undefined) {
+    options.requestHandler = config.requestHandler
+  } else if (config.timeoutMs !== undefined) {
     options.requestHandler = {
       connectionTimeout: config.timeoutMs,
       requestTimeout: config.timeoutMs,

--- a/typescript/packages/core/src/core/s3/_client.ts
+++ b/typescript/packages/core/src/core/s3/_client.ts
@@ -15,6 +15,7 @@
 import { mountPrefixOf } from '../../utils/key_prefix.ts'
 import type { S3Client } from '@aws-sdk/client-s3'
 import type { PathSpec } from '../../types.ts'
+import type { S3RuntimeConfig } from '../../accessor/s3.ts'
 import { loadOptionalPeer } from '../../utils/optional_peer.ts'
 import * as kp from '../../utils/key_prefix.ts'
 import type { S3Config } from '../../resource/s3/config.ts'
@@ -44,7 +45,7 @@ export interface S3SendClient {
 }
 
 export async function withClient<T>(
-  config: S3Config,
+  config: S3RuntimeConfig,
   fn: (client: S3SendClient) => Promise<T>,
 ): Promise<T> {
   const client = (await createS3Client(config)) as unknown as S3SendClient
@@ -93,7 +94,7 @@ export async function loadS3Module(config?: S3Config): Promise<S3Module> {
   return cachedModule
 }
 
-export async function createS3Client(config: S3Config): Promise<S3Client> {
+export async function createS3Client(config: S3RuntimeConfig): Promise<S3Client> {
   if (config.presignedUrlProvider !== undefined) {
     const { createBrowserS3Client } = await import('./_client_browser.ts')
     return createBrowserS3Client(config) as unknown as S3Client

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -607,6 +607,8 @@ export {
   type S3BrowserSignOptions,
   type S3Config,
   type S3ConfigRedacted,
+  type S3HttpAgentProvider,
+  type S3HttpAgents,
 } from './resource/s3/config.ts'
 export { remapCommandsResource, remapOpsResource } from './resource/s3/remap.ts'
 export { S3_PROMPT } from './resource/s3/prompt.ts'

--- a/typescript/packages/core/src/resource/s3/config.ts
+++ b/typescript/packages/core/src/resource/s3/config.ts
@@ -33,6 +33,19 @@ export type S3BrowserPresignedUrlProvider = (
   options?: S3BrowserSignOptions,
 ) => Promise<string>
 
+export interface S3HttpAgents {
+  httpAgent: unknown
+  httpsAgent: unknown
+}
+
+/**
+ * Runtime-supplied transport agents (Node proxy support). Called once per
+ * client so each client owns its own agents: every S3 op destroys its client
+ * when it finishes, and a shared agent pair would tear down sockets that
+ * concurrent ops are still using.
+ */
+export type S3HttpAgentProvider = () => S3HttpAgents
+
 export const S3ConfigSchema = z.object({
   bucket: z.string(),
   region: z.string().optional(),
@@ -44,6 +57,9 @@ export const S3ConfigSchema = z.object({
   timeoutMs: z.number().optional(),
   presignedUrlProvider: secretSchema(
     z.custom<S3BrowserPresignedUrlProvider>((value) => typeof value === 'function'),
+  ).optional(),
+  httpAgentProvider: secretSchema(
+    z.custom<S3HttpAgentProvider>((value) => typeof value === 'function'),
   ).optional(),
   defaultContentType: z.string().optional(),
   keyPrefix: z.string().optional(),
@@ -59,6 +75,7 @@ export interface S3Config {
   forcePathStyle?: boolean
   timeoutMs?: number
   presignedUrlProvider?: S3BrowserPresignedUrlProvider
+  httpAgentProvider?: S3HttpAgentProvider
   defaultContentType?: string
   keyPrefix?: string
 }
@@ -70,12 +87,13 @@ export function normalizeKeyPrefix(v: string | undefined): string | undefined {
 
 export interface S3ConfigRedacted extends Omit<
   S3Config,
-  'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'presignedUrlProvider'
+  'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'presignedUrlProvider' | 'httpAgentProvider'
 > {
   accessKeyId?: string
   secretAccessKey?: string
   sessionToken?: string
   presignedUrlProvider?: '<REDACTED>'
+  httpAgentProvider?: '<REDACTED>'
 }
 
 export function redactConfig(config: S3Config): S3ConfigRedacted {

--- a/typescript/packages/core/src/resource/s3/config.ts
+++ b/typescript/packages/core/src/resource/s3/config.ts
@@ -42,7 +42,6 @@ export const S3ConfigSchema = z.object({
   sessionToken: secretStr().optional(),
   forcePathStyle: z.boolean().optional(),
   timeoutMs: z.number().optional(),
-  requestHandler: secretSchema(z.unknown()).optional(),
   presignedUrlProvider: secretSchema(
     z.custom<S3BrowserPresignedUrlProvider>((value) => typeof value === 'function'),
   ).optional(),
@@ -59,7 +58,6 @@ export interface S3Config {
   sessionToken?: string
   forcePathStyle?: boolean
   timeoutMs?: number
-  requestHandler?: unknown
   presignedUrlProvider?: S3BrowserPresignedUrlProvider
   defaultContentType?: string
   keyPrefix?: string
@@ -72,12 +70,11 @@ export function normalizeKeyPrefix(v: string | undefined): string | undefined {
 
 export interface S3ConfigRedacted extends Omit<
   S3Config,
-  'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'requestHandler' | 'presignedUrlProvider'
+  'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'presignedUrlProvider'
 > {
   accessKeyId?: string
   secretAccessKey?: string
   sessionToken?: string
-  requestHandler?: '<REDACTED>'
   presignedUrlProvider?: '<REDACTED>'
 }
 

--- a/typescript/packages/core/src/resource/s3/config.ts
+++ b/typescript/packages/core/src/resource/s3/config.ts
@@ -42,6 +42,7 @@ export const S3ConfigSchema = z.object({
   sessionToken: secretStr().optional(),
   forcePathStyle: z.boolean().optional(),
   timeoutMs: z.number().optional(),
+  requestHandler: secretSchema(z.unknown()).optional(),
   presignedUrlProvider: secretSchema(
     z.custom<S3BrowserPresignedUrlProvider>((value) => typeof value === 'function'),
   ).optional(),
@@ -58,6 +59,7 @@ export interface S3Config {
   sessionToken?: string
   forcePathStyle?: boolean
   timeoutMs?: number
+  requestHandler?: unknown
   presignedUrlProvider?: S3BrowserPresignedUrlProvider
   defaultContentType?: string
   keyPrefix?: string
@@ -70,11 +72,12 @@ export function normalizeKeyPrefix(v: string | undefined): string | undefined {
 
 export interface S3ConfigRedacted extends Omit<
   S3Config,
-  'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'presignedUrlProvider'
+  'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'requestHandler' | 'presignedUrlProvider'
 > {
   accessKeyId?: string
   secretAccessKey?: string
   sessionToken?: string
+  requestHandler?: '<REDACTED>'
   presignedUrlProvider?: '<REDACTED>'
 }
 

--- a/typescript/packages/node/package.json
+++ b/typescript/packages/node/package.json
@@ -49,11 +49,14 @@
   },
   "dependencies": {
     "@napi-rs/lzma": "^1.4.5",
+    "@smithy/node-http-handler": "^4.9.7",
     "@struktoai/mirage-core": "workspace:*",
     "compressjs": "^1.0.3",
     "fast-xml-parser": "^5.9.0",
     "fast-xml-validator": "^1.4.0",
     "fs-monkey": "^1.1.0",
+    "http-proxy-agent": "^7.0.2",
+    "https-proxy-agent": "^7.0.6",
     "tree-sitter-bash": "^0.25.1",
     "web-tree-sitter": "^0.26.8"
   },

--- a/typescript/packages/node/package.json
+++ b/typescript/packages/node/package.json
@@ -49,7 +49,6 @@
   },
   "dependencies": {
     "@napi-rs/lzma": "^1.4.5",
-    "@smithy/node-http-handler": "^4.7.3",
     "@struktoai/mirage-core": "workspace:*",
     "compressjs": "^1.0.3",
     "fast-xml-parser": "^5.9.0",

--- a/typescript/packages/node/package.json
+++ b/typescript/packages/node/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@napi-rs/lzma": "^1.4.5",
-    "@smithy/node-http-handler": "^4.9.7",
+    "@smithy/node-http-handler": "^4.7.3",
     "@struktoai/mirage-core": "workspace:*",
     "compressjs": "^1.0.3",
     "fast-xml-parser": "^5.9.0",

--- a/typescript/packages/node/src/resource/aliyun/config.ts
+++ b/typescript/packages/node/src/resource/aliyun/config.ts
@@ -24,6 +24,7 @@ export interface AliyunConfig {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 export interface AliyunConfigRedacted {
@@ -35,6 +36,7 @@ export interface AliyunConfigRedacted {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 const AliyunConfigSchema = z.object({
@@ -46,6 +48,7 @@ const AliyunConfigSchema = z.object({
   forcePathStyle: z.boolean().optional(),
   keyPrefix: z.string().optional(),
   timeoutMs: z.number().optional(),
+  proxy: secretStr().optional(),
 })
 
 export function resolvedAliyunEndpoint(config: AliyunConfig): string {
@@ -64,6 +67,7 @@ export function aliyunToS3Config(config: AliyunConfig): S3Config {
     ...(config.forcePathStyle !== undefined ? { forcePathStyle: config.forcePathStyle } : {}),
     ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    ...(config.proxy !== undefined ? { proxy: config.proxy } : {}),
   }
 }
 
@@ -87,6 +91,5 @@ export function normalizeAliyunConfig(input: Record<string, unknown>): AliyunCon
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as AliyunConfig
 }

--- a/typescript/packages/node/src/resource/backblaze/config.ts
+++ b/typescript/packages/node/src/resource/backblaze/config.ts
@@ -24,6 +24,7 @@ export interface BackblazeConfig {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 export interface BackblazeConfigRedacted {
@@ -35,6 +36,7 @@ export interface BackblazeConfigRedacted {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 const BackblazeConfigSchema = z.object({
@@ -46,6 +48,7 @@ const BackblazeConfigSchema = z.object({
   forcePathStyle: z.boolean().optional(),
   keyPrefix: z.string().optional(),
   timeoutMs: z.number().optional(),
+  proxy: secretStr().optional(),
 })
 
 export function resolvedBackblazeEndpoint(config: BackblazeConfig): string {
@@ -64,6 +67,7 @@ export function backblazeToS3Config(config: BackblazeConfig): S3Config {
     ...(config.forcePathStyle !== undefined ? { forcePathStyle: config.forcePathStyle } : {}),
     ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    ...(config.proxy !== undefined ? { proxy: config.proxy } : {}),
   }
 }
 
@@ -87,6 +91,5 @@ export function normalizeBackblazeConfig(input: Record<string, unknown>): Backbl
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as BackblazeConfig
 }

--- a/typescript/packages/node/src/resource/ceph/config.ts
+++ b/typescript/packages/node/src/resource/ceph/config.ts
@@ -24,6 +24,7 @@ export interface CephConfig {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 export interface CephConfigRedacted {
@@ -35,6 +36,7 @@ export interface CephConfigRedacted {
   forcePathStyle: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 const CephConfigSchema = z.object({
@@ -46,6 +48,7 @@ const CephConfigSchema = z.object({
   forcePathStyle: z.boolean(),
   keyPrefix: z.string().optional(),
   timeoutMs: z.number().optional(),
+  proxy: secretStr().optional(),
 })
 
 export function cephToS3Config(config: CephConfig): S3Config {
@@ -58,6 +61,7 @@ export function cephToS3Config(config: CephConfig): S3Config {
     forcePathStyle: config.forcePathStyle ?? true,
     ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    ...(config.proxy !== undefined ? { proxy: config.proxy } : {}),
   }
 }
 
@@ -82,6 +86,5 @@ export function normalizeCephConfig(input: Record<string, unknown>): CephConfig 
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as CephConfig
 }

--- a/typescript/packages/node/src/resource/digitalocean/config.ts
+++ b/typescript/packages/node/src/resource/digitalocean/config.ts
@@ -24,6 +24,7 @@ export interface DigitalOceanConfig {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 export interface DigitalOceanConfigRedacted {
@@ -35,6 +36,7 @@ export interface DigitalOceanConfigRedacted {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 const DigitalOceanConfigSchema = z.object({
@@ -46,6 +48,7 @@ const DigitalOceanConfigSchema = z.object({
   forcePathStyle: z.boolean().optional(),
   keyPrefix: z.string().optional(),
   timeoutMs: z.number().optional(),
+  proxy: secretStr().optional(),
 })
 
 export function resolvedDigitalOceanEndpoint(config: DigitalOceanConfig): string {
@@ -64,6 +67,7 @@ export function digitalOceanToS3Config(config: DigitalOceanConfig): S3Config {
     ...(config.forcePathStyle !== undefined ? { forcePathStyle: config.forcePathStyle } : {}),
     ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    ...(config.proxy !== undefined ? { proxy: config.proxy } : {}),
   }
 }
 
@@ -87,6 +91,5 @@ export function normalizeDigitalOceanConfig(input: Record<string, unknown>): Dig
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as DigitalOceanConfig
 }

--- a/typescript/packages/node/src/resource/gcs/config.ts
+++ b/typescript/packages/node/src/resource/gcs/config.ts
@@ -26,6 +26,7 @@ export interface GCSConfig {
   timeoutMs?: number
   forcePathStyle?: boolean
   keyPrefix?: string
+  proxy?: string
 }
 
 export interface GCSConfigRedacted {
@@ -37,6 +38,7 @@ export interface GCSConfigRedacted {
   timeoutMs?: number
   forcePathStyle?: boolean
   keyPrefix?: string
+  proxy?: string
 }
 
 const GCSConfigSchema = z.object({
@@ -48,6 +50,7 @@ const GCSConfigSchema = z.object({
   timeoutMs: z.number().optional(),
   forcePathStyle: z.boolean().optional(),
   keyPrefix: z.string().optional(),
+  proxy: secretStr().optional(),
 })
 
 export function gcsToS3Config(config: GCSConfig): S3Config {
@@ -60,6 +63,7 @@ export function gcsToS3Config(config: GCSConfig): S3Config {
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
     ...(config.forcePathStyle !== undefined ? { forcePathStyle: config.forcePathStyle } : {}),
     ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
+    ...(config.proxy !== undefined ? { proxy: config.proxy } : {}),
   }
 }
 
@@ -84,6 +88,5 @@ export function normalizeGcsConfig(input: Record<string, unknown>): GCSConfig {
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as GCSConfig
 }

--- a/typescript/packages/node/src/resource/minio/config.ts
+++ b/typescript/packages/node/src/resource/minio/config.ts
@@ -24,6 +24,7 @@ export interface MinIOConfig {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 export interface MinIOConfigRedacted {
@@ -35,6 +36,7 @@ export interface MinIOConfigRedacted {
   forcePathStyle: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 const MinIOConfigSchema = z.object({
@@ -46,6 +48,7 @@ const MinIOConfigSchema = z.object({
   forcePathStyle: z.boolean(),
   keyPrefix: z.string().optional(),
   timeoutMs: z.number().optional(),
+  proxy: secretStr().optional(),
 })
 
 export function minioToS3Config(config: MinIOConfig): S3Config {
@@ -58,6 +61,7 @@ export function minioToS3Config(config: MinIOConfig): S3Config {
     forcePathStyle: config.forcePathStyle ?? true,
     ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    ...(config.proxy !== undefined ? { proxy: config.proxy } : {}),
   }
 }
 
@@ -82,6 +86,5 @@ export function normalizeMinIOConfig(input: Record<string, unknown>): MinIOConfi
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as MinIOConfig
 }

--- a/typescript/packages/node/src/resource/oci/config.ts
+++ b/typescript/packages/node/src/resource/oci/config.ts
@@ -24,6 +24,7 @@ export interface OCIConfig {
   endpoint?: string
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 export interface OCIConfigRedacted {
@@ -35,6 +36,7 @@ export interface OCIConfigRedacted {
   endpoint: string
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 const OCIConfigSchema = z.object({
@@ -46,6 +48,7 @@ const OCIConfigSchema = z.object({
   endpoint: z.string(),
   keyPrefix: z.string().optional(),
   timeoutMs: z.number().optional(),
+  proxy: secretStr().optional(),
 })
 
 function resolvedOciEndpoint(config: OCIConfig): string {
@@ -63,6 +66,7 @@ export function ociToS3Config(config: OCIConfig): S3Config {
     forcePathStyle: true,
     ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    ...(config.proxy !== undefined ? { proxy: config.proxy } : {}),
   }
 }
 
@@ -85,6 +89,5 @@ export function normalizeOciConfig(input: Record<string, unknown>): OCIConfig {
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as OCIConfig
 }

--- a/typescript/packages/node/src/resource/qingstor/config.ts
+++ b/typescript/packages/node/src/resource/qingstor/config.ts
@@ -24,6 +24,7 @@ export interface QingStorConfig {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 export interface QingStorConfigRedacted {
@@ -35,6 +36,7 @@ export interface QingStorConfigRedacted {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 const QingStorConfigSchema = z.object({
@@ -46,6 +48,7 @@ const QingStorConfigSchema = z.object({
   forcePathStyle: z.boolean().optional(),
   keyPrefix: z.string().optional(),
   timeoutMs: z.number().optional(),
+  proxy: secretStr().optional(),
 })
 
 export function resolvedQingStorEndpoint(config: QingStorConfig): string {
@@ -64,6 +67,7 @@ export function qingStorToS3Config(config: QingStorConfig): S3Config {
     ...(config.forcePathStyle !== undefined ? { forcePathStyle: config.forcePathStyle } : {}),
     ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    ...(config.proxy !== undefined ? { proxy: config.proxy } : {}),
   }
 }
 
@@ -87,6 +91,5 @@ export function normalizeQingStorConfig(input: Record<string, unknown>): QingSto
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as QingStorConfig
 }

--- a/typescript/packages/node/src/resource/r2/config.ts
+++ b/typescript/packages/node/src/resource/r2/config.ts
@@ -26,6 +26,7 @@ export interface R2Config {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 export interface R2ConfigRedacted {
@@ -39,6 +40,7 @@ export interface R2ConfigRedacted {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 const R2ConfigSchema = z.object({
@@ -52,6 +54,7 @@ const R2ConfigSchema = z.object({
   forcePathStyle: z.boolean().optional(),
   keyPrefix: z.string().optional(),
   timeoutMs: z.number().optional(),
+  proxy: secretStr().optional(),
 })
 
 function resolvedR2Endpoint(config: R2Config): string {
@@ -73,6 +76,7 @@ export function r2ToS3Config(config: R2Config): S3Config {
     ...(config.forcePathStyle !== undefined ? { forcePathStyle: config.forcePathStyle } : {}),
     ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    ...(config.proxy !== undefined ? { proxy: config.proxy } : {}),
   }
 }
 
@@ -99,6 +103,5 @@ export function normalizeR2Config(input: Record<string, unknown>): R2Config {
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as R2Config
 }

--- a/typescript/packages/node/src/resource/registry.test.ts
+++ b/typescript/packages/node/src/resource/registry.test.ts
@@ -97,7 +97,7 @@ describe('node resource registry', () => {
       endpoint_url: 'https://example.com',
       path_style: true,
       timeout: 30,
-      proxy: 'http://discarded',
+      proxy: 'http://proxy.example',
     })) as unknown as { config: Record<string, unknown> }
     expect(config).toMatchObject({
       bucket: 'b',
@@ -109,8 +109,8 @@ describe('node resource registry', () => {
       endpoint: 'https://example.com',
       forcePathStyle: true,
       timeoutMs: 30_000,
+      proxy: 'http://proxy.example',
     })
-    expect(config).not.toHaveProperty('proxy')
   })
 
   it('S3: accepts already-camelCase keys (TS-idiomatic)', async () => {
@@ -164,6 +164,7 @@ describe('node resource registry', () => {
       accessKeyId: 'A',
       endpoint: 'https://x',
       timeoutMs: 5_000,
+      proxy: 'p',
     })
   })
 })

--- a/typescript/packages/node/src/resource/s3/config.ts
+++ b/typescript/packages/node/src/resource/s3/config.ts
@@ -18,19 +18,23 @@ import {
   S3ConfigSchema as S3CoreConfigSchema,
   type S3Config as S3CoreConfig,
   type S3ConfigRedacted as S3CoreConfigRedacted,
+  secretStr,
   z,
 } from '@struktoai/mirage-core'
 
 export interface S3Config extends S3CoreConfig {
   profile?: string
+  proxy?: string
 }
 
 export interface S3ConfigRedacted extends S3CoreConfigRedacted {
   profile?: string
+  proxy?: string
 }
 
 const S3ConfigSchema = S3CoreConfigSchema.extend({
   profile: z.string().optional(),
+  proxy: secretStr().optional(),
 })
 
 export function redactConfig(config: S3Config): S3ConfigRedacted {
@@ -51,7 +55,7 @@ export function redactConfig(config: S3Config): S3ConfigRedacted {
  *   endpoint_url          ↔ endpoint
  *   path_style            ↔ forcePathStyle
  *   timeout (sec, int)    ↔ timeoutMs (ms, number — converted ×1000)
- *   proxy                 ↔ (dropped — not yet supported in TS)
+ *   proxy                 ↔ proxy
  */
 export function normalizeS3Config(input: Record<string, unknown>): S3Config {
   return normalizeFields(input, {
@@ -68,6 +72,5 @@ export function normalizeS3Config(input: Record<string, unknown>): S3Config {
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as S3Config
 }

--- a/typescript/packages/node/src/resource/s3/s3.test.ts
+++ b/typescript/packages/node/src/resource/s3/s3.test.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { PathSpec, mountKey } from '@struktoai/mirage-core'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { S3Resource } from './s3.ts'
 import type { S3Config } from './config.ts'
@@ -57,6 +58,19 @@ describe('S3Resource credential redaction', () => {
     expect(serialized).not.toContain('AKIA-OBVIOUS-LEAK')
     expect(serialized).not.toContain('SECRET-OBVIOUS-LEAK')
     expect(serialized).not.toContain('TOKEN-OBVIOUS-LEAK')
+    expect(serialized).toContain('<REDACTED>')
+  })
+
+  it('configures a Node request handler and redacts proxy credentials', async () => {
+    const res = new S3Resource({
+      bucket: 'b',
+      proxy: 'http://proxy-user:proxy-secret@localhost:8080',
+      timeoutMs: 1234,
+    })
+    expect(res.accessor.config.requestHandler).toBeInstanceOf(NodeHttpHandler)
+    const serialized = JSON.stringify(await res.getState())
+    expect(serialized).not.toContain('proxy-user')
+    expect(serialized).not.toContain('proxy-secret')
     expect(serialized).toContain('<REDACTED>')
   })
 })

--- a/typescript/packages/node/src/resource/s3/s3.test.ts
+++ b/typescript/packages/node/src/resource/s3/s3.test.ts
@@ -13,7 +13,8 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { PathSpec, mountKey } from '@struktoai/mirage-core'
-import { NodeHttpHandler } from '@smithy/node-http-handler'
+import { HttpProxyAgent } from 'http-proxy-agent'
+import { HttpsProxyAgent } from 'https-proxy-agent'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { S3Resource } from './s3.ts'
 import type { S3Config } from './config.ts'
@@ -61,17 +62,34 @@ describe('S3Resource credential redaction', () => {
     expect(serialized).toContain('<REDACTED>')
   })
 
-  it('configures a Node request handler and redacts proxy credentials', async () => {
+  it('configures proxy agents and redacts proxy credentials', async () => {
     const res = new S3Resource({
       bucket: 'b',
       proxy: 'http://proxy-user:proxy-secret@localhost:8080',
       timeoutMs: 1234,
     })
-    expect(res.accessor.config.requestHandler).toBeInstanceOf(NodeHttpHandler)
+    const provider = res.accessor.config.httpAgentProvider
+    expect(provider).toBeTypeOf('function')
+    const agents = provider?.()
+    expect(agents?.httpAgent).toBeInstanceOf(HttpProxyAgent)
+    expect(agents?.httpsAgent).toBeInstanceOf(HttpsProxyAgent)
     const serialized = JSON.stringify(await res.getState())
     expect(serialized).not.toContain('proxy-user')
     expect(serialized).not.toContain('proxy-secret')
     expect(serialized).toContain('<REDACTED>')
+  })
+
+  it('hands out fresh agents per call so a per-op destroy() cannot cross ops', () => {
+    const res = new S3Resource({ bucket: 'b', proxy: 'http://localhost:8080' })
+    const first = res.accessor.config.httpAgentProvider?.()
+    const second = res.accessor.config.httpAgentProvider?.()
+    expect(first?.httpAgent).not.toBe(second?.httpAgent)
+    expect(first?.httpsAgent).not.toBe(second?.httpsAgent)
+  })
+
+  it('treats an empty proxy as disabled', () => {
+    const res = new S3Resource({ bucket: 'b', proxy: '' })
+    expect(res.accessor.config.httpAgentProvider).toBeUndefined()
   })
 })
 

--- a/typescript/packages/node/src/resource/s3/s3.ts
+++ b/typescript/packages/node/src/resource/s3/s3.ts
@@ -49,9 +49,20 @@ import {
   unlink as unlinkCore,
   write as writeCore,
 } from '@struktoai/mirage-core'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
+import { HttpProxyAgent } from 'http-proxy-agent'
+import { HttpsProxyAgent } from 'https-proxy-agent'
 import { redactConfig, type S3Config, type S3ConfigRedacted } from './config.ts'
 
 const globCore = makeResolveGlob(readdirCore, S3_SCOPE_ERROR)
+
+function createProxyRequestHandler(proxy: string, timeoutMs: number | undefined): NodeHttpHandler {
+  return new NodeHttpHandler({
+    httpAgent: new HttpProxyAgent(proxy),
+    httpsAgent: new HttpsProxyAgent(proxy),
+    ...(timeoutMs !== undefined ? { connectionTimeout: timeoutMs, requestTimeout: timeoutMs } : {}),
+  })
+}
 
 export interface S3ResourceState {
   type: string
@@ -97,7 +108,11 @@ export class S3Resource extends BaseResource implements Resource {
       delete cfg.keyPrefix
     }
     this.config = cfg
-    this.accessor = new S3Accessor(this.config)
+    const accessorConfig: S3Config = { ...cfg }
+    if (cfg.proxy !== undefined) {
+      accessorConfig.requestHandler = createProxyRequestHandler(cfg.proxy, cfg.timeoutMs)
+    }
+    this.accessor = new S3Accessor(accessorConfig)
   }
 
   open(): Promise<void> {

--- a/typescript/packages/node/src/resource/s3/s3.ts
+++ b/typescript/packages/node/src/resource/s3/s3.ts
@@ -108,11 +108,12 @@ export class S3Resource extends BaseResource implements Resource {
       delete cfg.keyPrefix
     }
     this.config = cfg
-    const accessorConfig: S3Config = { ...cfg }
-    if (cfg.proxy !== undefined) {
-      accessorConfig.requestHandler = createProxyRequestHandler(cfg.proxy, cfg.timeoutMs)
-    }
-    this.accessor = new S3Accessor(accessorConfig)
+    this.accessor = new S3Accessor({
+      ...cfg,
+      ...(cfg.proxy !== undefined
+        ? { requestHandler: createProxyRequestHandler(cfg.proxy, cfg.timeoutMs) }
+        : {}),
+    })
   }
 
   open(): Promise<void> {

--- a/typescript/packages/node/src/resource/s3/s3.ts
+++ b/typescript/packages/node/src/resource/s3/s3.ts
@@ -43,25 +43,21 @@ import {
   truncate as truncateCore,
   type FileStat,
   type FindOptions,
+  type S3HttpAgents,
   type RegisteredCommand,
   type RegisteredOp,
   type Resource,
   unlink as unlinkCore,
   write as writeCore,
 } from '@struktoai/mirage-core'
-import { NodeHttpHandler } from '@smithy/node-http-handler'
 import { HttpProxyAgent } from 'http-proxy-agent'
 import { HttpsProxyAgent } from 'https-proxy-agent'
 import { redactConfig, type S3Config, type S3ConfigRedacted } from './config.ts'
 
 const globCore = makeResolveGlob(readdirCore, S3_SCOPE_ERROR)
 
-function createProxyRequestHandler(proxy: string, timeoutMs: number | undefined): NodeHttpHandler {
-  return new NodeHttpHandler({
-    httpAgent: new HttpProxyAgent(proxy),
-    httpsAgent: new HttpsProxyAgent(proxy),
-    ...(timeoutMs !== undefined ? { connectionTimeout: timeoutMs, requestTimeout: timeoutMs } : {}),
-  })
+function createProxyAgents(proxy: string): S3HttpAgents {
+  return { httpAgent: new HttpProxyAgent(proxy), httpsAgent: new HttpsProxyAgent(proxy) }
 }
 
 export interface S3ResourceState {
@@ -108,10 +104,11 @@ export class S3Resource extends BaseResource implements Resource {
       delete cfg.keyPrefix
     }
     this.config = cfg
+    const proxy = cfg.proxy
     this.accessor = new S3Accessor({
       ...cfg,
-      ...(cfg.proxy !== undefined
-        ? { requestHandler: createProxyRequestHandler(cfg.proxy, cfg.timeoutMs) }
+      ...(proxy !== undefined && proxy !== ''
+        ? { httpAgentProvider: () => createProxyAgents(proxy) }
         : {}),
     })
   }

--- a/typescript/packages/node/src/resource/s3_aliases.test.ts
+++ b/typescript/packages/node/src/resource/s3_aliases.test.ts
@@ -13,8 +13,9 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { ResourceName, type S3Config as S3CoreConfig } from '@struktoai/mirage-core'
+import { ResourceName } from '@struktoai/mirage-core'
 import { S3Resource } from './s3/s3.ts'
+import type { S3Config } from './s3/config.ts'
 import {
   aliyunToS3Config,
   normalizeAliyunConfig,
@@ -162,13 +163,18 @@ describe('region-derived S3 aliases', () => {
     })
 
     it(`${c.name}: toS3Config maps fields`, () => {
-      const s3 = c.toS3({ ...c.make(c.region), timeoutMs: 5000 } as never)
+      const s3 = c.toS3({
+        ...c.make(c.region),
+        timeoutMs: 5000,
+        proxy: 'http://localhost:8080',
+      } as never)
       expect(s3.bucket).toBe('b')
       expect(s3.region).toBe(c.region)
       expect(s3.endpoint).toBe(c.expectedEndpoint)
       expect(s3.accessKeyId).toBe('AKIA-LEAK')
       expect(s3.secretAccessKey).toBe('SECRET-LEAK')
       expect(s3.timeoutMs).toBe(5000)
+      expect(s3.proxy).toBe('http://localhost:8080')
       expect(s3.forcePathStyle).toBeUndefined()
     })
 
@@ -190,7 +196,7 @@ describe('region-derived S3 aliases', () => {
       expect(norm.forcePathStyle).toBe(true)
       expect(norm.keyPrefix).toBe('team/reports')
       expect(norm.timeoutMs).toBe(30000)
-      expect(norm).not.toHaveProperty('proxy')
+      expect(norm.proxy).toBe('http://localhost:8080')
       expect(norm).not.toHaveProperty('access_key_id')
     })
 
@@ -204,11 +210,14 @@ describe('region-derived S3 aliases', () => {
     })
 
     it(`${c.name}: getState redacts creds`, async () => {
-      const state = await c.build(c.make(c.region) as never).getState()
+      const state = await c
+        .build({ ...c.make(c.region), proxy: 'http://user:secret@localhost:8080' } as never)
+        .getState()
       expect(state.type).toBe(c.kind)
       const blob = JSON.stringify(state)
       expect(blob.includes('AKIA-LEAK')).toBe(false)
       expect(blob.includes('SECRET-LEAK')).toBe(false)
+      expect(blob.includes('user:secret')).toBe(false)
       expect(blob.includes('<REDACTED>')).toBe(true)
     })
   }
@@ -247,7 +256,7 @@ describe('wasabi endpoint defaults', () => {
     expect(norm.forcePathStyle).toBe(true)
     expect(norm.keyPrefix).toBe('team/reports')
     expect(norm.timeoutMs).toBe(30000)
-    expect(norm).not.toHaveProperty('proxy')
+    expect(norm.proxy).toBe('p')
   })
 
   it('resource remaps kind and redacts state', async () => {
@@ -264,7 +273,7 @@ const ENDPOINT_CASES = [
   {
     name: 'minio',
     kind: ResourceName.MINIO,
-    toS3: minioToS3Config as (config: never) => S3CoreConfig,
+    toS3: minioToS3Config as (config: never) => S3Config,
     normalize: normalizeMinIOConfig as (input: Record<string, unknown>) => unknown,
     make: (): MinIOConfig => ({ ...CREDS, endpoint: 'http://localhost:9000' }),
     build: (config: never) => new MinIOResource(config),
@@ -272,7 +281,7 @@ const ENDPOINT_CASES = [
   {
     name: 'ceph',
     kind: ResourceName.CEPH,
-    toS3: cephToS3Config as (config: never) => S3CoreConfig,
+    toS3: cephToS3Config as (config: never) => S3Config,
     normalize: normalizeCephConfig as (input: Record<string, unknown>) => unknown,
     make: (): CephConfig => ({ ...CREDS, endpoint: 'http://localhost:9000' }),
     build: (config: never) => new CephResource(config),
@@ -280,7 +289,7 @@ const ENDPOINT_CASES = [
   {
     name: 'seaweedfs',
     kind: ResourceName.SEAWEEDFS,
-    toS3: seaweedfsToS3Config as (config: never) => S3CoreConfig,
+    toS3: seaweedfsToS3Config as (config: never) => S3Config,
     normalize: normalizeSeaweedFSConfig as (input: Record<string, unknown>) => unknown,
     make: (): SeaweedFSConfig => ({ ...CREDS, endpoint: 'http://localhost:9000' }),
     build: (config: never) => new SeaweedFSResource(config),
@@ -317,7 +326,7 @@ describe('endpoint-required S3 aliases (minio/ceph/seaweedfs)', () => {
       expect(norm.forcePathStyle).toBe(false)
       expect(norm.keyPrefix).toBe('team/reports')
       expect(norm.timeoutMs).toBe(30000)
-      expect(norm).not.toHaveProperty('proxy')
+      expect(norm.proxy).toBe('p')
     })
 
     it(`${c.name}: resource remaps kind and redacts state`, async () => {
@@ -338,72 +347,72 @@ const PREFIX_CASES = [
   {
     name: 'aliyun',
     config: { ...CREDS, region: 'us-east-1', forcePathStyle: true } as AliyunConfig,
-    toS3: aliyunToS3Config as (config: never) => S3CoreConfig,
+    toS3: aliyunToS3Config as (config: never) => S3Config,
   },
   {
     name: 'backblaze',
     config: { ...CREDS, region: 'us-east-1', forcePathStyle: true } as BackblazeConfig,
-    toS3: backblazeToS3Config as (config: never) => S3CoreConfig,
+    toS3: backblazeToS3Config as (config: never) => S3Config,
   },
   {
     name: 'ceph',
     config: { ...CREDS, endpoint: 'http://localhost:9000' } as CephConfig,
-    toS3: cephToS3Config as (config: never) => S3CoreConfig,
+    toS3: cephToS3Config as (config: never) => S3Config,
   },
   {
     name: 'digitalocean',
     config: { ...CREDS, region: 'us-east-1', forcePathStyle: true } as DigitalOceanConfig,
-    toS3: digitalOceanToS3Config as (config: never) => S3CoreConfig,
+    toS3: digitalOceanToS3Config as (config: never) => S3Config,
   },
   {
     name: 'gcs',
     config: { ...CREDS, forcePathStyle: true } as GCSConfig,
-    toS3: gcsToS3Config as (config: never) => S3CoreConfig,
+    toS3: gcsToS3Config as (config: never) => S3Config,
   },
   {
     name: 'minio',
     config: { ...CREDS, endpoint: 'http://localhost:9000' } as MinIOConfig,
-    toS3: minioToS3Config as (config: never) => S3CoreConfig,
+    toS3: minioToS3Config as (config: never) => S3Config,
   },
   {
     name: 'oci',
     config: { ...CREDS, namespace: 'ns', region: 'us-east-1' } as OCIConfig,
-    toS3: ociToS3Config as (config: never) => S3CoreConfig,
+    toS3: ociToS3Config as (config: never) => S3Config,
   },
   {
     name: 'qingstor',
     config: { ...CREDS, region: 'us-east-1', forcePathStyle: true } as QingStorConfig,
-    toS3: qingStorToS3Config as (config: never) => S3CoreConfig,
+    toS3: qingStorToS3Config as (config: never) => S3Config,
   },
   {
     name: 'r2',
     config: { ...CREDS, accountId: 'account', forcePathStyle: true } as R2Config,
-    toS3: r2ToS3Config as (config: never) => S3CoreConfig,
+    toS3: r2ToS3Config as (config: never) => S3Config,
   },
   {
     name: 'scaleway',
     config: { ...CREDS, region: 'us-east-1', forcePathStyle: true } as ScalewayConfig,
-    toS3: scalewayToS3Config as (config: never) => S3CoreConfig,
+    toS3: scalewayToS3Config as (config: never) => S3Config,
   },
   {
     name: 'seaweedfs',
     config: { ...CREDS, endpoint: 'http://localhost:9000' } as SeaweedFSConfig,
-    toS3: seaweedfsToS3Config as (config: never) => S3CoreConfig,
+    toS3: seaweedfsToS3Config as (config: never) => S3Config,
   },
   {
     name: 'supabase',
     config: { ...CREDS, projectRef: 'project', region: 'us-east-1' } as SupabaseConfig,
-    toS3: supabaseToS3Config as (config: never) => S3CoreConfig,
+    toS3: supabaseToS3Config as (config: never) => S3Config,
   },
   {
     name: 'tencent',
     config: { ...CREDS, region: 'us-east-1', forcePathStyle: true } as TencentConfig,
-    toS3: tencentToS3Config as (config: never) => S3CoreConfig,
+    toS3: tencentToS3Config as (config: never) => S3Config,
   },
   {
     name: 'wasabi',
     config: { ...CREDS, forcePathStyle: true } as WasabiConfig,
-    toS3: wasabiToS3Config as (config: never) => S3CoreConfig,
+    toS3: wasabiToS3Config as (config: never) => S3Config,
   },
 ] as const
 
@@ -413,6 +422,16 @@ describe('S3 alias subfolder mounts', () => {
       const s3 = c.toS3({ ...c.config, keyPrefix: '/team/reports/' } as never)
       expect(s3.keyPrefix).toBe('/team/reports/')
       expect(s3.forcePathStyle).toBe(true)
+    })
+  }
+
+  for (const c of PREFIX_CASES) {
+    it(`${c.name}: forwards proxy`, () => {
+      const s3 = c.toS3({
+        ...c.config,
+        proxy: 'http://localhost:8080',
+      } as never)
+      expect(s3.proxy).toBe('http://localhost:8080')
     })
   }
 })

--- a/typescript/packages/node/src/resource/scaleway/config.ts
+++ b/typescript/packages/node/src/resource/scaleway/config.ts
@@ -24,6 +24,7 @@ export interface ScalewayConfig {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 export interface ScalewayConfigRedacted {
@@ -35,6 +36,7 @@ export interface ScalewayConfigRedacted {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 const ScalewayConfigSchema = z.object({
@@ -46,6 +48,7 @@ const ScalewayConfigSchema = z.object({
   forcePathStyle: z.boolean().optional(),
   keyPrefix: z.string().optional(),
   timeoutMs: z.number().optional(),
+  proxy: secretStr().optional(),
 })
 
 export function resolvedScalewayEndpoint(config: ScalewayConfig): string {
@@ -64,6 +67,7 @@ export function scalewayToS3Config(config: ScalewayConfig): S3Config {
     ...(config.forcePathStyle !== undefined ? { forcePathStyle: config.forcePathStyle } : {}),
     ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    ...(config.proxy !== undefined ? { proxy: config.proxy } : {}),
   }
 }
 
@@ -87,6 +91,5 @@ export function normalizeScalewayConfig(input: Record<string, unknown>): Scalewa
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as ScalewayConfig
 }

--- a/typescript/packages/node/src/resource/seaweedfs/config.ts
+++ b/typescript/packages/node/src/resource/seaweedfs/config.ts
@@ -24,6 +24,7 @@ export interface SeaweedFSConfig {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 export interface SeaweedFSConfigRedacted {
@@ -35,6 +36,7 @@ export interface SeaweedFSConfigRedacted {
   forcePathStyle: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 const SeaweedFSConfigSchema = z.object({
@@ -46,6 +48,7 @@ const SeaweedFSConfigSchema = z.object({
   forcePathStyle: z.boolean(),
   keyPrefix: z.string().optional(),
   timeoutMs: z.number().optional(),
+  proxy: secretStr().optional(),
 })
 
 export function seaweedfsToS3Config(config: SeaweedFSConfig): S3Config {
@@ -58,6 +61,7 @@ export function seaweedfsToS3Config(config: SeaweedFSConfig): S3Config {
     forcePathStyle: config.forcePathStyle ?? true,
     ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    ...(config.proxy !== undefined ? { proxy: config.proxy } : {}),
   }
 }
 
@@ -82,6 +86,5 @@ export function normalizeSeaweedFSConfig(input: Record<string, unknown>): Seawee
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as SeaweedFSConfig
 }

--- a/typescript/packages/node/src/resource/supabase/config.ts
+++ b/typescript/packages/node/src/resource/supabase/config.ts
@@ -25,6 +25,7 @@ export interface SupabaseConfig {
   sessionToken?: string
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 export interface SupabaseConfigRedacted {
@@ -37,6 +38,7 @@ export interface SupabaseConfigRedacted {
   sessionToken?: string
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 const SupabaseConfigSchema = z.object({
@@ -49,6 +51,7 @@ const SupabaseConfigSchema = z.object({
   sessionToken: secretStr().optional(),
   keyPrefix: z.string().optional(),
   timeoutMs: z.number().optional(),
+  proxy: secretStr().optional(),
 })
 
 export function resolvedSupabaseEndpoint(config: SupabaseConfig): string {
@@ -70,6 +73,7 @@ export function supabaseToS3Config(config: SupabaseConfig): S3Config {
     ...(config.sessionToken !== undefined ? { sessionToken: config.sessionToken } : {}),
     ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    ...(config.proxy !== undefined ? { proxy: config.proxy } : {}),
   }
 }
 
@@ -94,6 +98,5 @@ export function normalizeSupabaseConfig(input: Record<string, unknown>): Supabas
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as SupabaseConfig
 }

--- a/typescript/packages/node/src/resource/tencent/config.ts
+++ b/typescript/packages/node/src/resource/tencent/config.ts
@@ -24,6 +24,7 @@ export interface TencentConfig {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 export interface TencentConfigRedacted {
@@ -35,6 +36,7 @@ export interface TencentConfigRedacted {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 const TencentConfigSchema = z.object({
@@ -46,6 +48,7 @@ const TencentConfigSchema = z.object({
   forcePathStyle: z.boolean().optional(),
   keyPrefix: z.string().optional(),
   timeoutMs: z.number().optional(),
+  proxy: secretStr().optional(),
 })
 
 export function resolvedTencentEndpoint(config: TencentConfig): string {
@@ -64,6 +67,7 @@ export function tencentToS3Config(config: TencentConfig): S3Config {
     ...(config.forcePathStyle !== undefined ? { forcePathStyle: config.forcePathStyle } : {}),
     ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    ...(config.proxy !== undefined ? { proxy: config.proxy } : {}),
   }
 }
 
@@ -87,6 +91,5 @@ export function normalizeTencentConfig(input: Record<string, unknown>): TencentC
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as TencentConfig
 }

--- a/typescript/packages/node/src/resource/wasabi/config.ts
+++ b/typescript/packages/node/src/resource/wasabi/config.ts
@@ -24,6 +24,7 @@ export interface WasabiConfig {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 export interface WasabiConfigRedacted {
@@ -35,6 +36,7 @@ export interface WasabiConfigRedacted {
   forcePathStyle?: boolean
   keyPrefix?: string
   timeoutMs?: number
+  proxy?: string
 }
 
 const WasabiConfigSchema = z.object({
@@ -46,6 +48,7 @@ const WasabiConfigSchema = z.object({
   forcePathStyle: z.boolean().optional(),
   keyPrefix: z.string().optional(),
   timeoutMs: z.number().optional(),
+  proxy: secretStr().optional(),
 })
 
 export function resolvedWasabiEndpoint(config: WasabiConfig): string {
@@ -64,6 +67,7 @@ export function wasabiToS3Config(config: WasabiConfig): S3Config {
     ...(config.forcePathStyle !== undefined ? { forcePathStyle: config.forcePathStyle } : {}),
     ...(config.keyPrefix !== undefined ? { keyPrefix: config.keyPrefix } : {}),
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    ...(config.proxy !== undefined ? { proxy: config.proxy } : {}),
   }
 }
 
@@ -88,6 +92,5 @@ export function normalizeWasabiConfig(input: Record<string, unknown>): WasabiCon
     transform: {
       timeout: (v: unknown) => (typeof v === 'number' ? v * 1000 : v),
     },
-    drop: ['proxy'],
   }) as unknown as WasabiConfig
 }

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -492,8 +492,8 @@ importers:
         specifier: ^1.4.5
         version: 1.4.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@smithy/node-http-handler':
-        specifier: ^4.9.7
-        version: 4.9.7
+        specifier: ^4.7.3
+        version: 4.7.3
       '@struktoai/mirage-core':
         specifier: workspace:*
         version: link:../core
@@ -2807,6 +2807,10 @@ packages:
 
   '@smithy/node-config-provider@4.3.14':
     resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.6.0':
+    resolution: {integrity: sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.7.3':
@@ -6536,10 +6540,10 @@ snapshots:
       '@aws-sdk/middleware-websocket': 3.972.41
       '@aws-sdk/token-providers': 3.1048.0
       '@aws-sdk/types': 3.973.8
-      '@smithy/core': 3.29.5
+      '@smithy/core': 3.24.3
       '@smithy/fetch-http-handler': 5.6.7
-      '@smithy/node-http-handler': 4.9.7
-      '@smithy/types': 4.16.1
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/client-s3@3.1033.0':
@@ -6582,7 +6586,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.19
       '@smithy/middleware-stack': 4.2.14
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.9.7
+      '@smithy/node-http-handler': 4.6.0
       '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.12
       '@smithy/types': 4.14.1
@@ -6631,7 +6635,7 @@ snapshots:
 
   '@aws-sdk/crc64-nvme@3.972.7':
     dependencies:
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.28':
@@ -6639,7 +6643,7 @@ snapshots:
       '@aws-sdk/core': 3.974.2
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.59':
@@ -6655,11 +6659,11 @@ snapshots:
       '@aws-sdk/core': 3.974.2
       '@aws-sdk/types': 3.973.8
       '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.9.7
+      '@smithy/node-http-handler': 4.6.0
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.12
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       '@smithy/util-stream': 4.5.24
       tslib: 2.8.1
 
@@ -6687,7 +6691,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.2.14
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -6716,7 +6720,7 @@ snapshots:
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -6767,7 +6771,7 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.59':
@@ -6786,7 +6790,7 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -6808,7 +6812,7 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -6967,7 +6971,7 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.972.10
       '@aws-sdk/util-user-agent-node': 3.973.18
       '@smithy/config-resolver': 4.4.17
-      '@smithy/core': 3.29.5
+      '@smithy/core': 3.23.16
       '@smithy/fetch-http-handler': 5.3.17
       '@smithy/hash-node': 4.2.14
       '@smithy/invalid-dependency': 4.2.14
@@ -6977,10 +6981,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.19
       '@smithy/middleware-stack': 4.2.14
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.9.7
+      '@smithy/node-http-handler': 4.6.0
       '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.12
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       '@smithy/url-parser': 4.2.14
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
@@ -7048,7 +7052,7 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7058,8 +7062,8 @@ snapshots:
       '@aws-sdk/core': 3.975.3
       '@aws-sdk/nested-clients': 3.997.33
       '@aws-sdk/types': 3.973.8
-      '@smithy/core': 3.29.5
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1088.0':
@@ -7122,7 +7126,7 @@ snapshots:
 
   '@aws-sdk/xml-builder@3.972.18':
     dependencies:
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       fast-xml-parser: 5.9.0
       tslib: 2.8.1
 
@@ -8331,7 +8335,7 @@ snapshots:
   '@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
@@ -8367,7 +8371,7 @@ snapshots:
   '@opentelemetry/otlp-exporter-base@0.217.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/otlp-grpc-exporter-base@0.217.0(@opentelemetry/api@1.9.0)':
@@ -8382,7 +8386,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
@@ -8402,21 +8406,21 @@ snapshots:
   '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-logs@0.217.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/sdk-node@0.217.0(@opentelemetry/api@1.9.0)':
@@ -8453,7 +8457,7 @@ snapshots:
   '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.41.1
 
@@ -8867,7 +8871,7 @@ snapshots:
     dependencies:
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       '@smithy/url-parser': 4.2.14
       tslib: 2.8.1
 
@@ -8880,7 +8884,7 @@ snapshots:
   '@smithy/eventstream-codec@4.2.14':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       '@smithy/util-hex-encoding': 4.2.2
       tslib: 2.8.1
 
@@ -8904,7 +8908,7 @@ snapshots:
   '@smithy/eventstream-serde-universal@4.2.14':
     dependencies:
       '@smithy/eventstream-codec': 4.2.14
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.3.17':
@@ -9009,10 +9013,17 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.6.0':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/node-http-handler@4.7.3':
     dependencies:
-      '@smithy/core': 3.29.5
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.9.7':
@@ -9023,7 +9034,7 @@ snapshots:
 
   '@smithy/property-provider@4.2.14':
     dependencies:
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/protocol-http@5.3.14':
@@ -9033,29 +9044,29 @@ snapshots:
 
   '@smithy/querystring-builder@4.2.14':
     dependencies:
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
   '@smithy/querystring-parser@4.2.14':
     dependencies:
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/service-error-classification@4.3.0':
     dependencies:
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
 
   '@smithy/shared-ini-file-loader@4.4.9':
     dependencies:
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.3.14':
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
       '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.14.1
       '@smithy/util-hex-encoding': 4.2.2
       '@smithy/util-middleware': 4.2.14
       '@smithy/util-uri-escape': 4.2.2
@@ -9165,7 +9176,7 @@ snapshots:
   '@smithy/util-stream@4.5.24':
     dependencies:
       '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.9.7
+      '@smithy/node-http-handler': 4.6.0
       '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -491,6 +491,9 @@ importers:
       '@napi-rs/lzma':
         specifier: ^1.4.5
         version: 1.4.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@smithy/node-http-handler':
+        specifier: ^4.9.7
+        version: 4.9.7
       '@struktoai/mirage-core':
         specifier: workspace:*
         version: link:../core
@@ -506,6 +509,12 @@ importers:
       fs-monkey:
         specifier: ^1.1.0
         version: 1.1.0
+      http-proxy-agent:
+        specifier: ^7.0.2
+        version: 7.0.2
+      https-proxy-agent:
+        specifier: ^7.0.6
+        version: 7.0.6
       tree-sitter-bash:
         specifier: ^0.25.1
         version: 0.25.1
@@ -2798,10 +2807,6 @@ packages:
 
   '@smithy/node-config-provider@4.3.14':
     resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-http-handler@4.6.0':
-    resolution: {integrity: sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.7.3':
@@ -6531,10 +6536,10 @@ snapshots:
       '@aws-sdk/middleware-websocket': 3.972.41
       '@aws-sdk/token-providers': 3.1048.0
       '@aws-sdk/types': 3.973.8
-      '@smithy/core': 3.24.3
+      '@smithy/core': 3.29.5
       '@smithy/fetch-http-handler': 5.6.7
-      '@smithy/node-http-handler': 4.7.3
-      '@smithy/types': 4.14.2
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-s3@3.1033.0':
@@ -6577,7 +6582,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.19
       '@smithy/middleware-stack': 4.2.14
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.6.0
+      '@smithy/node-http-handler': 4.9.7
       '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.12
       '@smithy/types': 4.14.1
@@ -6626,7 +6631,7 @@ snapshots:
 
   '@aws-sdk/crc64-nvme@3.972.7':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.28':
@@ -6634,7 +6639,7 @@ snapshots:
       '@aws-sdk/core': 3.974.2
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.59':
@@ -6650,11 +6655,11 @@ snapshots:
       '@aws-sdk/core': 3.974.2
       '@aws-sdk/types': 3.973.8
       '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.6.0
+      '@smithy/node-http-handler': 4.9.7
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.12
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       '@smithy/util-stream': 4.5.24
       tslib: 2.8.1
 
@@ -6682,7 +6687,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.2.14
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -6711,7 +6716,7 @@ snapshots:
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -6762,7 +6767,7 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.59':
@@ -6781,7 +6786,7 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -6803,7 +6808,7 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -6962,7 +6967,7 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.972.10
       '@aws-sdk/util-user-agent-node': 3.973.18
       '@smithy/config-resolver': 4.4.17
-      '@smithy/core': 3.23.16
+      '@smithy/core': 3.29.5
       '@smithy/fetch-http-handler': 5.3.17
       '@smithy/hash-node': 4.2.14
       '@smithy/invalid-dependency': 4.2.14
@@ -6972,10 +6977,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.19
       '@smithy/middleware-stack': 4.2.14
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.6.0
+      '@smithy/node-http-handler': 4.9.7
       '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.12
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       '@smithy/url-parser': 4.2.14
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
@@ -7043,7 +7048,7 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7053,8 +7058,8 @@ snapshots:
       '@aws-sdk/core': 3.975.3
       '@aws-sdk/nested-clients': 3.997.33
       '@aws-sdk/types': 3.973.8
-      '@smithy/core': 3.24.3
-      '@smithy/types': 4.14.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1088.0':
@@ -7117,7 +7122,7 @@ snapshots:
 
   '@aws-sdk/xml-builder@3.972.18':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       fast-xml-parser: 5.9.0
       tslib: 2.8.1
 
@@ -8326,7 +8331,7 @@ snapshots:
   '@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
@@ -8362,7 +8367,7 @@ snapshots:
   '@opentelemetry/otlp-exporter-base@0.217.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/otlp-grpc-exporter-base@0.217.0(@opentelemetry/api@1.9.0)':
@@ -8377,7 +8382,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
@@ -8397,21 +8402,21 @@ snapshots:
   '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-logs@0.217.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/sdk-node@0.217.0(@opentelemetry/api@1.9.0)':
@@ -8448,7 +8453,7 @@ snapshots:
   '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.41.1
 
@@ -8862,7 +8867,7 @@ snapshots:
     dependencies:
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       '@smithy/url-parser': 4.2.14
       tslib: 2.8.1
 
@@ -8875,7 +8880,7 @@ snapshots:
   '@smithy/eventstream-codec@4.2.14':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       '@smithy/util-hex-encoding': 4.2.2
       tslib: 2.8.1
 
@@ -8899,7 +8904,7 @@ snapshots:
   '@smithy/eventstream-serde-universal@4.2.14':
     dependencies:
       '@smithy/eventstream-codec': 4.2.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.3.17':
@@ -9004,17 +9009,10 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.6.0':
-    dependencies:
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/querystring-builder': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
   '@smithy/node-http-handler@4.7.3':
     dependencies:
-      '@smithy/core': 3.24.3
-      '@smithy/types': 4.14.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.9.7':
@@ -9025,7 +9023,7 @@ snapshots:
 
   '@smithy/property-provider@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/protocol-http@5.3.14':
@@ -9035,29 +9033,29 @@ snapshots:
 
   '@smithy/querystring-builder@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
   '@smithy/querystring-parser@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/service-error-classification@4.3.0':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
 
   '@smithy/shared-ini-file-loader@4.4.9':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.3.14':
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
       '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       '@smithy/util-hex-encoding': 4.2.2
       '@smithy/util-middleware': 4.2.14
       '@smithy/util-uri-escape': 4.2.2
@@ -9167,7 +9165,7 @@ snapshots:
   '@smithy/util-stream@4.5.24':
     dependencies:
       '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.6.0
+      '@smithy/node-http-handler': 4.9.7
       '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -491,9 +491,6 @@ importers:
       '@napi-rs/lzma':
         specifier: ^1.4.5
         version: 1.4.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-      '@smithy/node-http-handler':
-        specifier: ^4.7.3
-        version: 4.7.3
       '@struktoai/mirage-core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary

- Node S3 and all 14 S3-compatible aliases accept `proxy`, which TypeScript previously normalized away
- Proxy agents are built per S3 client rather than once per resource, so one operation's cleanup cannot kill another operation's in-flight sockets
- Proxy URLs are redacted in serialized state on both sides: Python now types `proxy` as `SecretStr`, matching TypeScript's `secretStr()`
- LanceDB blob reads use the runtime neutral base64 helper instead of Node's `Buffer`
- The TypeScript S3 setup doc lists the optional fields, including `proxy`

## Why

Python has accepted S3 proxy configuration all along, TypeScript dropped the field on the floor. `proxy` was in fact the last Python config field TypeScript still discarded: after this change no `drop:` entry remains in any TypeScript normalizer.

Separately, LanceDB blob reads live in the runtime agnostic core package but depended on Node's `Buffer` global, so they could not run in a browser. That was the only unguarded `Buffer` use left in core.

## How the proxy reaches the client

Core has to compile for the browser, so it cannot import Node's proxy agents. It already has a seam for exactly this case: `presignedUrlProvider` is a callable the runtime package injects into `S3Config`. Proxy support follows the same shape with `S3HttpAgentProvider`, and `createS3Client` calls it once per client.

Per client is the load-bearing part. Every S3 operation builds its own `S3Client` and destroys it in a `finally` block, and `S3Client.destroy()` reaches through to `httpsAgent.destroy()`, which tears down sockets that are currently in use rather than just idle ones. A single agent pair shared for a resource's lifetime would let the first operation to finish kill sockets that concurrent operations are still using. `ls -l` triggers this directly, since it stats every entry under `Promise.all`.

Because the SDK builds the request handler itself from a plain options object, `@smithy/node-http-handler` is not needed as a dependency. Node supplies only the two proxy agents, and there is no second smithy copy that can drift from the one inside the installed AWS SDK.

## Notes

- An empty proxy string is treated as disabled, matching Python's `if config.proxy:`. This matters because an unset environment variable is a common source of one.
- Timeouts and proxy agents merge into the same request handler options, so configuring a proxy no longer discards `timeoutMs`.
- Left alone on purpose: Python's `timeout` maps to botocore's `read_timeout`, a per read inactivity timeout that raises, while smithy's `requestTimeout` is a total wall clock budget that only logs a warning unless `throwOnRequestTimeout` is set. Copying the 30 second default across would not produce matching behavior, so TypeScript's missing default timeout is worth its own change.

## Validation

- `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm test` (7343 passed)
- `uv run pytest` full suite, with the five Redis cases passing once `REDIS_URL` is set
- `pre-commit run` over every changed file, including mypy

New coverage: fresh agents per client, agents reaching the request handler, timeouts surviving alongside a proxy, empty proxy disabled, proxy credentials absent from serialized state in both languages.
