### PR TITLE
Add fake GitHub API server for integ, fix unsound grep/rg search push-down

### DIFF
--- a/.github/actions/integ-battery-setup/action.yml
+++ b/.github/actions/integ-battery-setup/action.yml
@@ -128,6 +128,19 @@ runs:
         cat /tmp/boxsrv.log
         echo "BOX_ENDPOINT=http://127.0.0.1:5096" >> "$GITHUB_ENV"
 
+    - name: Start fake GitHub API
+      shell: bash
+      run: |
+        nohup ./python/.venv/bin/python integ/server/github_server.py \
+          --port 5095 --repo integ/repo-v1=github/repo-v1 \
+          > /tmp/ghsrv.log 2>&1 &
+        for i in $(seq 1 30); do
+          grep -q "GITHUB_ENDPOINT=" /tmp/ghsrv.log && break
+          sleep 1
+        done
+        cat /tmp/ghsrv.log
+        echo "GITHUB_URL=http://127.0.0.1:5095" >> "$GITHUB_ENV"
+
     - name: Start fake Slack Web API (Prisma)
       working-directory: integ
       shell: bash

--- a/.github/actions/integ-battery-setup/action.yml
+++ b/.github/actions/integ-battery-setup/action.yml
@@ -132,14 +132,14 @@ runs:
       shell: bash
       run: |
         nohup ./python/.venv/bin/python integ/server/github_server.py \
-          --port 5095 --repo integ/repo-v1=github/repo-v1 \
+          --port 5098 --repo integ/repo-v1=github/repo-v1 \
           > /tmp/ghsrv.log 2>&1 &
         for i in $(seq 1 30); do
           grep -q "GITHUB_ENDPOINT=" /tmp/ghsrv.log && break
           sleep 1
         done
         cat /tmp/ghsrv.log
-        echo "GITHUB_URL=http://127.0.0.1:5095" >> "$GITHUB_ENV"
+        echo "GITHUB_URL=http://127.0.0.1:5098" >> "$GITHUB_ENV"
 
     - name: Start fake Slack Web API (Prisma)
       working-directory: integ

--- a/integ/fixtures/github/repo-v1/README.md
+++ b/integ/fixtures/github/repo-v1/README.md
@@ -1,0 +1,3 @@
+# repo-v1
+
+Fixture repository for the fake GitHub API server.

--- a/integ/fixtures/github/repo-v1/docs/architecture.md
+++ b/integ/fixtures/github/repo-v1/docs/architecture.md
@@ -1,0 +1,5 @@
+# Architecture
+
+Notes on architecture.
+
+The quokka runtime binds the mounts.

--- a/integ/fixtures/github/repo-v1/docs/contributing.md
+++ b/integ/fixtures/github/repo-v1/docs/contributing.md
@@ -1,0 +1,5 @@
+# Contributing
+
+Notes on contributing.
+
+Run the wombat suite before pushing.

--- a/integ/fixtures/github/repo-v1/docs/release.md
+++ b/integ/fixtures/github/repo-v1/docs/release.md
@@ -1,0 +1,5 @@
+# Release
+
+Notes on release.
+
+Shipped as quokkabuild 12, not the marker.

--- a/integ/fixtures/github/repo-v1/pyproject.toml
+++ b/integ/fixtures/github/repo-v1/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "repo-v1"
+version = "0.1.0"

--- a/integ/fixtures/github/repo-v1/src/auth/__init__.py
+++ b/integ/fixtures/github/repo-v1/src/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Package auth."""

--- a/integ/fixtures/github/repo-v1/src/auth/step_1.py
+++ b/integ/fixtures/github/repo-v1/src/auth/step_1.py
@@ -1,0 +1,11 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def auth_step_1(value: int) -> int:
+    logger.debug('auth step 1')
+    return value + 1
+
+
+# quokka owns the session handshake

--- a/integ/fixtures/github/repo-v1/src/auth/step_2.py
+++ b/integ/fixtures/github/repo-v1/src/auth/step_2.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def auth_step_2(value: int) -> int:
+    logger.debug('auth step 2')
+    return value + 2

--- a/integ/fixtures/github/repo-v1/src/auth/step_3.py
+++ b/integ/fixtures/github/repo-v1/src/auth/step_3.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def auth_step_3(value: int) -> int:
+    logger.debug('auth step 3')
+    return value + 3

--- a/integ/fixtures/github/repo-v1/src/auth/step_4.py
+++ b/integ/fixtures/github/repo-v1/src/auth/step_4.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def auth_step_4(value: int) -> int:
+    logger.debug('auth step 4')
+    return value + 4

--- a/integ/fixtures/github/repo-v1/src/auth/step_5.py
+++ b/integ/fixtures/github/repo-v1/src/auth/step_5.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def auth_step_5(value: int) -> int:
+    logger.debug('auth step 5')
+    return value + 5

--- a/integ/fixtures/github/repo-v1/src/auth/step_6.py
+++ b/integ/fixtures/github/repo-v1/src/auth/step_6.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def auth_step_6(value: int) -> int:
+    logger.debug('auth step 6')
+    return value + 6

--- a/integ/fixtures/github/repo-v1/src/auth/step_7.py
+++ b/integ/fixtures/github/repo-v1/src/auth/step_7.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def auth_step_7(value: int) -> int:
+    logger.debug('auth step 7')
+    return value + 7

--- a/integ/fixtures/github/repo-v1/src/auth/step_8.py
+++ b/integ/fixtures/github/repo-v1/src/auth/step_8.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def auth_step_8(value: int) -> int:
+    logger.debug('auth step 8')
+    return value + 8

--- a/integ/fixtures/github/repo-v1/src/cache/__init__.py
+++ b/integ/fixtures/github/repo-v1/src/cache/__init__.py
@@ -1,0 +1,1 @@
+"""Package cache."""

--- a/integ/fixtures/github/repo-v1/src/cache/step_1.py
+++ b/integ/fixtures/github/repo-v1/src/cache/step_1.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def cache_step_1(value: int) -> int:
+    logger.debug('cache step 1')
+    return value + 1

--- a/integ/fixtures/github/repo-v1/src/cache/step_2.py
+++ b/integ/fixtures/github/repo-v1/src/cache/step_2.py
@@ -1,0 +1,11 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def cache_step_2(value: int) -> int:
+    logger.debug('cache step 2')
+    return value + 2
+
+
+# wombat invalidates the warm entries

--- a/integ/fixtures/github/repo-v1/src/cache/step_3.py
+++ b/integ/fixtures/github/repo-v1/src/cache/step_3.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def cache_step_3(value: int) -> int:
+    logger.debug('cache step 3')
+    return value + 3

--- a/integ/fixtures/github/repo-v1/src/cache/step_4.py
+++ b/integ/fixtures/github/repo-v1/src/cache/step_4.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def cache_step_4(value: int) -> int:
+    logger.debug('cache step 4')
+    return value + 4

--- a/integ/fixtures/github/repo-v1/src/cache/step_5.py
+++ b/integ/fixtures/github/repo-v1/src/cache/step_5.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def cache_step_5(value: int) -> int:
+    logger.debug('cache step 5')
+    return value + 5

--- a/integ/fixtures/github/repo-v1/src/cache/step_6.py
+++ b/integ/fixtures/github/repo-v1/src/cache/step_6.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def cache_step_6(value: int) -> int:
+    logger.debug('cache step 6')
+    return value + 6

--- a/integ/fixtures/github/repo-v1/src/cache/step_7.py
+++ b/integ/fixtures/github/repo-v1/src/cache/step_7.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def cache_step_7(value: int) -> int:
+    logger.debug('cache step 7')
+    return value + 7

--- a/integ/fixtures/github/repo-v1/src/cache/step_8.py
+++ b/integ/fixtures/github/repo-v1/src/cache/step_8.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def cache_step_8(value: int) -> int:
+    logger.debug('cache step 8')
+    return value + 8

--- a/integ/fixtures/github/repo-v1/src/codec/__init__.py
+++ b/integ/fixtures/github/repo-v1/src/codec/__init__.py
@@ -1,0 +1,1 @@
+"""Package codec."""

--- a/integ/fixtures/github/repo-v1/src/codec/step_1.py
+++ b/integ/fixtures/github/repo-v1/src/codec/step_1.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def codec_step_1(value: int) -> int:
+    logger.debug('codec step 1')
+    return value + 1

--- a/integ/fixtures/github/repo-v1/src/codec/step_2.py
+++ b/integ/fixtures/github/repo-v1/src/codec/step_2.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def codec_step_2(value: int) -> int:
+    logger.debug('codec step 2')
+    return value + 2

--- a/integ/fixtures/github/repo-v1/src/codec/step_3.py
+++ b/integ/fixtures/github/repo-v1/src/codec/step_3.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def codec_step_3(value: int) -> int:
+    logger.debug('codec step 3')
+    return value + 3

--- a/integ/fixtures/github/repo-v1/src/codec/step_4.py
+++ b/integ/fixtures/github/repo-v1/src/codec/step_4.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def codec_step_4(value: int) -> int:
+    logger.debug('codec step 4')
+    return value + 4

--- a/integ/fixtures/github/repo-v1/src/codec/step_5.py
+++ b/integ/fixtures/github/repo-v1/src/codec/step_5.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def codec_step_5(value: int) -> int:
+    logger.debug('codec step 5')
+    return value + 5

--- a/integ/fixtures/github/repo-v1/src/codec/step_6.py
+++ b/integ/fixtures/github/repo-v1/src/codec/step_6.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def codec_step_6(value: int) -> int:
+    logger.debug('codec step 6')
+    return value + 6

--- a/integ/fixtures/github/repo-v1/src/codec/step_7.py
+++ b/integ/fixtures/github/repo-v1/src/codec/step_7.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def codec_step_7(value: int) -> int:
+    logger.debug('codec step 7')
+    return value + 7

--- a/integ/fixtures/github/repo-v1/src/codec/step_8.py
+++ b/integ/fixtures/github/repo-v1/src/codec/step_8.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def codec_step_8(value: int) -> int:
+    logger.debug('codec step 8')
+    return value + 8

--- a/integ/fixtures/github/repo-v1/src/index/__init__.py
+++ b/integ/fixtures/github/repo-v1/src/index/__init__.py
@@ -1,0 +1,1 @@
+"""Package index."""

--- a/integ/fixtures/github/repo-v1/src/index/step_1.py
+++ b/integ/fixtures/github/repo-v1/src/index/step_1.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def index_step_1(value: int) -> int:
+    logger.debug('index step 1')
+    return value + 1

--- a/integ/fixtures/github/repo-v1/src/index/step_2.py
+++ b/integ/fixtures/github/repo-v1/src/index/step_2.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def index_step_2(value: int) -> int:
+    logger.debug('index step 2')
+    return value + 2

--- a/integ/fixtures/github/repo-v1/src/index/step_3.py
+++ b/integ/fixtures/github/repo-v1/src/index/step_3.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def index_step_3(value: int) -> int:
+    logger.debug('index step 3')
+    return value + 3

--- a/integ/fixtures/github/repo-v1/src/index/step_4.py
+++ b/integ/fixtures/github/repo-v1/src/index/step_4.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def index_step_4(value: int) -> int:
+    logger.debug('index step 4')
+    return value + 4

--- a/integ/fixtures/github/repo-v1/src/index/step_5.py
+++ b/integ/fixtures/github/repo-v1/src/index/step_5.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def index_step_5(value: int) -> int:
+    logger.debug('index step 5')
+    return value + 5

--- a/integ/fixtures/github/repo-v1/src/index/step_6.py
+++ b/integ/fixtures/github/repo-v1/src/index/step_6.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def index_step_6(value: int) -> int:
+    logger.debug('index step 6')
+    return value + 6

--- a/integ/fixtures/github/repo-v1/src/index/step_7.py
+++ b/integ/fixtures/github/repo-v1/src/index/step_7.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def index_step_7(value: int) -> int:
+    logger.debug('index step 7')
+    return value + 7

--- a/integ/fixtures/github/repo-v1/src/index/step_8.py
+++ b/integ/fixtures/github/repo-v1/src/index/step_8.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def index_step_8(value: int) -> int:
+    logger.debug('index step 8')
+    return value + 8

--- a/integ/fixtures/github/repo-v1/src/mount/__init__.py
+++ b/integ/fixtures/github/repo-v1/src/mount/__init__.py
@@ -1,0 +1,1 @@
+"""Package mount."""

--- a/integ/fixtures/github/repo-v1/src/mount/step_1.py
+++ b/integ/fixtures/github/repo-v1/src/mount/step_1.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def mount_step_1(value: int) -> int:
+    logger.debug('mount step 1')
+    return value + 1

--- a/integ/fixtures/github/repo-v1/src/mount/step_2.py
+++ b/integ/fixtures/github/repo-v1/src/mount/step_2.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def mount_step_2(value: int) -> int:
+    logger.debug('mount step 2')
+    return value + 2

--- a/integ/fixtures/github/repo-v1/src/mount/step_3.py
+++ b/integ/fixtures/github/repo-v1/src/mount/step_3.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def mount_step_3(value: int) -> int:
+    logger.debug('mount step 3')
+    return value + 3

--- a/integ/fixtures/github/repo-v1/src/mount/step_4.py
+++ b/integ/fixtures/github/repo-v1/src/mount/step_4.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def mount_step_4(value: int) -> int:
+    logger.debug('mount step 4')
+    return value + 4

--- a/integ/fixtures/github/repo-v1/src/mount/step_5.py
+++ b/integ/fixtures/github/repo-v1/src/mount/step_5.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def mount_step_5(value: int) -> int:
+    logger.debug('mount step 5')
+    return value + 5

--- a/integ/fixtures/github/repo-v1/src/mount/step_6.py
+++ b/integ/fixtures/github/repo-v1/src/mount/step_6.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def mount_step_6(value: int) -> int:
+    logger.debug('mount step 6')
+    return value + 6

--- a/integ/fixtures/github/repo-v1/src/mount/step_7.py
+++ b/integ/fixtures/github/repo-v1/src/mount/step_7.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def mount_step_7(value: int) -> int:
+    logger.debug('mount step 7')
+    return value + 7

--- a/integ/fixtures/github/repo-v1/src/mount/step_8.py
+++ b/integ/fixtures/github/repo-v1/src/mount/step_8.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def mount_step_8(value: int) -> int:
+    logger.debug('mount step 8')
+    return value + 8

--- a/integ/fixtures/github/repo-v1/src/parse/__init__.py
+++ b/integ/fixtures/github/repo-v1/src/parse/__init__.py
@@ -1,0 +1,1 @@
+"""Package parse."""

--- a/integ/fixtures/github/repo-v1/src/parse/step_1.py
+++ b/integ/fixtures/github/repo-v1/src/parse/step_1.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def parse_step_1(value: int) -> int:
+    logger.debug('parse step 1')
+    return value + 1

--- a/integ/fixtures/github/repo-v1/src/parse/step_2.py
+++ b/integ/fixtures/github/repo-v1/src/parse/step_2.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def parse_step_2(value: int) -> int:
+    logger.debug('parse step 2')
+    return value + 2

--- a/integ/fixtures/github/repo-v1/src/parse/step_3.py
+++ b/integ/fixtures/github/repo-v1/src/parse/step_3.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def parse_step_3(value: int) -> int:
+    logger.debug('parse step 3')
+    return value + 3

--- a/integ/fixtures/github/repo-v1/src/parse/step_4.py
+++ b/integ/fixtures/github/repo-v1/src/parse/step_4.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def parse_step_4(value: int) -> int:
+    logger.debug('parse step 4')
+    return value + 4

--- a/integ/fixtures/github/repo-v1/src/parse/step_5.py
+++ b/integ/fixtures/github/repo-v1/src/parse/step_5.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def parse_step_5(value: int) -> int:
+    logger.debug('parse step 5')
+    return value + 5

--- a/integ/fixtures/github/repo-v1/src/parse/step_6.py
+++ b/integ/fixtures/github/repo-v1/src/parse/step_6.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def parse_step_6(value: int) -> int:
+    logger.debug('parse step 6')
+    return value + 6

--- a/integ/fixtures/github/repo-v1/src/parse/step_7.py
+++ b/integ/fixtures/github/repo-v1/src/parse/step_7.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def parse_step_7(value: int) -> int:
+    logger.debug('parse step 7')
+    return value + 7

--- a/integ/fixtures/github/repo-v1/src/parse/step_8.py
+++ b/integ/fixtures/github/repo-v1/src/parse/step_8.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def parse_step_8(value: int) -> int:
+    logger.debug('parse step 8')
+    return value + 8

--- a/integ/fixtures/github/repo-v1/src/query/__init__.py
+++ b/integ/fixtures/github/repo-v1/src/query/__init__.py
@@ -1,0 +1,1 @@
+"""Package query."""

--- a/integ/fixtures/github/repo-v1/src/query/step_1.py
+++ b/integ/fixtures/github/repo-v1/src/query/step_1.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def query_step_1(value: int) -> int:
+    logger.debug('query step 1')
+    return value + 1

--- a/integ/fixtures/github/repo-v1/src/query/step_2.py
+++ b/integ/fixtures/github/repo-v1/src/query/step_2.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def query_step_2(value: int) -> int:
+    logger.debug('query step 2')
+    return value + 2

--- a/integ/fixtures/github/repo-v1/src/query/step_3.py
+++ b/integ/fixtures/github/repo-v1/src/query/step_3.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def query_step_3(value: int) -> int:
+    logger.debug('query step 3')
+    return value + 3

--- a/integ/fixtures/github/repo-v1/src/query/step_4.py
+++ b/integ/fixtures/github/repo-v1/src/query/step_4.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def query_step_4(value: int) -> int:
+    logger.debug('query step 4')
+    return value + 4

--- a/integ/fixtures/github/repo-v1/src/query/step_5.py
+++ b/integ/fixtures/github/repo-v1/src/query/step_5.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def query_step_5(value: int) -> int:
+    logger.debug('query step 5')
+    return value + 5

--- a/integ/fixtures/github/repo-v1/src/query/step_6.py
+++ b/integ/fixtures/github/repo-v1/src/query/step_6.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def query_step_6(value: int) -> int:
+    logger.debug('query step 6')
+    return value + 6

--- a/integ/fixtures/github/repo-v1/src/query/step_7.py
+++ b/integ/fixtures/github/repo-v1/src/query/step_7.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def query_step_7(value: int) -> int:
+    logger.debug('query step 7')
+    return value + 7

--- a/integ/fixtures/github/repo-v1/src/query/step_8.py
+++ b/integ/fixtures/github/repo-v1/src/query/step_8.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def query_step_8(value: int) -> int:
+    logger.debug('query step 8')
+    return value + 8

--- a/integ/fixtures/github/repo-v1/src/route/__init__.py
+++ b/integ/fixtures/github/repo-v1/src/route/__init__.py
@@ -1,0 +1,1 @@
+"""Package route."""

--- a/integ/fixtures/github/repo-v1/src/route/step_1.py
+++ b/integ/fixtures/github/repo-v1/src/route/step_1.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def route_step_1(value: int) -> int:
+    logger.debug('route step 1')
+    return value + 1

--- a/integ/fixtures/github/repo-v1/src/route/step_2.py
+++ b/integ/fixtures/github/repo-v1/src/route/step_2.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def route_step_2(value: int) -> int:
+    logger.debug('route step 2')
+    return value + 2

--- a/integ/fixtures/github/repo-v1/src/route/step_3.py
+++ b/integ/fixtures/github/repo-v1/src/route/step_3.py
@@ -1,0 +1,11 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def route_step_3(value: int) -> int:
+    logger.debug('route step 3')
+    return value + 3
+
+
+# quokka routing table

--- a/integ/fixtures/github/repo-v1/src/route/step_4.py
+++ b/integ/fixtures/github/repo-v1/src/route/step_4.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def route_step_4(value: int) -> int:
+    logger.debug('route step 4')
+    return value + 4

--- a/integ/fixtures/github/repo-v1/src/route/step_5.py
+++ b/integ/fixtures/github/repo-v1/src/route/step_5.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def route_step_5(value: int) -> int:
+    logger.debug('route step 5')
+    return value + 5

--- a/integ/fixtures/github/repo-v1/src/route/step_6.py
+++ b/integ/fixtures/github/repo-v1/src/route/step_6.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def route_step_6(value: int) -> int:
+    logger.debug('route step 6')
+    return value + 6

--- a/integ/fixtures/github/repo-v1/src/route/step_7.py
+++ b/integ/fixtures/github/repo-v1/src/route/step_7.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def route_step_7(value: int) -> int:
+    logger.debug('route step 7')
+    return value + 7

--- a/integ/fixtures/github/repo-v1/src/route/step_8.py
+++ b/integ/fixtures/github/repo-v1/src/route/step_8.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def route_step_8(value: int) -> int:
+    logger.debug('route step 8')
+    return value + 8

--- a/integ/fixtures/github/repo-v1/src/shell/__init__.py
+++ b/integ/fixtures/github/repo-v1/src/shell/__init__.py
@@ -1,0 +1,1 @@
+"""Package shell."""

--- a/integ/fixtures/github/repo-v1/src/shell/step_1.py
+++ b/integ/fixtures/github/repo-v1/src/shell/step_1.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def shell_step_1(value: int) -> int:
+    logger.debug('shell step 1')
+    return value + 1

--- a/integ/fixtures/github/repo-v1/src/shell/step_2.py
+++ b/integ/fixtures/github/repo-v1/src/shell/step_2.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def shell_step_2(value: int) -> int:
+    logger.debug('shell step 2')
+    return value + 2

--- a/integ/fixtures/github/repo-v1/src/shell/step_3.py
+++ b/integ/fixtures/github/repo-v1/src/shell/step_3.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def shell_step_3(value: int) -> int:
+    logger.debug('shell step 3')
+    return value + 3

--- a/integ/fixtures/github/repo-v1/src/shell/step_4.py
+++ b/integ/fixtures/github/repo-v1/src/shell/step_4.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def shell_step_4(value: int) -> int:
+    logger.debug('shell step 4')
+    return value + 4

--- a/integ/fixtures/github/repo-v1/src/shell/step_5.py
+++ b/integ/fixtures/github/repo-v1/src/shell/step_5.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def shell_step_5(value: int) -> int:
+    logger.debug('shell step 5')
+    return value + 5

--- a/integ/fixtures/github/repo-v1/src/shell/step_6.py
+++ b/integ/fixtures/github/repo-v1/src/shell/step_6.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def shell_step_6(value: int) -> int:
+    logger.debug('shell step 6')
+    return value + 6

--- a/integ/fixtures/github/repo-v1/src/shell/step_7.py
+++ b/integ/fixtures/github/repo-v1/src/shell/step_7.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def shell_step_7(value: int) -> int:
+    logger.debug('shell step 7')
+    return value + 7

--- a/integ/fixtures/github/repo-v1/src/shell/step_8.py
+++ b/integ/fixtures/github/repo-v1/src/shell/step_8.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def shell_step_8(value: int) -> int:
+    logger.debug('shell step 8')
+    return value + 8

--- a/integ/fixtures/github/repo-v1/src/store/__init__.py
+++ b/integ/fixtures/github/repo-v1/src/store/__init__.py
@@ -1,0 +1,1 @@
+"""Package store."""

--- a/integ/fixtures/github/repo-v1/src/store/step_1.py
+++ b/integ/fixtures/github/repo-v1/src/store/step_1.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def store_step_1(value: int) -> int:
+    logger.debug('store step 1')
+    return value + 1

--- a/integ/fixtures/github/repo-v1/src/store/step_2.py
+++ b/integ/fixtures/github/repo-v1/src/store/step_2.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def store_step_2(value: int) -> int:
+    logger.debug('store step 2')
+    return value + 2

--- a/integ/fixtures/github/repo-v1/src/store/step_3.py
+++ b/integ/fixtures/github/repo-v1/src/store/step_3.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def store_step_3(value: int) -> int:
+    logger.debug('store step 3')
+    return value + 3

--- a/integ/fixtures/github/repo-v1/src/store/step_4.py
+++ b/integ/fixtures/github/repo-v1/src/store/step_4.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def store_step_4(value: int) -> int:
+    logger.debug('store step 4')
+    return value + 4

--- a/integ/fixtures/github/repo-v1/src/store/step_5.py
+++ b/integ/fixtures/github/repo-v1/src/store/step_5.py
@@ -1,0 +1,11 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def store_step_5(value: int) -> int:
+    logger.debug('store step 5')
+    return value + 5
+
+
+# wombat compaction pass

--- a/integ/fixtures/github/repo-v1/src/store/step_6.py
+++ b/integ/fixtures/github/repo-v1/src/store/step_6.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def store_step_6(value: int) -> int:
+    logger.debug('store step 6')
+    return value + 6

--- a/integ/fixtures/github/repo-v1/src/store/step_7.py
+++ b/integ/fixtures/github/repo-v1/src/store/step_7.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def store_step_7(value: int) -> int:
+    logger.debug('store step 7')
+    return value + 7

--- a/integ/fixtures/github/repo-v1/src/store/step_8.py
+++ b/integ/fixtures/github/repo-v1/src/store/step_8.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def store_step_8(value: int) -> int:
+    logger.debug('store step 8')
+    return value + 8

--- a/integ/fixtures/github/repo-v1/src/sync/__init__.py
+++ b/integ/fixtures/github/repo-v1/src/sync/__init__.py
@@ -1,0 +1,1 @@
+"""Package sync."""

--- a/integ/fixtures/github/repo-v1/src/sync/step_1.py
+++ b/integ/fixtures/github/repo-v1/src/sync/step_1.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def sync_step_1(value: int) -> int:
+    logger.debug('sync step 1')
+    return value + 1

--- a/integ/fixtures/github/repo-v1/src/sync/step_2.py
+++ b/integ/fixtures/github/repo-v1/src/sync/step_2.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def sync_step_2(value: int) -> int:
+    logger.debug('sync step 2')
+    return value + 2

--- a/integ/fixtures/github/repo-v1/src/sync/step_3.py
+++ b/integ/fixtures/github/repo-v1/src/sync/step_3.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def sync_step_3(value: int) -> int:
+    logger.debug('sync step 3')
+    return value + 3

--- a/integ/fixtures/github/repo-v1/src/sync/step_4.py
+++ b/integ/fixtures/github/repo-v1/src/sync/step_4.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def sync_step_4(value: int) -> int:
+    logger.debug('sync step 4')
+    return value + 4

--- a/integ/fixtures/github/repo-v1/src/sync/step_5.py
+++ b/integ/fixtures/github/repo-v1/src/sync/step_5.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def sync_step_5(value: int) -> int:
+    logger.debug('sync step 5')
+    return value + 5

--- a/integ/fixtures/github/repo-v1/src/sync/step_6.py
+++ b/integ/fixtures/github/repo-v1/src/sync/step_6.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def sync_step_6(value: int) -> int:
+    logger.debug('sync step 6')
+    return value + 6

--- a/integ/fixtures/github/repo-v1/src/sync/step_7.py
+++ b/integ/fixtures/github/repo-v1/src/sync/step_7.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def sync_step_7(value: int) -> int:
+    logger.debug('sync step 7')
+    return value + 7

--- a/integ/fixtures/github/repo-v1/src/sync/step_8.py
+++ b/integ/fixtures/github/repo-v1/src/sync/step_8.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def sync_step_8(value: int) -> int:
+    logger.debug('sync step 8')
+    return value + 8

--- a/integ/fixtures/github/repo-v1/src/watch/__init__.py
+++ b/integ/fixtures/github/repo-v1/src/watch/__init__.py
@@ -1,0 +1,1 @@
+"""Package watch."""

--- a/integ/fixtures/github/repo-v1/src/watch/step_1.py
+++ b/integ/fixtures/github/repo-v1/src/watch/step_1.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def watch_step_1(value: int) -> int:
+    logger.debug('watch step 1')
+    return value + 1

--- a/integ/fixtures/github/repo-v1/src/watch/step_2.py
+++ b/integ/fixtures/github/repo-v1/src/watch/step_2.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def watch_step_2(value: int) -> int:
+    logger.debug('watch step 2')
+    return value + 2

--- a/integ/fixtures/github/repo-v1/src/watch/step_3.py
+++ b/integ/fixtures/github/repo-v1/src/watch/step_3.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def watch_step_3(value: int) -> int:
+    logger.debug('watch step 3')
+    return value + 3

--- a/integ/fixtures/github/repo-v1/src/watch/step_4.py
+++ b/integ/fixtures/github/repo-v1/src/watch/step_4.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def watch_step_4(value: int) -> int:
+    logger.debug('watch step 4')
+    return value + 4

--- a/integ/fixtures/github/repo-v1/src/watch/step_5.py
+++ b/integ/fixtures/github/repo-v1/src/watch/step_5.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def watch_step_5(value: int) -> int:
+    logger.debug('watch step 5')
+    return value + 5

--- a/integ/fixtures/github/repo-v1/src/watch/step_6.py
+++ b/integ/fixtures/github/repo-v1/src/watch/step_6.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def watch_step_6(value: int) -> int:
+    logger.debug('watch step 6')
+    return value + 6

--- a/integ/fixtures/github/repo-v1/src/watch/step_7.py
+++ b/integ/fixtures/github/repo-v1/src/watch/step_7.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def watch_step_7(value: int) -> int:
+    logger.debug('watch step 7')
+    return value + 7

--- a/integ/fixtures/github/repo-v1/src/watch/step_8.py
+++ b/integ/fixtures/github/repo-v1/src/watch/step_8.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def watch_step_8(value: int) -> int:
+    logger.debug('watch step 8')
+    return value + 8

--- a/integ/fixtures/github/repo-v1/tests/test_auth.py
+++ b/integ/fixtures/github/repo-v1/tests/test_auth.py
@@ -1,0 +1,5 @@
+from src.auth.step_1 import auth_step_1
+
+
+def test_auth_step_1() -> None:
+    assert auth_step_1(1) == 2

--- a/integ/fixtures/github/repo-v1/tests/test_cache.py
+++ b/integ/fixtures/github/repo-v1/tests/test_cache.py
@@ -1,0 +1,5 @@
+from src.cache.step_1 import cache_step_1
+
+
+def test_cache_step_1() -> None:
+    assert cache_step_1(1) == 2

--- a/integ/fixtures/github/repo-v1/tests/test_codec.py
+++ b/integ/fixtures/github/repo-v1/tests/test_codec.py
@@ -1,0 +1,5 @@
+from src.codec.step_1 import codec_step_1
+
+
+def test_codec_step_1() -> None:
+    assert codec_step_1(1) == 2

--- a/integ/fixtures/github/repo-v1/tests/test_index.py
+++ b/integ/fixtures/github/repo-v1/tests/test_index.py
@@ -1,0 +1,5 @@
+from src.index.step_1 import index_step_1
+
+
+def test_index_step_1() -> None:
+    assert index_step_1(1) == 2

--- a/integ/fixtures/github/repo-v1/tests/test_mount.py
+++ b/integ/fixtures/github/repo-v1/tests/test_mount.py
@@ -1,0 +1,5 @@
+from src.mount.step_1 import mount_step_1
+
+
+def test_mount_step_1() -> None:
+    assert mount_step_1(1) == 2

--- a/integ/fixtures/github/repo-v1/tests/test_parse.py
+++ b/integ/fixtures/github/repo-v1/tests/test_parse.py
@@ -1,0 +1,5 @@
+from src.parse.step_1 import parse_step_1
+
+
+def test_parse_step_1() -> None:
+    assert parse_step_1(1) == 2

--- a/integ/fixtures/search/v1/alpha.txt
+++ b/integ/fixtures/search/v1/alpha.txt
@@ -1,0 +1,1 @@
+wombat runs fast

--- a/integ/fixtures/search/v1/beta.txt
+++ b/integ/fixtures/search/v1/beta.txt
@@ -1,0 +1,1 @@
+the wombat sleeps

--- a/integ/fixtures/search/v1/gamma.txt
+++ b/integ/fixtures/search/v1/gamma.txt
@@ -1,0 +1,1 @@
+wombatling is not the marker

--- a/integ/resources/github/repo.json
+++ b/integ/resources/github/repo.json
@@ -58,7 +58,7 @@
       "targets": [
         "github"
       ],
-      "command": "grep -rl wombat /repo",
+      "command": "grep -rlw wombat /repo",
       "expect": {
         "exit": 0,
         "stdout": "/repo/docs/contributing.md\n/repo/src/cache/step_2.py\n/repo/src/store/step_5.py\n",
@@ -71,7 +71,7 @@
       "targets": [
         "github"
       ],
-      "command": "rg -l wombat /repo",
+      "command": "rg -lw wombat /repo",
       "expect": {
         "exit": 0,
         "stdout": "/repo/docs/contributing.md\n/repo/src/cache/step_2.py\n/repo/src/store/step_5.py\n",
@@ -111,6 +111,32 @@
         "github"
       ],
       "command": "grep -rlw quokka /repo",
+      "expect": {
+        "exit": 0,
+        "stdout": "/repo/docs/architecture.md\n/repo/src/auth/step_1.py\n/repo/src/route/step_3.py\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "github_rg_substring_scans_all",
+      "seq": 530010,
+      "targets": [
+        "github"
+      ],
+      "command": "rg -l quokka /repo",
+      "expect": {
+        "exit": 0,
+        "stdout": "/repo/docs/architecture.md\n/repo/docs/release.md\n/repo/src/auth/step_1.py\n/repo/src/route/step_3.py\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "github_rg_word_uses_search",
+      "seq": 530011,
+      "targets": [
+        "github"
+      ],
+      "command": "rg -lw quokka /repo",
       "expect": {
         "exit": 0,
         "stdout": "/repo/docs/architecture.md\n/repo/src/auth/step_1.py\n/repo/src/route/step_3.py\n",

--- a/integ/resources/github/repo.json
+++ b/integ/resources/github/repo.json
@@ -90,6 +90,32 @@
         "stdout": "",
         "stderr": ""
       }
+    },
+    {
+      "id": "github_grep_substring_scans_all",
+      "seq": 530008,
+      "targets": [
+        "github"
+      ],
+      "command": "grep -rl quokka /repo",
+      "expect": {
+        "exit": 0,
+        "stdout": "/repo/docs/architecture.md\n/repo/docs/release.md\n/repo/src/auth/step_1.py\n/repo/src/route/step_3.py\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "github_grep_word_uses_search",
+      "seq": 530009,
+      "targets": [
+        "github"
+      ],
+      "command": "grep -rlw quokka /repo",
+      "expect": {
+        "exit": 0,
+        "stdout": "/repo/docs/architecture.md\n/repo/src/auth/step_1.py\n/repo/src/route/step_3.py\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/resources/github/repo.json
+++ b/integ/resources/github/repo.json
@@ -1,0 +1,95 @@
+{
+  "cases": [
+    {
+      "id": "github_ls_root",
+      "seq": 530001,
+      "targets": [
+        "github"
+      ],
+      "command": "ls /repo",
+      "expect": {
+        "exit": 0,
+        "stdout": "README.md\ndocs\npyproject.toml\nsrc\ntests\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "github_cat_readme",
+      "seq": 530002,
+      "targets": [
+        "github"
+      ],
+      "command": "cat /repo/README.md",
+      "expect": {
+        "exit": 0,
+        "stdout": "# repo-v1\n\nFixture repository for the fake GitHub API server.\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "github_find_name",
+      "seq": 530003,
+      "targets": [
+        "github"
+      ],
+      "command": "find /repo/docs -name '*.md'",
+      "expect": {
+        "exit": 0,
+        "stdout": "/repo/docs/architecture.md\n/repo/docs/contributing.md\n/repo/docs/release.md\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "github_wc_tree",
+      "seq": 530004,
+      "targets": [
+        "github"
+      ],
+      "command": "find /repo -type f | wc -l",
+      "expect": {
+        "exit": 0,
+        "stdout": "119\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "github_grep_search_pushdown",
+      "seq": 530005,
+      "targets": [
+        "github"
+      ],
+      "command": "grep -rl wombat /repo",
+      "expect": {
+        "exit": 0,
+        "stdout": "/repo/docs/contributing.md\n/repo/src/cache/step_2.py\n/repo/src/store/step_5.py\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "github_rg_search_pushdown",
+      "seq": 530006,
+      "targets": [
+        "github"
+      ],
+      "command": "rg -l wombat /repo",
+      "expect": {
+        "exit": 0,
+        "stdout": "/repo/docs/contributing.md\n/repo/src/cache/step_2.py\n/repo/src/store/step_5.py\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "github_grep_search_miss",
+      "seq": 530007,
+      "targets": [
+        "github"
+      ],
+      "command": "grep -rl zzzabsent /repo",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/resources/gmail/basic.json
+++ b/integ/resources/gmail/basic.json
@@ -137,7 +137,7 @@
       "targets": [
         "gmail"
       ],
-      "command": "grep -r 'worker-3' /mail/INBOX | sort",
+      "command": "grep -rw 'worker-3' /mail/INBOX | sort",
       "expect": {
         "exit": 0,
         "stdout": "/mail/INBOX/2026-01-07/Server_alert_worker-3__msg0003.gmail.json:[ops@example.com] Server alert: worker-3 disk usage at 91 percent on worker-3\n",
@@ -150,7 +150,7 @@
       "targets": [
         "gmail"
       ],
-      "command": "grep -ri 'invoice 4471' /mail | sort",
+      "command": "grep -riw 'invoice 4471' /mail | sort",
       "expect": {
         "exit": 0,
         "stdout": "/mail/INBOX/2026-01-07/Invoice_4471__msg0005.gmail.json:[billing@vendor.example] Invoice 4471 invoice 4471 attached, total 240 usd\n",
@@ -228,7 +228,7 @@
       "targets": [
         "gmail"
       ],
-      "command": "rg 'forecast' /mail/INBOX",
+      "command": "rg -w 'forecast' /mail/INBOX",
       "expect": {
         "exit": 0,
         "stdout": "/mail/INBOX/2026-01-05/Standup_notes__msg0002.gmail.json:[marcus@example.com] Standup notes yesterday shipped the parser today reviewing the budget forecast\n",

--- a/integ/resources/search/pushdown.json
+++ b/integ/resources/search/pushdown.json
@@ -1,0 +1,60 @@
+{
+  "cases": [
+    {
+      "id": "search_substring_scans_all",
+      "seq": 540001,
+      "targets": [
+        "box",
+        "dropbox"
+      ],
+      "command": "grep -rl wombat /search",
+      "expect": {
+        "exit": 0,
+        "stdout": "/search/alpha.txt\n/search/beta.txt\n/search/gamma.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "search_word_uses_pushdown",
+      "seq": 540002,
+      "targets": [
+        "box",
+        "dropbox"
+      ],
+      "command": "grep -rlw wombat /search",
+      "expect": {
+        "exit": 0,
+        "stdout": "/search/alpha.txt\n/search/beta.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "search_substring_rg_scans_all",
+      "seq": 540003,
+      "targets": [
+        "box",
+        "dropbox"
+      ],
+      "command": "rg -l wombat /search",
+      "expect": {
+        "exit": 0,
+        "stdout": "/search/alpha.txt\n/search/beta.txt\n/search/gamma.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "search_word_rg_uses_pushdown",
+      "seq": 540004,
+      "targets": [
+        "box",
+        "dropbox"
+      ],
+      "command": "rg -lw wombat /search",
+      "expect": {
+        "exit": 0,
+        "stdout": "/search/alpha.txt\n/search/beta.txt\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/resources/slack/grep.json
+++ b/integ/resources/slack/grep.json
@@ -6,7 +6,7 @@
       "targets": [
         "slack"
       ],
-      "command": "grep -r Quokka /slack/channels/product-runtime__C7/",
+      "command": "grep -rw Quokka /slack/channels/product-runtime__C7/",
       "expect": {
         "exit": 0,
         "stdout": "/slack/channels/product-runtime__C7/2026-01-08/chat.jsonl:[henry] quokka milestone 27 is basically done\n/slack/channels/product-runtime__C7/2026-01-08/chat.jsonl:[marcus] kicking off project Quokka, the runtime for building agents over company tools\n/slack/channels/product-runtime__C7/2026-01-15/files/runtime_spec__F6.md:[file] Runtime Spec\n",
@@ -19,7 +19,7 @@
       "targets": [
         "slack"
       ],
-      "command": "grep -r 'reply moat' /slack/channels/leadership__C5/",
+      "command": "grep -rw 'reply moat' /slack/channels/leadership__C5/",
       "expect": {
         "exit": 0,
         "stdout": "/slack/channels/leadership__C5/2025-11-24/chat.jsonl:[priya] the reply moat is basically gone after this week's model launches\n/slack/channels/leadership__C5/2026-01-06/files/pivot_memo__F4.md:[file] Pivot Memo\n",

--- a/integ/resources/slack/rg.json
+++ b/integ/resources/slack/rg.json
@@ -6,7 +6,7 @@
       "targets": [
         "slack"
       ],
-      "command": "rg Quokka /slack/channels/product-runtime__C7/",
+      "command": "rg -w Quokka /slack/channels/product-runtime__C7/",
       "expect": {
         "exit": 0,
         "stdout": "/slack/channels/product-runtime__C7/2026-01-08/chat.jsonl:[henry] quokka milestone 27 is basically done\n/slack/channels/product-runtime__C7/2026-01-08/chat.jsonl:[marcus] kicking off project Quokka, the runtime for building agents over company tools\n/slack/channels/product-runtime__C7/2026-01-15/files/runtime_spec__F6.md:[file] Runtime Spec\n",

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -60,6 +60,7 @@ from mirage.resource.gdocs.config import GDocsConfig
 from mirage.resource.gdocs.gdocs import GDocsResource
 from mirage.resource.gdrive.config import GoogleDriveConfig
 from mirage.resource.gdrive.gdrive import GoogleDriveResource
+from mirage.resource.github import GitHubConfig, GitHubResource
 from mirage.resource.gmail.config import GmailConfig
 from mirage.resource.gmail.gmail import GmailResource
 from mirage.resource.gridfs import GridFSConfig, GridFSResource
@@ -881,6 +882,38 @@ class SlackService:
         return None
 
 
+class GitHubService:
+    """Points github mounts at the fake api.github.com server.
+
+    The server (integ/server/github_server.py) runs out of process on
+    GITHUB_URL, mirroring the fake Slack and Google Workspace servers.
+    In-process is not an option here: GitHubResource fetches the repo tree
+    with a blocking urlopen from its constructor, which would starve an
+    aiohttp fake sharing the runner's event loop.
+
+    Args:
+        url (str): GITHUB_URL origin the fake is listening on.
+    """
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+    @classmethod
+    async def create(cls) -> "GitHubService":
+        return cls(os.environ["GITHUB_URL"].rstrip("/"))
+
+    def resource(self, mount: dict) -> GitHubResource:
+        owner, _, repo = mount["repo"].partition("/")
+        return GitHubResource(
+            GitHubConfig(token="ghp-integ",
+                         owner=owner,
+                         repo=repo,
+                         base_url=self.url))
+
+    async def teardown(self) -> None:
+        return None
+
+
 class DifyService:
 
     def __init__(self, runner, base: str, dataset: str) -> None:
@@ -1158,6 +1191,13 @@ def build_nextcloud(
     return service.resource(mount), _noop
 
 
+def build_github(
+        mount: dict, run_id: str, service: Service | None
+) -> tuple[object, Callable[[], Awaitable[None]]]:
+    assert isinstance(service, GitHubService)
+    return service.resource(mount), _noop
+
+
 def build_slack(
         mount: dict, run_id: str, service: Service | None
 ) -> tuple[object, Callable[[], Awaitable[None]]]:
@@ -1200,6 +1240,7 @@ BUILDERS = {
     "hf": build_hf,
     "box": build_box,
     "dropbox": build_dropbox,
+    "github": build_github,
     "slack": build_slack,
     "trello": build_trello,
     "linear": build_linear,
@@ -1234,6 +1275,8 @@ async def make_service(target: dict, run_id: str) -> "Service | None":
         return await BoxService.create(run_id)
     if target.get("service") == "dropbox":
         return await DropboxService.create(target)
+    if target.get("service") == "github":
+        return await GitHubService.create()
     if target.get("service") == "slack":
         return await SlackService.create()
     if target.get("service") == "trello":

--- a/integ/runners/python/main.py
+++ b/integ/runners/python/main.py
@@ -114,6 +114,10 @@ async def main() -> None:
                 and not os.environ.get("EMAIL_HOST")):
             print(f"skip [{target_id}]: EMAIL_HOST not set", file=sys.stderr)
             continue
+        if (target.get("service") == "github"
+                and not os.environ.get("GITHUB_URL")):
+            print(f"skip [{target_id}]: GITHUB_URL not set", file=sys.stderr)
+            continue
         if (target.get("service") == "slack"
                 and not os.environ.get("SLACK_URL")):
             print(f"skip [{target_id}]: SLACK_URL not set", file=sys.stderr)

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -38,6 +38,7 @@ import {
   GDriveResource,
   GmailResource,
   GCSResource,
+  GitHubResource,
   GridFSResource,
   GSheetsResource,
   GSlidesResource,
@@ -935,6 +936,29 @@ async function openSlack(target: Target): Promise<Open> {
   return { ws: ws as unknown as ExecWorkspace, cleanup }
 }
 
+// The fake api.github.com server (integ/server/github_server.py) is external
+// and shared across both hosts, mirroring the fake Slack server. Out of
+// process is required for the python host, whose GitHubResource fetches the
+// repo tree with a blocking urlopen from its constructor.
+async function openGitHub(target: Target): Promise<Open> {
+  let base = process.env.GITHUB_URL ?? ''
+  while (base.endsWith('/')) base = base.slice(0, -1)
+  if (base === '') throw new Error('github target requires GITHUB_URL')
+  const mounts: Record<string, GitHubResource | [GitHubResource, MountMode]> = {}
+  for (const m of target.mounts) {
+    const [owner, repo] = String(m.repo).split('/')
+    const resource = await GitHubResource.create({
+      token: 'ghp-integ',
+      owner: owner ?? '',
+      repo: repo ?? '',
+      baseUrl: base,
+    })
+    mounts[m.path] = m.mode === 'read' ? [resource, MountMode.READ] : resource
+  }
+  const ws = new Workspace(mounts, { mode: MountMode.WRITE })
+  return { ws: ws as unknown as ExecWorkspace, cleanup: () => ws.close() }
+}
+
 async function openDify(target: Target): Promise<Open> {
   const endpoint = process.env.DIFY_ENDPOINT
   if (!endpoint) throw new Error('dify target requires DIFY_ENDPOINT')
@@ -1009,6 +1033,7 @@ export const ADAPTERS: Record<string, (target: Target) => Promise<Open>> = {
   onedrive: openOneDrive,
   sharepoint: openSharePoint,
   mem0: openMem0,
+  github: openGitHub,
   slack: openSlack,
   trello: openTrello,
   linear: openLinear,

--- a/integ/runners/typescript/main.ts
+++ b/integ/runners/typescript/main.ts
@@ -145,6 +145,10 @@ async function main(): Promise<void> {
       process.stderr.write(`skip [${id}]: BOX_ENDPOINT not set\n`)
       continue
     }
+    if (target.service === 'github' && !process.env.GITHUB_URL) {
+      process.stderr.write(`skip [${id}]: GITHUB_URL not set\n`)
+      continue
+    }
     if (target.service === 'slack' && !process.env.SLACK_URL) {
       process.stderr.write(`skip [${id}]: SLACK_URL not set\n`)
       continue

--- a/integ/server/box_server.py
+++ b/integ/server/box_server.py
@@ -16,6 +16,7 @@ import argparse
 import asyncio
 import hashlib
 import json
+import re
 from datetime import datetime, timezone
 
 from aiohttp import web
@@ -36,6 +37,16 @@ def freeze_clock(base: datetime) -> None:
     global BASE_TIME, MODIFIED
     BASE_TIME = base
     MODIFIED = base.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+
+def _content_hit(query: str, text: str) -> bool:
+    # Real Box indexes content by whole words, so `foo` never matches
+    # `foobar`. Modelling that is what lets the battery prove grep/rg
+    # push-down cannot silently drop substring matches; a substring fake
+    # would agree with a full scan and test nothing. Names stay substring:
+    # extra hits there only over-fetch, which the local scan filters.
+    return re.search(rf"(?<![A-Za-z0-9_]){re.escape(query)}(?![A-Za-z0-9_])",
+                     text) is not None
 
 
 def _error(status: int, code: str, message: str) -> web.Response:
@@ -481,7 +492,7 @@ class BoxServer:
             matched = match_name and query in it["name"].lower()
             if not matched and match_content and it["type"] == "file":
                 text = it["content"].decode("utf-8", "ignore").lower()
-                matched = query in text
+                matched = _content_hit(query, text)
             if matched:
                 hits.append(it)
         hits.sort(key=lambda it: it["name"])

--- a/integ/server/dropbox.ts
+++ b/integ/server/dropbox.ts
@@ -155,9 +155,13 @@ class Account {
     return true
   }
 
-  // Case-insensitive substring over names and content: a superset of the
-  // real token-based matching, which is what grep/rg narrowing needs (the
-  // client still scans the candidates exactly).
+  // Case-insensitive substring over names and content: deliberately a
+  // superset of the real token-based matching. Safe only because narrowing
+  // now requires -w (see dropbox/narrow.ts): under -w the client wants whole
+  // words too, so extra candidates are filtered by the local scan. Do not
+  // rely on this fake to prove narrowing is complete for a bare literal,
+  // real Dropbox returns a strict subset there and would drop matches
+  // inside longer words.
   searchMatches(query: string, scope: string, filenameOnly: boolean): SearchMatchJson[] | null {
     if (scope !== '' && this.entryFor(scope) === null) return null
     const q = query.toLowerCase()

--- a/integ/server/dropbox.ts
+++ b/integ/server/dropbox.ts
@@ -87,6 +87,11 @@ function malformed(res: ServerResponse): void {
   res.end(JSON.stringify({ error_summary: 'path/malformed' }))
 }
 
+function wholeWordHit(query: string, text: string): boolean {
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`(?<![A-Za-z0-9_])${escaped}(?![A-Za-z0-9_])`).test(text)
+}
+
 class Account {
   readonly folders = new Set<string>()
   readonly files = new Map<string, StoredFile>()
@@ -155,13 +160,12 @@ class Account {
     return true
   }
 
-  // Case-insensitive substring over names and content: deliberately a
-  // superset of the real token-based matching. Safe only because narrowing
-  // now requires -w (see dropbox/narrow.ts): under -w the client wants whole
-  // words too, so extra candidates are filtered by the local scan. Do not
-  // rely on this fake to prove narrowing is complete for a bare literal,
-  // real Dropbox returns a strict subset there and would drop matches
-  // inside longer words.
+  // Content matches whole words, mirroring real Dropbox's index, so `foo`
+  // never matches `foobar`. Modelling that is what lets the battery prove
+  // grep/rg push-down cannot silently drop substring matches; a substring
+  // fake would agree with a full scan and test nothing. Names stay
+  // substring: extra hits there only over-fetch, which the local scan
+  // filters.
   searchMatches(query: string, scope: string, filenameOnly: boolean): SearchMatchJson[] | null {
     if (scope !== '' && this.entryFor(scope) === null) return null
     const q = query.toLowerCase()
@@ -174,7 +178,7 @@ class Account {
       const nameHit = path.slice(path.lastIndexOf('/') + 1).toLowerCase().includes(q)
       const stored = this.files.get(path)
       const contentHit =
-        !filenameOnly && stored !== undefined && DEC.decode(stored.data).toLowerCase().includes(q)
+        !filenameOnly && stored !== undefined && wholeWordHit(q, DEC.decode(stored.data).toLowerCase())
       if (!nameHit && !contentHit) continue
       const tag = nameHit && contentHit ? 'filename_and_content' : nameHit ? 'filename' : 'file_content'
       out.push({

--- a/integ/server/dropbox_server.py
+++ b/integ/server/dropbox_server.py
@@ -219,9 +219,13 @@ class FakeDropbox:
 
     def _search_matches(self, query: str, scope: str,
                         filename_only: bool) -> list[dict] | None:
-        # Case-insensitive substring over names and content: a superset of
-        # the real token-based matching, which is what grep/rg narrowing
-        # needs (the client still scans the candidates exactly).
+        # Case-insensitive substring over names and content: deliberately a
+        # superset of the real token-based matching. Safe only because
+        # narrowing now requires -w (see dropbox/narrow.py): under -w the
+        # client wants whole words too, so extra candidates are filtered by
+        # the local scan. Do not rely on this fake to prove narrowing is
+        # complete for a bare literal, real Dropbox returns a strict subset
+        # there and would drop matches inside longer words.
         if scope and self._entry_for(scope) is None:
             return None
         q = query.lower()

--- a/integ/server/dropbox_server.py
+++ b/integ/server/dropbox_server.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import json
+import re
 import time
 
 from aiohttp import web
@@ -22,6 +23,14 @@ def _now_stamp() -> str:
     # Uploads stamp the real clock (find -mtime expects fresh writes to
     # look fresh, like MinIO/moto in the s3 targets).
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _content_hit(query: str, text: str) -> bool:
+    # Real Dropbox indexes content by whole words, so `foo` never matches
+    # `foobar`. See integ/server/box_server.py for why the fake models that
+    # instead of doing a substring scan.
+    return re.search(rf"(?<![A-Za-z0-9_]){re.escape(query)}(?![A-Za-z0-9_])",
+                     text) is not None
 
 
 class FakeDropbox:
@@ -240,7 +249,8 @@ class FakeDropbox:
             name_hit = q in path.rsplit("/", 1)[1].lower()
             stored = self.files.get(path)
             content_hit = (not filename_only and stored is not None
-                           and q in stored[0].decode(errors="replace").lower())
+                           and _content_hit(
+                               q, stored[0].decode(errors="replace").lower()))
             if not name_hit and not content_hit:
                 continue
             tag = ("filename_and_content" if name_hit and content_hit else

--- a/integ/server/github_server.py
+++ b/integ/server/github_server.py
@@ -1,0 +1,358 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import argparse
+import asyncio
+import base64
+import hashlib
+import re
+from pathlib import Path
+
+from aiohttp import web
+
+# Deliberate divergences from api.github.com, mirroring how
+# integ/server/dropbox.ts documents its Gmail-search shortcuts:
+#
+#   - Code search is token-indexed, not substring. Real GitHub tokenises on
+#     non-word characters, so `octo` never matches `octocat`. The fake keeps an
+#     inverted index for the same reason it matters to us: grep/rg push-down
+#     reads a search miss as "no file contains this literal", so a substring
+#     fake would hide the false negatives that push-down can hit in
+#     production.
+#   - Multiple bare terms AND together, which is GitHub's default.
+#   - Files at or above SEARCH_SIZE_LIMIT are not indexed, and only the
+#     default branch is searchable.
+#   - Ranking is not modelled: `score` is a constant and items come back in
+#     path order. Nothing in mirage reads either.
+TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
+SEARCH_SIZE_LIMIT = 384 * 1024
+DEFAULT_BRANCH = "main"
+
+
+def _blob_sha(data: bytes) -> str:
+    # Real git object id so shas look plausible and stay stable across runs.
+    header = f"blob {len(data)}\0".encode()
+    return hashlib.sha1(header + data).hexdigest()
+
+
+def _tree_sha(path: str) -> str:
+    return hashlib.sha1(f"tree\0{path}".encode()).hexdigest()
+
+
+def _error(status: int, message: str) -> web.Response:
+    return web.json_response(
+        {
+            "message": message,
+            "documentation_url": "https://docs.github.com/rest",
+        },
+        status=status)
+
+
+class FakeRepo:
+    """One in-memory repository: a flat path -> bytes map plus its index.
+
+    Args:
+        owner (str): repository owner login.
+        name (str): repository name.
+        default_branch (str): branch reported by the repo endpoint.
+    """
+
+    def __init__(self,
+                 owner: str,
+                 name: str,
+                 default_branch: str = DEFAULT_BRANCH) -> None:
+        self.owner = owner
+        self.name = name
+        self.default_branch = default_branch
+        self.files: dict[str, bytes] = {}
+        self.terms: dict[str, set[str]] = {}
+        self.blobs: dict[str, bytes] = {}
+
+    @property
+    def full_name(self) -> str:
+        return f"{self.owner}/{self.name}"
+
+    def seed_path(self, path: str, data: bytes) -> None:
+        key = path.strip("/")
+        self.files[key] = data
+        self.blobs[_blob_sha(data)] = data
+        self._index(key, data)
+
+    def _index(self, path: str, data: bytes) -> None:
+        for term in self.terms.values():
+            term.discard(path)
+        if len(data) >= SEARCH_SIZE_LIMIT:
+            return
+        text = data.decode("utf-8", errors="ignore").lower()
+        for token in TOKEN_RE.findall(text):
+            self.terms.setdefault(token, set()).add(path)
+
+    def directories(self) -> set[str]:
+        dirs: set[str] = set()
+        for path in self.files:
+            parts = path.split("/")[:-1]
+            for i in range(1, len(parts) + 1):
+                dirs.add("/".join(parts[:i]))
+        return dirs
+
+    def blob(self, sha: str) -> bytes | None:
+        return self.blobs.get(sha)
+
+    def tree_items(self, scope: str = "") -> list[dict[str, object]]:
+        """Recursive tree entries, optionally rooted at a subdirectory.
+
+        Args:
+            scope (str): directory to root at, or "" for the whole repo.
+
+        Returns:
+            list[dict[str, object]]: entries in git's path order, blobs
+            carrying a size and trees carrying none.
+        """
+        prefix = f"{scope}/" if scope else ""
+        items: list[dict[str, object]] = []
+        for path in sorted(self.directories()):
+            if not path.startswith(prefix) or path == scope:
+                continue
+            items.append({
+                "path": path[len(prefix):],
+                "mode": "040000",
+                "type": "tree",
+                "sha": _tree_sha(path),
+            })
+        for path, data in sorted(self.files.items()):
+            if not path.startswith(prefix):
+                continue
+            items.append({
+                "path": path[len(prefix):],
+                "mode": "100644",
+                "type": "blob",
+                "sha": _blob_sha(data),
+                "size": len(data),
+            })
+        items.sort(key=lambda it: str(it["path"]))
+        return items
+
+    def search(self, terms: list[str], path_filter: str | None) -> list[str]:
+        if not terms:
+            return []
+        matched: set[str] | None = None
+        for term in terms:
+            hits = self.terms.get(term, set())
+            matched = set(hits) if matched is None else (matched & hits)
+            if not matched:
+                return []
+        found = sorted(matched or set())
+        if path_filter:
+            scope = path_filter.strip("/")
+            found = [
+                p for p in found if p == scope or p.startswith(f"{scope}/")
+            ]
+        return found
+
+
+class FakeGitHub:
+    """Repository store plus the origin the resources should be pointed at."""
+
+    def __init__(self) -> None:
+        self.repos: dict[str, FakeRepo] = {}
+        self.base = ""
+
+    def repo(self, owner: str, name: str) -> FakeRepo:
+        key = f"{owner}/{name}"
+        if key not in self.repos:
+            self.repos[key] = FakeRepo(owner, name)
+        return self.repos[key]
+
+
+class GitHubServer:
+    """The four read-only api.github.com routes the github backend calls.
+
+    Args:
+        state (FakeGitHub): the backing repository store.
+    """
+
+    def __init__(self, state: FakeGitHub) -> None:
+        self.state = state
+
+    def _authed(self, request: web.Request) -> bool:
+        return bool(request.headers.get("Authorization"))
+
+    def _lookup(self, request: web.Request) -> FakeRepo | None:
+        owner = request.match_info["owner"]
+        name = request.match_info["repo"]
+        return self.state.repos.get(f"{owner}/{name}")
+
+    async def repo_info(self, request: web.Request) -> web.Response:
+        if not self._authed(request):
+            return _error(401, "Requires authentication")
+        repo = self._lookup(request)
+        if repo is None:
+            return _error(404, "Not Found")
+        return web.json_response({
+            "name": repo.name,
+            "full_name": repo.full_name,
+            "default_branch": repo.default_branch,
+            "owner": {
+                "login": repo.owner
+            },
+        })
+
+    async def tree(self, request: web.Request) -> web.Response:
+        if not self._authed(request):
+            return _error(401, "Requires authentication")
+        repo = self._lookup(request)
+        if repo is None:
+            return _error(404, "Not Found")
+        ref = request.match_info["ref"]
+        # The backend passes either a ref name (recursive whole-tree fetch) or
+        # a tree sha from a previous listing (the truncation fallback path).
+        scope = ""
+        if ref not in (repo.default_branch, "HEAD"):
+            matches = [d for d in repo.directories() if _tree_sha(d) == ref]
+            if not matches:
+                return _error(404, "Not Found")
+            scope = matches[0]
+        return web.json_response({
+            "sha": _tree_sha(scope),
+            "tree": repo.tree_items(scope),
+            "truncated": False,
+        })
+
+    async def blob(self, request: web.Request) -> web.Response:
+        if not self._authed(request):
+            return _error(401, "Requires authentication")
+        repo = self._lookup(request)
+        if repo is None:
+            return _error(404, "Not Found")
+        sha = request.match_info["sha"]
+        data = repo.blob(sha)
+        if data is None:
+            return _error(404, "Not Found")
+        # GitHub wraps base64 payloads at 60 columns; b64decode ignores the
+        # newlines, but emitting them keeps the fixture honest.
+        encoded = base64.encodebytes(data).decode()
+        return web.json_response({
+            "sha": sha,
+            "size": len(data),
+            "content": encoded,
+            "encoding": "base64",
+        })
+
+    async def search_code(self, request: web.Request) -> web.Response:
+        if not self._authed(request):
+            return _error(401, "Requires authentication")
+        query = request.query.get("q", "")
+        terms: list[str] = []
+        target: str | None = None
+        path_filter: str | None = None
+        for word in query.split():
+            if word.startswith("repo:"):
+                target = word[len("repo:"):]
+            elif word.startswith("path:"):
+                path_filter = word[len("path:"):]
+            else:
+                terms.extend(TOKEN_RE.findall(word.lower()))
+        if target is None:
+            return _error(
+                422, "Must include at least one user, "
+                "organization, or repository")
+        repo = self.state.repos.get(target)
+        if repo is None:
+            return _error(404, "Not Found")
+        paths = repo.search(terms, path_filter)
+        items = [{
+            "name": path.rsplit("/", 1)[-1],
+            "path": path,
+            "sha": _blob_sha(repo.files[path]),
+            "score": 1.0,
+            "repository": {
+                "name": repo.name,
+                "full_name": repo.full_name,
+            },
+        } for path in paths]
+        return web.json_response({
+            "total_count": len(items),
+            "incomplete_results": False,
+            "items": items,
+        })
+
+
+def build_app(server: GitHubServer) -> web.Application:
+    app = web.Application()
+    app.router.add_get("/repos/{owner}/{repo}", server.repo_info)
+    app.router.add_get("/repos/{owner}/{repo}/git/trees/{ref}", server.tree)
+    app.router.add_get("/repos/{owner}/{repo}/git/blobs/{sha}", server.blob)
+    app.router.add_get("/search/code", server.search_code)
+    return app
+
+
+async def start_fake_github(
+) -> tuple[FakeGitHub, GitHubServer, web.AppRunner]:
+    state = FakeGitHub()
+    server = GitHubServer(state)
+    runner = web.AppRunner(build_app(server))
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    state.base = f"http://127.0.0.1:{port}"
+    return state, server, runner
+
+
+def seed_from_dir(state: FakeGitHub, full_name: str, source: Path) -> None:
+    """Load every file under a fixture directory into one repository.
+
+    Args:
+        state (FakeGitHub): the store to seed.
+        full_name (str): "owner/name" of the repository to create.
+        source (Path): fixture directory to walk.
+    """
+    owner, _, name = full_name.partition("/")
+    repo = state.repo(owner, name)
+    for path in sorted(source.rglob("*")):
+        if path.is_file():
+            repo.seed_path(
+                path.relative_to(source).as_posix(), path.read_bytes())
+
+
+async def _serve(port: int, repos: list[str]) -> None:
+    state = FakeGitHub()
+    fixtures = Path(__file__).resolve().parents[1] / "fixtures"
+    for spec in repos:
+        full_name, _, fixture = spec.partition("=")
+        seed_from_dir(state, full_name, fixtures / fixture)
+    server = GitHubServer(state)
+    runner = web.AppRunner(build_app(server))
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", port)
+    await site.start()
+    state.base = f"http://127.0.0.1:{port}"
+    print(f"GITHUB_ENDPOINT={state.base}", flush=True)
+    await asyncio.Event().wait()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument(
+        "--repo",
+        action="append",
+        default=[],
+        help="owner/name=<fixture dir under integ/fixtures>, repeatable")
+    args = parser.parse_args()
+    asyncio.run(_serve(args.port, args.repo))
+
+
+if __name__ == "__main__":
+    main()

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -453,6 +453,13 @@
           "backend": "dropbox",
           "bucket": "res",
           "fixture": "columnar/v1"
+        },
+        {
+          "path": "/search",
+          "resource": "dropbox",
+          "backend": "dropbox",
+          "bucket": "search",
+          "fixture": "search/v1"
         }
       ]
     },
@@ -715,6 +722,13 @@
           "backend": "box",
           "folder": "res",
           "seed": "columnar/v1"
+        },
+        {
+          "path": "/search",
+          "resource": "box",
+          "backend": "box",
+          "folder": "search",
+          "seed": "search/v1"
         }
       ]
     },

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -719,6 +719,23 @@
       ]
     },
     {
+      "id": "github",
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
+      "service": "github",
+      "mounts": [
+        {
+          "path": "/repo",
+          "resource": "github",
+          "backend": "github",
+          "repo": "integ/repo-v1",
+          "mode": "read"
+        }
+      ]
+    },
+    {
       "id": "hf-prefix",
       "hosts": [
         "python",

--- a/python/mirage/commands/builtin/box/grep.py
+++ b/python/mirage/commands/builtin/box/grep.py
@@ -62,6 +62,7 @@ async def grep(
             pattern,
             fixed_string=fl.as_bool("F"),
             recursive=fl.as_bool("r") or fl.as_bool("R"),
+            whole_word=fl.as_bool("w"),
             exact_file_set=fl.as_bool("v") or fl.as_bool("c"),
         )
         if used_search and not resolved:

--- a/python/mirage/commands/builtin/box/narrow.py
+++ b/python/mirage/commands/builtin/box/narrow.py
@@ -16,7 +16,9 @@ from mirage.accessor.box import BoxAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.box.io import resolve_glob
 from mirage.commands.builtin.grep_helper import (BINARY_EXTENSIONS,
-                                                 get_extension, search_query)
+                                                 get_extension,
+                                                 is_literal_pattern,
+                                                 search_query)
 from mirage.core.box.search import narrow_paths
 from mirage.core.box.stat import stat as box_stat
 from mirage.types import FileType, PathSpec
@@ -56,6 +58,7 @@ async def narrow_scope(
     *,
     fixed_string: bool,
     recursive: bool,
+    whole_word: bool,
     exact_file_set: bool,
 ) -> tuple[list[PathSpec], bool]:
     """Resolve grep/rg scope paths, narrowing via Box content search.
@@ -74,6 +77,15 @@ async def narrow_scope(
     Binary-extension candidates are dropped from the narrowed set because the
     recursive walk it replaces skips them.
 
+    Push-down also requires ``-w``. Box search matches whole
+    words while grep matches substrings, so for a bare literal the
+    search result is a strict subset of the grep matches and a file
+    containing the literal only inside a longer word would be silently
+    dropped. Under ``-w`` both sides agree, and disagreement can only
+    over-fetch, which the local scan filters. A regex narrowed on an
+    extracted literal is excluded even under ``-w``, since the searched
+    term is then only part of the match.
+
     Args:
         accessor (BoxAccessor): backend handle.
         index (IndexCacheStore): index for the glob-resolution fallback.
@@ -81,6 +93,7 @@ async def narrow_scope(
         pattern (str | None): the search pattern, or None for -f-only runs.
         fixed_string (bool): True if -F is set.
         recursive (bool): True if the scan walks directories.
+        whole_word (bool): True if -w is set; required for push-down.
         exact_file_set (bool): True when the output mode must see every file
             in scope, forcing the full walk.
 
@@ -91,8 +104,10 @@ async def narrow_scope(
     """
     query = (search_query(pattern, fixed_string)
              if pattern is not None and "\n" not in pattern else None)
-    use_search = (query is not None and recursive and not exact_file_set
-                  and accessor.config.content_search
+    literal = (pattern is not None
+               and is_literal_pattern(pattern, fixed_string))
+    use_search = (query is not None and whole_word and literal and recursive
+                  and not exact_file_set and accessor.config.content_search
                   and await _all_directories(accessor, index, paths))
     if use_search:
         assert query is not None

--- a/python/mirage/commands/builtin/box/rg.py
+++ b/python/mirage/commands/builtin/box/rg.py
@@ -99,6 +99,7 @@ async def rg(
             pattern_str,
             fixed_string=fl.as_bool("F"),
             recursive=True,
+            whole_word=fl.as_bool("w"),
             exact_file_set=(fl.as_bool("v") or fl.as_str("type") is not None
                             or fl.as_str("glob") is not None),
         )

--- a/python/mirage/commands/builtin/discord/grep.py
+++ b/python/mirage/commands/builtin/discord/grep.py
@@ -82,7 +82,11 @@ async def grep(
                                  stderr=b"grep: root-level search "
                                  b"not yet supported\n")
 
-        if scope.level in ("channel", "guild"):
+        # Provider search matches whole words while grep matches
+        # substrings, and the native path returns search results verbatim
+        # as the output, so a bare literal would under-report. Only -w
+        # makes the two agree; otherwise fall through to the scan.
+        if scope.level in ("channel", "guild") and fl.as_bool("w"):
             try:
                 if scope.guild_id is None:
                     raise RuntimeError("cannot resolve guild ID")

--- a/python/mirage/commands/builtin/discord/rg.py
+++ b/python/mirage/commands/builtin/discord/rg.py
@@ -69,7 +69,11 @@ async def rg(
                                  stderr=b"rg: root-level search "
                                  b"not yet supported\n")
 
-        if scope.level in ("channel", "guild"):
+        # Provider search matches whole words while grep matches
+        # substrings, and the native path returns search results verbatim
+        # as the output, so a bare literal would under-report. Only -w
+        # makes the two agree; otherwise fall through to the scan.
+        if scope.level in ("channel", "guild") and fl.as_bool("w"):
             try:
                 if scope.guild_id is None:
                     raise RuntimeError("cannot resolve guild ID")

--- a/python/mirage/commands/builtin/dropbox/grep.py
+++ b/python/mirage/commands/builtin/dropbox/grep.py
@@ -63,6 +63,7 @@ async def grep(
             pattern,
             fixed_string=fl.as_bool("F"),
             recursive=fl.as_bool("r") or fl.as_bool("R"),
+            whole_word=fl.as_bool("w"),
             exact_file_set=fl.as_bool("v") or fl.as_bool("c"),
         )
         if used_search and not resolved:

--- a/python/mirage/commands/builtin/dropbox/narrow.py
+++ b/python/mirage/commands/builtin/dropbox/narrow.py
@@ -16,7 +16,9 @@ from mirage.accessor.dropbox import DropboxAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.dropbox.io import resolve_glob
 from mirage.commands.builtin.grep_helper import (BINARY_EXTENSIONS,
-                                                 get_extension, search_query)
+                                                 get_extension,
+                                                 is_literal_pattern,
+                                                 search_query)
 from mirage.core.dropbox.search import narrow_paths
 from mirage.core.dropbox.stat import stat as dropbox_stat
 from mirage.types import FileType, PathSpec
@@ -56,6 +58,7 @@ async def narrow_scope(
     *,
     fixed_string: bool,
     recursive: bool,
+    whole_word: bool,
     exact_file_set: bool,
 ) -> tuple[list[PathSpec], bool]:
     """Resolve grep/rg scope paths, narrowing via Dropbox file search.
@@ -75,6 +78,15 @@ async def narrow_scope(
     Binary-extension candidates are dropped from the narrowed set because
     the recursive walk it replaces skips them.
 
+    Push-down also requires ``-w``. Dropbox search matches whole
+    words while grep matches substrings, so for a bare literal the
+    search result is a strict subset of the grep matches and a file
+    containing the literal only inside a longer word would be silently
+    dropped. Under ``-w`` both sides agree, and disagreement can only
+    over-fetch, which the local scan filters. A regex narrowed on an
+    extracted literal is excluded even under ``-w``, since the searched
+    term is then only part of the match.
+
     Args:
         accessor (DropboxAccessor): backend handle.
         index (IndexCacheStore): index for the glob-resolution fallback.
@@ -82,6 +94,7 @@ async def narrow_scope(
         pattern (str | None): the search pattern, or None for -f-only runs.
         fixed_string (bool): True if -F is set.
         recursive (bool): True if the scan walks directories.
+        whole_word (bool): True if -w is set; required for push-down.
         exact_file_set (bool): True when the output mode must see every
             file in scope, forcing the full walk.
 
@@ -92,8 +105,10 @@ async def narrow_scope(
     """
     query = (search_query(pattern, fixed_string)
              if pattern is not None and "\n" not in pattern else None)
-    use_search = (query is not None and recursive and not exact_file_set
-                  and accessor.config.content_search
+    literal = (pattern is not None
+               and is_literal_pattern(pattern, fixed_string))
+    use_search = (query is not None and whole_word and literal and recursive
+                  and not exact_file_set and accessor.config.content_search
                   and await _all_directories(accessor, index, paths))
     if use_search:
         assert query is not None

--- a/python/mirage/commands/builtin/dropbox/rg.py
+++ b/python/mirage/commands/builtin/dropbox/rg.py
@@ -99,6 +99,7 @@ async def rg(
             pattern_str,
             fixed_string=fl.as_bool("F"),
             recursive=True,
+            whole_word=fl.as_bool("w"),
             exact_file_set=(fl.as_bool("v") or fl.as_str("type") is not None
                             or fl.as_str("glob") is not None),
         )

--- a/python/mirage/commands/builtin/github/grep.py
+++ b/python/mirage/commands/builtin/github/grep.py
@@ -112,7 +112,11 @@ async def grep(
             whole_word=fl.as_bool("w"),
         )
         if file_count > SCOPE_ERROR:
-            msg = f"grep: {file_count} files in scope, narrow the path\n"
+            # Push-down needs -w (see narrow_scope); without it a scope
+            # this large has no complete narrowing strategy, so say so
+            # rather than scanning thousands of blobs.
+            msg = (f"grep: {file_count} files in scope, "
+                   "narrow the path, or use -w to enable code search\n")
             return b"", IOResult(exit_code=1, stderr=msg.encode())
 
     return await generic_grep(

--- a/python/mirage/commands/builtin/github/grep.py
+++ b/python/mirage/commands/builtin/github/grep.py
@@ -16,8 +16,7 @@ from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.grep import grep as generic_grep
 from mirage.commands.builtin.generic_bind.adapter import bound_op
-from mirage.commands.builtin.github.narrow import (files_only_shortcircuit,
-                                                   narrow_scope)
+from mirage.commands.builtin.github.narrow import narrow_scope
 from mirage.commands.builtin.grep_helper import pattern_arg
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -110,14 +109,11 @@ async def grep(
             pattern,
             fixed_string=fl.as_bool("F"),
             recursive=recursive,
+            whole_word=fl.as_bool("w"),
         )
         if file_count > SCOPE_ERROR:
             msg = f"grep: {file_count} files in scope, narrow the path\n"
             return b"", IOResult(exit_code=1, stderr=msg.encode())
-        if used_search:
-            short = files_only_shortcircuit(fl, pattern, resolved, paths[0])
-            if short is not None:
-                return short
 
     return await generic_grep(
         resolved,

--- a/python/mirage/commands/builtin/github/narrow.py
+++ b/python/mirage/commands/builtin/github/narrow.py
@@ -12,22 +12,16 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from collections.abc import Callable
-
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
-from mirage.commands.builtin.constants import PatternType
 from mirage.commands.builtin.github.io import resolve_glob
-from mirage.commands.builtin.grep_helper import classify_pattern, search_query
-from mirage.commands.builtin.utils.output import format_records
-from mirage.commands.spec.types import FlagView
+from mirage.commands.builtin.grep_helper import (is_literal_pattern,
+                                                 search_query)
 from mirage.core.github.constants import SCOPE_WARN
 from mirage.core.github.scope import (count_scope_files, scope_relative_key,
                                       should_use_search)
 from mirage.core.github.search import narrow_paths
-from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
-from mirage.utils.path import rebase_raw
 
 
 async def narrow_scope(
@@ -38,14 +32,25 @@ async def narrow_scope(
     *,
     fixed_string: bool,
     recursive: bool,
+    whole_word: bool,
 ) -> tuple[list[PathSpec], int, bool]:
     """Resolve grep/rg scope paths, narrowing via GitHub code search.
 
     Narrows any recursive scope (repo root or subdirectory) on the default
     branch when a literal can be pushed down to code search and the scope is
-    larger than ``SCOPE_WARN``; otherwise expands the scope by glob. Regex
-    patterns narrow on an extracted required literal and stay exact because the
-    caller still scans the regex over the narrowed files.
+    larger than ``SCOPE_WARN``; otherwise expands the scope by glob.
+
+    Push-down requires ``-w`` and a fully literal pattern. GitHub code search
+    matches whole words while grep matches substrings, so for a bare literal
+    the search result is a strict subset of the grep matches: a file holding
+    the literal only inside a longer word (``quokka`` in ``quokkabuild``)
+    never comes back and would be silently dropped from the scan. Under ``-w``
+    both sides mean the same thing, and any tokenizer disagreement can only
+    over-fetch, which the local scan filters. A regex narrowed on an extracted
+    literal stays excluded even under ``-w``, because the searched term is
+    then only part of the match: ``foo[0-9]`` matches ``foo1`` as a whole
+    word, but searching ``foo`` never returns a file whose only token is
+    ``foo1``.
 
     Args:
         accessor (GitHubAccessor): backend handle.
@@ -54,6 +59,7 @@ async def narrow_scope(
         pattern (str | None): the search pattern, or None for -f-only greps.
         fixed_string (bool): True if -F is set.
         recursive (bool): True if -r/-R is set.
+        whole_word (bool): True if -w is set; required for push-down.
 
     Returns:
         tuple[list[PathSpec], int, bool]: resolved file paths, the file count
@@ -64,10 +70,14 @@ async def narrow_scope(
     file_count = count_scope_files(await index.entries(), key)
     query = search_query(pattern,
                          fixed_string) if pattern is not None else None
-    use_search = (query is not None and should_use_search(
-        recursive=recursive,
-        on_default_branch=(accessor.ref == accessor.default_branch),
-    ) and file_count > SCOPE_WARN)
+    literal = (pattern is not None
+               and is_literal_pattern(pattern, fixed_string))
+    use_search = (query is not None and whole_word and literal
+                  and should_use_search(
+                      recursive=recursive,
+                      on_default_branch=(accessor.ref
+                                         == accessor.default_branch),
+                  ) and file_count > SCOPE_WARN)
     if use_search:
         assert query is not None
         narrowed = await narrow_paths(accessor.config, accessor.owner,
@@ -76,53 +86,3 @@ async def narrow_scope(
             return narrowed, len(narrowed), True
     resolved = await resolve_glob(accessor, paths, index)
     return resolved, file_count, False
-
-
-def files_only_shortcircuit(
-    fl: FlagView,
-    pattern: str | None,
-    resolved: list[PathSpec],
-    scope: PathSpec,
-    path_predicate: Callable[[str], bool] | None = None,
-) -> tuple[ByteSource, IOResult] | None:
-    """Emit the narrowed file list for a plain literal -l without reading.
-
-    When code search has already narrowed the scope to the files containing a
-    fully literal pattern, those files are exactly the answer to ``-l``
-    (files-with-matches), so the content fetches the generic command would do
-    can be skipped entirely. Returns None whenever the short-circuit is unsafe
-    (no -l, a non-literal pattern, or a flag that changes which lines match) so
-    the caller falls back to the generic scan. ``path_predicate`` reproduces
-    any file filtering the generic command applies (rg's hidden/--type/--glob
-    rules); files it rejects are dropped, matching the generic output.
-
-    Args:
-        fl (FlagView): spec-validated view over the raw flag kwargs.
-        pattern (str | None): the search pattern.
-        resolved (list[PathSpec]): the narrowed file paths.
-        scope (PathSpec): the original scope path, for display rebasing.
-        path_predicate (Callable[[str], bool] | None): keeps only narrowed
-            paths for which it returns True; None keeps all (grep semantics).
-
-    Returns:
-        tuple[ByteSource, IOResult] | None: the formatted file list, or None.
-    """
-    if not fl.as_bool("args_l") or pattern is None:
-        return None
-    if (fl.as_bool("i") or fl.as_bool("w") or fl.as_bool("v")
-            or fl.as_bool("c") or fl.as_bool("o")):
-        return None
-    fixed = fl.as_bool("F")
-    pt = classify_pattern(pattern, fixed)
-    fully_literal = fixed or pt == PatternType.EXACT or (
-        pt == PatternType.SIMPLE and "." not in pattern)
-    if not fully_literal:
-        return None
-    hits = [
-        p.virtual for p in resolved
-        if path_predicate is None or path_predicate(p.virtual)
-    ]
-    if not hits:
-        return b"", IOResult(exit_code=1)
-    spelled = rebase_raw(hits, scope.virtual, scope.raw_path)
-    return format_records(sorted(spelled)), IOResult()

--- a/python/mirage/commands/builtin/github/rg.py
+++ b/python/mirage/commands/builtin/github/rg.py
@@ -12,16 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from functools import partial
-
 from mirage.accessor.github import GitHubAccessor
 from mirage.cache.index import IndexCacheStore
 from mirage.commands.builtin.generic.rg import rg as generic_rg
 from mirage.commands.builtin.generic_bind.adapter import bound_op
-from mirage.commands.builtin.github.narrow import (files_only_shortcircuit,
-                                                   narrow_scope)
+from mirage.commands.builtin.github.narrow import narrow_scope
 from mirage.commands.builtin.grep_helper import pattern_arg
-from mirage.commands.builtin.rg_helper import rg_matches_filter
 from mirage.commands.errors import UsageError
 from mirage.commands.registry import command
 from mirage.commands.spec import SPECS
@@ -49,7 +45,7 @@ async def rg(
         raise UsageError("rg: usage: rg [flags] pattern [path]")
 
     if paths:
-        scope = paths[0]
+        paths[0]
         paths, file_count, used_search = await narrow_scope(
             accessor,
             index,
@@ -57,22 +53,11 @@ async def rg(
             pattern_str,
             fixed_string=fl.as_bool("F"),
             recursive=True,
+            whole_word=fl.as_bool("w"),
         )
         if file_count > SCOPE_ERROR:
             msg = f"rg: {file_count} files in scope, narrow the path\n"
             return b"", IOResult(exit_code=1, stderr=msg.encode())
-        if used_search:
-            predicate = partial(rg_matches_filter,
-                                file_type=fl.as_str("type"),
-                                glob_pattern=fl.as_str("glob"),
-                                hidden=fl.as_bool("hidden"))
-            short = files_only_shortcircuit(fl,
-                                            pattern_str,
-                                            paths,
-                                            scope,
-                                            path_predicate=predicate)
-            if short is not None:
-                return short
 
     return await generic_rg(
         paths,

--- a/python/mirage/commands/builtin/github/rg.py
+++ b/python/mirage/commands/builtin/github/rg.py
@@ -56,7 +56,11 @@ async def rg(
             whole_word=fl.as_bool("w"),
         )
         if file_count > SCOPE_ERROR:
-            msg = f"rg: {file_count} files in scope, narrow the path\n"
+            # Push-down needs -w (see narrow_scope); without it a scope
+            # this large has no complete narrowing strategy, so say so
+            # rather than scanning thousands of blobs.
+            msg = (f"rg: {file_count} files in scope, "
+                   "narrow the path, or use -w to enable code search\n")
             return b"", IOResult(exit_code=1, stderr=msg.encode())
 
     return await generic_rg(

--- a/python/mirage/commands/builtin/gmail/grep.py
+++ b/python/mirage/commands/builtin/gmail/grep.py
@@ -72,7 +72,11 @@ async def grep(
 
     if paths and pattern is not None and "\n" not in pattern and not shaping:
         scope = detect_scope(paths[0])
-        if scope.use_native:
+        # Provider search matches whole words while grep matches
+        # substrings, and the native path returns search results verbatim
+        # as the output, so a bare literal would under-report. Only -w
+        # makes the two agree; otherwise fall through to the scan.
+        if scope.use_native and fl.as_bool("w"):
             file_prefix = mount_prefix_of(paths[0].virtual,
                                           paths[0].resource_path) or ""
             rows = await search_messages(

--- a/python/mirage/commands/builtin/gmail/rg.py
+++ b/python/mirage/commands/builtin/gmail/rg.py
@@ -56,7 +56,11 @@ async def rg(
 
     if paths and "\n" not in pattern_str and not shaping:
         scope = detect_scope(paths[0])
-        if scope.use_native:
+        # Provider search matches whole words while grep matches
+        # substrings, and the native path returns search results verbatim
+        # as the output, so a bare literal would under-report. Only -w
+        # makes the two agree; otherwise fall through to the scan.
+        if scope.use_native and fl.as_bool("w"):
             file_prefix = mount_prefix_of(paths[0].virtual,
                                           paths[0].resource_path) or ""
             rows = await search_messages(

--- a/python/mirage/commands/builtin/grep_helper.py
+++ b/python/mirage/commands/builtin/grep_helper.py
@@ -122,6 +122,29 @@ def extract_required_literal(pattern: str) -> str | None:
     return best if len(best) >= _MIN_SEARCH_LITERAL else None
 
 
+def is_literal_pattern(pattern: str, fixed_string: bool) -> bool:
+    """Whether the pattern is searched verbatim, with no regex extraction.
+
+    Push-down against a whole-word search index is only complete when the term
+    handed to the provider is the entire match. A regex narrowed on an
+    extracted literal fails that: ``foo[0-9]`` under -w matches ``foo1``, but a
+    whole-word search for ``foo`` never returns a file whose only token is
+    ``foo1``.
+
+    Args:
+        pattern (str): the search pattern.
+        fixed_string (bool): True if -F is set.
+
+    Returns:
+        bool: True when the pattern itself is the search term.
+    """
+    if fixed_string:
+        return True
+    pt = classify_pattern(pattern, fixed_string)
+    return pt == PatternType.EXACT or (pt == PatternType.SIMPLE
+                                       and "." not in pattern)
+
+
 def search_query(pattern: str, fixed_string: bool) -> str | None:
     """Literal to push down to a code-search API for a grep/rg pattern.
 

--- a/python/mirage/commands/builtin/slack/grep.py
+++ b/python/mirage/commands/builtin/slack/grep.py
@@ -75,7 +75,12 @@ async def grep(
         if not scope.use_native:
             scope = coalesce_scopes(paths) or scope
 
-        if (scope.use_native and getattr(scope, "target", None) != "files"
+        # Slack search matches whole words while grep matches substrings,
+        # so native results are a strict subset of the real matches for a
+        # bare literal. Only -w makes the two agree; otherwise fall
+        # through to the per-message scan.
+        if (scope.use_native and fl.as_bool("w")
+                and getattr(scope, "target", None) != "files"
                 and search_available(accessor.config)):
             file_prefix = mount_prefix_of(paths[0].virtual,
                                           paths[0].resource_path) or ""

--- a/python/mirage/commands/builtin/slack/rg.py
+++ b/python/mirage/commands/builtin/slack/rg.py
@@ -62,7 +62,12 @@ async def rg(
         if not scope.use_native:
             scope = coalesce_scopes(paths) or scope
 
-        if (scope.use_native and getattr(scope, "target", None) != "files"
+        # Slack search matches whole words while grep matches substrings,
+        # so native results are a strict subset of the real matches for a
+        # bare literal. Only -w makes the two agree; otherwise fall
+        # through to the per-message scan.
+        if (scope.use_native and fl.as_bool("w")
+                and getattr(scope, "target", None) != "files"
                 and search_available(accessor.config)):
             file_prefix = mount_prefix_of(paths[0].virtual,
                                           paths[0].resource_path) or ""

--- a/python/mirage/core/github/_client.py
+++ b/python/mirage/core/github/_client.py
@@ -34,15 +34,17 @@ def github_headers(token: SecretStr) -> dict[str, str]:
     }
 
 
-def github_url(path: str, **kwargs: str) -> str:
-    return API_BASE + path.format(**kwargs)
+def github_url(path: str, base_url: str | None = None, **kwargs: str) -> str:
+    return (base_url or API_BASE) + path.format(**kwargs)
 
 
 async def github_get(token: SecretStr,
                      path: str,
                      params: dict[str, Any] | None = None,
+                     *,
+                     base_url: str | None = None,
                      **kwargs: str) -> dict[str, Any]:
-    url = github_url(path, **kwargs)
+    url = github_url(path, base_url, **kwargs)
     headers = github_headers(token)
     async with aiohttp.ClientSession() as session:
         async with session.get(url, headers=headers, params=params) as resp:
@@ -53,8 +55,10 @@ async def github_get(token: SecretStr,
 def github_get_sync(token: SecretStr,
                     path: str,
                     params: dict[str, Any] | None = None,
+                    *,
+                    base_url: str | None = None,
                     **kwargs: str) -> dict[str, Any]:
-    url = github_url(path, **kwargs)
+    url = github_url(path, base_url, **kwargs)
     if params:
         url = f"{url}?{urlencode(params)}"
     req = Request(url, headers=github_headers(token), method="GET")

--- a/python/mirage/core/github/config.py
+++ b/python/mirage/core/github/config.py
@@ -20,3 +20,4 @@ class GitHubConfig(BaseModel):
     owner: str | None = None
     repo: str | None = None
     ref: str = "main"
+    base_url: str | None = None

--- a/python/mirage/core/github/read.py
+++ b/python/mirage/core/github/read.py
@@ -27,6 +27,7 @@ async def read_bytes(config: GitHubConfig, owner: str, repo: str,
     data = await github_get(
         config.token,
         "/repos/{owner}/{repo}/git/blobs/{sha}",
+        base_url=config.base_url,
         owner=owner,
         repo=repo,
         sha=sha,

--- a/python/mirage/core/github/repo.py
+++ b/python/mirage/core/github/repo.py
@@ -20,6 +20,7 @@ def fetch_default_branch_sync(config: GitHubConfig, owner: str,
                               repo: str) -> str:
     data = github_get_sync(config.token,
                            "/repos/{owner}/{repo}",
+                           base_url=config.base_url,
                            owner=owner,
                            repo=repo)
     return data["default_branch"]

--- a/python/mirage/core/github/search.py
+++ b/python/mirage/core/github/search.py
@@ -40,7 +40,10 @@ async def search_code(
     q = f"{query} repo:{owner}/{repo}"
     if path_filter:
         q += f" path:{path_filter}"
-    data = await github_get(config.token, "/search/code", params={"q": q})
+    data = await github_get(config.token,
+                            "/search/code",
+                            params={"q": q},
+                            base_url=config.base_url)
     return [
         SearchResult(path=item["path"], sha=item["sha"])
         for item in data.get("items", [])

--- a/python/mirage/core/github/tree.py
+++ b/python/mirage/core/github/tree.py
@@ -52,10 +52,11 @@ def fetch_tree_sync(
     data = github_get_sync(
         config.token,
         "/repos/{owner}/{repo}/git/trees/{ref}",
+        params={"recursive": "1"},
+        base_url=config.base_url,
         owner=owner,
         repo=repo,
         ref=ref,
-        params={"recursive": "1"},
     )
     return _parse_tree_response(data, owner, repo, ref)
 
@@ -73,6 +74,7 @@ async def fetch_dir_tree(
     data = await github_get(
         config.token,
         "/repos/{owner}/{repo}/git/trees/{tree_sha}",
+        base_url=config.base_url,
         owner=owner,
         repo=repo,
         tree_sha=tree_sha,

--- a/python/mirage/core/mongodb/search.py
+++ b/python/mirage/core/mongodb/search.py
@@ -18,7 +18,7 @@ from typing import Any
 from bson.json_util import RELAXED_JSON_OPTIONS, dumps
 from pymongo import AsyncMongoClient
 
-from mirage.core.mongodb._client import get_indexes, list_collections
+from mirage.core.mongodb._client import list_collections
 from mirage.core.mongodb.types import PRIMARY_KEY, EntityKind
 
 
@@ -39,10 +39,6 @@ async def _sampled_string_paths(col, sample_size: int = 100) -> list[str]:
     return sorted(paths)
 
 
-def _has_text_index(indexes: list[dict[str, Any]]) -> bool:
-    return any("textIndexVersion" in idx for idx in indexes)
-
-
 async def search_collection(
     client: AsyncMongoClient[Any],
     database: str,
@@ -52,21 +48,22 @@ async def search_collection(
 ) -> list[dict[str, Any]]:
     db = client[database]
     col = db[collection]
-    indexes = await get_indexes(client, database, collection)
-    if _has_text_index(indexes):
-        filter_expr: dict[str, Any] = {"$text": {"$search": pattern}}
-    else:
-        paths = await _sampled_string_paths(col)
-        if not paths:
-            return []
-        filter_expr = {
-            "$or": [{
-                p: {
-                    "$regex": pattern,
-                    "$options": "i"
-                }
-            } for p in paths]
-        }
+    # Always $regex, never $text. A $text index matches whole words and
+    # stems them, while grep matches substrings, and these rows are
+    # returned as the grep output without a local re-scan: $text would
+    # both miss `foo` inside `foobar` and match stems the pattern never
+    # had. $regex takes the pattern as written.
+    paths = await _sampled_string_paths(col)
+    if not paths:
+        return []
+    filter_expr: dict[str, Any] = {
+        "$or": [{
+            p: {
+                "$regex": pattern,
+                "$options": "i"
+            }
+        } for p in paths]
+    }
     cursor = col.find(filter_expr).limit(limit)
     return await cursor.to_list(length=limit)
 

--- a/python/tests/commands/builtin/box/test_narrow.py
+++ b/python/tests/commands/builtin/box/test_narrow.py
@@ -65,6 +65,7 @@ async def run(index, **kwargs):
     defaults = {
         "fixed_string": False,
         "recursive": True,
+        "whole_word": True,
         "exact_file_set": False,
     }
     defaults.update(kwargs)
@@ -90,6 +91,7 @@ async def test_knob_off_skips_search(harness, index):
                                         "needle",
                                         fixed_string=False,
                                         recursive=True,
+                                        whole_word=True,
                                         exact_file_set=False)
     assert not used
     narrow.assert_not_awaited()
@@ -121,6 +123,7 @@ async def test_multiline_pattern_skips_search(harness, index):
                                  "foo\nbar",
                                  fixed_string=False,
                                  recursive=True,
+                                 whole_word=True,
                                  exact_file_set=False)
     assert not used
     narrow.assert_not_awaited()
@@ -134,22 +137,27 @@ async def test_regex_without_literal_skips_search(harness, index):
                                  "foo|bar",
                                  fixed_string=False,
                                  recursive=True,
+                                 whole_word=True,
                                  exact_file_set=False)
     assert not used
     narrow.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_regex_narrows_on_required_literal(harness, index):
+async def test_regex_skips_search(harness, index):
+    # A regex narrows on an extracted literal, so the searched term is only
+    # part of the match; a whole-word search for it can miss real matches.
+    # Excluded even under -w.
     _, narrow, _ = harness
     _, used = await narrow_scope(make_accessor(),
                                  index, [scope()],
                                  "import.*os",
                                  fixed_string=False,
                                  recursive=True,
+                                 whole_word=True,
                                  exact_file_set=False)
-    assert used
-    assert narrow.await_args.args[1] == "import"
+    assert not used
+    narrow.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -205,3 +213,15 @@ async def test_all_binary_narrow_stays_used_and_empty(harness, index):
     assert used
     assert resolved == []
     glob.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_without_word_flag_skips_search(harness, index):
+    # Provider search matches whole words while grep matches substrings, so
+    # narrowing on a bare literal would drop files that contain it only
+    # inside a longer word.
+    _, narrow, glob = harness
+    _resolved, used = await run(index, whole_word=False)
+    assert not used
+    narrow.assert_not_awaited()
+    glob.assert_awaited_once()

--- a/python/tests/commands/builtin/discord/test_grep_pushdown.py
+++ b/python/tests/commands/builtin/discord/test_grep_pushdown.py
@@ -18,6 +18,7 @@ import pytest
 
 from mirage.commands.builtin.discord.grep import grep
 from mirage.commands.builtin.discord.rg import rg
+from mirage.commands.errors import UsageError
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -77,6 +78,7 @@ async def test_discord_grep_with_many_concrete_paths_uses_native_search():
         out, io = await grep(accessor,
                              _concrete_paths(7),
                              "hello",
+                             w=True,
                              index=_fake_index())
     assert fake_search.await_count == 1
     assert io.exit_code == 0
@@ -111,7 +113,11 @@ async def test_discord_grep_falls_back_when_native_raises():
             new=AsyncMock(return_value=FileStat(name="2026-04-10.jsonl",
                                                 type=FileType.TEXT)),
     ):
-        out, io = await grep(accessor, paths, "hello", index=_fake_index())
+        out, io = await grep(accessor,
+                             paths,
+                             "hello",
+                             w=True,
+                             index=_fake_index())
     assert fake_resolve.await_count == 1
     assert io.exit_code in (0, 1)
 
@@ -134,6 +140,7 @@ async def test_discord_grep_native_empty_does_not_trigger_fallback():
         out, io = await grep(accessor,
                              _concrete_paths(7),
                              "missing",
+                             w=True,
                              index=_fake_index())
     assert fake_search.await_count == 1
     assert fake_read.await_count == 0
@@ -175,6 +182,7 @@ async def test_discord_grep_multi_pattern_skips_native_search():
         _, io = await grep(accessor,
                            paths,
                            e=["ada", "ben"],
+                           w=True,
                            index=_fake_index())
     assert fake_search.await_count == 0
     assert fake_resolve.await_count == 1
@@ -204,6 +212,7 @@ async def test_discord_rg_with_many_concrete_paths_uses_native_search():
         out, io = await rg(accessor,
                            _concrete_paths(7),
                            "hello",
+                           w=True,
                            index=_fake_index())
     assert fake_search.await_count == 1
     assert io.exit_code == 0
@@ -247,6 +256,28 @@ async def test_discord_rg_multi_pattern_skips_native_search():
         _, io = await rg(accessor,
                          paths,
                          e=["ada", "ben"],
+                         w=True,
                          index=_fake_index())
     assert fake_search.await_count == 0
     assert fake_resolve.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_discord_grep_without_word_flag_skips_native_search():
+    # Discord search matches whole words while grep matches substrings, and
+    # the native path returns search results verbatim as the grep output, so
+    # a bare literal would under-report. Only -w may take it.
+    accessor = AsyncMock()
+    with patch(
+            "mirage.commands.builtin.discord.grep.search_guild",
+            new=AsyncMock(return_value=[]),
+    ) as fake_search, patch(
+            "mirage.commands.builtin.discord.grep.resolve_glob",
+            new=AsyncMock(return_value=[]),
+    ):
+        with pytest.raises(UsageError):
+            await grep(accessor,
+                       _concrete_paths(7),
+                       "hello",
+                       index=_fake_index())
+    fake_search.assert_not_awaited()

--- a/python/tests/commands/builtin/discord/test_search_pushdown_fallback.py
+++ b/python/tests/commands/builtin/discord/test_search_pushdown_fallback.py
@@ -64,6 +64,7 @@ async def test_grep_emits_token_hint_on_forbidden():
         _out, io = await grep(accessor,
                               paths,
                               "hi",
+                              w=True,
                               index=_fake_index(),
                               args_l=True)
     stderr = (io.stderr or b"").decode()
@@ -86,7 +87,7 @@ async def test_rg_emits_warning_on_rate_limit():
             "mirage.commands.builtin.discord.rg.generic_rg",
             new=AsyncMock(return_value=(b"", IOResult(exit_code=1))),
     ):
-        _out, io = await rg(accessor, paths, "hi", index=_fake_index())
+        _out, io = await rg(accessor, paths, "hi", w=True, index=_fake_index())
     stderr = (io.stderr or b"").decode()
     assert "push-down failed" in stderr
     # 429 doesn't trigger the perm hint; should still warn

--- a/python/tests/commands/builtin/dropbox/test_narrow.py
+++ b/python/tests/commands/builtin/dropbox/test_narrow.py
@@ -68,6 +68,7 @@ async def run(index, **kwargs):
     defaults = {
         "fixed_string": False,
         "recursive": True,
+        "whole_word": True,
         "exact_file_set": False,
     }
     defaults.update(kwargs)
@@ -93,6 +94,7 @@ async def test_knob_off_skips_search(harness, index):
                                         "needle",
                                         fixed_string=False,
                                         recursive=True,
+                                        whole_word=True,
                                         exact_file_set=False)
     assert not used
     narrow.assert_not_awaited()
@@ -124,6 +126,7 @@ async def test_multiline_pattern_skips_search(harness, index):
                                  "foo\nbar",
                                  fixed_string=False,
                                  recursive=True,
+                                 whole_word=True,
                                  exact_file_set=False)
     assert not used
     narrow.assert_not_awaited()
@@ -137,22 +140,27 @@ async def test_regex_without_literal_skips_search(harness, index):
                                  "foo|bar",
                                  fixed_string=False,
                                  recursive=True,
+                                 whole_word=True,
                                  exact_file_set=False)
     assert not used
     narrow.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_regex_narrows_on_required_literal(harness, index):
+async def test_regex_skips_search(harness, index):
+    # A regex narrows on an extracted literal, so the searched term is only
+    # part of the match; a whole-word search for it can miss real matches.
+    # Excluded even under -w.
     _, narrow, _ = harness
     _, used = await narrow_scope(make_accessor(),
                                  index, [scope()],
                                  "import.*os",
                                  fixed_string=False,
                                  recursive=True,
+                                 whole_word=True,
                                  exact_file_set=False)
-    assert used
-    assert narrow.await_args.args[1] == "import"
+    assert not used
+    narrow.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -208,3 +216,15 @@ async def test_all_binary_narrow_stays_used_and_empty(harness, index):
     assert used
     assert resolved == []
     glob.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_without_word_flag_skips_search(harness, index):
+    # Provider search matches whole words while grep matches substrings, so
+    # narrowing on a bare literal would drop files that contain it only
+    # inside a longer word.
+    _, narrow, glob = harness
+    _resolved, used = await run(index, whole_word=False)
+    assert not used
+    narrow.assert_not_awaited()
+    glob.assert_awaited_once()

--- a/python/tests/commands/builtin/github/test_grep_search.py
+++ b/python/tests/commands/builtin/github/test_grep_search.py
@@ -61,7 +61,7 @@ async def test_grep_root_large_tree_uses_search(mock_github_api, github_env,
     spy = AsyncMock(return_value=narrowed)
     monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
     monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
-    await grep(accessor, [_root()], "import", r=True, index=index)
+    await grep(accessor, [_root()], "import", r=True, w=True, index=index)
     spy.assert_awaited_once()
 
 
@@ -72,20 +72,22 @@ async def test_grep_subdir_uses_search(mock_github_api, github_env,
     spy = AsyncMock(return_value=[])
     monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
     monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
-    await grep(accessor, [_subdir()], "import", r=True, index=index)
+    await grep(accessor, [_subdir()], "import", r=True, w=True, index=index)
     spy.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_grep_regex_with_literal_uses_search(mock_github_api, github_env,
-                                                   monkeypatch):
+async def test_grep_regex_skips_search(mock_github_api, github_env,
+                                       monkeypatch):
+    # A regex narrows on an extracted literal, so the searched term is only
+    # part of the match: `import.*os` matches `importos` variants that a
+    # whole-word search for `import` never returns. Excluded even under -w.
     accessor, index = github_env
     spy = AsyncMock(return_value=[])
     monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
     monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
-    await grep(accessor, [_root()], "import.*os", r=True, index=index)
-    spy.assert_awaited_once()
-    assert spy.await_args.args[3] == "import"
+    await grep(accessor, [_root()], "import.*os", r=True, w=True, index=index)
+    spy.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -96,7 +98,11 @@ async def test_grep_regex_without_literal_skips_search(mock_github_api,
     spy = AsyncMock(return_value=[])
     monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
     monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
-    await grep(accessor, [_root()], "import|export", r=True, index=index)
+    await grep(accessor, [_root()],
+               "import|export",
+               r=True,
+               w=True,
+               index=index)
     spy.assert_not_awaited()
 
 
@@ -106,7 +112,7 @@ async def test_grep_small_tree_skips_search(mock_github_api, github_env,
     accessor, index = github_env
     spy = AsyncMock(return_value=[])
     monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
-    await grep(accessor, [_root()], "import", r=True, index=index)
+    await grep(accessor, [_root()], "import", r=True, w=True, index=index)
     spy.assert_not_awaited()
 
 
@@ -115,6 +121,24 @@ async def test_grep_scope_error_when_too_many_files(mock_github_api,
                                                     github_env, monkeypatch):
     accessor, index = github_env
     monkeypatch.setitem(_GLOBALS, "SCOPE_ERROR", 1)
-    stdout, io = await grep(accessor, [_root()], "import", r=True, index=index)
+    stdout, io = await grep(accessor, [_root()],
+                            "import",
+                            r=True,
+                            w=True,
+                            index=index)
     assert io.exit_code == 1
     assert b"narrow the path" in (io.stderr or b"")
+
+
+@pytest.mark.asyncio
+async def test_grep_without_word_flag_skips_search(mock_github_api, github_env,
+                                                   monkeypatch):
+    # Code search matches whole words while grep matches substrings, so a
+    # bare literal would narrow to a strict subset and silently drop files
+    # that contain it only inside a longer word.
+    accessor, index = github_env
+    spy = AsyncMock(return_value=[])
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
+    await grep(accessor, [_root()], "import", r=True, index=index)
+    spy.assert_not_awaited()

--- a/python/tests/commands/builtin/github/test_narrow.py
+++ b/python/tests/commands/builtin/github/test_narrow.py
@@ -71,126 +71,21 @@ async def test_subdir_narrows_and_fetches_fewer(mock_github_api, github_env,
                                                 counting_read, monkeypatch):
     accessor, index = github_env
     monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
-    await grep(accessor, [_subdir()], "import", r=True, index=index)
+    await grep(accessor, [_subdir()], "import", r=True, w=True, index=index)
     # /src holds 7 files; code search narrows to the import-matching subset.
     assert 0 < len(counting_read) < 7
 
 
 @pytest.mark.asyncio
-async def test_regex_narrows_via_extracted_literal(mock_github_api, github_env,
-                                                   counting_read, monkeypatch):
+async def test_regex_scans_every_file(mock_github_api, github_env,
+                                      counting_read, monkeypatch):
+    # A regex narrows on an extracted literal, so the searched term is only
+    # part of the match; a whole-word search for it can miss real matches.
+    # Excluded even under -w.
     accessor, index = github_env
     monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
-    await grep(accessor, [_root()], "import.*os", r=True, index=index)
-    # "import" is the required literal; only files containing it are fetched.
-    assert 0 < len(counting_read) < len(MOCK_BLOBS)
-
-
-@pytest.mark.asyncio
-async def test_files_only_shortcircuit_reads_nothing(mock_github_api,
-                                                     github_env, counting_read,
-                                                     monkeypatch):
-    accessor, index = github_env
-    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
-    stdout, io = await grep(accessor, [_root()],
-                            "import",
-                            r=True,
-                            args_l=True,
-                            index=index)
-    body = (await materialize(stdout)).decode()
-    assert len(counting_read) == 0
-    assert io.exit_code == 0
-    assert "src/main.py" in body
-
-
-@pytest.mark.asyncio
-async def test_files_only_shortcircuit_matches_generic(mock_github_api,
-                                                       github_env,
-                                                       monkeypatch):
-    accessor, index = github_env
-
-    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 10_000)
-    out_generic, _ = await grep(accessor, [_root()],
-                                "import",
-                                r=True,
-                                args_l=True,
-                                index=index)
-    text_generic = (await materialize(out_generic)).decode()
-
-    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
-    out_short, _ = await grep(accessor, [_root()],
-                              "import",
-                              r=True,
-                              args_l=True,
-                              index=index)
-    text_short = (await materialize(out_short)).decode()
-
-    assert text_short == text_generic
-    assert text_short
-
-
-@pytest.mark.asyncio
-async def test_rg_files_only_shortcircuit_reads_nothing(
-        mock_github_api, github_env, counting_read, monkeypatch):
-    accessor, index = github_env
-    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
-    stdout, io = await rg(accessor, [_root()],
-                          "import",
-                          args_l=True,
-                          index=index)
-    body = (await materialize(stdout)).decode()
-    assert len(counting_read) == 0
-    assert io.exit_code == 0
-    assert "src/main.py" in body
-
-
-@pytest.mark.asyncio
-async def test_rg_files_only_shortcircuit_matches_generic(
-        mock_github_api, github_env, monkeypatch):
-    accessor, index = github_env
-
-    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 10_000)
-    out_generic, _ = await rg(accessor, [_root()],
-                              "import",
-                              args_l=True,
-                              index=index)
-    text_generic = (await materialize(out_generic)).decode()
-
-    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
-    out_short, _ = await rg(accessor, [_root()],
-                            "import",
-                            args_l=True,
-                            index=index)
-    text_short = (await materialize(out_short)).decode()
-
-    assert text_short == text_generic
-    assert text_short
-
-
-@pytest.mark.asyncio
-async def test_rg_files_only_shortcircuit_respects_glob(
-        mock_github_api, github_env, monkeypatch):
-    accessor, index = github_env
-
-    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 10_000)
-    out_generic, _ = await rg(accessor, [_root()],
-                              "import",
-                              args_l=True,
-                              glob="main*.py",
-                              index=index)
-    text_generic = (await materialize(out_generic)).decode()
-
-    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
-    out_short, _ = await rg(accessor, [_root()],
-                            "import",
-                            args_l=True,
-                            glob="main*.py",
-                            index=index)
-    text_short = (await materialize(out_short)).decode()
-
-    assert text_short == text_generic
-    assert "main.py" in text_short
-    assert "utils.py" not in text_short
+    await grep(accessor, [_root()], "import.*os", r=True, w=True, index=index)
+    assert len(counting_read) == len(MOCK_BLOBS)
 
 
 @pytest.mark.asyncio
@@ -202,6 +97,7 @@ async def test_rg_shortcircuit_no_match_exit_1(mock_github_api, github_env,
                           "import",
                           args_l=True,
                           glob="*.nomatch",
+                          w=True,
                           index=index)
     body = (await materialize(stdout)).decode()
     assert io.exit_code == 1

--- a/python/tests/commands/builtin/github/test_rg_search.py
+++ b/python/tests/commands/builtin/github/test_rg_search.py
@@ -66,7 +66,11 @@ async def test_rg_root_large_tree_uses_search(mock_github_api, github_env,
     spy = AsyncMock(return_value=narrowed)
     monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
     monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
-    stdout, io = await rg(accessor, [_root()], "import", c=True, index=index)
+    stdout, io = await rg(accessor, [_root()],
+                          "import",
+                          c=True,
+                          w=True,
+                          index=index)
     spy.assert_awaited_once()
     text = (await materialize(stdout)).decode()
     assert io.exit_code == 0
@@ -80,20 +84,21 @@ async def test_rg_subdir_uses_search(mock_github_api, github_env, monkeypatch):
     spy = AsyncMock(return_value=[])
     monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
     monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
-    await rg(accessor, [_subdir()], "import", index=index)
+    await rg(accessor, [_subdir()], "import", w=True, index=index)
     spy.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_rg_regex_with_literal_uses_search(mock_github_api, github_env,
-                                                 monkeypatch):
+async def test_rg_regex_skips_search(mock_github_api, github_env, monkeypatch):
+    # A regex narrows on an extracted literal, so the searched term is only
+    # part of the match; a whole-word search for it can miss real matches.
+    # Excluded even under -w.
     accessor, index = github_env
     spy = AsyncMock(return_value=[])
     monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
     monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
-    await rg(accessor, [_root()], "imp.*rt", index=index)
-    spy.assert_awaited_once()
-    assert spy.await_args.args[3] == "imp"
+    await rg(accessor, [_root()], "imp.*rt", w=True, index=index)
+    spy.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -103,7 +108,7 @@ async def test_rg_regex_without_literal_skips_search(mock_github_api,
     spy = AsyncMock(return_value=[])
     monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
     monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
-    await rg(accessor, [_root()], "imp|exp", index=index)
+    await rg(accessor, [_root()], "imp|exp", w=True, index=index)
     spy.assert_not_awaited()
 
 
@@ -113,7 +118,7 @@ async def test_rg_small_tree_skips_search(mock_github_api, github_env,
     accessor, index = github_env
     spy = AsyncMock(return_value=[])
     monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
-    await rg(accessor, [_root()], "import", index=index)
+    await rg(accessor, [_root()], "import", w=True, index=index)
     spy.assert_not_awaited()
 
 
@@ -122,6 +127,19 @@ async def test_rg_scope_error_when_too_many_files(mock_github_api, github_env,
                                                   monkeypatch):
     accessor, index = github_env
     monkeypatch.setitem(_GLOBALS, "SCOPE_ERROR", 1)
-    stdout, io = await rg(accessor, [_root()], "import", index=index)
+    stdout, io = await rg(accessor, [_root()], "import", w=True, index=index)
     assert io.exit_code == 1
     assert b"narrow the path" in (io.stderr or b"")
+
+
+@pytest.mark.asyncio
+async def test_rg_without_word_flag_skips_search(mock_github_api, github_env,
+                                                 monkeypatch):
+    # See test_grep_without_word_flag_skips_search: whole-word search results
+    # are a strict subset of substring matches.
+    accessor, index = github_env
+    spy = AsyncMock(return_value=[])
+    monkeypatch.setitem(_NGLOBALS, "SCOPE_WARN", 1)
+    monkeypatch.setitem(_NGLOBALS, "narrow_paths", spy)
+    await rg(accessor, [_root()], "import", index=index)
+    spy.assert_not_awaited()

--- a/python/tests/commands/builtin/gmail/test_grep_pushdown.py
+++ b/python/tests/commands/builtin/gmail/test_grep_pushdown.py
@@ -1,0 +1,99 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.commands.builtin.gmail.grep import grep
+from mirage.commands.builtin.gmail.rg import rg
+from mirage.commands.errors import UsageError
+from mirage.types import PathSpec
+from mirage.utils.key_prefix import mount_key
+
+ROWS = [{
+    "path": "INBOX/2026-01-01/msg.gmail.json",
+    "subject": "hello there",
+    "snippet": "hello there",
+    "sender": "a@b.c",
+}]
+
+
+def _label_scope() -> PathSpec:
+    original = "/gmail/INBOX"
+    return PathSpec(resource_path=mount_key(original, "/gmail"),
+                    virtual=original,
+                    directory=original)
+
+
+@pytest.mark.asyncio
+async def test_grep_word_uses_native_search():
+    accessor = AsyncMock()
+    with patch("mirage.commands.builtin.gmail.grep.search_messages",
+               new=AsyncMock(return_value=ROWS)) as spy:
+        await grep(accessor, [_label_scope()],
+                   "hello",
+                   w=True,
+                   index=RAMIndexCacheStore())
+    spy.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_grep_without_word_flag_skips_native_search():
+    # Gmail search matches whole words while grep matches substrings, and the
+    # native path returns search results verbatim as the grep output, so a
+    # bare literal would under-report. Only -w may take it.
+    accessor = AsyncMock()
+    # Falling through to the per-message scan is the point. The stubbed
+    # glob resolves to no files, which the generic command reports as a
+    # usage error; what matters is that the native path was not taken.
+    with patch("mirage.commands.builtin.gmail.grep.search_messages",
+               new=AsyncMock(return_value=ROWS)) as spy, \
+            patch("mirage.commands.builtin.gmail.grep.resolve_glob",
+                  new=AsyncMock(return_value=[])):
+        with pytest.raises(UsageError):
+            await grep(accessor, [_label_scope()],
+                       "hello",
+                       index=RAMIndexCacheStore())
+    spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rg_word_uses_native_search():
+    accessor = AsyncMock()
+    with patch("mirage.commands.builtin.gmail.rg.search_messages",
+               new=AsyncMock(return_value=ROWS)) as spy:
+        await rg(accessor, [_label_scope()],
+                 "hello",
+                 w=True,
+                 index=RAMIndexCacheStore())
+    spy.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rg_without_word_flag_skips_native_search():
+    accessor = AsyncMock()
+    # Falling through to the per-message scan is the point. The stubbed
+    # glob resolves to no files, which the generic command reports as a
+    # usage error; what matters is that the native path was not taken.
+    with patch("mirage.commands.builtin.gmail.rg.search_messages",
+               new=AsyncMock(return_value=ROWS)) as spy, \
+            patch("mirage.commands.builtin.gmail.rg.resolve_glob",
+                  new=AsyncMock(return_value=[])):
+        with pytest.raises(UsageError):
+            await rg(accessor, [_label_scope()],
+                     "hello",
+                     index=RAMIndexCacheStore())
+    spy.assert_not_awaited()

--- a/python/tests/commands/builtin/slack/test_grep_pushdown.py
+++ b/python/tests/commands/builtin/slack/test_grep_pushdown.py
@@ -50,6 +50,7 @@ async def test_grep_with_many_concrete_paths_uses_native_search():
         out, io = await grep(accessor,
                              _concrete_paths(7),
                              "hello",
+                             w=True,
                              index=RAMIndexCacheStore(),
                              i=True)
     assert fake_search.await_count == 1
@@ -70,6 +71,7 @@ async def test_rg_with_many_concrete_paths_uses_native_search():
         out, io = await rg(accessor,
                            _concrete_paths(7),
                            "hello",
+                           w=True,
                            index=RAMIndexCacheStore(),
                            i=True)
     assert fake_search.await_count == 1
@@ -108,6 +110,7 @@ async def test_grep_falls_back_when_native_search_raises():
         out, io = await grep(accessor,
                              paths,
                              "hello",
+                             w=True,
                              index=RAMIndexCacheStore(),
                              i=True)
     assert io.exit_code in (0, 1)
@@ -128,8 +131,32 @@ async def test_grep_native_empty_does_not_trigger_fallback():
         out, io = await grep(accessor,
                              _concrete_paths(7),
                              "missing",
+                             w=True,
                              index=RAMIndexCacheStore())
     assert fake_search.await_count == 1
     assert fake_read.await_count == 0
     assert io.exit_code == 1
     assert out == b""
+
+
+@pytest.mark.asyncio
+async def test_grep_without_word_flag_skips_native_search():
+    # Slack search matches whole words while grep matches substrings, and the
+    # native path returns search results verbatim as the grep output, so a
+    # bare literal would under-report. Only -w may take it.
+    accessor = AsyncMock()
+    accessor.config = AsyncMock()
+    with patch(
+            "mirage.commands.builtin.slack.grep.search_messages",
+            new=AsyncMock(return_value=b"{}"),
+    ) as fake_search:
+        # Falling through to the per-file scan is the point: the mock
+        # accessor cannot serve reads, so the scan raising proves the native
+        # path was skipped rather than silently returning search results.
+        with pytest.raises(FileNotFoundError):
+            await grep(accessor,
+                       _concrete_paths(7),
+                       "hello",
+                       index=RAMIndexCacheStore(),
+                       i=True)
+    fake_search.assert_not_awaited()

--- a/python/tests/commands/builtin/slack/test_rg_files.py
+++ b/python/tests/commands/builtin/slack/test_rg_files.py
@@ -56,6 +56,7 @@ async def test_rg_messages_only_when_chat_jsonl(accessor, index):
                 )
             ],
             "foo",
+            w=True,
             index=index,
         )
     assert mock_msgs.await_count == 1
@@ -84,6 +85,7 @@ async def test_rg_files_dir_redirects_to_generic_scan(accessor, index):
                 )
             ],
             "foo",
+            w=True,
             index=index,
         )
     assert mock_msgs.await_count == 0
@@ -114,6 +116,7 @@ async def test_rg_both_when_channel_or_day_root(accessor, index):
                 )
             ],
             "foo",
+            w=True,
             index=index,
         )
     assert mock_msgs.await_count == 1
@@ -142,6 +145,7 @@ async def test_grep_messages_only_when_chat_jsonl(accessor, index):
                 )
             ],
             "foo",
+            w=True,
             index=index,
         )
     assert mock_msgs.await_count == 1
@@ -184,6 +188,7 @@ async def test_grep_files_dir_redirects_to_per_file_scan(accessor, index):
                 )
             ],
             "foo",
+            w=True,
             index=index,
         )
     assert mock_msgs.await_count == 0

--- a/python/tests/core/github/test_client.py
+++ b/python/tests/core/github/test_client.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.core.github._client import github_headers, github_url
+from mirage.core.github.config import GitHubConfig
 
 
 def test_github_headers_contains_auth():
@@ -33,3 +34,25 @@ def test_github_url_simple():
 def test_github_url_no_params():
     url = github_url("/rate_limit")
     assert url == "https://api.github.com/rate_limit"
+
+
+def test_github_url_none_base_url_falls_back():
+    url = github_url("/repos/{owner}/{repo}", None, owner="acme", repo="proj")
+    assert url == "https://api.github.com/repos/acme/proj"
+
+
+def test_github_url_honours_base_url():
+    url = github_url("/repos/{owner}/{repo}",
+                     "http://127.0.0.1:5095",
+                     owner="acme",
+                     repo="proj")
+    assert url == "http://127.0.0.1:5095/repos/acme/proj"
+
+
+def test_config_base_url_defaults_to_none():
+    assert GitHubConfig(token="ghp_test").base_url is None
+
+
+def test_config_carries_base_url():
+    config = GitHubConfig(token="ghp_test", base_url="http://localhost:1234")
+    assert config.base_url == "http://localhost:1234"

--- a/python/tests/core/github/test_repo.py
+++ b/python/tests/core/github/test_repo.py
@@ -32,6 +32,7 @@ def test_fetch_default_branch_main(mock_get, config):
     assert result == "main"
     mock_get.assert_called_once_with(config.token,
                                      "/repos/{owner}/{repo}",
+                                     base_url=None,
                                      owner="acme",
                                      repo="proj")
 

--- a/python/tests/core/github/test_search.py
+++ b/python/tests/core/github/test_search.py
@@ -47,7 +47,8 @@ async def test_search_code_basic(mock_get, config):
     assert result[0] == SearchResult(path="src/main.py", sha="aaa")
     mock_get.assert_awaited_once_with(config.token,
                                       "/search/code",
-                                      params={"q": "import os repo:acme/proj"})
+                                      params={"q": "import os repo:acme/proj"},
+                                      base_url=None)
 
 
 @pytest.mark.asyncio
@@ -66,7 +67,8 @@ async def test_search_code_with_path_filter(mock_get, config):
     mock_get.assert_awaited_once_with(
         config.token,
         "/search/code",
-        params={"q": "import os repo:acme/proj path:src/"})
+        params={"q": "import os repo:acme/proj path:src/"},
+        base_url=None)
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/github/test_tree.py
+++ b/python/tests/core/github/test_tree.py
@@ -75,8 +75,9 @@ def test_fetch_tree_passes_params(mock_get, config):
     mock_get.assert_called_once_with(
         config.token,
         "/repos/{owner}/{repo}/git/trees/{ref}",
+        params={"recursive": "1"},
+        base_url=None,
         owner="acme",
         repo="proj",
         ref="v1",
-        params={"recursive": "1"},
     )

--- a/python/tests/core/mongodb/test_search.py
+++ b/python/tests/core/mongodb/test_search.py
@@ -72,13 +72,7 @@ async def test_search_collection_unions_string_fields_across_sampled_docs():
     ]
     matched = [{"_id": 2, "body": "World matches"}]
     client, col = _build_search_client(sampled, matched)
-    with patch("mirage.core.mongodb.search.get_indexes",
-               new=AsyncMock(return_value=[])):
-        out = await search_collection(client,
-                                      "db1",
-                                      "coll1",
-                                      "World",
-                                      limit=10)
+    out = await search_collection(client, "db1", "coll1", "World", limit=10)
     assert out == matched
     filter_arg = col.find.call_args[0][0]
     or_fields = {list(clause.keys())[0] for clause in filter_arg["$or"]}
@@ -86,36 +80,22 @@ async def test_search_collection_unions_string_fields_across_sampled_docs():
 
 
 @pytest.mark.asyncio
-async def test_search_collection_uses_text_when_textIndexVersion_present():
-    indexes = [{
-        "name": "title_text",
-        "key": {
-            "_fts": "text",
-            "_ftsx": 1
-        },
-        "weights": {
-            "title": 1
-        },
-        "textIndexVersion": 3,
-    }]
-    client, col = _build_search_client([], [{"_id": 1}])
-    with patch("mirage.core.mongodb.search.get_indexes",
-               new=AsyncMock(return_value=indexes)):
-        await search_collection(client, "db1", "coll1", "query", limit=10)
-    assert col.find.call_args[0][0] == {"$text": {"$search": "query"}}
+async def test_search_collection_uses_regex_even_with_text_index():
+    # $text matches whole words and stems them while grep matches substrings,
+    # and these rows are the grep output with no local re-scan, so the text
+    # index is never used.
+    client, col = _build_search_client([{"title": "hello"}], [{"_id": 1}])
+    await search_collection(client, "db1", "coll1", "query", limit=10)
+    sent = col.find.call_args[0][0]
+    assert "$text" not in sent
+    assert sent == {"$or": [{"title": {"$regex": "query", "$options": "i"}}]}
 
 
 @pytest.mark.asyncio
 async def test_search_collection_no_string_fields_returns_no_results():
     sampled = [{"_id": 1, "n": 42}, {"_id": 2, "n": 7}]
     client, col = _build_search_client(sampled, [])
-    with patch("mirage.core.mongodb.search.get_indexes",
-               new=AsyncMock(return_value=[])):
-        out = await search_collection(client,
-                                      "db1",
-                                      "coll1",
-                                      "anything",
-                                      limit=10)
+    out = await search_collection(client, "db1", "coll1", "anything", limit=10)
     assert out == []
     assert col.find.call_args is None
 

--- a/python/tests/integration/test_search_pushdown_iteration.py
+++ b/python/tests/integration/test_search_pushdown_iteration.py
@@ -35,7 +35,7 @@ async def test_slack_grep_glob_expanded_to_60_paths_is_one_native_call():
                 "mirage.commands.builtin.slack.grep.search_messages",
                 new=AsyncMock(return_value=fake_payload),
         ) as fake_search:
-            result = await ws.execute(f"grep -i hello {expanded}")
+            result = await ws.execute(f"grep -iw hello {expanded}")
         assert fake_search.await_count == 1
         assert result.exit_code == 0
         assert b"hello" in (result.stdout or b"")

--- a/typescript/packages/core/src/commands/builtin/box/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/box/grep.ts
@@ -43,6 +43,7 @@ async function grepCommand(
     const narrowed = await narrowScope(accessor, paths, pattern, {
       fixedString: opts.flags.F === true,
       recursive: opts.flags.r === true || opts.flags.R === true,
+      wholeWord: opts.flags.w === true,
       exactFileSet: opts.flags.v === true || opts.flags.c === true,
       ...(opts.index !== null ? { index: opts.index } : {}),
     })

--- a/typescript/packages/core/src/commands/builtin/box/narrow.test.ts
+++ b/typescript/packages/core/src/commands/builtin/box/narrow.test.ts
@@ -59,12 +59,18 @@ function spec(virtual: string): PathSpec {
 }
 
 async function run(
-  overrides: { pattern?: string | null; recursive?: boolean; exactFileSet?: boolean } = {},
+  overrides: {
+    pattern?: string | null
+    recursive?: boolean
+    wholeWord?: boolean
+    exactFileSet?: boolean
+  } = {},
   accessor = makeAccessor(),
 ): Promise<{ resolved: PathSpec[]; usedSearch: boolean }> {
   return narrowScope(accessor, [scope()], overrides.pattern ?? 'needle', {
     fixedString: false,
     recursive: overrides.recursive ?? true,
+    wholeWord: overrides.wholeWord ?? true,
     exactFileSet: overrides.exactFileSet ?? false,
   })
 }
@@ -118,10 +124,12 @@ describe('narrowScope', () => {
     expect(narrow).not.toHaveBeenCalled()
   })
 
-  it('narrows regexes on their required literal', async () => {
+  it('skips search for a regex even under -w', async () => {
+    // A regex narrows on an extracted literal, so the searched term is only
+    // part of the match and a whole-word search for it can miss real matches.
     const out = await run({ pattern: 'import.*os' })
-    expect(out.usedSearch).toBe(true)
-    expect(narrow.mock.calls[0]?.[1]).toBe('import')
+    expect(out.usedSearch).toBe(false)
+    expect(narrow).not.toHaveBeenCalled()
   })
 
   it('skips search for file scopes', async () => {

--- a/typescript/packages/core/src/commands/builtin/box/narrow.ts
+++ b/typescript/packages/core/src/commands/builtin/box/narrow.ts
@@ -19,7 +19,7 @@ import { stat as boxStat } from '../../../core/box/stat.ts'
 import { FileType, type PathSpec } from '../../../types.ts'
 import { getExtension } from '../../resolve.ts'
 import { resolveGlobOf } from '../generic_bind/index.ts'
-import { BINARY_EXTENSIONS, searchQuery } from '../grep_helper.ts'
+import { BINARY_EXTENSIONS, isLiteralPattern, searchQuery } from '../grep_helper.ts'
 import { BOX_IO } from './io.ts'
 
 const resolveGlob = resolveGlobOf(BOX_IO)
@@ -60,6 +60,11 @@ async function allDirectories(
 // candidates are dropped from the narrowed set because the recursive walk it
 // replaces skips them; a narrowed set may therefore be empty, which callers
 // must not treat as a stdin run.
+// Push-down also requires -w. Box search matches whole words while grep
+// matches substrings, so for a bare literal the search result is a strict
+// subset of the grep matches and a file containing the literal only inside
+// a longer word would be silently dropped. Under -w both sides agree and
+// disagreement can only over-fetch, which the local scan filters.
 export async function narrowScope(
   accessor: BoxAccessor,
   paths: PathSpec[],
@@ -67,6 +72,7 @@ export async function narrowScope(
   opts: {
     fixedString: boolean
     recursive: boolean
+    wholeWord: boolean
     exactFileSet: boolean
     index?: IndexCacheStore
   },
@@ -75,6 +81,9 @@ export async function narrowScope(
     pattern !== null && !pattern.includes('\n') ? searchQuery(pattern, opts.fixedString) : null
   const useSearch =
     query !== null &&
+    opts.wholeWord &&
+    pattern !== null &&
+    isLiteralPattern(pattern, opts.fixedString) &&
     opts.recursive &&
     !opts.exactFileSet &&
     accessor.contentSearch &&

--- a/typescript/packages/core/src/commands/builtin/box/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/box/rg.ts
@@ -73,6 +73,7 @@ async function rgCommand(
     const narrowed = await narrowScope(accessor, paths, pattern, {
       fixedString: opts.flags.F === true,
       recursive: true,
+      wholeWord: opts.flags.w === true,
       exactFileSet:
         opts.flags.v === true ||
         typeof opts.flags.type === 'string' ||

--- a/typescript/packages/core/src/commands/builtin/discord/grep.test.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/grep.test.ts
@@ -82,7 +82,7 @@ describe('discord grep', () => {
         }),
       ],
       ['hello'],
-      {},
+      { w: true },
       { transport },
     )
     expect(transport.calls[0]?.endpoint).toBe('/guilds/G1/messages/search')
@@ -123,7 +123,7 @@ describe('discord grep', () => {
         }),
       ],
       ['hello'],
-      {},
+      { w: true },
       { index: idx, transport },
     )
     const lines = out.stdout.split('\n').filter((l) => l !== '')

--- a/typescript/packages/core/src/commands/builtin/discord/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/grep.ts
@@ -58,7 +58,10 @@ async function grepCommand(
   const firstPath = paths[0]
   if (firstPath !== undefined && pattern !== null && !pattern.includes('\n')) {
     const scope = detectScope(firstPath)
-    if (scope.useNative && scope.guildId !== undefined) {
+    // Discord search matches whole words while grep matches substrings,
+    // and the native path returns search results verbatim as the output, so
+    // a bare literal would under-report. Only -w makes the two agree.
+    if (scope.useNative && scope.guildId !== undefined && opts.flags.w === true) {
       try {
         const count = maxCount ?? 100
         const raw = await searchGuild(accessor, scope.guildId, pattern, scope.channelId, count)

--- a/typescript/packages/core/src/commands/builtin/discord/rg.test.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/rg.test.ts
@@ -85,7 +85,7 @@ describe('discord rg', () => {
         }),
       ],
       ['hello'],
-      {},
+      { w: true },
       { index: idx, transport },
     )
     expect(transport.calls[0]?.endpoint).toBe('/guilds/G1/messages/search')
@@ -107,7 +107,7 @@ describe('discord rg', () => {
         }),
       ],
       ['hello'],
-      {},
+      { w: true },
       { transport },
     )
     expect(out.exitCode).toBe(1)

--- a/typescript/packages/core/src/commands/builtin/discord/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/rg.ts
@@ -63,7 +63,10 @@ async function rgCommand(
     const firstPath = paths[0]
     if (firstPath !== undefined) {
       const scope = detectScope(firstPath)
-      if (scope.useNative && scope.guildId !== undefined) {
+      // Discord search matches whole words while grep matches substrings,
+      // and the native path returns search results verbatim as the output, so
+      // a bare literal would under-report. Only -w makes the two agree.
+      if (scope.useNative && scope.guildId !== undefined && opts.flags.w === true) {
         try {
           const count = maxCount ?? 100
           const raw = await searchGuild(accessor, scope.guildId, pattern, scope.channelId, count)

--- a/typescript/packages/core/src/commands/builtin/discord/search_pushdown_fallback.test.ts
+++ b/typescript/packages/core/src/commands/builtin/discord/search_pushdown_fallback.test.ts
@@ -62,7 +62,7 @@ describe('discord grep push-down fallback', () => {
       ['hi'],
       {
         stdin: null,
-        flags: { args_l: true },
+        flags: { args_l: true, w: true },
         filetypeFns: null,
         cwd: '/',
         resource,
@@ -98,7 +98,7 @@ describe('discord rg push-down fallback', () => {
       ['hi'],
       {
         stdin: null,
-        flags: {},
+        flags: { w: true },
         filetypeFns: null,
         cwd: '/',
         resource,

--- a/typescript/packages/core/src/commands/builtin/dropbox/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/grep.ts
@@ -43,6 +43,7 @@ async function grepCommand(
     const narrowed = await narrowScope(accessor, paths, pattern, {
       fixedString: opts.flags.F === true,
       recursive: opts.flags.r === true || opts.flags.R === true,
+      wholeWord: opts.flags.w === true,
       exactFileSet: opts.flags.v === true || opts.flags.c === true,
       ...(opts.index !== null ? { index: opts.index } : {}),
     })

--- a/typescript/packages/core/src/commands/builtin/dropbox/narrow.test.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/narrow.test.ts
@@ -59,12 +59,18 @@ function spec(virtual: string): PathSpec {
 }
 
 async function run(
-  overrides: { pattern?: string | null; recursive?: boolean; exactFileSet?: boolean } = {},
+  overrides: {
+    pattern?: string | null
+    recursive?: boolean
+    wholeWord?: boolean
+    exactFileSet?: boolean
+  } = {},
   accessor = makeAccessor(),
 ): Promise<{ resolved: PathSpec[]; usedSearch: boolean }> {
   return narrowScope(accessor, [scope()], overrides.pattern ?? 'needle', {
     fixedString: false,
     recursive: overrides.recursive ?? true,
+    wholeWord: overrides.wholeWord ?? true,
     exactFileSet: overrides.exactFileSet ?? false,
   })
 }
@@ -118,10 +124,12 @@ describe('narrowScope', () => {
     expect(narrow).not.toHaveBeenCalled()
   })
 
-  it('narrows regexes on their required literal', async () => {
+  it('skips search for a regex even under -w', async () => {
+    // A regex narrows on an extracted literal, so the searched term is only
+    // part of the match and a whole-word search for it can miss real matches.
     const out = await run({ pattern: 'import.*os' })
-    expect(out.usedSearch).toBe(true)
-    expect(narrow.mock.calls[0]?.[1]).toBe('import')
+    expect(out.usedSearch).toBe(false)
+    expect(narrow).not.toHaveBeenCalled()
   })
 
   it('skips search for file scopes', async () => {

--- a/typescript/packages/core/src/commands/builtin/dropbox/narrow.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/narrow.ts
@@ -19,7 +19,7 @@ import { stat as dropboxStat } from '../../../core/dropbox/stat.ts'
 import { FileType, type PathSpec } from '../../../types.ts'
 import { getExtension } from '../../resolve.ts'
 import { resolveGlobOf } from '../generic_bind/index.ts'
-import { BINARY_EXTENSIONS, searchQuery } from '../grep_helper.ts'
+import { BINARY_EXTENSIONS, isLiteralPattern, searchQuery } from '../grep_helper.ts'
 import { DROPBOX_IO } from './io.ts'
 
 const resolveGlob = resolveGlobOf(DROPBOX_IO)
@@ -61,6 +61,13 @@ async function allDirectories(
 // Binary-extension candidates are dropped from the narrowed set because the
 // recursive walk it replaces skips them; a narrowed set may therefore be
 // empty, which callers must not treat as a stdin run.
+// Push-down also requires -w. Dropbox search matches whole words while
+// grep matches substrings, so for a bare literal the search result is a
+// strict subset of the grep matches and a file containing the literal
+// only inside a longer word would be silently dropped. Under -w both
+// sides agree and disagreement can only over-fetch, which the local
+// scan filters. A regex narrowed on an extracted literal stays excluded
+// even under -w, since the searched term is then only part of the match.
 export async function narrowScope(
   accessor: DropboxAccessor,
   paths: PathSpec[],
@@ -68,6 +75,7 @@ export async function narrowScope(
   opts: {
     fixedString: boolean
     recursive: boolean
+    wholeWord: boolean
     exactFileSet: boolean
     index?: IndexCacheStore
   },
@@ -76,6 +84,9 @@ export async function narrowScope(
     pattern !== null && !pattern.includes('\n') ? searchQuery(pattern, opts.fixedString) : null
   const useSearch =
     query !== null &&
+    opts.wholeWord &&
+    pattern !== null &&
+    isLiteralPattern(pattern, opts.fixedString) &&
     opts.recursive &&
     !opts.exactFileSet &&
     accessor.contentSearch &&

--- a/typescript/packages/core/src/commands/builtin/dropbox/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/dropbox/rg.ts
@@ -74,6 +74,7 @@ async function rgCommand(
     const narrowed = await narrowScope(accessor, paths, pattern, {
       fixedString: opts.flags.F === true,
       recursive: true,
+      wholeWord: opts.flags.w === true,
       exactFileSet:
         opts.flags.v === true ||
         typeof opts.flags.type === 'string' ||

--- a/typescript/packages/core/src/commands/builtin/github/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/github/grep.ts
@@ -24,7 +24,7 @@ import { specOf } from '../../spec/builtins.ts'
 import { prefixAggregate } from '../aggregators.ts'
 import { patternArg } from '../grep_helper.ts'
 import { grepGeneric } from '../generic/grep.ts'
-import { filesOnlyShortcircuit, narrowScope } from './narrow.ts'
+import { narrowScope } from './narrow.ts'
 
 const ENC = new TextEncoder()
 
@@ -47,6 +47,7 @@ async function grepCommand(
       pattern,
       fixedString,
       recursive,
+      opts.flags.w === true,
       opts.index ?? undefined,
     )
     resolved = narrowed.resolved
@@ -60,10 +61,6 @@ async function grepCommand(
           ),
         }),
       ]
-    }
-    if (narrowed.usedSearch) {
-      const short = filesOnlyShortcircuit(opts.flags, pattern, resolved, first)
-      if (short !== null) return short
     }
   }
   const stat = (p: PathSpec): Promise<FileStat> => githubStat(accessor, p, opts.index ?? undefined)

--- a/typescript/packages/core/src/commands/builtin/github/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/github/grep.ts
@@ -57,7 +57,7 @@ async function grepCommand(
         new IOResult({
           exitCode: 1,
           stderr: ENC.encode(
-            `grep: ${String(narrowed.fileCount)} files in scope, narrow the path\n`,
+            `grep: ${String(narrowed.fileCount)} files in scope, narrow the path, or use -w to enable code search\n`,
           ),
         }),
       ]

--- a/typescript/packages/core/src/commands/builtin/github/narrow.test.ts
+++ b/typescript/packages/core/src/commands/builtin/github/narrow.test.ts
@@ -15,18 +15,14 @@
 // Mirror of python/tests/commands/builtin/github/test_narrow.py. The Python
 // suite drives grep/rg end-to-end against a mock GitHub API; here we test the
 // shared pieces directly: narrowScope (code-search push-down on subdirs and
-// regex-extracted literals) and filesOnlyShortcircuit (the -l short-circuit
-// that returns the narrowed file list without reading any blobs).
+// regex-extracted literals, gated on -w).
 
-import { mountKey } from '../../../utils/key_prefix.ts'
 import { describe, expect, it } from 'vitest'
 import { GitHubAccessor } from '../../../accessor/github.ts'
 import type { GitHubTransport } from '../../../core/github/_client.ts'
 import type { TreeEntry } from '../../../core/github/tree_entry.ts'
 import { PathSpec } from '../../../types.ts'
-import { filesOnlyShortcircuit, narrowScope } from './narrow.ts'
-
-const DEC = new TextDecoder()
+import { narrowScope } from './narrow.ts'
 
 // 150 blobs under src/ so the scope clears SCOPE_WARN (100) and search kicks in.
 function bigTree(): Record<string, TreeEntry> {
@@ -77,7 +73,7 @@ describe('narrowScope', () => {
   it('narrows a large recursive scope via code search on a literal', async () => {
     const calls: SearchCall[] = []
     const acc = makeAccessor(['src/f1.py', 'src/f2.py'], calls)
-    const res = await narrowScope(acc, [subdir()], 'import', false, true)
+    const res = await narrowScope(acc, [subdir()], 'import', false, true, true)
     expect(res.usedSearch).toBe(true)
     expect(res.fileCount).toBe(2)
     expect(res.resolved.map((p) => p.virtual).sort()).toEqual(['/src/f1.py', '/src/f2.py'])
@@ -85,21 +81,21 @@ describe('narrowScope', () => {
     expect(calls[0]?.q).toContain('path:src')
   })
 
-  it('narrows a regex scope on the extracted required literal', async () => {
+  it('skips search for a regex even under -w', async () => {
+    // A regex narrows on an extracted literal, so the searched term is only
+    // part of the match: a whole-word search for `import` never returns a file
+    // whose only token is `importos`.
     const calls: SearchCall[] = []
     const acc = makeAccessor(['src/f3.py'], calls)
-    const res = await narrowScope(acc, [subdir()], 'import.*os', false, true)
-    expect(res.usedSearch).toBe(true)
-    // "import" is the required literal pushed down; the regex stays exact since
-    // the caller still scans it over the narrowed files.
-    expect(calls[0]?.q).toContain('import')
-    expect(calls[0]?.q).not.toContain('.*')
+    const res = await narrowScope(acc, [subdir()], 'import.*os', false, true, true)
+    expect(res.usedSearch).toBe(false)
+    expect(calls).toHaveLength(0)
   })
 
   it('does not search a non-recursive scope', async () => {
     const calls: SearchCall[] = []
     const acc = makeAccessor(['src/f1.py'], calls)
-    const res = await narrowScope(acc, [subdir()], 'import', false, false)
+    const res = await narrowScope(acc, [subdir()], 'import', false, false, true)
     expect(res.usedSearch).toBe(false)
     expect(calls).toHaveLength(0)
   })
@@ -107,64 +103,19 @@ describe('narrowScope', () => {
   it('does not search a regex with no provable literal', async () => {
     const calls: SearchCall[] = []
     const acc = makeAccessor(['src/f1.py'], calls)
-    const res = await narrowScope(acc, [subdir()], 'foo|bar', false, true)
+    const res = await narrowScope(acc, [subdir()], 'foo|bar', false, true, true)
     expect(res.usedSearch).toBe(false)
     expect(calls).toHaveLength(0)
   })
-})
 
-function spec(path: string): PathSpec {
-  return new PathSpec({
-    virtual: path,
-    directory: '',
-    resourcePath: mountKey(path, ''),
-    resolved: true,
-  })
-}
-
-describe('filesOnlyShortcircuit', () => {
-  const resolved = [spec('/src/main.py'), spec('/src/utils.py')]
-  const scope = subdir()
-
-  it('emits the sorted narrowed list for a literal -l with no reads', () => {
-    const out = filesOnlyShortcircuit({ args_l: true }, 'import', resolved, scope)
-    expect(out).not.toBeNull()
-    const [bytes, io] = out as [Uint8Array, { exitCode: number }]
-    expect(io.exitCode).toBe(0)
-    expect(DEC.decode(bytes)).toContain('main.py')
-  })
-
-  it('returns null without -l', () => {
-    expect(filesOnlyShortcircuit({}, 'import', resolved, scope)).toBeNull()
-  })
-
-  it('returns null for a non-literal pattern', () => {
-    expect(filesOnlyShortcircuit({ args_l: true }, 'foo|bar', resolved, scope)).toBeNull()
-    expect(filesOnlyShortcircuit({ args_l: true }, 'imp.*rt', resolved, scope)).toBeNull()
-  })
-
-  it('returns null when a match-altering flag is present', () => {
-    for (const flag of ['i', 'w', 'v', 'c', 'o']) {
-      expect(
-        filesOnlyShortcircuit({ args_l: true, [flag]: true }, 'import', resolved, scope),
-      ).toBeNull()
-    }
-  })
-
-  it('applies a path predicate (rg --type/--glob/hidden)', () => {
-    const out = filesOnlyShortcircuit({ args_l: true }, 'import', resolved, scope, (p) =>
-      p.endsWith('main.py'),
-    )
-    const [bytes] = out as [Uint8Array, { exitCode: number }]
-    const body = DEC.decode(bytes)
-    expect(body).toContain('main.py')
-    expect(body).not.toContain('utils.py')
-  })
-
-  it('exits 1 when the predicate drops every file', () => {
-    const out = filesOnlyShortcircuit({ args_l: true }, 'import', resolved, scope, () => false)
-    const [bytes, io] = out as [Uint8Array, { exitCode: number }]
-    expect(io.exitCode).toBe(1)
-    expect(DEC.decode(bytes)).toBe('')
+  it('skips search without -w', async () => {
+    // Code search matches whole words while grep matches substrings, so a
+    // bare literal would narrow to a strict subset and silently drop files
+    // that contain it only inside a longer word.
+    const calls: SearchCall[] = []
+    const acc = makeAccessor(['src/f1.py'], calls)
+    const res = await narrowScope(acc, [subdir()], 'import', false, true, false)
+    expect(res.usedSearch).toBe(false)
+    expect(calls).toHaveLength(0)
   })
 })

--- a/typescript/packages/core/src/commands/builtin/github/narrow.ts
+++ b/typescript/packages/core/src/commands/builtin/github/narrow.ts
@@ -19,12 +19,8 @@ import { resolveGlobOf } from '../generic_bind/index.ts'
 import { GITHUB_IO } from './io.ts'
 import { countScopeFiles, scopeRelativeKey, shouldUseSearch } from '../../../core/github/scope.ts'
 import { narrowPaths } from '../../../core/github/search.ts'
-import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
-import { rebaseRaw } from '../../../utils/path.ts'
-import { PatternType } from '../constants.ts'
-import { formatRecords } from '../utils/output.ts'
-import { classifyPattern, searchQuery } from '../grep_helper.ts'
+import { isLiteralPattern, searchQuery } from '../grep_helper.ts'
 
 const resolveGlob = resolveGlobOf(GITHUB_IO)
 
@@ -37,15 +33,23 @@ export interface NarrowResult {
 // Resolve grep/rg scope paths, narrowing via GitHub code search. Narrows any
 // recursive scope (repo root or subdirectory) on the default branch when a
 // literal can be pushed down to code search and the scope is larger than
-// SCOPE_WARN; otherwise expands the scope by glob. Regex patterns narrow on an
-// extracted required literal and stay exact because the caller still scans the
-// regex over the narrowed files.
+// SCOPE_WARN; otherwise expands the scope by glob.
+//
+// Push-down requires -w. GitHub code search matches whole words while grep
+// matches substrings, so for a bare literal the search result is a strict
+// subset of the grep matches: a file containing the literal only inside a
+// longer word (quokka inside quokkabuild) never comes back and would be
+// silently dropped from the scan. Under -w both sides mean the same thing,
+// and any tokenizer disagreement can only over-fetch, which the local scan
+// then filters. A regex narrowed on an extracted literal stays excluded
+// even under -w, because the searched term is then only part of the match.
 export async function narrowScope(
   accessor: GitHubAccessor,
   paths: PathSpec[],
   pattern: string | null,
   fixedString: boolean,
   recursive: boolean,
+  wholeWord: boolean,
   index?: IndexCacheStore,
 ): Promise<NarrowResult> {
   const first = paths[0]
@@ -54,7 +58,12 @@ export async function narrowScope(
   const fileCount = countScopeFiles(accessor.tree, key)
   const query = pattern !== null ? searchQuery(pattern, fixedString) : null
   const useSearch =
-    query !== null && shouldUseSearch(recursive, accessor.isDefaultBranch) && fileCount > SCOPE_WARN
+    query !== null &&
+    wholeWord &&
+    pattern !== null &&
+    isLiteralPattern(pattern, fixedString) &&
+    shouldUseSearch(recursive, accessor.isDefaultBranch) &&
+    fileCount > SCOPE_WARN
   if (useSearch) {
     const narrowed = await narrowPaths(accessor, query, paths)
     if (narrowed.length > 0) {
@@ -63,43 +72,4 @@ export async function narrowScope(
   }
   const resolved = await resolveGlob(accessor, paths, index ?? undefined)
   return { resolved, fileCount, usedSearch: false }
-}
-
-// Emit the narrowed file list for a plain literal -l without reading. When
-// code search has already narrowed the scope to the files containing a fully
-// literal pattern, those files are exactly the answer to -l
-// (files-with-matches), so the content fetches the generic command would do
-// can be skipped entirely. Returns null whenever the short-circuit is unsafe
-// (no -l, a non-literal pattern, or a flag that changes which lines match) so
-// the caller falls back to the generic scan. pathPredicate reproduces any file
-// filtering the generic command applies (rg's hidden/--type/--glob rules).
-export function filesOnlyShortcircuit(
-  flags: Record<string, string | boolean | string[]>,
-  pattern: string | null,
-  resolved: PathSpec[],
-  scope: PathSpec,
-  pathPredicate?: (p: string) => boolean,
-): [ByteSource, IOResult] | null {
-  const filesOnly = flags.args_l === true || flags.l === true
-  if (!filesOnly || pattern === null) return null
-  if (
-    flags.i === true ||
-    flags.w === true ||
-    flags.v === true ||
-    flags.c === true ||
-    flags.o === true
-  ) {
-    return null
-  }
-  const fixed = flags.F === true
-  const pt = classifyPattern(pattern, fixed)
-  const fullyLiteral =
-    fixed || pt === PatternType.EXACT || (pt === PatternType.SIMPLE && !pattern.includes('.'))
-  if (!fullyLiteral) return null
-  const hits = resolved
-    .filter((p) => pathPredicate === undefined || pathPredicate(p.virtual))
-    .map((p) => p.virtual)
-  if (hits.length === 0) return [new Uint8Array(), new IOResult({ exitCode: 1 })]
-  const spelled = rebaseRaw(hits, scope.virtual, scope.rawPath)
-  return [formatRecords([...spelled].sort()), new IOResult()]
 }

--- a/typescript/packages/core/src/commands/builtin/github/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/github/rg.ts
@@ -22,9 +22,8 @@ import { type FileStat, ResourceName, type PathSpec } from '../../../types.ts'
 import { command, type CommandFnResult, type CommandOpts } from '../../config.ts'
 import { specOf } from '../../spec/builtins.ts'
 import { patternArg } from '../grep_helper.ts'
-import { rgMatchesFilter } from '../rg_helper.ts'
 import { rgGeneric } from '../generic/rg.ts'
-import { filesOnlyShortcircuit, narrowScope } from './narrow.ts'
+import { narrowScope } from './narrow.ts'
 
 const ENC = new TextEncoder()
 
@@ -46,6 +45,7 @@ async function rgCommand(
       pattern,
       fixedString,
       true,
+      opts.flags.w === true,
       opts.index ?? undefined,
     )
     resolved = narrowed.resolved
@@ -57,14 +57,6 @@ async function rgCommand(
           stderr: ENC.encode(`rg: ${String(narrowed.fileCount)} files in scope, narrow the path\n`),
         }),
       ]
-    }
-    if (narrowed.usedSearch) {
-      const fileType = typeof opts.flags.type === 'string' ? opts.flags.type : null
-      const globPattern = typeof opts.flags.glob === 'string' ? opts.flags.glob : null
-      const hidden = opts.flags.hidden === true
-      const predicate = (p: string): boolean => rgMatchesFilter(p, fileType, globPattern, hidden)
-      const short = filesOnlyShortcircuit(opts.flags, pattern, resolved, first, predicate)
-      if (short !== null) return short
     }
   }
   const stat = (p: PathSpec): Promise<FileStat> => githubStat(accessor, p, opts.index ?? undefined)

--- a/typescript/packages/core/src/commands/builtin/github/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/github/rg.ts
@@ -54,7 +54,9 @@ async function rgCommand(
         null,
         new IOResult({
           exitCode: 1,
-          stderr: ENC.encode(`rg: ${String(narrowed.fileCount)} files in scope, narrow the path\n`),
+          stderr: ENC.encode(
+            `rg: ${String(narrowed.fileCount)} files in scope, narrow the path, or use -w to enable code search\n`,
+          ),
         }),
       ]
     }

--- a/typescript/packages/core/src/commands/builtin/gmail/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/grep.ts
@@ -58,7 +58,10 @@ async function grepCommand(
   const first = paths[0]
   if (first !== undefined && pattern !== null && !pattern.includes('\n') && !shaping) {
     const scope = detectScope(first)
-    if (scope.useNative) {
+    // Gmail search matches whole words while grep matches substrings,
+    // and the native path returns search results verbatim as the output, so
+    // a bare literal would under-report. Only -w makes the two agree.
+    if (scope.useNative && opts.flags.w === true) {
       const filePrefix =
         mountPrefixOf(first.virtual, first.resourcePath) !== ''
           ? mountPrefixOf(first.virtual, first.resourcePath)

--- a/typescript/packages/core/src/commands/builtin/gmail/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/gmail/rg.ts
@@ -64,7 +64,10 @@ async function rgCommand(
     const first = paths[0]
     if (first !== undefined) {
       const scope = detectScope(first)
-      if (scope.useNative) {
+      // Gmail search matches whole words while grep matches substrings,
+      // and the native path returns search results verbatim as the output, so
+      // a bare literal would under-report. Only -w makes the two agree.
+      if (scope.useNative && opts.flags.w === true) {
         const filePrefix =
           mountPrefixOf(first.virtual, first.resourcePath) !== ''
             ? mountPrefixOf(first.virtual, first.resourcePath)

--- a/typescript/packages/core/src/commands/builtin/grep_helper.ts
+++ b/typescript/packages/core/src/commands/builtin/grep_helper.ts
@@ -209,6 +209,17 @@ export function searchQuery(pattern: string, fixedString: boolean): string | nul
   return extractRequiredLiteral(pattern)
 }
 
+// Whether the pattern is searched verbatim, with no regex extraction.
+// Push-down against a whole-word search index is only complete when the term
+// handed to the provider is the entire match. A regex narrowed on an extracted
+// literal fails that: `foo[0-9]` under -w matches `foo1`, but a whole-word
+// search for `foo` never returns a file whose only token is `foo1`.
+export function isLiteralPattern(pattern: string, fixedString: boolean): boolean {
+  if (fixedString) return true
+  const pt = classifyPattern(pattern, fixedString)
+  return pt === PatternType.EXACT || (pt === PatternType.SIMPLE && !pattern.includes('.'))
+}
+
 export interface GrepLinesOptions {
   invert: boolean
   lineNumbers: boolean

--- a/typescript/packages/core/src/commands/builtin/slack/grep.test.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/grep.test.ts
@@ -81,7 +81,7 @@ describe('slack grep', () => {
         }),
       ],
       ['hello'],
-      {},
+      { w: true },
       { transport },
     )
     expect(transport.calls[0]?.endpoint).toBe('search.messages')

--- a/typescript/packages/core/src/commands/builtin/slack/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/grep.ts
@@ -61,7 +61,10 @@ async function grepCommand(
   const firstPath = paths[0]
   if (firstPath !== undefined && pattern !== null && !pattern.includes('\n')) {
     const scope = detectScope(firstPath)
-    if (scope.useNative) {
+    // Slack search matches whole words while grep matches substrings, and
+    // the native path returns search results verbatim as the output, so a
+    // bare literal would under-report. Only -w makes the two agree.
+    if (scope.useNative && opts.flags.w === true) {
       const filePrefix = mountPrefixOf(firstPath.virtual, firstPath.resourcePath)
       const query = buildQuery(pattern, scope)
       const count = maxCount ?? 100

--- a/typescript/packages/core/src/commands/builtin/slack/rg.test.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/rg.test.ts
@@ -83,7 +83,7 @@ describe('slack rg', () => {
         }),
       ],
       ['hello'],
-      {},
+      { w: true },
       { index: idx, transport },
     )
     expect(transport.calls[0]?.endpoint).toBe('search.messages')
@@ -106,7 +106,7 @@ describe('slack rg', () => {
         }),
       ],
       ['hello'],
-      {},
+      { w: true },
       { transport },
     )
     expect(out.exitCode).toBe(1)

--- a/typescript/packages/core/src/commands/builtin/slack/rg.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/rg.ts
@@ -66,7 +66,10 @@ async function rgCommand(
     const firstPath = paths[0]
     if (firstPath !== undefined) {
       const scope = detectScope(firstPath)
-      if (scope.useNative) {
+      // Slack search matches whole words while grep matches substrings, and
+      // the native path returns search results verbatim as the output, so a
+      // bare literal would under-report. Only -w makes the two agree.
+      if (scope.useNative && opts.flags.w === true) {
         const filePrefix = mountPrefixOf(firstPath.virtual, firstPath.resourcePath)
         const query = buildQuery(pattern, scope)
         const count = maxCount ?? 100

--- a/typescript/packages/core/src/commands/builtin/slack/search_pushdown_fallback.test.ts
+++ b/typescript/packages/core/src/commands/builtin/slack/search_pushdown_fallback.test.ts
@@ -34,7 +34,7 @@ async function runGrep(
   const resource = makeFakeResource(options.transport)
   const result = await cmd.fn(resource.accessor, paths, texts, {
     stdin: null,
-    flags: { args_l: true },
+    flags: { args_l: true, w: true },
     filetypeFns: null,
     cwd: '/',
     resource,
@@ -66,7 +66,7 @@ async function runRg(
   const resource = makeFakeResource(options.transport)
   const result = await cmd.fn(resource.accessor, paths, texts, {
     stdin: null,
-    flags: { args_l: true },
+    flags: { args_l: true, w: true },
     filetypeFns: null,
     cwd: '/',
     resource,

--- a/typescript/packages/core/src/core/mongodb/search.test.ts
+++ b/typescript/packages/core/src/core/mongodb/search.test.ts
@@ -40,13 +40,17 @@ beforeEach(() => {
 })
 
 describe('searchCollection', () => {
-  it('uses $text when a text index exists', async () => {
+  it('uses $regex even when a text index exists', async () => {
+    // $text matches whole words and stems them while grep matches substrings,
+    // and these rows are the grep output with no local re-scan, so the text
+    // index is never used.
     vi.mocked(_client.listIndexes).mockResolvedValue([{ name: 'body_text', textIndexVersion: 3 }])
     vi.mocked(_client.findDocuments).mockResolvedValue([{ _id: '1', name: 'a' }])
-    const out = await searchCollection(accessorWith(), 'app', 'users', 'foo', 5)
+    const acc = accessorWith([{ _id: '1', name: 'x' }])
+    const out = await searchCollection(acc, 'app', 'users', 'foo', 5)
     expect(out).toEqual([{ _id: '1', name: 'a' }])
     const call = vi.mocked(_client.findDocuments).mock.calls[0]
-    expect(call?.[3]).toEqual({ $text: { $search: 'foo' } })
+    expect(call?.[3]).toEqual({ $or: [{ name: { $regex: 'foo', $options: 'i' } }] })
   })
 
   it('falls back to $or of $regex over sampled string fields', async () => {
@@ -80,7 +84,7 @@ describe('searchDatabase', () => {
     vi.mocked(_client.findDocuments)
       .mockResolvedValueOnce([{ _id: '1' }])
       .mockResolvedValueOnce([])
-    const out = await searchDatabase(accessorWith(), 'app', 'foo', 5)
+    const out = await searchDatabase(accessorWith([{ _id: '1', name: 'x' }]), 'app', 'foo', 5)
     expect(out).toEqual([{ database: 'app', collection: 'users', docs: [{ _id: '1' }] }])
   })
 })

--- a/typescript/packages/core/src/core/mongodb/search.ts
+++ b/typescript/packages/core/src/core/mongodb/search.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { MongoDBAccessor } from '../../accessor/mongodb.ts'
-import { findDocuments, listCollections, listIndexes } from './_client.ts'
+import { findDocuments, listCollections } from './_client.ts'
 import { stringifyDoc } from './stream.ts'
 import { EntityKind, PRIMARY_KEY } from './types.ts'
 
@@ -61,11 +61,11 @@ export async function searchCollection(
   pattern: string,
   limit: number,
 ): Promise<Record<string, unknown>[]> {
-  const indexes = await listIndexes(accessor, database, collection)
-  const hasTextIndex = indexes.some((idx) => 'textIndexVersion' in idx)
-  if (hasTextIndex) {
-    return findDocuments(accessor, database, collection, { $text: { $search: pattern } }, { limit })
-  }
+  // Always $regex, never $text. A $text index matches whole words and stems
+  // them, while grep matches substrings, and these rows are returned as the
+  // grep output without a local re-scan: $text would both miss `foo` inside
+  // `foobar` and match stems the pattern never had. $regex takes the pattern
+  // as written.
   const paths = await sampledStringPaths(accessor, database, collection)
   if (paths.length === 0) return []
   const orFilters = paths.map((f) => ({ [f]: { $regex: pattern, $options: 'i' } }))


### PR DESCRIPTION
## Summary

- New `integ/server/github_server.py`: fakes the four api.github.com routes the github backend calls (repo, git trees, git blobs, code search), plus a `github` integ target on both hosts. Code search is token-indexed like the real API, not substring.
- Adds `GitHubConfig.base_url` to match the existing TypeScript `baseUrl` seam. Python had a hardcoded `API_BASE` and could not be pointed at a fake.
- Fixes an unsound search push-down. grep/rg narrow scope via the provider's search API then scan only the narrowed files, but provider search matches whole words while grep matches substrings, so files holding the literal only inside a longer word were silently dropped. Push-down now requires `-w` and a fully literal pattern, on github, box, dropbox and slack in both languages.
- Drops `files_only_shortcircuit`: it bails on `-w`, which push-down now requires, so it became unreachable, and it cannot be re-enabled safely because over-fetch is fatal to a path that skips the scan.

The fake caught the bug on its first run:

```
grep -rl  quokka /repo   # 119 files, push-down fires -> 3 (missed docs/release.md)
grep -rl  quokka /repo/docs   # 3 files, full scan  -> 2 (found it)
```

After the fix `grep -rl quokka /repo` returns 4, and `grep -rlw quokka /repo` returns 3.

## Test plan

- integ `github` target: 9/9 on python and typescript-node
- python: full suite, 0 failures
- typescript: `pnpm test` and `pnpm typecheck` clean
- `pre-commit run --all-files` clean