### PR TITLE
feat(shell): case ;&/;;& fallthrough, printf -v, source args, unset -f/-v (#608 Tier 2)

### DIFF
--- a/integ/bash/builtin/unset.json
+++ b/integ/bash/builtin/unset.json
@@ -237,6 +237,74 @@
         "stdout": "rc=1\n",
         "stderr": "bash: unset: UE: not an array variable\n"
       }
+    },
+    {
+      "id": "unset_element_leaves_a_hole",
+      "seq": 609238,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "unset UH; declare -a UH=(zero one two); unset 'UH[1]'; echo \"${#UH[@]} [${UH[@]}] [${!UH[@]}]\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "2 [zero two] [0 2]\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "unset_hole_then_append_skips_it",
+      "seq": 609239,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "unset UI; declare -a UI=(x y z); unset 'UI[1]'; UI+=(w); echo \"[${!UI[@]}] [${UI[@]}]\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "[0 2 3] [x z w]\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/bash/builtin/unset.json
+++ b/integ/bash/builtin/unset.json
@@ -1,0 +1,106 @@
+{
+  "cases": [
+    {
+      "id": "unset_f_removes_function",
+      "seq": 609231,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "fnx(){ echo F; }; fnx=keep; unset -f fnx; echo v=$fnx; fnx 2>&1; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "v=keep\nfnx: command not found\nrc=127\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "unset_v_keeps_function",
+      "seq": 609232,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "fny(){ echo G; }; fny=val; unset -v fny; fny; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "G\nrc=0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "unset_array_element",
+      "seq": 609233,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "unset UA; declare -a UA=(1 2 3); unset 'UA[1]'; echo [${UA[@]}]",
+      "expect": {
+        "exit": 0,
+        "stdout": "[1 3]\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/bash/builtin/unset.json
+++ b/integ/bash/builtin/unset.json
@@ -95,11 +95,147 @@
         "gdrive-folder",
         "box"
       ],
-      "command": "unset UA; declare -a UA=(1 2 3); unset 'UA[1]'; echo [${UA[@]}]",
+      "command": "unset UA; declare -a UA=(1 2 3); unset 'UA[1]'; echo [${UA[0]}][${UA[1]}][${UA[2]}]",
       "expect": {
         "exit": 0,
-        "stdout": "[1 3]\n",
+        "stdout": "[1][][3]\n",
         "stderr": ""
+      }
+    },
+    {
+      "id": "unset_trailing_element_shortens",
+      "seq": 609234,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "unset UB; declare -a UB=(1 2 3); unset 'UB[2]'; echo [${UB[@]}] n=${#UB[@]}",
+      "expect": {
+        "exit": 0,
+        "stdout": "[1 2] n=2\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "unset_readonly_array_element",
+      "seq": 609235,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "readonly -a UC=(x y); unset 'UC[1]'; echo rc=$?; echo [${UC[@]}]",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=1\n[x y]\n",
+        "stderr": "bash: unset: UC: cannot unset: readonly variable\n"
+      }
+    },
+    {
+      "id": "unset_scalar_element_zero",
+      "seq": 609236,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "unset UD; UD=sc; unset 'UD[0]'; echo rc=$? [${UD}]",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=0 []\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "unset_scalar_nonzero_element_errors",
+      "seq": 609237,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "unset UE; UE=sc; unset 'UE[1]'; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=1\n",
+        "stderr": "bash: unset: UE: not an array variable\n"
       }
     }
   ]

--- a/integ/bash/case/fallthrough.json
+++ b/integ/bash/case/fallthrough.json
@@ -1,0 +1,106 @@
+{
+  "cases": [
+    {
+      "id": "case_fallthrough_semi_amp",
+      "seq": 609201,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "case a in a) echo one;& b) echo two;; c) echo three;; esac",
+      "expect": {
+        "exit": 0,
+        "stdout": "one\ntwo\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "case_continue_semi_semi_amp",
+      "seq": 609202,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "case a in a) echo one;;& a) echo two;;& b) echo three;; esac",
+      "expect": {
+        "exit": 0,
+        "stdout": "one\ntwo\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "case_semi_semi_amp_no_further_match",
+      "seq": 609203,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "case a in a) echo one;;& z) echo two;; esac",
+      "expect": {
+        "exit": 0,
+        "stdout": "one\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/bash/printf/vflag.json
+++ b/integ/bash/printf/vflag.json
@@ -98,8 +98,110 @@
       "command": "printf -v 1bad x; echo rc=$?",
       "expect": {
         "exit": 0,
-        "stdout": "rc=1\n",
-        "stderr": "printf: `1bad': not a valid variable name\n"
+        "stdout": "rc=2\n",
+        "stderr": "printf: `1bad': not a valid identifier\n"
+      }
+    },
+    {
+      "id": "printf_v_bare_name_keeps_array_tail",
+      "seq": 609214,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "unset PB; declare -a PB=(p q r); printf -v PB Q; echo [${PB[@]}]",
+      "expect": {
+        "exit": 0,
+        "stdout": "[Q q r]\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_v_readonly_is_rejected",
+      "seq": 609215,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "readonly -a UF=(x y); printf -v 'UF[0]' zz; echo rc=$?; echo [${UF[@]}]",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=1\n[x y]\n",
+        "stderr": "bash: UF: readonly variable\n"
+      }
+    },
+    {
+      "id": "printf_v_bad_subscript_keeps_scalar",
+      "seq": 609216,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "unset PS; PS=orig; printf -v 'PS[-2]' hi; echo rc=$? [$PS]",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=1 [orig]\n",
+        "stderr": "bash: PS[-2]: bad array subscript\n"
       }
     }
   ]

--- a/integ/bash/printf/vflag.json
+++ b/integ/bash/printf/vflag.json
@@ -1,0 +1,106 @@
+{
+  "cases": [
+    {
+      "id": "printf_v_scalar",
+      "seq": 609211,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "printf -v PV 'x=%d' 42; echo [$PV]",
+      "expect": {
+        "exit": 0,
+        "stdout": "[x=42]\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_v_array_element",
+      "seq": 609212,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "unset PA; printf -v 'PA[2]' hi; echo [${PA[2]}]",
+      "expect": {
+        "exit": 0,
+        "stdout": "[hi]\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_v_invalid_name",
+      "seq": 609213,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "printf -v 1bad x; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=1\n",
+        "stderr": "printf: `1bad': not a valid variable name\n"
+      }
+    }
+  ]
+}

--- a/integ/bash/source/args.json
+++ b/integ/bash/source/args.json
@@ -1,0 +1,72 @@
+{
+  "cases": [
+    {
+      "id": "source_positional_args",
+      "seq": 609221,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "printf 'echo argc=$# a1=$1 a2=$2\\n' > /data/sa.sh && source /data/sa.sh AA BB && rm /data/sa.sh",
+      "expect": {
+        "exit": 0,
+        "stdout": "argc=2 a1=AA a2=BB\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "source_args_restore_parent",
+      "seq": 609222,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "printf 'echo inner=$1\\n' > /data/sb.sh && set -- P1 P2 && source /data/sb.sh QQ && echo after=$1 && rm /data/sb.sh",
+      "expect": {
+        "exit": 0,
+        "stdout": "inner=QQ\nafter=P1\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/bash/source/args.json
+++ b/integ/bash/source/args.json
@@ -67,6 +67,40 @@
         "stdout": "inner=QQ\nafter=P1\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "source_args_keep_spelling",
+      "seq": 609223,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "printf 'echo a1=$1\\n' > /data/sc.sh && source /data/sc.sh ./sub/x.txt && rm /data/sc.sh",
+      "expect": {
+        "exit": 0,
+        "stdout": "a1=./sub/x.txt\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/python/mirage/shell/array.py
+++ b/python/mirage/shell/array.py
@@ -107,6 +107,34 @@ def array_append(arr: ShellArray, values: list[str]) -> None:
     arr.extend(values)
 
 
+def array_slice(arr: ShellArray, offset: int, length: int | None) -> list[str]:
+    """Take the assigned elements from index ``offset`` on, in order.
+
+    bash slices an indexed array by *subscript*, not by position among
+    the assigned values: for ``a=([1]=b [3]=d [9]=j)``, ``${a[@]:2}`` is
+    ``d j`` because it keeps every index >= 2. ``length`` then caps how
+    many of those are taken. A negative offset counts back from the
+    extent and yields nothing if it is still negative.
+
+    Args:
+        arr (ShellArray): the array.
+        offset (int): the first subscript to keep, or a negative count
+            back from the extent.
+        length (int | None): how many elements to take; a negative value
+            drops that many from the end.
+    """
+    if offset < 0:
+        offset += array_extent(arr)
+        if offset < 0:
+            return []
+    picked = [v for i, v in enumerate(arr) if v is not None and i >= offset]
+    if length is None:
+        return picked
+    if length < 0:
+        return picked[:max(0, len(picked) + length)]
+    return picked[:length]
+
+
 def array_unset(arr: ShellArray, idx: int) -> None:
     """Clear one element, keeping the indices of the elements after it.
 

--- a/python/mirage/shell/array.py
+++ b/python/mirage/shell/array.py
@@ -1,0 +1,124 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+ShellArray = list[str | None]
+
+
+def make_array(values: list[str]) -> ShellArray:
+    """Build a dense array from consecutive values.
+
+    Args:
+        values (list[str]): the element values, starting at index 0.
+    """
+    return list(values)
+
+
+def array_extent(arr: ShellArray) -> int:
+    """Return one past the highest assigned index, which is what bash
+    resolves a negative subscript against.
+
+    Args:
+        arr (ShellArray): the array.
+    """
+    return len(arr)
+
+
+def array_values(arr: ShellArray) -> list[str]:
+    """Return the assigned values in index order, skipping holes.
+
+    Args:
+        arr (ShellArray): the array.
+    """
+    return [v for v in arr if v is not None]
+
+
+def array_indices(arr: ShellArray) -> list[int]:
+    """Return the assigned indices in order, skipping holes.
+
+    Args:
+        arr (ShellArray): the array.
+    """
+    return [i for i, v in enumerate(arr) if v is not None]
+
+
+def array_count(arr: ShellArray) -> int:
+    """Return the number of assigned elements, which is ``${#arr[@]}``.
+
+    Args:
+        arr (ShellArray): the array.
+    """
+    return sum(1 for v in arr if v is not None)
+
+
+def array_has(arr: ShellArray, idx: int) -> bool:
+    """Report whether ``idx`` holds an assigned element.
+
+    Args:
+        arr (ShellArray): the array.
+        idx (int): a non-negative index.
+    """
+    return 0 <= idx < len(arr) and arr[idx] is not None
+
+
+def array_get(arr: ShellArray, idx: int) -> str:
+    """Return the element at ``idx``, or the empty string for a hole or
+    an out-of-range index.
+
+    Args:
+        arr (ShellArray): the array.
+        idx (int): a non-negative index.
+    """
+    if not 0 <= idx < len(arr):
+        return ""
+    return arr[idx] or ""
+
+
+def array_set(arr: ShellArray, idx: int, value: str) -> None:
+    """Assign ``value`` at ``idx``, extending with holes as needed.
+
+    Args:
+        arr (ShellArray): the array, mutated in place.
+        idx (int): a non-negative index.
+        value (str): the element value.
+    """
+    while len(arr) <= idx:
+        arr.append(None)
+    arr[idx] = value
+
+
+def array_append(arr: ShellArray, values: list[str]) -> None:
+    """Append values after the highest assigned index, as ``arr+=(...)``.
+
+    Args:
+        arr (ShellArray): the array, mutated in place.
+        values (list[str]): the element values to add.
+    """
+    arr.extend(values)
+
+
+def array_unset(arr: ShellArray, idx: int) -> None:
+    """Clear one element, keeping the indices of the elements after it.
+
+    Trailing holes are dropped so the extent stays at one past the
+    highest assigned index, matching how bash resolves ``arr[-1]``.
+
+    Args:
+        arr (ShellArray): the array, mutated in place.
+        idx (int): a non-negative index.
+    """
+    if not 0 <= idx < len(arr):
+        return
+    arr[idx] = None
+    while arr and arr[-1] is None:
+        arr.pop()

--- a/python/mirage/shell/helpers.py
+++ b/python/mirage/shell/helpers.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import shlex
 from enum import StrEnum
 
 import tree_sitter
@@ -352,26 +353,32 @@ def get_case_word(node: tree_sitter.Node) -> tree_sitter.Node:
 
 def get_case_items(
     node: tree_sitter.Node,
-) -> list[tuple[list[str], list[tree_sitter.Node]]]:  # noqa: E125,E501
-    """Get (patterns, body_statements) pairs from case.
+) -> list[tuple[list[str], list[tree_sitter.Node], str]]:  # noqa: E125,E501
+    """Get (patterns, body_statements, terminator) triples from case.
 
-    An arm's body is every statement up to its ;; terminator, so
-    multi-statement arms (x) cmd1; cmd2;;) keep all commands.
+    An arm's body is every statement up to its terminator, so
+    multi-statement arms (x) cmd1; cmd2;;) keep all commands. The
+    terminator is one of ``;;`` (default/last arm), ``;&`` (fall through
+    into the next arm's body unconditionally), or ``;;&`` (keep testing
+    the remaining patterns).
     """
-    items: list[tuple[list[str], list[tree_sitter.Node]]] = []
+    items: list[tuple[list[str], list[tree_sitter.Node], str]] = []
     for c in node.named_children:
         if c.type == NT.CASE_ITEM:
             patterns = []
             body: list[tree_sitter.Node] = []
+            terminator = ";;"
             for child in c.children:
-                if not body and child.type in (NT.EXTGLOB_PATTERN, NT.WORD,
-                                               NT.CONCATENATION, NT.STRING):
+                if child.type in (";;", ";&", ";;&"):
+                    terminator = child.type
+                elif not body and child.type in (NT.EXTGLOB_PATTERN, NT.WORD,
+                                                 NT.CONCATENATION, NT.STRING):
                     patterns.append(get_text(child))
                 elif child.is_named and child.type != "|":
                     body.append(child)
             if not patterns:
                 patterns = [get_text(c.named_children[0])]
-            items.append((patterns, body))
+            items.append((patterns, body, terminator))
     return items
 
 
@@ -385,6 +392,25 @@ def get_unset_names(node: tree_sitter.Node) -> list[str]:
     return [
         get_text(c) for c in node.named_children if c.type == NT.VARIABLE_NAME
     ]
+
+
+def get_unset_args(node: tree_sitter.Node) -> list[str]:
+    """Get every operand word of unset_command, keeping ``-f``/``-v``/``-n``.
+
+    Unlike ``get_unset_names`` this preserves the leading option words so
+    the handler can tell a function unset (``unset -f``) from a variable
+    unset, and splits the operand span the way the shell does so a
+    subscript target (``unset arr[1]``, quoted or not) stays one word.
+    """
+    operands = node.children[1:]
+    if not operands:
+        return []
+    start = operands[0].start_byte - node.start_byte
+    text = (node.text or b"")[start:].decode()
+    try:
+        return shlex.split(text)
+    except ValueError:
+        return [get_text(c) for c in node.named_children]
 
 
 def get_negated_command(node: tree_sitter.Node) -> tree_sitter.Node:

--- a/python/mirage/workspace/executor/builtins/__init__.py
+++ b/python/mirage/workspace/executor/builtins/__init__.py
@@ -44,7 +44,7 @@ from mirage.workspace.executor.builtins.xargs import handle_xargs
 from mirage.workspace.executor.builtins.vars import (  # isort: skip
     handle_env, handle_exit, handle_export, handle_getopts, handle_local,
     handle_printenv, handle_read, handle_readonly, handle_return, handle_set,
-    handle_shift, handle_trap, handle_unset, handle_whoami)
+    handle_shift, handle_trap, handle_unset, handle_whoami, note_local_array)
 
 __all__ = [
     '_collect_man_hits',
@@ -91,5 +91,6 @@ __all__ = [
     'handle_trap',
     'handle_unset',
     'handle_whoami',
+    'note_local_array',
     'handle_xargs',
 ]

--- a/python/mirage/workspace/executor/builtins/condition/tree.py
+++ b/python/mirage/workspace/executor/builtins/condition/tree.py
@@ -15,6 +15,7 @@
 import re
 
 from mirage.shell.arith import ArithError, evaluate_arith
+from mirage.shell.array import make_array
 from mirage.utils.fnmatch import fnmatch
 from mirage.workspace.executor.builtins.condition.constants import (
     FILE_PAIR_BINARY, INT_COMPARATORS, UNARY_OPS)
@@ -73,7 +74,8 @@ async def _eval_cond_binary(ctx: CondContext, node: CondBinary) -> bool:
         if match is None:
             return False
         groups = [g if g is not None else "" for g in match.groups()]
-        ctx.session.arrays["BASH_REMATCH"] = [match.group(0), *groups]
+        ctx.session.arrays["BASH_REMATCH"] = make_array(
+            [match.group(0), *groups])
         return True
     if node.op == "<":
         return node.left < node.right

--- a/python/mirage/workspace/executor/builtins/script.py
+++ b/python/mirage/workspace/executor/builtins/script.py
@@ -34,8 +34,20 @@ async def handle_source(
     execute_fn: Callable[..., Any],
     path: str | PathSpec,
     session: Session,
+    args: list[str] | None = None,
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
-    """Read a script file and execute it."""
+    """Read a script file and execute it.
+
+    Args:
+        dispatch (Callable): op dispatcher, used to read the file.
+        execute_fn (Callable): runs the script text in this session.
+        path (str | PathSpec): the script to source.
+        session (Session): shell session state.
+        args (list[str] | None): positional parameters to expose to the
+            script. When given they replace ``$1..$#`` for the duration
+            of the source and are restored afterwards, matching bash;
+            when omitted the parent's positional parameters are kept.
+    """
     raw = _scope_path(path)
     resolved = resolve_path(raw, session.cwd)
     scope = _to_scope(resolved)
@@ -44,11 +56,17 @@ async def handle_source(
         script = data.decode(errors="replace")
     else:
         script = ""
+    saved_positional: list[str] | None = None
+    if args:
+        saved_positional = session.positional_args
+        session.positional_args = args
     session.source_depth += 1
     try:
         io = await execute_fn(script, session_id=session.session_id)
     finally:
         session.source_depth -= 1
+        if saved_positional is not None:
+            session.positional_args = saved_positional
     return io.stdout, io, ExecutionNode(command=f"source {raw}",
                                         exit_code=io.exit_code)
 

--- a/python/mirage/workspace/executor/builtins/text.py
+++ b/python/mirage/workspace/executor/builtins/text.py
@@ -18,6 +18,7 @@ import re
 from mirage.commands.spec.shell import ECHO_OPTION
 from mirage.io import IOResult
 from mirage.io.types import ByteSource
+from mirage.shell.array import array_extent, array_set
 from mirage.workspace.expand.variable import _array_index
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
@@ -663,10 +664,8 @@ def _assign_printf_target(session: Session, name: str, subscript: str | None,
         arr = session.arrays.get(name)
         if arr is None:
             session.env[name] = value
-        elif arr:
-            arr[0] = value
         else:
-            arr.append(value)
+            array_set(arr, 0, value)
         return "ok"
     arr = session.arrays.get(name)
     from_scalar = arr is None
@@ -677,12 +676,10 @@ def _assign_printf_target(session: Session, name: str, subscript: str | None,
         arr = [] if scalar is None else [scalar]
     idx = _array_index(subscript, session.env)
     if idx < 0:
-        idx += len(arr)
+        idx += array_extent(arr)
     if idx < 0:
         return "subscript"
-    while len(arr) <= idx:
-        arr.append("")
-    arr[idx] = value
+    array_set(arr, idx, value)
     if from_scalar:
         session.env.pop(name, None)
     session.arrays[name] = arr

--- a/python/mirage/workspace/executor/builtins/text.py
+++ b/python/mirage/workspace/executor/builtins/text.py
@@ -23,7 +23,9 @@ from mirage.workspace.expand.variable import _array_index
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
 
-_PRINTF_TARGET_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)(?:\[(.*)\])?\Z")
+# A subscript must be non-empty: bash rejects `a[]` as an invalid
+# identifier, while `a[ ]` is a valid arithmetic 0.
+_PRINTF_TARGET_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)(?:\[(.+)\])?\Z")
 
 _SIMPLE_ESCAPES = {
     "\\": "\\",

--- a/python/mirage/workspace/executor/builtins/text.py
+++ b/python/mirage/workspace/executor/builtins/text.py
@@ -639,39 +639,54 @@ def _convert(conv: str, raw: str | None, flags: str, width: int | None,
     return _format_float(value_f, conv, flags, width, precision), err, False
 
 
-def _assign_printf_target(session: Session, target: str, value: str) -> bool:
+def _assign_printf_target(session: Session, name: str, subscript: str | None,
+                          value: str) -> str:
     """Assign ``value`` to a ``printf -v`` target (scalar or ``name[idx]``).
+
+    A bare name assigns element 0 when the name already holds an array,
+    leaving its other elements alone, as bash does. Nothing is mutated
+    unless the whole assignment succeeds: a readonly name or an
+    out-of-range subscript leaves the variable exactly as it was.
 
     Args:
         session (Session): shell session whose variables are written.
-        target (str): the ``-v`` operand, a name or ``name[subscript]``.
+        name (str): the target's base variable name.
+        subscript (str | None): the ``[...]`` text, or None for a scalar.
         value (str): the formatted text to store.
 
     Returns:
-        bool: True on success, False when ``target`` is not a valid name.
+        str: ``"ok"``, ``"readonly"``, or ``"subscript"``.
     """
-    match = _PRINTF_TARGET_RE.match(target)
-    if match is None:
-        return False
-    name, subscript = match.group(1), match.group(2)
+    if name in session.readonly_vars:
+        return "readonly"
     if subscript is None:
-        session.env[name] = value
-        session.arrays.pop(name, None)
-        return True
+        arr = session.arrays.get(name)
+        if arr is None:
+            session.env[name] = value
+        elif arr:
+            arr[0] = value
+        else:
+            arr.append(value)
+        return "ok"
     arr = session.arrays.get(name)
+    from_scalar = arr is None
     if arr is None:
-        scalar = session.env.pop(name, None)
-        arr = [scalar] if scalar else []
+        scalar = session.env.get(name)
+        # An existing scalar becomes element 0, even when empty: bash
+        # resolves `x[-1]` against the length-1 array that produces.
+        arr = [] if scalar is None else [scalar]
     idx = _array_index(subscript, session.env)
     if idx < 0:
         idx += len(arr)
     if idx < 0:
-        return False
+        return "subscript"
     while len(arr) <= idx:
         arr.append("")
     arr[idx] = value
+    if from_scalar:
+        session.env.pop(name, None)
     session.arrays[name] = arr
-    return True
+    return "ok"
 
 
 async def handle_printf(
@@ -691,7 +706,10 @@ async def handle_printf(
 
     With ``-v NAME`` the formatted text is stored in the shell variable
     ``NAME`` (or the array element ``NAME[idx]``) instead of written to
-    stdout, matching GNU printf.
+    stdout, matching GNU printf. An unusable ``NAME`` is rejected before
+    the format runs (status 2); a readonly name or an out-of-range
+    subscript still reports the format's own errors first, then fails
+    with status 1 and leaves the variable untouched.
 
     Args:
         args (list[str]): the format followed by its arguments, optionally
@@ -699,9 +717,19 @@ async def handle_printf(
         session (Session): shell session, for the ``-v`` assignment.
     """
     target: str | None = None
+    parsed: re.Match[str] | None = None
     if len(args) >= 2 and args[0] == "-v":
         target = args[1]
         args = args[2:]
+        parsed = _PRINTF_TARGET_RE.match(target)
+        if parsed is None:
+            # bash validates the name before formatting, so a bad name
+            # suppresses the conversion errors the format would report.
+            err = f"printf: `{target}': not a valid identifier\n".encode()
+            return None, IOResult(exit_code=2,
+                                  stderr=err), ExecutionNode(command="printf",
+                                                             exit_code=2,
+                                                             stderr=err)
     if not args:
         if target is not None:
             # `printf -v x` with no format is a usage error in bash.
@@ -712,12 +740,17 @@ async def handle_printf(
         return b"", IOResult(), ExecutionNode(command="printf", exit_code=0)
     output, errors = _run_printf(args[0], args[1:])
     err_bytes = "".join(errors).encode() if errors else b""
-    if target is not None:
-        if not _assign_printf_target(session, target, output):
-            err = (f"printf: `{target}': not a valid variable name\n").encode()
-            return None, IOResult(exit_code=1,
-                                  stderr=err), ExecutionNode(command="printf",
-                                                             exit_code=1)
+    if target is not None and parsed is not None:
+        base, subscript = parsed.group(1), parsed.group(2)
+        status = _assign_printf_target(session, base, subscript, output)
+        if status != "ok":
+            err_bytes += (f"bash: {base}: readonly variable\n"
+                          if status == "readonly" else
+                          f"bash: {target}: bad array subscript\n").encode()
+            return None, IOResult(
+                exit_code=1, stderr=err_bytes), ExecutionNode(command="printf",
+                                                              exit_code=1,
+                                                              stderr=err_bytes)
         exit_code = 1 if errors else 0
         return None, IOResult(exit_code=exit_code, stderr=err_bytes
                               or None), ExecutionNode(command="printf",

--- a/python/mirage/workspace/executor/builtins/text.py
+++ b/python/mirage/workspace/executor/builtins/text.py
@@ -18,7 +18,11 @@ import re
 from mirage.commands.spec.shell import ECHO_OPTION
 from mirage.io import IOResult
 from mirage.io.types import ByteSource
+from mirage.workspace.expand.variable import _array_index
+from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
+
+_PRINTF_TARGET_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)(?:\[(.*)\])?\Z")
 
 _SIMPLE_ESCAPES = {
     "\\": "\\",
@@ -635,8 +639,44 @@ def _convert(conv: str, raw: str | None, flags: str, width: int | None,
     return _format_float(value_f, conv, flags, width, precision), err, False
 
 
+def _assign_printf_target(session: Session, target: str, value: str) -> bool:
+    """Assign ``value`` to a ``printf -v`` target (scalar or ``name[idx]``).
+
+    Args:
+        session (Session): shell session whose variables are written.
+        target (str): the ``-v`` operand, a name or ``name[subscript]``.
+        value (str): the formatted text to store.
+
+    Returns:
+        bool: True on success, False when ``target`` is not a valid name.
+    """
+    match = _PRINTF_TARGET_RE.match(target)
+    if match is None:
+        return False
+    name, subscript = match.group(1), match.group(2)
+    if subscript is None:
+        session.env[name] = value
+        session.arrays.pop(name, None)
+        return True
+    arr = session.arrays.get(name)
+    if arr is None:
+        scalar = session.env.pop(name, None)
+        arr = [scalar] if scalar else []
+    idx = _array_index(subscript, session.env)
+    if idx < 0:
+        idx += len(arr)
+    if idx < 0:
+        return False
+    while len(arr) <= idx:
+        arr.append("")
+    arr[idx] = value
+    session.arrays[name] = arr
+    return True
+
+
 async def handle_printf(
-        args: list[str],  # noqa: E125
+    args: list[str],
+    session: Session,
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
     """Print formatted output, honoring GNU printf's format-reuse rules.
 
@@ -649,17 +689,43 @@ async def handle_printf(
     string / ``0``. Integers wrap at 64 bits; ``%a`` formats at IEEE
     double precision.
 
+    With ``-v NAME`` the formatted text is stored in the shell variable
+    ``NAME`` (or the array element ``NAME[idx]``) instead of written to
+    stdout, matching GNU printf.
+
     Args:
-        args (list[str]): the format followed by its arguments.
+        args (list[str]): the format followed by its arguments, optionally
+            preceded by ``-v NAME``.
+        session (Session): shell session, for the ``-v`` assignment.
     """
+    target: str | None = None
+    if len(args) >= 2 and args[0] == "-v":
+        target = args[1]
+        args = args[2:]
     if not args:
+        if target is not None:
+            # `printf -v x` with no format is a usage error in bash.
+            err = b"printf: usage: printf [-v var] format [arguments]\n"
+            return None, IOResult(exit_code=2,
+                                  stderr=err), ExecutionNode(command="printf",
+                                                             exit_code=2)
         return b"", IOResult(), ExecutionNode(command="printf", exit_code=0)
     output, errors = _run_printf(args[0], args[1:])
+    err_bytes = "".join(errors).encode() if errors else b""
+    if target is not None:
+        if not _assign_printf_target(session, target, output):
+            err = (f"printf: `{target}': not a valid variable name\n").encode()
+            return None, IOResult(exit_code=1,
+                                  stderr=err), ExecutionNode(command="printf",
+                                                             exit_code=1)
+        exit_code = 1 if errors else 0
+        return None, IOResult(exit_code=exit_code, stderr=err_bytes
+                              or None), ExecutionNode(command="printf",
+                                                      exit_code=exit_code)
     out = output.encode()
     if errors:
-        err = "".join(errors).encode()
         return out, IOResult(exit_code=1,
-                             stderr=err), ExecutionNode(command="printf",
-                                                        exit_code=1,
-                                                        stderr=err)
+                             stderr=err_bytes), ExecutionNode(command="printf",
+                                                              exit_code=1,
+                                                              stderr=err_bytes)
     return out, IOResult(), ExecutionNode(command="printf", exit_code=0)

--- a/python/mirage/workspace/executor/builtins/vars.py
+++ b/python/mirage/workspace/executor/builtins/vars.py
@@ -22,6 +22,7 @@ from mirage.io import IOResult
 from mirage.io.async_line_iterator import AsyncLineIterator
 from mirage.io.stream import async_chain
 from mirage.io.types import ByteSource
+from mirage.shell.array import array_extent, array_unset
 from mirage.shell.call_stack import CallStack
 from mirage.shell.errors import ExitSignal
 from mirage.shell.types import SET_FLAG_TO_OPTION
@@ -81,12 +82,11 @@ async def handle_readonly(
 def _unset_variable(session: Session, name: str) -> str:
     """Remove a scalar/array variable, or one array element ``name[idx]``.
 
-    Clearing an element keeps the positions of the elements after it, as
-    bash does: only a trailing element shortens the array, an interior
-    one leaves an empty hole. Mirage stores arrays densely, so a hole is
-    an empty string (the same representation ``arr[9]=v`` produces) and
-    still counts toward ``${#arr[@]}`` and ``${arr[@]}``, where bash
-    would skip it.
+    Clearing an element keeps the indices of the elements after it, as
+    bash does: it leaves a hole, which neither expands in ``${arr[@]}``
+    nor counts toward ``${#arr[@]}`` but keeps ``${arr[i]}`` addressing
+    the same values. Trailing holes are dropped, so ``arr+=(x)`` refills
+    the slot a trailing unset freed.
 
     A subscript on a scalar names element 0 only: ``x[0]`` unsets the
     scalar and any other subscript is an error. A subscript on a name
@@ -113,13 +113,8 @@ def _unset_variable(session: Session, name: str) -> str:
             return "ok"
         idx = _array_index(subscript, session.env)
         if idx < 0:
-            idx += len(arr)
-        if not 0 <= idx < len(arr):
-            return "ok"
-        if idx == len(arr) - 1:
-            del arr[idx]
-        else:
-            arr[idx] = ""
+            idx += array_extent(arr)
+        array_unset(arr, idx)
         return "ok"
     session.env.pop(name, None)
     session.arrays.pop(name, None)

--- a/python/mirage/workspace/executor/builtins/vars.py
+++ b/python/mirage/workspace/executor/builtins/vars.py
@@ -78,29 +78,54 @@ async def handle_readonly(
     return None, IOResult(), ExecutionNode(command="readonly", exit_code=0)
 
 
-def _unset_variable(session: Session, name: str) -> None:
+def _unset_variable(session: Session, name: str) -> str:
     """Remove a scalar/array variable, or one array element ``name[idx]``.
+
+    Clearing an element keeps the positions of the elements after it, as
+    bash does: only a trailing element shortens the array, an interior
+    one leaves an empty hole. Mirage stores arrays densely, so a hole is
+    an empty string (the same representation ``arr[9]=v`` produces) and
+    still counts toward ``${#arr[@]}`` and ``${arr[@]}``, where bash
+    would skip it.
+
+    A subscript on a scalar names element 0 only: ``x[0]`` unsets the
+    scalar and any other subscript is an error. A subscript on a name
+    that holds nothing at all is a silent no-op.
 
     Args:
         session (Session): shell session state.
         name (str): a variable name or ``name[subscript]``.
+
+    Returns:
+        str: ``"ok"``, or ``"notarray"`` when a non-zero subscript was
+            applied to a scalar.
     """
     match = _PRINTF_TARGET_RE.match(name)
     if match is not None and match.group(2) is not None:
         base, subscript = match.group(1), match.group(2)
         arr = session.arrays.get(base)
         if arr is None:
-            return
+            if base not in session.env:
+                return "ok"
+            if _array_index(subscript, session.env) != 0:
+                return "notarray"
+            session.env.pop(base, None)
+            return "ok"
         idx = _array_index(subscript, session.env)
         if idx < 0:
             idx += len(arr)
-        if 0 <= idx < len(arr):
+        if not 0 <= idx < len(arr):
+            return "ok"
+        if idx == len(arr) - 1:
             del arr[idx]
-        return
+        else:
+            arr[idx] = ""
+        return "ok"
     session.env.pop(name, None)
     session.arrays.pop(name, None)
     if name == "OPTIND":
         session._getopts_optind = None
+    return "ok"
 
 
 async def handle_unset(
@@ -110,10 +135,12 @@ async def handle_unset(
     """Unset shell variables, arrays, or functions, with bash's flags.
 
     ``-v`` targets a variable only, ``-f`` a function only, and a bare
-    name a variable if one exists or else a function. ``-n`` (unset a
-    nameref itself) has no referent here — mirage has no nameref
-    attribute — so it matches bash on a non-nameref name and leaves it
-    untouched.
+    name a variable if one exists or else a function. A ``name[idx]``
+    operand clears one element; the readonly guard resolves it to the
+    base name first, since that is what ``readonly`` records. ``-n``
+    (unset a nameref itself) has no referent here — mirage has no
+    nameref attribute — so it matches bash on a non-nameref name and
+    leaves it untouched.
 
     Args:
         args (list[str]): option words followed by names to unset.
@@ -148,17 +175,26 @@ async def handle_unset(
         if mode == "f":
             session.functions.pop(name, None)
             continue
-        if name in session.readonly_vars:
-            err = (f"bash: unset: {name}: cannot unset: "
+        target = _PRINTF_TARGET_RE.match(name)
+        is_element = target is not None and target.group(2) is not None
+        # `readonly arr` records the base name, so an `arr[i]` operand has
+        # to be resolved before the guard, as bash does (which also names
+        # the base, not the element, in the error).
+        base = target.group(1) if target is not None else name
+        if base in session.readonly_vars:
+            err = (f"bash: unset: {base}: cannot unset: "
                    f"readonly variable\n").encode()
             return None, IOResult(exit_code=1,
                                   stderr=err), ExecutionNode(command="unset",
                                                              exit_code=1,
                                                              stderr=err)
-        target = _PRINTF_TARGET_RE.match(name)
-        is_element = target is not None and target.group(2) is not None
         existed = is_element or name in session.env or name in session.arrays
-        _unset_variable(session, name)
+        if _unset_variable(session, name) == "notarray":
+            err = f"bash: unset: {base}: not an array variable\n".encode()
+            return None, IOResult(exit_code=1,
+                                  stderr=err), ExecutionNode(command="unset",
+                                                             exit_code=1,
+                                                             stderr=err)
         if mode == "auto" and not existed and name in session.functions:
             session.functions.pop(name, None)
     return None, IOResult(), ExecutionNode(command="unset", exit_code=0)

--- a/python/mirage/workspace/executor/builtins/vars.py
+++ b/python/mirage/workspace/executor/builtins/vars.py
@@ -90,15 +90,18 @@ def _unset_variable(session: Session, name: str) -> str:
 
     A subscript on a scalar names element 0 only: ``x[0]`` unsets the
     scalar and any other subscript is an error. A subscript on a name
-    that holds nothing at all is a silent no-op.
+    that holds nothing at all is a silent no-op, but on an existing array
+    a negative subscript still below zero after the extent is added is a
+    bad-subscript error.
 
     Args:
         session (Session): shell session state.
         name (str): a variable name or ``name[subscript]``.
 
     Returns:
-        str: ``"ok"``, or ``"notarray"`` when a non-zero subscript was
-            applied to a scalar.
+        str: ``"ok"``, ``"notarray"`` when a non-zero subscript was
+            applied to a scalar, or ``"subscript"`` for a negative
+            subscript outside an existing array.
     """
     match = _PRINTF_TARGET_RE.match(name)
     if match is not None and match.group(2) is not None:
@@ -114,6 +117,8 @@ def _unset_variable(session: Session, name: str) -> str:
         idx = _array_index(subscript, session.env)
         if idx < 0:
             idx += array_extent(arr)
+            if idx < 0:
+                return "subscript"
         array_unset(arr, idx)
         return "ok"
     session.env.pop(name, None)
@@ -184,8 +189,14 @@ async def handle_unset(
                                                              exit_code=1,
                                                              stderr=err)
         existed = is_element or name in session.env or name in session.arrays
-        if _unset_variable(session, name) == "notarray":
-            err = f"bash: unset: {base}: not an array variable\n".encode()
+        status = _unset_variable(session, name)
+        if status != "ok":
+            # bash names the base for "not an array variable" but prints
+            # only the bracketed part for a bad subscript.
+            detail = (f"unset: {base}: not an array variable"
+                      if status == "notarray" else
+                      f"unset: {name[len(base):]}: bad array subscript")
+            err = f"bash: {detail}\n".encode()
             return None, IOResult(exit_code=1,
                                   stderr=err), ExecutionNode(command="unset",
                                                              exit_code=1,
@@ -416,6 +427,30 @@ async def handle_read(
         # the variable_assignment path.
         session.arrays.pop(var, None)
     return None, IOResult(), ExecutionNode(command="read", exit_code=0)
+
+
+def note_local_array(session: Session, name: str) -> bool:
+    """Record the caller's array before a function shadows ``name``.
+
+    ``local -a`` / ``declare -a`` inside a function shadow the caller's
+    array, so the old value (or its absence) has to be remembered for the
+    teardown in ``execute_command``.
+
+    Args:
+        session (Session): shell session state.
+        name (str): the array name being declared.
+
+    Returns:
+        bool: True when a function scope is active, so the caller should
+            shadow rather than reuse whatever is already there.
+    """
+    local_arrays = session._local_arrays
+    if local_arrays is None:
+        return False
+    if name not in local_arrays:
+        existing = session.arrays.get(name)
+        local_arrays[name] = None if existing is None else list(existing)
+    return True
 
 
 async def handle_local(

--- a/python/mirage/workspace/executor/builtins/vars.py
+++ b/python/mirage/workspace/executor/builtins/vars.py
@@ -25,7 +25,9 @@ from mirage.io.types import ByteSource
 from mirage.shell.call_stack import CallStack
 from mirage.shell.errors import ExitSignal
 from mirage.shell.types import SET_FLAG_TO_OPTION
+from mirage.workspace.executor.builtins.text import _PRINTF_TARGET_RE
 from mirage.workspace.executor.control import ReturnSignal
+from mirage.workspace.expand.variable import _array_index
 from mirage.workspace.mount.namespace import Namespace
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
@@ -76,11 +78,76 @@ async def handle_readonly(
     return None, IOResult(), ExecutionNode(command="readonly", exit_code=0)
 
 
+def _unset_variable(session: Session, name: str) -> None:
+    """Remove a scalar/array variable, or one array element ``name[idx]``.
+
+    Args:
+        session (Session): shell session state.
+        name (str): a variable name or ``name[subscript]``.
+    """
+    match = _PRINTF_TARGET_RE.match(name)
+    if match is not None and match.group(2) is not None:
+        base, subscript = match.group(1), match.group(2)
+        arr = session.arrays.get(base)
+        if arr is None:
+            return
+        idx = _array_index(subscript, session.env)
+        if idx < 0:
+            idx += len(arr)
+        if 0 <= idx < len(arr):
+            del arr[idx]
+        return
+    session.env.pop(name, None)
+    session.arrays.pop(name, None)
+    if name == "OPTIND":
+        session._getopts_optind = None
+
+
 async def handle_unset(
-    names: list[str],
+    args: list[str],
     session: Session,
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
-    for name in names:
+    """Unset shell variables, arrays, or functions, with bash's flags.
+
+    ``-v`` targets a variable only, ``-f`` a function only, and a bare
+    name a variable if one exists or else a function. ``-n`` (unset a
+    nameref itself) has no referent here — mirage has no nameref
+    attribute — so it matches bash on a non-nameref name and leaves it
+    untouched.
+
+    Args:
+        args (list[str]): option words followed by names to unset.
+        session (Session): shell session state.
+    """
+    mode = "auto"
+    i = 0
+    while i < len(args) and args[i].startswith("-") and args[i] != "-":
+        tok = args[i]
+        if tok == "--":
+            i += 1
+            break
+        if all(ch in "vfn" for ch in tok[1:]):
+            if "f" in tok[1:]:
+                mode = "f"
+            elif "n" in tok[1:]:
+                mode = "n"
+            else:
+                mode = "v"
+            i += 1
+            continue
+        err = f"bash: unset: {tok}: invalid option\n".encode()
+        return None, IOResult(exit_code=2,
+                              stderr=err), ExecutionNode(command="unset",
+                                                         exit_code=2,
+                                                         stderr=err)
+    for name in args[i:]:
+        if mode == "n":
+            # No nameref attribute exists, so as in bash on a plain
+            # variable this leaves the name untouched.
+            continue
+        if mode == "f":
+            session.functions.pop(name, None)
+            continue
         if name in session.readonly_vars:
             err = (f"bash: unset: {name}: cannot unset: "
                    f"readonly variable\n").encode()
@@ -88,9 +155,12 @@ async def handle_unset(
                                   stderr=err), ExecutionNode(command="unset",
                                                              exit_code=1,
                                                              stderr=err)
-        session.env.pop(name, None)
-        if name == "OPTIND":
-            session._getopts_optind = None
+        target = _PRINTF_TARGET_RE.match(name)
+        is_element = target is not None and target.group(2) is not None
+        existed = is_element or name in session.env or name in session.arrays
+        _unset_variable(session, name)
+        if mode == "auto" and not existed and name in session.functions:
+            session.functions.pop(name, None)
     return None, IOResult(), ExecutionNode(command="unset", exit_code=0)
 
 

--- a/python/mirage/workspace/executor/command.py
+++ b/python/mirage/workspace/executor/command.py
@@ -38,6 +38,7 @@ from mirage.io.types import ByteSource
 from mirage.runtime.base import Runtime
 from mirage.runtime.route import RoutingDecision
 from mirage.runtime.table import VfsRuntime
+from mirage.shell.array import ShellArray
 from mirage.shell.call_stack import CallStack
 from mirage.shell.job_table import JobTable
 from mirage.shell.types import ERREXIT_EXEMPT_TYPES
@@ -584,7 +585,9 @@ async def handle_command(
         text_args = [word_text(p) for p in parts[1:]]
         cs.push(text_args, function_name=cmd_name)
         saved_locals: dict[str, str | None] = {}
+        saved_arrays: dict[str, ShellArray | None] = {}
         session._local_vars = saved_locals
+        session._local_arrays = saved_arrays
         try:
             all_stdout: list[Any] = []
             merged_io = IOResult()
@@ -620,7 +623,13 @@ async def handle_command(
                     session.env.pop(key, None)
                 else:
                     session.env[key] = old_val
+            for key, old_arr in saved_arrays.items():
+                if old_arr is None:
+                    session.arrays.pop(key, None)
+                else:
+                    session.arrays[key] = old_arr
             session._local_vars = None
+            session._local_arrays = None
 
     # Cross-mount: paths span different mounts (e.g. cp /ram/a /disk/b).
     # Use dispatch to read/write across mounts directly.

--- a/python/mirage/workspace/executor/control.py
+++ b/python/mirage/workspace/executor/control.py
@@ -313,28 +313,42 @@ async def handle_until(
 async def handle_case(
     execute_node: Callable[..., Any],
     word: str,
-    items: list[tuple[list[str], list[tree_sitter.Node]]],
+    items: list[tuple[list[str], list[tree_sitter.Node], str]],
     session: Session,
     stdin: ByteSource | None = None,
     call_stack: CallStack | None = None,
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
-    for patterns, body in items:
-        if any(fnmatch(word, p.strip()) for p in patterns):
-            all_stdout: list[ByteSource] = []
-            merged_io = IOResult()
-            last_exec = ExecutionNode(command="case", exit_code=0)
-            for stmt in body:
-                stdout, io, last_exec = await execute_node(
-                    stmt, session, stdin, call_stack)
-                stdin = None
-                if stdout is not None:
-                    all_stdout.append(stdout)
-                merged_io = await merged_io.merge(io)
-            if len(all_stdout) == 1:
-                return all_stdout[0], merged_io, last_exec
-            combined = async_chain(*all_stdout) if all_stdout else None
-            return combined, merged_io, last_exec
-    return None, IOResult(), ExecutionNode(command="case", exit_code=0)
+    all_stdout: list[ByteSource] = []
+    merged_io = IOResult()
+    last_exec = ExecutionNode(command="case", exit_code=0)
+    ran = False
+    fallthrough = False
+    for patterns, body, terminator in items:
+        if not (fallthrough or any(fnmatch(word, p.strip())
+                                   for p in patterns)):
+            continue
+        ran = True
+        for stmt in body:
+            stdout, io, last_exec = await execute_node(stmt, session, stdin,
+                                                       call_stack)
+            stdin = None
+            if stdout is not None:
+                all_stdout.append(stdout)
+            merged_io = await merged_io.merge(io)
+        if terminator == ";&":
+            # Fall through: run the next arm's body without testing it.
+            fallthrough = True
+            continue
+        # ;;& keeps testing remaining patterns; ;; stops here.
+        fallthrough = False
+        if terminator != ";;&":
+            break
+    if not ran:
+        return None, IOResult(), ExecutionNode(command="case", exit_code=0)
+    if len(all_stdout) == 1:
+        return all_stdout[0], merged_io, last_exec
+    combined = async_chain(*all_stdout) if all_stdout else None
+    return combined, merged_io, last_exec
 
 
 async def handle_select(

--- a/python/mirage/workspace/expand/variable.py
+++ b/python/mirage/workspace/expand/variable.py
@@ -19,8 +19,8 @@ from dataclasses import dataclass
 import tree_sitter
 
 from mirage.shell.arith import evaluate_arith
-from mirage.shell.array import (array_extent, array_get, array_has,
-                                array_indices, array_values)
+from mirage.shell.array import (ShellArray, array_extent, array_get, array_has,
+                                array_indices, array_slice, array_values)
 from mirage.shell.call_stack import CallStack
 from mirage.shell.errors import ArithError, ExitSignal
 from mirage.shell.helpers import get_text
@@ -483,7 +483,7 @@ async def expand_braces(node: tree_sitter.Node, session: Session,
             if p.length_op:
                 return str(len(values))
             if p.op == ":":
-                sliced = _slice_array(values, groups, env)
+                sliced = _slice_array(arr, groups, env)
                 return " ".join(sliced)
             if p.op in _STRIP_OPS | _REPLACE_OPS | _CASE_OPS:
                 return " ".join(
@@ -562,25 +562,26 @@ async def expand_braces(node: tree_sitter.Node, session: Session,
     return _value_op(p.op, val, groups, env)
 
 
-def _slice_array(arr: list[str], groups: list[str],
+def _slice_array(arr: ShellArray, groups: list[str],
                  env: dict[str, str]) -> list[str]:
+    """Resolve ``${a[@]:offset:length}`` against a shell array.
+
+    Args:
+        arr (ShellArray): the array being sliced.
+        groups (list[str]): the raw offset and length words.
+        env (dict[str, str]): environment for the arithmetic context.
+    """
     if not groups:
-        return arr
+        return array_values(arr)
     offset = _arith_int(groups[0], env)
     if offset is None:
-        return arr
+        return array_values(arr)
     length = None
     if len(groups) > 1:
         length = _arith_int(groups[1], env)
         if length is None:
-            return arr
-    if offset < 0:
-        offset = max(0, len(arr) + offset)
-    if length is None:
-        return arr[offset:]
-    if length < 0:
-        return arr[offset:max(offset, len(arr) + length)]
-    return arr[offset:offset + length]
+            return array_values(arr)
+    return array_slice(arr, offset, length)
 
 
 def is_multiword_at(node: tree_sitter.Node) -> bool:
@@ -637,5 +638,5 @@ async def expand_array_at(node: tree_sitter.Node, session: Session,
         groups.append(await _expand_group(group, expand_child, pattern_mode,
                                           session, call_stack))
     if p.op == ":":
-        return _slice_array(values, groups, session.env)
+        return _slice_array(arr, groups, session.env)
     return [_value_op(p.op, el, groups, session.env) for el in values]

--- a/python/mirage/workspace/expand/variable.py
+++ b/python/mirage/workspace/expand/variable.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass
 import tree_sitter
 
 from mirage.shell.arith import evaluate_arith
+from mirage.shell.array import (array_extent, array_get, array_has,
+                                array_indices, array_values)
 from mirage.shell.call_stack import CallStack
 from mirage.shell.errors import ArithError, ExitSignal
 from mirage.shell.helpers import get_text
@@ -121,8 +123,7 @@ def _lookup_var(var: str,
             return local_val
     arrays = getattr(session, "arrays", None)
     if arrays and var in arrays:
-        arr = arrays[var]
-        return arr[0] if arr else ""
+        return array_get(arrays[var], 0)
     if var == "PWD":
         return session.cwd
     if var == "HOME":
@@ -472,26 +473,27 @@ async def expand_braces(node: tree_sitter.Node, session: Session,
             arr = [scalar] if scalar else []
         var_in_env = p.var_name in arrays or p.var_name in env
         if p.subscript in ("@", "*"):
+            # ${a[@]} and friends see only the assigned elements: a hole
+            # left by `unset a[i]` (or skipped by a[9]=v) neither expands
+            # nor counts, though it keeps the later indices in place.
+            values = array_values(arr)
             if p.indirect_op:
-                return " ".join(str(i) for i in range(len(arr)))
+                return " ".join(str(i) for i in array_indices(arr))
             if p.length_op:
-                return str(len(arr))
+                return str(len(values))
             if p.op == ":":
-                sliced = _slice_array(arr, groups, env)
+                sliced = _slice_array(values, groups, env)
                 return " ".join(sliced)
             if p.op in _STRIP_OPS | _REPLACE_OPS | _CASE_OPS:
-                return " ".join(_value_op(p.op, el, groups, env) for el in arr)
-            val = " ".join(arr)
+                return " ".join(
+                    _value_op(p.op, el, groups, env) for el in values)
+            val = " ".join(values)
         else:
             idx = _array_index(p.subscript, env)
             if idx < 0:
-                idx += len(arr)
-            if 0 <= idx < len(arr):
-                val = arr[idx]
-                var_in_env = True
-            else:
-                val = ""
-                var_in_env = False
+                idx += array_extent(arr)
+            val = array_get(arr, idx)
+            var_in_env = array_has(arr, idx)
     elif p.var_name:
         if call_stack:
             local_val = call_stack.get_local(p.var_name)
@@ -499,8 +501,7 @@ async def expand_braces(node: tree_sitter.Node, session: Session,
                 val = local_val
                 var_in_env = True
         if not var_in_env and p.var_name in arrays:
-            arr = arrays[p.var_name]
-            val = arr[0] if arr else ""
+            val = array_get(arrays[p.var_name], 0)
             var_in_env = True
         if not var_in_env and p.var_name in env:
             val = env[p.var_name]
@@ -625,14 +626,15 @@ async def expand_array_at(node: tree_sitter.Node, session: Session,
         scalar = session.env.get(p.var_name or "", "")
         arr = [scalar] if scalar else []
     if p.indirect_op:
-        return [str(i) for i in range(len(arr))]
+        return [str(i) for i in array_indices(arr)]
+    values = array_values(arr)
     if p.op is None:
-        return list(arr)
+        return values
     groups: list[str] = []
     for gi, group in enumerate(p.groups):
         pattern_mode = gi == 0 and p.op in _PATTERN_OPS
         groups.append(await _expand_group(group, expand_child, pattern_mode,
                                           session, call_stack))
     if p.op == ":":
-        return _slice_array(arr, groups, session.env)
-    return [_value_op(p.op, el, groups, session.env) for el in arr]
+        return _slice_array(values, groups, session.env)
+    return [_value_op(p.op, el, groups, session.env) for el in values]

--- a/python/mirage/workspace/expand/variable.py
+++ b/python/mirage/workspace/expand/variable.py
@@ -469,8 +469,9 @@ async def expand_braces(node: tree_sitter.Node, session: Session,
     if p.subscript is not None and p.var_name is not None:
         arr = arrays.get(p.var_name)
         if arr is None:
-            scalar = env.get(p.var_name, "")
-            arr = [scalar] if scalar else []
+            # A scalar is element 0 of a one-element array, even when
+            # empty: ${#x[@]} is 1 for x="" but 0 for an unset name.
+            arr = [env[p.var_name]] if p.var_name in env else []
         var_in_env = p.var_name in arrays or p.var_name in env
         if p.subscript in ("@", "*"):
             # ${a[@]} and friends see only the assigned elements: a hole
@@ -623,8 +624,8 @@ async def expand_array_at(node: tree_sitter.Node, session: Session,
     arrays = getattr(session, "arrays", {})
     arr = arrays.get(p.var_name)
     if arr is None:
-        scalar = session.env.get(p.var_name or "", "")
-        arr = [scalar] if scalar else []
+        name = p.var_name or ""
+        arr = [session.env[name]] if name in session.env else []
     if p.indirect_op:
         return [str(i) for i in array_indices(arr)]
     values = array_values(arr)

--- a/python/mirage/workspace/node/command_dispatch.py
+++ b/python/mirage/workspace/node/command_dispatch.py
@@ -355,7 +355,8 @@ async def _run_argv(
 
     if name in (SB.SOURCE, SB.DOT):
         path = operands[0] if operands else ""
-        return await handle_source(dispatch, execute_fn, path, session)
+        return await handle_source(dispatch, execute_fn, path, session,
+                                   [word_text(o) for o in operands[1:]])
 
     if name == SB.EVAL:
         return await handle_eval(execute_fn, args, session)
@@ -422,7 +423,7 @@ async def _run_argv(
         return await handle_echo(args)
 
     if name == SB.PRINTF:
-        return await handle_printf(args)
+        return await handle_printf(args, session)
 
     if name == SB.SLEEP:
         return await handle_sleep(args, cancel=cancel)

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -58,7 +58,8 @@ from mirage.shell.helpers import (  # isort: skip
     get_negated_command, get_pipeline_commands, get_redirects, get_text,
     get_unset_args, get_while_parts)
 from mirage.workspace.executor.builtins import (  # isort: skip
-    handle_export, handle_local, handle_readonly, handle_test, handle_unset)
+    handle_export, handle_local, handle_readonly, handle_test, handle_unset,
+    note_local_array)
 
 
 async def _expand_array_items(
@@ -425,7 +426,9 @@ async def execute_node(
     if kind == NodeKind.DECLARATION:
         keyword = get_declaration_keyword(node)
         assignments = []
-        array_names: list[str] = []
+        # Array literals are staged, not stored: `readonly -a a=(y)` on an
+        # already-readonly name has to fail with the old value intact.
+        staged: list[tuple[str, bool, list[str]]] = []
         flag_chars: set[str] = set()
         for child in node.named_children:
             if child.type == NT.VARIABLE_ASSIGNMENT:
@@ -435,9 +438,10 @@ async def execute_node(
                 ]
                 if val_nodes and val_nodes[0].type == NT.ARRAY:
                     key = get_text(child).partition("=")[0]
-                    session.arrays[key] = make_array(await _expand_array_items(
-                        val_nodes[0], session, execute_fn, registry, cs))
-                    array_names.append(key.removesuffix("+"))
+                    items = await _expand_array_items(val_nodes[0], session,
+                                                      execute_fn, registry, cs)
+                    staged.append(
+                        (key.removesuffix("+"), key.endswith("+"), items))
                     continue
                 expanded = await expand_node(child, session, execute_fn, cs)
                 assignments.append(expanded)
@@ -452,13 +456,40 @@ async def execute_node(
                     flag_chars.update(expanded[1:])
                 else:
                     assignments.append(expanded)
+        array_names = [name for name, _, _ in staged]
+        is_readonly = keyword == "readonly" or "r" in flag_chars
+        for name in array_names:
+            if is_readonly and name in session.readonly_vars:
+                err = f"bash: {name}: readonly variable\n".encode()
+                return None, IOResult(exit_code=1, stderr=err), ExecutionNode(
+                    command=keyword, exit_code=1, stderr=err)
+        for name, append, items in staged:
+            note_local_array(session, name)
+            if append:
+                base = session.arrays.get(name)
+                if base is None:
+                    scalar = session.env.get(name)
+                    base = [] if scalar is None else [scalar]
+                array_append(base, items)
+            else:
+                base = make_array(items)
+            session.arrays[name] = base
+            session.env.pop(name, None)
         if "a" in flag_chars:
             # `declare -a NAME` with no value declares an empty array, so
             # ${#NAME[@]} is 0 and NAME[3]=x leaves index 0 unassigned.
             for bare in assignments:
-                if "=" not in bare:
-                    session.arrays.setdefault(bare, [])
-        if keyword == "readonly" or "r" in flag_chars:
+                if "=" in bare:
+                    continue
+                if note_local_array(session, bare):
+                    # Inside a function this shadows whatever the caller
+                    # had with a fresh empty array.
+                    session.arrays[bare] = []
+                elif bare not in session.arrays:
+                    # At top level an existing scalar becomes element 0.
+                    scalar = session.env.pop(bare, None)
+                    session.arrays[bare] = [] if scalar is None else [scalar]
+        if is_readonly:
             # An array assignment stores itself above, but the name still
             # has to be marked readonly.
             return await handle_readonly(assignments + array_names, session)

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -423,6 +423,7 @@ async def execute_node(
     if kind == NodeKind.DECLARATION:
         keyword = get_declaration_keyword(node)
         assignments = []
+        array_names: list[str] = []
         flag_chars: set[str] = set()
         for child in node.named_children:
             if child.type == NT.VARIABLE_ASSIGNMENT:
@@ -434,11 +435,14 @@ async def execute_node(
                     key = get_text(child).partition("=")[0]
                     session.arrays[key] = await _expand_array_items(
                         val_nodes[0], session, execute_fn, registry, cs)
+                    array_names.append(key.removesuffix("+"))
                     continue
                 expanded = await expand_node(child, session, execute_fn, cs)
                 assignments.append(expanded)
             elif child.type in (NT.SIMPLE_EXPANSION, NT.EXPANSION,
-                                NT.CONCATENATION, NT.WORD):
+                                NT.CONCATENATION, NT.WORD, NT.VARIABLE_NAME):
+                # A bare `readonly NAME` / `export NAME` operand parses as
+                # a variable_name, not a word.
                 expanded = await expand_node(child, session, execute_fn, cs)
                 if not expanded:
                     continue
@@ -447,7 +451,9 @@ async def execute_node(
                 else:
                     assignments.append(expanded)
         if keyword == "readonly" or "r" in flag_chars:
-            return await handle_readonly(assignments, session)
+            # An array assignment stores itself above, but the name still
+            # has to be marked readonly.
+            return await handle_readonly(assignments + array_names, session)
         # declare/typeset scope like `local` inside a function (bash
         # semantics) and assign globally at top level, which is exactly
         # handle_local's fallback when no function scope is active.

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -20,6 +20,8 @@ from mirage.io import IOResult
 from mirage.io.stream import async_chain
 from mirage.runtime.route import RoutingDecision
 from mirage.shell.arith import evaluate_arith
+from mirage.shell.array import (array_append, array_extent, array_get,
+                                array_set, make_array)
 from mirage.shell.call_stack import CallStack
 from mirage.shell.errors import ArithError, ExitSignal
 from mirage.shell.job_table import JobTable
@@ -433,8 +435,8 @@ async def execute_node(
                 ]
                 if val_nodes and val_nodes[0].type == NT.ARRAY:
                     key = get_text(child).partition("=")[0]
-                    session.arrays[key] = await _expand_array_items(
-                        val_nodes[0], session, execute_fn, registry, cs)
+                    session.arrays[key] = make_array(await _expand_array_items(
+                        val_nodes[0], session, execute_fn, registry, cs))
                     array_names.append(key.removesuffix("+"))
                     continue
                 expanded = await expand_node(child, session, execute_fn, cs)
@@ -450,6 +452,12 @@ async def execute_node(
                     flag_chars.update(expanded[1:])
                 else:
                     assignments.append(expanded)
+        if "a" in flag_chars:
+            # `declare -a NAME` with no value declares an empty array, so
+            # ${#NAME[@]} is 0 and NAME[3]=x leaves index 0 unassigned.
+            for bare in assignments:
+                if "=" not in bare:
+                    session.arrays.setdefault(bare, [])
         if keyword == "readonly" or "r" in flag_chars:
             # An array assignment stores itself above, but the name still
             # has to be marked readonly.
@@ -529,10 +537,13 @@ async def execute_node(
                 base = session.arrays.get(key)
                 if base is None:
                     scalar = session.env.pop(key, None)
-                    base = [scalar] if scalar else []
-                session.arrays[key] = base + items
+                    base = [] if scalar is None else [scalar]
+                # `arr+=(...)` starts at the extent, so it fills the hole
+                # a trailing `unset arr[last]` left but skips interior ones.
+                array_append(base, items)
+                session.arrays[key] = base
             else:
-                session.arrays[key] = items
+                session.arrays[key] = make_array(items)
                 session.env.pop(key, None)
             return None, IOResult(), ExecutionNode(command=text, exit_code=0)
         if val_nodes:
@@ -548,10 +559,10 @@ async def execute_node(
             arr = session.arrays.get(key)
             if arr is None:
                 scalar = session.env.pop(key, None)
-                arr = [scalar] if scalar else []
+                arr = [] if scalar is None else [scalar]
             idx = _array_index(idx_text, session.env)
             if idx < 0:
-                idx += len(arr)
+                idx += array_extent(arr)
             if idx < 0:
                 # bash aborts the whole line on a bad assignment
                 # subscript (status 1); containment mirrors ${var:?}.
@@ -560,17 +571,13 @@ async def execute_node(
                                  stderr=(f"bash: {name_text}: "
                                          "bad array subscript\n").encode(),
                                  contained_code=1)
-            while len(arr) <= idx:
-                arr.append("")
-            arr[idx] = arr[idx] + val if append else val
+            array_set(arr, idx, array_get(arr, idx) + val if append else val)
             session.arrays[key] = arr
             return None, IOResult(), ExecutionNode(command=text, exit_code=0)
         if append:
             arr = session.arrays.get(key)
-            if arr:
-                arr[0] = arr[0] + val
-            elif arr is not None:
-                arr.append(val)
+            if arr is not None:
+                array_set(arr, 0, array_get(arr, 0) + val)
             else:
                 session.env[key] = session.env.get(key, "") + val
         else:

--- a/python/mirage/workspace/node/execute_node.py
+++ b/python/mirage/workspace/node/execute_node.py
@@ -54,7 +54,7 @@ from mirage.shell.helpers import (  # isort: skip
     get_case_items, get_case_word, get_declaration_keyword, get_for_parts,
     get_function_body, get_function_name, get_if_branches, get_list_parts,
     get_negated_command, get_pipeline_commands, get_redirects, get_text,
-    get_unset_names, get_while_parts)
+    get_unset_args, get_while_parts)
 from mirage.workspace.executor.builtins import (  # isort: skip
     handle_export, handle_local, handle_readonly, handle_test, handle_unset)
 
@@ -457,8 +457,8 @@ async def execute_node(
 
     # ── unset ───────────────────────────────────
     if kind == NodeKind.UNSET:
-        names = get_unset_names(node)
-        return await handle_unset(names, session)
+        args = get_unset_args(node)
+        return await handle_unset(args, session)
 
     # ── test ([ ] or [[ ]]) ─────────────────────
     if kind == NodeKind.TEST:

--- a/python/mirage/workspace/node/provision_node.py
+++ b/python/mirage/workspace/node/provision_node.py
@@ -292,7 +292,7 @@ async def provision_node(
     if kind == NodeKind.CASE:
         items = get_case_items(node)
         children = []
-        for _, body in items:
+        for _, body, _ in items:
             if not body:
                 continue
             stmts = [await recurse(stmt, session) for stmt in body]

--- a/python/mirage/workspace/session/session.py
+++ b/python/mirage/workspace/session/session.py
@@ -48,6 +48,10 @@ class Session:
     _stdin_buffer: AsyncLineIterator | None = field(default=None, repr=False)
     _stdin_source: object = field(default=None, repr=False)
     _local_vars: dict[str, str | None] | None = field(default=None, repr=False)
+    # Arrays shadowed by `local -a` / `declare -a` in the running
+    # function; None means the caller had no array of that name.
+    _local_arrays: (dict[str, ShellArray | None]
+                    | None) = field(default=None, repr=False)
     # Hidden `getopts` state: the 1-based char offset within the current
     # word being scanned, plus the OPTIND value that offset belongs to.
     # A caller resetting OPTIND (e.g. to 1) makes the seen value stale,

--- a/python/mirage/workspace/session/session.py
+++ b/python/mirage/workspace/session/session.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from mirage.io.async_line_iterator import AsyncLineIterator
+from mirage.shell.array import ShellArray
 from mirage.shell.types import FunctionBody
 from mirage.types import MountMode
 
@@ -31,7 +32,7 @@ class Session:
     last_exit_code: int = 0
     shell_options: dict[str, bool] = field(default_factory=dict)
     readonly_vars: set[str] = field(default_factory=set)
-    arrays: dict[str, list[str]] = field(default_factory=dict)
+    arrays: dict[str, ShellArray] = field(default_factory=dict)
     mount_modes: dict[str, MountMode] | None = None
     generation: int = 0
     pipeline_timeout_seconds: float | None = None

--- a/python/tests/shell/test_array.py
+++ b/python/tests/shell/test_array.py
@@ -1,6 +1,7 @@
 from mirage.shell.array import (array_append, array_count, array_extent,
                                 array_get, array_has, array_indices, array_set,
-                                array_unset, array_values, make_array)
+                                array_slice, array_unset, array_values,
+                                make_array)
 
 
 def test_make_array_is_dense_from_zero():
@@ -81,3 +82,36 @@ def test_empty_string_is_an_element_not_a_hole():
     assert array_count(arr) == 2
     assert array_indices(arr) == [0, 1]
     assert array_values(arr) == ["", "y"]
+
+
+def test_slice_keeps_subscripts_not_ordinals():
+    arr: list[str | None] = []
+    array_set(arr, 1, "b")
+    array_set(arr, 3, "d")
+    array_set(arr, 9, "j")
+    # Offset 2 means "index >= 2", not "skip the first two values".
+    assert array_slice(arr, 2, None) == ["d", "j"]
+    assert array_slice(arr, 0, None) == ["b", "d", "j"]
+    assert array_slice(arr, 4, None) == ["j"]
+    assert array_slice(arr, 20, None) == []
+
+
+def test_slice_length_counts_elements_taken():
+    arr: list[str | None] = []
+    array_set(arr, 1, "b")
+    array_set(arr, 3, "d")
+    array_set(arr, 9, "j")
+    assert array_slice(arr, 2, 1) == ["d"]
+    assert array_slice(arr, 0, 2) == ["b", "d"]
+    assert array_slice(arr, 0, -1) == ["b", "d"]
+
+
+def test_slice_negative_offset_counts_from_the_extent():
+    arr: list[str | None] = []
+    array_set(arr, 1, "b")
+    array_set(arr, 9, "j")
+    assert array_slice(arr, -1, None) == ["j"]
+    # Still negative after the extent is added: nothing, not everything.
+    assert array_slice(arr, -20, None) == []
+    assert array_slice(make_array(["x", "y", "z"]), -5, None) == []
+    assert array_slice(make_array(["x", "y", "z"]), -2, None) == ["y", "z"]

--- a/python/tests/shell/test_array.py
+++ b/python/tests/shell/test_array.py
@@ -1,0 +1,83 @@
+from mirage.shell.array import (array_append, array_count, array_extent,
+                                array_get, array_has, array_indices, array_set,
+                                array_unset, array_values, make_array)
+
+
+def test_make_array_is_dense_from_zero():
+    arr = make_array(["a", "b"])
+    assert arr == ["a", "b"]
+    assert array_indices(arr) == [0, 1]
+
+
+def test_set_pads_with_holes_not_empty_strings():
+    arr: list[str | None] = []
+    array_set(arr, 3, "v")
+    assert arr == [None, None, None, "v"]
+    # The hole is addressable but is not an element.
+    assert array_count(arr) == 1
+    assert array_values(arr) == ["v"]
+    assert array_indices(arr) == [3]
+    assert array_extent(arr) == 4
+    assert array_get(arr, 0) == ""
+    assert not array_has(arr, 0)
+    assert array_has(arr, 3)
+
+
+def test_unset_interior_element_keeps_later_indices():
+    arr = make_array(["zero", "one", "two"])
+    array_unset(arr, 1)
+    assert arr == ["zero", None, "two"]
+    assert array_get(arr, 2) == "two"
+    assert array_count(arr) == 2
+    assert array_indices(arr) == [0, 2]
+
+
+def test_unset_trailing_element_shrinks_the_extent():
+    arr = make_array(["x", "y", "z"])
+    array_unset(arr, 2)
+    assert arr == ["x", "y"]
+    assert array_extent(arr) == 2
+
+
+def test_unset_trailing_element_drops_earlier_holes_too():
+    arr = make_array(["x", "y", "z"])
+    array_unset(arr, 1)
+    array_unset(arr, 2)
+    assert arr == ["x"]
+
+
+def test_unset_out_of_range_is_a_no_op():
+    arr = make_array(["x"])
+    array_unset(arr, 5)
+    array_unset(arr, -1)
+    assert arr == ["x"]
+
+
+def test_append_starts_at_the_extent():
+    arr = make_array(["x", "y", "z"])
+    array_unset(arr, 1)
+    array_append(arr, ["w"])
+    assert arr == ["x", None, "z", "w"]
+    assert array_indices(arr) == [0, 2, 3]
+
+
+def test_append_refills_a_trailing_hole():
+    arr = make_array(["x", "y", "z"])
+    array_unset(arr, 2)
+    array_append(arr, ["w"])
+    assert arr == ["x", "y", "w"]
+
+
+def test_set_reassigns_a_hole():
+    arr = make_array(["x", "y", "z"])
+    array_unset(arr, 1)
+    array_set(arr, 1, "new")
+    assert arr == ["x", "new", "z"]
+    assert array_count(arr) == 3
+
+
+def test_empty_string_is_an_element_not_a_hole():
+    arr = make_array(["", "y"])
+    assert array_count(arr) == 2
+    assert array_indices(arr) == [0, 1]
+    assert array_values(arr) == ["", "y"]

--- a/python/tests/shell/test_arrays.py
+++ b/python/tests/shell/test_arrays.py
@@ -82,6 +82,45 @@ CASES = [
     ('Z=""; echo "${#Z[@]} [${Z[@]}] [${!Z[@]}]"', "1 [] [0]\n"),
     ('Y=v; echo "${#Y[@]} [${!Y[@]}]"', "1 [0]\n"),
     ('unset Q; echo "${#Q[@]} [${!Q[@]}]"', "0 []\n"),
+    # Slicing an indexed array works on subscripts, not on position among
+    # the assigned values, and a negative offset counts from the extent.
+    # Pinned against GNU bash 5.2.
+    ('a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]:2}]"', "[d j]\n"),
+    ('a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]:0}]"', "[b d j]\n"),
+    ('a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]:2:1}]"', "[d]\n"),
+    ('a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]:4}]"', "[j]\n"),
+    ('a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]:0:2}]"', "[b d]\n"),
+    ('a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]: -1}]"', "[j]\n"),
+    ('a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]: -3}]"', "[j]\n"),
+    ('a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]: -20}]"', "[]\n"),
+    ('a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]:20}]"', "[]\n"),
+    ('a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[*]:2}]"', "[d j]\n"),
+    ('a=(x y z w); unset "a[1]"; echo "[${a[@]:1}]"', "[z w]\n"),
+    ('a=(x y z); echo "[${a[@]: -5}]"', "[]\n"),
+    ('a=(x y z); echo "[${a[@]: -2}]"', "[y z]\n"),
+    # `declare -a` / `local -a` are local to a function and shadow the
+    # caller's array with a fresh empty one.
+    ('f(){ declare -a leak; leak[2]=x; }; f; echo "[${leak[@]}] ${#leak[@]}"',
+     "[] 0\n"),
+    ('g=(outer); f(){ declare -a g; g[0]=inner; echo "in=${g[@]}"; }; f; '
+     'echo "out=${g[@]}"', "in=inner\nout=outer\n"),
+    ('f(){ local -a l=(a b); echo "in=${l[@]}"; }; f; echo "out=[${l[@]}]"',
+     "in=a b\nout=[]\n"),
+    ('m=(keep); f(){ local -a m; m[1]=x; echo "in=${!m[@]}"; }; f; '
+     'echo "out=${m[@]}"', "in=1\nout=keep\n"),
+    ('n=(outer); f(){ declare -a n=(inner); }; f; echo "out=${n[@]}"',
+     "out=outer\n"),
+    ('x=foo; f(){ declare -a x; echo "in=[${x[@]}] ${#x[@]}"; }; f; '
+     'echo "out=$x"', "in=[] 0\nout=foo\n"),
+    # At top level `declare -a` keeps an existing array and migrates an
+    # existing scalar to element 0.
+    ('x=foo; declare -a x; echo "${#x[@]} [${!x[@]}] [${x[0]}]"',
+     "1 [0] [foo]\n"),
+    ('x=""; declare -a x; echo "${#x[@]} [${!x[@]}]"', "1 [0]\n"),
+    ('unset x; declare -a x; echo "${#x[@]}"', "0\n"),
+    ('a=(1 2 3); declare -a a; echo "[${a[@]}]"', "[1 2 3]\n"),
+    ('a=(x); declare -a a+=(y); echo "[${a[@]}]"', "[x y]\n"),
+    ('b=(p); declare b+=(q); echo "[${b[@]}]"', "[p q]\n"),
 ]
 
 

--- a/python/tests/shell/test_arrays.py
+++ b/python/tests/shell/test_arrays.py
@@ -77,6 +77,11 @@ CASES = [
      "[0 1 2] [x NEW z]\n"),
     ('declare -a e; e[3]=x; e[1]=y; echo "${#e[@]} [${!e[@]}] [${e[@]}]"',
      "2 [1 3] [y x]\n"),
+    # A scalar is element 0 of a one-element array, even when empty; an
+    # unset name has no elements at all.
+    ('Z=""; echo "${#Z[@]} [${Z[@]}] [${!Z[@]}]"', "1 [] [0]\n"),
+    ('Y=v; echo "${#Y[@]} [${!Y[@]}]"', "1 [0]\n"),
+    ('unset Q; echo "${#Q[@]} [${!Q[@]}]"', "0 []\n"),
 ]
 
 

--- a/python/tests/shell/test_arrays.py
+++ b/python/tests/shell/test_arrays.py
@@ -50,6 +50,33 @@ CASES = [
     ('a=(cat car cow); printf "<%s>" "${a[@]/c/K}"; echo',
      "<Kat><Kar><Kow>\n"),
     ('a=(w x y z); printf "<%s>" "${!a[@]}"; echo', "<0><1><2><3>\n"),
+    # Sparse arrays: `unset a[i]` leaves a hole and `a[9]=v` skips one,
+    # so the later indices hold still while ${a[@]}/${#a[@]}/${!a[@]} see
+    # only the assigned elements. Pinned against GNU bash 5.2.
+    ('a=(zero one two); unset "a[1]"; '
+     'echo "${#a[@]} [${a[@]}] [${!a[@]}] [${a[*]}]"',
+     "2 [zero two] [0 2] [zero two]\n"),
+    ('a=(zero one two); unset "a[1]"; echo "[${a[0]}][${a[1]}][${a[2]}]"',
+     "[zero][][two]\n"),
+    ('a=(); a[9]=v; echo "${#a[@]} [${a[@]}] [${!a[@]}] [${a[-1]}]"',
+     "1 [v] [9] [v]\n"),
+    ('a=(x y z); unset "a[1]"; echo "[${a[-1]}] [${a[-2]}] [${a[-3]}]"',
+     "[z] [] [x]\n"),
+    ('a=(a b c d); unset "a[1]"; echo "[${a[@]:1:2}]"', "[c d]\n"),
+    ('a=(a b c d); unset "a[1]"; echo "[${a[@]^^}]"', "[A C D]\n"),
+    ('a=(x y z); unset "a[1]"; echo "${a[@]/x/Q}"', "Q z\n"),
+    ('a=(x y z); unset "a[1]"; a+=(w); echo "[${!a[@]}] [${a[@]}]"',
+     "[0 2 3] [x z w]\n"),
+    ('a=(x y z); unset "a[2]"; a+=(w); echo "[${!a[@]}] [${a[@]}]"',
+     "[0 1 2] [x y w]\n"),
+    ('a=(x y z); unset "a[1]"; echo "${#a[1]} ${#a[2]}"', "0 1\n"),
+    ('a=(x y z); unset "a[1]"; for v in "${a[@]}"; do echo "v=[$v]"; done',
+     "v=[x]\nv=[z]\n"),
+    ('a=(x y z); unset "a[0]"; echo "[$a]"', "[]\n"),
+    ('a=(x y z); unset "a[1]"; a[1]=NEW; echo "[${!a[@]}] [${a[@]}]"',
+     "[0 1 2] [x NEW z]\n"),
+    ('declare -a e; e[3]=x; e[1]=y; echo "${#e[@]} [${!e[@]}] [${e[@]}]"',
+     "2 [1 3] [y x]\n"),
 ]
 
 

--- a/python/tests/workspace/executor/builtins/test_text.py
+++ b/python/tests/workspace/executor/builtins/test_text.py
@@ -219,7 +219,8 @@ async def test_printf_v_targets_array_element():
     out, io, node = await handle_printf(["-v", "arr[2]", "hi"], session)
     assert out is None
     assert node.exit_code == 0
-    assert session.arrays["arr"] == ["", "", "hi"]
+    # Indices 0 and 1 are holes, not empty elements.
+    assert session.arrays["arr"] == [None, None, "hi"]
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/executor/builtins/test_text.py
+++ b/python/tests/workspace/executor/builtins/test_text.py
@@ -226,8 +226,70 @@ async def test_printf_v_targets_array_element():
 async def test_printf_v_invalid_name_errors():
     session = Session(session_id="s1")
     out, io, node = await handle_printf(["-v", "1bad", "x"], session)
+    assert node.exit_code == 2
+    assert b"`1bad': not a valid identifier" in (io.stderr or b"")
+
+
+@pytest.mark.asyncio
+async def test_printf_v_invalid_name_suppresses_conversion_errors():
+    session = Session(session_id="s1")
+    out, io, node = await handle_printf(["-v", "1bad", "%d", "nope"], session)
+    assert node.exit_code == 2
+    assert io.stderr == b"printf: `1bad': not a valid identifier\n"
+
+
+@pytest.mark.asyncio
+async def test_printf_v_readonly_scalar_is_rejected():
+    session = Session(session_id="s1")
+    session.env["R"] = "orig"
+    session.readonly_vars.add("R")
+    out, io, node = await handle_printf(["-v", "R", "new"], session)
     assert node.exit_code == 1
-    assert b"not a valid variable name" in (io.stderr or b"")
+    assert io.stderr == b"bash: R: readonly variable\n"
+    assert session.env["R"] == "orig"
+
+
+@pytest.mark.asyncio
+async def test_printf_v_readonly_array_element_is_rejected():
+    session = Session(session_id="s1")
+    session.arrays["A"] = ["x", "y"]
+    session.readonly_vars.add("A")
+    out, io, node = await handle_printf(["-v", "A[0]", "%d", "nope"], session)
+    assert node.exit_code == 1
+    assert io.stderr == (b"printf: nope: invalid number\n"
+                         b"bash: A: readonly variable\n")
+    assert session.arrays["A"] == ["x", "y"]
+
+
+@pytest.mark.asyncio
+async def test_printf_v_scalar_target_keeps_other_array_elements():
+    session = Session(session_id="s1")
+    session.arrays["B"] = ["p", "q", "r"]
+    out, io, node = await handle_printf(["-v", "B", "Q"], session)
+    assert node.exit_code == 0
+    assert session.arrays["B"] == ["Q", "q", "r"]
+    assert "B" not in session.env
+
+
+@pytest.mark.asyncio
+async def test_printf_v_bad_subscript_keeps_the_scalar():
+    session = Session(session_id="s1")
+    session.env["V"] = "orig"
+    out, io, node = await handle_printf(["-v", "V[-2]", "hi"], session)
+    assert node.exit_code == 1
+    assert io.stderr == b"bash: V[-2]: bad array subscript\n"
+    assert session.env["V"] == "orig"
+    assert "V" not in session.arrays
+
+
+@pytest.mark.asyncio
+async def test_printf_v_negative_subscript_wraps_over_the_scalar():
+    session = Session(session_id="s1")
+    session.env["W"] = "orig"
+    out, io, node = await handle_printf(["-v", "W[-1]", "hi"], session)
+    assert node.exit_code == 0
+    assert session.arrays["W"] == ["hi"]
+    assert "W" not in session.env
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/executor/builtins/test_text.py
+++ b/python/tests/workspace/executor/builtins/test_text.py
@@ -1,6 +1,7 @@
 import pytest
 
 from mirage.workspace.executor.builtins.text import handle_echo, handle_printf
+from mirage.workspace.session import Session
 
 
 async def echo_bytes(args: list[str]) -> bytes:
@@ -11,7 +12,7 @@ async def echo_bytes(args: list[str]) -> bytes:
 
 
 async def printf_result(args: list[str]) -> tuple[bytes, int]:
-    out, io, node = await handle_printf(args)
+    out, io, node = await handle_printf(args, Session(session_id="s1"))
     assert isinstance(out, bytes)
     assert io.exit_code == node.exit_code
     return out, node.exit_code
@@ -201,3 +202,37 @@ async def test_printf_invalid_number_reports_exit_1():
     out, code = await printf_result(["%d\n", "abc"])
     assert out == b"0\n"
     assert code == 1
+
+
+@pytest.mark.asyncio
+async def test_printf_v_assigns_variable_and_prints_nothing():
+    session = Session(session_id="s1")
+    out, io, node = await handle_printf(["-v", "V", "x=%d", "42"], session)
+    assert out is None
+    assert node.exit_code == 0
+    assert session.env["V"] == "x=42"
+
+
+@pytest.mark.asyncio
+async def test_printf_v_targets_array_element():
+    session = Session(session_id="s1")
+    out, io, node = await handle_printf(["-v", "arr[2]", "hi"], session)
+    assert out is None
+    assert node.exit_code == 0
+    assert session.arrays["arr"] == ["", "", "hi"]
+
+
+@pytest.mark.asyncio
+async def test_printf_v_invalid_name_errors():
+    session = Session(session_id="s1")
+    out, io, node = await handle_printf(["-v", "1bad", "x"], session)
+    assert node.exit_code == 1
+    assert b"not a valid variable name" in (io.stderr or b"")
+
+
+@pytest.mark.asyncio
+async def test_printf_v_keeps_exit_1_on_bad_number_but_still_assigns():
+    session = Session(session_id="s1")
+    out, io, node = await handle_printf(["-v", "V", "%d", "notanum"], session)
+    assert node.exit_code == 1
+    assert session.env["V"] == "0"

--- a/python/tests/workspace/executor/builtins/test_text.py
+++ b/python/tests/workspace/executor/builtins/test_text.py
@@ -240,6 +240,23 @@ async def test_printf_v_invalid_name_suppresses_conversion_errors():
 
 
 @pytest.mark.asyncio
+async def test_printf_v_empty_subscript_is_not_an_identifier():
+    session = Session(session_id="s1")
+    out, io, node = await handle_printf(["-v", "a[]", "x"], session)
+    assert node.exit_code == 2
+    assert io.stderr == b"printf: `a[]': not a valid identifier\n"
+    assert "a" not in session.arrays
+
+
+@pytest.mark.asyncio
+async def test_printf_v_blank_subscript_is_arithmetic_zero():
+    session = Session(session_id="s1")
+    out, io, node = await handle_printf(["-v", "a[ ]", "x"], session)
+    assert node.exit_code == 0
+    assert session.arrays["a"] == ["x"]
+
+
+@pytest.mark.asyncio
 async def test_printf_v_readonly_scalar_is_rejected():
     session = Session(session_id="s1")
     session.env["R"] = "orig"

--- a/python/tests/workspace/executor/builtins/test_vars.py
+++ b/python/tests/workspace/executor/builtins/test_vars.py
@@ -9,7 +9,7 @@ from mirage.shell.call_stack import CallStack
 from mirage.shell.errors import ExitSignal
 from mirage.workspace.executor.builtins.vars import (  # yapf: disable
     handle_env, handle_exit, handle_getopts, handle_read, handle_return,
-    handle_shift, handle_whoami)
+    handle_shift, handle_unset, handle_whoami)
 from mirage.workspace.executor.control import ReturnSignal
 from mirage.workspace.mount.namespace import Namespace
 from mirage.workspace.session.session import Session
@@ -51,6 +51,59 @@ async def test_env_unset_removes_variable():
     rendered = await materialize(out)
     assert b"DROP=" not in rendered
     assert b"KEEP=2" in rendered
+
+
+@pytest.mark.asyncio
+async def test_unset_f_removes_function_only():
+    session = make_session()
+    session.functions["fn"] = []
+    session.env["fn"] = "keepvar"
+    await handle_unset(["-f", "fn"], session)
+    assert "fn" not in session.functions
+    assert session.env["fn"] == "keepvar"
+
+
+@pytest.mark.asyncio
+async def test_unset_v_removes_variable_not_function():
+    session = make_session()
+    session.functions["fn"] = []
+    session.env["fn"] = "v"
+    await handle_unset(["-v", "fn"], session)
+    assert "fn" in session.functions
+    assert "fn" not in session.env
+
+
+@pytest.mark.asyncio
+async def test_unset_bare_prefers_variable_then_function():
+    session = make_session()
+    session.functions["a"] = []
+    session.env["a"] = "v"
+    await handle_unset(["a"], session)
+    # The variable existed, so only it is removed.
+    assert "a" not in session.env
+    assert "a" in session.functions
+    # No variable of this name: the function is removed instead.
+    session.functions["b"] = []
+    await handle_unset(["b"], session)
+    assert "b" not in session.functions
+
+
+@pytest.mark.asyncio
+async def test_unset_removes_whole_array_and_one_element():
+    session = make_session()
+    session.arrays["arr"] = ["x", "y", "z"]
+    await handle_unset(["arr[1]"], session)
+    assert session.arrays["arr"] == ["x", "z"]
+    await handle_unset(["arr"], session)
+    assert "arr" not in session.arrays
+
+
+@pytest.mark.asyncio
+async def test_unset_invalid_option_errors():
+    session = make_session()
+    _, io, node = await handle_unset(["-z", "x"], session)
+    assert node.exit_code == 2
+    assert b"invalid option" in (io.stderr or b"")
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/executor/builtins/test_vars.py
+++ b/python/tests/workspace/executor/builtins/test_vars.py
@@ -95,10 +95,10 @@ async def test_unset_removes_whole_array_and_one_element():
     # An interior element leaves a hole: the later indices keep their
     # positions, as bash does.
     await handle_unset(["arr[1]"], session)
-    assert session.arrays["arr"] == ["x", "", "z"]
-    # A trailing element shortens the array instead.
+    assert session.arrays["arr"] == ["x", None, "z"]
+    # A trailing element drops off, so the extent shrinks with it.
     await handle_unset(["arr[2]"], session)
-    assert session.arrays["arr"] == ["x", ""]
+    assert session.arrays["arr"] == ["x"]
     await handle_unset(["arr"], session)
     assert "arr" not in session.arrays
 

--- a/python/tests/workspace/executor/builtins/test_vars.py
+++ b/python/tests/workspace/executor/builtins/test_vars.py
@@ -92,10 +92,52 @@ async def test_unset_bare_prefers_variable_then_function():
 async def test_unset_removes_whole_array_and_one_element():
     session = make_session()
     session.arrays["arr"] = ["x", "y", "z"]
+    # An interior element leaves a hole: the later indices keep their
+    # positions, as bash does.
     await handle_unset(["arr[1]"], session)
-    assert session.arrays["arr"] == ["x", "z"]
+    assert session.arrays["arr"] == ["x", "", "z"]
+    # A trailing element shortens the array instead.
+    await handle_unset(["arr[2]"], session)
+    assert session.arrays["arr"] == ["x", ""]
     await handle_unset(["arr"], session)
     assert "arr" not in session.arrays
+
+
+@pytest.mark.asyncio
+async def test_unset_readonly_array_element_is_rejected():
+    session = make_session()
+    session.arrays["arr"] = ["x", "y"]
+    session.readonly_vars.add("arr")
+    _, io, node = await handle_unset(["arr[1]"], session)
+    assert node.exit_code == 1
+    assert io.stderr == b"bash: unset: arr: cannot unset: readonly variable\n"
+    assert session.arrays["arr"] == ["x", "y"]
+
+
+@pytest.mark.asyncio
+async def test_unset_element_zero_of_a_scalar_removes_it():
+    session = make_session()
+    session.env["Y"] = "sc"
+    _, io, node = await handle_unset(["Y[0]"], session)
+    assert node.exit_code == 0
+    assert "Y" not in session.env
+
+
+@pytest.mark.asyncio
+async def test_unset_nonzero_element_of_a_scalar_errors():
+    session = make_session()
+    session.env["Y"] = "sc"
+    _, io, node = await handle_unset(["Y[1]"], session)
+    assert node.exit_code == 1
+    assert io.stderr == b"bash: unset: Y: not an array variable\n"
+    assert session.env["Y"] == "sc"
+
+
+@pytest.mark.asyncio
+async def test_unset_element_of_an_unset_name_is_a_no_op():
+    session = make_session()
+    _, io, node = await handle_unset(["GONE[3]"], session)
+    assert node.exit_code == 0
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/executor/builtins/test_vars.py
+++ b/python/tests/workspace/executor/builtins/test_vars.py
@@ -134,6 +134,26 @@ async def test_unset_nonzero_element_of_a_scalar_errors():
 
 
 @pytest.mark.asyncio
+async def test_unset_negative_element_outside_the_extent_errors():
+    session = make_session()
+    session.arrays["arr"] = ["x"]
+    _, io, node = await handle_unset(["arr[-2]"], session)
+    assert node.exit_code == 1
+    # bash prints only the bracketed part here, not the base name.
+    assert io.stderr == b"bash: unset: [-2]: bad array subscript\n"
+    assert session.arrays["arr"] == ["x"]
+
+
+@pytest.mark.asyncio
+async def test_unset_negative_element_inside_the_extent_works():
+    session = make_session()
+    session.arrays["arr"] = ["x", "y"]
+    _, io, node = await handle_unset(["arr[-2]"], session)
+    assert node.exit_code == 0
+    assert session.arrays["arr"] == [None, "y"]
+
+
+@pytest.mark.asyncio
 async def test_unset_element_of_an_unset_name_is_a_no_op():
     session = make_session()
     _, io, node = await handle_unset(["GONE[3]"], session)

--- a/python/tests/workspace/test_workspace.py
+++ b/python/tests/workspace/test_workspace.py
@@ -224,6 +224,40 @@ def test_case_match():
     assert ws.get_session(ws.default_session_id).env["M"] == "yes"
 
 
+def test_case_fallthrough_semi_amp():
+    ws = _ws()
+    io = _exec(ws,
+               "case a in a) echo one;& b) echo two;; c) echo three;; esac")
+    assert _stdout(io) == b"one\ntwo\n"
+
+
+def test_case_continue_match_semi_semi_amp():
+    ws = _ws()
+    io = _exec(ws,
+               "case a in a) echo one;;& a) echo two;;& b) echo three;; esac")
+    assert _stdout(io) == b"one\ntwo\n"
+
+
+def test_case_semi_semi_amp_no_further_match():
+    ws = _ws()
+    io = _exec(ws, "case a in a) echo one;;& z) echo two;; esac")
+    assert _stdout(io) == b"one\n"
+
+
+def test_source_sets_positional_args():
+    ws = _ws()
+    _exec(ws, "printf 'echo argc=$# a1=$1 a2=$2\\n' > /ram/s.sh")
+    io = _exec(ws, "source /ram/s.sh AA BB")
+    assert _stdout(io) == b"argc=2 a1=AA a2=BB\n"
+
+
+def test_source_without_args_keeps_parent_positional():
+    ws = _ws()
+    _exec(ws, "printf 'echo a1=$1\\n' > /ram/s.sh")
+    io = _exec(ws, "set -- P1 P2; source /ram/s.sh; echo after=$1")
+    assert _stdout(io) == b"a1=P1\nafter=P1\n"
+
+
 # ── operators ──────────────────────────────────
 
 

--- a/python/tests/workspace/test_workspace.py
+++ b/python/tests/workspace/test_workspace.py
@@ -258,6 +258,29 @@ def test_source_without_args_keeps_parent_positional():
     assert _stdout(io) == b"a1=P1\nafter=P1\n"
 
 
+def test_source_positional_args_keep_the_spelling():
+    ws = _ws()
+    _exec(ws, "printf 'echo a1=$1\\n' > /ram/s.sh")
+    # A path-looking argument stays as typed, not resolved.
+    io = _exec(ws, "cd /ram && source /ram/s.sh ./sub/x.txt")
+    assert _stdout(io) == b"a1=./sub/x.txt\n"
+
+
+def test_readonly_bare_name_registers():
+    ws = _ws()
+    io = _exec(ws, "RO=1; readonly RO; RO=2")
+    assert io.exit_code == 1
+    assert io.stderr == b"bash: RO: readonly variable\n"
+
+
+def test_readonly_array_form_registers():
+    ws = _ws()
+    io = _exec(ws, "readonly -a RA=(x y); unset 'RA[1]'; echo rc=$?")
+    assert _stdout(io) == b"rc=1\n"
+    assert io.stderr == (b"bash: unset: RA: cannot unset: "
+                         b"readonly variable\n")
+
+
 # ── operators ──────────────────────────────────
 
 

--- a/typescript/packages/core/src/shell/array.test.ts
+++ b/typescript/packages/core/src/shell/array.test.ts
@@ -22,6 +22,7 @@ import {
   arrayHas,
   arrayIndices,
   arraySet,
+  arraySlice,
   arrayUnset,
   arrayValues,
   makeArray,
@@ -99,6 +100,39 @@ describe('shell array', () => {
     arraySet(arr, 1, 'new')
     expect(arr).toEqual(['x', 'new', 'z'])
     expect(arrayCount(arr)).toBe(3)
+  })
+
+  it('slicing keeps subscripts, not ordinals', () => {
+    const arr: ShellArray = []
+    arraySet(arr, 1, 'b')
+    arraySet(arr, 3, 'd')
+    arraySet(arr, 9, 'j')
+    // Offset 2 means "index >= 2", not "skip the first two values".
+    expect(arraySlice(arr, 2, null)).toEqual(['d', 'j'])
+    expect(arraySlice(arr, 0, null)).toEqual(['b', 'd', 'j'])
+    expect(arraySlice(arr, 4, null)).toEqual(['j'])
+    expect(arraySlice(arr, 20, null)).toEqual([])
+  })
+
+  it('slice length counts elements taken', () => {
+    const arr: ShellArray = []
+    arraySet(arr, 1, 'b')
+    arraySet(arr, 3, 'd')
+    arraySet(arr, 9, 'j')
+    expect(arraySlice(arr, 2, 1)).toEqual(['d'])
+    expect(arraySlice(arr, 0, 2)).toEqual(['b', 'd'])
+    expect(arraySlice(arr, 0, -1)).toEqual(['b', 'd'])
+  })
+
+  it('a negative slice offset counts from the extent', () => {
+    const arr: ShellArray = []
+    arraySet(arr, 1, 'b')
+    arraySet(arr, 9, 'j')
+    expect(arraySlice(arr, -1, null)).toEqual(['j'])
+    // Still negative after the extent is added: nothing, not everything.
+    expect(arraySlice(arr, -20, null)).toEqual([])
+    expect(arraySlice(makeArray(['x', 'y', 'z']), -5, null)).toEqual([])
+    expect(arraySlice(makeArray(['x', 'y', 'z']), -2, null)).toEqual(['y', 'z'])
   })
 
   it('an empty string is an element, not a hole', () => {

--- a/typescript/packages/core/src/shell/array.test.ts
+++ b/typescript/packages/core/src/shell/array.test.ts
@@ -1,0 +1,110 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import {
+  type ShellArray,
+  arrayAppend,
+  arrayCount,
+  arrayExtent,
+  arrayGet,
+  arrayHas,
+  arrayIndices,
+  arraySet,
+  arrayUnset,
+  arrayValues,
+  makeArray,
+} from './array.ts'
+
+describe('shell array', () => {
+  it('makeArray is dense from zero', () => {
+    const arr = makeArray(['a', 'b'])
+    expect(arr).toEqual(['a', 'b'])
+    expect(arrayIndices(arr)).toEqual([0, 1])
+  })
+
+  it('arraySet pads with holes, not empty strings', () => {
+    const arr: ShellArray = []
+    arraySet(arr, 3, 'v')
+    expect(arr).toEqual([null, null, null, 'v'])
+    // The hole is addressable but is not an element.
+    expect(arrayCount(arr)).toBe(1)
+    expect(arrayValues(arr)).toEqual(['v'])
+    expect(arrayIndices(arr)).toEqual([3])
+    expect(arrayExtent(arr)).toBe(4)
+    expect(arrayGet(arr, 0)).toBe('')
+    expect(arrayHas(arr, 0)).toBe(false)
+    expect(arrayHas(arr, 3)).toBe(true)
+  })
+
+  it('unsetting an interior element keeps the later indices', () => {
+    const arr = makeArray(['zero', 'one', 'two'])
+    arrayUnset(arr, 1)
+    expect(arr).toEqual(['zero', null, 'two'])
+    expect(arrayGet(arr, 2)).toBe('two')
+    expect(arrayCount(arr)).toBe(2)
+    expect(arrayIndices(arr)).toEqual([0, 2])
+  })
+
+  it('unsetting a trailing element shrinks the extent', () => {
+    const arr = makeArray(['x', 'y', 'z'])
+    arrayUnset(arr, 2)
+    expect(arr).toEqual(['x', 'y'])
+    expect(arrayExtent(arr)).toBe(2)
+  })
+
+  it('unsetting a trailing element drops earlier holes too', () => {
+    const arr = makeArray(['x', 'y', 'z'])
+    arrayUnset(arr, 1)
+    arrayUnset(arr, 2)
+    expect(arr).toEqual(['x'])
+  })
+
+  it('unsetting an out-of-range index is a no-op', () => {
+    const arr = makeArray(['x'])
+    arrayUnset(arr, 5)
+    arrayUnset(arr, -1)
+    expect(arr).toEqual(['x'])
+  })
+
+  it('append starts at the extent', () => {
+    const arr = makeArray(['x', 'y', 'z'])
+    arrayUnset(arr, 1)
+    arrayAppend(arr, ['w'])
+    expect(arr).toEqual(['x', null, 'z', 'w'])
+    expect(arrayIndices(arr)).toEqual([0, 2, 3])
+  })
+
+  it('append refills a trailing hole', () => {
+    const arr = makeArray(['x', 'y', 'z'])
+    arrayUnset(arr, 2)
+    arrayAppend(arr, ['w'])
+    expect(arr).toEqual(['x', 'y', 'w'])
+  })
+
+  it('a hole can be reassigned', () => {
+    const arr = makeArray(['x', 'y', 'z'])
+    arrayUnset(arr, 1)
+    arraySet(arr, 1, 'new')
+    expect(arr).toEqual(['x', 'new', 'z'])
+    expect(arrayCount(arr)).toBe(3)
+  })
+
+  it('an empty string is an element, not a hole', () => {
+    const arr = makeArray(['', 'y'])
+    expect(arrayCount(arr)).toBe(2)
+    expect(arrayIndices(arr)).toEqual([0, 1])
+    expect(arrayValues(arr)).toEqual(['', 'y'])
+  })
+})

--- a/typescript/packages/core/src/shell/array.ts
+++ b/typescript/packages/core/src/shell/array.ts
@@ -65,10 +65,17 @@ export function arrayGet(arr: ShellArray, idx: number): string {
   return arr[idx] ?? ''
 }
 
-/** Assign `value` at `idx`, extending with holes as needed. */
+/**
+ * Assign `value` at `idx`, extending with holes as needed.
+ *
+ * The subscript comes from script text, so the write goes through
+ * `splice` rather than `arr[idx] = value`: an element assignment on a
+ * caller-supplied key is a prototype-pollution shape, and `splice`
+ * cannot name a property at all.
+ */
 export function arraySet(arr: ShellArray, idx: number, value: string): void {
   while (arr.length <= idx) arr.push(null)
-  arr[idx] = value
+  arr.splice(idx, 1, value)
 }
 
 /** Append values after the highest assigned index, as `arr+=(...)`. */
@@ -84,6 +91,6 @@ export function arrayAppend(arr: ShellArray, values: string[]): void {
  */
 export function arrayUnset(arr: ShellArray, idx: number): void {
   if (idx < 0 || idx >= arr.length) return
-  arr[idx] = null
+  arr.splice(idx, 1, null)
   while (arr.length > 0 && arr[arr.length - 1] === null) arr.pop()
 }

--- a/typescript/packages/core/src/shell/array.ts
+++ b/typescript/packages/core/src/shell/array.ts
@@ -1,0 +1,89 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+/**
+ * A shell array: assigned values by index, with `null` for a hole left by
+ * `unset arr[i]` or skipped by `arr[9]=v`. Holes are addressable but do
+ * not count toward `${#arr[@]}` and do not expand in `${arr[@]}`.
+ */
+export type ShellArray = (string | null)[]
+
+/** Build a dense array from consecutive values, starting at index 0. */
+export function makeArray(values: string[]): ShellArray {
+  return [...values]
+}
+
+/**
+ * One past the highest assigned index, which is what bash resolves a
+ * negative subscript against.
+ */
+export function arrayExtent(arr: ShellArray): number {
+  return arr.length
+}
+
+/** The assigned values in index order, skipping holes. */
+export function arrayValues(arr: ShellArray): string[] {
+  return arr.filter((v): v is string => v !== null)
+}
+
+/** The assigned indices in order, skipping holes. */
+export function arrayIndices(arr: ShellArray): number[] {
+  const out: number[] = []
+  arr.forEach((v, i) => {
+    if (v !== null) out.push(i)
+  })
+  return out
+}
+
+/** The number of assigned elements, which is `${#arr[@]}`. */
+export function arrayCount(arr: ShellArray): number {
+  return arrayValues(arr).length
+}
+
+/** Whether `idx` holds an assigned element. */
+export function arrayHas(arr: ShellArray, idx: number): boolean {
+  return idx >= 0 && idx < arr.length && arr[idx] !== null && arr[idx] !== undefined
+}
+
+/**
+ * The element at `idx`, or the empty string for a hole or an
+ * out-of-range index.
+ */
+export function arrayGet(arr: ShellArray, idx: number): string {
+  if (idx < 0 || idx >= arr.length) return ''
+  return arr[idx] ?? ''
+}
+
+/** Assign `value` at `idx`, extending with holes as needed. */
+export function arraySet(arr: ShellArray, idx: number, value: string): void {
+  while (arr.length <= idx) arr.push(null)
+  arr[idx] = value
+}
+
+/** Append values after the highest assigned index, as `arr+=(...)`. */
+export function arrayAppend(arr: ShellArray, values: string[]): void {
+  arr.push(...values)
+}
+
+/**
+ * Clear one element, keeping the indices of the elements after it.
+ *
+ * Trailing holes are dropped so the extent stays at one past the highest
+ * assigned index, matching how bash resolves `arr[-1]`.
+ */
+export function arrayUnset(arr: ShellArray, idx: number): void {
+  if (idx < 0 || idx >= arr.length) return
+  arr[idx] = null
+  while (arr.length > 0 && arr[arr.length - 1] === null) arr.pop()
+}

--- a/typescript/packages/core/src/shell/array.ts
+++ b/typescript/packages/core/src/shell/array.ts
@@ -84,6 +84,30 @@ export function arrayAppend(arr: ShellArray, values: string[]): void {
 }
 
 /**
+ * Take the assigned elements from index `offset` on, in index order.
+ *
+ * bash slices an indexed array by *subscript*, not by position among the
+ * assigned values: for `a=([1]=b [3]=d [9]=j)`, `${a[@]:2}` is `d j`
+ * because it keeps every index >= 2. `length` then caps how many of those
+ * are taken. A negative offset counts back from the extent and yields
+ * nothing if it is still negative.
+ */
+export function arraySlice(arr: ShellArray, offset: number, length: number | null): string[] {
+  let start = offset
+  if (start < 0) {
+    start += arrayExtent(arr)
+    if (start < 0) return []
+  }
+  const picked: string[] = []
+  arr.forEach((v, i) => {
+    if (v !== null && i >= start) picked.push(v)
+  })
+  if (length === null) return picked
+  if (length < 0) return picked.slice(0, Math.max(0, picked.length + length))
+  return picked.slice(0, length)
+}
+
+/**
  * Clear one element, keeping the indices of the elements after it.
  *
  * Trailing holes are dropped so the extent stays at one past the highest

--- a/typescript/packages/core/src/shell/helpers.ts
+++ b/typescript/packages/core/src/shell/helpers.ts
@@ -336,14 +336,17 @@ export function getCaseWord(node: TSNodeLike): TSNodeLike {
  * every statement up to its ;; terminator, so multi-statement arms
  * (x) cmd1; cmd2;;) keep all commands.
  */
-export function getCaseItems(node: TSNodeLike): [string[], TSNodeLike[]][] {
-  const items: [string[], TSNodeLike[]][] = []
+export function getCaseItems(node: TSNodeLike): [string[], TSNodeLike[], string][] {
+  const items: [string[], TSNodeLike[], string][] = []
   for (const c of node.namedChildren) {
     if (c.type !== NT.CASE_ITEM) continue
     const patterns: string[] = []
     const body: TSNodeLike[] = []
+    let terminator = ';;'
     for (const child of c.children) {
-      if (
+      if (child.type === ';;' || child.type === ';&' || child.type === ';;&') {
+        terminator = child.type
+      } else if (
         body.length === 0 &&
         (child.type === NT.EXTGLOB_PATTERN ||
           child.type === NT.WORD ||
@@ -359,7 +362,7 @@ export function getCaseItems(node: TSNodeLike): [string[], TSNodeLike[]][] {
       const first = c.namedChildren[0]
       if (first !== undefined) patterns.push(getText(first))
     }
-    items.push([patterns, body])
+    items.push([patterns, body, terminator])
   }
   return items
 }
@@ -374,6 +377,73 @@ export function getDeclarationKeyword(node: TSNodeLike): string {
 
 export function getUnsetNames(node: TSNodeLike): string[] {
   return node.namedChildren.filter((c) => c.type === NT.VARIABLE_NAME).map((c) => getText(c))
+}
+
+/**
+ * Split a whitespace-separated operand string, honoring single and
+ * double quotes the way the shell does. Returns null on an unbalanced
+ * quote so the caller can fall back. Mirrors Python's `shlex.split` for
+ * the un-expanded operand cases `unset` needs.
+ */
+function shellSplit(text: string): string[] | null {
+  const tokens: string[] = []
+  let cur = ''
+  let has = false
+  let inSingle = false
+  let inDouble = false
+  for (let i = 0; i < text.length; i++) {
+    const ch = text.charAt(i)
+    if (inSingle) {
+      if (ch === "'") inSingle = false
+      else cur += ch
+      continue
+    }
+    if (inDouble) {
+      if (ch === '"') inDouble = false
+      else if (ch === '\\' && (text.charAt(i + 1) === '"' || text.charAt(i + 1) === '\\'))
+        cur += text.charAt(++i)
+      else cur += ch
+      continue
+    }
+    if (ch === "'") {
+      inSingle = true
+      has = true
+    } else if (ch === '"') {
+      inDouble = true
+      has = true
+    } else if (ch === '\\' && i + 1 < text.length) {
+      cur += text.charAt(++i)
+      has = true
+    } else if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (has) {
+        tokens.push(cur)
+        cur = ''
+        has = false
+      }
+    } else {
+      cur += ch
+      has = true
+    }
+  }
+  if (inSingle || inDouble) return null
+  if (has) tokens.push(cur)
+  return tokens
+}
+
+/**
+ * Get every operand word of an unset_command, keeping `-f`/`-v`/`-n` and
+ * keeping a subscript target (`unset arr[1]`, quoted or not) as one word.
+ * Mirrors Python's `get_unset_args`.
+ */
+export function getUnsetArgs(node: TSNodeLike): string[] {
+  const operands = node.children.slice(1)
+  const first = operands[0]
+  if (first === undefined) return []
+  if (first.startIndex !== undefined && node.startIndex !== undefined) {
+    const split = shellSplit(node.text.slice(first.startIndex - node.startIndex))
+    if (split !== null) return split
+  }
+  return node.namedChildren.map((c) => getText(c))
 }
 
 export function getTestArgv(node: TSNodeLike): string[] {

--- a/typescript/packages/core/src/workspace/execute.test.ts
+++ b/typescript/packages/core/src/workspace/execute.test.ts
@@ -62,12 +62,10 @@ describe('Workspace.execute', () => {
     const { ws } = buildWorkspace()
     const res = await ws.execute('RO=1; readonly RO; RO=2')
     expect(res.exitCode).toBe(1)
-    expect(new TextDecoder().decode(res.stderr ?? new Uint8Array())).toBe(
-      'bash: RO: readonly variable\n',
-    )
+    expect(new TextDecoder().decode(res.stderr)).toBe('bash: RO: readonly variable\n')
     const res2 = await ws.execute("readonly -a RA=(x y); unset 'RA[1]'; echo rc=$?")
     expect(new TextDecoder().decode(res2.stdout)).toBe('rc=1\n')
-    expect(new TextDecoder().decode(res2.stderr ?? new Uint8Array())).toBe(
+    expect(new TextDecoder().decode(res2.stderr)).toBe(
       'bash: unset: RA: cannot unset: readonly variable\n',
     )
     await ws.close()

--- a/typescript/packages/core/src/workspace/execute.test.ts
+++ b/typescript/packages/core/src/workspace/execute.test.ts
@@ -58,6 +58,30 @@ describe('Workspace.execute', () => {
     await ws.close()
   })
 
+  it('readonly registers a bare name and an array assignment', async () => {
+    const { ws } = buildWorkspace()
+    const res = await ws.execute('RO=1; readonly RO; RO=2')
+    expect(res.exitCode).toBe(1)
+    expect(new TextDecoder().decode(res.stderr ?? new Uint8Array())).toBe(
+      'bash: RO: readonly variable\n',
+    )
+    const res2 = await ws.execute("readonly -a RA=(x y); unset 'RA[1]'; echo rc=$?")
+    expect(new TextDecoder().decode(res2.stdout)).toBe('rc=1\n')
+    expect(new TextDecoder().decode(res2.stderr ?? new Uint8Array())).toBe(
+      'bash: unset: RA: cannot unset: readonly variable\n',
+    )
+    await ws.close()
+  })
+
+  it("source positional args keep the operand's spelling", async () => {
+    const { ws } = buildWorkspace()
+    await ws.execute("printf 'echo a1=$1\\n' > /ram/s.sh")
+    // A path-looking argument stays as typed, not resolved.
+    const res = await ws.execute('cd /ram && source /ram/s.sh ./sub/x.txt')
+    expect(new TextDecoder().decode(res.stdout)).toBe('a1=./sub/x.txt\n')
+    await ws.close()
+  })
+
   it('runs `pwd` and prints /', async () => {
     const { ws } = buildWorkspace()
     const res = await ws.execute('pwd')

--- a/typescript/packages/core/src/workspace/executor/builtins.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins.test.ts
@@ -102,6 +102,48 @@ describe('handleExport / handleUnset / handlePrintenv', () => {
     expect(s.env.B).toBe('2')
   })
 
+  it('unset -f removes a function but not a same-named variable', () => {
+    const s = new Session({ sessionId: 'test', env: { fn: 'v' } })
+    s.functions.fn = []
+    handleUnset(['-f', 'fn'], s)
+    expect('fn' in s.functions).toBe(false)
+    expect(s.env.fn).toBe('v')
+  })
+
+  it('unset -v removes a variable but not a same-named function', () => {
+    const s = new Session({ sessionId: 'test', env: { fn: 'v' } })
+    s.functions.fn = []
+    handleUnset(['-v', 'fn'], s)
+    expect('fn' in s.functions).toBe(true)
+    expect('fn' in s.env).toBe(false)
+  })
+
+  it('unset bare prefers a variable, else the function', () => {
+    const s = new Session({ sessionId: 'test', env: { a: 'v' } })
+    s.functions.a = []
+    handleUnset(['a'], s)
+    expect('a' in s.env).toBe(false)
+    expect('a' in s.functions).toBe(true)
+    s.functions.b = []
+    handleUnset(['b'], s)
+    expect('b' in s.functions).toBe(false)
+  })
+
+  it('unset removes a whole array and a single element', () => {
+    const s = new Session({ sessionId: 'test' })
+    s.arrays.arr = ['x', 'y', 'z']
+    handleUnset(['arr[1]'], s)
+    expect(s.arrays.arr).toEqual(['x', 'z'])
+    handleUnset(['arr'], s)
+    expect('arr' in s.arrays).toBe(false)
+  })
+
+  it('unset -z is an invalid option (exit 2)', () => {
+    const s = new Session({ sessionId: 'test' })
+    const [, io] = handleUnset(['-z', 'x'], s)
+    expect(io.exitCode).toBe(2)
+  })
+
   it('printenv VAR emits value + newline; exit 1 if missing', () => {
     const s = new Session({ sessionId: 'test', env: { X: 'yes' } })
     const [out, io] = handlePrintenv('X', s)
@@ -173,7 +215,7 @@ describe('handleEcho', () => {
 
 describe('handlePrintf', () => {
   const run = (args: string[]): [string, number] => {
-    const [out, io] = handlePrintf(args)
+    const [out, io] = handlePrintf(args, new Session({ sessionId: 'test' }))
     return [decode(out as Uint8Array), io.exitCode]
   }
   const stdout = (args: string[]): string => {
@@ -250,7 +292,7 @@ describe('handlePrintf', () => {
   })
 
   it('empty args → empty output', () => {
-    const [out] = handlePrintf([])
+    const [out] = handlePrintf([], new Session({ sessionId: 'test' }))
     expect((out as Uint8Array).byteLength).toBe(0)
   })
 
@@ -287,6 +329,34 @@ describe('handlePrintf', () => {
     expect(stdout(['%a\n', '0.5'])).toBe('0x1p-1\n')
     expect(stdout(['%a\n', '3.14'])).toBe('0x1.91eb851eb851fp+1\n')
     expect(stdout(['%A\n', '255.5'])).toBe('0X1.FFP+7\n')
+  })
+
+  it('-v assigns to a variable and prints nothing', () => {
+    const s = new Session({ sessionId: 'test' })
+    const [out, io] = handlePrintf(['-v', 'V', 'x=%d', '42'], s)
+    expect(out).toBeNull()
+    expect(io.exitCode).toBe(0)
+    expect(s.env.V).toBe('x=42')
+  })
+
+  it('-v targets an array element', () => {
+    const s = new Session({ sessionId: 'test' })
+    const [, io] = handlePrintf(['-v', 'arr[2]', 'hi'], s)
+    expect(io.exitCode).toBe(0)
+    expect(s.arrays.arr).toEqual(['', '', 'hi'])
+  })
+
+  it('-v with an invalid name errors', () => {
+    const s = new Session({ sessionId: 'test' })
+    const [, io] = handlePrintf(['-v', '1bad', 'x'], s)
+    expect(io.exitCode).toBe(1)
+  })
+
+  it('-v keeps exit 1 on a bad number but still assigns', () => {
+    const s = new Session({ sessionId: 'test' })
+    const [, io] = handlePrintf(['-v', 'V', '%d', 'notanum'], s)
+    expect(io.exitCode).toBe(1)
+    expect(s.env.V).toBe('0')
   })
 })
 
@@ -856,6 +926,22 @@ describe('handleSource', () => {
     expect(io.exitCode).toBe(1)
     expect(decode(io.stderr instanceof Uint8Array ? io.stderr : null)).toMatch(/missing.sh/)
     expect(executeFn).not.toHaveBeenCalled()
+  })
+
+  it('sets positional args for the script and restores them after', async () => {
+    const s = new Session({ sessionId: 'test', cwd: '/', positionalArgs: ['P1', 'P2'] })
+    const dispatch = vi.fn(() => {
+      const data = new TextEncoder().encode('echo hi\n')
+      return Promise.resolve([data, new IOResult()] as [Uint8Array, IOResult])
+    }) as unknown as DispatchFn
+    let seen: string[] = []
+    const executeFn = vi.fn((_script: string, _opts: { sessionId: string }) => {
+      seen = [...s.positionalArgs]
+      return Promise.resolve(new IOResult())
+    })
+    await handleSource(dispatch, executeFn, '/script.sh', s, ['AA', 'BB'])
+    expect(seen).toEqual(['AA', 'BB'])
+    expect(s.positionalArgs).toEqual(['P1', 'P2'])
   })
 })
 

--- a/typescript/packages/core/src/workspace/executor/builtins.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins.test.ts
@@ -132,10 +132,43 @@ describe('handleExport / handleUnset / handlePrintenv', () => {
   it('unset removes a whole array and a single element', () => {
     const s = new Session({ sessionId: 'test' })
     s.arrays.arr = ['x', 'y', 'z']
+    // An interior element leaves a hole so later indices keep their
+    // positions; a trailing one shortens the array, as bash does.
     handleUnset(['arr[1]'], s)
-    expect(s.arrays.arr).toEqual(['x', 'z'])
+    expect(s.arrays.arr).toEqual(['x', '', 'z'])
+    handleUnset(['arr[2]'], s)
+    expect(s.arrays.arr).toEqual(['x', ''])
     handleUnset(['arr'], s)
     expect('arr' in s.arrays).toBe(false)
+  })
+
+  it('unset rejects an element of a readonly array', () => {
+    const s = new Session({ sessionId: 'test' })
+    s.arrays.arr = ['x', 'y']
+    s.readonlyVars.add('arr')
+    const [, io] = handleUnset(['arr[1]'], s)
+    expect(io.exitCode).toBe(1)
+    expect(decode(io.stderr as Uint8Array)).toBe(
+      'bash: unset: arr: cannot unset: readonly variable\n',
+    )
+    expect(s.arrays.arr).toEqual(['x', 'y'])
+  })
+
+  it('unset NAME[0] removes a scalar, a non-zero subscript errors', () => {
+    const s = new Session({ sessionId: 'test', env: { Y: 'sc', Z: 'sc' } })
+    const [, io] = handleUnset(['Y[0]'], s)
+    expect(io.exitCode).toBe(0)
+    expect('Y' in s.env).toBe(false)
+    const [, io2] = handleUnset(['Z[1]'], s)
+    expect(io2.exitCode).toBe(1)
+    expect(decode(io2.stderr as Uint8Array)).toBe('bash: unset: Z: not an array variable\n')
+    expect(s.env.Z).toBe('sc')
+  })
+
+  it('unset of an element of an unset name is a no-op', () => {
+    const s = new Session({ sessionId: 'test' })
+    const [, io] = handleUnset(['GONE[3]'], s)
+    expect(io.exitCode).toBe(0)
   })
 
   it('unset -z is an invalid option (exit 2)', () => {
@@ -346,10 +379,65 @@ describe('handlePrintf', () => {
     expect(s.arrays.arr).toEqual(['', '', 'hi'])
   })
 
-  it('-v with an invalid name errors', () => {
+  it('-v with an invalid name errors before the format runs', () => {
     const s = new Session({ sessionId: 'test' })
     const [, io] = handlePrintf(['-v', '1bad', 'x'], s)
+    expect(io.exitCode).toBe(2)
+    expect(decode(io.stderr as Uint8Array)).toBe("printf: `1bad': not a valid identifier\n")
+    const [, io2] = handlePrintf(['-v', '1bad', '%d', 'nope'], s)
+    expect(io2.exitCode).toBe(2)
+    expect(decode(io2.stderr as Uint8Array)).toBe("printf: `1bad': not a valid identifier\n")
+  })
+
+  it('-v refuses a readonly scalar and a readonly array element', () => {
+    const s = new Session({ sessionId: 'test', env: { R: 'orig' } })
+    s.readonlyVars.add('R')
+    const [, io] = handlePrintf(['-v', 'R', 'new'], s)
     expect(io.exitCode).toBe(1)
+    expect(decode(io.stderr as Uint8Array)).toBe('bash: R: readonly variable\n')
+    expect(s.env.R).toBe('orig')
+    s.arrays.A = ['x', 'y']
+    s.readonlyVars.add('A')
+    const [, io2] = handlePrintf(['-v', 'A[0]', '%d', 'nope'], s)
+    expect(io2.exitCode).toBe(1)
+    expect(decode(io2.stderr as Uint8Array)).toBe(
+      'printf: nope: invalid number\nbash: A: readonly variable\n',
+    )
+    expect(s.arrays.A).toEqual(['x', 'y'])
+  })
+
+  it('-v on a bare name keeps the other elements of an existing array', () => {
+    const s = new Session({ sessionId: 'test' })
+    s.arrays.B = ['p', 'q', 'r']
+    const [, io] = handlePrintf(['-v', 'B', 'Q'], s)
+    expect(io.exitCode).toBe(0)
+    expect(s.arrays.B).toEqual(['Q', 'q', 'r'])
+    expect('B' in s.env).toBe(false)
+  })
+
+  it('-v with an out-of-range subscript keeps the scalar', () => {
+    const s = new Session({ sessionId: 'test', env: { V: 'orig' } })
+    const [, io] = handlePrintf(['-v', 'V[-2]', 'hi'], s)
+    expect(io.exitCode).toBe(1)
+    expect(decode(io.stderr as Uint8Array)).toBe('bash: V[-2]: bad array subscript\n')
+    expect(s.env.V).toBe('orig')
+    expect('V' in s.arrays).toBe(false)
+  })
+
+  it('-v with a negative subscript wraps over the scalar', () => {
+    const s = new Session({ sessionId: 'test', env: { W: 'orig' } })
+    const [, io] = handlePrintf(['-v', 'W[-1]', 'hi'], s)
+    expect(io.exitCode).toBe(0)
+    expect(s.arrays.W).toEqual(['hi'])
+    expect('W' in s.env).toBe(false)
+  })
+
+  it('-v on __proto__ makes a real variable instead of touching the prototype', () => {
+    const s = new Session({ sessionId: 'test' })
+    expect(handlePrintf(['-v', '__proto__[0]', 'hi'], s)[1].exitCode).toBe(0)
+    expect(Object.hasOwn(s.arrays, '__proto__')).toBe(true)
+    expect(Object.getPrototypeOf(s.arrays)).toBe(Object.prototype)
+    expect(({} as Record<string, unknown>)[0]).toBeUndefined()
   })
 
   it('-v keeps exit 1 on a bad number but still assigns', () => {

--- a/typescript/packages/core/src/workspace/executor/builtins.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins.test.ts
@@ -165,6 +165,20 @@ describe('handleExport / handleUnset / handlePrintenv', () => {
     expect(s.env.Z).toBe('sc')
   })
 
+  it('unset of a negative element outside the extent errors', () => {
+    const s = new Session({ sessionId: 'test' })
+    s.arrays.arr = ['x']
+    const [, io] = handleUnset(['arr[-2]'], s)
+    expect(io.exitCode).toBe(1)
+    // bash prints only the bracketed part here, not the base name.
+    expect(decode(io.stderr as Uint8Array)).toBe('bash: unset: [-2]: bad array subscript\n')
+    expect(s.arrays.arr).toEqual(['x'])
+    s.arrays.two = ['x', 'y']
+    const [, io2] = handleUnset(['two[-2]'], s)
+    expect(io2.exitCode).toBe(0)
+    expect(s.arrays.two).toEqual([null, 'y'])
+  })
+
   it('unset of an element of an unset name is a no-op', () => {
     const s = new Session({ sessionId: 'test' })
     const [, io] = handleUnset(['GONE[3]'], s)
@@ -388,6 +402,18 @@ describe('handlePrintf', () => {
     const [, io2] = handlePrintf(['-v', '1bad', '%d', 'nope'], s)
     expect(io2.exitCode).toBe(2)
     expect(decode(io2.stderr as Uint8Array)).toBe("printf: `1bad': not a valid identifier\n")
+  })
+
+  it('-v rejects an empty subscript but allows a blank one', () => {
+    const s = new Session({ sessionId: 'test' })
+    const [, io] = handlePrintf(['-v', 'a[]', 'x'], s)
+    expect(io.exitCode).toBe(2)
+    expect(decode(io.stderr as Uint8Array)).toBe("printf: `a[]': not a valid identifier\n")
+    expect('a' in s.arrays).toBe(false)
+    // `a[ ]` is a valid arithmetic 0, not an empty subscript.
+    const [, io2] = handlePrintf(['-v', 'a[ ]', 'x'], s)
+    expect(io2.exitCode).toBe(0)
+    expect(s.arrays.a).toEqual(['x'])
   })
 
   it('-v refuses a readonly scalar and a readonly array element', () => {

--- a/typescript/packages/core/src/workspace/executor/builtins.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins.test.ts
@@ -133,11 +133,11 @@ describe('handleExport / handleUnset / handlePrintenv', () => {
     const s = new Session({ sessionId: 'test' })
     s.arrays.arr = ['x', 'y', 'z']
     // An interior element leaves a hole so later indices keep their
-    // positions; a trailing one shortens the array, as bash does.
+    // positions; a trailing one drops off, as bash does.
     handleUnset(['arr[1]'], s)
-    expect(s.arrays.arr).toEqual(['x', '', 'z'])
+    expect(s.arrays.arr).toEqual(['x', null, 'z'])
     handleUnset(['arr[2]'], s)
-    expect(s.arrays.arr).toEqual(['x', ''])
+    expect(s.arrays.arr).toEqual(['x'])
     handleUnset(['arr'], s)
     expect('arr' in s.arrays).toBe(false)
   })
@@ -376,7 +376,8 @@ describe('handlePrintf', () => {
     const s = new Session({ sessionId: 'test' })
     const [, io] = handlePrintf(['-v', 'arr[2]', 'hi'], s)
     expect(io.exitCode).toBe(0)
-    expect(s.arrays.arr).toEqual(['', '', 'hi'])
+    // Indices 0 and 1 are holes, not empty elements.
+    expect(s.arrays.arr).toEqual([null, null, 'hi'])
   })
 
   it('-v with an invalid name errors before the format runs', () => {

--- a/typescript/packages/core/src/workspace/executor/builtins/condition/tree.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/condition/tree.ts
@@ -14,6 +14,7 @@
 
 import { evaluateArith } from '../../../../shell/arith.ts'
 import { ArithError } from '../../../../shell/errors.ts'
+import { makeArray } from '../../../../shell/array.ts'
 import { fnmatch } from '../../../../utils/fnmatch.ts'
 import { FILE_PAIR_BINARY, INT_COMPARATORS, UNARY_OPS } from './constants.ts'
 import { applyUnary } from './operators.ts'
@@ -59,10 +60,10 @@ function evalCondBinary(ctx: CondContext, node: Extract<CondNode, { kind: 'binar
       throw new CondError('mirage: syntax error in conditional expression')
     }
     if (match === null) return false
-    ctx.session.arrays.BASH_REMATCH = [
+    ctx.session.arrays.BASH_REMATCH = makeArray([
       match[0],
       ...match.slice(1).map((g: string | undefined) => g ?? ''),
-    ]
+    ])
     return true
   }
   if (node.op === '<') return node.left < node.right

--- a/typescript/packages/core/src/workspace/executor/builtins/index.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/index.ts
@@ -40,6 +40,7 @@ export {
   handleTrap,
   handleUnset,
   handleWhoami,
+  noteLocalArray,
 } from './vars.ts'
 export { handleMan } from './man.ts'
 export { handleHistory } from './history.ts'

--- a/typescript/packages/core/src/workspace/executor/builtins/script.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/script.ts
@@ -129,6 +129,7 @@ export async function handleSource(
   executeFn: ExecuteStringFn,
   path: string | PathSpec,
   session: Session,
+  args: string[] = [],
 ): Promise<Result> {
   const raw = scopePath(path)
   const resolved = resolvePath(raw, session.cwd)
@@ -157,12 +158,18 @@ export async function handleSource(
       new ExecutionNode({ command: `source ${raw}`, exitCode: 1 }),
     ]
   }
+  let savedPositional: string[] | null = null
+  if (args.length > 0) {
+    savedPositional = session.positionalArgs
+    session.positionalArgs = args
+  }
   session.sourceDepth += 1
   try {
     const io = await executeFn(script, { sessionId: session.sessionId })
     return [io.stdout, io, new ExecutionNode({ command: `source ${raw}`, exitCode: io.exitCode })]
   } finally {
     session.sourceDepth -= 1
+    if (savedPositional !== null) session.positionalArgs = savedPositional
   }
 }
 

--- a/typescript/packages/core/src/workspace/executor/builtins/text.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/text.ts
@@ -22,7 +22,9 @@ import type { Session } from '../../session/session.ts'
 import { ExecutionNode } from '../../types.ts'
 import type { Result } from './scope.ts'
 
-export const PRINTF_TARGET_RE = /^([A-Za-z_][A-Za-z0-9_]*)(?:\[(.*)\])?$/
+// A subscript must be non-empty: bash rejects `a[]` as an invalid
+// identifier, while `a[ ]` is a valid arithmetic 0.
+export const PRINTF_TARGET_RE = /^([A-Za-z_][A-Za-z0-9_]*)(?:\[(.+)\])?$/
 
 /**
  * Print arguments, honoring GNU echo's option rules.

--- a/typescript/packages/core/src/workspace/executor/builtins/text.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/text.ts
@@ -15,8 +15,12 @@
 import { interpretEscapes } from '../../../commands/builtin/utils/escapes.ts'
 import { ECHO_OPTION } from '../../../commands/spec/shell.ts'
 import { IOResult } from '../../../io/types.ts'
+import { arrayIndex } from '../../expand/variable.ts'
+import type { Session } from '../../session/session.ts'
 import { ExecutionNode } from '../../types.ts'
 import type { Result } from './scope.ts'
+
+export const PRINTF_TARGET_RE = /^([A-Za-z_][A-Za-z0-9_]*)(?:\[(.*)\])?$/
 
 /**
  * Print arguments, honoring GNU echo's option rules.
@@ -766,18 +770,77 @@ function runPrintf(fmt: string, args: string[]): [string, string[]] {
  * exhausted; a missing argument renders as the empty string / `0`.
  * Integers wrap at 64 bits; `%a` formats at IEEE double precision.
  */
-export function handlePrintf(args: string[]): Result {
+function assignPrintfTarget(session: Session, target: string, value: string): boolean {
+  const match = PRINTF_TARGET_RE.exec(target)
+  if (match === null) return false
+  const name = match[1] ?? ''
+  const subscript = match[2]
+  if (subscript === undefined) {
+    session.env[name] = value
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete session.arrays[name]
+    return true
+  }
+  let arr = session.arrays[name]
+  if (arr === undefined) {
+    const scalar = session.env[name]
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete session.env[name]
+    arr = scalar !== undefined ? [scalar] : []
+  }
+  let idx = arrayIndex(subscript, session.env)
+  if (idx < 0) idx += arr.length
+  if (idx < 0) return false
+  while (arr.length <= idx) arr.push('')
+  arr[idx] = value
+  session.arrays[name] = arr
+  return true
+}
+
+export function handlePrintf(args: string[], session: Session): Result {
+  let target: string | null = null
+  if (args.length >= 2 && args[0] === '-v') {
+    target = args[1] ?? ''
+    args = args.slice(2)
+  }
   if (args.length === 0) {
+    if (target !== null) {
+      const err = new TextEncoder().encode('printf: usage: printf [-v var] format [arguments]\n')
+      return [
+        null,
+        new IOResult({ exitCode: 2, stderr: err }),
+        new ExecutionNode({ command: 'printf', exitCode: 2, stderr: err }),
+      ]
+    }
     return [new Uint8Array(), new IOResult(), new ExecutionNode({ command: 'printf', exitCode: 0 })]
   }
   const [output, errors] = runPrintf(args[0] ?? '', args.slice(1))
+  const errBytes = errors.length > 0 ? new TextEncoder().encode(errors.join('')) : null
+  if (target !== null) {
+    if (!assignPrintfTarget(session, target, output)) {
+      const err = new TextEncoder().encode(`printf: \`${target}': not a valid variable name\n`)
+      return [
+        null,
+        new IOResult({ exitCode: 1, stderr: err }),
+        new ExecutionNode({ command: 'printf', exitCode: 1, stderr: err }),
+      ]
+    }
+    const exitCode = errors.length > 0 ? 1 : 0
+    if (errBytes !== null) {
+      return [
+        null,
+        new IOResult({ exitCode, stderr: errBytes }),
+        new ExecutionNode({ command: 'printf', exitCode, stderr: errBytes }),
+      ]
+    }
+    return [null, new IOResult({ exitCode }), new ExecutionNode({ command: 'printf', exitCode })]
+  }
   const out = new TextEncoder().encode(output)
-  if (errors.length > 0) {
-    const err = new TextEncoder().encode(errors.join(''))
+  if (errBytes !== null) {
     return [
       out,
-      new IOResult({ exitCode: 1, stderr: err }),
-      new ExecutionNode({ command: 'printf', exitCode: 1, stderr: err }),
+      new IOResult({ exitCode: 1, stderr: errBytes }),
+      new ExecutionNode({ command: 'printf', exitCode: 1, stderr: errBytes }),
     ]
   }
   return [out, new IOResult(), new ExecutionNode({ command: 'printf', exitCode: 0 })]

--- a/typescript/packages/core/src/workspace/executor/builtins/text.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/text.ts
@@ -15,6 +15,7 @@
 import { interpretEscapes } from '../../../commands/builtin/utils/escapes.ts'
 import { ECHO_OPTION } from '../../../commands/spec/shell.ts'
 import { IOResult } from '../../../io/types.ts'
+import { arrayExtent, arraySet } from '../../../shell/array.ts'
 import { arrayIndex } from '../../expand/variable.ts'
 import { sessionEntry, setSessionEntry } from '../../session/session.ts'
 import type { Session } from '../../session/session.ts'
@@ -778,8 +779,7 @@ function assignPrintfTarget(
   if (subscript === undefined) {
     const existing = sessionEntry(session.arrays, name)
     if (existing === undefined) setSessionEntry(session.env, name, value)
-    else if (existing.length > 0) existing[0] = value
-    else existing.push(value)
+    else arraySet(existing, 0, value)
     return 'ok'
   }
   const existing = sessionEntry(session.arrays, name)
@@ -792,10 +792,9 @@ function assignPrintfTarget(
     arr = scalar === undefined ? [] : [scalar]
   }
   let idx = arrayIndex(subscript, session.env)
-  if (idx < 0) idx += arr.length
+  if (idx < 0) idx += arrayExtent(arr)
   if (idx < 0) return 'subscript'
-  while (arr.length <= idx) arr.push('')
-  arr[idx] = value
+  arraySet(arr, idx, value)
   if (fromScalar) {
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
     delete session.env[name]

--- a/typescript/packages/core/src/workspace/executor/builtins/text.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/text.ts
@@ -16,6 +16,7 @@ import { interpretEscapes } from '../../../commands/builtin/utils/escapes.ts'
 import { ECHO_OPTION } from '../../../commands/spec/shell.ts'
 import { IOResult } from '../../../io/types.ts'
 import { arrayIndex } from '../../expand/variable.ts'
+import { sessionEntry, setSessionEntry } from '../../session/session.ts'
 import type { Session } from '../../session/session.ts'
 import { ExecutionNode } from '../../types.ts'
 import type { Result } from './scope.ts'
@@ -760,6 +761,50 @@ function runPrintf(fmt: string, args: string[]): [string, string[]] {
 }
 
 /**
+ * Assign `value` to a `printf -v` target (a scalar or `name[idx]`).
+ *
+ * A bare name assigns element 0 when the name already holds an array,
+ * leaving its other elements alone, as bash does. Nothing is mutated
+ * unless the whole assignment succeeds: a readonly name or an
+ * out-of-range subscript leaves the variable exactly as it was.
+ */
+function assignPrintfTarget(
+  session: Session,
+  name: string,
+  subscript: string | undefined,
+  value: string,
+): 'ok' | 'readonly' | 'subscript' {
+  if (session.readonlyVars.has(name)) return 'readonly'
+  if (subscript === undefined) {
+    const existing = sessionEntry(session.arrays, name)
+    if (existing === undefined) setSessionEntry(session.env, name, value)
+    else if (existing.length > 0) existing[0] = value
+    else existing.push(value)
+    return 'ok'
+  }
+  const existing = sessionEntry(session.arrays, name)
+  const fromScalar = existing === undefined
+  let arr = existing
+  if (arr === undefined) {
+    // An existing scalar becomes element 0, even when empty: bash
+    // resolves `x[-1]` against the length-1 array that produces.
+    const scalar = sessionEntry(session.env, name)
+    arr = scalar === undefined ? [] : [scalar]
+  }
+  let idx = arrayIndex(subscript, session.env)
+  if (idx < 0) idx += arr.length
+  if (idx < 0) return 'subscript'
+  while (arr.length <= idx) arr.push('')
+  arr[idx] = value
+  if (fromScalar) {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete session.env[name]
+  }
+  setSessionEntry(session.arrays, name, arr)
+  return 'ok'
+}
+
+/**
  * Print formatted output, honoring GNU printf's format-reuse rules.
  *
  * Supports `%s %c %b %q`, the integer conversions `%d %i %o %u %x %X`,
@@ -769,39 +814,31 @@ function runPrintf(fmt: string, args: string[]): [string, string[]] {
  * arguments remain after one pass the format is reused until they are
  * exhausted; a missing argument renders as the empty string / `0`.
  * Integers wrap at 64 bits; `%a` formats at IEEE double precision.
+ *
+ * With `-v NAME` the formatted text is stored in the shell variable
+ * `NAME` (or the array element `NAME[idx]`) instead of written to
+ * stdout, matching GNU printf. An unusable `NAME` is rejected before the
+ * format runs (status 2); a readonly name or an out-of-range subscript
+ * still reports the format's own errors first, then fails with status 1
+ * and leaves the variable untouched.
  */
-function assignPrintfTarget(session: Session, target: string, value: string): boolean {
-  const match = PRINTF_TARGET_RE.exec(target)
-  if (match === null) return false
-  const name = match[1] ?? ''
-  const subscript = match[2]
-  if (subscript === undefined) {
-    session.env[name] = value
-    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-    delete session.arrays[name]
-    return true
-  }
-  let arr = session.arrays[name]
-  if (arr === undefined) {
-    const scalar = session.env[name]
-    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-    delete session.env[name]
-    arr = scalar !== undefined ? [scalar] : []
-  }
-  let idx = arrayIndex(subscript, session.env)
-  if (idx < 0) idx += arr.length
-  if (idx < 0) return false
-  while (arr.length <= idx) arr.push('')
-  arr[idx] = value
-  session.arrays[name] = arr
-  return true
-}
-
 export function handlePrintf(args: string[], session: Session): Result {
   let target: string | null = null
+  let parsed: RegExpExecArray | null = null
   if (args.length >= 2 && args[0] === '-v') {
     target = args[1] ?? ''
     args = args.slice(2)
+    parsed = PRINTF_TARGET_RE.exec(target)
+    if (parsed === null) {
+      // bash validates the name before formatting, so a bad name
+      // suppresses the conversion errors the format would report.
+      const err = new TextEncoder().encode(`printf: \`${target}': not a valid identifier\n`)
+      return [
+        null,
+        new IOResult({ exitCode: 2, stderr: err }),
+        new ExecutionNode({ command: 'printf', exitCode: 2, stderr: err }),
+      ]
+    }
   }
   if (args.length === 0) {
     if (target !== null) {
@@ -816,9 +853,15 @@ export function handlePrintf(args: string[], session: Session): Result {
   }
   const [output, errors] = runPrintf(args[0] ?? '', args.slice(1))
   const errBytes = errors.length > 0 ? new TextEncoder().encode(errors.join('')) : null
-  if (target !== null) {
-    if (!assignPrintfTarget(session, target, output)) {
-      const err = new TextEncoder().encode(`printf: \`${target}': not a valid variable name\n`)
+  if (target !== null && parsed !== null) {
+    const base = parsed[1] ?? ''
+    const status = assignPrintfTarget(session, base, parsed[2], output)
+    if (status !== 'ok') {
+      const detail =
+        status === 'readonly'
+          ? `bash: ${base}: readonly variable\n`
+          : `bash: ${target}: bad array subscript\n`
+      const err = new TextEncoder().encode(errors.join('') + detail)
       return [
         null,
         new IOResult({ exitCode: 1, stderr: err }),

--- a/typescript/packages/core/src/workspace/executor/builtins/vars.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/vars.ts
@@ -85,9 +85,11 @@ export function handleReadonly(assignments: string[], session: Session): Result 
  *
  * A subscript on a scalar names element 0 only: `x[0]` unsets the scalar
  * and any other subscript reports `notarray`. A subscript on a name that
- * holds nothing at all is a silent no-op.
+ * holds nothing at all is a silent no-op, but on an existing array a
+ * negative subscript still below zero after the extent is added reports
+ * `subscript`.
  */
-function unsetVariable(session: Session, name: string): 'ok' | 'notarray' {
+function unsetVariable(session: Session, name: string): 'ok' | 'notarray' | 'subscript' {
   const match = PRINTF_TARGET_RE.exec(name)
   if (match?.[2] !== undefined) {
     const base = match[1] ?? ''
@@ -100,7 +102,10 @@ function unsetVariable(session: Session, name: string): 'ok' | 'notarray' {
       return 'ok'
     }
     let idx = arrayIndex(match[2], session.env)
-    if (idx < 0) idx += arrayExtent(arr)
+    if (idx < 0) {
+      idx += arrayExtent(arr)
+      if (idx < 0) return 'subscript'
+    }
     arrayUnset(arr, idx)
     return 'ok'
   }
@@ -173,8 +178,15 @@ export function handleUnset(args: string[], session: Session): Result {
       ]
     }
     const existed = isElement || name in session.env || name in session.arrays
-    if (unsetVariable(session, name) === 'notarray') {
-      const err = new TextEncoder().encode(`bash: unset: ${base}: not an array variable\n`)
+    const status = unsetVariable(session, name)
+    if (status !== 'ok') {
+      // bash names the base for "not an array variable" but prints only
+      // the bracketed part for a bad subscript.
+      const detail =
+        status === 'notarray'
+          ? `unset: ${base}: not an array variable`
+          : `unset: ${name.slice(base.length)}: bad array subscript`
+      const err = new TextEncoder().encode(`bash: ${detail}\n`)
       return [
         null,
         new IOResult({ exitCode: 1, stderr: err }),
@@ -353,6 +365,24 @@ export function handleWhoami(namespace: Namespace): Result {
   }
   const out = new TextEncoder().encode(`${namespace.user}\n`)
   return [out, new IOResult(), new ExecutionNode({ command: 'whoami', exitCode: 0 })]
+}
+
+/**
+ * Record the caller's array before a function shadows `name`.
+ *
+ * `local -a` / `declare -a` inside a function shadow the caller's array,
+ * so the old value (or its absence) has to be remembered for the teardown
+ * in `executeCommand`. Returns true when a function scope is active, so
+ * the caller should shadow rather than reuse whatever is already there.
+ */
+export function noteLocalArray(session: Session, name: string): boolean {
+  const localArrays = session.localArrays
+  if (localArrays === null) return false
+  if (!localArrays.has(name)) {
+    const existing = sessionEntry(session.arrays, name)
+    localArrays.set(name, existing === undefined ? null : [...existing])
+  }
+  return true
 }
 
 export function handleLocal(assignments: string[], session: Session): Result {

--- a/typescript/packages/core/src/workspace/executor/builtins/vars.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/vars.ts
@@ -23,6 +23,7 @@ import { shellJoin } from '../../../shell/join.ts'
 import { SET_FLAG_TO_OPTION } from '../../../shell/types.ts'
 import type { Namespace } from '../../mount/namespace/namespace.ts'
 import { arrayIndex } from '../../expand/variable.ts'
+import { sessionEntry } from '../../session/session.ts'
 import type { Session } from '../../session/session.ts'
 import { ExecutionNode } from '../../types.ts'
 import { ReturnSignal } from '../command.ts'
@@ -72,24 +73,56 @@ export function handleReadonly(assignments: string[], session: Session): Result 
   return [null, new IOResult(), new ExecutionNode({ command: 'readonly', exitCode: 0 })]
 }
 
-function unsetVariable(session: Session, name: string): void {
+/**
+ * Remove a scalar/array variable, or one array element `name[idx]`.
+ *
+ * Clearing an element keeps the positions of the elements after it, as
+ * bash does: only a trailing element shortens the array, an interior one
+ * leaves an empty hole. Mirage stores arrays densely, so a hole is an
+ * empty string (the same representation `arr[9]=v` produces) and still
+ * counts toward `${#arr[@]}` and `${arr[@]}`, where bash would skip it.
+ *
+ * A subscript on a scalar names element 0 only: `x[0]` unsets the scalar
+ * and any other subscript reports `notarray`. A subscript on a name that
+ * holds nothing at all is a silent no-op.
+ */
+function unsetVariable(session: Session, name: string): 'ok' | 'notarray' {
   const match = PRINTF_TARGET_RE.exec(name)
   if (match?.[2] !== undefined) {
     const base = match[1] ?? ''
-    const arr = session.arrays[base]
-    if (arr === undefined) return
+    const arr = sessionEntry(session.arrays, base)
+    if (arr === undefined) {
+      if (sessionEntry(session.env, base) === undefined) return 'ok'
+      if (arrayIndex(match[2], session.env) !== 0) return 'notarray'
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete session.env[base]
+      return 'ok'
+    }
     let idx = arrayIndex(match[2], session.env)
     if (idx < 0) idx += arr.length
-    if (idx >= 0 && idx < arr.length) arr.splice(idx, 1)
-    return
+    if (idx < 0 || idx >= arr.length) return 'ok'
+    if (idx === arr.length - 1) arr.pop()
+    else arr[idx] = ''
+    return 'ok'
   }
   // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
   delete session.env[name]
   // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
   delete session.arrays[name]
   if (name === 'OPTIND') session.getoptsOptind = null
+  return 'ok'
 }
 
+/**
+ * Unset shell variables, arrays, or functions, with bash's flags.
+ *
+ * `-v` targets a variable only, `-f` a function only, and a bare name a
+ * variable if one exists or else a function. A `name[idx]` operand clears
+ * one element; the readonly guard resolves it to the base name first,
+ * since that is what `readonly` records. `-n` (unset a nameref itself)
+ * has no referent here — mirage has no nameref attribute — so it matches
+ * bash on a non-nameref name and leaves it untouched.
+ */
 export function handleUnset(args: string[], session: Session): Result {
   let mode: 'auto' | 'v' | 'f' | 'n' = 'auto'
   let i = 0
@@ -124,9 +157,15 @@ export function handleUnset(args: string[], session: Session): Result {
       delete session.functions[name]
       continue
     }
-    if (session.readonlyVars.has(name)) {
+    const match = PRINTF_TARGET_RE.exec(name)
+    const isElement = match?.[2] !== undefined
+    // `readonly arr` records the base name, so an `arr[i]` operand has to
+    // be resolved before the guard, as bash does (which also names the
+    // base, not the element, in the error).
+    const base = match?.[1] ?? name
+    if (session.readonlyVars.has(base)) {
       const err = new TextEncoder().encode(
-        `bash: unset: ${name}: cannot unset: readonly variable\n`,
+        `bash: unset: ${base}: cannot unset: readonly variable\n`,
       )
       return [
         null,
@@ -134,10 +173,15 @@ export function handleUnset(args: string[], session: Session): Result {
         new ExecutionNode({ command: 'unset', exitCode: 1, stderr: err }),
       ]
     }
-    const match = PRINTF_TARGET_RE.exec(name)
-    const isElement = match?.[2] !== undefined
     const existed = isElement || name in session.env || name in session.arrays
-    unsetVariable(session, name)
+    if (unsetVariable(session, name) === 'notarray') {
+      const err = new TextEncoder().encode(`bash: unset: ${base}: not an array variable\n`)
+      return [
+        null,
+        new IOResult({ exitCode: 1, stderr: err }),
+        new ExecutionNode({ command: 'unset', exitCode: 1, stderr: err }),
+      ]
+    }
     if (mode === 'auto' && !existed && name in session.functions) {
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete session.functions[name]

--- a/typescript/packages/core/src/workspace/executor/builtins/vars.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/vars.ts
@@ -22,9 +22,11 @@ import { ExitSignal } from '../../../shell/errors.ts'
 import { shellJoin } from '../../../shell/join.ts'
 import { SET_FLAG_TO_OPTION } from '../../../shell/types.ts'
 import type { Namespace } from '../../mount/namespace/namespace.ts'
+import { arrayIndex } from '../../expand/variable.ts'
 import type { Session } from '../../session/session.ts'
 import { ExecutionNode } from '../../types.ts'
 import { ReturnSignal } from '../command.ts'
+import { PRINTF_TARGET_RE } from './text.ts'
 import type { ExecuteStringFn, Result } from './scope.ts'
 
 export function handleExport(assignments: string[], session: Session): Result {
@@ -70,8 +72,58 @@ export function handleReadonly(assignments: string[], session: Session): Result 
   return [null, new IOResult(), new ExecutionNode({ command: 'readonly', exitCode: 0 })]
 }
 
-export function handleUnset(names: string[], session: Session): Result {
-  for (const name of names) {
+function unsetVariable(session: Session, name: string): void {
+  const match = PRINTF_TARGET_RE.exec(name)
+  if (match?.[2] !== undefined) {
+    const base = match[1] ?? ''
+    const arr = session.arrays[base]
+    if (arr === undefined) return
+    let idx = arrayIndex(match[2], session.env)
+    if (idx < 0) idx += arr.length
+    if (idx >= 0 && idx < arr.length) arr.splice(idx, 1)
+    return
+  }
+  // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+  delete session.env[name]
+  // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+  delete session.arrays[name]
+  if (name === 'OPTIND') session.getoptsOptind = null
+}
+
+export function handleUnset(args: string[], session: Session): Result {
+  let mode: 'auto' | 'v' | 'f' | 'n' = 'auto'
+  let i = 0
+  while (i < args.length && (args[i] ?? '').startsWith('-') && args[i] !== '-') {
+    const tok = args[i] ?? ''
+    if (tok === '--') {
+      i += 1
+      break
+    }
+    if (/^-[vfn]+$/.test(tok)) {
+      if (tok.includes('f')) mode = 'f'
+      else if (tok.includes('n')) mode = 'n'
+      else mode = 'v'
+      i += 1
+      continue
+    }
+    const err = new TextEncoder().encode(`bash: unset: ${tok}: invalid option\n`)
+    return [
+      null,
+      new IOResult({ exitCode: 2, stderr: err }),
+      new ExecutionNode({ command: 'unset', exitCode: 2, stderr: err }),
+    ]
+  }
+  for (const name of args.slice(i)) {
+    if (mode === 'n') {
+      // No nameref attribute exists, so this leaves the name untouched,
+      // matching bash on a plain variable.
+      continue
+    }
+    if (mode === 'f') {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete session.functions[name]
+      continue
+    }
     if (session.readonlyVars.has(name)) {
       const err = new TextEncoder().encode(
         `bash: unset: ${name}: cannot unset: readonly variable\n`,
@@ -82,9 +134,14 @@ export function handleUnset(names: string[], session: Session): Result {
         new ExecutionNode({ command: 'unset', exitCode: 1, stderr: err }),
       ]
     }
-    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-    delete session.env[name]
-    if (name === 'OPTIND') session.getoptsOptind = null
+    const match = PRINTF_TARGET_RE.exec(name)
+    const isElement = match?.[2] !== undefined
+    const existed = isElement || name in session.env || name in session.arrays
+    unsetVariable(session, name)
+    if (mode === 'auto' && !existed && name in session.functions) {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete session.functions[name]
+    }
   }
   return [null, new IOResult(), new ExecutionNode({ command: 'unset', exitCode: 0 })]
 }

--- a/typescript/packages/core/src/workspace/executor/builtins/vars.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/vars.ts
@@ -22,6 +22,7 @@ import { ExitSignal } from '../../../shell/errors.ts'
 import { shellJoin } from '../../../shell/join.ts'
 import { SET_FLAG_TO_OPTION } from '../../../shell/types.ts'
 import type { Namespace } from '../../mount/namespace/namespace.ts'
+import { arrayExtent, arrayUnset } from '../../../shell/array.ts'
 import { arrayIndex } from '../../expand/variable.ts'
 import { sessionEntry } from '../../session/session.ts'
 import type { Session } from '../../session/session.ts'
@@ -76,11 +77,11 @@ export function handleReadonly(assignments: string[], session: Session): Result 
 /**
  * Remove a scalar/array variable, or one array element `name[idx]`.
  *
- * Clearing an element keeps the positions of the elements after it, as
- * bash does: only a trailing element shortens the array, an interior one
- * leaves an empty hole. Mirage stores arrays densely, so a hole is an
- * empty string (the same representation `arr[9]=v` produces) and still
- * counts toward `${#arr[@]}` and `${arr[@]}`, where bash would skip it.
+ * Clearing an element keeps the indices of the elements after it, as bash
+ * does: it leaves a hole, which neither expands in `${arr[@]}` nor counts
+ * toward `${#arr[@]}` but keeps `${arr[i]}` addressing the same values.
+ * Trailing holes are dropped, so `arr+=(x)` refills the slot a trailing
+ * unset freed.
  *
  * A subscript on a scalar names element 0 only: `x[0]` unsets the scalar
  * and any other subscript reports `notarray`. A subscript on a name that
@@ -99,10 +100,8 @@ function unsetVariable(session: Session, name: string): 'ok' | 'notarray' {
       return 'ok'
     }
     let idx = arrayIndex(match[2], session.env)
-    if (idx < 0) idx += arr.length
-    if (idx < 0 || idx >= arr.length) return 'ok'
-    if (idx === arr.length - 1) arr.pop()
-    else arr[idx] = ''
+    if (idx < 0) idx += arrayExtent(arr)
+    arrayUnset(arr, idx)
     return 'ok'
   }
   // eslint-disable-next-line @typescript-eslint/no-dynamic-delete

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -22,6 +22,7 @@ import type { ByteSource } from '../../io/types.ts'
 import { IOResult, materialize } from '../../io/types.ts'
 import type { Resource } from '../../resource/base.ts'
 import { assertMountAllowed, MountNotAllowedError } from '../../context/session_context.ts'
+import type { ShellArray } from '../../shell/array.ts'
 import { CallStack } from '../../shell/call_stack.ts'
 import type { JobTable } from '../../shell/job_table.ts'
 import { ERREXIT_EXEMPT_TYPES } from '../../shell/types.ts'
@@ -931,7 +932,9 @@ async function executeShellFunction(
   const textArgs = restParts.map(wordText)
   cs.push(textArgs, cmdName)
   const savedLocals = new Map<string, string | null>()
+  const savedArrays = new Map<string, ShellArray | null>()
   session.localVars = savedLocals
+  session.localArrays = savedArrays
   const allStdout: (ByteSource | null)[] = []
   let mergedIo = new IOResult()
   let lastExec = new ExecutionNode({ command: cmdName, exitCode: 0 })
@@ -977,7 +980,16 @@ async function executeShellFunction(
         session.env[key] = oldVal
       }
     }
+    for (const [key, oldArr] of savedArrays) {
+      if (oldArr === null) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete session.arrays[key]
+      } else {
+        session.arrays[key] = oldArr
+      }
+    }
     session.localVars = null
+    session.localArrays = null
   }
 
   const combined = allStdout.length > 0 ? asyncChain(...allStdout) : null

--- a/typescript/packages/core/src/workspace/executor/control.test.ts
+++ b/typescript/packages/core/src/workspace/executor/control.test.ts
@@ -208,10 +208,10 @@ describe('handleCase', () => {
       which = n.text
       return Promise.resolve([null, new IOResult(), new ExecutionNode()])
     }
-    const items: [string[], TSNodeLike[]][] = [
-      [['a*'], [node('A')]],
-      [['b*'], [node('B')]],
-      [['*'], [node('catchall')]],
+    const items: [string[], TSNodeLike[], string][] = [
+      [['a*'], [node('A')], ';;'],
+      [['b*'], [node('B')], ';;'],
+      [['*'], [node('catchall')], ';;'],
     ]
     await handleCase(execute, 'banana', items, new Session({ sessionId: 'test' }))
     expect(which).toBe('B')
@@ -223,9 +223,9 @@ describe('handleCase', () => {
       which = n.text
       return Promise.resolve([null, new IOResult(), new ExecutionNode()])
     }
-    const items: [string[], TSNodeLike[]][] = [
-      [['a*'], [node('A')]],
-      [['*'], [node('catchall')]],
+    const items: [string[], TSNodeLike[], string][] = [
+      [['a*'], [node('A')], ';;'],
+      [['*'], [node('catchall')], ';;'],
     ]
     await handleCase(execute, 'xyz', items, new Session({ sessionId: 'test' }))
     expect(which).toBe('catchall')
@@ -234,8 +234,38 @@ describe('handleCase', () => {
   it('matches nothing when no pattern fits', async () => {
     const execute: ExecuteNodeFn = () =>
       Promise.resolve([null, new IOResult(), new ExecutionNode()])
-    const items: [string[], TSNodeLike[]][] = [[['z*'], [node('body')]]]
+    const items: [string[], TSNodeLike[], string][] = [[['z*'], [node('body')], ';;']]
     const [, io] = await handleCase(execute, 'abc', items, new Session({ sessionId: 'test' }))
     expect(io.exitCode).toBe(0)
+  })
+
+  it('runs the next arm body on ;& (fallthrough)', async () => {
+    const ran: string[] = []
+    const execute: ExecuteNodeFn = (n) => {
+      ran.push(n.text)
+      return Promise.resolve([null, new IOResult(), new ExecutionNode()])
+    }
+    const items: [string[], TSNodeLike[], string][] = [
+      [['a'], [node('A')], ';&'],
+      [['b'], [node('B')], ';;'],
+      [['c'], [node('C')], ';;'],
+    ]
+    await handleCase(execute, 'a', items, new Session({ sessionId: 'test' }))
+    expect(ran).toEqual(['A', 'B'])
+  })
+
+  it('keeps testing later patterns on ;;&', async () => {
+    const ran: string[] = []
+    const execute: ExecuteNodeFn = (n) => {
+      ran.push(n.text)
+      return Promise.resolve([null, new IOResult(), new ExecutionNode()])
+    }
+    const items: [string[], TSNodeLike[], string][] = [
+      [['a'], [node('A')], ';;&'],
+      [['a'], [node('A2')], ';;&'],
+      [['b'], [node('B')], ';;'],
+    ]
+    await handleCase(execute, 'a', items, new Session({ sessionId: 'test' }))
+    expect(ran).toEqual(['A', 'A2'])
   })
 })

--- a/typescript/packages/core/src/workspace/executor/control.ts
+++ b/typescript/packages/core/src/workspace/executor/control.ts
@@ -310,31 +310,41 @@ export function handleUntil(
 export async function handleCase(
   executeNode: ExecuteNodeFn,
   word: string,
-  items: readonly [readonly string[], readonly TSNodeLike[]][],
+  items: readonly [readonly string[], readonly TSNodeLike[], string][],
   session: Session,
   stdin: ByteSource | null = null,
   callStack: CallStack | null = null,
 ): Promise<Result> {
-  for (const [patterns, body] of items) {
-    if (patterns.some((p) => fnmatch(word, p.trim()))) {
-      const allStdout: ByteSource[] = []
-      let mergedIo = new IOResult()
-      let lastExec = new ExecutionNode({ command: 'case', exitCode: 0 })
-      let stageStdin = stdin
-      for (const stmt of body) {
-        const [stdout, io, execNode] = await executeNode(stmt, session, stageStdin, callStack)
-        stageStdin = null
-        lastExec = execNode
-        if (stdout !== null) allStdout.push(stdout)
-        mergedIo = await mergedIo.merge(io)
-      }
-      const first = allStdout[0]
-      if (allStdout.length === 1 && first !== undefined) return [first, mergedIo, lastExec]
-      const combined = allStdout.length > 0 ? asyncChain(...allStdout) : null
-      return [combined, mergedIo, lastExec]
+  const allStdout: ByteSource[] = []
+  let mergedIo = new IOResult()
+  let lastExec = new ExecutionNode({ command: 'case', exitCode: 0 })
+  let stageStdin = stdin
+  let ran = false
+  let fallthrough = false
+  for (const [patterns, body, terminator] of items) {
+    if (!(fallthrough || patterns.some((p) => fnmatch(word, p.trim())))) continue
+    ran = true
+    for (const stmt of body) {
+      const [stdout, io, execNode] = await executeNode(stmt, session, stageStdin, callStack)
+      stageStdin = null
+      lastExec = execNode
+      if (stdout !== null) allStdout.push(stdout)
+      mergedIo = await mergedIo.merge(io)
     }
+    if (terminator === ';&') {
+      // Fall through: run the next arm's body without testing it.
+      fallthrough = true
+      continue
+    }
+    // ;;& keeps testing remaining patterns; ;; stops here.
+    fallthrough = false
+    if (terminator !== ';;&') break
   }
-  return [null, new IOResult(), new ExecutionNode({ command: 'case', exitCode: 0 })]
+  if (!ran) return [null, new IOResult(), new ExecutionNode({ command: 'case', exitCode: 0 })]
+  const first = allStdout[0]
+  if (allStdout.length === 1 && first !== undefined) return [first, mergedIo, lastExec]
+  const combined = allStdout.length > 0 ? asyncChain(...allStdout) : null
+  return [combined, mergedIo, lastExec]
 }
 
 /**

--- a/typescript/packages/core/src/workspace/executor/pipes.ts
+++ b/typescript/packages/core/src/workspace/executor/pipes.ts
@@ -17,6 +17,7 @@ import { asyncChain, closeQuietly, mergeStdoutStderr } from '../../io/stream.ts'
 import type { ByteSource } from '../../io/types.ts'
 import { IOResult, materialize } from '../../io/types.ts'
 import { applyBarrier, BarrierPolicy } from '../../shell/barrier.ts'
+import type { ShellArray } from '../../shell/array.ts'
 import type { CallStack } from '../../shell/call_stack.ts'
 import { ExitSignal } from '../../shell/errors.ts'
 import { ERREXIT_EXEMPT_TYPES, NodeType as NT } from '../../shell/types.ts'
@@ -261,7 +262,7 @@ export async function handleSubshell(
   const savedEnv = { ...session.env }
   const savedOptions = { ...session.shellOptions }
   const savedReadonly = new Set(session.readonlyVars)
-  const savedArrays: Record<string, string[]> = {}
+  const savedArrays: Record<string, ShellArray> = {}
   for (const [k, v] of Object.entries(session.arrays)) savedArrays[k] = [...v]
   const savedFunctions = { ...session.functions }
   const savedPositional = [...session.positionalArgs]

--- a/typescript/packages/core/src/workspace/expand/variable.ts
+++ b/typescript/packages/core/src/workspace/expand/variable.ts
@@ -13,7 +13,15 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { evaluateArith } from '../../shell/arith.ts'
-import { arrayExtent, arrayGet, arrayHas, arrayIndices, arrayValues } from '../../shell/array.ts'
+import {
+  type ShellArray,
+  arrayExtent,
+  arrayGet,
+  arrayHas,
+  arrayIndices,
+  arraySlice,
+  arrayValues,
+} from '../../shell/array.ts'
 import type { CallStack } from '../../shell/call_stack.ts'
 import { ArithError, ExitSignal } from '../../shell/errors.ts'
 import { NodeType as NT } from '../../shell/types.ts'
@@ -420,21 +428,19 @@ function substring(val: string, groups: string[], env: Record<string, string>): 
   return val.slice(offset, offset + length)
 }
 
-function sliceArray(arr: string[], groups: string[], env: Record<string, string>): string[] {
+/** Resolve `${a[@]:offset:length}` against a shell array. */
+function sliceArray(arr: ShellArray, groups: string[], env: Record<string, string>): string[] {
   const offsetRaw = groups[0]
-  if (offsetRaw === undefined) return arr
-  let offset = arithInt(offsetRaw, env)
-  if (offset === null) return arr
+  if (offsetRaw === undefined) return arrayValues(arr)
+  const offset = arithInt(offsetRaw, env)
+  if (offset === null) return arrayValues(arr)
   let length: number | null = null
   const lengthRaw = groups[1]
   if (lengthRaw !== undefined) {
     length = arithInt(lengthRaw, env)
-    if (length === null) return arr
+    if (length === null) return arrayValues(arr)
   }
-  if (offset < 0) offset = Math.max(0, arr.length + offset)
-  if (length === null) return arr.slice(offset)
-  if (length < 0) return arr.slice(offset, Math.max(offset, arr.length + length))
-  return arr.slice(offset, offset + length)
+  return arraySlice(arr, offset, length)
 }
 
 // True for the "${a[@]...}" forms bash keeps as one word per element:
@@ -474,7 +480,7 @@ export async function expandArrayAt(
     const patternMode = gi === 0 && PATTERN_OPS.has(op)
     groups.push(await expandGroup(p.groups[gi] ?? [], expandChild, patternMode, session, callStack))
   }
-  if (op === ':') return sliceArray(values, groups, env)
+  if (op === ':') return sliceArray(arr, groups, env)
   return values.map((el) => valueOp(op, el, groups, env))
 }
 
@@ -561,7 +567,7 @@ export async function expandBraces(
       }
       if (p.lengthOp) return String(values.length)
       if (p.op === ':') {
-        return sliceArray(values, groups, env).join(' ')
+        return sliceArray(arr, groups, env).join(' ')
       }
       if (p.op !== null && (STRIP_OPS.has(p.op) || REPLACE_OPS.has(p.op) || CASE_OPS.has(p.op))) {
         const op = p.op

--- a/typescript/packages/core/src/workspace/expand/variable.ts
+++ b/typescript/packages/core/src/workspace/expand/variable.ts
@@ -462,8 +462,8 @@ export async function expandArrayAt(
   const env = session.env
   let arr = session.arrays[p.varName ?? '']
   if (arr === undefined) {
-    const scalar = env[p.varName ?? ''] ?? ''
-    arr = scalar !== '' ? [scalar] : []
+    const scalar = env[p.varName ?? '']
+    arr = scalar === undefined ? [] : [scalar]
   }
   if (p.indirectOp) return arrayIndices(arr).map((i) => String(i))
   const values = arrayValues(arr)
@@ -543,8 +543,10 @@ export async function expandBraces(
   if (p.subscript !== null && p.varName !== null) {
     let arr = arrays[p.varName]
     if (arr === undefined) {
-      const scalar = env[p.varName] ?? ''
-      arr = scalar !== '' ? [scalar] : []
+      // A scalar is element 0 of a one-element array, even when empty:
+      // ${#x[@]} is 1 for x="" but 0 for an unset name.
+      const scalar = env[p.varName]
+      arr = scalar === undefined ? [] : [scalar]
     }
     varInEnv = p.varName in arrays || p.varName in env
     if (p.subscript === '@' || p.subscript === '*') {

--- a/typescript/packages/core/src/workspace/expand/variable.ts
+++ b/typescript/packages/core/src/workspace/expand/variable.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { evaluateArith } from '../../shell/arith.ts'
+import { arrayExtent, arrayGet, arrayHas, arrayIndices, arrayValues } from '../../shell/array.ts'
 import type { CallStack } from '../../shell/call_stack.ts'
 import { ArithError, ExitSignal } from '../../shell/errors.ts'
 import { NodeType as NT } from '../../shell/types.ts'
@@ -155,7 +156,7 @@ export function lookupVar(
   }
   const fromArray = session.arrays[name]
   if (fromArray !== undefined) {
-    return fromArray[0] ?? ''
+    return arrayGet(fromArray, 0)
   }
   if (name === 'PWD') return session.cwd
   if (name === 'HOME') return homeDir(session) ?? ''
@@ -464,16 +465,17 @@ export async function expandArrayAt(
     const scalar = env[p.varName ?? ''] ?? ''
     arr = scalar !== '' ? [scalar] : []
   }
-  if (p.indirectOp) return arr.map((_, i) => String(i))
-  if (p.op === null) return [...arr]
+  if (p.indirectOp) return arrayIndices(arr).map((i) => String(i))
+  const values = arrayValues(arr)
+  if (p.op === null) return values
   const op = p.op
   const groups: string[] = []
   for (let gi = 0; gi < p.groups.length; gi++) {
     const patternMode = gi === 0 && PATTERN_OPS.has(op)
     groups.push(await expandGroup(p.groups[gi] ?? [], expandChild, patternMode, session, callStack))
   }
-  if (op === ':') return sliceArray(arr, groups, env)
-  return arr.map((el) => valueOp(op, el, groups, env))
+  if (op === ':') return sliceArray(values, groups, env)
+  return values.map((el) => valueOp(op, el, groups, env))
 }
 
 // bash evaluates subscripts in arithmetic context (${a[i+1]});
@@ -546,28 +548,29 @@ export async function expandBraces(
     }
     varInEnv = p.varName in arrays || p.varName in env
     if (p.subscript === '@' || p.subscript === '*') {
+      // ${a[@]} and friends see only the assigned elements: a hole left
+      // by `unset a[i]` (or skipped by a[9]=v) neither expands nor
+      // counts, though it keeps the later indices in place.
+      const values = arrayValues(arr)
       if (p.indirectOp) {
-        return arr.map((_, i) => String(i)).join(' ')
+        return arrayIndices(arr)
+          .map((i) => String(i))
+          .join(' ')
       }
-      if (p.lengthOp) return String(arr.length)
+      if (p.lengthOp) return String(values.length)
       if (p.op === ':') {
-        return sliceArray(arr, groups, env).join(' ')
+        return sliceArray(values, groups, env).join(' ')
       }
       if (p.op !== null && (STRIP_OPS.has(p.op) || REPLACE_OPS.has(p.op) || CASE_OPS.has(p.op))) {
         const op = p.op
-        return arr.map((el) => valueOp(op, el, groups, env)).join(' ')
+        return values.map((el) => valueOp(op, el, groups, env)).join(' ')
       }
-      val = arr.join(' ')
+      val = values.join(' ')
     } else {
       let idx = arrayIndex(p.subscript, env)
-      if (idx < 0) idx += arr.length
-      if (idx >= 0 && idx < arr.length) {
-        val = arr[idx] ?? ''
-        varInEnv = true
-      } else {
-        val = ''
-        varInEnv = false
-      }
+      if (idx < 0) idx += arrayExtent(arr)
+      val = arrayGet(arr, idx)
+      varInEnv = arrayHas(arr, idx)
     }
   } else if (p.varName !== null) {
     if (callStack) {
@@ -578,8 +581,7 @@ export async function expandBraces(
       }
     }
     if (!varInEnv && p.varName in arrays) {
-      const arr = arrays[p.varName] ?? []
-      val = arr[0] ?? ''
+      val = arrayGet(arrays[p.varName] ?? [], 0)
       varInEnv = true
     }
     if (!varInEnv && p.varName in env) {

--- a/typescript/packages/core/src/workspace/node/command_dispatch.ts
+++ b/typescript/packages/core/src/workspace/node/command_dispatch.ts
@@ -563,7 +563,9 @@ async function runArgv(
   }
   if (name === SB.SOURCE || name === SB.DOT) {
     const target = operands[0] ?? ''
-    const sourceArgs = operands.slice(1).map((o) => (o instanceof PathSpec ? o.virtual : o))
+    // Positional parameters keep the words as typed, so a path operand
+    // contributes its spelling, not its resolved mount path.
+    const sourceArgs = operands.slice(1).map((o) => wordText(o))
     return handleSource(dispatch, executeFn, target, session, sourceArgs)
   }
   if (name === SB.RETURN) {

--- a/typescript/packages/core/src/workspace/node/command_dispatch.ts
+++ b/typescript/packages/core/src/workspace/node/command_dispatch.ts
@@ -556,14 +556,15 @@ async function runArgv(
   if (name === SB.ECHO) {
     return handleEcho(args)
   }
-  if (name === SB.PRINTF) return handlePrintf(args)
+  if (name === SB.PRINTF) return handlePrintf(args, session)
   if (name === SB.SLEEP) return handleSleep(args, signal)
   if (name === SB.READ) {
     return handleRead(args, session, stdin)
   }
   if (name === SB.SOURCE || name === SB.DOT) {
     const target = operands[0] ?? ''
-    return handleSource(dispatch, executeFn, target, session)
+    const sourceArgs = operands.slice(1).map((o) => (o instanceof PathSpec ? o.virtual : o))
+    return handleSource(dispatch, executeFn, target, session, sourceArgs)
   }
   if (name === SB.RETURN) {
     return handleReturn(args, session, callStack)

--- a/typescript/packages/core/src/workspace/node/execute_node.ts
+++ b/typescript/packages/core/src/workspace/node/execute_node.ts
@@ -41,7 +41,14 @@ import { NodeKind, nodeKind } from '../../shell/node_kind.ts'
 import { expandRedirects } from '../expand/redirects.ts'
 import { type ExecuteFn, expandArith, expandNode } from '../expand/node.ts'
 import { evaluateArith } from '../../shell/arith.ts'
-import { arrayAppend, arrayExtent, arrayGet, arraySet, makeArray } from '../../shell/array.ts'
+import {
+  type ShellArray,
+  arrayAppend,
+  arrayExtent,
+  arrayGet,
+  arraySet,
+  makeArray,
+} from '../../shell/array.ts'
 import { ArithError, ExitSignal } from '../../shell/errors.ts'
 import { expandAndClassify } from '../expand/parts.ts'
 import { arrayIndex, type TSNodeLike } from '../expand/variable.ts'
@@ -61,6 +68,7 @@ import {
   handleReadonly,
   handleTest,
   handleUnset,
+  noteLocalArray,
 } from '../executor/builtins/index.ts'
 import { handleConnection, handlePipe, handleSubshell } from '../executor/pipes.ts'
 import { handleRedirect } from '../executor/redirect.ts'
@@ -478,7 +486,9 @@ export async function executeNode(
   if (kind === NodeKind.DECLARATION) {
     const keyword = getDeclarationKeyword(node)
     const assignments: string[] = []
-    const arrayNames: string[] = []
+    // Array literals are staged, not stored: `readonly -a a=(y)` on an
+    // already-readonly name has to fail with the old value intact.
+    const staged: { name: string; append: boolean; items: string[] }[] = []
     const flagChars = new Set<string>()
     for (const child of node.namedChildren) {
       if (child.type === NT.VARIABLE_ASSIGNMENT) {
@@ -488,10 +498,12 @@ export async function executeNode(
           const text = getText(child)
           const eq = text.indexOf('=')
           const key = eq >= 0 ? text.slice(0, eq) : text
-          session.arrays[key] = makeArray(
-            await expandArrayItems(firstVal, session, executeFn, registry, callStack),
-          )
-          arrayNames.push(key.endsWith('+') ? key.slice(0, -1) : key)
+          const append = key.endsWith('+')
+          staged.push({
+            name: append ? key.slice(0, -1) : key,
+            append,
+            items: await expandArrayItems(firstVal, session, executeFn, registry, callStack),
+          })
           continue
         }
         assignments.push(await expandNode(child, session, executeFn, callStack))
@@ -513,16 +525,56 @@ export async function executeNode(
         }
       }
     }
+    const arrayNames = staged.map((entry) => entry.name)
+    const isReadonly = keyword === 'readonly' || flagChars.has('r')
+    for (const name of arrayNames) {
+      if (isReadonly && session.readonlyVars.has(name)) {
+        const err = new TextEncoder().encode(`bash: ${name}: readonly variable\n`)
+        return [
+          null,
+          new IOResult({ exitCode: 1, stderr: err }),
+          new ExecutionNode({ command: keyword, exitCode: 1, stderr: err }),
+        ]
+      }
+    }
+    for (const { name, append, items } of staged) {
+      noteLocalArray(session, name)
+      let base: ShellArray
+      if (append) {
+        const existing = session.arrays[name]
+        if (existing === undefined) {
+          const scalar = session.env[name]
+          base = scalar === undefined ? [] : [scalar]
+        } else {
+          base = existing
+        }
+        arrayAppend(base, items)
+      } else {
+        base = makeArray(items)
+      }
+      session.arrays[name] = base
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete session.env[name]
+    }
     if (flagChars.has('a')) {
       // `declare -a NAME` with no value declares an empty array, so
       // ${#NAME[@]} is 0 and NAME[3]=x leaves index 0 unassigned.
       for (const bare of assignments) {
-        if (!bare.includes('=') && !Object.hasOwn(session.arrays, bare)) {
+        if (bare.includes('=')) continue
+        if (noteLocalArray(session, bare)) {
+          // Inside a function this shadows whatever the caller had with a
+          // fresh empty array.
           session.arrays[bare] = []
+        } else if (!Object.hasOwn(session.arrays, bare)) {
+          // At top level an existing scalar becomes element 0.
+          const scalar = session.env[bare]
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete session.env[bare]
+          session.arrays[bare] = scalar === undefined ? [] : [scalar]
         }
       }
     }
-    if (keyword === 'readonly' || flagChars.has('r')) {
+    if (isReadonly) {
       // An array assignment stores itself above, but the name still has
       // to be marked readonly.
       return handleReadonly([...assignments, ...arrayNames], session)

--- a/typescript/packages/core/src/workspace/node/execute_node.ts
+++ b/typescript/packages/core/src/workspace/node/execute_node.ts
@@ -477,6 +477,7 @@ export async function executeNode(
   if (kind === NodeKind.DECLARATION) {
     const keyword = getDeclarationKeyword(node)
     const assignments: string[] = []
+    const arrayNames: string[] = []
     const flagChars = new Set<string>()
     for (const child of node.namedChildren) {
       if (child.type === NT.VARIABLE_ASSIGNMENT) {
@@ -493,6 +494,7 @@ export async function executeNode(
             registry,
             callStack,
           )
+          arrayNames.push(key.endsWith('+') ? key.slice(0, -1) : key)
           continue
         }
         assignments.push(await expandNode(child, session, executeFn, callStack))
@@ -500,7 +502,10 @@ export async function executeNode(
         child.type === NT.SIMPLE_EXPANSION ||
         child.type === NT.EXPANSION ||
         child.type === NT.CONCATENATION ||
-        child.type === NT.WORD
+        child.type === NT.WORD ||
+        // A bare `readonly NAME` / `export NAME` operand parses as a
+        // variable_name, not a word.
+        child.type === NT.VARIABLE_NAME
       ) {
         const expanded = await expandNode(child, session, executeFn, callStack)
         if (expanded === '') continue
@@ -512,7 +517,9 @@ export async function executeNode(
       }
     }
     if (keyword === 'readonly' || flagChars.has('r')) {
-      return handleReadonly(assignments, session)
+      // An array assignment stores itself above, but the name still has
+      // to be marked readonly.
+      return handleReadonly([...assignments, ...arrayNames], session)
     }
     // declare/typeset scope like `local` inside a function (bash
     // semantics) and assign globally at top level, which is exactly

--- a/typescript/packages/core/src/workspace/node/execute_node.ts
+++ b/typescript/packages/core/src/workspace/node/execute_node.ts
@@ -32,7 +32,7 @@ import {
   getPipelineCommands,
   getRedirects,
   getText,
-  getUnsetNames,
+  getUnsetArgs,
   getWhileParts,
 } from '../../shell/helpers.ts'
 import { JobTable } from '../../shell/job_table.ts'
@@ -524,7 +524,7 @@ export async function executeNode(
   }
 
   if (kind === NodeKind.UNSET) {
-    return handleUnset(getUnsetNames(node), session)
+    return handleUnset(getUnsetArgs(node), session)
   }
 
   if (kind === NodeKind.TEST) {

--- a/typescript/packages/core/src/workspace/node/execute_node.ts
+++ b/typescript/packages/core/src/workspace/node/execute_node.ts
@@ -41,6 +41,7 @@ import { NodeKind, nodeKind } from '../../shell/node_kind.ts'
 import { expandRedirects } from '../expand/redirects.ts'
 import { type ExecuteFn, expandArith, expandNode } from '../expand/node.ts'
 import { evaluateArith } from '../../shell/arith.ts'
+import { arrayAppend, arrayExtent, arrayGet, arraySet, makeArray } from '../../shell/array.ts'
 import { ArithError, ExitSignal } from '../../shell/errors.ts'
 import { expandAndClassify } from '../expand/parts.ts'
 import { arrayIndex, type TSNodeLike } from '../expand/variable.ts'
@@ -487,12 +488,8 @@ export async function executeNode(
           const text = getText(child)
           const eq = text.indexOf('=')
           const key = eq >= 0 ? text.slice(0, eq) : text
-          session.arrays[key] = await expandArrayItems(
-            firstVal,
-            session,
-            executeFn,
-            registry,
-            callStack,
+          session.arrays[key] = makeArray(
+            await expandArrayItems(firstVal, session, executeFn, registry, callStack),
           )
           arrayNames.push(key.endsWith('+') ? key.slice(0, -1) : key)
           continue
@@ -513,6 +510,15 @@ export async function executeNode(
           for (const ch of expanded.slice(1)) flagChars.add(ch)
         } else {
           assignments.push(expanded)
+        }
+      }
+    }
+    if (flagChars.has('a')) {
+      // `declare -a NAME` with no value declares an empty array, so
+      // ${#NAME[@]} is 0 and NAME[3]=x leaves index 0 unassigned.
+      for (const bare of assignments) {
+        if (!bare.includes('=') && !Object.hasOwn(session.arrays, bare)) {
+          session.arrays[bare] = []
         }
       }
     }
@@ -590,11 +596,14 @@ export async function executeNode(
           const scalar = session.env[key]
           // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
           delete session.env[key]
-          base = scalar !== undefined && scalar !== '' ? [scalar] : []
+          base = scalar === undefined ? [] : [scalar]
         }
-        session.arrays[key] = [...base, ...items]
+        // `arr+=(...)` starts at the extent, so it fills the hole a
+        // trailing `unset arr[last]` left but skips interior ones.
+        arrayAppend(base, items)
+        session.arrays[key] = base
       } else {
-        session.arrays[key] = items
+        session.arrays[key] = makeArray(items)
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete session.env[key]
       }
@@ -617,10 +626,10 @@ export async function executeNode(
         const scalar = session.env[key]
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete session.env[key]
-        arr = scalar !== undefined && scalar !== '' ? [scalar] : []
+        arr = scalar === undefined ? [] : [scalar]
       }
       let idx = arrayIndex(idxText, session.env)
-      if (idx < 0) idx += arr.length
+      if (idx < 0) idx += arrayExtent(arr)
       if (idx < 0) {
         // bash aborts the whole line on a bad assignment subscript
         // (status 1); containment mirrors ${var:?}.
@@ -632,17 +641,14 @@ export async function executeNode(
           1,
         )
       }
-      while (arr.length <= idx) arr.push('')
-      arr.splice(idx, 1, append ? (arr[idx] ?? '') + val : val)
+      arraySet(arr, idx, append ? arrayGet(arr, idx) + val : val)
       session.arrays[key] = arr
       return [null, new IOResult(), new ExecutionNode({ command: text, exitCode: 0 })]
     }
     if (append) {
       const arr = session.arrays[key]
-      if (arr !== undefined && arr.length > 0) {
-        arr[0] = (arr[0] ?? '') + val
-      } else if (arr !== undefined) {
-        arr.push(val)
+      if (arr !== undefined) {
+        arraySet(arr, 0, arrayGet(arr, 0) + val)
       } else {
         session.env[key] = (session.env[key] ?? '') + val
       }

--- a/typescript/packages/core/src/workspace/session/session.ts
+++ b/typescript/packages/core/src/workspace/session/session.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { AsyncLineIterator } from '../../io/async_line_iterator.ts'
+import type { ShellArray } from '../../shell/array.ts'
 import type { MountMode } from '../../types.ts'
 
 /**
@@ -51,7 +52,7 @@ export interface SessionInit {
   positionalArgs?: string[]
   shellOptions?: Record<string, boolean>
   readonlyVars?: Set<string>
-  arrays?: Record<string, string[]>
+  arrays?: Record<string, ShellArray>
   /**
    * Per-mount mode caps for this session. `null` (the default) means
    * no restriction: every mount in the workspace is reachable at its own
@@ -77,7 +78,7 @@ export class Session {
   positionalArgs: string[]
   shellOptions: Record<string, boolean>
   readonlyVars: Set<string>
-  arrays: Record<string, string[]>
+  arrays: Record<string, ShellArray>
   // Transient `set -e` marker: true when the failure just returned
   // came from a short-circuited &&/|| branch or a `!`-negated command,
   // which bash exempts from errexit. Reset on every node execution.

--- a/typescript/packages/core/src/workspace/session/session.ts
+++ b/typescript/packages/core/src/workspace/session/session.ts
@@ -15,6 +15,32 @@
 import type { AsyncLineIterator } from '../../io/async_line_iterator.ts'
 import type { MountMode } from '../../types.ts'
 
+/**
+ * Read one entry of a session record, ignoring anything inherited from
+ * `Object.prototype`. Shell names are script-controlled, so a plain
+ * `record[name]` lookup would hand back `Object.prototype` (or one of
+ * its methods) for a name like `__proto__` or `toString`; Python's dicts
+ * have no such shadow, so this guard is the TypeScript side only.
+ */
+export function sessionEntry<T>(record: Record<string, T>, name: string): T | undefined {
+  return Object.hasOwn(record, name) ? record[name] : undefined
+}
+
+/**
+ * Write one entry of a session record as an own property. A plain
+ * `record[name] = value` on the name `__proto__` runs the inherited
+ * setter instead: it silently drops a string value and rewrites the
+ * record's prototype for an array one.
+ */
+export function setSessionEntry<T>(record: Record<string, T>, name: string, value: T): void {
+  Object.defineProperty(record, name, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  })
+}
+
 export interface SessionInit {
   sessionId: string
   cwd?: string

--- a/typescript/packages/core/src/workspace/session/session.ts
+++ b/typescript/packages/core/src/workspace/session/session.ts
@@ -89,6 +89,9 @@ export class Session {
   stdinBuffer: AsyncLineIterator | null = null
   stdinSource: unknown = null
   localVars: Map<string, string | null> | null = null
+  // Arrays shadowed by `local -a` / `declare -a` in the running
+  // function; null means the caller had no array of that name.
+  localArrays: Map<string, ShellArray | null> | null = null
   // Hidden `getopts` state: the char offset within the word being
   // scanned (0 = positioned at the word's leading dash), plus the OPTIND
   // that offset belongs to. A caller resetting OPTIND makes the seen

--- a/typescript/packages/core/src/workspace/shell_arrays.test.ts
+++ b/typescript/packages/core/src/workspace/shell_arrays.test.ts
@@ -50,6 +50,26 @@ const CASES: [string, string][] = [
   ['a=(w x y z); printf "<%s>" "p${a[@]:1:2}s"; echo', '<px><ys>\n'],
   ['a=(cat car cow); printf "<%s>" "${a[@]/c/K}"; echo', '<Kat><Kar><Kow>\n'],
   ['a=(w x y z); printf "<%s>" "${!a[@]}"; echo', '<0><1><2><3>\n'],
+  // Sparse arrays: `unset a[i]` leaves a hole and `a[9]=v` skips one, so
+  // the later indices hold still while ${a[@]}/${#a[@]}/${!a[@]} see only
+  // the assigned elements. Pinned against GNU bash 5.2.
+  [
+    'a=(zero one two); unset "a[1]"; echo "${#a[@]} [${a[@]}] [${!a[@]}] [${a[*]}]"',
+    '2 [zero two] [0 2] [zero two]\n',
+  ],
+  ['a=(zero one two); unset "a[1]"; echo "[${a[0]}][${a[1]}][${a[2]}]"', '[zero][][two]\n'],
+  ['a=(); a[9]=v; echo "${#a[@]} [${a[@]}] [${!a[@]}] [${a[-1]}]"', '1 [v] [9] [v]\n'],
+  ['a=(x y z); unset "a[1]"; echo "[${a[-1]}] [${a[-2]}] [${a[-3]}]"', '[z] [] [x]\n'],
+  ['a=(a b c d); unset "a[1]"; echo "[${a[@]:1:2}]"', '[c d]\n'],
+  ['a=(a b c d); unset "a[1]"; echo "[${a[@]^^}]"', '[A C D]\n'],
+  ['a=(x y z); unset "a[1]"; echo "${a[@]/x/Q}"', 'Q z\n'],
+  ['a=(x y z); unset "a[1]"; a+=(w); echo "[${!a[@]}] [${a[@]}]"', '[0 2 3] [x z w]\n'],
+  ['a=(x y z); unset "a[2]"; a+=(w); echo "[${!a[@]}] [${a[@]}]"', '[0 1 2] [x y w]\n'],
+  ['a=(x y z); unset "a[1]"; echo "${#a[1]} ${#a[2]}"', '0 1\n'],
+  ['a=(x y z); unset "a[1]"; for v in "${a[@]}"; do echo "v=[$v]"; done', 'v=[x]\nv=[z]\n'],
+  ['a=(x y z); unset "a[0]"; echo "[$a]"', '[]\n'],
+  ['a=(x y z); unset "a[1]"; a[1]=NEW; echo "[${!a[@]}] [${a[@]}]"', '[0 1 2] [x NEW z]\n'],
+  ['declare -a e; e[3]=x; e[1]=y; echo "${#e[@]} [${!e[@]}] [${e[@]}]"', '2 [1 3] [y x]\n'],
 ]
 
 describe('shell arrays', () => {

--- a/typescript/packages/core/src/workspace/shell_arrays.test.ts
+++ b/typescript/packages/core/src/workspace/shell_arrays.test.ts
@@ -70,6 +70,11 @@ const CASES: [string, string][] = [
   ['a=(x y z); unset "a[0]"; echo "[$a]"', '[]\n'],
   ['a=(x y z); unset "a[1]"; a[1]=NEW; echo "[${!a[@]}] [${a[@]}]"', '[0 1 2] [x NEW z]\n'],
   ['declare -a e; e[3]=x; e[1]=y; echo "${#e[@]} [${!e[@]}] [${e[@]}]"', '2 [1 3] [y x]\n'],
+  // A scalar is element 0 of a one-element array, even when empty; an
+  // unset name has no elements at all.
+  ['Z=""; echo "${#Z[@]} [${Z[@]}] [${!Z[@]}]"', '1 [] [0]\n'],
+  ['Y=v; echo "${#Y[@]} [${!Y[@]}]"', '1 [0]\n'],
+  ['unset Q; echo "${#Q[@]} [${!Q[@]}]"', '0 []\n'],
 ]
 
 describe('shell arrays', () => {

--- a/typescript/packages/core/src/workspace/shell_arrays.test.ts
+++ b/typescript/packages/core/src/workspace/shell_arrays.test.ts
@@ -75,6 +75,47 @@ const CASES: [string, string][] = [
   ['Z=""; echo "${#Z[@]} [${Z[@]}] [${!Z[@]}]"', '1 [] [0]\n'],
   ['Y=v; echo "${#Y[@]} [${!Y[@]}]"', '1 [0]\n'],
   ['unset Q; echo "${#Q[@]} [${!Q[@]}]"', '0 []\n'],
+  // Slicing an indexed array works on subscripts, not on position among
+  // the assigned values, and a negative offset counts from the extent.
+  // Pinned against GNU bash 5.2.
+  ['a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]:2}]"', '[d j]\n'],
+  ['a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]:0}]"', '[b d j]\n'],
+  ['a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]:2:1}]"', '[d]\n'],
+  ['a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]:4}]"', '[j]\n'],
+  ['a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]:0:2}]"', '[b d]\n'],
+  ['a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]: -1}]"', '[j]\n'],
+  ['a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]: -3}]"', '[j]\n'],
+  ['a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]: -20}]"', '[]\n'],
+  ['a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[@]:20}]"', '[]\n'],
+  ['a=(); a[1]=b; a[3]=d; a[9]=j; echo "[${a[*]:2}]"', '[d j]\n'],
+  ['a=(x y z w); unset "a[1]"; echo "[${a[@]:1}]"', '[z w]\n'],
+  ['a=(x y z); echo "[${a[@]: -5}]"', '[]\n'],
+  ['a=(x y z); echo "[${a[@]: -2}]"', '[y z]\n'],
+  // `declare -a` / `local -a` are local to a function and shadow the
+  // caller's array with a fresh empty one.
+  ['f(){ declare -a leak; leak[2]=x; }; f; echo "[${leak[@]}] ${#leak[@]}"', '[] 0\n'],
+  [
+    'g=(outer); f(){ declare -a g; g[0]=inner; echo "in=${g[@]}"; }; f; echo "out=${g[@]}"',
+    'in=inner\nout=outer\n',
+  ],
+  ['f(){ local -a l=(a b); echo "in=${l[@]}"; }; f; echo "out=[${l[@]}]"', 'in=a b\nout=[]\n'],
+  [
+    'm=(keep); f(){ local -a m; m[1]=x; echo "in=${!m[@]}"; }; f; echo "out=${m[@]}"',
+    'in=1\nout=keep\n',
+  ],
+  ['n=(outer); f(){ declare -a n=(inner); }; f; echo "out=${n[@]}"', 'out=outer\n'],
+  [
+    'x=foo; f(){ declare -a x; echo "in=[${x[@]}] ${#x[@]}"; }; f; echo "out=$x"',
+    'in=[] 0\nout=foo\n',
+  ],
+  // At top level `declare -a` keeps an existing array and migrates an
+  // existing scalar to element 0.
+  ['x=foo; declare -a x; echo "${#x[@]} [${!x[@]}] [${x[0]}]"', '1 [0] [foo]\n'],
+  ['x=""; declare -a x; echo "${#x[@]} [${!x[@]}]"', '1 [0]\n'],
+  ['unset x; declare -a x; echo "${#x[@]}"', '0\n'],
+  ['a=(1 2 3); declare -a a; echo "[${a[@]}]"', '[1 2 3]\n'],
+  ['a=(x); declare -a a+=(y); echo "[${a[@]}]"', '[x y]\n'],
+  ['b=(p); declare b+=(q); echo "[${b[@]}]"', '[p q]\n'],
 ]
 
 describe('shell arrays', () => {


### PR DESCRIPTION
## Summary

Fixes the four **#608 Tier 2** items that produced *wrong output today* rather than a missing feature — the silent-lie bugs surfaced by the fit audit on the issue. All are pure language/session semantics with **no job-table involvement**, so they don't touch the in-flight job-console PR (#611).

| Item | Before | After |
|---|---|---|
| `case ;&` / `;;&` | stopped at the first arm (`one`) | `;&` falls through to the next body; `;;&` keeps testing later patterns |
| `printf -v NAME` | printed `-v` literally | assigns the formatted text to `NAME` (scalar) or `NAME[idx]` (array element); keeps GNU's exit-1-still-assigns on a bad number |
| `source`/`.` positional args | `$1` empty | sets `$1..$#` for the sourced script, restores the parent's after; no-arg form keeps the parent's params |
| `unset -f` | function still callable | `-f` unsets a function only, `-v` a variable only, bare name prefers a variable then falls back to a function; plus whole-array and `arr[i]` element unset |

`unset -n` is a documented no-op: mirage has no nameref attribute, so it matches bash on a non-nameref name (leaves it untouched).

## Implementation

- **case**: `get_case_items`/`getCaseItems` now capture the terminator (`;;`/`;&`/`;;&`) as a third tuple element; `handle_case`/`handleCase` run a fallthrough loop over it. Both consumers (`execute_node`, `provision_node`) updated.
- **printf -v**: `session` threaded into `handle_printf`/`handlePrintf`; a shared name/subscript target parser assigns scalars and array elements, reusing `_array_index`/`arrayIndex`.
- **source args**: `handle_source`/`handleSource` save/set/restore `positional_args` when args are given; the dispatch passes the operand tail.
- **unset**: rewritten flag parse (`-v`/`-f`/`-n`) with function/array/element handling and the bare-name variable-then-function fallback. `get_unset_names` → `get_unset_args` (operand span + shell-split, which dequotes and keeps `arr[1]` a single word on both dispatch paths).

## Divergence

A trailing `;&`/`;;&` **immediately before `esac`** does not parse in tree-sitter-bash (same on `main`). Since that spelling is a no-op difference from `;;` — no next arm to fall into, no remaining patterns — the loud rejection is acceptable.

## Validation

- GNU bash 5.2 pinned in Docker for every case.
- Python `tests/shell` + `tests/workspace` green; TS core **4935 tests** + `tsc` clean.
- `pre-commit run --all-files` clean (mypy, eslint, knip, prettier).
- 11 new integ cases under `bash/{case,printf,source,builtin}`; the shared battery runs **1834 passed / 0 failed on both the Python and TS hosts**.

Each new unit test was confirmed to fail on the unfixed code first.

Refs #608