### PR TITLE
fix stat sizes across onedrive, box, dropbox, ssh and nextcloud; mark them size-known

### DIFF
--- a/integ/resources/sizes/stat_read.json
+++ b/integ/resources/sizes/stat_read.json
@@ -1,0 +1,124 @@
+{
+  "cases": [
+    {
+      "id": "sz_stat_poem",
+      "seq": 680001,
+      "targets": [
+        "s3",
+        "box",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "stat -c %s /data/poem.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "46\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "sz_read_poem",
+      "seq": 680002,
+      "targets": [
+        "s3",
+        "box",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "cat /data/poem.txt | wc -c",
+      "expect": {
+        "exit": 0,
+        "stdout": "46\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "sz_stat_empty",
+      "seq": 680003,
+      "targets": [
+        "s3",
+        "box",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "stat -c %s /data/empty.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "sz_read_empty",
+      "seq": 680004,
+      "targets": [
+        "s3",
+        "box",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "cat /data/empty.txt | wc -c",
+      "expect": {
+        "exit": 0,
+        "stdout": "0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "sz_stat_nested",
+      "seq": 680005,
+      "targets": [
+        "s3",
+        "box",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "stat -c %s /data/sub/nested.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "15\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "sz_read_nested",
+      "seq": 680006,
+      "targets": [
+        "s3",
+        "box",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud"
+      ],
+      "command": "cat /data/sub/nested.txt | wc -c",
+      "expect": {
+        "exit": 0,
+        "stdout": "15\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/resources/sizes/stat_read.json
+++ b/integ/resources/sizes/stat_read.json
@@ -101,6 +101,58 @@
       }
     },
     {
+      "id": "sz_ssh_symlink_stat_follows_target",
+      "seq": 680010,
+      "targets": [
+        "ssh"
+      ],
+      "command": "stat -c %s /links/poem_link.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "46\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "sz_ssh_symlink_read",
+      "seq": 680011,
+      "targets": [
+        "ssh"
+      ],
+      "command": "cat /links/poem_link.txt | wc -c",
+      "expect": {
+        "exit": 0,
+        "stdout": "46\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "sz_box_weblink_hidden_from_listing",
+      "seq": 680012,
+      "targets": [
+        "box"
+      ],
+      "command": "find /data -name homepage",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "sz_box_weblink_direct_stat_enoent",
+      "seq": 680013,
+      "targets": [
+        "box"
+      ],
+      "command": "stat /data/homepage",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "stat: /data/homepage: No such file or directory\n"
+      }
+    },
+    {
       "id": "sz_read_nested",
       "seq": 680006,
       "targets": [

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -403,6 +403,15 @@ class SSHService:
         paths = " ".join(f"/admin/{base}/{m['root']}"
                          for m in target["mounts"])
         await _admin_exec(admin_ws, f"mkdir -p {paths}")
+        # A server-side symlink in the /links mount: mirage's shell ln -s
+        # only makes namespace links, so the battery needs one created over
+        # SFTP to pin that ssh stat follows links (target size, not
+        # link-text length). Dangling until the fixture seeds poem.txt.
+        sftp = await admin.accessor.sftp()
+        for m in target["mounts"]:
+            if m["root"] == "links":
+                await sftp.symlink("../data/poem.txt",
+                                   f"/{base}/{m['root']}/poem_link.txt")
         return cls(host, port, server, root_dir, admin, admin_ws, base)
 
     def resource(self, mount: dict) -> SSHResource:
@@ -897,6 +906,11 @@ class BoxService:
                 rel = src.relative_to(base).as_posix()
                 self.state.seed_path(f"{mount['folder']}/{rel}",
                                      src.read_bytes())
+        if seed == "files/v1":
+            # A weblink beside the fixture: sizeless and content-free, so
+            # listings must hide it and a direct stat must ENOENT.
+            self.state.add_web_link(folder["id"], "homepage",
+                                    "https://example.com/")
         return BoxResource(
             BoxConfig(
                 access_token="integ-box-token",

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -464,6 +464,20 @@ async function openHf(target: Target): Promise<Open> {
 
 const BOX_AUTH = { Authorization: 'Bearer integ-box-token' }
 
+async function boxCreateWebLink(
+  endpoint: string,
+  parentId: string,
+  name: string,
+  url: string,
+): Promise<void> {
+  const r = await fetch(`${endpoint}/2.0/web_links`, {
+    method: 'POST',
+    headers: { ...BOX_AUTH, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, url, parent: { id: parentId } }),
+  })
+  if (r.status !== 201) throw new Error(`box web_link seed failed: ${String(r.status)}`)
+}
+
 async function boxCreateFolder(endpoint: string, parentId: string, name: string): Promise<string> {
   const r = await fetch(`${endpoint}/2.0/folders`, {
     method: 'POST',
@@ -529,6 +543,11 @@ async function openBox(target: Target): Promise<Open> {
           new Uint8Array(readFileSync(file)),
         )
       }
+    }
+    if (m.seed === 'files/v1') {
+      // A weblink beside the fixture: sizeless and content-free, so
+      // listings must hide it and a direct stat must ENOENT.
+      await boxCreateWebLink(endpoint, folderId, 'homepage', 'https://example.com/')
     }
     mounts[m.path] = new BoxResource({
       accessToken: 'integ-box-token',
@@ -973,12 +992,24 @@ async function openSsh(target: Target): Promise<Open> {
   if (!host) throw new Error('ssh target requires SSH_HOST')
   const port = Number(process.env.SSH_PORT ?? '22')
   const base = `mirage-integ-${runId()}`
-  const admin = new Workspace(
-    { '/admin': new SSHResource({ host, port, username: 'integ' }) },
-    { mode: MountMode.WRITE },
-  )
+  const adminResource = new SSHResource({ host, port, username: 'integ' })
+  const admin = new Workspace({ '/admin': adminResource }, { mode: MountMode.WRITE })
   const paths = target.mounts.map((m) => `/admin/${base}/${String(m.root)}`).join(' ')
   await adminExec(admin, `mkdir -p ${paths}`)
+  // A server-side symlink in the /links mount: mirage's shell ln -s only
+  // makes namespace links, so the battery needs one created over SFTP to
+  // pin that ssh stat follows links (target size, not link-text length).
+  // Dangling until the fixture seeds poem.txt.
+  const sftp = await adminResource.accessor.sftp()
+  for (const m of target.mounts) {
+    if (m.root !== 'links') continue
+    await new Promise<void>((resolveFn, rejectFn) => {
+      sftp.symlink('../data/poem.txt', `/${base}/${String(m.root)}/poem_link.txt`, (err) => {
+        if (err !== undefined) rejectFn(err)
+        else resolveFn()
+      })
+    })
+  }
   const mounts: Record<string, SSHResource> = {}
   for (const m of target.mounts) {
     mounts[m.path] = new SSHResource({

--- a/integ/server/box_server.py
+++ b/integ/server/box_server.py
@@ -129,6 +129,18 @@ class FakeBox:
         self.items[item["id"]] = item
         return item
 
+    def add_web_link(self, parent_id: str, name: str, url: str) -> dict:
+        item = {
+            "type": "web_link",
+            "id": self._new_id(),
+            "name": name,
+            "parent": parent_id,
+            "modified_at": MODIFIED,
+            "url": url,
+        }
+        self.items[item["id"]] = item
+        return item
+
     def update_file(self, item: dict, content: bytes) -> dict:
         item["content"] = content
         item["sha1"] = hashlib.sha1(content).hexdigest()
@@ -280,6 +292,22 @@ class BoxServer:
         if self.state.child_by_name(parent_id, name) is not None:
             return _error(409, "item_name_in_use", f"{name} already exists")
         item = self.state.add_folder(parent_id, name)
+        return web.json_response(self.state.render(item), status=201)
+
+    async def create_web_link(self, request: web.Request) -> web.Response:
+        if not self._authed(request):
+            return _error(401, "unauthorized", "missing bearer token")
+        body = await request.json()
+        parent_id = body.get("parent", {}).get("id", "")
+        name = body.get("name", "")
+        parent = self.state.items.get(parent_id)
+        if parent is None or parent["type"] != "folder":
+            return _error(404, "not_found", "parent folder not found")
+        if not name:
+            return _error(400, "bad_request", "name is required")
+        if self.state.child_by_name(parent_id, name) is not None:
+            return _error(409, "item_name_in_use", f"{name} already exists")
+        item = self.state.add_web_link(parent_id, name, body.get("url", ""))
         return web.json_response(self.state.render(item), status=201)
 
     async def folder_info(self, request: web.Request) -> web.Response:
@@ -515,6 +543,7 @@ def build_app(server: BoxServer) -> web.Application:
     app.router.add_get("/2.0/folders/{folder_id}/items", server.list_items)
     app.router.add_get("/2.0/folders/{folder_id}", server.folder_info)
     app.router.add_post("/2.0/folders", server.create_folder)
+    app.router.add_post("/2.0/web_links", server.create_web_link)
     app.router.add_get("/2.0/files/{file_id}", server.file_info)
     app.router.add_get("/2.0/files/{file_id}/content", server.download)
     app.router.add_post("/2.0/files/content", server.upload)

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -650,6 +650,12 @@
           "backend": "ssh",
           "root": "res",
           "fixture": "columnar/v1"
+        },
+        {
+          "path": "/links",
+          "resource": "ssh",
+          "backend": "ssh",
+          "root": "links"
         }
       ]
     },

--- a/python/mirage/core/box/readdir.py
+++ b/python/mirage/core/box/readdir.py
@@ -75,16 +75,19 @@ async def readdir(
     items = await list_folder_items(accessor.token_manager, folder_id)
     entries: list[tuple[str, IndexEntry, bool]] = []
     for it in items:
+        if it.get("type") == "web_link":
+            # Weblinks are bookmarks: no content endpoint, no size. Hide
+            # them from listings instead of serving an unreadable entry.
+            continue
         is_dir = it.get("type") == "folder"
         filename = it["name"]
-        size = it.get("size")
         entry = IndexEntry(
             id=it["id"],
             name=filename,
             resource_type=resource_type_for(it),
             remote_time=it.get("modified_at") or "",
             vfs_name=filename,
-            size=size if not is_dir and size else None,
+            size=None if is_dir else it.get("size"),
         )
         entries.append((filename, entry, is_dir))
 

--- a/python/mirage/core/box/stat.py
+++ b/python/mirage/core/box/stat.py
@@ -94,7 +94,9 @@ async def stat(
             # threaded index, so the readdir above populates a NULL store
             # that can't be read back. Resolve the id directly instead.
             item = await resolve_item(accessor, path_parts(path))
-            if item is None:
+            if item is None or resource_type_for(item) == "box/weblink":
+                # Weblinks are hidden from listings; a direct lookup must
+                # not resurface a sizeless, unreadable entry.
                 raise enoent(virtual)
             return _stat_from_item(item)
     if result.entry.resource_type == "box/folder":

--- a/python/mirage/core/box/stat.py
+++ b/python/mirage/core/box/stat.py
@@ -40,11 +40,10 @@ def _stat_from_item(item: dict[str, Any]) -> FileStat:
             modified=item.get("modified_at") or "",
             extra={"box_id": item["id"]},
         )
-    size = item.get("size")
     remote_time = item.get("modified_at") or ""
     return FileStat(
         name=vfs_name,
-        size=size if size else None,
+        size=item.get("size"),
         type=guess_type(vfs_name),
         modified=remote_time,
         fingerprint=remote_time or None,

--- a/python/mirage/core/dropbox/readdir.py
+++ b/python/mirage/core/dropbox/readdir.py
@@ -78,8 +78,7 @@ async def readdir(
             resource_type=_resource_type(f),
             remote_time=modified,
             vfs_name=filename,
-            size=size
-            if not is_dir and isinstance(size, int) and size > 0 else None,
+            size=size if not is_dir and isinstance(size, int) else None,
         )
         entries.append((filename, entry, is_dir))
 

--- a/python/mirage/core/dropbox/stat.py
+++ b/python/mirage/core/dropbox/stat.py
@@ -44,7 +44,7 @@ def _stat_from_entry(entry: dict[str, Any]) -> FileStat:
     size = entry.get("size")
     return FileStat(
         name=name,
-        size=size if isinstance(size, int) and size > 0 else None,
+        size=size if isinstance(size, int) else None,
         type=guess_type(name),
         modified=modified,
         fingerprint=modified or None,

--- a/python/mirage/core/nextcloud/readdir.py
+++ b/python/mirage/core/nextcloud/readdir.py
@@ -50,6 +50,15 @@ async def readdir(accessor: NextcloudAccessor,
                 sizes[base] = meta.content_length if meta else None
     except NotFound as exc:
         raise enoent(path) from exc
+    # PROPFIND normally carries getcontentlength for every file; when the
+    # lister omits the metadata, one stat per affected file fills the gap
+    # so the index never caches an unknown size.
+    for base, size in sizes.items():
+        if size is None:
+            md = await op.stat(base.lstrip("/"))
+            sizes[base] = md.content_length
+            if md.last_modified and base not in times:
+                times[base] = md.last_modified.isoformat()
     # WebDAV PROPFIND on a file returns the file itself; POSIX readdir of a
     # non-directory raises ENOTDIR instead.
     target_key = "/" + target.strip("/")

--- a/python/mirage/core/onedrive/stat.py
+++ b/python/mirage/core/onedrive/stat.py
@@ -14,7 +14,7 @@
 
 from mirage.accessor.onedrive import OneDriveAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore
-from mirage.core.msgraph.drive_ops import stat_item
+from mirage.core.msgraph.drive_ops import folder_child_count, stat_item
 from mirage.core.onedrive._client import (GraphError, drive_loc, graph_get,
                                           split_path)
 from mirage.types import FileStat, FileType, PathSpec
@@ -37,10 +37,16 @@ async def stat(accessor: OneDriveAccessor,
             if exc.status == 404:
                 raise enoent(virtual)
             raise
+        # The root's `size` is Graph's aggregate subtree storage number,
+        # not rendered content length: expose it as extra, like every
+        # other folder (see entry_stat).
         return FileStat(name="/",
                         type=FileType.DIRECTORY,
-                        size=item.get("size"),
-                        modified=item.get("lastModifiedDateTime"))
+                        modified=item.get("lastModifiedDateTime"),
+                        extra={
+                            "size_bytes": item.get("size"),
+                            "child_count": folder_child_count(item),
+                        })
     virtual_key = (prefix + "/" + stripped if prefix else "/" + stripped)
     return await stat_item(accessor.config, drive_loc(accessor.config,
                                                       stripped), virtual,

--- a/python/mirage/core/ssh/readdir.py
+++ b/python/mirage/core/ssh/readdir.py
@@ -20,6 +20,7 @@ from mirage.accessor.ssh import SSHAccessor
 from mirage.cache.index import NULL_INDEX, IndexCacheStore, IndexEntry
 from mirage.core.ssh._client import _abs
 from mirage.core.ssh.constants import SCOPE_ERROR
+from mirage.core.timeutil import epoch_to_iso
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 from mirage.utils.key_prefix import mount_prefix_of
@@ -50,7 +51,7 @@ async def readdir(accessor: SSHAccessor,
         remote_path = _abs(config, path)
         entries = await sftp.readdir(remote_path)
         base = "/" + path.strip("/")
-        names: list[str] = []
+        found: list[tuple[str, asyncssh.SFTPAttrs]] = []
         for entry in entries:
             name = entry.filename
             if isinstance(name, bytes):
@@ -58,8 +59,9 @@ async def readdir(accessor: SSHAccessor,
             if name in (".", ".."):
                 continue
             child = base.rstrip("/") + "/" + name
-            names.append(child)
-        names = sorted(names)
+            found.append((child, entry.attrs))
+        found.sort(key=lambda pair: pair[0])
+        names = [child for child, _ in found]
         if len(names) > SCOPE_ERROR:
             logger.warning(
                 "ssh readdir: %s returned %d entries (limit %d)",
@@ -68,10 +70,20 @@ async def readdir(accessor: SSHAccessor,
                 SCOPE_ERROR,
             )
         virtual_entries = sorted((prefix + e if prefix else e) for e in names)
-        index_entries = [(e.rsplit("/", 1)[-1],
-                          IndexEntry(id=e,
-                                     name=e.rsplit("/", 1)[-1],
-                                     resource_type="file")) for e in names]
+        # SFTP readdir already returns each entry's attrs; keep type, size
+        # and mtime in the index instead of discarding them.
+        index_entries = []
+        for child, attrs in found:
+            leaf = child.rsplit("/", 1)[-1]
+            is_dir = attrs.type == asyncssh.FILEXFER_TYPE_DIRECTORY
+            index_entries.append(
+                (leaf,
+                 IndexEntry(id=child,
+                            name=leaf,
+                            resource_type="folder" if is_dir else "file",
+                            size=None if is_dir else attrs.size,
+                            remote_time=epoch_to_iso(attrs.mtime)
+                            if attrs.mtime is not None else "")))
         await index.set_dir(virtual_key, index_entries)
         return virtual_entries
     except asyncssh.SFTPNoSuchFile:

--- a/python/mirage/core/ssh/readdir.py
+++ b/python/mirage/core/ssh/readdir.py
@@ -71,17 +71,20 @@ async def readdir(accessor: SSHAccessor,
             )
         virtual_entries = sorted((prefix + e if prefix else e) for e in names)
         # SFTP readdir already returns each entry's attrs; keep type, size
-        # and mtime in the index instead of discarding them.
+        # and mtime in the index instead of discarding them. Readdir attrs
+        # are lstat-style, so only regular files get a size: a symlink's
+        # link-text length is not what stat (which follows) or read serve.
         index_entries = []
         for child, attrs in found:
             leaf = child.rsplit("/", 1)[-1]
             is_dir = attrs.type == asyncssh.FILEXFER_TYPE_DIRECTORY
+            is_file = attrs.type == asyncssh.FILEXFER_TYPE_REGULAR
             index_entries.append(
                 (leaf,
                  IndexEntry(id=child,
                             name=leaf,
                             resource_type="folder" if is_dir else "file",
-                            size=None if is_dir else attrs.size,
+                            size=attrs.size if is_file else None,
                             remote_time=epoch_to_iso(attrs.mtime)
                             if attrs.mtime is not None else "")))
         await index.set_dir(virtual_key, index_entries)

--- a/python/mirage/core/ssh/rm.py
+++ b/python/mirage/core/ssh/rm.py
@@ -33,7 +33,10 @@ async def rm_r(accessor: SSHAccessor, path_spec: PathSpec) -> None:
 
 async def _rm_r_inner(sftp, config, path: str) -> None:
     remote = _abs(config, path)
-    attrs = await sftp.stat(remote)
+    # lstat, not stat: rm never follows symlinks (a link to a directory
+    # must be unlinked, not recursed into), and a dangling link is still
+    # removable. Mirrors the TS core, which already uses lstat here.
+    attrs = await sftp.lstat(remote)
     if attrs.type == asyncssh.FILEXFER_TYPE_DIRECTORY:
         entries = await sftp.readdir(remote)
         for entry in entries:

--- a/python/mirage/resource/box/box.py
+++ b/python/mirage/resource/box/box.py
@@ -36,6 +36,9 @@ class BoxResource(BaseResource):
     name: str = ResourceName.BOX
     caches_reads: bool = True
     index_ttl: float = 86_400
+    # Box item listings carry an exact byte `size` for every file (0
+    # included); sizeless weblinks are filtered out of listings.
+    SIZES_ALWAYS_KNOWN: bool = True
     PROMPT: str = PROMPT
 
     def __init__(self, config: BoxConfig) -> None:

--- a/python/mirage/resource/dropbox/dropbox.py
+++ b/python/mirage/resource/dropbox/dropbox.py
@@ -52,6 +52,10 @@ class DropboxResource(BaseResource):
     name: str = ResourceName.DROPBOX
     caches_reads: bool = True
     index_ttl: float = 86_400
+    # list_folder carries an exact byte `size` for every file (0 included).
+    # Paper docs 409 on raw download, a loud error, never a silent empty
+    # read.
+    SIZES_ALWAYS_KNOWN: bool = True
     _ops: dict[str, Any] = _DROPBOX_OPS
     PROMPT: str = PROMPT
 

--- a/python/mirage/resource/nextcloud/nextcloud.py
+++ b/python/mirage/resource/nextcloud/nextcloud.py
@@ -36,6 +36,9 @@ class NextcloudResource(BaseResource):
     accessor: NextcloudAccessor
     name: str = ResourceName.NEXTCLOUD
     caches_reads: bool = True
+    # WebDAV PROPFIND carries getcontentlength for every file; readdir
+    # backfills any lister-omitted size with one stat per affected file.
+    SIZES_ALWAYS_KNOWN: bool = True
     _ops: dict[str, Any] = _NEXTCLOUD_OPS
     PROMPT: str = PROMPT
     SUPPORTS_SNAPSHOT: bool = True

--- a/python/mirage/resource/onedrive/onedrive.py
+++ b/python/mirage/resource/onedrive/onedrive.py
@@ -70,6 +70,10 @@ class OneDriveResource(BaseResource):
     accessor: OneDriveAccessor
     name: str = ResourceName.ONEDRIVE
     caches_reads: bool = True
+    # Graph driveItems carry an exact byte `size` for every file in both
+    # listings and item gets; folders (including the root) report None
+    # with the aggregate storage number in extra.
+    SIZES_ALWAYS_KNOWN: bool = True
     _ops: dict[str, Any] = _ONEDRIVE_OPS
     PROMPT: str = PROMPT
     SUPPORTS_SNAPSHOT: bool = True

--- a/python/mirage/resource/ssh/ssh.py
+++ b/python/mirage/resource/ssh/ssh.py
@@ -72,6 +72,9 @@ class SSHResource(BaseResource):
     accessor: SSHAccessor
     name: str = ResourceName.SSH
     caches_reads: bool = True
+    # SFTP stat/readdir report the remote inode's exact byte size for
+    # every file; reads are the same raw bytes.
+    SIZES_ALWAYS_KNOWN: bool = True
     _ops: dict[str, Any] = _SSH_OPS
     PROMPT: str = PROMPT
 

--- a/python/tests/commands/ssh/test_ssh_commands.py
+++ b/python/tests/commands/ssh/test_ssh_commands.py
@@ -91,6 +91,11 @@ class MockSFTPClient:
             return MockSFTPAttrs(size=len(self.files[path]))
         raise asyncssh.SFTPNoSuchFile("not found")
 
+    async def lstat(self, path):
+        # No symlinks in the mock tree, so lstat and stat agree (rm uses
+        # lstat to avoid following links).
+        return await self.stat(path)
+
     async def readdir(self, path):
         if path not in self.dirs:
             raise asyncssh.SFTPNoSuchFile("not found")

--- a/python/tests/core/box/test_stat.py
+++ b/python/tests/core/box/test_stat.py
@@ -17,6 +17,8 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from mirage.cache.index.config import IndexEntry
+from mirage.core.box.read import read
+from mirage.core.box.readdir import readdir
 from mirage.core.box.stat import stat
 from mirage.types import FileType, PathSpec
 
@@ -117,3 +119,82 @@ async def test_stat_missing_raises(accessor, index):
                 PathSpec(resource_path="ghost",
                          virtual="/ghost",
                          directory="/"), index)
+
+
+@pytest.mark.asyncio
+async def test_stat_size_matches_read_for_every_file(accessor, index):
+    # The fskit invariant behind SIZES_ALWAYS_KNOWN: the size stat serves
+    # from the listing must equal the byte length a read delivers, 0-byte
+    # files included; weblinks never appear at all.
+    contents = {
+        "200": b"hello",
+        "201": b"",
+        "400": b"abc",
+    }
+    tree = {
+        "0": [
+            {
+                "id": "100",
+                "name": "docs",
+                "type": "folder",
+                "modified_at": "2026-04-01T00:00:00+00:00",
+            },
+            {
+                "id": "200",
+                "name": "a.txt",
+                "type": "file",
+                "size": 5,
+                "modified_at": "2026-04-01T00:00:00+00:00",
+            },
+            {
+                "id": "201",
+                "name": "empty.txt",
+                "type": "file",
+                "size": 0,
+                "modified_at": "2026-04-01T00:00:00+00:00",
+            },
+            {
+                "id": "300",
+                "name": "homepage",
+                "type": "web_link",
+                "modified_at": "2026-04-01T00:00:00+00:00",
+            },
+        ],
+        "100": [{
+            "id": "400",
+            "name": "b.bin",
+            "type": "file",
+            "size": 3,
+            "modified_at": "2026-04-01T00:00:00+00:00",
+        }],
+    }
+
+    async def _list(_tm, folder_id):
+        return tree[folder_id]
+
+    async def _download(_tm, file_id):
+        return contents[file_id]
+
+    files: list[str] = []
+    with patch("mirage.core.box.readdir.list_folder_items",
+               side_effect=_list), \
+         patch("mirage.core.box.read.download_file",
+               side_effect=_download):
+        stack = ["/"]
+        while stack:
+            current = stack.pop()
+            listing = await readdir(accessor, PathSpec.from_str_path(current),
+                                    index)
+            for child in listing:
+                trimmed = child.rstrip("/")
+                info = await stat(accessor, PathSpec.from_str_path(trimmed),
+                                  index)
+                if info.type == FileType.DIRECTORY:
+                    stack.append(trimmed)
+                    continue
+                assert info.size is not None, trimmed
+                body = await read(accessor, PathSpec.from_str_path(trimmed),
+                                  index)
+                assert info.size == len(body), trimmed
+                files.append(trimmed)
+    assert sorted(files) == ["/a.txt", "/docs/b.bin", "/empty.txt"]

--- a/python/tests/core/box/test_stat.py
+++ b/python/tests/core/box/test_stat.py
@@ -198,3 +198,30 @@ async def test_stat_size_matches_read_for_every_file(accessor, index):
                 assert info.size == len(body), trimmed
                 files.append(trimmed)
     assert sorted(files) == ["/a.txt", "/docs/b.bin", "/empty.txt"]
+
+
+@pytest.mark.asyncio
+async def test_stat_direct_resolve_hides_weblinks(accessor, index):
+    # Weblinks are filtered from listings; the resolve_item fallback must
+    # not resurface one as a sizeless, unreadable entry.
+    weblink = {
+        "id": "300",
+        "name": "homepage",
+        "type": "web_link",
+        "modified_at": "2026-04-01T00:00:00+00:00",
+    }
+    with patch(
+            "mirage.core.box.readdir.list_folder_items",
+            new_callable=AsyncMock,
+            return_value=[weblink],
+    ), patch(
+            "mirage.core.box.resolve.list_folder_items",
+            new_callable=AsyncMock,
+            return_value=[weblink],
+    ):
+        with pytest.raises(FileNotFoundError):
+            await stat(
+                accessor,
+                PathSpec(resource_path="homepage",
+                         virtual="/homepage",
+                         directory="/"), index)

--- a/python/tests/core/dropbox/test_stat.py
+++ b/python/tests/core/dropbox/test_stat.py
@@ -19,6 +19,8 @@ import pytest
 from mirage.accessor.dropbox import DropboxAccessor
 from mirage.cache.index.ram import RAMIndexCacheStore
 from mirage.core.dropbox._client import DropboxApiError, DropboxTokenManager
+from mirage.core.dropbox.read import read
+from mirage.core.dropbox.readdir import readdir
 from mirage.core.dropbox.stat import stat
 from mirage.resource.dropbox.config import DropboxConfig
 from mirage.types import FileType, PathSpec
@@ -77,3 +79,80 @@ async def test_stat_missing_maps_api_error_to_enoent(index):
                 PathSpec(resource_path="ghost/missing.txt",
                          virtual="/ghost/missing.txt",
                          directory="/ghost"), index)
+
+
+@pytest.mark.asyncio
+async def test_stat_size_matches_read_for_every_file(index):
+    # The fskit invariant behind SIZES_ALWAYS_KNOWN: the size stat serves
+    # from the listing must equal the byte length a read delivers, 0-byte
+    # files included.
+    contents = {
+        "/a.txt": b"hello",
+        "/empty.txt": b"",
+        "/docs/b.bin": b"abc",
+    }
+    tree = {
+        "": [
+            {
+                ".tag": "folder",
+                "id": "id:docs",
+                "name": "docs",
+                "path_display": "/docs",
+            },
+            {
+                ".tag": "file",
+                "id": "id:a",
+                "name": "a.txt",
+                "path_display": "/a.txt",
+                "size": 5,
+                "server_modified": "2026-04-01T00:00:00Z",
+            },
+            {
+                ".tag": "file",
+                "id": "id:empty",
+                "name": "empty.txt",
+                "path_display": "/empty.txt",
+                "size": 0,
+                "server_modified": "2026-04-01T00:00:00Z",
+            },
+        ],
+        "/docs": [{
+            ".tag": "file",
+            "id": "id:b",
+            "name": "b.bin",
+            "path_display": "/docs/b.bin",
+            "size": 3,
+            "server_modified": "2026-04-01T00:00:00Z",
+        }],
+    }
+
+    async def _list(_tm, path, **_kw):
+        return tree[path]
+
+    async def _download(_tm, path):
+        return contents[path]
+
+    accessor = make_accessor()
+    files: list[str] = []
+    with patch("mirage.core.dropbox.readdir.list_folder",
+               side_effect=_list), \
+         patch("mirage.core.dropbox.read.dropbox_download",
+               side_effect=_download):
+        stack = ["/"]
+        while stack:
+            current = stack.pop()
+            listing = await readdir(accessor, PathSpec.from_str_path(current),
+                                    index)
+            for child in listing:
+                trimmed = child.rstrip("/")
+                info = await stat(accessor, PathSpec.from_str_path(trimmed),
+                                  index)
+                if info.type == FileType.DIRECTORY:
+                    stack.append(trimmed)
+                    continue
+                assert info.size is not None, trimmed
+                body = await read(accessor, PathSpec.from_str_path(trimmed),
+                                  index)
+                assert info.size == len(body), trimmed
+                files.append(trimmed)
+    assert sorted(files) == ["/a.txt", "/docs/b.bin", "/empty.txt"]

--- a/python/tests/core/nextcloud/test_stat.py
+++ b/python/tests/core/nextcloud/test_stat.py
@@ -1,6 +1,7 @@
 import pytest
 
 from mirage.cache.index import RAMIndexCacheStore
+from mirage.core.nextcloud.read import read_bytes
 from mirage.core.nextcloud.readdir import readdir
 from mirage.core.nextcloud.stat import stat
 from mirage.types import FileType, PathSpec
@@ -47,3 +48,63 @@ async def test_stat_returns_modified_from_index(make_acc):
     assert s.modified == "2026-01-01T00:00:00+00:00"
     assert s.size == 5
     assert s.type != FileType.DIRECTORY
+
+
+@pytest.mark.asyncio
+async def test_readdir_backfills_lister_omitted_size(make_acc):
+    # When PROPFIND metadata is missing, readdir does one stat per affected
+    # file instead of caching an unknown size.
+    acc = make_acc({"a.txt": b"hello", "b.txt": b"abc"})
+    fake = acc._fake
+    real_list = fake.list
+
+    async def _stripped_list(path, **kw):
+        entries = await real_list(path, **kw)
+
+        async def _iter():
+            async for entry in entries:
+                if entry.path == "a.txt":
+                    entry.metadata = None
+                yield entry
+
+        return _iter()
+
+    acc.operator = lambda: fake
+    fake.list = _stripped_list
+    index = RAMIndexCacheStore()
+    await readdir(acc, PathSpec.from_str_path("/"), index)
+    entry = (await index.get("/a.txt")).entry
+    assert entry is not None
+    assert entry.size == 5
+    assert entry.remote_time != ""
+
+
+@pytest.mark.asyncio
+async def test_stat_size_matches_read_for_every_file(make_acc):
+    # The fskit invariant behind SIZES_ALWAYS_KNOWN: the size stat serves
+    # from the listing must equal the byte length a read delivers, 0-byte
+    # files included.
+    contents = {
+        "a.txt": b"hello",
+        "empty.txt": b"",
+        "docs/b.bin": b"abc",
+    }
+    acc = make_acc(contents)
+    index = RAMIndexCacheStore()
+    files: list[str] = []
+    stack = ["/"]
+    while stack:
+        current = stack.pop()
+        listing = await readdir(acc, PathSpec.from_str_path(current), index)
+        for child in listing:
+            trimmed = child.rstrip("/")
+            info = await stat(acc, PathSpec.from_str_path(trimmed), index)
+            if info.type == FileType.DIRECTORY:
+                stack.append(trimmed)
+                continue
+            assert info.size is not None, trimmed
+            body = await read_bytes(acc, PathSpec.from_str_path(trimmed),
+                                    index)
+            assert info.size == len(body), trimmed
+            files.append(trimmed)
+    assert sorted(files) == ["/a.txt", "/docs/b.bin", "/empty.txt"]

--- a/python/tests/core/onedrive/test_stat.py
+++ b/python/tests/core/onedrive/test_stat.py
@@ -3,6 +3,7 @@ from aioresponses import aioresponses
 
 from mirage.accessor.onedrive import OneDriveAccessor, OneDriveConfig
 from mirage.cache.index import RAMIndexCacheStore
+from mirage.core.onedrive.read import read_bytes
 from mirage.core.onedrive.readdir import readdir
 from mirage.core.onedrive.stat import stat
 from mirage.types import FileType, PathSpec
@@ -35,6 +36,11 @@ async def test_stat_root_is_directory():
     assert result.type == FileType.DIRECTORY
     assert result.name == "/"
     assert result.modified == "2026-05-01T10:00:00Z"
+    # The root's Graph `size` is the aggregate subtree storage number,
+    # never a content length: it belongs in extra, like any folder.
+    assert result.size is None
+    assert result.extra["size_bytes"] == 4096
+    assert result.extra["child_count"] == 2
 
 
 @pytest.mark.asyncio
@@ -120,6 +126,79 @@ async def test_stat_from_index_returns_modified():
     assert result.name == "notes.txt"
     assert result.size == 42
     assert result.modified == "2026-06-19T09:28:00Z"
+
+
+@pytest.mark.asyncio
+async def test_stat_size_matches_read_for_every_file():
+    # The fskit invariant behind SIZES_ALWAYS_KNOWN: the size stat reports
+    # from the listing must equal the byte length a read delivers, for
+    # every file in the tree, 0-byte files included.
+    contents = {
+        "/notes.txt": b"hello onedrive",
+        "/Docs/empty.bin": b"",
+        "/Docs/report.docx": b"docx bytes",
+    }
+    base = "https://graph.microsoft.com/v1.0/me/drive"
+    index = RAMIndexCacheStore()
+    accessor = _accessor()
+    with aioresponses() as m:
+        m.get(base + "/root/children",
+              payload={
+                  "value": [
+                      {
+                          "id": "1",
+                          "name": "notes.txt",
+                          "size": len(contents["/notes.txt"]),
+                          "file": {},
+                          "lastModifiedDateTime": "2026-06-19T09:28:00Z",
+                      },
+                      {
+                          "id": "2",
+                          "name": "Docs",
+                          "size": 9000,
+                          "folder": {
+                              "childCount": 2
+                          },
+                          "lastModifiedDateTime": "2026-06-19T09:28:00Z",
+                      },
+                  ]
+              })
+        m.get(base + "/root:/Docs:/children",
+              payload={
+                  "value": [{
+                      "id": "3",
+                      "name": "empty.bin",
+                      "size": 0,
+                      "file": {},
+                      "lastModifiedDateTime": "2026-06-19T09:28:00Z",
+                  }, {
+                      "id": "4",
+                      "name": "report.docx",
+                      "size": len(contents["/Docs/report.docx"]),
+                      "file": {},
+                      "lastModifiedDateTime": "2026-06-19T09:28:00Z",
+                  }]
+              })
+        for path, body in contents.items():
+            m.get(base + f"/root:{path}:/content", body=body)
+        files: list[str] = []
+        stack = ["/"]
+        while stack:
+            current = stack.pop()
+            listing = await readdir(accessor, PathSpec.from_str_path(current),
+                                    index)
+            for child in listing:
+                info = await stat(accessor, PathSpec.from_str_path(child),
+                                  index)
+                if info.type == FileType.DIRECTORY:
+                    stack.append(child)
+                else:
+                    assert info.size is not None, child
+                    files.append(child)
+                    body = await read_bytes(accessor,
+                                            PathSpec.from_str_path(child))
+                    assert info.size == len(body), child
+    assert sorted(files) == sorted(contents)
 
 
 @pytest.mark.asyncio

--- a/python/tests/core/ssh/test_readdir.py
+++ b/python/tests/core/ssh/test_readdir.py
@@ -1,0 +1,163 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from types import SimpleNamespace
+
+import asyncssh
+import pytest
+
+from mirage.accessor.ssh import SSHAccessor
+from mirage.cache.index.ram import RAMIndexCacheStore
+from mirage.core.ssh.config import SSHConfig
+from mirage.core.ssh.read import read_bytes
+from mirage.core.ssh.readdir import readdir
+from mirage.core.ssh.stat import stat
+from mirage.types import FileType, PathSpec
+
+_MTIME = 1_750_000_000
+
+
+class _FakeFile:
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self._pos = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return None
+
+    async def seek(self, offset: int) -> None:
+        self._pos = offset
+
+    async def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            out = self._data[self._pos:]
+        else:
+            out = self._data[self._pos:self._pos + size]
+        self._pos += len(out)
+        return out
+
+
+class _FakeSFTP:
+    """Just enough of asyncssh's SFTPClient for readdir/stat/read.
+
+    Args:
+        files (dict[str, bytes]): absolute remote path to content.
+        dirs (set[str]): absolute remote directory paths.
+    """
+
+    def __init__(self, files: dict[str, bytes], dirs: set[str]) -> None:
+        self.files = files
+        self.dirs = dirs
+
+    def _attrs(self, path: str) -> SimpleNamespace:
+        if path in self.dirs:
+            return SimpleNamespace(type=asyncssh.FILEXFER_TYPE_DIRECTORY,
+                                   size=4096,
+                                   mtime=_MTIME)
+        return SimpleNamespace(type=asyncssh.FILEXFER_TYPE_REGULAR,
+                               size=len(self.files[path]),
+                               mtime=_MTIME)
+
+    async def readdir(self, path: str):
+        base = path.rstrip("/") or "/"
+        if base not in self.dirs:
+            raise asyncssh.SFTPNoSuchFile("no such directory")
+        out = []
+        for child in sorted(self.files | {d: b"" for d in self.dirs}):
+            parent = child.rsplit("/", 1)[0] or "/"
+            if parent != base or child == base:
+                continue
+            leaf = child.rsplit("/", 1)[-1]
+            out.append(SimpleNamespace(filename=leaf,
+                                       attrs=self._attrs(child)))
+        return out
+
+    async def stat(self, path: str) -> SimpleNamespace:
+        key = path.rstrip("/") or "/"
+        if key not in self.dirs and key not in self.files:
+            raise asyncssh.SFTPNoSuchFile("no such file")
+        return self._attrs(key)
+
+    def open(self, path: str, mode: str) -> _FakeFile:
+        if path not in self.files:
+            raise asyncssh.SFTPNoSuchFile("no such file")
+        return _FakeFile(self.files[path])
+
+
+def _accessor(files: dict[str, bytes], dirs: set[str]) -> SSHAccessor:
+    accessor = SSHAccessor(SSHConfig(host="example.test"))
+    accessor._sftp = _FakeSFTP(files, dirs)
+    return accessor
+
+
+@pytest.fixture
+def index():
+    return RAMIndexCacheStore()
+
+
+@pytest.mark.asyncio
+async def test_readdir_stores_sftp_attrs_in_index(index):
+    accessor = _accessor(
+        {
+            "/a.txt": b"hello",
+            "/docs/b.bin": b"abc"
+        },
+        {"/", "/docs"},
+    )
+    listing = await readdir(accessor, PathSpec.from_str_path("/"), index)
+    assert listing == ["/a.txt", "/docs"]
+    entry = (await index.get("/a.txt")).entry
+    assert entry is not None
+    assert entry.resource_type == "file"
+    assert entry.size == 5
+    assert entry.remote_time != ""
+    folder = (await index.get("/docs")).entry
+    assert folder is not None
+    assert folder.resource_type == "folder"
+    assert folder.size is None
+
+
+@pytest.mark.asyncio
+async def test_stat_size_matches_read_for_every_file(index):
+    # The fskit invariant behind SIZES_ALWAYS_KNOWN: the size stat reports
+    # must equal the byte length a read delivers, 0-byte files included.
+    accessor = _accessor(
+        {
+            "/a.txt": b"hello",
+            "/empty.txt": b"",
+            "/docs/b.bin": b"abc"
+        },
+        {"/", "/docs"},
+    )
+    files: list[str] = []
+    stack = ["/"]
+    while stack:
+        current = stack.pop()
+        listing = await readdir(accessor, PathSpec.from_str_path(current),
+                                index)
+        for child in listing:
+            info = await stat(accessor, PathSpec.from_str_path(child), index)
+            if info.type == FileType.DIRECTORY:
+                stack.append(child)
+                continue
+            assert info.size is not None, child
+            body = await read_bytes(accessor, PathSpec.from_str_path(child),
+                                    index)
+            assert info.size == len(body), child
+            files.append(child)
+    assert sorted(files) == ["/a.txt", "/docs/b.bin", "/empty.txt"]

--- a/typescript/packages/browser/src/resource/box/box.ts
+++ b/typescript/packages/browser/src/resource/box/box.ts
@@ -44,6 +44,9 @@ export interface BoxResourceState {
 export class BoxResource implements Resource {
   readonly kind: string = ResourceName.BOX
   readonly cachesReads: boolean = true
+  // Box item listings carry an exact byte `size` for every file (0
+  // included); sizeless weblinks are filtered out of listings.
+  readonly sizesAlwaysKnown: boolean = true
   readonly indexTtl: number = 86_400
   readonly prompt: string = BOX_PROMPT
   readonly config: BoxConfig

--- a/typescript/packages/browser/src/resource/dropbox/dropbox.ts
+++ b/typescript/packages/browser/src/resource/dropbox/dropbox.ts
@@ -44,6 +44,9 @@ export interface DropboxResourceState {
 export class DropboxResource implements Resource {
   readonly kind: string = ResourceName.DROPBOX
   readonly cachesReads: boolean = true
+  // list_folder carries an exact byte `size` for every file (0 included).
+  // Paper docs 409 on raw download, a loud error, never a silent empty read.
+  readonly sizesAlwaysKnown: boolean = true
   readonly indexTtl: number = 86_400
   readonly prompt: string = DROPBOX_PROMPT
   readonly config: DropboxConfig

--- a/typescript/packages/core/src/core/box/readdir.test.ts
+++ b/typescript/packages/core/src/core/box/readdir.test.ts
@@ -102,4 +102,34 @@ describe('box readdir', () => {
     )
     expect(out).toEqual(['/box/a.txt'])
   })
+
+  it('indexes 0-byte files with size 0 and hides weblinks', async () => {
+    vi.mocked(api.listFolderItems).mockResolvedValue([
+      {
+        type: 'file' as const,
+        id: '444',
+        name: 'empty.txt',
+        size: 0,
+        modified_at: '2026-04-01T00:00:00Z',
+      },
+      {
+        type: 'web_link' as const,
+        id: '555',
+        name: 'homepage',
+        modified_at: '2026-04-01T00:00:00Z',
+      },
+    ])
+
+    const accessor = makeAccessor()
+    const index = new RAMIndexCacheStore()
+    const out = await readdir(
+      accessor,
+      new PathSpec({ resourcePath: '', virtual: '/', directory: '/' }),
+      index,
+    )
+    expect(out).toEqual(['/empty.txt'])
+    const entry = (await index.get('/empty.txt')).entry
+    expect(entry?.size).toBe(0)
+    expect((await index.get('/homepage')).entry ?? null).toBeNull()
+  })
 })

--- a/typescript/packages/core/src/core/box/readdir.ts
+++ b/typescript/packages/core/src/core/box/readdir.ts
@@ -75,16 +75,20 @@ export async function readdir(
   const items = await listFolderItems(accessor.tokenManager, folderId)
   const entries: { name: string; entry: IndexEntry; isDir: boolean }[] = []
   for (const it of items) {
+    if (it.type === 'web_link') {
+      // Weblinks are bookmarks: no content endpoint, no size. Hide them
+      // from listings instead of serving an unreadable entry.
+      continue
+    }
     const isDir = it.type === 'folder'
     const filename = it.name
-    const sizeNum = typeof it.size === 'number' ? it.size : null
     const entry = new IndexEntry({
       id: it.id,
       name: filename,
       resourceType: resourceTypeFor(it),
       remoteTime: it.modified_at ?? '',
       vfsName: filename,
-      size: !isDir && sizeNum !== null && sizeNum > 0 ? sizeNum : null,
+      size: isDir ? null : typeof it.size === 'number' ? it.size : null,
     })
     entries.push({ name: filename, entry, isDir })
   }

--- a/typescript/packages/core/src/core/box/stat.ts
+++ b/typescript/packages/core/src/core/box/stat.ts
@@ -83,7 +83,9 @@ export async function stat(
     // The write-family builders and provision estimation call stat without a
     // threaded index; resolve the id directly rather than ENOENT.
     const item = await resolveItem(accessor, pathParts(path))
-    if (item === null) throw enoent(path.virtual)
+    // Weblinks are hidden from listings; a direct lookup must not
+    // resurface a sizeless, unreadable entry.
+    if (item === null || item.type === 'web_link') throw enoent(path.virtual)
     return statFromItem(item)
   }
   const virtualKey = prefix !== '' ? `${prefix}/${key}` : `/${key}`
@@ -109,7 +111,7 @@ export async function stat(
     result = await index.get(virtualKey)
     if (result.entry === undefined || result.entry === null) {
       const item = await resolveItem(accessor, pathParts(path))
-      if (item === null) throw enoent(path.virtual)
+      if (item === null || item.type === 'web_link') throw enoent(path.virtual)
       return statFromItem(item)
     }
   }

--- a/typescript/packages/core/src/core/box/stat.ts
+++ b/typescript/packages/core/src/core/box/stat.ts
@@ -47,7 +47,7 @@ function statFromItem(item: BoxItem): FileStat {
       extra: { box_id: item.id },
     })
   }
-  const size = typeof item.size === 'number' && item.size > 0 ? item.size : null
+  const size = typeof item.size === 'number' ? item.size : null
   return new FileStat({
     name: vfsName,
     size,

--- a/typescript/packages/core/src/core/dropbox/readdir.test.ts
+++ b/typescript/packages/core/src/core/dropbox/readdir.test.ts
@@ -150,4 +150,28 @@ describe('dropbox readdir', () => {
     )
     expect(out).toEqual(['/dropbox/a.txt'])
   })
+
+  it('indexes 0-byte files with size 0', async () => {
+    vi.mocked(api.listFolder).mockResolvedValue([
+      {
+        '.tag': 'file',
+        id: 'id:empty',
+        name: 'empty.txt',
+        path_display: '/empty.txt',
+        size: 0,
+        server_modified: '2026-04-01T00:00:00Z',
+      },
+    ])
+
+    const accessor = makeAccessor()
+    const index = new RAMIndexCacheStore()
+    const out = await readdir(
+      accessor,
+      new PathSpec({ resourcePath: '', virtual: '/', directory: '/' }),
+      index,
+    )
+    expect(out).toEqual(['/empty.txt'])
+    const entry = (await index.get('/empty.txt')).entry
+    expect(entry?.size).toBe(0)
+  })
 })

--- a/typescript/packages/core/src/core/dropbox/readdir.ts
+++ b/typescript/packages/core/src/core/dropbox/readdir.ts
@@ -71,7 +71,7 @@ export async function readdir(
       resourceType: resourceTypeFor(f),
       remoteTime: modified,
       vfsName: filename,
-      size: !isDir && size !== null && size > 0 ? size : null,
+      size: !isDir ? size : null,
     })
     entries.push({ name: filename, entry, isDir })
   }

--- a/typescript/packages/core/src/core/dropbox/stat.ts
+++ b/typescript/packages/core/src/core/dropbox/stat.ts
@@ -49,7 +49,7 @@ function statFromEntry(entry: DropboxEntry): FileStat {
   }
   return new FileStat({
     name: entry.name,
-    size: typeof entry.size === 'number' && entry.size > 0 ? entry.size : null,
+    size: typeof entry.size === 'number' ? entry.size : null,
     type: guessType(entry.name),
     modified,
     fingerprint: modified !== '' ? modified : null,

--- a/typescript/packages/core/src/core/msgraph/drive.ts
+++ b/typescript/packages/core/src/core/msgraph/drive.ts
@@ -104,7 +104,7 @@ function asString(value: unknown): string | null {
   return typeof value === 'string' ? value : null
 }
 
-function asNumber(value: unknown): number | null {
+export function asNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
@@ -114,7 +114,7 @@ function isFolder(item: Record<string, unknown>): boolean {
 
 // Graph returns the folder facet's childCount by default, so `-empty` needs
 // no extra request. Absent (a $select that dropped it) reads as unknown.
-function folderChildCount(item: Record<string, unknown>): number | null {
+export function folderChildCount(item: Record<string, unknown>): number | null {
   const facet = item.folder
   if (facet === null || typeof facet !== 'object' || Array.isArray(facet)) return null
   return asNumber((facet as Record<string, unknown>).childCount)

--- a/typescript/packages/core/src/core/onedrive/index.ts
+++ b/typescript/packages/core/src/core/onedrive/index.ts
@@ -27,11 +27,13 @@ import { enoent } from '../../utils/errors.ts'
 import { mountPrefixOf } from '../../utils/key_prefix.ts'
 import { GraphError, graphDelete, graphGet, graphList } from '../msgraph/client.ts'
 import {
+  asNumber,
   copyTree,
   createChildFolder,
   duTreeEntries,
   duTreeTotal,
   findItems,
+  folderChildCount,
   readItem,
   readdirItems,
   renameReplace,
@@ -124,11 +126,14 @@ export async function stat(
   if (path.resourcePath === '') {
     try {
       const item = await graphGet(accessor.config, accessor.loc('').item())
+      // The root's `size` is Graph's aggregate subtree storage number, not
+      // rendered content length: expose it as extra, like every other
+      // folder (see entryStat).
       return new FileStat({
         name: '/',
         type: FileType.DIRECTORY,
-        size: typeof item.size === 'number' ? item.size : null,
         modified: typeof item.lastModifiedDateTime === 'string' ? item.lastModifiedDateTime : null,
+        extra: { size_bytes: asNumber(item.size), child_count: folderChildCount(item) },
       })
     } catch (error) {
       if (error instanceof GraphError && error.status === 404) throw enoent(path)

--- a/typescript/packages/core/src/core/onedrive/onedrive.test.ts
+++ b/typescript/packages/core/src/core/onedrive/onedrive.test.ts
@@ -124,6 +124,29 @@ describe('OneDrive filesystem operations', () => {
     expect(info.extra).toMatchObject({ size_bytes: 4096, child_count: 2 })
   })
 
+  it('keeps the root aggregate size out of FileStat.size', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: 'root',
+            name: 'root',
+            size: 123456,
+            lastModifiedDateTime: '2026-01-01T00:00:00Z',
+            folder: { childCount: 3 },
+          }),
+          { status: 200 },
+        ),
+      ),
+    )
+    const accessor = new OneDriveAccessor({ accessToken: 'token' })
+    const info = await stat(accessor, PathSpec.fromStrPath('/'))
+
+    expect(info.size).toBeNull()
+    expect(info.extra).toMatchObject({ size_bytes: 123456, child_count: 3 })
+  })
+
   it('matches -empty against a childless folder', async () => {
     const fetchMock = vi.fn((input: URL | RequestInfo) => {
       const url = requestUrl(input)

--- a/typescript/packages/core/src/resource/onedrive/onedrive.ts
+++ b/typescript/packages/core/src/resource/onedrive/onedrive.ts
@@ -19,6 +19,10 @@ const resolveGlob = makeResolveGlob(readdir)
 export class OneDriveResource extends BaseResource implements Resource {
   readonly kind: string = ResourceName.ONEDRIVE
   readonly cachesReads: boolean = true
+  // Graph driveItems carry an exact byte `size` for every file in both
+  // listings and item gets; folders (including the root) report null with
+  // the aggregate storage number in extra.
+  readonly sizesAlwaysKnown: boolean = true
   readonly supportsSnapshot: boolean = true
   override readonly indexTtl: number = 86_400
   readonly prompt: string = ONEDRIVE_PROMPT

--- a/typescript/packages/node/src/core/nextcloud/readdir.test.ts
+++ b/typescript/packages/node/src/core/nextcloud/readdir.test.ts
@@ -1,0 +1,52 @@
+import { PathSpec, RAMIndexCacheStore } from '@struktoai/mirage-core'
+import { describe, expect, it } from 'vitest'
+import { NextcloudAccessor } from '../../accessor/nextcloud.ts'
+import { FakeNextcloudOperator, installFakeOperator } from './mock.ts'
+import { readdir } from './readdir.ts'
+
+function accessorWith(fake: FakeNextcloudOperator): NextcloudAccessor {
+  const accessor = new NextcloudAccessor({
+    url: 'https://cloud.example/remote.php/dav/files/user/',
+  })
+  installFakeOperator(accessor, fake)
+  return accessor
+}
+
+describe('nextcloud readdir', () => {
+  it('indexes listing sizes, 0-byte files included', async () => {
+    const accessor = accessorWith(
+      new FakeNextcloudOperator({ 'a.txt': 'hello', 'empty.txt': '' }),
+    )
+    const index = new RAMIndexCacheStore()
+    const out = await readdir(accessor, PathSpec.fromStrPath('/'), index)
+    expect(out).toEqual(['/a.txt', '/empty.txt'])
+    expect((await index.get('/a.txt')).entry?.size).toBe(5)
+    expect((await index.get('/empty.txt')).entry?.size).toBe(0)
+  })
+
+  it('backfills a lister-omitted size with one stat', async () => {
+    const fake = new FakeNextcloudOperator({ 'a.txt': 'hello' })
+    const realList = fake.list.bind(fake)
+    fake.list = async (path, options) => {
+      const entries = await realList(path, options)
+      return entries.map((entry) =>
+        entry.path() === 'a.txt'
+          ? {
+              path: entry.path,
+              metadata: () => ({
+                isDirectory: () => false,
+                isFile: () => true,
+                contentLength: null,
+                etag: null,
+                lastModified: null,
+              }),
+            }
+          : entry,
+      )
+    }
+    const accessor = accessorWith(fake)
+    const index = new RAMIndexCacheStore()
+    await readdir(accessor, PathSpec.fromStrPath('/'), index)
+    expect((await index.get('/a.txt')).entry?.size).toBe(5)
+  })
+})

--- a/typescript/packages/node/src/core/nextcloud/readdir.test.ts
+++ b/typescript/packages/node/src/core/nextcloud/readdir.test.ts
@@ -14,9 +14,7 @@ function accessorWith(fake: FakeNextcloudOperator): NextcloudAccessor {
 
 describe('nextcloud readdir', () => {
   it('indexes listing sizes, 0-byte files included', async () => {
-    const accessor = accessorWith(
-      new FakeNextcloudOperator({ 'a.txt': 'hello', 'empty.txt': '' }),
-    )
+    const accessor = accessorWith(new FakeNextcloudOperator({ 'a.txt': 'hello', 'empty.txt': '' }))
     const index = new RAMIndexCacheStore()
     const out = await readdir(accessor, PathSpec.fromStrPath('/'), index)
     expect(out).toEqual(['/a.txt', '/empty.txt'])

--- a/typescript/packages/node/src/core/nextcloud/readdir.ts
+++ b/typescript/packages/node/src/core/nextcloud/readdir.ts
@@ -55,6 +55,15 @@ export async function readdir(
       modified: info.lastModified ?? '',
     })
   }
+  // PROPFIND normally carries getcontentlength for every file; when the
+  // lister omits the metadata, one stat per affected file fills the gap so
+  // the index never caches an unknown size.
+  for (const [key, info] of metadata) {
+    if (directories.has(key) || info.size !== null) continue
+    const md = await op.stat(stripSlash(key))
+    info.size = md.contentLength !== null ? Number(md.contentLength) : null
+    if (info.modified === '' && md.lastModified !== null) info.modified = md.lastModified
+  }
   const targetKey = `/${stripSlash(target)}`
   if (names.length === 1 && names[0] === targetKey && !directories.has(targetKey)) {
     throw enotdir(path)

--- a/typescript/packages/node/src/core/ssh/stat.ts
+++ b/typescript/packages/node/src/core/ssh/stat.ts
@@ -24,7 +24,9 @@ export async function stat(accessor: SSHAccessor, p: PathSpec): Promise<FileStat
   const virtual = stripPrefix(p)
   const remote = joinRoot(accessor.config.root ?? '/', virtual)
   const attrs = await new Promise<Stats>((resolveFn, rejectFn) => {
-    sftp.lstat(remote, (err, stats) => {
+    // Follow symlinks (stat, not lstat), like the Python core: reads
+    // follow the link, so the reported size must be the target's.
+    sftp.stat(remote, (err, stats) => {
       if (err !== undefined) {
         if (isNoSuchFile(err)) rejectFn(enoent(p))
         else rejectFn(err)

--- a/typescript/packages/node/src/resource/box/box.ts
+++ b/typescript/packages/node/src/resource/box/box.ts
@@ -44,6 +44,9 @@ export interface BoxResourceState {
 export class BoxResource extends BaseResource implements Resource {
   readonly kind: string = ResourceName.BOX
   readonly cachesReads: boolean = true
+  // Box item listings carry an exact byte `size` for every file (0
+  // included); sizeless weblinks are filtered out of listings.
+  readonly sizesAlwaysKnown: boolean = true
   override readonly indexTtl: number = 86_400
   readonly prompt: string = BOX_PROMPT
   readonly config: BoxConfig

--- a/typescript/packages/node/src/resource/dropbox/dropbox.ts
+++ b/typescript/packages/node/src/resource/dropbox/dropbox.ts
@@ -44,6 +44,9 @@ export interface DropboxResourceState {
 export class DropboxResource extends BaseResource implements Resource {
   readonly kind: string = ResourceName.DROPBOX
   readonly cachesReads: boolean = true
+  // list_folder carries an exact byte `size` for every file (0 included).
+  // Paper docs 409 on raw download, a loud error, never a silent empty read.
+  readonly sizesAlwaysKnown: boolean = true
   override readonly indexTtl: number = 86_400
   readonly prompt: string = DROPBOX_PROMPT
   readonly config: DropboxConfig

--- a/typescript/packages/node/src/resource/nextcloud/nextcloud.ts
+++ b/typescript/packages/node/src/resource/nextcloud/nextcloud.ts
@@ -50,6 +50,9 @@ export interface NextcloudResourceState {
 export class NextcloudResource extends BaseResource implements Resource {
   readonly kind = ResourceName.NEXTCLOUD
   readonly cachesReads = true
+  // WebDAV PROPFIND carries getcontentlength for every file; readdir
+  // backfills any lister-omitted size with one stat per affected file.
+  readonly sizesAlwaysKnown: boolean = true
   readonly supportsSnapshot = true
   readonly prompt = NEXTCLOUD_PROMPT
   readonly accessor: NextcloudAccessor

--- a/typescript/packages/node/src/resource/ssh/ssh.ts
+++ b/typescript/packages/node/src/resource/ssh/ssh.ts
@@ -59,6 +59,9 @@ export interface SSHResourceState {
 export class SSHResource extends BaseResource implements Resource {
   readonly kind = ResourceName.SSH
   readonly cachesReads: boolean = true
+  // SFTP stat/readdir report the remote inode's exact byte size for every
+  // file; reads are the same raw bytes.
+  readonly sizesAlwaysKnown: boolean = true
   override readonly indexTtl: number = 60
   readonly prompt = SSH_PROMPT
   readonly config: SSHConfig


### PR DESCRIPTION
Stat/readdir size correctness for five backends, in both languages. These are general metadata bugs (wrong or missing sizes visible to `ls -l`, `find -size`, `du`, `wc -c`, and any stat consumer); with them fixed, each backend flips `SIZES_ALWAYS_KNOWN` / `sizesAlwaysKnown`, which is step 2 of the fskit size push-down rollout (fskit is the consumer where a wrong size turns into silently empty reads).

- **onedrive**: root stat reported Graph's aggregate subtree size as `FileStat.size`; now `None` with the aggregate in `extra.size_bytes`, like every other folder.
- **box**: falsy `if size` made 0-byte files size-unknown; fixed. Sizeless weblinks (bookmarks, no content endpoint) are filtered from listings, and the direct `resolve_item` stat fallback ENOENTs them too.
- **dropbox**: same falsy-zero fix in readdir and stat.
- **ssh**: readdir keeps the SFTP attrs it already receives (type, size, mtime) in the index; TS stat now follows symlinks (stat, not lstat) so a link reports the target's size, matching Python and the read path; Python rm now uses lstat so it unlinks symlinks instead of following them (matching TS and GNU rm).
- **nextcloud**: readdir backfills a lister-omitted `getcontentlength` with one stat per affected file.

Tests:
- Per-backend invariant unit tests: for every listed file, `stat().size == len(read())`, 0-byte files included (mirrors the Linear reference test from #656).
- Shared integ battery (`integ/resources/sizes/stat_read.json`, both hosts): `stat -c %s` vs `cat | wc -c` for plain, empty and nested files across s3, box, dropbox, dropbox-root, onedrive, sharepoint, ssh and nextcloud; a server-side symlink on a new ssh `/links` mount pins stat-follows-target (46, not the 16-byte link text); a seeded Box weblink pins hidden-from-listings and ENOENT-on-direct-stat. The fake Box server gained `POST /2.0/web_links`.
- Ran locally: python battery green for all affected targets, TS battery green for ssh, box, dropbox and onedrive against the same fakes CI uses; scoped vitest and pytest suites green; pre-commit incl. mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)