### PR TITLE
fix(stat): apply the namespace attr overlay in the bespoke opfs/s3/gridfs stat commands (py+ts)

### DIFF
--- a/integ/unix/meta_overlay/cleanup.json
+++ b/integ/unix/meta_overlay/cleanup.json
@@ -2,7 +2,7 @@
   "cases": [
     {
       "id": "ometa_cleanup",
-      "seq": 201015,
+      "seq": 201018,
       "targets": [
         "opfs",
         "s3",

--- a/integ/unix/meta_overlay/stat.json
+++ b/integ/unix/meta_overlay/stat.json
@@ -1,0 +1,58 @@
+{
+  "cases": [
+    {
+      "id": "ometa_stat_c_mtime",
+      "seq": 201016,
+      "targets": [
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "box"
+      ],
+      "command": "touch -t 202401010000 /data/metao/sc.txt && stat -c \"%y|%Y\" /data/metao/sc.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "2024-01-01T00:00:00Z|1704067200\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "ometa_stat_c_mode",
+      "seq": 201017,
+      "targets": [
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "box"
+      ],
+      "command": "chmod 640 /data/metao/sc.txt && stat -c \"%a|%A\" /data/metao/sc.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "640|-rw-r-----\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/python/mirage/commands/builtin/gridfs/stat.py
+++ b/python/mirage/commands/builtin/gridfs/stat.py
@@ -12,16 +12,20 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.gridfs import GridFSAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.stat import stat as generic_stat
-from mirage.commands.builtin.generic_bind.adapter import bound_op
+from mirage.commands.builtin.generic_bind.adapter import (bound_op,
+                                                          overlaid_stat)
 from mirage.commands.builtin.generic_bind.provision import metadata_provision
 from mirage.commands.builtin.gridfs.io import resolve_glob
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.gridfs.stat import stat as stat_core
 from mirage.io.types import ByteSource, IOResult
+from mirage.ops.config import StatOverlay
 from mirage.types import PathSpec
 
 
@@ -37,12 +41,16 @@ async def stat(
     c: str | None = None,
     f: str | None = None,
     index: IndexCacheStore,
+    stat_overlay: StatOverlay | None = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     if not paths:
         raise ValueError("stat: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    return await generic_stat(paths,
-                              stat_fn=bound_op(stat_core, accessor, index),
-                              c=c,
-                              f=f)
+    stat_fn = bound_op(stat_core, accessor, index)
+    if stat_overlay is not None:
+        stat_fn = partial(overlaid_stat,
+                          partial(stat_core, accessor),
+                          stat_overlay,
+                          index=index)
+    return await generic_stat(paths, stat_fn=stat_fn, c=c, f=f)

--- a/python/mirage/commands/builtin/s3/stat.py
+++ b/python/mirage/commands/builtin/s3/stat.py
@@ -12,16 +12,20 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from functools import partial
+
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.stat import stat as generic_stat
-from mirage.commands.builtin.generic_bind.adapter import bound_op
+from mirage.commands.builtin.generic_bind.adapter import (bound_op,
+                                                          overlaid_stat)
 from mirage.commands.builtin.generic_bind.provision import metadata_provision
 from mirage.commands.builtin.s3.io import resolve_glob
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
 from mirage.core.s3.stat import stat as stat_core
 from mirage.io.types import ByteSource, IOResult
+from mirage.ops.config import StatOverlay
 from mirage.types import PathSpec
 
 
@@ -37,12 +41,16 @@ async def stat(
     c: str | None = None,
     f: str | None = None,
     index: IndexCacheStore,
+    stat_overlay: StatOverlay | None = None,
     **_extra: object,
 ) -> tuple[ByteSource | None, IOResult]:
     if not paths:
         raise ValueError("stat: missing operand")
     paths = await resolve_glob(accessor, paths, index)
-    return await generic_stat(paths,
-                              stat_fn=bound_op(stat_core, accessor, index),
-                              c=c,
-                              f=f)
+    stat_fn = bound_op(stat_core, accessor, index)
+    if stat_overlay is not None:
+        stat_fn = partial(overlaid_stat,
+                          partial(stat_core, accessor),
+                          stat_overlay,
+                          index=index)
+    return await generic_stat(paths, stat_fn=stat_fn, c=c, f=f)

--- a/python/tests/commands/builtin/gridfs/test_stat.py
+++ b/python/tests/commands/builtin/gridfs/test_stat.py
@@ -3,9 +3,10 @@ from typing import cast
 import pytest
 
 from mirage.accessor.gridfs import GridFSAccessor
-from mirage.cache.index import NULL_INDEX
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.commands.builtin.gridfs.stat import stat
 from mirage.io.types import materialize
+from mirage.ops.config import StatOverlay
 from mirage.types import FileStat, FileType, PathSpec
 
 _BACKEND_MTIME = "2020-05-05T05:05:05Z"
@@ -20,14 +21,14 @@ def _backend_stat() -> FileStat:
                     type=FileType.TEXT)
 
 
-async def _fake_stat_core(_accessor: object,
+async def _fake_stat_core(_accessor: GridFSAccessor,
                           _path: PathSpec,
-                          index: object = None) -> FileStat:
+                          index: IndexCacheStore = NULL_INDEX) -> FileStat:
     return _backend_stat()
 
 
-async def _fake_resolve_glob(_accessor: object, paths: list[PathSpec],
-                             _index: object) -> list[PathSpec]:
+async def _fake_resolve_glob(_accessor: GridFSAccessor, paths: list[PathSpec],
+                             _index: IndexCacheStore) -> list[PathSpec]:
     return paths
 
 
@@ -42,12 +43,13 @@ def patched_backend(monkeypatch):
     monkeypatch.setitem(globals_, "resolve_glob", _fake_resolve_glob)
 
 
-async def _render(fmt: str, **kw: object) -> tuple[int, str]:
+async def _render(fmt: str,
+                  stat_overlay: StatOverlay | None = None) -> tuple[int, str]:
     out, io = await stat(cast(GridFSAccessor, object()),
                          [PathSpec.from_str_path("/gridfs/f.txt")],
                          c=fmt,
                          index=NULL_INDEX,
-                         **kw)
+                         stat_overlay=stat_overlay)
     return io.exit_code, (await materialize(out)).decode()
 
 

--- a/python/tests/commands/builtin/gridfs/test_stat.py
+++ b/python/tests/commands/builtin/gridfs/test_stat.py
@@ -1,0 +1,68 @@
+from typing import cast
+
+import pytest
+
+from mirage.accessor.gridfs import GridFSAccessor
+from mirage.cache.index import NULL_INDEX
+from mirage.commands.builtin.gridfs.stat import stat
+from mirage.io.types import materialize
+from mirage.types import FileStat, FileType, PathSpec
+
+_BACKEND_MTIME = "2020-05-05T05:05:05Z"
+_OVERLAY_MTIME = "2024-01-01T00:00:00Z"
+
+
+def _backend_stat() -> FileStat:
+    return FileStat(name="f.txt",
+                    size=6,
+                    modified=_BACKEND_MTIME,
+                    mode=0o644,
+                    type=FileType.TEXT)
+
+
+async def _fake_stat_core(_accessor: object,
+                          _path: PathSpec,
+                          index: object = None) -> FileStat:
+    return _backend_stat()
+
+
+async def _fake_resolve_glob(_accessor: object, paths: list[PathSpec],
+                             _index: object) -> list[PathSpec]:
+    return paths
+
+
+def _overlay(_virtual: str, st: FileStat) -> FileStat:
+    return st.model_copy(update={"mode": 0o600, "modified": _OVERLAY_MTIME})
+
+
+@pytest.fixture
+def patched_backend(monkeypatch):
+    globals_ = stat.__wrapped__.__globals__
+    monkeypatch.setitem(globals_, "stat_core", _fake_stat_core)
+    monkeypatch.setitem(globals_, "resolve_glob", _fake_resolve_glob)
+
+
+async def _render(fmt: str, **kw: object) -> tuple[int, str]:
+    out, io = await stat(cast(GridFSAccessor, object()),
+                         [PathSpec.from_str_path("/gridfs/f.txt")],
+                         c=fmt,
+                         index=NULL_INDEX,
+                         **kw)
+    return io.exit_code, (await materialize(out)).decode()
+
+
+@pytest.mark.asyncio
+async def test_stat_c_applies_namespace_overlay(patched_backend):
+    """GridFS registers no setattr op, so chmod/touch state lives only in the
+    namespace overlay; the bespoke stat command must merge it in, like the
+    generic_bind builder does, or stat -c disagrees with ls -l."""
+    code, out = await _render("%a|%y", stat_overlay=_overlay)
+    assert code == 0
+    assert out == f"600|{_OVERLAY_MTIME}\n"
+
+
+@pytest.mark.asyncio
+async def test_stat_c_without_overlay_reports_backend_values(patched_backend):
+    code, out = await _render("%a|%y")
+    assert code == 0
+    assert out == f"644|{_BACKEND_MTIME}\n"

--- a/python/tests/commands/builtin/s3/test_stat.py
+++ b/python/tests/commands/builtin/s3/test_stat.py
@@ -3,9 +3,10 @@ from typing import cast
 import pytest
 
 from mirage.accessor.s3 import S3Accessor
-from mirage.cache.index import NULL_INDEX
+from mirage.cache.index import NULL_INDEX, IndexCacheStore
 from mirage.commands.builtin.s3.stat import stat
 from mirage.io.types import materialize
+from mirage.ops.config import StatOverlay
 from mirage.types import FileStat, FileType, PathSpec
 
 _BACKEND_MTIME = "2020-05-05T05:05:05Z"
@@ -20,14 +21,14 @@ def _backend_stat() -> FileStat:
                     type=FileType.TEXT)
 
 
-async def _fake_stat_core(_accessor: object,
+async def _fake_stat_core(_accessor: S3Accessor,
                           _path: PathSpec,
-                          index: object = None) -> FileStat:
+                          index: IndexCacheStore = NULL_INDEX) -> FileStat:
     return _backend_stat()
 
 
-async def _fake_resolve_glob(_accessor: object, paths: list[PathSpec],
-                             _index: object) -> list[PathSpec]:
+async def _fake_resolve_glob(_accessor: S3Accessor, paths: list[PathSpec],
+                             _index: IndexCacheStore) -> list[PathSpec]:
     return paths
 
 
@@ -42,12 +43,13 @@ def patched_backend(monkeypatch):
     monkeypatch.setitem(globals_, "resolve_glob", _fake_resolve_glob)
 
 
-async def _render(fmt: str, **kw: object) -> tuple[int, str]:
+async def _render(fmt: str,
+                  stat_overlay: StatOverlay | None = None) -> tuple[int, str]:
     out, io = await stat(cast(S3Accessor, object()),
                          [PathSpec.from_str_path("/s3/f.txt")],
                          c=fmt,
                          index=NULL_INDEX,
-                         **kw)
+                         stat_overlay=stat_overlay)
     return io.exit_code, (await materialize(out)).decode()
 
 

--- a/python/tests/commands/builtin/s3/test_stat.py
+++ b/python/tests/commands/builtin/s3/test_stat.py
@@ -1,0 +1,68 @@
+from typing import cast
+
+import pytest
+
+from mirage.accessor.s3 import S3Accessor
+from mirage.cache.index import NULL_INDEX
+from mirage.commands.builtin.s3.stat import stat
+from mirage.io.types import materialize
+from mirage.types import FileStat, FileType, PathSpec
+
+_BACKEND_MTIME = "2020-05-05T05:05:05Z"
+_OVERLAY_MTIME = "2024-01-01T00:00:00Z"
+
+
+def _backend_stat() -> FileStat:
+    return FileStat(name="f.txt",
+                    size=6,
+                    modified=_BACKEND_MTIME,
+                    mode=0o644,
+                    type=FileType.TEXT)
+
+
+async def _fake_stat_core(_accessor: object,
+                          _path: PathSpec,
+                          index: object = None) -> FileStat:
+    return _backend_stat()
+
+
+async def _fake_resolve_glob(_accessor: object, paths: list[PathSpec],
+                             _index: object) -> list[PathSpec]:
+    return paths
+
+
+def _overlay(_virtual: str, st: FileStat) -> FileStat:
+    return st.model_copy(update={"mode": 0o600, "modified": _OVERLAY_MTIME})
+
+
+@pytest.fixture
+def patched_backend(monkeypatch):
+    globals_ = stat.__wrapped__.__globals__
+    monkeypatch.setitem(globals_, "stat_core", _fake_stat_core)
+    monkeypatch.setitem(globals_, "resolve_glob", _fake_resolve_glob)
+
+
+async def _render(fmt: str, **kw: object) -> tuple[int, str]:
+    out, io = await stat(cast(S3Accessor, object()),
+                         [PathSpec.from_str_path("/s3/f.txt")],
+                         c=fmt,
+                         index=NULL_INDEX,
+                         **kw)
+    return io.exit_code, (await materialize(out)).decode()
+
+
+@pytest.mark.asyncio
+async def test_stat_c_applies_namespace_overlay(patched_backend):
+    """S3 registers no setattr op, so chmod/touch state lives only in the
+    namespace overlay; the bespoke stat command must merge it in, like the
+    generic_bind builder does, or stat -c disagrees with ls -l."""
+    code, out = await _render("%a|%y", stat_overlay=_overlay)
+    assert code == 0
+    assert out == f"600|{_OVERLAY_MTIME}\n"
+
+
+@pytest.mark.asyncio
+async def test_stat_c_without_overlay_reports_backend_values(patched_backend):
+    code, out = await _render("%a|%y")
+    assert code == 0
+    assert out == f"644|{_BACKEND_MTIME}\n"

--- a/typescript/packages/browser/src/commands/builtin/opfs/ls/ls.ts
+++ b/typescript/packages/browser/src/commands/builtin/opfs/ls/ls.ts
@@ -12,8 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { ResourceName, command, lsGeneric, specOf } from '@struktoai/mirage-core'
-import type { PathSpec } from '@struktoai/mirage-core'
+import { ResourceName, command, lsGeneric, overlaidStat, specOf } from '@struktoai/mirage-core'
 import { stat as opfsStat } from '../../../../core/opfs/stat.ts'
 import { readdir as opfsReaddir } from '../../../../core/opfs/readdir.ts'
 import type { OPFSAccessor } from '../../../../accessor/opfs.ts'
@@ -22,15 +21,11 @@ export const OPFS_LS = command({
   name: 'ls',
   resource: ResourceName.OPFS,
   spec: specOf('ls'),
-  fn: (accessor: OPFSAccessor, paths, _texts, opts) => {
-    const overlay = opts.statOverlay
-    // ls renders stat rows the backend produces, which never see the
-    // namespace attr overlay (chmod/chown/touch on overlay backends);
-    // merge it in so ls -l matches the ops facade.
-    const stat =
-      overlay !== undefined
-        ? async (p: PathSpec) => overlay(p.virtual, await opfsStat(accessor, p))
-        : (p: PathSpec) => opfsStat(accessor, p)
-    return lsGeneric(paths, opts, (p) => opfsReaddir(accessor, p), stat)
-  },
+  fn: (accessor: OPFSAccessor, paths, _texts, opts) =>
+    lsGeneric(
+      paths,
+      opts,
+      (p) => opfsReaddir(accessor, p),
+      overlaidStat((p) => opfsStat(accessor, p), opts.statOverlay),
+    ),
 })

--- a/typescript/packages/browser/src/commands/builtin/opfs/opfs.test.ts
+++ b/typescript/packages/browser/src/commands/builtin/opfs/opfs.test.ts
@@ -141,3 +141,32 @@ describe('OPFS commands — writers', () => {
     expect(after).toBe('hello from opfs\nappended\n')
   })
 })
+
+// OPFS registers no setattr op, so chmod/touch state lives only in the
+// namespace overlay. stat renders backend stat rows, so without the overlay
+// merge it reports the OPFS write wall-clock and the default mode while ls -l
+// reports the touched/chmod'd values for the same file.
+describe('OPFS commands — namespace attr overlay', () => {
+  it('stat -c reports the touched mtime, not the backend write time', async () => {
+    expect((await run('touch -t 202401010000 /data/hello.txt')).exitCode).toBe(0)
+    const r = await run('stat -c "%y|%Y" /data/hello.txt')
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toBe('2024-01-01T00:00:00Z|1704067200\n')
+  })
+
+  it('stat -c reports the chmod mode', async () => {
+    expect((await run('chmod 640 /data/hello.txt')).exitCode).toBe(0)
+    const r = await run('stat -c "%a|%A" /data/hello.txt')
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toBe('640|-rw-r-----\n')
+  })
+
+  it('stat -c and ls -l agree after chmod and touch', async () => {
+    await run('chmod 640 /data/hello.txt')
+    await run('touch -t 202401010000 /data/hello.txt')
+    const statOut = await run('stat -c "%A" /data/hello.txt')
+    const lsOut = await run('ls -l /data/hello.txt')
+    expect(lsOut.stdout.split(' ')[0]).toBe(statOut.stdout.trim())
+    expect(lsOut.stdout).toContain('Jan  1 00:00')
+  })
+})

--- a/typescript/packages/browser/src/commands/builtin/opfs/stat/stat.ts
+++ b/typescript/packages/browser/src/commands/builtin/opfs/stat/stat.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { ResourceName, command, specOf, statGeneric } from '@struktoai/mirage-core'
+import { ResourceName, command, overlaidStat, specOf, statGeneric } from '@struktoai/mirage-core'
 import { stat as opfsStat } from '../../../../core/opfs/stat.ts'
 import type { OPFSAccessor } from '../../../../accessor/opfs.ts'
 
@@ -21,5 +21,9 @@ export const OPFS_STAT = command({
   resource: ResourceName.OPFS,
   spec: specOf('stat'),
   fn: (accessor: OPFSAccessor, paths, _texts, opts) =>
-    statGeneric(paths, opts, (p) => opfsStat(accessor, p)),
+    statGeneric(
+      paths,
+      opts,
+      overlaidStat((p) => opfsStat(accessor, p), opts.statOverlay),
+    ),
 })

--- a/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/adapter.ts
@@ -14,6 +14,7 @@
 
 import type { Accessor } from '../../../accessor/base.ts'
 import type { IndexCacheStore } from '../../../cache/index/store.ts'
+import type { StatOverlay } from '../../../ops/config.ts'
 import type { FindOptions } from '../../../resource/base.ts'
 import {
   FileType,
@@ -201,6 +202,20 @@ export function dirAwareStat<A extends Accessor>(
     if (st.type === FileType.DIRECTORY) throw eisdir(p)
     return st
   }
+}
+
+// Stat through the backend, then merge the namespace attr overlay, so the
+// stat-rendering commands (ls -l, stat -c) show the chmod/chown/touch state a
+// backend without an attribute slot cannot hold itself. Returns the plain stat
+// unchanged when the executor injected no overlay. Mirrors the Python
+// `overlaid_stat`; every stat-rendering command binds through here so no
+// backend can quietly skip the merge and disagree with the ops facade.
+export function overlaidStat(
+  stat: (p: PathSpec) => Promise<FileStat>,
+  overlay: StatOverlay | undefined,
+): (p: PathSpec) => Promise<FileStat> {
+  if (overlay === undefined) return stat
+  return async (p) => overlay(p.virtual, await stat(p))
 }
 
 async function* streamRefusingDirs<A extends Accessor>(

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/ls.ts
@@ -12,23 +12,19 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { PathSpec } from '../../../../types.ts'
 import { lsGeneric } from '../../generic/ls.ts'
-import { type Builder, resolveGlobOf } from '../adapter.ts'
+import { type Builder, overlaidStat, resolveGlobOf } from '../adapter.ts'
 
 export const LS_BUILDER: Builder = {
   name: 'ls',
   fn: async (ops, accessor, paths, _texts, opts) => {
     const idx = opts.index ?? undefined
     const resolved = paths.length > 0 ? await resolveGlobOf(ops)(accessor, paths, idx) : []
-    const overlay = opts.statOverlay
-    // ls renders stat rows the backend produces, which never see the
-    // namespace attr overlay (chmod/chown/touch on overlay backends);
-    // merge it in so ls -l matches the ops facade.
-    const stat =
-      overlay !== undefined
-        ? async (p: PathSpec) => overlay(p.virtual, await ops.stat(accessor, p, idx))
-        : (p: PathSpec) => ops.stat(accessor, p, idx)
-    return lsGeneric(resolved, opts, (p) => ops.readdir(accessor, p, idx), stat)
+    return lsGeneric(
+      resolved,
+      opts,
+      (p) => ops.readdir(accessor, p, idx),
+      overlaidStat((p) => ops.stat(accessor, p, idx), opts.statOverlay),
+    )
   },
 }

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/stat.ts
@@ -12,23 +12,18 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { PathSpec } from '../../../../types.ts'
 import { statGeneric } from '../../generic/stat.ts'
-import { type Builder, resolveGlobOf } from '../adapter.ts'
+import { type Builder, overlaidStat, resolveGlobOf } from '../adapter.ts'
 
 export const STAT_BUILDER: Builder = {
   name: 'stat',
   fn: async (ops, accessor, paths, _texts, opts) => {
     const idx = opts.index ?? undefined
     const resolved = paths.length > 0 ? await resolveGlobOf(ops)(accessor, paths, idx) : []
-    const overlay = opts.statOverlay
-    // stat, like ls -l, renders backend stat rows that never see the
-    // namespace attr overlay (chmod/chown/touch) or the default owner;
-    // merge it in so stat -c and ls -l agree.
-    const stat =
-      overlay !== undefined
-        ? async (p: PathSpec) => overlay(p.virtual, await ops.stat(accessor, p, idx))
-        : (p: PathSpec) => ops.stat(accessor, p, idx)
-    return statGeneric(resolved, opts, stat)
+    return statGeneric(
+      resolved,
+      opts,
+      overlaidStat((p) => ops.stat(accessor, p, idx), opts.statOverlay),
+    )
   },
 }

--- a/typescript/packages/core/src/commands/builtin/generic_bind/index.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/index.ts
@@ -17,6 +17,7 @@ export {
   type BuilderFn,
   type CommandIO,
   makeResolveGlob,
+  overlaidStat,
   resolveGlobOf,
 } from './adapter.ts'
 export { type MakeGenericCommandsOptions, makeGenericCommands } from './factory.ts'

--- a/typescript/packages/core/src/commands/builtin/s3/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/s3/stat.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { S3Accessor } from '../../../accessor/s3.ts'
-import { resolveGlobOf } from '../generic_bind/index.ts'
+import { overlaidStat, resolveGlobOf } from '../generic_bind/index.ts'
 import { S3_IO } from './io.ts'
 import { stat as s3Stat } from '../../../core/s3/stat.ts'
 import { ResourceName, type PathSpec } from '../../../types.ts'
@@ -32,7 +32,11 @@ async function statCommand(
 ): Promise<CommandFnResult> {
   const resolved =
     paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
-  return statGeneric(resolved, opts, (p) => s3Stat(accessor, p, opts.index ?? undefined))
+  return statGeneric(
+    resolved,
+    opts,
+    overlaidStat((p) => s3Stat(accessor, p, opts.index ?? undefined), opts.statOverlay),
+  )
 }
 
 export const S3_STAT = command({

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -188,6 +188,7 @@ export {
   makeSedProvision,
   makeTransformProvision,
   metadataProvision,
+  overlaidStat,
   pureProvision,
   resolveGlobOf,
   withDefaultProvisions,

--- a/typescript/packages/node/src/commands/builtin/gridfs/stat.ts
+++ b/typescript/packages/node/src/commands/builtin/gridfs/stat.ts
@@ -16,6 +16,7 @@ import {
   ResourceName,
   command,
   metadataProvision,
+  overlaidStat,
   resolveGlobOf,
   specOf,
   statGeneric,
@@ -37,7 +38,11 @@ async function statCommand(
 ): Promise<CommandFnResult> {
   const resolved =
     paths.length > 0 ? await resolveGlob(accessor, paths, opts.index ?? undefined) : []
-  return statGeneric(resolved, opts, (p) => gridfsStat(accessor, p, opts.index ?? undefined))
+  return statGeneric(
+    resolved,
+    opts,
+    overlaidStat((p) => gridfsStat(accessor, p, opts.index ?? undefined), opts.statOverlay),
+  )
 }
 
 export const GRIDFS_STAT = command({


### PR DESCRIPTION
## Problem

#626 wired the namespace attr overlay (where `chmod`/`chown`/`touch` land for backends with no `setattr` op) into the generic_bind `stat` **builder**. Three backends hand-write their own `stat` command and bypass that builder entirely, so they kept reading the raw backend stat. None of them override `ls`, so `ls` picked the overlay up from `LS_BUILDER` while `stat -c` did not — the two disagreed about the same file:

```
$ touch -t 202401010000 f && chmod 640 f      # on an opfs mount
$ stat -c "%y|%a" f
2026-07-24T23:44:39.946Z|644                  # OPFS write wall-clock, default mode
$ ls -l f
-rw-r----- 1 user user 6 Jan  1 00:00 f       # the touched + chmod'd values
```

The `dispatch('stat')` ops facade was always correct — only the command surface was wrong.

## Fix

| file | side |
|---|---|
| `browser/.../opfs/stat/stat.ts` | ts |
| `core/.../s3/stat.ts` | ts |
| `node/.../gridfs/stat.ts` | ts |
| `python/.../s3/stat.py` | py |
| `python/.../gridfs/stat.py` | py |

The report that prompted this covered opfs only; s3 and gridfs had the identical one-line gap, so all three are fixed together rather than leaving the same split in two other backends.

**Python was affected too.** `s3/stat.py` and `gridfs/stat.py` never declared `stat_overlay`, so the executor's kwarg fell into `**_extra` and was **silently swallowed**. Both now declare it and bind through the existing `overlaid_stat` helper, exactly as the generic_bind builder does.

`history` overrides both `ls` and `stat` with raw stats, so it already self-agrees; it is a read-only view mount and is deliberately untouched.

## One design note for reviewers

Instead of repeating the inline overlay ternary a fourth, fifth and sixth time, this adds an exported `overlaidStat(stat, overlay)` to `generic_bind/adapter.ts` — mirroring the `overlaid_stat` Python already had — and routes all six stat/ls sites through it. Per the CLAUDE.md parity rule, Python's shared helper was the better of the two designs, so TS was brought up to it rather than duplicating.

This also means the helper **is** exported now, so the in-flight `OPFS_CP`/`OPFS_MV` overlay work on #629 can drop its inline ternaries in favour of `overlaidStat` once both land. No file overlap between the two PRs.

## Coverage

New integ cases in `integ/unix/meta_overlay/stat.json` (`ometa_stat_c_mtime` 201016, `ometa_stat_c_mode` 201017; `ometa_cleanup` bumped 201015 → 201018 so it still runs last), across the 15 overlay backends including `opfs`.

The pre-existing `meta_overlay` cases **could not** have caught this: they assert through the harness `check`, which routes via `ws.dispatch('stat')` and therefore gets the overlay at the dispatcher level. The new cases assert on `stat -c` stdout directly, pinning the command path.

Proven to catch the bug — with the source reverted but the cases kept:

```
FAIL [opfs] ometa_stat_c_mtime: expected "2024-01-01T00:00:00Z|1704067200\n", got "2026-07-25T00:32:39.024Z|1784939559\n"
FAIL [opfs] ometa_stat_c_mode:  expected "640|-rw-r-----\n", got "644|-rw-r--r--\n"
```

Unit tests: 3 workspace-level cases in `browser/.../opfs/opfs.test.ts`, plus new `tests/commands/builtin/{s3,gridfs}/test_stat.py`. (`moto` cannot drive mirage's `aioboto3` S3 path — it fails with `object bytes can't be used in 'await' expression` — so the Python tests use the `monkeypatch.setitem(stat.__wrapped__.__globals__, ...)` pattern CLAUDE.md documents for backend command modules.)

## Verification

- integ: `opfs` 1768/0, `ram` 1823/0, `disk` 1811/0 — `ram`/`disk` on **both** hosts, confirming the shared-builder refactor is parity-clean.
- units: core 4929, browser 170, full Python suite clean.
- `%y` is byte-identical across hosts by construction: both `epoch_to_iso`/`epochToIso` floor to whole seconds and emit a `Z` suffix.
- Rebased on `e3ed2d13` (#627); `pre-commit run --all-files` converges.

s3/gridfs/dropbox and the other service-backed targets in the new cases get their first real exercise in CI, since those need services unavailable locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)