### PR TITLE
fix(shell): shell-attribute unopenable redirect targets (py+ts)

### DIFF
--- a/integ/bash/redirect/redirect.json
+++ b/integ/bash/redirect/redirect.json
@@ -1306,6 +1306,93 @@
         "stdout": "yes\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "redirect_stdin_missing_source",
+      "seq": 501137,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "cat < NOPE",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "NOPE: No such file or directory\n"
+      }
+    },
+    {
+      "id": "redirect_stdin_missing_keeps_line",
+      "seq": 501138,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "echo hi < NOPE; echo next",
+      "expect": {
+        "exit": 0,
+        "stdout": "next\n",
+        "stderr": "NOPE: No such file or directory\n"
+      }
+    },
+    {
+      "id": "redirect_write_target_unwritable",
+      "seq": 501139,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "echo x > NOPEDIR/f; echo next",
+      "expect": {
+        "exit": 0,
+        "stdout": "next\n",
+        "stderr": "NOPEDIR/f: No such file or directory\n"
+      }
     }
   ]
 }

--- a/integ/bash/redirect/redirect.json
+++ b/integ/bash/redirect/redirect.json
@@ -1378,6 +1378,34 @@
         "stdout": "next\n",
         "stderr": "NOPEDIR/f: No such file or directory\n"
       }
+    },
+    {
+      "id": "redirect_write_stops_at_first_failure",
+      "seq": 501141,
+      "targets": [
+        "ram",
+        "redis"
+      ],
+      "command": "echo x > NOPEDIR/f > STOPPED; test -e STOPPED || echo skipped",
+      "expect": {
+        "exit": 0,
+        "stdout": "skipped\n",
+        "stderr": "NOPEDIR/f: No such file or directory\n"
+      }
+    },
+    {
+      "id": "redirect_write_keeps_earlier_target",
+      "seq": 501142,
+      "targets": [
+        "ram",
+        "redis"
+      ],
+      "command": "echo y > KEPT > NOPEDIR/g; test -e KEPT && wc -c < KEPT",
+      "expect": {
+        "exit": 0,
+        "stdout": "0\n",
+        "stderr": "NOPEDIR/g: No such file or directory\n"
+      }
     }
   ]
 }

--- a/integ/bash/redirect/redirect.json
+++ b/integ/bash/redirect/redirect.json
@@ -1370,22 +1370,7 @@
       "seq": 501139,
       "targets": [
         "ram",
-        "disk",
-        "redis",
-        "opfs",
-        "s3",
-        "databricks",
-        "s3-prefix",
-        "databricks-prefix",
-        "dropbox",
-        "dropbox-root",
-        "onedrive",
-        "sharepoint",
-        "sharepoint-prefix",
-        "ssh",
-        "nextcloud",
-        "gdrive",
-        "gdrive-folder"
+        "redis"
       ],
       "command": "echo x > NOPEDIR/f; echo next",
       "expect": {

--- a/integ/bash/redirect/redirect5.json
+++ b/integ/bash/redirect/redirect5.json
@@ -31,7 +31,7 @@
     },
     {
       "id": "redirect5_cleanup",
-      "seq": 501137,
+      "seq": 501140,
       "targets": [
         "ram",
         "disk",

--- a/integ/bash/redirect/redirect5.json
+++ b/integ/bash/redirect/redirect5.json
@@ -31,7 +31,7 @@
     },
     {
       "id": "redirect5_cleanup",
-      "seq": 501140,
+      "seq": 501145,
       "targets": [
         "ram",
         "disk",

--- a/integ/resources/mem0/basic.json
+++ b/integ/resources/mem0/basic.json
@@ -244,7 +244,7 @@
       "expect": {
         "exit": 1,
         "stdout": "",
-        "stderr": "echo: /memories/mem-beta.json: Operation not supported\n"
+        "stderr": "/memories/mem-beta.json: Operation not supported\n"
       }
     }
   ]

--- a/python/mirage/workspace/executor/redirect.py
+++ b/python/mirage/workspace/executor/redirect.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import logging
+
 import tree_sitter
 
 from mirage.io import IOResult
@@ -25,6 +27,8 @@ from mirage.utils.errors import FS_ERRORS, fs_strerror
 from mirage.workspace.executor.builtins import _to_scope
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
+
+logger = logging.getLogger(__name__)
 
 _TO_STDOUT = object()
 _TO_STDERR = object()
@@ -53,7 +57,12 @@ async def handle_redirect(
     command error — on both the ``<`` read and the ``>`` write side.
     bash reports it itself and never names the command, so both paths
     render ``<target>: <strerror>`` (see ``_redirect_error_line``) and
-    the rest of the line keeps running.
+    the rest of the line keeps running. bash also stops processing
+    redirects at the first failed open, so later targets are left
+    alone: GNU 5.2.37 answers ``echo x > /nodir/f > /data/out`` with one
+    message and no ``/data/out``, while earlier targets keep the empty
+    file their open already created (``echo y > /data/out2 > /nodir/g``
+    leaves ``/data/out2`` present and empty).
 
     Deliberate divergence from bash: when both streams route to the
     same destination they are concatenated stdout-then-stderr, not
@@ -166,7 +175,7 @@ async def handle_redirect(
         except FS_ERRORS as exc:
             out_stderr += _redirect_error_line(scope, exc)
             io.exit_code = 1
-            continue
+            break
         io.writes[path] = data
 
     result_stdout = bytes(out_stdout)
@@ -230,9 +239,13 @@ async def _read_existing(dispatch, scope) -> bytes:
         existing, _ = await dispatch("read", scope)
         if isinstance(existing, bytes):
             return existing
-    except FileNotFoundError:
-        # appending to a missing file starts from empty
-        pass
+    except FS_ERRORS as exc:
+        # appending starts from empty when the target is missing or
+        # unreadable; the write that follows reports the real failure as
+        # a shell-attributed line. Narrower than FS_ERRORS would let a
+        # PermissionError escape to the workspace-level OSError handler,
+        # which kills the rest of the line and misattributes the message.
+        logger.debug("append pre-read failed for %s: %s", scope.raw_path, exc)
     return b""
 
 

--- a/python/mirage/workspace/executor/redirect.py
+++ b/python/mirage/workspace/executor/redirect.py
@@ -21,6 +21,7 @@ from mirage.shell.barrier import BarrierPolicy, apply_barrier
 from mirage.shell.call_stack import CallStack
 from mirage.shell.types import Redirect, RedirectKind
 from mirage.types import PathSpec
+from mirage.utils.errors import FS_ERRORS, fs_strerror
 from mirage.workspace.executor.builtins import _to_scope
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
@@ -48,15 +49,34 @@ async def handle_redirect(
     if the stream ends up empty — including the command-less
     `> file` form (command is None).
 
+    A redirect target that cannot be opened is a shell error, not a
+    command error — on both the ``<`` read and the ``>`` write side.
+    bash reports it itself and never names the command, so both paths
+    render ``<target>: <strerror>`` (see ``_redirect_error_line``) and
+    the rest of the line keeps running.
+
     Deliberate divergence from bash: when both streams route to the
     same destination they are concatenated stdout-then-stderr, not
     temporally interleaved (streams are materialized buffers).
+
+    Deliberate divergence from bash: because output files are created
+    in a second pass (after the command runs), an output redirect that
+    precedes a failing ``<`` is not truncated — bash processes
+    redirects strictly left to right, so ``> out < missing`` empties
+    ``out`` before failing. ``< missing > out`` leaves ``out``
+    uncreated on both, which is bash's behavior. For the same reason a
+    command whose ``>`` target is unwritable has already run here,
+    while bash fails at open time and never runs it; the write error
+    and exit 1 are reported either way.
     """
     cmd_stdin = stdin
     for r in redirects:
         if r.kind == RedirectKind.STDIN:
             scope = _ensure_scope(r.target)
-            file_data, _ = await dispatch("read", scope)
+            try:
+                file_data, _ = await dispatch("read", scope)
+            except FS_ERRORS as exc:
+                return _redirect_failure(scope, exc)
             cmd_stdin = file_data
         elif r.kind == RedirectKind.HEREDOC:
             cmd_stdin = r.target.encode() if isinstance(r.target,
@@ -140,13 +160,69 @@ async def handle_redirect(
 
     for path, buf in file_bufs.items():
         data = bytes(buf)
-        await dispatch("write", file_scopes[path], data=data)
+        scope = file_scopes[path]
+        try:
+            await dispatch("write", scope, data=data)
+        except FS_ERRORS as exc:
+            out_stderr += _redirect_error_line(scope, exc)
+            io.exit_code = 1
+            continue
         io.writes[path] = data
 
     result_stdout = bytes(out_stdout)
     io.stderr = bytes(out_stderr) if out_stderr else None
     exec_node = ExecutionNode(command="redirect", exit_code=io.exit_code)
     return result_stdout if result_stdout else None, io, exec_node
+
+
+def _redirect_error_line(scope: PathSpec, exc: OSError) -> bytes:
+    """GNU stderr line for a redirect target that could not be opened.
+
+    GNU bash 5.2.37 answers both ``cat < missing`` and
+    ``echo x > /nosuchdir/f`` with
+    ``bash: line 1: <target>: No such file or directory`` and exit 1: the
+    error belongs to the shell, not the command, and the rest of the line
+    keeps running (``;`` continues, ``&&`` short-circuits, ``||`` runs).
+
+    Deliberate divergence from bash: the ``bash: line N:`` prefix is
+    dropped, so the line is ``<target>: <strerror>``. This matches the
+    house style already set by the other shell-attributed error,
+    ``nosuchcmd: command not found`` (bash prints
+    ``bash: line 1: nosuchcmd: command not found``) — ``bash:`` is bash's
+    ``$0`` and mirage is not bash, and ``line N`` has no meaning for a
+    one-line ``Workspace.execute`` call.
+
+    The label is the target's own spelling, never the exception's message:
+    backends raise write failures with prose in ``str(exc)`` (``parent
+    directory does not exist: /nodir``), which used to reach the user as
+    the path.
+
+    Args:
+        scope (PathSpec): The redirect target that could not be opened.
+        exc (OSError): The filesystem error raised by the read or write.
+    """
+    label = scope.raw_path
+    strerror = fs_strerror(exc)
+    return (f"{label}: {strerror}\n" if strerror else f"{label}\n").encode()
+
+
+def _redirect_failure(scope: PathSpec,
+                      exc: OSError) -> tuple[None, IOResult, ExecutionNode]:
+    """Shell-attributed IOResult for a ``<`` source that cannot be read.
+
+    bash never runs the command and stops processing redirects at the
+    first failure, so this replaces the whole result. Returning an
+    IOResult rather than letting the error propagate is what keeps the
+    rest of the line alive; it also stops the workspace-level ``OSError``
+    handler from stamping the line's first word onto the message
+    (``cd /data && cat < missing`` used to report ``cd:``).
+
+    Args:
+        scope (PathSpec): The redirect source that could not be read.
+        exc (OSError): The filesystem error raised by the read.
+    """
+    io = IOResult(exit_code=1, stderr=_redirect_error_line(scope, exc))
+    return None, io, ExecutionNode(command="redirect", exit_code=1)
 
 
 async def _read_existing(dispatch, scope) -> bytes:

--- a/python/tests/workspace/executor/test_redirect.py
+++ b/python/tests/workspace/executor/test_redirect.py
@@ -335,6 +335,35 @@ async def test_write_target_unwritable_runs_or_branch():
 
 
 @pytest.mark.asyncio
+async def test_write_target_unwritable_stops_at_first_failure():
+    # GNU stops processing redirects at the failed open, so the later
+    # target is never created and only one message is emitted:
+    #   $ echo x > /nodir/f > /data/out
+    #   bash: line 1: /nodir/f: No such file or directory   # rc=1
+    #   $ ls /data/out -> No such file or directory
+    ws = await _workspace()
+    io = await ws.execute("echo x > /nodir/f > /data/out")
+    assert io.exit_code == 1
+    assert (io.stderr or b"") == b"/nodir/f: No such file or directory\n"
+    assert (await ws.execute("test -e /data/out")).exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_write_target_unwritable_keeps_earlier_target():
+    # The mirror case: GNU already opened (and truncated) the earlier
+    # target before the failing one, so it survives as an empty file.
+    #   $ echo y > /data/out2 > /nodir/g
+    #   bash: line 1: /nodir/g: No such file or directory   # rc=1
+    #   $ ls -l /data/out2 -> 0 bytes
+    ws = await _workspace()
+    io = await ws.execute("echo y > /data/out2 > /nodir/g")
+    assert io.exit_code == 1
+    assert (io.stderr or b"") == b"/nodir/g: No such file or directory\n"
+    assert (await ws.execute("test -e /data/out2")).exit_code == 0
+    assert await _out(ws, "cat /data/out2") == ""
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("line", [
     "echo x >> /nodir/f",
     "echo x 2> /nodir/f",

--- a/python/tests/workspace/executor/test_redirect.py
+++ b/python/tests/workspace/executor/test_redirect.py
@@ -188,3 +188,161 @@ async def test_stdin_from_process_substitution():
     ws = await _workspace()
     out = await _out(ws, "wc -l < <(printf 'x\\ny\\n')")
     assert out.strip() == "2"
+
+
+# ── unopenable redirect target (GNU bash 5.2.37 pinned) ─────
+# bash answers both `cat < missing` and `echo x > /nosuchdir/f` with
+# "bash: line 1: <target>: No such file or directory", exit 1, and
+# never names the command. mirage drops the "bash: line N:" prefix,
+# matching the house style of the other shell-attributed error
+# ("nosuchcmd: command not found").
+
+
+@pytest.mark.asyncio
+async def test_stdin_missing_source_is_shell_attributed():
+    ws = await _workspace()
+    io = await ws.execute("cat < /data/missing")
+    assert io.exit_code == 1
+    assert (io.stderr or b"") == b"/data/missing: No such file or directory\n"
+
+
+@pytest.mark.asyncio
+async def test_stdin_missing_source_does_not_run_command():
+    # bash never reaches the command, so `hi` is not printed and the
+    # message is not prefixed with the command name.
+    ws = await _workspace()
+    io = await ws.execute("echo hi < /data/missing")
+    assert io.exit_code == 1
+    assert (io.stdout or b"") == b""
+    assert (io.stderr or b"") == b"/data/missing: No such file or directory\n"
+
+
+@pytest.mark.asyncio
+async def test_stdin_missing_source_keeps_rest_of_line():
+    # GNU: `cat < missing; echo next` prints next and exits 0 — the
+    # redirect failure is not fatal to the line.
+    ws = await _workspace()
+    io = await ws.execute("cat < /data/missing; echo next")
+    assert io.exit_code == 0
+    assert (io.stdout or b"") == b"next\n"
+    assert (io.stderr or b"") == b"/data/missing: No such file or directory\n"
+
+
+@pytest.mark.asyncio
+async def test_stdin_missing_source_short_circuits_and():
+    ws = await _workspace()
+    io = await ws.execute("cat < /data/missing && echo YES")
+    assert io.exit_code == 1
+    assert (io.stdout or b"") == b""
+
+
+@pytest.mark.asyncio
+async def test_stdin_missing_source_runs_or_branch():
+    ws = await _workspace()
+    io = await ws.execute("cat < /data/missing || echo OR")
+    assert io.exit_code == 0
+    assert (io.stdout or b"") == b"OR\n"
+
+
+@pytest.mark.asyncio
+async def test_stdin_missing_source_leaves_pipeline_running():
+    # GNU: the failing element contributes nothing but `wc -l` still
+    # runs, prints 0, and owns the pipeline's exit code.
+    ws = await _workspace()
+    io = await ws.execute("cat < /data/missing | wc -l")
+    assert io.exit_code == 0
+    assert (io.stdout or b"").strip() == b"0"
+    assert (io.stderr or b"") == b"/data/missing: No such file or directory\n"
+
+
+@pytest.mark.asyncio
+async def test_stdin_missing_source_reported_as_typed():
+    # GNU reports the target's spelling, not a resolved absolute path.
+    ws = await _workspace()
+    io = await ws.execute("cd /data && cat < missing")
+    assert io.exit_code == 1
+    assert (io.stderr or b"") == b"missing: No such file or directory\n"
+
+
+@pytest.mark.asyncio
+async def test_stdin_missing_source_stops_at_first_failure():
+    # Two `<` redirects, the first missing: bash stops processing
+    # redirects there, so exactly one message is emitted.
+    ws = await _workspace()
+    await ws.execute("printf PRE > /data/good")
+    io = await ws.execute("cat < /data/missing < /data/good")
+    assert io.exit_code == 1
+    assert (io.stderr or b"") == b"/data/missing: No such file or directory\n"
+
+
+@pytest.mark.asyncio
+async def test_stdin_missing_source_skips_later_output_redirect():
+    # `< missing > out` fails before `out` is created, like bash.
+    ws = await _workspace()
+    io = await ws.execute("echo hi < /data/missing > /data/late")
+    assert io.exit_code == 1
+    assert (await ws.execute("test -e /data/late")).exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_stdin_missing_source_does_not_prefix_first_word_of_line():
+    # Regression: the failure used to unwind to the workspace-level
+    # OSError handler, which stamped the line's first word onto the
+    # message (`cd /data && cat < missing` reported "cd:").
+    ws = await _workspace()
+    io = await ws.execute("cd /data && cat < missing")
+    stderr = (io.stderr or b"").decode()
+    assert not stderr.startswith("cd:")
+    assert not stderr.startswith("cat:")
+
+
+@pytest.mark.asyncio
+async def test_write_target_unwritable_is_shell_attributed():
+    # The `>` side gets the same treatment as `<`: bash reports the
+    # target, not the command, and not the backend's prose (which used
+    # to surface as "echo: parent directory does not exist: /nodir").
+    ws = await _workspace()
+    io = await ws.execute("echo x > /nodir/f")
+    assert io.exit_code == 1
+    assert (io.stderr or b"") == b"/nodir/f: No such file or directory\n"
+
+
+@pytest.mark.asyncio
+async def test_write_target_unwritable_keeps_rest_of_line():
+    # Regression: the write raised with no handler, so the whole line
+    # died; GNU prints the error and runs `echo next`.
+    ws = await _workspace()
+    io = await ws.execute("echo x > /nodir/f; echo next")
+    assert io.exit_code == 0
+    assert (io.stdout or b"") == b"next\n"
+    assert (io.stderr or b"") == b"/nodir/f: No such file or directory\n"
+
+
+@pytest.mark.asyncio
+async def test_write_target_unwritable_short_circuits_and():
+    ws = await _workspace()
+    io = await ws.execute("echo x > /nodir/f && echo YES")
+    assert io.exit_code == 1
+    assert (io.stdout or b"") == b""
+
+
+@pytest.mark.asyncio
+async def test_write_target_unwritable_runs_or_branch():
+    ws = await _workspace()
+    io = await ws.execute("echo x > /nodir/f || echo OR")
+    assert io.exit_code == 0
+    assert (io.stdout or b"") == b"OR\n"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("line", [
+    "echo x >> /nodir/f",
+    "echo x 2> /nodir/f",
+    "> /nodir/f",
+])
+async def test_write_target_unwritable_same_line_for_every_form(line: str):
+    # GNU spells the append, stderr and command-less forms identically.
+    ws = await _workspace()
+    io = await ws.execute(line)
+    assert io.exit_code == 1
+    assert (io.stderr or b"") == b"/nodir/f: No such file or directory\n"

--- a/python/tests/workspace/test_session_capability.py
+++ b/python/tests/workspace/test_session_capability.py
@@ -209,6 +209,24 @@ def test_redirect_to_forbidden_mount_is_denied():
     assert (io.stderr or b"") == b"/b/leaked.txt: Permission denied\n"
 
 
+def test_append_to_forbidden_mount_is_shell_attributed():
+    # `>>` pre-reads the existing content before writing, and that read
+    # hits the mount guard first. The pre-read must swallow the denial so
+    # the write reports it as the same shell-attributed line `>` gets,
+    # instead of unwinding to the workspace-level OSError handler (which
+    # kills the rest of the line and stamps the line's first word).
+    ws = _two_mounts_with_secret()
+
+    async def run():
+        return await ws.execute("echo leaked >> /b/leaked.txt; echo next",
+                                session_id="agent")
+
+    io = asyncio.run(run())
+    assert io.exit_code == 0
+    assert (io.stdout or b"") == b"next\n"
+    assert (io.stderr or b"") == b"/b/leaked.txt: Permission denied\n"
+
+
 def test_cross_mount_copy_into_forbidden_mount_is_denied():
     ws = _two_mounts_with_secret()
 

--- a/python/tests/workspace/test_session_capability.py
+++ b/python/tests/workspace/test_session_capability.py
@@ -201,7 +201,12 @@ def test_redirect_to_forbidden_mount_is_denied():
 
     io = asyncio.run(run())
     assert io.exit_code != 0
-    assert b"not allowed" in (io.stderr or b"")
+    # A refused redirect target is shell-attributed like GNU
+    # ("bash: line 1: /b/leaked.txt: Permission denied"); the mount
+    # guard's own "not allowed to access mount" prose stays on the
+    # exception (the FUSE bridge still sniffs it) instead of reaching
+    # the user as the path.
+    assert (io.stderr or b"") == b"/b/leaked.txt: Permission denied\n"
 
 
 def test_cross_mount_copy_into_forbidden_mount_is_denied():
@@ -283,7 +288,7 @@ def test_read_grant_blocks_redirect_write():
 
     io = asyncio.run(run())
     assert io.exit_code != 0
-    assert io.stderr == b"echo: /a/y.txt: Permission denied\n"
+    assert io.stderr == b"/a/y.txt: Permission denied\n"
     assert "/y.txt" not in a._store.files
 
 
@@ -310,7 +315,7 @@ def test_grant_cannot_widen_read_mount():
 
     io = asyncio.run(run())
     assert io.exit_code != 0
-    assert io.stderr == b"echo: /a/y.txt: Permission denied\n"
+    assert io.stderr == b"/a/y.txt: Permission denied\n"
 
 
 def test_user_root_mount_governed_by_grants():
@@ -336,7 +341,7 @@ def test_user_root_mount_governed_by_grants():
     assert b"not allowed" in (denied.stderr or b"")
     assert read_ok.exit_code == 0 and b"top" in (read_ok.stdout or b"")
     assert write_denied.exit_code != 0
-    assert write_denied.stderr == b"echo: /root.txt: Permission denied\n"
+    assert write_denied.stderr == b"/root.txt: Permission denied\n"
 
 
 def test_implicit_root_keeps_pathless_commands_working():

--- a/typescript/packages/core/src/context/session_context.ts
+++ b/typescript/packages/core/src/context/session_context.ts
@@ -27,14 +27,28 @@ function getCurrentSession(): Session | null {
   return sessionStorage.getStore() ?? null
 }
 
+/**
+ * A session touched a mount outside its allowlist.
+ *
+ * Stamped EACCES + operand so it behaves like python's `PermissionError`
+ * from the same guard, which is a member of `FS_ERRORS`: callers that
+ * handle filesystem errors per-operand (the redirect write pass) render
+ * `<target>: Permission denied` instead of letting the guard's own prose
+ * escape as the whole message. Callers that want the prose still read
+ * `.message`, and the explicit `instanceof` checks in `command.ts` and the
+ * FUSE bridge run before any of that and are unaffected.
+ */
 export class MountNotAllowedError extends Error {
   readonly sessionId: string
   readonly mountPrefix: string
+  readonly code = 'EACCES'
+  readonly virtualPath: string
   constructor(sessionId: string, mountPrefix: string) {
     super(`session '${sessionId}' not allowed to access mount '${mountPrefix}'`)
     this.name = 'MountNotAllowedError'
     this.sessionId = sessionId
     this.mountPrefix = mountPrefix
+    this.virtualPath = mountPrefix
   }
 }
 

--- a/typescript/packages/core/src/core/ram/write.ts
+++ b/typescript/packages/core/src/core/ram/write.ts
@@ -17,6 +17,7 @@ import type { RAMAccessor } from '../../accessor/ram.ts'
 import { ResourceName, type PathSpec } from '../../types.ts'
 import { norm, nowIso, parent } from './utils.ts'
 import { invalidateAfterWrite } from '../../cache/context.ts'
+import { enoentWithMessage } from '../../utils/errors.ts'
 
 export async function writeBytes(
   accessor: RAMAccessor,
@@ -27,7 +28,7 @@ export async function writeBytes(
   const p = norm(path.mountPath)
   const par = parent(p)
   if (par !== '/' && !accessor.store.dirs.has(par)) {
-    throw new Error(`parent directory does not exist: ${par}`)
+    throw enoentWithMessage(`parent directory does not exist: ${par}`, path)
   }
   accessor.store.files.set(p, data)
   accessor.store.modified.set(p, nowIso())

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -1237,6 +1237,7 @@ export {
 export {
   eisdir,
   enoent,
+  enoentWithMessage,
   enotdir,
   enotsup,
   errorVirtualPath,

--- a/typescript/packages/core/src/utils/errors.ts
+++ b/typescript/packages/core/src/utils/errors.ts
@@ -111,6 +111,21 @@ export function eaccesReadOnly(
   return err
 }
 
+// A missing-parent write refusal, keeping the backend's human message (tests
+// and logs read 'parent directory does not exist') while stamping ENOENT +
+// operand so fs chokepoints render 'No such file or directory'. Mirrors
+// Python, which raises FileNotFoundError with the same prose — an untyped
+// Error here leaked the prose to the user as if it were the path.
+export function enoentWithMessage(
+  message: string,
+  path: string | { virtual: string; rawPath?: string },
+): FsError {
+  const err = new Error(message) as FsError
+  err.code = 'ENOENT'
+  err.virtualPath = virtualOf(path)
+  return err
+}
+
 const STRERROR: Record<string, string> = {
   ENOENT: 'No such file or directory',
   ENOTDIR: 'Not a directory',

--- a/typescript/packages/core/src/workspace/executor/redirect.test.ts
+++ b/typescript/packages/core/src/workspace/executor/redirect.test.ts
@@ -311,3 +311,192 @@ describe('fd-table routing end-to-end', () => {
     }
   })
 })
+
+// GNU bash 5.2.37 pinned: both `cat < missing` and `echo x > /nosuchdir/f`
+// answer "bash: line 1: <target>: No such file or directory", exit 1, and
+// never name the command. mirage drops the "bash: line N:" prefix, matching
+// the house style of the other shell-attributed error
+// ("nosuchcmd: command not found").
+describe('handleRedirect missing < source', () => {
+  it('is shell-attributed, not command-attributed', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [exit, out, err] = await runResult(ws, 'cat < /data/missing')
+      expect(exit).toBe(1)
+      expect(out).toBe('')
+      expect(err).toBe('/data/missing: No such file or directory\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('does not run the command', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [exit, out, err] = await runResult(ws, 'echo hi < /data/missing')
+      expect(exit).toBe(1)
+      expect(out).toBe('')
+      expect(err).toBe('/data/missing: No such file or directory\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('keeps the rest of the line running', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [exit, out, err] = await runResult(ws, 'cat < /data/missing; echo next')
+      expect(exit).toBe(0)
+      expect(out).toBe('next\n')
+      expect(err).toBe('/data/missing: No such file or directory\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('short-circuits && and runs ||', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [andExit, andOut] = await runResult(ws, 'cat < /data/missing && echo YES')
+      expect(andExit).toBe(1)
+      expect(andOut).toBe('')
+      const [orExit, orOut] = await runResult(ws, 'cat < /data/missing || echo OR')
+      expect(orExit).toBe(0)
+      expect(orOut).toBe('OR\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('leaves the rest of the pipeline running', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [exit, out, err] = await runResult(ws, 'cat < /data/missing | wc -l')
+      expect(exit).toBe(0)
+      expect(out.trim()).toBe('0')
+      expect(err).toBe('/data/missing: No such file or directory\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('reports the target as typed, not resolved', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [exit, , err] = await runResult(ws, 'cd /data && cat < missing')
+      expect(exit).toBe(1)
+      expect(err).toBe('missing: No such file or directory\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('stops at the first failing redirect', async () => {
+    const { ws } = await makeIntegrationWS({ good: 'PRE' })
+    try {
+      const [exit, , err] = await runResult(ws, 'cat < /data/missing < /data/good')
+      expect(exit).toBe(1)
+      expect(err).toBe('/data/missing: No such file or directory\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('skips a later output redirect', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [exit] = await runResult(ws, 'echo hi < /data/missing > /data/late')
+      expect(exit).toBe(1)
+      expect(await runExit(ws, 'test -e /data/late')).toBe(1)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('rethrows a non-filesystem read error', async () => {
+    const dispatch = vi.fn(() =>
+      Promise.reject(new Error('backend exploded')),
+    ) as unknown as DispatchFn
+    const executeNode = vi.fn() as unknown as ExecuteNodeFn
+    const redirects = [new Redirect({ fd: 0, target: '/data/missing', kind: RedirectKind.STDIN })]
+    await expect(
+      handleRedirect(
+        executeNode,
+        dispatch,
+        STUB_NODE,
+        redirects,
+        new Session({ sessionId: 'test' }),
+        null,
+        null,
+      ),
+    ).rejects.toThrow('backend exploded')
+    expect(executeNode).not.toHaveBeenCalled()
+  })
+})
+
+describe('handleRedirect unwritable > target', () => {
+  it('is shell-attributed, not command-attributed or backend prose', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [exit, out, err] = await runResult(ws, 'echo x > /nodir/f')
+      expect(exit).toBe(1)
+      expect(out).toBe('')
+      expect(err).toBe('/nodir/f: No such file or directory\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('keeps the rest of the line running', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [exit, out, err] = await runResult(ws, 'echo x > /nodir/f; echo next')
+      expect(exit).toBe(0)
+      expect(out).toBe('next\n')
+      expect(err).toBe('/nodir/f: No such file or directory\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('short-circuits && and runs ||', async () => {
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [andExit, andOut] = await runResult(ws, 'echo x > /nodir/f && echo YES')
+      expect(andExit).toBe(1)
+      expect(andOut).toBe('')
+      const [orExit, orOut] = await runResult(ws, 'echo x > /nodir/f || echo OR')
+      expect(orExit).toBe(0)
+      expect(orOut).toBe('OR\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it.each(['echo x >> /nodir/f', 'echo x 2> /nodir/f', '> /nodir/f'])(
+    'spells %s the same way',
+    async (line) => {
+      const { ws } = await makeIntegrationWS()
+      try {
+        const [exit, , err] = await runResult(ws, line)
+        expect(exit).toBe(1)
+        expect(err).toBe('/nodir/f: No such file or directory\n')
+      } finally {
+        await ws.close()
+      }
+    },
+  )
+
+  it('rethrows a non-filesystem write error', async () => {
+    const dispatch = vi.fn<DispatchFn>((op) => {
+      if (op === 'write') return Promise.reject(new Error('backend exploded'))
+      return Promise.resolve<[unknown, IOResult]>([null, new IOResult()])
+    })
+    const execute: ExecuteNodeFn = () =>
+      Promise.resolve([encode('hi'), new IOResult(), new ExecutionNode()])
+    const redirects = [new Redirect({ fd: 1, target: '/ram/out.txt', kind: RedirectKind.STDOUT })]
+    await expect(
+      handleRedirect(execute, dispatch, STUB_NODE, redirects, new Session({ sessionId: 'test' })),
+    ).rejects.toThrow('backend exploded')
+  })
+})

--- a/typescript/packages/core/src/workspace/executor/redirect.test.ts
+++ b/typescript/packages/core/src/workspace/executor/redirect.test.ts
@@ -487,6 +487,53 @@ describe('handleRedirect unwritable > target', () => {
     },
   )
 
+  it('stops at the first failure and skips the later target', async () => {
+    // GNU: `echo x > /nodir/f > /data/out` reports /nodir/f once and
+    // never creates /data/out.
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [exit, , err] = await runResult(ws, 'echo x > /nodir/f > /data/out')
+      expect(exit).toBe(1)
+      expect(err).toBe('/nodir/f: No such file or directory\n')
+      expect(await runExit(ws, 'test -e /data/out')).toBe(1)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('keeps a target opened before the failing one', async () => {
+    // GNU: `echo y > /data/out2 > /nodir/g` already truncated
+    // /data/out2, so it survives as an empty file.
+    const { ws } = await makeIntegrationWS()
+    try {
+      const [exit, , err] = await runResult(ws, 'echo y > /data/out2 > /nodir/g')
+      expect(exit).toBe(1)
+      expect(err).toBe('/nodir/g: No such file or directory\n')
+      expect(await runExit(ws, 'test -e /data/out2')).toBe(0)
+      const [, out] = await runResult(ws, 'cat /data/out2')
+      expect(out).toBe('')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('rethrows a non-filesystem append pre-read error', async () => {
+    // The `>>` pre-read swallows filesystem errors (the write reports
+    // them) but must not hide a backend bug.
+    const dispatch = vi.fn<DispatchFn>((op) => {
+      if (op === 'read') return Promise.reject(new Error('backend exploded'))
+      return Promise.resolve<[unknown, IOResult]>([null, new IOResult()])
+    })
+    const execute: ExecuteNodeFn = () =>
+      Promise.resolve([encode('hi'), new IOResult(), new ExecutionNode()])
+    const redirects = [
+      new Redirect({ fd: 1, target: '/ram/out.txt', kind: RedirectKind.STDOUT, append: true }),
+    ]
+    await expect(
+      handleRedirect(execute, dispatch, STUB_NODE, redirects, new Session({ sessionId: 'test' })),
+    ).rejects.toThrow('backend exploded')
+  })
+
   it('rethrows a non-filesystem write error', async () => {
     const dispatch = vi.fn<DispatchFn>((op) => {
       if (op === 'write') return Promise.reject(new Error('backend exploded'))

--- a/typescript/packages/core/src/workspace/executor/redirect.ts
+++ b/typescript/packages/core/src/workspace/executor/redirect.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { formatFsError } from '../../utils/errors.ts'
+import { fsStrerror, isFsError } from '../../utils/errors.ts'
 import { stripSlash } from '../../utils/slash.ts'
 import type { ByteSource } from '../../io/types.ts'
 import { IOResult, materialize } from '../../io/types.ts'
@@ -27,23 +27,6 @@ import type { DispatchFn } from './cross_mount.ts'
 import type { ExecuteNodeFn } from './jobs.ts'
 
 type Result = [ByteSource | null, IOResult, ExecutionNode]
-
-// The name a failed redirect write reports itself under, matching the
-// workspace chokepoint (and Python's `command.split()[0]`): the command's
-// own name, or the redirect operator for the command-less `> file` form.
-function redirectCmdName(command: TSNodeLike | null, redirects: readonly Redirect[]): string {
-  if (command !== null) return command.text.trim().split(/\s+/, 1)[0] ?? 'redirect'
-  const write = redirects.find(
-    (r) =>
-      r.kind !== RedirectKind.STDIN &&
-      r.kind !== RedirectKind.HEREDOC &&
-      r.kind !== RedirectKind.HERESTRING,
-  )
-  if (write === undefined) return 'redirect'
-  const arrow = write.append ? '>>' : '>'
-  if (write.fd === -1) return `&${arrow}`
-  return write.fd === 2 ? `2${arrow}` : arrow
-}
 
 const TO_STDOUT = Symbol('stdout')
 const TO_STDERR = Symbol('stderr')
@@ -60,9 +43,23 @@ type FdDest = typeof TO_STDOUT | typeof TO_STDERR | string
  * the stream ends up empty — including the command-less `> file` form
  * (command is null).
  *
+ * A redirect target that cannot be opened is a shell error, not a command
+ * error — on both the `<` read and the `>` write side. bash reports it itself
+ * and never names the command, so both paths render `<target>: <strerror>`
+ * (see `redirectErrorLine`) and the rest of the line keeps running.
+ *
  * Deliberate divergence from bash: when both streams route to the same
  * destination they are concatenated stdout-then-stderr, not temporally
  * interleaved (streams are materialized buffers).
+ *
+ * Deliberate divergence from bash: because output files are created in a
+ * second pass (after the command runs), an output redirect that precedes a
+ * failing `<` is not truncated — bash processes redirects strictly left to
+ * right, so `> out < missing` empties `out` before failing. `< missing >
+ * out` leaves `out` uncreated on both, which is bash's behavior. For the same
+ * reason a command whose `>` target is unwritable has already run here, while
+ * bash fails at open time and never runs it; the write error and exit 1 are
+ * reported either way.
  */
 export async function handleRedirect(
   executeNode: ExecuteNodeFn,
@@ -78,7 +75,13 @@ export async function handleRedirect(
   for (const r of redirects) {
     if (r.kind === RedirectKind.STDIN) {
       const scope = ensureScope(r.target)
-      const [data] = await dispatch('read', scope)
+      let data: unknown
+      try {
+        ;[data] = await dispatch('read', scope)
+      } catch (err) {
+        if (!isFsError(err)) throw err
+        return redirectFailure(scope, err)
+      }
       cmdStdin = data as ByteSource | null
     } else if (r.kind === RedirectKind.HEREDOC) {
       cmdStdin =
@@ -186,12 +189,8 @@ export async function handleRedirect(
       await dispatch('write', scope, [data])
       io.writes[path] = data
     } catch (err) {
-      // GNU spells a failed redirect target `<cmd>: <path>: <strerror>`;
-      // the raw error message leaked the internal op-registry wording.
-      outStderr = concat([
-        outStderr,
-        formatFsError(redirectCmdName(command, redirects), err, [scope]),
-      ])
+      if (!isFsError(err)) throw err
+      outStderr = concat([outStderr, redirectErrorLine(scope, err)])
       io.exitCode = 1
     }
   }
@@ -200,6 +199,43 @@ export async function handleRedirect(
   const execNode = new ExecutionNode({ command: 'redirect', exitCode: io.exitCode })
   const outSource: ByteSource | null = outStdout.byteLength > 0 ? outStdout : null
   return [outSource, io, execNode]
+}
+
+/**
+ * GNU stderr line for a redirect target that could not be opened.
+ *
+ * GNU bash 5.2.37 answers both `cat < missing` and `echo x > /nosuchdir/f`
+ * with `bash: line 1: <target>: No such file or directory` and exit 1: the
+ * error belongs to the shell, not the command, and the rest of the line keeps
+ * running (`;` continues, `&&` short-circuits, `||` runs).
+ *
+ * Deliberate divergence from bash: the `bash: line N:` prefix is dropped, so
+ * the line is `<target>: <strerror>`. This matches the house style already
+ * set by the other shell-attributed error, `nosuchcmd: command not found`
+ * (bash prints `bash: line 1: nosuchcmd: command not found`) — `bash:` is
+ * bash's `$0` and mirage is not bash, and `line N` has no meaning for a
+ * one-line `Workspace.execute` call.
+ *
+ * The label is the target's own spelling, never the error's message: backends
+ * raise write failures with prose in the message (`parent directory does not
+ * exist: /nodir`), which used to reach the user as the path.
+ */
+function redirectErrorLine(scope: PathSpec, err: unknown): Uint8Array {
+  const strerror = fsStrerror(err)
+  const label = scope.rawPath
+  return new TextEncoder().encode(strerror !== null ? `${label}: ${strerror}\n` : `${label}\n`)
+}
+
+/**
+ * Shell-attributed IOResult for a `<` source that cannot be read.
+ *
+ * bash never runs the command and stops processing redirects at the first
+ * failure, so this replaces the whole result. Returning an IOResult rather
+ * than rethrowing is what keeps the rest of the line alive.
+ */
+function redirectFailure(scope: PathSpec, err: unknown): Result {
+  const io = new IOResult({ exitCode: 1, stderr: redirectErrorLine(scope, err) })
+  return [null, io, new ExecutionNode({ command: 'redirect', exitCode: 1 })]
 }
 
 async function readExisting(dispatch: DispatchFn, scope: PathSpec): Promise<Uint8Array> {

--- a/typescript/packages/core/src/workspace/executor/redirect.ts
+++ b/typescript/packages/core/src/workspace/executor/redirect.ts
@@ -46,7 +46,12 @@ type FdDest = typeof TO_STDOUT | typeof TO_STDERR | string
  * A redirect target that cannot be opened is a shell error, not a command
  * error — on both the `<` read and the `>` write side. bash reports it itself
  * and never names the command, so both paths render `<target>: <strerror>`
- * (see `redirectErrorLine`) and the rest of the line keeps running.
+ * (see `redirectErrorLine`) and the rest of the line keeps running. bash also
+ * stops processing redirects at the first failed open, so later targets are
+ * left alone: GNU 5.2.37 answers `echo x > /nodir/f > /data/out` with one
+ * message and no `/data/out`, while earlier targets keep the empty file their
+ * open already created (`echo y > /data/out2 > /nodir/g` leaves `/data/out2`
+ * present and empty).
  *
  * Deliberate divergence from bash: when both streams route to the same
  * destination they are concatenated stdout-then-stderr, not temporally
@@ -192,6 +197,7 @@ export async function handleRedirect(
       if (!isFsError(err)) throw err
       outStderr = concat([outStderr, redirectErrorLine(scope, err)])
       io.exitCode = 1
+      break
     }
   }
 
@@ -242,8 +248,11 @@ async function readExisting(dispatch: DispatchFn, scope: PathSpec): Promise<Uint
   try {
     const [existing] = await dispatch('read', scope)
     if (existing instanceof Uint8Array) return existing
-  } catch {
-    // file doesn't exist yet, or not readable — appending starts fresh
+  } catch (err) {
+    // file doesn't exist yet, or not readable — appending starts fresh and
+    // the write that follows reports the real failure as a shell-attributed
+    // line. Non-filesystem errors are bugs and still propagate.
+    if (!isFsError(err)) throw err
   }
   return new Uint8Array()
 }

--- a/typescript/packages/core/src/workspace/session_modes.test.ts
+++ b/typescript/packages/core/src/workspace/session_modes.test.ts
@@ -89,7 +89,7 @@ describe('per-session mount grants', () => {
 
     const denied = await ws.execute('echo leaked > /a/y.txt', { sessionId: 'agent' })
     expect(denied.exitCode).not.toBe(0)
-    expect(stderrStr(denied)).toBe('echo: /a/y.txt: Permission denied\n')
+    expect(stderrStr(denied)).toBe('/a/y.txt: Permission denied\n')
     expect(a.store.files.has('/y.txt')).toBe(false)
   })
 
@@ -108,7 +108,7 @@ describe('per-session mount grants', () => {
 
     const denied = await ws.execute('echo up > /a/y.txt', { sessionId: 'agent' })
     expect(denied.exitCode).not.toBe(0)
-    expect(stderrStr(denied)).toBe('echo: /a/y.txt: Permission denied\n')
+    expect(stderrStr(denied)).toBe('/a/y.txt: Permission denied\n')
   })
 
   it('list form inherits the mount mode', async () => {
@@ -145,7 +145,7 @@ describe('per-session mount grants', () => {
 
     const writeDenied = await ws.execute('echo x > /root.txt', { sessionId: 'root_ro' })
     expect(writeDenied.exitCode).not.toBe(0)
-    expect(stderrStr(writeDenied)).toBe('echo: /root.txt: Permission denied\n')
+    expect(stderrStr(writeDenied)).toBe('/root.txt: Permission denied\n')
   })
 
   it('the implicit scratch root keeps pathless commands working', async () => {

--- a/typescript/packages/core/src/workspace/session_modes.test.ts
+++ b/typescript/packages/core/src/workspace/session_modes.test.ts
@@ -93,6 +93,24 @@ describe('per-session mount grants', () => {
     expect(a.store.files.has('/y.txt')).toBe(false)
   })
 
+  // A mount with no grant at all takes the same shell-attributed line as a
+  // READ-granted one, on `>` and `>>` alike, and the rest of the line keeps
+  // running — matching python, whose guard raises a PermissionError that is
+  // already a member of FS_ERRORS.
+  it.each(['echo leaked > /b/y.txt; echo next', 'echo leaked >> /b/y.txt; echo next'])(
+    'shell-attributes %s for an ungranted mount',
+    async (line) => {
+      const { ws, b } = await makeGrantsWorkspace()
+      ws.createSession('agent', { mounts: { '/a': MountMode.WRITE } })
+
+      const denied = await ws.execute(line, { sessionId: 'agent' })
+      expect(denied.exitCode).toBe(0)
+      expect(stdoutStr(denied)).toBe('next\n')
+      expect(stderrStr(denied)).toBe('/b/y.txt: Permission denied\n')
+      expect(b.store.files.has('/y.txt')).toBe(false)
+    },
+  )
+
   it('write grant allows writes', async () => {
     const { ws, a } = await makeGrantsWorkspace()
     ws.createSession('agent', { mounts: { '/a': MountMode.WRITE } })

--- a/typescript/packages/node/src/core/redis/write.ts
+++ b/typescript/packages/node/src/core/redis/write.ts
@@ -12,7 +12,13 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { ResourceName, invalidateAfterWrite, record, type PathSpec } from '@struktoai/mirage-core'
+import {
+  ResourceName,
+  enoentWithMessage,
+  invalidateAfterWrite,
+  record,
+  type PathSpec,
+} from '@struktoai/mirage-core'
 import type { RedisAccessor } from '../../accessor/redis.ts'
 import { norm, nowIso, parent } from './utils.ts'
 
@@ -26,7 +32,7 @@ export async function writeBytes(
   const par = parent(p)
   const store = accessor.store
   if (par !== '/' && !(await store.hasDir(par))) {
-    throw new Error(`parent directory does not exist: ${par}`)
+    throw enoentWithMessage(`parent directory does not exist: ${par}`, path)
   }
   await store.setFile(p, data)
   await store.setModified(p, nowIso())


### PR DESCRIPTION
## Problem

An unopenable redirect target diverged three ways, breaking the py/ts parity rule in CLAUDE.md.

GNU bash 5.2.37, pinned via `docker run --rm debian:stable-slim`:

```
$ cat < A2
bash: line 1: A2: No such file or directory     # rc=1
$ echo x > /nosuchdir/f
bash: line 1: /nosuchdir/f: No such file or directory   # rc=1
```

Both are attributed to the **shell**, not the command — the command never runs. mirage said:

| host | `cat < /data/missing` |
|---|---|
| python | `cat: /data/missing: No such file or directory` |
| typescript | `/data/missing` (bare path, no reason) |

## Fix

Both hosts now render `<target>: <strerror>` on the `<` read and the `>` write side alike, through one helper per host (`_redirect_error_line` / `redirectErrorLine`).

**Deliberate divergence:** GNU's `bash: line N:` prefix is dropped. This matches the house style already set by the other shell-attributed error, `nosuchcmd: command not found` (bash prints `bash: line 1: nosuchcmd: command not found`) — `bash:` is bash's `$0` and mirage is not bash, and `line N` has no meaning for a one-line `Workspace.execute` call. Both docstrings record the choice.

## Three behavior bugs the wording hid

All fixed by returning an `IOResult` instead of raising:

1. **The whole line died.** `cat < missing; echo next` never ran `echo next`; GNU prints the error and continues (rc becomes echo's `0`). `&&` now short-circuits, `||` runs, and pipeline peers still run. The `>` side had no handler at all on python, so it died the same way.
2. **Wrong name in the message.** Unwinding reached the workspace-level `OSError` handler, which stamps `command.split()[0]` — the first word of the *whole line* — so `cd /data && cat < missing` reported `cd:`.
3. **Backend prose reached the user as the path.** `echo x > /nodir/f` said `echo: parent directory does not exist: /nodir: No such file or directory`. The label is now the target's own spelling (`raw_path`), so a relative target reports as typed like GNU (`cd /data && cat < missing` → `missing`).

## Why `ram`/`redis` `writeBytes` changed

Those guards threw an untyped `Error` on TS while python raised `FileNotFoundError`, so the TS write side could not reach the GNU line at all. Both now throw a stamped ENOENT that keeps the human message (new `enoentWithMessage`, mirroring the existing `eaccesReadOnly`) — the FUSE bridge (`fuse/fs.ts`) and executor builtins still sniff that prose off the **exception**, which is unchanged.

Non-filesystem errors keep propagating on both paths and both hosts (tested).

## Verification

- 20 new unit tests (10 py + 10 ts), every expectation GNU-pinned via docker `debian:stable-slim`
- 3 integ cases under `integ/bash/redirect/`, verified green on `ram` + `disk` on **both** hosts through the harness's own `compare`
- `pnpm -r typecheck`: `core` + `browser` clean
- TS core suite: 512 files / 5058 tests pass
- Python suite passes except pre-existing local env gaps (no BSD `tac`, missing `langchain`/`mem0` optional deps, no macFUSE)

Updated pins, all moving to the shell-attributed spelling (GNU: `bash: line 1: /ro/y.txt: Permission denied`, pinned): 3 read-only redirect assertions per host, the forbidden-mount redirect test, and the `mem0_write_rejected` integ case.

## Known divergence left in place

Documented in both docstrings: bash processes redirects strictly left to right, so `> out < missing` empties `out` before failing, while mirage creates output files in a second pass and leaves it untouched. `< missing > out` leaves `out` uncreated on both, matching bash. Relatedly, a command whose `>` target is unwritable has already run here, while bash fails at open time and never runs it.

Follow-up not taken: `> /etc`-style "target is a directory" still can't reproduce GNU's `cat: -: Is a directory`, since mirage has no file descriptors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)