### PR TITLE
fix: stop masking backend failures as missing paths, widen TS conformance

### DIFF
--- a/.github/workflows/test_integ.yml
+++ b/.github/workflows/test_integ.yml
@@ -414,6 +414,37 @@ jobs:
         working-directory: integ
         run: pnpm exec tsx runners/typescript/main.ts
 
+  # The two jobs above prove each language passes its own battery. This one
+  # runs both emitters and diffs them case by case, so a change that breaks
+  # the same way in both languages still fails. Shared targets only (ram,
+  # disk, redis) — the credentialed targets stay in their own jobs.
+  integ-shared-parity:
+    needs: changes
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.ts == 'true') }}
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      REDIS_URL: redis://localhost:6379/0
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/integ-battery-setup
+      # Targets are pinned: with no arguments parity.py adds the Graph and
+      # Mem0 groups unconditionally, and the setup action exports
+      # S3_ENDPOINT/SSH_HOST/GWS_URL, which would pull in the S3, SSH and
+      # Drive groups too. That would gate every core/TypeScript PR on the
+      # whole credentialed battery, which has its own jobs already.
+      - name: Diff python and typescript battery output
+        run: ./python/.venv/bin/python integ/runners/parity.py ram disk redis
+
   integ-database:
     needs: changes
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.database == 'true') }}
@@ -924,7 +955,7 @@ jobs:
   gate:
     name: integ-gate
     runs-on: ubuntu-latest
-    needs: [changes, integ, integ-ts, integ-shared-py, integ-shared-ts, integ-database, integ-database-ts, integ-data, integ-fuse, runtime-py, runtime-ts]
+    needs: [changes, integ, integ-ts, integ-shared-py, integ-shared-ts, integ-shared-parity, integ-database, integ-database-ts, integ-data, integ-fuse, runtime-py, runtime-ts]
     if: always()
     steps:
       - name: Check required jobs

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -10,6 +10,7 @@ permissions:
       - python/**
       - examples/python/**
       - integ/**
+      - conformance/**
       - .github/workflows/test_python.yml
   pull_request:
     branches: [main]
@@ -36,6 +37,7 @@ jobs:
               - 'python/**'
               - 'examples/python/**'
               - 'integ/**'
+              - 'conformance/**'
               - '.github/workflows/test_python.yml'
 
   test:

--- a/.github/workflows/test_typescript.yml
+++ b/.github/workflows/test_typescript.yml
@@ -10,6 +10,7 @@ permissions:
       - typescript/**
       - examples/typescript/**
       - integ/**
+      - conformance/**
       - .github/workflows/test_typescript.yml
   pull_request:
     branches: [main]
@@ -36,6 +37,7 @@ jobs:
               - 'typescript/**'
               - 'examples/typescript/**'
               - 'integ/**'
+              - 'conformance/**'
               - '.github/workflows/test_typescript.yml'
 
   test:

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -10,8 +10,18 @@ empty output, and binary output are all part of the contract.
 - Python: `python/tests/conformance/test_conformance.py` runs every case
   against `ram` and `disk`, plus `redis` when `REDIS_URL` is set. Runs as part
   of `uv run pytest`.
-- TypeScript: `typescript/packages/node/src/conformance.test.ts` runs every
-  case against `ram`. Runs as part of `pnpm test`.
+- TypeScript: `typescript/packages/node/src/conformance.test.ts` runs the same
+  matrix — `ram` and `disk`, plus `redis` when `REDIS_URL` is set. Runs as part
+  of `pnpm test`.
+
+Both CI test jobs provide a `redis:7` service and set `REDIS_URL`, so the
+redis rows run there rather than skipping.
+
+A third runner, `integ/runners/parity.py`, is a different net: instead of
+checking each language against a fixed expectation, it runs both integ
+batteries over the shared targets (`ram`, `disk`, `redis`) and diffs them case
+by case, so a change that breaks *identically* in both languages still fails.
+CI runs it as the `integ-shared-parity` job.
 
 ## Files
 
@@ -27,7 +37,10 @@ empty output, and binary output are all part of the contract.
     {
       "id": "wc_default",
       "cmd": "wc /data/a.txt",
-      "matrix": { "python": ["ram", "disk", "redis"], "typescript": ["ram"] },
+      "matrix": {
+        "python": ["ram", "disk", "redis"],
+        "typescript": ["ram", "disk", "redis"]
+      },
       "expect": {
         "exit": 0,
         "stdout_text": " 5  5 24 /data/a.txt\n",
@@ -76,7 +89,7 @@ expectations as the existing implementations:
    ```json
    "matrix": {
      "python": ["ram", "disk", "redis", "github"],
-     "typescript": ["ram", "github"]
+     "typescript": ["ram", "disk", "redis", "github"]
    }
    ```
 

--- a/conformance/cases/cat.json
+++ b/conformance/cases/cat.json
@@ -11,7 +11,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -30,7 +32,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -49,7 +53,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {

--- a/conformance/cases/cmp.json
+++ b/conformance/cases/cmp.json
@@ -11,7 +11,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -30,7 +32,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {

--- a/conformance/cases/du.json
+++ b/conformance/cases/du.json
@@ -11,7 +11,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -30,7 +32,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {

--- a/conformance/cases/file.json
+++ b/conformance/cases/file.json
@@ -11,7 +11,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -30,7 +32,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {

--- a/conformance/cases/find.json
+++ b/conformance/cases/find.json
@@ -11,7 +11,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -30,7 +32,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {

--- a/conformance/cases/grep.json
+++ b/conformance/cases/grep.json
@@ -11,7 +11,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -30,7 +32,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {

--- a/conformance/cases/head.json
+++ b/conformance/cases/head.json
@@ -11,7 +11,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {

--- a/conformance/cases/ls.json
+++ b/conformance/cases/ls.json
@@ -11,7 +11,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -30,7 +32,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {

--- a/conformance/cases/md5.json
+++ b/conformance/cases/md5.json
@@ -11,7 +11,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {

--- a/conformance/cases/sort.json
+++ b/conformance/cases/sort.json
@@ -6,7 +6,7 @@
       "cmd": "sort -k2 /data/sk_fields.txt",
       "matrix": {
         "python": ["ram", "disk", "redis"],
-        "typescript": ["ram"]
+        "typescript": ["ram", "disk", "redis"]
       },
       "expect": {
         "exit": 0,
@@ -19,7 +19,7 @@
       "cmd": "sort -k2,2 /data/sk_fields.txt",
       "matrix": {
         "python": ["ram", "disk", "redis"],
-        "typescript": ["ram"]
+        "typescript": ["ram", "disk", "redis"]
       },
       "expect": {
         "exit": 0,
@@ -32,7 +32,7 @@
       "cmd": "sort -k2,2n -k1,1r /data/sk_fields.txt",
       "matrix": {
         "python": ["ram", "disk", "redis"],
-        "typescript": ["ram"]
+        "typescript": ["ram", "disk", "redis"]
       },
       "expect": {
         "exit": 0,
@@ -45,7 +45,7 @@
       "cmd": "sort -k2,2n /data/sk_ties.txt",
       "matrix": {
         "python": ["ram", "disk", "redis"],
-        "typescript": ["ram"]
+        "typescript": ["ram", "disk", "redis"]
       },
       "expect": {
         "exit": 0,
@@ -58,7 +58,7 @@
       "cmd": "sort -s -k2,2n /data/sk_ties.txt",
       "matrix": {
         "python": ["ram", "disk", "redis"],
-        "typescript": ["ram"]
+        "typescript": ["ram", "disk", "redis"]
       },
       "expect": {
         "exit": 0,
@@ -71,7 +71,7 @@
       "cmd": "sort -rk2,2n /data/sk_ties.txt",
       "matrix": {
         "python": ["ram", "disk", "redis"],
-        "typescript": ["ram"]
+        "typescript": ["ram", "disk", "redis"]
       },
       "expect": {
         "exit": 0,
@@ -84,7 +84,7 @@
       "cmd": "sort -t: -k1.2,1.3 /data/sk_colon.txt",
       "matrix": {
         "python": ["ram", "disk", "redis"],
-        "typescript": ["ram"]
+        "typescript": ["ram", "disk", "redis"]
       },
       "expect": {
         "exit": 0,
@@ -97,7 +97,7 @@
       "cmd": "sort -k0 /data/sk_fields.txt",
       "matrix": {
         "python": ["ram", "disk", "redis"],
-        "typescript": ["ram"]
+        "typescript": ["ram", "disk", "redis"]
       },
       "expect": {
         "exit": 2,

--- a/conformance/cases/stat.json
+++ b/conformance/cases/stat.json
@@ -11,7 +11,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -30,7 +32,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -49,7 +53,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -68,7 +74,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -87,7 +95,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {

--- a/conformance/cases/tree.json
+++ b/conformance/cases/tree.json
@@ -11,7 +11,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {

--- a/conformance/cases/wc.json
+++ b/conformance/cases/wc.json
@@ -11,7 +11,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -30,7 +32,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -49,7 +53,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -68,7 +74,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -87,7 +95,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -107,7 +117,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {
@@ -127,7 +139,9 @@
           "redis"
         ],
         "typescript": [
-          "ram"
+          "ram",
+          "disk",
+          "redis"
         ]
       },
       "expect": {

--- a/python/tests/conformance/test_conformance.py
+++ b/python/tests/conformance/test_conformance.py
@@ -29,7 +29,7 @@ CONFORMANCE_DIR = REPO_ROOT / "conformance"
 REDIS_URL = os.environ.get("REDIS_URL", "")
 SUPPORTED_MATRIX = {
     "python": {"ram", "disk", "redis"},
-    "typescript": {"ram"},
+    "typescript": {"ram", "disk", "redis"},
 }
 
 
@@ -161,7 +161,7 @@ async def test_conformance(backend: str, case: dict, tmp_path: Path) -> None:
             "pyhton": ["ram"]
         }, "unknown matrix language"),
         ({
-            "typescript": ["disk"]
+            "typescript": ["s3"]
         }, "unsupported typescript backend"),
         ({
             "python": [],
@@ -181,7 +181,7 @@ def test_validate_matrix_accepts_supported_targets() -> None:
         "id": "valid_matrix",
         "matrix": {
             "python": ["ram", "disk", "redis"],
-            "typescript": ["ram"],
+            "typescript": ["ram", "disk", "redis"],
         },
     }
     _validate_matrix(case, "valid.json")

--- a/typescript/packages/core/src/commands/builtin/generic/cp.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cp.test.ts
@@ -15,11 +15,26 @@
 import { mountKey } from '../../../utils/key_prefix.ts'
 import { describe, expect, it } from 'vitest'
 import type { ByteSource, IOResult } from '../../../io/types.ts'
-import { FileStat, FileType, PathSpec, type PrimitiveCopy, type ReaddirFn } from '../../../types.ts'
+import {
+  FileStat,
+  FileType,
+  PathSpec,
+  type PrimitiveCopy,
+  type ReaddirFn,
+  type StatFn,
+} from '../../../types.ts'
 import type { FindOptions } from '../../../resource/base.ts'
-import { eacces, enotsup } from '../../../utils/errors.ts'
+import { eacces, enoent, enotsup } from '../../../utils/errors.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
-import { cpFlags, cpGeneric, parseCpFlags, type CpFlags } from './cp.ts'
+import {
+  cpFlags,
+  cpGeneric,
+  entryKind,
+  overwriteGate,
+  parseCpFlags,
+  targetDirError,
+  type CpFlags,
+} from './cp.ts'
 
 const DEC = new TextDecoder()
 
@@ -49,7 +64,7 @@ function makeBackend(
       )
     }
     const data = files.get(k)
-    if (data === undefined) return Promise.reject(new Error(`not found: ${k}`))
+    if (data === undefined) return Promise.reject(enoent(k))
     return Promise.resolve(
       new FileStat({
         name: k.split('/').pop() ?? '',
@@ -60,7 +75,7 @@ function makeBackend(
   }
   const copy = (src: PathSpec, dst: PathSpec): Promise<void> => {
     const data = files.get(key(src))
-    if (data === undefined) return Promise.reject(new Error(`not found: ${key(src)}`))
+    if (data === undefined) return Promise.reject(enoent(key(src)))
     files.set(key(dst), data)
     return Promise.resolve()
   }
@@ -240,7 +255,7 @@ describe('cpGeneric guards', () => {
     const { stat } = makeBackend(files, new Set())
     const readBytes = (p: PathSpec): Promise<Uint8Array> => {
       const data = files.get(key(p))
-      if (data === undefined) return Promise.reject(new Error(`not found: ${key(p)}`))
+      if (data === undefined) return Promise.reject(enoent(key(p)))
       return Promise.resolve(data)
     }
     const write = (p: PathSpec, data: Uint8Array): Promise<void> => {
@@ -274,7 +289,7 @@ function makePrimitive(files: Map<string, Uint8Array>, dirs: Set<string>, fails:
     const err = readErr.get(key(p))
     if (err !== undefined) return Promise.reject(err)
     const data = files.get(key(p))
-    if (data === undefined) return Promise.reject(new Error(`not found: ${key(p)}`))
+    if (data === undefined) return Promise.reject(enoent(key(p)))
     return Promise.resolve(data)
   }
   const write = (p: PathSpec, data: Uint8Array): Promise<void> => {
@@ -782,5 +797,37 @@ describe('backup version scan failures', () => {
     expect(io.exitCode).toBe(1)
     expect(await io.stderrStr()).toContain("cp: cannot backup '/b.txt': Operation not supported")
     expect(files.get('/b.txt')).toEqual(new Uint8Array([79]))
+  })
+})
+
+// The per-operand probes answer "is this path there?". A stat that fails for
+// any other reason is not an answer, and must not be read as one: returning
+// "missing" would let -n overwrite the very target it exists to protect.
+// Python's twins narrow to (FileNotFoundError, ValueError) in all three.
+// Exercised directly, because whichever probe runs first would otherwise
+// mask the others.
+describe('cp probes propagate non-missing stat failures', () => {
+  const boom: StatFn = () => Promise.reject(new Error('401 Unauthorized'))
+  const missing: StatFn = (p) => Promise.reject(enoent(key(p)))
+
+  it('overwriteGate rethrows instead of reporting "safe to overwrite"', async () => {
+    const policy = { cmdName: 'cp', noClobber: true, update: null, backup: null, suffix: '~' }
+    await expect(overwriteGate(policy, boom, spec('/a.txt'), spec('/dst.txt'), [])).rejects.toThrow(
+      '401 Unauthorized',
+    )
+    // A genuinely missing target still means "nothing to clobber".
+    expect(await overwriteGate(policy, missing, spec('/a.txt'), spec('/dst.txt'), [])).toBe(true)
+  })
+
+  it('entryKind rethrows instead of reporting the path as absent', async () => {
+    await expect(entryKind(boom, spec('/a.txt'))).rejects.toThrow('401 Unauthorized')
+    expect(await entryKind(missing, spec('/a.txt'))).toEqual({ exists: false, isDir: false })
+  })
+
+  it('targetDirError rethrows instead of claiming No such file or directory', async () => {
+    await expect(targetDirError('cp', boom, spec('/d'))).rejects.toThrow('401 Unauthorized')
+    expect(await targetDirError('cp', missing, spec('/d'))).toBe(
+      "cp: target directory '/d': No such file or directory",
+    )
   })
 })

--- a/typescript/packages/core/src/commands/builtin/generic/cp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cp.ts
@@ -38,7 +38,7 @@ import {
   pathExists,
   type BackendKeyFn,
 } from '../utils/copy.ts'
-import { fsStrerror, isFsError } from '../../../utils/errors.ts'
+import { fsStrerror, isFsError, isMissingPath } from '../../../utils/errors.ts'
 import { rstripSlash, stripSlash } from '../../../utils/slash.ts'
 
 const ENC = new TextEncoder()
@@ -237,7 +237,8 @@ export async function targetDirError(
   let info: FileStat
   try {
     info = await stat(target)
-  } catch {
+  } catch (err) {
+    if (!isMissingPath(err)) throw err
     return `${cmdName}: target directory '${target.virtual}': No such file or directory`
   }
   if (info.type !== FileType.DIRECTORY) {
@@ -254,7 +255,8 @@ export async function entryKind(
   let info: FileStat
   try {
     info = await stat(path)
-  } catch {
+  } catch (err) {
+    if (!isMissingPath(err)) throw err
     return { exists: false, isDir: false }
   }
   return { exists: true, isDir: info.type === FileType.DIRECTORY }
@@ -297,7 +299,10 @@ export async function overwriteGate(
   let targetInfo: FileStat
   try {
     targetInfo = await stat(target)
-  } catch {
+  } catch (err) {
+    // A probe failure here is not permission to clobber: returning true on an
+    // auth error or timeout would silently defeat -n / --update=none.
+    if (!isMissingPath(err)) throw err
     return true
   }
   if (policy.noClobber || policy.update === 'none') return false
@@ -309,7 +314,8 @@ export async function overwriteGate(
     let srcInfo: FileStat
     try {
       srcInfo = await stat(src)
-    } catch {
+    } catch (err) {
+      if (!isMissingPath(err)) throw err
       return true
     }
     const srcTs = modifiedTs(srcInfo.modified)

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/cp.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/cp.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, it } from 'vitest'
 import { IOResult } from '../../../../../io/types.ts'
 import { FileStat, FileType, PathSpec } from '../../../../../types.ts'
+import { enoent } from '../../../../../utils/errors.ts'
 import { mountKey } from '../../../../../utils/key_prefix.ts'
 import { rstripSlash } from '../../../../../utils/slash.ts'
 import type { DispatchFn } from '../types.ts'
@@ -40,7 +41,7 @@ function makeDispatch(files: Map<string, Uint8Array>, dirs: Set<string>): Dispat
       if (files.has(k)) {
         return Promise.resolve([new FileStat({ name, type: FileType.TEXT }), new IOResult()])
       }
-      return Promise.reject(new Error(`not found: ${k}`))
+      return Promise.reject(enoent(k))
     }
     if (op === 'read') return Promise.resolve([files.get(k) ?? null, new IOResult()])
     if (op === 'readdir') {

--- a/typescript/packages/core/src/commands/builtin/generic/mv.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/mv.test.ts
@@ -16,7 +16,7 @@ import { mountKey } from '../../../utils/key_prefix.ts'
 import { describe, expect, it } from 'vitest'
 import type { ByteSource, IOResult } from '../../../io/types.ts'
 import { FileStat, FileType, PathSpec, type PrimitiveMove, type ReaddirFn } from '../../../types.ts'
-import { eacces, enotsup } from '../../../utils/errors.ts'
+import { eacces, enoent, enotsup } from '../../../utils/errors.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
 import { mvFlags, mvGeneric, parseMvFlags, type MvFlags } from './mv.ts'
 
@@ -48,7 +48,7 @@ function makeBackend(
       )
     }
     const data = files.get(k)
-    if (data === undefined) return Promise.reject(new Error(`not found: ${k}`))
+    if (data === undefined) return Promise.reject(enoent(k))
     return Promise.resolve(
       new FileStat({
         name: k.split('/').pop() ?? '',
@@ -59,7 +59,7 @@ function makeBackend(
   }
   const rename = (src: PathSpec, dst: PathSpec): Promise<void> => {
     const data = files.get(key(src))
-    if (data === undefined) return Promise.reject(new Error(`not found: ${key(src)}`))
+    if (data === undefined) return Promise.reject(enoent(key(src)))
     files.delete(key(src))
     files.set(key(dst), data)
     return Promise.resolve()
@@ -196,7 +196,7 @@ function makePrimitive(files: Map<string, Uint8Array>, dirs: Set<string>, fails:
     const err = readErr.get(key(p))
     if (err !== undefined) return Promise.reject(err)
     const data = files.get(key(p))
-    if (data === undefined) return Promise.reject(new Error(`not found: ${key(p)}`))
+    if (data === undefined) return Promise.reject(enoent(key(p)))
     return Promise.resolve(data)
   }
   const write = (p: PathSpec, data: Uint8Array): Promise<void> => {
@@ -690,7 +690,7 @@ function treeRename(files: Map<string, Uint8Array>, dirs: Set<string>) {
       return Promise.resolve()
     }
     const data = files.get(s)
-    if (data === undefined) return Promise.reject(new Error(`not found: ${s}`))
+    if (data === undefined) return Promise.reject(enoent(s))
     files.delete(s)
     files.set(d, data)
     return Promise.resolve()

--- a/typescript/packages/core/src/commands/builtin/generic/realpath.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/realpath.ts
@@ -15,6 +15,7 @@
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
+import { isMissingPath } from '../../../utils/errors.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
 
 const ENC = new TextEncoder()
@@ -34,8 +35,9 @@ async function pathExists(stat: (p: PathSpec) => Promise<unknown>, p: PathSpec):
   try {
     await stat(p)
     return true
-  } catch {
-    return false
+  } catch (err) {
+    if (isMissingPath(err)) return false
+    throw err
   }
 }
 

--- a/typescript/packages/core/src/commands/builtin/utils/copy.ts
+++ b/typescript/packages/core/src/commands/builtin/utils/copy.ts
@@ -15,7 +15,7 @@
 import { rekey } from '../../../utils/key_prefix.ts'
 import type { IndexCacheStore } from '../../../cache/index/store.ts'
 import { FileType, PathSpec, type StatFn } from '../../../types.ts'
-import { enotdir } from '../../../utils/errors.ts'
+import { enotdir, isMissingPath } from '../../../utils/errors.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
 
 export type BackendKeyFn = (path: PathSpec) => string
@@ -50,8 +50,9 @@ export function copyTargets(
 export async function pathExists(stat: StatFn, path: PathSpec): Promise<boolean> {
   try {
     await stat(path)
-  } catch {
-    return false
+  } catch (err) {
+    if (isMissingPath(err)) return false
+    throw err
   }
   return true
 }
@@ -64,7 +65,8 @@ export async function isDirectory(
   try {
     const info = await stat(path, index)
     return info.type === FileType.DIRECTORY
-  } catch {
-    return false
+  } catch (err) {
+    if (isMissingPath(err)) return false
+    throw err
   }
 }

--- a/typescript/packages/core/src/core/gmail/messages.ts
+++ b/typescript/packages/core/src/core/gmail/messages.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { decodeBase64 } from '../../utils/base64.ts'
 import { type TokenManager, gmailBase, googleGet } from '../google/_client.ts'
 
 export interface GmailHeader {
@@ -117,12 +118,7 @@ export async function getMessageRaw(
 
 function base64UrlDecodeToBytes(input: string): Uint8Array {
   const padded = input + '=='.slice((input.length + 2) % 4)
-  const standard = padded.replace(/-/g, '+').replace(/_/g, '/')
-  const binary =
-    typeof atob === 'function' ? atob(standard) : Buffer.from(standard, 'base64').toString('binary')
-  const out = new Uint8Array(binary.length)
-  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i)
-  return out
+  return decodeBase64(padded.replace(/-/g, '+').replace(/_/g, '/'))
 }
 
 const TEXT_DECODER = new TextDecoder('utf-8', { fatal: false })

--- a/typescript/packages/core/src/core/gmail/send.ts
+++ b/typescript/packages/core/src/core/gmail/send.ts
@@ -12,17 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { encodeBase64 } from '../../utils/base64.ts'
 import { type TokenManager, gmailBase, googlePost } from '../google/_client.ts'
 import { extractHeader, getMessageProcessed, getMessageRaw } from './messages.ts'
 
 const ENC = new TextEncoder()
 
 function base64UrlEncode(bytes: Uint8Array): string {
-  let binary = ''
-  for (const b of bytes) binary += String.fromCharCode(b)
-  const std =
-    typeof btoa === 'function' ? btoa(binary) : Buffer.from(binary, 'binary').toString('base64')
-  return std.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  return encodeBase64(bytes).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
 }
 
 function buildMime(headers: Record<string, string>, body: string): string {

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -1243,7 +1243,10 @@ export {
   type FsError,
   gnuStrerror,
   isMissingOp,
+  isMissingPath,
   type MissingOpError,
+  noMount,
+  type NoMountError,
 } from './utils/errors.ts'
 
 export {

--- a/typescript/packages/core/src/utils/base64.test.ts
+++ b/typescript/packages/core/src/utils/base64.test.ts
@@ -1,0 +1,51 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { decodeBase64, encodeBase64 } from './base64.ts'
+
+const HELD = globalThis.Buffer
+
+// Core must work in browsers, where `Buffer` does not exist. Running the
+// round-trip with the global removed is the only way to prove that.
+function withoutBuffer<T>(fn: () => T): T {
+  delete (globalThis as { Buffer?: unknown }).Buffer
+  return fn()
+}
+
+afterEach(() => {
+  globalThis.Buffer = HELD
+})
+
+describe('base64 round-trip', () => {
+  it('encodes and decodes arbitrary bytes without Buffer', () => {
+    const bytes = new Uint8Array([0, 1, 127, 128, 255, 65, 0, 254])
+    const { encoded, decoded } = withoutBuffer(() => {
+      const encoded = encodeBase64(bytes)
+      return { encoded, decoded: decodeBase64(encoded) }
+    })
+    expect(encoded).toBe(HELD.from(bytes).toString('base64'))
+    expect([...decoded]).toEqual([...bytes])
+  })
+
+  it('decodes the same bytes Node would, without Buffer', () => {
+    const encoded = HELD.from('héllo wörld', 'utf8').toString('base64')
+    const decoded = withoutBuffer(() => decodeBase64(encoded))
+    expect(new TextDecoder().decode(decoded)).toBe('héllo wörld')
+  })
+
+  it('decodes empty input to an empty array', () => {
+    expect([...withoutBuffer(() => decodeBase64(''))]).toEqual([])
+  })
+})

--- a/typescript/packages/core/src/utils/errors.test.ts
+++ b/typescript/packages/core/src/utils/errors.test.ts
@@ -18,9 +18,12 @@ import {
   eaccesReadOnly,
   enoent,
   enotsup,
+  enotdir,
   formatFsError,
   fsStrerror,
   isFsError,
+  isMissingPath,
+  noMount,
 } from './errors.ts'
 
 const decode = (bytes: Uint8Array): string => new TextDecoder().decode(bytes)
@@ -93,6 +96,30 @@ describe('eaccesReadOnly', () => {
     expect(err.virtualPath).toBe('/mail/a.txt')
     expect(err.message).toContain('read-only')
     expect(fsStrerror(err)).toBe('Permission denied')
+  })
+})
+
+describe('noMount', () => {
+  it('keeps the Python message text and carries no POSIX code', () => {
+    const err = noMount('/nowhere/x')
+    expect(err.message).toBe('no mount matches path: /nowhere/x')
+    expect(isFsError(err)).toBe(false)
+    expect(fsStrerror(err)).toBeNull()
+  })
+})
+
+describe('isMissingPath', () => {
+  it('accepts the two Python swallows: FileNotFoundError and the no-mount ValueError', () => {
+    expect(isMissingPath(enoent('/x'))).toBe(true)
+    expect(isMissingPath(noMount('/nowhere/x'))).toBe(true)
+  })
+
+  it('rejects every other failure, including other fs errors', () => {
+    expect(isMissingPath(eacces('/x'))).toBe(false)
+    expect(isMissingPath(enotdir('/x'))).toBe(false)
+    expect(isMissingPath(enotsup('email', 'stat', '/mail/a.txt'))).toBe(false)
+    expect(isMissingPath(new Error('401 Unauthorized'))).toBe(false)
+    expect(isMissingPath(undefined)).toBe(false)
   })
 })
 

--- a/typescript/packages/core/src/utils/errors.ts
+++ b/typescript/packages/core/src/utils/errors.ts
@@ -64,6 +64,33 @@ export function enotempty(path: string | { virtual: string }): FsError {
   return fsError(path, 'ENOTEMPTY')
 }
 
+// The registry's refusal for a path that falls outside every mount. Mirrors
+// Python's `ValueError("no mount matches path: ...")`; the stamp exists so
+// the exists-family probes can recognize it without sniffing message text,
+// and the message stays unstamped by a POSIX code so command stderr keeps
+// rendering it verbatim (parity with Python, where ValueError is not an
+// OSError and gets no strerror suffix).
+export interface NoMountError extends Error {
+  noMount: true
+}
+
+export function noMount(path: string): NoMountError {
+  const err = new Error(`no mount matches path: ${path}`) as NoMountError
+  err.noMount = true
+  return err
+}
+
+// True when the error means the path is simply not there: a stamped ENOENT,
+// or a path outside every mount. This is the whole swallow set for the
+// exists-family probes, mirroring Python's `(FileNotFoundError, ValueError)`.
+// Everything else — auth failures, transport errors, timeouts, ENOTDIR,
+// backend bugs — must propagate instead of reading back as "missing".
+export function isMissingPath(err: unknown): boolean {
+  if (err === null || typeof err !== 'object') return false
+  const stamped = err as { code?: unknown; noMount?: unknown }
+  return stamped.code === 'ENOENT' || stamped.noMount === true
+}
+
 // A missing-op error also names the op the backend did not register, so
 // capability probes (metadata.ts) can test for one specific gap instead of
 // sniffing message text.

--- a/typescript/packages/core/src/workspace/executor/builtins/capacity.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/capacity.ts
@@ -16,6 +16,7 @@ import { humanSize } from '../../../commands/builtin/utils/formatting.ts'
 import { IOResult } from '../../../io/types.ts'
 import { CapacityState, FileStat, PathSpec } from '../../../types.ts'
 import type { CapacityResult } from '../../../types.ts'
+import { isMissingPath } from '../../../utils/errors.ts'
 import { resolvePath } from '../../../utils/path.ts'
 import { rstripSlash } from '../../../utils/slash.ts'
 import type { DispatchFn } from '../cross_mount.ts'
@@ -103,8 +104,9 @@ async function pathExists(dispatch: DispatchFn, spec: PathSpec): Promise<boolean
   try {
     const [stat] = await dispatch('stat', spec)
     return stat instanceof FileStat
-  } catch {
-    return false
+  } catch (err) {
+    if (isMissingPath(err)) return false
+    throw err
   }
 }
 

--- a/typescript/packages/core/src/workspace/executor/cross_mount.test.ts
+++ b/typescript/packages/core/src/workspace/executor/cross_mount.test.ts
@@ -81,7 +81,7 @@ describe('handleCrossMount — cp / mv', () => {
     >((op, p) => {
       if (op === 'stat') {
         // dst does not exist yet; src is an existing file.
-        if (p.virtual === '/disk/b') return Promise.reject(new Error('ENOENT'))
+        if (p.virtual === '/disk/b') return Promise.reject(enoent(p))
         return Promise.resolve<[unknown, IOResult]>([fileStat('a'), new IOResult()])
       }
       if (op === 'read')
@@ -120,7 +120,7 @@ describe('handleCrossMount — cp / mv', () => {
       ) => Promise<[unknown, IOResult]>
     >((op, p) => {
       if (op === 'stat') {
-        if (p.virtual === '/disk/b') return Promise.reject(new Error('ENOENT'))
+        if (p.virtual === '/disk/b') return Promise.reject(enoent(p))
         return Promise.resolve<[unknown, IOResult]>([dirStat('a'), new IOResult()])
       }
       return Promise.resolve<[unknown, IOResult]>([null, new IOResult()])
@@ -151,7 +151,7 @@ describe('handleCrossMount — cp / mv', () => {
     >((op, p) => {
       if (op === 'stat') {
         if (p.virtual === '/disk/b' || p.virtual.startsWith('/disk/'))
-          return Promise.reject(new Error('ENOENT'))
+          return Promise.reject(enoent(p))
         if (p.virtual === '/ram/dir')
           return Promise.resolve<[unknown, IOResult]>([dirStat('dir'), new IOResult()])
         return Promise.resolve<[unknown, IOResult]>([fileStat('f'), new IOResult()])
@@ -189,7 +189,7 @@ describe('handleCrossMount — cp / mv', () => {
       ) => Promise<[unknown, IOResult]>
     >((op, p) => {
       if (op === 'stat') {
-        if (p.virtual === '/disk/b') return Promise.reject(new Error('ENOENT'))
+        if (p.virtual === '/disk/b') return Promise.reject(enoent(p))
         return Promise.resolve<[unknown, IOResult]>([fileStat('a'), new IOResult()])
       }
       if (op === 'read')

--- a/typescript/packages/core/src/workspace/fs.test.ts
+++ b/typescript/packages/core/src/workspace/fs.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it } from 'vitest'
 import { OpsRegistry } from '../ops/registry.ts'
 import { RAMResource } from '../resource/ram/ram.ts'
 import { MountMode } from '../types.ts'
+import { enotdir } from '../utils/errors.ts'
 import { Workspace } from './workspace.ts'
 
 function mkWorkspace(): Workspace {
@@ -23,6 +24,25 @@ function mkWorkspace(): Workspace {
   const ops = new OpsRegistry()
   for (const op of resource.ops()) ops.register(op)
   return new Workspace({ '/data': resource }, { mode: MountMode.WRITE, ops })
+}
+
+// The Workspace constructor re-registers each mount's ops, so the failing
+// stat has to land on the registry after the workspace is built.
+function mkFailingStat(err: unknown): Workspace {
+  const resource = new RAMResource()
+  const ops = new OpsRegistry()
+  for (const op of resource.ops()) ops.register(op)
+  const ws = new Workspace({ '/data': resource }, { mode: MountMode.WRITE, ops })
+  ops.register({
+    name: 'stat',
+    resource: resource.kind,
+    filetype: null,
+    fn: () => {
+      throw err
+    },
+    write: false,
+  })
+  return ws
 }
 
 describe('WorkspaceFS', () => {
@@ -87,5 +107,35 @@ describe('WorkspaceFS', () => {
     const ws = mkWorkspace()
     await ws.fs.writeFile('/data/t.txt', 'content')
     expect(await ws.fs.cat('/data/t.txt')).toBe('content')
+  })
+})
+
+describe('WorkspaceFS existence probes', () => {
+  it('report false for a missing path', async () => {
+    const ws = mkWorkspace()
+    expect(await ws.fs.exists('/data/nope')).toBe(false)
+    expect(await ws.fs.isDir('/data/nope')).toBe(false)
+    expect(await ws.fs.isFile('/data/nope')).toBe(false)
+  })
+
+  it('report false for a path outside every mount', async () => {
+    const ws = mkWorkspace()
+    expect(await ws.fs.exists('/nowhere/x')).toBe(false)
+    expect(await ws.fs.isDir('/nowhere/x')).toBe(false)
+    expect(await ws.fs.isFile('/nowhere/x')).toBe(false)
+  })
+
+  it('propagate a backend failure instead of reporting it as missing', async () => {
+    const ws = mkFailingStat(new Error('401 Unauthorized'))
+    await expect(ws.fs.exists('/data/a.txt')).rejects.toThrow('401 Unauthorized')
+    await expect(ws.fs.isDir('/data/a.txt')).rejects.toThrow('401 Unauthorized')
+    await expect(ws.fs.isFile('/data/a.txt')).rejects.toThrow('401 Unauthorized')
+  })
+
+  it('propagate a non-ENOENT fs error, matching Python which swallows only two', async () => {
+    const ws = mkFailingStat(enotdir('/data/a.txt'))
+    await expect(ws.fs.exists('/data/a.txt')).rejects.toThrow('/data/a.txt')
+    await expect(ws.fs.isDir('/data/a.txt')).rejects.toThrow('/data/a.txt')
+    await expect(ws.fs.isFile('/data/a.txt')).rejects.toThrow('/data/a.txt')
   })
 })

--- a/typescript/packages/core/src/workspace/fs.ts
+++ b/typescript/packages/core/src/workspace/fs.ts
@@ -20,6 +20,7 @@ import type { OpKwargs, OpsRegistry } from '../ops/registry.ts'
 import type { Resource } from '../resource/base.ts'
 import type { FileStat, MountMode, PathSpec } from '../types.ts'
 import { FileType } from '../types.ts'
+import { isMissingPath } from '../utils/errors.ts'
 
 const NOOP_ACCESSOR_INSTANCE = new NOOPAccessor()
 
@@ -153,12 +154,18 @@ export class WorkspaceFS {
     return result
   }
 
+  // The three probes below answer "is this path there?", so only a genuine
+  // missing path may read back as false. An auth failure, a timeout, or a
+  // backend bug is not an answer to that question: swallowing it would let a
+  // caller act on a false "missing" (overwrite, recreate, skip). Mirrors
+  // Python's `(FileNotFoundError, ValueError)` swallow set.
   async exists(path: string): Promise<boolean> {
     try {
       await this.stat(path)
       return true
-    } catch {
-      return false
+    } catch (err) {
+      if (isMissingPath(err)) return false
+      throw err
     }
   }
 
@@ -166,8 +173,9 @@ export class WorkspaceFS {
     try {
       const s = await this.stat(path)
       return s.type === FileType.DIRECTORY
-    } catch {
-      return false
+    } catch (err) {
+      if (isMissingPath(err)) return false
+      throw err
     }
   }
 
@@ -175,8 +183,9 @@ export class WorkspaceFS {
     try {
       const s = await this.stat(path)
       return s.type !== FileType.DIRECTORY
-    } catch {
-      return false
+    } catch (err) {
+      if (isMissingPath(err)) return false
+      throw err
     }
   }
 

--- a/typescript/packages/core/src/workspace/mount/registry.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { noMount } from '../../utils/errors.ts'
 import { mountKey } from '../../utils/key_prefix.ts'
 import type { Runtime } from '../executor/runtime.ts'
 import type { FileCache } from '../../cache/file/mixin.ts'
@@ -291,7 +292,7 @@ export class MountRegistry {
   resolve(path: string): [Resource, PathSpec, MountMode] {
     const m = this.mountFor(path)
     if (m === null) {
-      throw new Error(`no mount matches path: ${path}`)
+      throw noMount(path)
     }
     const hadTrailing = path.endsWith('/')
     const norm = `/${stripSlash(path)}`

--- a/typescript/packages/node/src/conformance.test.ts
+++ b/typescript/packages/node/src/conformance.test.ts
@@ -12,13 +12,14 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { readFileSync, readdirSync } from 'node:fs'
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { describe, expect, it } from 'vitest'
 
-import { MountMode, RAMResource, Workspace } from './index.ts'
+import { DiskResource, MountMode, RAMResource, RedisResource, Workspace } from './index.ts'
 
 const CONFORMANCE_DIR = join(
   dirname(fileURLToPath(import.meta.url)),
@@ -30,9 +31,10 @@ const CONFORMANCE_DIR = join(
 )
 
 const ENC = new TextEncoder()
+const REDIS_URL = process.env.REDIS_URL ?? ''
 const SUPPORTED_MATRIX: Record<string, ReadonlySet<string>> = {
   python: new Set(['ram', 'disk', 'redis']),
-  typescript: new Set(['ram']),
+  typescript: new Set(['ram', 'disk', 'redis']),
 }
 
 interface ConformanceExpect {
@@ -142,8 +144,53 @@ async function seedWorkspace(ws: Workspace): Promise<void> {
   }
 }
 
-async function runCase(c: ConformanceCase): Promise<void> {
-  const ws = new Workspace({ '/': new RAMResource() }, { mode: MountMode.WRITE })
+// Each case gets a workspace with fresh backend state: a new RAM store, a
+// new temp directory, or a Redis key prefix cleared before the run.
+//
+// Teardown is split because Workspace.close() closes the mount's resource,
+// and for Redis that destroys the client. Anything needing a live connection
+// has to run in `reset` (before the close); anything outliving the resource
+// runs in `dispose` (after). Clearing Redis in `dispose` would silently open
+// a second connection per case just to delete keys.
+interface Backend {
+  ws: Workspace
+  reset: () => Promise<void>
+  dispose: () => Promise<void>
+}
+
+const NOOP = (): Promise<void> => Promise.resolve()
+
+async function buildBackend(backend: string, caseId: string): Promise<Backend> {
+  if (backend === 'ram') {
+    const ws = new Workspace({ '/': new RAMResource() }, { mode: MountMode.WRITE })
+    return { ws, reset: NOOP, dispose: NOOP }
+  }
+  if (backend === 'disk') {
+    const root = mkdtempSync(join(tmpdir(), 'mirage-conformance-'))
+    const ws = new Workspace({ '/': new DiskResource({ root }) }, { mode: MountMode.WRITE })
+    return {
+      ws,
+      reset: NOOP,
+      dispose: () => {
+        rmSync(root, { recursive: true, force: true })
+        return Promise.resolve()
+      },
+    }
+  }
+  if (backend === 'redis') {
+    const resource = new RedisResource({
+      url: REDIS_URL,
+      keyPrefix: `test:conformance:ts:${caseId}:`,
+    })
+    await resource.store.clear()
+    const ws = new Workspace({ '/': resource }, { mode: MountMode.WRITE })
+    return { ws, reset: () => resource.store.clear(), dispose: NOOP }
+  }
+  throw new Error(`unknown typescript backend in matrix: ${backend}`)
+}
+
+async function runCase(c: ConformanceCase, backend: string): Promise<void> {
+  const { ws, reset, dispose } = await buildBackend(backend, c.id)
   try {
     await seedWorkspace(ws)
     const hasStdin = 'stdin_text' in c || 'stdin_base64' in c
@@ -157,24 +204,29 @@ async function runCase(c: ConformanceCase): Promise<void> {
       comparable(decodeBytes(c.expect, 'stderr_text', 'stderr_base64')),
     )
   } finally {
+    await reset()
     await ws.close()
+    await dispose()
   }
 }
 
-describe('command conformance spec (ram)', () => {
-  for (const c of CASES) {
-    const backends = c.matrix.typescript ?? []
-    if (!backends.includes('ram')) continue
-    it(c.id, async () => {
-      await runCase(c)
-    })
-  }
-})
+for (const backend of ['ram', 'disk', 'redis']) {
+  describe(`command conformance spec (${backend})`, () => {
+    for (const c of CASES) {
+      const backends = c.matrix.typescript ?? []
+      if (!backends.includes(backend)) continue
+      const run = backend === 'redis' && REDIS_URL === '' ? it.skip : it
+      run(c.id, async () => {
+        await runCase(c, backend)
+      })
+    }
+  })
+}
 
 describe('command conformance matrix validation', () => {
   it.each([
     [{ pyhton: ['ram'] }, 'unknown matrix language'],
-    [{ typescript: ['disk'] }, 'unsupported typescript backend'],
+    [{ typescript: ['s3'] }, 'unsupported typescript backend'],
     [{ python: [], typescript: [] }, 'applies to no backend'],
   ])('rejects invalid targets', (matrix, message) => {
     const c = {
@@ -194,7 +246,7 @@ describe('command conformance matrix validation', () => {
       cmd: 'true',
       matrix: {
         python: ['ram', 'disk', 'redis'],
-        typescript: ['ram'],
+        typescript: ['ram', 'disk', 'redis'],
       },
       expect: { exit: 0, stdout_text: '', stderr_text: '' },
     }

--- a/typescript/packages/node/vitest.config.ts
+++ b/typescript/packages/node/vitest.config.ts
@@ -1,0 +1,27 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    // This package's tests do real I/O: temp directories, Redis connections,
+    // and the lazy `redis` import the first case in a worker pays for.
+    // Vitest's 5s default is sized for pure computation, and the first Redis
+    // test in a file was already marginal under the full 200-file run.
+    testTimeout: 15_000,
+  },
+})


### PR DESCRIPTION
Fixes three TypeScript correctness and parity issues found in an audit, plus the review findings on this PR.

## 1. Probes masked backend failures as missing paths

`WorkspaceFS.exists`, `isDir`, and `isFile` caught every exception and returned `false`, so an auth failure, network error, or backend bug read back as "this path does not exist". A caller could then overwrite, recreate, or skip based on a wrong answer.

Python already had the right answer, and it is not just ENOENT: it swallows `(FileNotFoundError, ValueError)`, where the `ValueError` is the registry's `no mount matches path`. An ENOENT-only fix would have turned unmounted paths into throws and broken the ~15 `fs.exists` calls in `packages/agents`.

So `noMount()` now stamps the registry error (message text unchanged, no POSIX code, so command stderr still renders it verbatim) and `isMissingPath()` accepts exactly ENOENT plus no-mount. Everything else propagates.

Sweeping for the same bug class found more sites, all of them already diverged from a narrow Python twin:

| Site | Python | TypeScript before |
|---|---|---|
| `workspace/fs.ts` ×3 | n/a (TS-only facade) | bare `catch` |
| `utils/copy.ts` `pathExists`/`isDirectory` | `except (FileNotFoundError, ValueError)` | bare `catch` |
| `generic/realpath.ts` | `except (FileNotFoundError, ValueError)` | bare `catch` |
| `builtins/capacity.ts` (df) | `except FileNotFoundError` | bare `catch` |
| `generic/cp.ts` `targetDirError`, `entryKind`, `overwriteGate` ×2 | `except (FileNotFoundError, ValueError)` | bare `catch` |

The `cp.ts` group came from review and is the most serious: `overwriteGate` returned `true` ("safe to overwrite") on *any* stat failure, so an auth error or timeout silently defeated `-n` / `--update=none` and clobbered the target. `mv.ts` reuses all three helpers from `cp.ts`, so both commands were affected.

Left alone deliberately: `opfs/exists.ts` already rethrows non-not-found errors; `generic_bind/adapter.ts` is a documented negative-probe fallback that runs *after* an ENOENT; `disk/exists.ts` matches Python's equally broad `aio_path.exists`, so it is a shared choice rather than a divergence; the CLI health probe and `fs_monkey` routing check answer a different question.

Python needed no changes here. It was the correct side throughout.

## 2. Node-only `Buffer` in runtime-agnostic core

`lancedb/read.ts` called `Buffer.from(value, 'base64')` unconditionally, which breaks in browsers. **#628 landed the identical fix while this PR was open**, so that file is no longer part of this diff — only the two gmail base64url helpers remain here, moved onto the shared `utils/base64.ts` helpers and dropping their Node fallbacks.

`langfuse/_client.ts` keeps its `globalThis.Buffer` guard: already conditional, with a deliberate error.

## 3. TypeScript conformance was narrower than Python

Python ran RAM, disk and Redis; TypeScript ran RAM only, and the matrix validator rejected `typescript: ["disk"]` as a load-time error.

All 38 cases now run on all three backends in both languages, with fresh state per case (new RAM store, fresh `mkdtemp`, cleared Redis key prefix). **All 38 pass on every backend with zero divergences.** Redis skips when `REDIS_URL` is unset and runs for real in CI, which already provides the service.

Two bugs in the new runner, both fixed:

- `Workspace.close()` already closes the mount's resource, destroying the Redis client. Clearing keys afterwards silently opened a second connection per case. Teardown is now split into `reset` (needs a live connection, before close) and `dispose` (after).
- The extra Redis load pushed a pre-existing marginal test (`redis.test.ts`, untouched by this PR) past vitest's 5s default. Rather than bump that one test, added `packages/node/vitest.config.ts` with `testTimeout: 15_000`, following the pattern `packages/server` already uses — the package does real temp-directory and Redis I/O, and 5s is a unit-test default.

Python's `SUPPORTED_MATRIX` had to change in step, since `_validate_matrix` raises at load time and would have failed every Python conformance test.

## CI

`integ/runners/parity.py` existed but no workflow or script ran it. It is now the `integ-shared-parity` job, in `integ-gate`'s `needs` list (a job outside the gate can fail silently). Targets are pinned to `ram disk redis`: with no arguments the script adds the Graph and Mem0 groups unconditionally, and `integ-battery-setup` exports `S3_ENDPOINT`/`SSH_HOST`/`GWS_URL`, so the default would have gated every core/TypeScript PR on 16 targets' worth of credentialed batteries that already have their own jobs.

Neither test workflow ran the conformance suite when only `conformance/**` changed. That needed fixing in two places, and the second came from review:
- `push.paths` in both workflows (push to main).
- the `dorny/paths-filter` `hit` list in each `changes` job — `pull_request` has no `paths:` restriction, so job selection depends entirely on that filter. A PR touching only a case JSON computed `hit=false`, skipped the test jobs, and still showed a green gate, because the gate treats `skipped` as success.

## Test stubs

Four test files faked backend errors as `new Error('not found')` or `new Error('ENOENT')`, putting the code in the message instead of on the error. Real backends throw `enoent()`. These surfaced as 19 failures against the tightened predicate, which is the bug class working as intended; the stubs are now honest rather than the predicate loosened.

The three new `cp.ts` probe tests exercise the helpers directly. Going through `cpGeneric` produced a false positive — `entryKind` throws first, so `overwriteGate` never ran and the test passed even with the fix reverted. Each test was checked against a fix-reverted build, and also asserts that a genuine ENOENT still returns the missing-path answer.

## Verification

- Full Python suite `uv run pytest`: exit 0
- Full TypeScript suite `pnpm test`: exit 0 (core 5062, node 1849, browser 168, agents 175, server 205, cli 92, opencode 2)
- Conformance: 114 tests per language with Redis; skips cleanly without
- `pnpm typecheck`: exit 0, all 7 packages
- `parity.py`: exit 0, 0 mismatches
- `pre-commit run --all-files`: exit 0
