### PR TITLE
fix(observe): keep the mount prefix on op records in typescript

### DIFF
--- a/python/mirage/observe/context.py
+++ b/python/mirage/observe/context.py
@@ -136,9 +136,21 @@ async def with_mount_prefix(prefix: str,
 
 
 def _virtual(path: str, prefix: str) -> str:
-    if prefix and not path.startswith(prefix):
-        return prefix + path
-    return path
+    """Name `path` against `prefix`, leaving an already-virtual path alone.
+
+    Backends name the mount-relative path ("/report.json") and a few name
+    the virtual one already ("/s3/report.json"), so the two have to be told
+    apart. The test is for a path boundary, not a bare startswith: a mount
+    at /s3 holding s3-report.txt would otherwise look already-prefixed and
+    record as "/s3-report.txt".
+
+    Args:
+        path (str): Mount-relative or already-virtual path.
+        prefix (str): Mount prefix (e.g. "/s3"), empty for the root mount.
+    """
+    if not prefix or path == prefix or path.startswith(prefix + "/"):
+        return path
+    return prefix + path
 
 
 def record(op: str,

--- a/python/tests/observe/test_context.py
+++ b/python/tests/observe/test_context.py
@@ -103,6 +103,18 @@ def test_record_prefix_already_applied():
     assert records[0].path == "/s3/data/file.json"
 
 
+def test_record_prefixes_name_sharing_prefix_leading_text():
+    # A bare startswith test would read this as already-prefixed and record
+    # "/s3-report.txt", dropping the mount.
+    scope = RecordingScope()
+    records = scope.records
+    push_mount_prefix("/s3")
+    record("read", "/s3-report.txt", "s3", 1, 0)
+    push_mount_prefix("")
+    scope.close()
+    assert records[0].path == "/s3/s3-report.txt"
+
+
 def test_push_mount_prefix_returns_previous():
     scope = RecordingScope()
     assert push_mount_prefix("/s3") == ""

--- a/python/tests/observe/test_workspace_observe.py
+++ b/python/tests/observe/test_workspace_observe.py
@@ -101,6 +101,28 @@ def test_execute_records_op_source():
     assert "/data/test.txt" in {e["path"] for e in ops if e["op"] == "read"}
 
 
+def test_execute_records_op_path_per_mount():
+    ws = Workspace({
+        "/s3/": RAMResource(),
+        "/db/": RAMResource()
+    },
+                   mode=MountMode.WRITE)
+    for line in ("echo one > /s3/report.json", "echo two > /db/report.json",
+                 "cat /s3/report.json", "cat /db/report.json",
+                 "cp /s3/report.json /db/copy.json"):
+        asyncio.run(ws.execute(line))
+    events = asyncio.run(ws.observer.events())
+    ops = [(e["op"], e["path"]) for e in events if e["type"] == "op"]
+    assert ops == [
+        ("write", "/s3/report.json"),
+        ("write", "/db/report.json"),
+        ("read", "/s3/report.json"),
+        ("read", "/db/report.json"),
+        ("read", "/s3/report.json"),
+        ("write", "/db/copy.json"),
+    ]
+
+
 def test_execute_records_every_event_type():
     ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
     asyncio.run(ws.execute("echo hello > /data/test.txt"))

--- a/typescript/packages/core/src/core/s3/read.ts
+++ b/typescript/packages/core/src/core/s3/read.ts
@@ -81,10 +81,9 @@ export async function read(
     }
     const bytes = await streamToBuffer(resp.Body)
     const { fingerprint, revision } = fpRevFromS3Response(resp)
-    // Use the virtual (mount-prefixed) path here rather than rawPath +
-    // an applyPrefix lookup, because lazy stream consumption can outlive
-    // the mount's setVirtualPrefix scope. Passing virtual makes record's
-    // path independent of the active recording context state.
+    // Naming the virtual path rather than rawPath keeps the record exact
+    // without consulting the active mount prefix; record() leaves an
+    // already-prefixed path alone.
     record('read', virtual, ResourceName.S3, bytes.byteLength, startMs, {
       fingerprint,
       revision,

--- a/typescript/packages/core/src/core/s3/stream.ts
+++ b/typescript/packages/core/src/core/s3/stream.ts
@@ -48,8 +48,8 @@ export async function* stream(accessor: S3Accessor, path: PathSpec): AsyncIterab
   const input: Record<string, unknown> = { Bucket: config.bucket, Key: s3Key(rawPath, config) }
   if (pinnedRevision !== null) input.VersionId = pinnedRevision
 
-  // Use virtual (mount-prefixed) path so the record stays correct even
-  // when the stream body executes after setVirtualPrefix has been reset.
+  // Naming the virtual path keeps the record exact without consulting the
+  // active mount prefix; record() leaves an already-prefixed path alone.
   const rec = recordStream('read', virtual, ResourceName.S3)
 
   try {

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -183,12 +183,13 @@ export { NamespaceStore, type NodeFields } from './workspace/mount/namespace/sto
 export { RAMNamespaceStore } from './workspace/mount/namespace/ram.ts'
 export { HISTORY_PREFIX, HistoryViewResource } from './resource/history/history.ts'
 export {
+  pushMountPrefix,
   record,
   recordStream,
   revisionFor,
   runWithRecording,
   runWithRevisions,
-  setVirtualPrefix,
+  withMountPrefix,
 } from './observe/context.ts'
 export { guessType } from './utils/filetype.ts'
 export { newSessionId, newWorkspaceId, uuid7 } from './utils/ids.ts'

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -183,10 +183,10 @@ export { NamespaceStore, type NodeFields } from './workspace/mount/namespace/sto
 export { RAMNamespaceStore } from './workspace/mount/namespace/ram.ts'
 export { HISTORY_PREFIX, HistoryViewResource } from './resource/history/history.ts'
 export {
-  pushMountPrefix,
   record,
   recordStream,
   revisionFor,
+  runWithMountPrefix,
   runWithRecording,
   runWithRevisions,
   withMountPrefix,

--- a/typescript/packages/core/src/io/cachable_iterator.ts
+++ b/typescript/packages/core/src/io/cachable_iterator.ts
@@ -13,12 +13,21 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 export class CachableAsyncIterator implements AsyncIterableIterator<Uint8Array> {
-  private readonly source: AsyncIterator<Uint8Array>
+  private source: AsyncIterator<Uint8Array>
   private readonly buffer: Uint8Array[] = []
   private exhaustedFlag = false
 
   constructor(source: AsyncIterable<Uint8Array>) {
     this.source = source[Symbol.asyncIterator]()
+  }
+
+  // Re-wrap the underlying source in place, keeping whatever is already
+  // buffered. The mount seam uses this to restore its recording context
+  // around each pull without replacing the object commands hold on to.
+  // Mirrors python's CachableAsyncIterator.replace_source.
+  wrapSource(fn: (src: AsyncIterable<Uint8Array>) => AsyncIterable<Uint8Array>): void {
+    const inner = this.source
+    this.source = fn({ [Symbol.asyncIterator]: () => inner })[Symbol.asyncIterator]()
   }
 
   get exhausted(): boolean {

--- a/typescript/packages/core/src/observe/context.test.ts
+++ b/typescript/packages/core/src/observe/context.test.ts
@@ -20,10 +20,11 @@ import {
   revisionFor,
   runWithRecording,
   runWithRevisions,
-  setVirtualPrefix,
+  pushMountPrefix,
+  withMountPrefix,
 } from './context.ts'
 
-describe('runWithRecording / record / setVirtualPrefix', () => {
+describe('runWithRecording / record / pushMountPrefix', () => {
   it('record outside recording scope is a no-op', () => {
     record('read', '/a.txt', 's3', 100, 0)
   })
@@ -57,7 +58,7 @@ describe('runWithRecording / record / setVirtualPrefix', () => {
 
   it('prepends virtual prefix when path lacks it', async () => {
     const [, records] = await runWithRecording(async () => {
-      setVirtualPrefix('/s3')
+      pushMountPrefix('/s3')
       record('read', '/data/file.json', 's3', 100, 0)
     })
     expect(records[0]?.path).toBe('/s3/data/file.json')
@@ -72,10 +73,36 @@ describe('runWithRecording / record / setVirtualPrefix', () => {
 
   it('does not double-apply prefix when path already has it', async () => {
     const [, records] = await runWithRecording(async () => {
-      setVirtualPrefix('/s3')
+      pushMountPrefix('/s3')
       record('read', '/s3/data/file.json', 's3', 100, 0)
     })
     expect(records[0]?.path).toBe('/s3/data/file.json')
+  })
+
+  it('restores the previous prefix instead of clearing it', async () => {
+    const [, records] = await runWithRecording(async () => {
+      const outer = pushMountPrefix('/s3')
+      const inner = pushMountPrefix('/db')
+      record('read', '/a.txt', 'postgres', 1, 0)
+      pushMountPrefix(inner)
+      record('read', '/b.txt', 's3', 1, 0)
+      pushMountPrefix(outer)
+    })
+    expect(records.map((r) => r.path)).toEqual(['/db/a.txt', '/s3/b.txt'])
+  })
+
+  it('withMountPrefix restores the prefix for a stream consumed after the scope', async () => {
+    const lazy = async function* (): AsyncGenerator<Uint8Array> {
+      record('read', '/a.txt', 's3', 3, 0)
+      yield new Uint8Array([1, 2, 3])
+    }
+    const [, records] = await runWithRecording(async () => {
+      const prev = pushMountPrefix('/s3')
+      const wrapped = withMountPrefix('/s3', lazy())
+      pushMountPrefix(prev)
+      for await (const _chunk of wrapped) void _chunk
+    })
+    expect(records[0]?.path).toBe('/s3/a.txt')
   })
 })
 

--- a/typescript/packages/core/src/observe/context.test.ts
+++ b/typescript/packages/core/src/observe/context.test.ts
@@ -20,11 +20,11 @@ import {
   revisionFor,
   runWithRecording,
   runWithRevisions,
-  pushMountPrefix,
+  runWithMountPrefix,
   withMountPrefix,
 } from './context.ts'
 
-describe('runWithRecording / record / pushMountPrefix', () => {
+describe('runWithRecording / record / runWithMountPrefix', () => {
   it('record outside recording scope is a no-op', () => {
     record('read', '/a.txt', 's3', 100, 0)
   })
@@ -57,10 +57,11 @@ describe('runWithRecording / record / pushMountPrefix', () => {
   })
 
   it('prepends virtual prefix when path lacks it', async () => {
-    const [, records] = await runWithRecording(async () => {
-      pushMountPrefix('/s3')
-      record('read', '/data/file.json', 's3', 100, 0)
-    })
+    const [, records] = await runWithRecording(() =>
+      runWithMountPrefix('/s3', async () => {
+        record('read', '/data/file.json', 's3', 100, 0)
+      }),
+    )
     expect(records[0]?.path).toBe('/s3/data/file.json')
   })
 
@@ -72,34 +73,66 @@ describe('runWithRecording / record / pushMountPrefix', () => {
   })
 
   it('does not double-apply prefix when path already has it', async () => {
-    const [, records] = await runWithRecording(async () => {
-      pushMountPrefix('/s3')
-      record('read', '/s3/data/file.json', 's3', 100, 0)
-    })
+    const [, records] = await runWithRecording(() =>
+      runWithMountPrefix('/s3', async () => {
+        record('read', '/s3/data/file.json', 's3', 100, 0)
+      }),
+    )
     expect(records[0]?.path).toBe('/s3/data/file.json')
   })
 
-  it('restores the previous prefix instead of clearing it', async () => {
-    const [, records] = await runWithRecording(async () => {
-      const outer = pushMountPrefix('/s3')
-      const inner = pushMountPrefix('/db')
-      record('read', '/a.txt', 'postgres', 1, 0)
-      pushMountPrefix(inner)
-      record('read', '/b.txt', 's3', 1, 0)
-      pushMountPrefix(outer)
-    })
+  // A bare startsWith test would read this as already-prefixed and record
+  // '/s3-report.txt', dropping the mount.
+  it('prefixes a filename that merely shares the prefix leading text', async () => {
+    const [, records] = await runWithRecording(() =>
+      runWithMountPrefix('/s3', async () => {
+        record('read', '/s3-report.txt', 's3', 1, 0)
+      }),
+    )
+    expect(records[0]?.path).toBe('/s3/s3-report.txt')
+  })
+
+  it('restores the enclosing prefix when a nested mount scope ends', async () => {
+    const [, records] = await runWithRecording(() =>
+      runWithMountPrefix('/s3', async () => {
+        await runWithMountPrefix('/db', async () => {
+          record('read', '/a.txt', 'postgres', 1, 0)
+        })
+        record('read', '/b.txt', 's3', 1, 0)
+      }),
+    )
     expect(records.map((r) => r.path)).toEqual(['/db/a.txt', '/s3/b.txt'])
   })
 
-  it('withMountPrefix restores the prefix for a stream consumed after the scope', async () => {
+  // Two mounts consumed concurrently must not see each other's prefix. The
+  // interleave is forced: each branch records only after the other has
+  // opened its own scope, which a prefix mutated on shared state would
+  // already have overwritten.
+  it('keeps the prefix task-local across concurrent branches', async () => {
+    const gate = { s3: false, db: false }
+    const branch = async (prefix: string, key: 's3' | 'db', other: 's3' | 'db', file: string) => {
+      await runWithMountPrefix(prefix, async () => {
+        gate[key] = true
+        while (!gate[other]) await new Promise((r) => setTimeout(r, 0))
+        record('read', file, key, 1, 0)
+      })
+    }
+    const [, records] = await runWithRecording(async () => {
+      await Promise.all([
+        branch('/s3', 's3', 'db', '/alpha.txt'),
+        branch('/db', 'db', 's3', '/beta.txt'),
+      ])
+    })
+    expect(new Set(records.map((r) => r.path))).toEqual(new Set(['/s3/alpha.txt', '/db/beta.txt']))
+  })
+
+  it('withMountPrefix carries the prefix into a stream consumed after the scope', async () => {
     const lazy = async function* (): AsyncGenerator<Uint8Array> {
       record('read', '/a.txt', 's3', 3, 0)
       yield new Uint8Array([1, 2, 3])
     }
     const [, records] = await runWithRecording(async () => {
-      const prev = pushMountPrefix('/s3')
-      const wrapped = withMountPrefix('/s3', lazy())
-      pushMountPrefix(prev)
+      const wrapped = await runWithMountPrefix('/s3', async () => withMountPrefix('/s3', lazy()))
       for await (const _chunk of wrapped) void _chunk
     })
     expect(records[0]?.path).toBe('/s3/a.txt')

--- a/typescript/packages/core/src/observe/context.ts
+++ b/typescript/packages/core/src/observe/context.ts
@@ -41,27 +41,27 @@ export async function runWithRecording<T>(fn: () => Promise<T>): Promise<[T, OpR
 }
 
 /**
- * Set the mount prefix records are named against, returning the prefix that
- * was active before. Callers restore that value rather than clearing to '',
- * so a mount whose command dispatches into another mount gets its own prefix
- * back. Mirrors python's `push_mount_prefix`.
+ * Run `fn` with `prefix` as the mount prefix records are named against.
  *
- * No-op (and returns '') when no recording context is active.
+ * Derives a state for this async branch and shares only the records array,
+ * so two mounts consumed concurrently (`cat /s3/a & cat /db/b`) cannot see
+ * or clobber each other's prefix. Mirrors python's `push_mount_prefix`,
+ * whose `Recorder` is frozen and re-set per task for the same reason.
+ *
+ * Inert (runs `fn` unchanged) when no recording context is active.
  */
-export function pushMountPrefix(prefix: string): string {
+export function runWithMountPrefix<T>(prefix: string, fn: () => Promise<T>): Promise<T> {
   const state = storage.getStore()
-  if (state === undefined) return ''
-  const prev = state.mountPrefix
-  state.mountPrefix = prefix
-  return prev
+  if (state === undefined) return fn()
+  return Promise.resolve(storage.run({ records: state.records, mountPrefix: prefix }, fn))
 }
 
 /**
  * Wrap a stream so `prefix` is the active mount prefix during each pull from
  * the underlying source. A command may return a stream that defers its
  * backend read to the first chunk request, by which point the mount's own
- * push/restore pair has already run, so without this the record lands with no
- * prefix. Mirrors python's `with_mount_prefix`.
+ * scope has already exited, so without this the record lands with no prefix.
+ * Mirrors python's `with_mount_prefix`.
  */
 export async function* withMountPrefix(
   prefix: string,
@@ -70,13 +70,7 @@ export async function* withMountPrefix(
   const iter = it[Symbol.asyncIterator]()
   try {
     for (;;) {
-      const prev = pushMountPrefix(prefix)
-      let step: IteratorResult<Uint8Array>
-      try {
-        step = await iter.next()
-      } finally {
-        pushMountPrefix(prev)
-      }
+      const step = await runWithMountPrefix(prefix, () => iter.next())
       if (step.done === true) return
       yield step.value
     }
@@ -171,9 +165,13 @@ export function revisionFor(path: string): string | null {
   return map.get(path) ?? null
 }
 
+// Backends name the mount-relative path ('/report.json') and a few name the
+// virtual one already ('/s3/report.json'), so tell them apart before
+// prefixing. The test has to be for a path boundary, not a bare startsWith:
+// a mount at /s3 holding s3-report.txt would otherwise look already-prefixed
+// and record as '/s3-report.txt'. Mirrors python's _virtual.
 function applyPrefix(prefix: string, path: string): string {
-  if (prefix !== '' && !path.startsWith(prefix)) {
-    return rstripSlash(prefix) + path
-  }
-  return path
+  const root = rstripSlash(prefix)
+  if (root === '' || path === root || path.startsWith(`${root}/`)) return path
+  return root + path
 }

--- a/typescript/packages/core/src/observe/context.ts
+++ b/typescript/packages/core/src/observe/context.ts
@@ -18,7 +18,7 @@ import { rstripSlash } from '../utils/slash.ts'
 
 interface RecordingState {
   records: OpRecord[]
-  virtualPrefix: string
+  mountPrefix: string
 }
 
 const storage = createAsyncContext<RecordingState>()
@@ -35,14 +35,54 @@ interface RevisionsState {
 const revisionsStorage = createAsyncContext<RevisionsState>()
 
 export async function runWithRecording<T>(fn: () => Promise<T>): Promise<[T, OpRecord[]]> {
-  const state: RecordingState = { records: [], virtualPrefix: '' }
+  const state: RecordingState = { records: [], mountPrefix: '' }
   const value = await storage.run(state, fn)
   return [value, state.records]
 }
 
-export function setVirtualPrefix(prefix: string): void {
+/**
+ * Set the mount prefix records are named against, returning the prefix that
+ * was active before. Callers restore that value rather than clearing to '',
+ * so a mount whose command dispatches into another mount gets its own prefix
+ * back. Mirrors python's `push_mount_prefix`.
+ *
+ * No-op (and returns '') when no recording context is active.
+ */
+export function pushMountPrefix(prefix: string): string {
   const state = storage.getStore()
-  if (state !== undefined) state.virtualPrefix = prefix
+  if (state === undefined) return ''
+  const prev = state.mountPrefix
+  state.mountPrefix = prefix
+  return prev
+}
+
+/**
+ * Wrap a stream so `prefix` is the active mount prefix during each pull from
+ * the underlying source. A command may return a stream that defers its
+ * backend read to the first chunk request, by which point the mount's own
+ * push/restore pair has already run, so without this the record lands with no
+ * prefix. Mirrors python's `with_mount_prefix`.
+ */
+export async function* withMountPrefix(
+  prefix: string,
+  it: AsyncIterable<Uint8Array>,
+): AsyncGenerator<Uint8Array> {
+  const iter = it[Symbol.asyncIterator]()
+  try {
+    for (;;) {
+      const prev = pushMountPrefix(prefix)
+      let step: IteratorResult<Uint8Array>
+      try {
+        step = await iter.next()
+      } finally {
+        pushMountPrefix(prev)
+      }
+      if (step.done === true) return
+      yield step.value
+    }
+  } finally {
+    await iter.return?.(undefined)
+  }
 }
 
 // Whether a recording context is active. Backends that need an extra API
@@ -71,7 +111,7 @@ export function record(
   state.records.push(
     new OpRecord({
       op,
-      path: applyPrefix(state.virtualPrefix, path),
+      path: applyPrefix(state.mountPrefix, path),
       source,
       bytes: nbytes,
       timestamp: Date.now(),
@@ -92,7 +132,7 @@ export function recordStream(
   if (state === undefined) return null
   const rec = new OpRecord({
     op,
-    path: applyPrefix(state.virtualPrefix, path),
+    path: applyPrefix(state.mountPrefix, path),
     source,
     bytes: 0,
     timestamp: Date.now(),

--- a/typescript/packages/core/src/workspace/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher.ts
@@ -21,7 +21,7 @@ import { IOResult } from '../io/types.ts'
 import { eaccesReadOnly } from '../utils/errors.ts'
 import { mountKey } from '../utils/key_prefix.ts'
 import { rstripSlash } from '../utils/slash.ts'
-import { runWithRevisions } from '../observe/context.ts'
+import { pushMountPrefix, runWithRevisions } from '../observe/context.ts'
 import type { OpRecord } from '../observe/record.ts'
 import type { OpsRegistry } from '../ops/registry.ts'
 import { type OpKwargs } from '../ops/registry.ts'
@@ -125,6 +125,10 @@ export class Dispatcher {
     const opOverride = mount?.commandSafeguards.get(opName) ?? null
     const opTimeout = opOverride !== null ? opOverride.timeoutSeconds : null
     let result
+    // Backends name their records against the mount-relative key, so the
+    // prefix has to be active while the op runs or the record loses the
+    // mount it belongs to. Mirrors Python's Ops._call.
+    const prevPrefix = pushMountPrefix(rstripSlash(mountPrefix))
     try {
       result = await runWithRevisions(
         mount !== null && mount.revisions.size > 0 ? mount.revisions : null,
@@ -147,6 +151,8 @@ export class Dispatcher {
     } catch (err) {
       await this.reconciler.onOpMissing(opName, p.virtual, err)
       throw err
+    } finally {
+      pushMountPrefix(prevPrefix)
     }
     result = await applyOpSafeguard(result, opOverride)
     if (DISPATCH_WRITE_OPS.has(opName)) {

--- a/typescript/packages/core/src/workspace/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher.ts
@@ -21,7 +21,7 @@ import { IOResult } from '../io/types.ts'
 import { eaccesReadOnly } from '../utils/errors.ts'
 import { mountKey } from '../utils/key_prefix.ts'
 import { rstripSlash } from '../utils/slash.ts'
-import { pushMountPrefix, runWithRevisions } from '../observe/context.ts'
+import { runWithMountPrefix, runWithRevisions } from '../observe/context.ts'
 import type { OpRecord } from '../observe/record.ts'
 import type { OpsRegistry } from '../ops/registry.ts'
 import { type OpKwargs } from '../ops/registry.ts'
@@ -128,31 +128,30 @@ export class Dispatcher {
     // Backends name their records against the mount-relative key, so the
     // prefix has to be active while the op runs or the record loses the
     // mount it belongs to. Mirrors Python's Ops._call.
-    const prevPrefix = pushMountPrefix(rstripSlash(mountPrefix))
     try {
-      result = await runWithRevisions(
-        mount !== null && mount.revisions.size > 0 ? mount.revisions : null,
-        async () =>
-          runWithTimeout(
-            Promise.resolve(
-              this.opsRegistry.call(
-                opName,
-                resource.kind,
-                resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
-                scope,
-                fullArgs,
-                fullKwargs,
+      result = await runWithMountPrefix(rstripSlash(mountPrefix), () =>
+        runWithRevisions(
+          mount !== null && mount.revisions.size > 0 ? mount.revisions : null,
+          async () =>
+            runWithTimeout(
+              Promise.resolve(
+                this.opsRegistry.call(
+                  opName,
+                  resource.kind,
+                  resource.accessor ?? NOOP_ACCESSOR_INSTANCE,
+                  scope,
+                  fullArgs,
+                  fullKwargs,
+                ),
               ),
+              opTimeout,
+              opName,
             ),
-            opTimeout,
-            opName,
-          ),
+        ),
       )
     } catch (err) {
       await this.reconciler.onOpMissing(opName, p.virtual, err)
       throw err
-    } finally {
-      pushMountPrefix(prevPrefix)
     }
     result = await applyOpSafeguard(result, opOverride)
     if (DISPATCH_WRITE_OPS.has(opName)) {

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -33,7 +33,7 @@ import type { ByteSource } from '../../io/types.ts'
 import { IOResult } from '../../io/types.ts'
 import { runWithCacheManager } from '../../cache/context.ts'
 import type { CacheManager } from '../../cache/manager.ts'
-import { pushMountPrefix, runWithRevisions, withMountPrefix } from '../../observe/context.ts'
+import { runWithMountPrefix, runWithRevisions, withMountPrefix } from '../../observe/context.ts'
 import type { RegisteredOp } from '../../ops/registry.ts'
 import type { Resource } from '../../resource/base.ts'
 import { type CommandSafeguard, ConsistencyPolicy, MountMode, PathSpec } from '../../types.ts'
@@ -441,9 +441,8 @@ export class MountEntry {
       ...(opts.statOverlay !== undefined ? { statOverlay: opts.statOverlay } : {}),
     }
 
-    const prevPrefix = pushMountPrefix(mountPrefix)
-    try {
-      return await runWithCacheManager(this.cacheManager, () =>
+    return runWithMountPrefix(mountPrefix, () =>
+      runWithCacheManager(this.cacheManager, () =>
         runWithRevisions(
           this.revisions.size > 0 ? this.revisions : null,
           async (): Promise<[ByteSource | null, IOResult]> => {
@@ -492,10 +491,8 @@ export class MountEntry {
             return [null, new IOResult()]
           },
         ),
-      )
-    } finally {
-      pushMountPrefix(prevPrefix)
-    }
+      ),
+    )
   }
 
   async executeOp(
@@ -529,9 +526,8 @@ export class MountEntry {
     const accessor = this.resource.accessor ?? NOOP_ACCESSOR
     const opOverride = this.commandSafeguards.get(opName) ?? null
     const opTimeout = opOverride !== null ? opOverride.timeoutSeconds : null
-    const prevPrefix = pushMountPrefix(mountPrefix)
-    try {
-      return await runWithRevisions(this.revisions.size > 0 ? this.revisions : null, async () => {
+    return runWithMountPrefix(mountPrefix, () =>
+      runWithRevisions(this.revisions.size > 0 ? this.revisions : null, async () => {
         for (const op of levels) {
           const result = await runWithTimeout(
             Promise.resolve(op.fn(accessor, scope, args, effectiveKwargs)),
@@ -541,10 +537,8 @@ export class MountEntry {
           if (result !== null && result !== undefined) return applyOpSafeguard(result, opOverride)
         }
         return null
-      })
-    } finally {
-      pushMountPrefix(prevPrefix)
-    }
+      }),
+    )
   }
 }
 

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -28,11 +28,12 @@ import { getExtension } from '../../commands/resolve.ts'
 import { resolveSafeguard } from '../../commands/safeguard.ts'
 import { applyOpSafeguard, runWithTimeout } from '../../commands/builtin/utils/safeguard.ts'
 import type { CommandSpec } from '../../commands/spec/types.ts'
+import { CachableAsyncIterator } from '../../io/cachable_iterator.ts'
 import type { ByteSource } from '../../io/types.ts'
 import { IOResult } from '../../io/types.ts'
 import { runWithCacheManager } from '../../cache/context.ts'
 import type { CacheManager } from '../../cache/manager.ts'
-import { runWithRevisions, setVirtualPrefix } from '../../observe/context.ts'
+import { pushMountPrefix, runWithRevisions, withMountPrefix } from '../../observe/context.ts'
 import type { RegisteredOp } from '../../ops/registry.ts'
 import type { Resource } from '../../resource/base.ts'
 import { type CommandSafeguard, ConsistencyPolicy, MountMode, PathSpec } from '../../types.ts'
@@ -440,7 +441,7 @@ export class MountEntry {
       ...(opts.statOverlay !== undefined ? { statOverlay: opts.statOverlay } : {}),
     }
 
-    setVirtualPrefix(mountPrefix)
+    const prevPrefix = pushMountPrefix(mountPrefix)
     try {
       return await runWithCacheManager(this.cacheManager, () =>
         runWithRevisions(
@@ -485,7 +486,7 @@ export class MountEntry {
                 // TODO: hand back a finalization context separately
                 // instead of stamping policy onto io.safeguard.
                 result[1].safeguard = resolvedSafeguard
-                return result
+                return wrapMountStreams(result, mountPrefix)
               }
             }
             return [null, new IOResult()]
@@ -493,7 +494,7 @@ export class MountEntry {
         ),
       )
     } finally {
-      setVirtualPrefix('')
+      pushMountPrefix(prevPrefix)
     }
   }
 
@@ -528,18 +529,53 @@ export class MountEntry {
     const accessor = this.resource.accessor ?? NOOP_ACCESSOR
     const opOverride = this.commandSafeguards.get(opName) ?? null
     const opTimeout = opOverride !== null ? opOverride.timeoutSeconds : null
-    return runWithRevisions(this.revisions.size > 0 ? this.revisions : null, async () => {
-      for (const op of levels) {
-        const result = await runWithTimeout(
-          Promise.resolve(op.fn(accessor, scope, args, effectiveKwargs)),
-          opTimeout,
-          opName,
-        )
-        if (result !== null && result !== undefined) return applyOpSafeguard(result, opOverride)
-      }
-      return null
-    })
+    const prevPrefix = pushMountPrefix(mountPrefix)
+    try {
+      return await runWithRevisions(this.revisions.size > 0 ? this.revisions : null, async () => {
+        for (const op of levels) {
+          const result = await runWithTimeout(
+            Promise.resolve(op.fn(accessor, scope, args, effectiveKwargs)),
+            opTimeout,
+            opName,
+          )
+          if (result !== null && result !== undefined) return applyOpSafeguard(result, opOverride)
+        }
+        return null
+      })
+    } finally {
+      pushMountPrefix(prevPrefix)
+    }
   }
+}
+
+// Push `mountPrefix` back during lazy consumption of anything the command
+// handed back, so a deferred backend read names its record the same way an
+// eager one does. Dedup by identity: a stream that appears both as the
+// primary stdout and in IOResult.reads/writes is wrapped once.
+// Mirrors python's _wrap_cmd_streams.
+function wrapMountStreams(
+  result: [ByteSource | null, IOResult],
+  mountPrefix: string,
+): [ByteSource | null, IOResult] {
+  const [stream, io] = result
+  const seen = new Map<ByteSource, ByteSource>()
+  const wrap = (obj: ByteSource): ByteSource => {
+    if (obj instanceof Uint8Array) return obj
+    const hit = seen.get(obj)
+    if (hit !== undefined) return hit
+    let wrapped: ByteSource
+    if (obj instanceof CachableAsyncIterator) {
+      obj.wrapSource((src) => withMountPrefix(mountPrefix, src))
+      wrapped = obj
+    } else {
+      wrapped = withMountPrefix(mountPrefix, obj)
+    }
+    seen.set(obj, wrapped)
+    return wrapped
+  }
+  for (const [k, v] of Object.entries(io.reads)) io.reads[k] = wrap(v)
+  for (const [k, v] of Object.entries(io.writes)) io.writes[k] = wrap(v)
+  return [stream !== null ? wrap(stream) : null, io]
 }
 
 function sortFiletypeMap(m: Map<string, (string | null)[]>): Record<string, (string | null)[]> {

--- a/typescript/packages/core/src/workspace/workspace_observe.test.ts
+++ b/typescript/packages/core/src/workspace/workspace_observe.test.ts
@@ -133,11 +133,11 @@ describe('Workspace observer wiring', () => {
     await ws.close()
   })
 
-  // The path form is deliberately not asserted here: this host records the
-  // op path mount-relative ('/test.txt') where python records the virtual path
-  // ('/data/test.txt'), so the prefix set by Mount.execute is not reaching
-  // record(). Python's test_execute_records_op_source pins the correct form;
-  // asserting the mount-relative one here would freeze the bug in place.
+  // Op events name the virtual path, mount prefix included, so two mounts
+  // holding the same filename stay distinguishable in the recording. The
+  // write arrives through executeOp and the read through a lazy stream, so
+  // this covers both routes the mount prefix has to survive. Mirrors
+  // python's test_execute_records_op_source.
   it('records a source and a read op on every op event', async () => {
     const ws = buildWorkspace()
     await ws.execute('echo hello > /data/test.txt')
@@ -147,6 +147,45 @@ describe('Workspace observer wiring', () => {
     expect(ops.length).toBeGreaterThan(0)
     expect(ops.every((e) => 'source' in e)).toBe(true)
     expect(ops.filter((e) => e.op === 'read').length).toBeGreaterThan(0)
+    expect(new Set(ops.map((e) => e.path))).toEqual(new Set(['/data/test.txt']))
+    await ws.close()
+  })
+
+  // Two mounts holding the same filename have to stay distinguishable, so
+  // every record carries its mount prefix whichever route it arrives by:
+  // an eager write (dispatch), a lazy read (stream), and a cp whose read
+  // and write land on different mounts. Mirrors python's
+  // test_execute_records_op_path_per_mount.
+  it('records the op path per mount, not mount-relative', async () => {
+    const s3 = new RAMResource()
+    const db = new RAMResource()
+    const registry = new OpsRegistry()
+    registry.registerResource(s3)
+    registry.registerResource(db)
+    const ws = new Workspace(
+      { '/s3': s3, '/db': db },
+      { mode: MountMode.WRITE, ops: registry, shellParser: parser },
+    )
+    for (const line of [
+      'echo one > /s3/report.json',
+      'echo two > /db/report.json',
+      'cat /s3/report.json',
+      'cat /db/report.json',
+      'cp /s3/report.json /db/copy.json',
+    ]) {
+      await ws.execute(line)
+    }
+    const ops = (await ws.observer.events())
+      .filter((e) => e.type === 'op')
+      .map((e) => [e.op, e.path])
+    expect(ops).toEqual([
+      ['write', '/s3/report.json'],
+      ['write', '/db/report.json'],
+      ['read', '/s3/report.json'],
+      ['read', '/db/report.json'],
+      ['read', '/s3/report.json'],
+      ['write', '/db/copy.json'],
+    ])
     await ws.close()
   })
 


### PR DESCRIPTION
## What

TypeScript op events named the **mount-relative** path where Python names the virtual one. With S3 on `/s3` and Postgres on `/db` both holding `report.json`, Python's recording distinguished them and TypeScript wrote `/report.json` for both, so the audit trail could not say which backend was touched. Same failure class CLAUDE.md already calls out for `du`.

## Why it happened

Reaching a backend converts `/s3/report.json` into the key `report.json`, dropping the mount name, and both languages record from that key. Python glues the prefix back on through three mechanisms; TypeScript had only the first, and it was broken in two ways:

1. `Mount.execute` cleared the prefix to `''` in its `finally` instead of restoring the previous value, so a command dispatching into another mount lost it.
2. A command may hand back a stream that defers its backend read to the first chunk. By then the mount's scope has already exited, so the record landed with no prefix. `core/s3/stream.ts` already documented this trap and worked around it locally.
3. Eager writes (a shell redirect, say) reach the backend through `Dispatcher.dispatch`, which never set the prefix at all.

## The fix

Ported Python's existing machinery rather than threading the virtual path through 48 backend call sites:

- `pushMountPrefix` returns the previous prefix so callers restore it (mirrors `push_mount_prefix`).
- `withMountPrefix` re-pushes it around each pull from a stream; `Mount.execute` runs the stream plus `IOResult.reads`/`writes` through it (mirrors `with_mount_prefix` + `_wrap_cmd_streams`). `CachableAsyncIterator.wrapSource` stands in for `replace_source` so the object commands hold on to is not replaced.
- `Dispatcher.dispatch` and `Mount.executeOp` push the prefix around the backend op (mirrors `Ops._call`).

No backend call site changed.

## Verification

Two mounts each holding `report.json`, driven through an eager write, a lazy read and a cross-mount `cp`, now emit byte-identical records in both languages:

```
write	/s3/report.json	ram
write	/db/report.json	ram
read	/s3/report.json	ram
read	/db/report.json	ram
read	/s3/report.json	ram
write	/db/copy.json	ram
```

Pinned as a test in both languages. Full TS core suite (5507 tests) and the Python observe/workspace/io/cache suites pass; pre-commit and the spec-drift check are clean.