### PR TITLE
fix(jq): preserve output arity instead of guessing it from the program

### DIFF
--- a/docs/home/bash.mdx
+++ b/docs/home/bash.mdx
@@ -134,9 +134,19 @@ Because evaluation is per document, commands that emit newline-delimited
 JSON (such as [paginated `gws` list calls](/python/resource/gdrive#pagination))
 pipe straight into `jq` with no reshaping.
 
-Output arity follows the program, not the input: a program that collects
-into an array (`[.a[] | .t]`) prints one array, and only a top-level
-iterator (`.a[]`) prints one line per element.
+Output arity follows the program, not the input. A jq program emits a
+stream of values and each one prints on its own line, so `.a[]`, `.a, .b`
+and `range(3)` all print several lines, while a program that collects
+into an array (`[.a[] | .t]`) emits one value and prints one line.
+
+```bash
+jq -c '.name, .age' /data/user.json
+"alice"
+30
+
+jq -c '[.name, .age]' /data/user.json
+["alice",30]
+```
 
 ## Supported bash syntax
 

--- a/integ/unix/jq/comma.json
+++ b/integ/unix/jq/comma.json
@@ -1,0 +1,446 @@
+{
+  "cases": [
+    {
+      "id": "jq_comma_two_outputs",
+      "seq": 700000,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "jq -c \".name, .age\" /data/user.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "\"alice\"\n30\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c"
+      ]
+    },
+    {
+      "id": "jq_comma_raw",
+      "seq": 700001,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "jq -r \".name, .age\" /data/user.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "alice\n30\n",
+        "stderr": ""
+      },
+      "flags": [
+        "r"
+      ]
+    },
+    {
+      "id": "jq_comma_pretty_prints_each_output",
+      "seq": 700002,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "jq \".users[0], .users[1]\" /data/users.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "{\n  \"name\": \"alice\",\n  \"age\": 30\n}\n{\n  \"name\": \"bob\",\n  \"age\": 25\n}\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "jq_comma_keeps_each_array_whole",
+      "seq": 700003,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "jq -c \"[.name], [.age]\" /data/user.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "[\"alice\"]\n[30]\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c"
+      ]
+    },
+    {
+      "id": "jq_collector_is_one_output",
+      "seq": 700004,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "jq -c \"[.name, .age]\" /data/user.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "[\"alice\",30]\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c"
+      ]
+    },
+    {
+      "id": "jq_comma_per_document",
+      "seq": 700005,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "jq -c \".id, .id\" /data/data.jsonl",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n1\n2\n2\n3\n3\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c"
+      ]
+    },
+    {
+      "id": "jq_comma_slurped",
+      "seq": 700006,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "jq -c -s \".[0].id, .[2].id\" /data/data.jsonl",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n3\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c",
+        "s"
+      ]
+    },
+    {
+      "id": "jq_range_is_many_outputs",
+      "seq": 700007,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "jq -c \"range(3)\" /data/user.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "0\n1\n2\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c"
+      ]
+    },
+    {
+      "id": "jq_recurse_is_many_outputs",
+      "seq": 700008,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "jq -c \"..\" /data/user.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "{\"name\":\"alice\",\"age\":30}\n\"alice\"\n30\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c"
+      ]
+    },
+    {
+      "id": "jq_comma_counts_as_lines",
+      "seq": 700009,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "jq -r \".name, .age\" /data/user.json | wc -l",
+      "expect": {
+        "exit": 0,
+        "stdout": "2\n",
+        "stderr": ""
+      },
+      "flags": [
+        "r"
+      ]
+    },
+    {
+      "id": "jq_comma_from_stdin",
+      "seq": 700010,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "cat /data/user.json | jq -c \".name, .age\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "\"alice\"\n30\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c"
+      ]
+    },
+    {
+      "id": "jq_comma_over_jsonl_stream",
+      "seq": 700011,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "jq -c \".[] | .id, .id\" /data/data.jsonl",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n1\n2\n2\n3\n3\n",
+        "stderr": ""
+      },
+      "flags": [
+        "c"
+      ]
+    }
+  ]
+}

--- a/python/mirage/commands/builtin/generic/jq.py
+++ b/python/mirage/commands/builtin/generic/jq.py
@@ -1,7 +1,6 @@
 from collections.abc import AsyncIterator, Awaitable, Callable
 
-from mirage.core.jq import (eval_jsonl_stream, format_jq_output,
-                            has_top_level_spread, is_jsonl_path,
+from mirage.core.jq import (eval_jsonl_stream, format_jq_output, is_jsonl_path,
                             is_streamable_jsonl_expr, jq_eval, parse_json_docs)
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
@@ -30,10 +29,6 @@ async def jq(
 ) -> tuple[ByteSource | None, IOResult]:
     # GNU jq defaults the filter to "." when no expression is given
     expression = texts[0] if texts else "."
-    # Must match the arity rule jq_eval used: a nested `[]` inside a
-    # collector still yields one output, so a substring test would
-    # explode a single array one element per line.
-    spread = has_top_level_spread(expression)
     if paths:
         if is_jsonl_path(
                 paths[0].virtual) and is_streamable_jsonl_expr(expression):
@@ -43,15 +38,15 @@ async def jq(
         for p in paths:
             docs = parse_json_docs(await read_bytes(p))
             if s:
-                result = jq_eval(docs, expression.strip())
-                outputs.append(format_jq_output(result, r, c, spread))
+                values = jq_eval(docs, expression.strip())
+                outputs.append(format_jq_output(values, r, c))
                 continue
             # jq applies the program to every document in the stream, so
             # a multi-value file evaluates per document whatever it is
             # named; only slurp collapses the stream into one array.
             for doc in docs:
-                result = jq_eval(doc, expression.strip())
-                outputs.append(format_jq_output(result, r, c, spread))
+                values = jq_eval(doc, expression.strip())
+                outputs.append(format_jq_output(values, r, c))
         return b"".join(outputs), IOResult()
     if stdin is None:
         # GNU jq: empty input -> no output, exit 0 (jq . </dev/null)
@@ -59,14 +54,14 @@ async def jq(
     raw_bytes = await _read_stdin_bytes(stdin)
     docs = parse_json_docs(raw_bytes)
     if s:
-        result = jq_eval(docs, expression.strip())
-        return format_jq_output(result, r, c, spread), IOResult()
+        values = jq_eval(docs, expression.strip())
+        return format_jq_output(values, r, c), IOResult()
     # Same stream rule as the path branch: piped input is a stream of
     # values, so each document is evaluated on its own.
     stdin_out: list[bytes] = []
     for doc in docs:
-        result = jq_eval(doc, expression.strip())
-        stdin_out.append(format_jq_output(result, r, c, spread))
+        values = jq_eval(doc, expression.strip())
+        stdin_out.append(format_jq_output(values, r, c))
     return b"".join(stdin_out), IOResult()
 
 

--- a/python/mirage/core/jq/__init__.py
+++ b/python/mirage/core/jq/__init__.py
@@ -12,18 +12,16 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.core.jq.eval import has_top_level_spread, jq_eval
-from mirage.core.jq.format import JQ_EMPTY, format_jq_output
+from mirage.core.jq.eval import jq_eval
+from mirage.core.jq.format import format_jq_output
 from mirage.core.jq.stream import (eval_jsonl_stream, is_jsonl_path,
                                    is_streamable_jsonl_expr, parse_json_auto,
                                    parse_json_docs, parse_json_path,
                                    parse_jsonl)
 
 __all__ = [
-    "JQ_EMPTY",
     "eval_jsonl_stream",
     "format_jq_output",
-    "has_top_level_spread",
     "is_jsonl_path",
     "is_streamable_jsonl_expr",
     "jq_eval",

--- a/python/mirage/core/jq/eval.py
+++ b/python/mirage/core/jq/eval.py
@@ -14,61 +14,24 @@
 
 import jq as _libjq
 
-from mirage.core.jq.format import JQ_EMPTY
 
-
-def has_top_level_spread(expr: str) -> bool:
-    """Report whether a jq program spreads its input at the top level.
-
-    A top-level ``[]`` means the program emits one output per element,
-    so the caller must print each on its own line. A ``[]`` nested
-    inside a collector (``[.a[] | .b]``) does not: that program emits a
-    single array. Strings are skipped so a literal "[]" never counts.
-
-    Args:
-        expr (str): jq program text.
-    """
-    depth = 0
-    in_str = False
-    i = 0
-    while i < len(expr):
-        ch = expr[i]
-        if ch == '"' and (i == 0 or expr[i - 1] != "\\"):
-            in_str = not in_str
-            i += 1
-            continue
-        if in_str:
-            i += 1
-            continue
-        if (depth == 0 and ch == "[" and i + 1 < len(expr)
-                and expr[i + 1] == "]"):
-            return True
-        if ch in ("(", "[", "{"):
-            depth += 1
-        elif ch in (")", "]", "}"):
-            depth -= 1
-        i += 1
-    return False
-
-
-def jq_eval(obj: object, expr: str) -> object:
+def jq_eval(obj: object, expr: str) -> list[object]:
     """Evaluate a jq expression against obj using libjq.
+
+    A jq program is a stream transformer: it emits zero, one or many
+    values, and jq prints each on its own line. That arity is preserved
+    here rather than collapsed, so two outputs are never confused with
+    one output that happens to be an array. `.a, .b` yields two values;
+    `[.a, .b]` yields one.
 
     Args:
         obj (object): JSON-like input value (dict / list / scalar).
         expr (str): jq program text.
 
     Returns:
-        object: single value when the program produces one output,
-            list of values when it produces more than one,
-            JQ_EMPTY sentinel when the program produces zero outputs.
-            Callers must check `result is JQ_EMPTY` and treat that
-            as "no output" (real jq exits 0 with empty stdout).
+        list[object]: every output value, in order. Empty when the
+            program produces no output at all, which real jq reports as
+            exit 0 with empty stdout.
     """
     program = _libjq.compile(expr)
-    outputs = list(program.input_value(obj))
-    if not outputs:
-        return JQ_EMPTY
-    if len(outputs) == 1 and not has_top_level_spread(expr):
-        return outputs[0]
-    return outputs
+    return list(program.input_value(obj))

--- a/python/mirage/core/jq/format.py
+++ b/python/mirage/core/jq/format.py
@@ -14,8 +14,6 @@
 
 import orjson
 
-JQ_EMPTY: object = object()
-
 
 def _format_one(value: object, raw: bool, compact: bool) -> bytes:
     if raw and isinstance(value, str):
@@ -26,16 +24,18 @@ def _format_one(value: object, raw: bool, compact: bool) -> bytes:
 
 
 def format_jq_output(
-    result: object,
+    outputs: list[object],
     raw: bool,
     compact: bool,
-    spread: bool,
 ) -> bytes:
-    if result is JQ_EMPTY:
-        return b""
-    if spread and isinstance(result, list):
-        parts: list[bytes] = []
-        for item in result:
-            parts.append(_format_one(item, raw, compact))
-        return b"".join(parts)
-    return _format_one(result, raw, compact)
+    """Render every output of a jq program, one per line.
+
+    Args:
+        outputs (list[object]): values the program emitted, in order.
+        raw (bool): -r, print string outputs unquoted.
+        compact (bool): -c, print one line of JSON instead of indenting.
+    """
+    parts: list[bytes] = []
+    for value in outputs:
+        parts.append(_format_one(value, raw, compact))
+    return b"".join(parts)

--- a/python/mirage/core/jq/stream.py
+++ b/python/mirage/core/jq/stream.py
@@ -19,7 +19,6 @@ from typing import Any
 import orjson
 
 from mirage.core.jq.eval import jq_eval
-from mirage.core.jq.format import JQ_EMPTY
 from mirage.io.async_line_iterator import AsyncLineIterator
 
 
@@ -111,10 +110,8 @@ async def eval_jsonl_stream(
         if not text:
             continue
         obj = orjson.loads(text)
-        result = jq_eval(obj, per_item)
-        if result is JQ_EMPTY:
-            continue
-        if raw and isinstance(result, str):
-            yield result.encode("utf-8") + b"\n"
-        else:
-            yield orjson.dumps(result) + b"\n"
+        for value in jq_eval(obj, per_item):
+            if raw and isinstance(value, str):
+                yield value.encode("utf-8") + b"\n"
+            else:
+                yield orjson.dumps(value) + b"\n"

--- a/python/tests/commands/builtin/jq/conftest.py
+++ b/python/tests/commands/builtin/jq/conftest.py
@@ -30,10 +30,32 @@ def write_to_backend(backend, path, data):
     store.files[_norm(path)] = data
 
 
-def jq(backend, path, expression):
+def eval_one(obj: object, expr: str) -> object:
+    """Evaluate expr and return its single output.
+
+    jq_eval is arity-preserving, so a program that emits one value still
+    comes back as a one-element list. Tests of single-valued programs go
+    through here, which asserts the arity instead of assuming it.
+
+    Args:
+        obj (object): JSON-like input value.
+        expr (str): jq program text.
+    """
+    outputs = jq_eval(obj, expr.strip())
+    assert len(outputs) == 1
+    return outputs[0]
+
+
+def jq_all(backend, path, expression):
     store = backend.accessor.store
     data = parse_json_path(store.files[_norm(path)], path)
     return jq_eval(data, expression.strip())
+
+
+def jq(backend, path, expression):
+    outputs = jq_all(backend, path, expression)
+    assert len(outputs) == 1
+    return outputs[0]
 
 
 def mem_ws(files: dict[str, bytes] | None = None) -> Workspace:

--- a/python/tests/commands/builtin/jq/test_builtins.py
+++ b/python/tests/commands/builtin/jq/test_builtins.py
@@ -14,245 +14,247 @@
 
 import pytest
 
-from mirage.core.jq import JQ_EMPTY, jq_eval
+from mirage.core.jq import jq_eval
+
+from .conftest import eval_one
 
 
 class TestJqType:
 
     def test_type_object(self):
-        assert jq_eval({"a": 1}, "type") == "object"
+        assert eval_one({"a": 1}, "type") == "object"
 
     def test_type_array(self):
-        assert jq_eval([1, 2], "type") == "array"
+        assert eval_one([1, 2], "type") == "array"
 
     def test_type_string(self):
-        assert jq_eval("hello", "type") == "string"
+        assert eval_one("hello", "type") == "string"
 
     def test_type_number_int(self):
-        assert jq_eval(42, "type") == "number"
+        assert eval_one(42, "type") == "number"
 
     def test_type_number_float(self):
-        assert jq_eval(3.14, "type") == "number"
+        assert eval_one(3.14, "type") == "number"
 
     def test_type_boolean(self):
-        assert jq_eval(True, "type") == "boolean"
+        assert eval_one(True, "type") == "boolean"
 
     def test_type_null(self):
-        assert jq_eval(None, "type") == "null"
+        assert eval_one(None, "type") == "null"
 
 
 class TestJqFlatten:
 
     def test_flatten_nested(self):
-        assert jq_eval([[1, 2], [3, 4]], "flatten") == [1, 2, 3, 4]
+        assert eval_one([[1, 2], [3, 4]], "flatten") == [1, 2, 3, 4]
 
     def test_flatten_mixed(self):
-        assert jq_eval([[1], 2, [3, 4]], "flatten") == [1, 2, 3, 4]
+        assert eval_one([[1], 2, [3, 4]], "flatten") == [1, 2, 3, 4]
 
     def test_flatten_already_flat(self):
-        assert jq_eval([1, 2, 3], "flatten") == [1, 2, 3]
+        assert eval_one([1, 2, 3], "flatten") == [1, 2, 3]
 
     def test_flatten_empty(self):
-        assert jq_eval([], "flatten") == []
+        assert eval_one([], "flatten") == []
 
     def test_flatten_non_list_raises(self):
         with pytest.raises(ValueError):
-            jq_eval("hello", "flatten")
+            eval_one("hello", "flatten")
 
 
 class TestJqUnique:
 
     def test_unique_with_duplicates(self):
-        assert jq_eval([1, 2, 2, 3, 1], "unique") == [1, 2, 3]
+        assert eval_one([1, 2, 2, 3, 1], "unique") == [1, 2, 3]
 
     def test_unique_already_unique(self):
-        assert jq_eval([1, 2, 3], "unique") == [1, 2, 3]
+        assert eval_one([1, 2, 3], "unique") == [1, 2, 3]
 
     def test_unique_empty(self):
-        assert jq_eval([], "unique") == []
+        assert eval_one([], "unique") == []
 
     def test_unique_strings(self):
-        assert jq_eval(["a", "b", "a"], "unique") == ["a", "b"]
+        assert eval_one(["a", "b", "a"], "unique") == ["a", "b"]
 
     def test_unique_non_list_raises(self):
         with pytest.raises(ValueError):
-            jq_eval("hello", "unique")
+            eval_one("hello", "unique")
 
 
 class TestJqSort:
 
     def test_sort_numbers(self):
-        assert jq_eval([3, 1, 2], "sort") == [1, 2, 3]
+        assert eval_one([3, 1, 2], "sort") == [1, 2, 3]
 
     def test_sort_strings(self):
-        assert jq_eval(["c", "a", "b"], "sort") == ["a", "b", "c"]
+        assert eval_one(["c", "a", "b"], "sort") == ["a", "b", "c"]
 
     def test_sort_already_sorted(self):
-        assert jq_eval([1, 2, 3], "sort") == [1, 2, 3]
+        assert eval_one([1, 2, 3], "sort") == [1, 2, 3]
 
     def test_sort_empty(self):
-        assert jq_eval([], "sort") == []
+        assert eval_one([], "sort") == []
 
     def test_sort_non_list_raises(self):
         with pytest.raises(ValueError):
-            jq_eval("hello", "sort")
+            eval_one("hello", "sort")
 
 
 class TestJqReverse:
 
     def test_reverse_list(self):
-        assert jq_eval([1, 2, 3], "reverse") == [3, 2, 1]
+        assert eval_one([1, 2, 3], "reverse") == [3, 2, 1]
 
     def test_reverse_string_raises(self):
         with pytest.raises(ValueError):
-            jq_eval("hello", "reverse")
+            eval_one("hello", "reverse")
 
     def test_reverse_empty_list(self):
-        assert jq_eval([], "reverse") == []
+        assert eval_one([], "reverse") == []
 
     def test_reverse_single_element(self):
-        assert jq_eval([42], "reverse") == [42]
+        assert eval_one([42], "reverse") == [42]
 
 
 class TestJqNot:
 
     def test_not_true(self):
-        assert jq_eval(True, "not") is False
+        assert eval_one(True, "not") is False
 
     def test_not_false(self):
-        assert jq_eval(False, "not") is True
+        assert eval_one(False, "not") is True
 
     def test_not_none(self):
-        assert jq_eval(None, "not") is True
+        assert eval_one(None, "not") is True
 
     def test_not_zero_is_false_in_jq(self):
-        assert jq_eval(0, "not") is False
+        assert eval_one(0, "not") is False
 
     def test_not_nonempty_list(self):
-        assert jq_eval([1], "not") is False
+        assert eval_one([1], "not") is False
 
     def test_not_empty_list_is_false_in_jq(self):
-        assert jq_eval([], "not") is False
+        assert eval_one([], "not") is False
 
 
 class TestJqLiterals:
 
     def test_null(self):
-        assert jq_eval({"a": 1}, "null") is None
+        assert eval_one({"a": 1}, "null") is None
 
     def test_true(self):
-        assert jq_eval({}, "true") is True
+        assert eval_one({}, "true") is True
 
     def test_false(self):
-        assert jq_eval({}, "false") is False
+        assert eval_one({}, "false") is False
 
-    def test_empty_returns_sentinel(self):
-        assert jq_eval({}, "empty") is JQ_EMPTY
+    def test_empty_produces_no_output(self):
+        assert jq_eval({}, "empty") == []
 
 
 class TestJqAddMinMax:
 
     def test_add_sum_array(self):
-        assert jq_eval([1, 2, 3], "add") == 6
+        assert eval_one([1, 2, 3], "add") == 6
 
     def test_add_concat_strings(self):
-        assert jq_eval(["a", "b", "c"], "add") == "abc"
+        assert eval_one(["a", "b", "c"], "add") == "abc"
 
     def test_add_empty_array(self):
-        assert jq_eval([], "add") is None
+        assert eval_one([], "add") is None
 
     def test_add_concat_arrays(self):
-        assert jq_eval([[1, 2], [3, 4]], "add") == [1, 2, 3, 4]
+        assert eval_one([[1, 2], [3, 4]], "add") == [1, 2, 3, 4]
 
     def test_min(self):
-        assert jq_eval([3, 1, 2], "min") == 1
+        assert eval_one([3, 1, 2], "min") == 1
 
     def test_max(self):
-        assert jq_eval([3, 1, 2], "max") == 3
+        assert eval_one([3, 1, 2], "max") == 3
 
     def test_min_strings(self):
-        assert jq_eval(["b", "a", "c"], "min") == "a"
+        assert eval_one(["b", "a", "c"], "min") == "a"
 
     def test_max_strings(self):
-        assert jq_eval(["b", "a", "c"], "max") == "c"
+        assert eval_one(["b", "a", "c"], "max") == "c"
 
     def test_min_empty(self):
-        assert jq_eval([], "min") is None
+        assert eval_one([], "min") is None
 
     def test_max_empty(self):
-        assert jq_eval([], "max") is None
+        assert eval_one([], "max") is None
 
 
 class TestJqFirstLastAnyAll:
 
     def test_first(self):
-        assert jq_eval([10, 20, 30], "first") == 10
+        assert eval_one([10, 20, 30], "first") == 10
 
     def test_last(self):
-        assert jq_eval([10, 20, 30], "last") == 30
+        assert eval_one([10, 20, 30], "last") == 30
 
     def test_any_true(self):
-        assert jq_eval([False, True, False], "any") is True
+        assert eval_one([False, True, False], "any") is True
 
     def test_any_false(self):
-        assert jq_eval([False, False], "any") is False
+        assert eval_one([False, False], "any") is False
 
     def test_all_true(self):
-        assert jq_eval([True, True], "all") is True
+        assert eval_one([True, True], "all") is True
 
     def test_all_false(self):
-        assert jq_eval([True, False], "all") is False
+        assert eval_one([True, False], "all") is False
 
     def test_any_empty(self):
-        assert jq_eval([], "any") is False
+        assert eval_one([], "any") is False
 
     def test_all_empty(self):
-        assert jq_eval([], "all") is True
+        assert eval_one([], "all") is True
 
 
 class TestJqConversions:
 
     def test_to_number(self):
-        assert jq_eval("42", "tonumber") == 42
+        assert eval_one("42", "tonumber") == 42
 
     def test_to_number_float(self):
-        assert jq_eval("3.14", "tonumber") == 3.14
+        assert eval_one("3.14", "tonumber") == 3.14
 
     def test_tostring(self):
-        assert jq_eval(42, "tostring") == "42"
+        assert eval_one(42, "tostring") == "42"
 
     def test_tostring_on_string(self):
-        assert jq_eval("hello", "tostring") == "hello"
+        assert eval_one("hello", "tostring") == "hello"
 
 
 class TestJqCsvTsv:
 
     def test_csv(self):
-        result = jq_eval(["a", "b", "c"], "@csv")
+        result = eval_one(["a", "b", "c"], "@csv")
         assert result == '"a","b","c"'
 
     def test_tsv(self):
-        result = jq_eval(["a", "b", "c"], "@tsv")
+        result = eval_one(["a", "b", "c"], "@tsv")
         assert result == "a\tb\tc"
 
     def test_csv_with_numbers(self):
-        result = jq_eval([1, 2, 3], "@csv")
+        result = eval_one([1, 2, 3], "@csv")
         assert result == "1,2,3"
 
     def test_tsv_with_numbers(self):
-        result = jq_eval([1, 2, 3], "@tsv")
+        result = eval_one([1, 2, 3], "@tsv")
         assert result == "1\t2\t3"
 
     def test_csv_non_list_raises(self):
         with pytest.raises(ValueError):
-            jq_eval("hello", "@csv")
+            eval_one("hello", "@csv")
 
     def test_tsv_non_list_raises(self):
         with pytest.raises(ValueError):
-            jq_eval("hello", "@tsv")
+            eval_one("hello", "@tsv")
 
 
 class TestJqFlattenRecursive:
 
     def test_flatten_recursive(self):
-        assert jq_eval([[[1, [2]], [3]], [4]], "flatten") == [1, 2, 3, 4]
+        assert eval_one([[[1, [2]], [3]], [4]], "flatten") == [1, 2, 3, 4]

--- a/python/tests/commands/builtin/jq/test_eval.py
+++ b/python/tests/commands/builtin/jq/test_eval.py
@@ -21,10 +21,11 @@ import pytest
 from mirage.accessor.s3 import S3Accessor
 from mirage.commands.builtin.generic_bind.adapter import CommandIO
 from mirage.commands.builtin.generic_bind.builders.jq import jq as jq_builder
-from mirage.core.jq import JQ_EMPTY, jq_eval
+from mirage.core.jq import jq_eval
 from mirage.types import MountMode, PathSpec
 
-from .conftest import collect, jq, mem_ws, run_raw, write_to_backend
+from .conftest import (collect, eval_one, jq, jq_all, mem_ws, run_raw,
+                       write_to_backend)
 
 
 async def _const_bytes(data, accessor, path, index=None):
@@ -59,7 +60,7 @@ def test_jq_nested_key(backend):
 
 def test_jq_array_iteration(backend):
     write_to_backend(backend, "/tmp/f.json", b'{"items": [1, 2, 3]}')
-    result = jq(backend, "/tmp/f.json", ".items[]")
+    result = jq_all(backend, "/tmp/f.json", ".items[]")
     assert result == [1, 2, 3]
 
 
@@ -77,7 +78,7 @@ def test_jq_pipe(backend):
 
 def test_jq_select(backend):
     write_to_backend(backend, "/tmp/f.json", b'[{"a": 1}, {"a": 2}, {"a": 3}]')
-    result = jq(backend, "/tmp/f.json", ".[] | select(.a > 1)")
+    result = jq_all(backend, "/tmp/f.json", ".[] | select(.a > 1)")
     assert result == [{"a": 2}, {"a": 3}]
 
 
@@ -101,7 +102,7 @@ def test_jq_values_passes_through_non_null(backend):
 
 def test_jq_values_drops_null(backend):
     write_to_backend(backend, "/tmp/f.json", b'{"a": 1}')
-    assert jq(backend, "/tmp/f.json", ".missing | values") is JQ_EMPTY
+    assert jq_all(backend, "/tmp/f.json", ".missing | values") == []
 
 
 def test_jq_object_values_via_spread(backend):
@@ -123,123 +124,123 @@ def test_jq_length(backend):
 
 
 def test_jq_string_interpolation():
-    result = jq_eval({"name": "world"}, '"Hello \\(.name)"')
+    result = eval_one({"name": "world"}, '"Hello \\(.name)"')
     assert result == "Hello world"
 
 
 def test_jq_string_interpolation_nested():
-    result = jq_eval({"a": 1, "b": 2}, '"\\(.a) + \\(.b)"')
+    result = eval_one({"a": 1, "b": 2}, '"\\(.a) + \\(.b)"')
     assert result == "1 + 2"
 
 
 def test_jq_try_catch_returns_null_when_no_error():
     # In real jq, .missing.x is NOT an error; it returns null.
     # Hence catch is never triggered.
-    assert jq_eval({}, 'try .missing.x catch "fallback"') is None
+    assert eval_one({}, 'try .missing.x catch "fallback"') is None
 
 
 def test_jq_try_catch_triggered_on_real_error():
-    assert jq_eval([1, 2, 3], 'try .name catch "fallback"') == "fallback"
+    assert eval_one([1, 2, 3], 'try .name catch "fallback"') == "fallback"
 
 
 def test_jq_try_no_catch_returns_null():
-    assert jq_eval({}, "try .missing.x") is None
+    assert eval_one({}, "try .missing.x") is None
 
 
 def test_jq_try_no_catch_swallows_real_error():
-    assert jq_eval([1, 2, 3], "try .name") is JQ_EMPTY
+    assert jq_eval([1, 2, 3], "try .name") == []
 
 
 class TestJqMapValues:
 
     def test_map_values_dict(self):
-        result = jq_eval({"a": 1, "b": 2}, "map_values(. > 1)")
+        result = eval_one({"a": 1, "b": 2}, "map_values(. > 1)")
         assert result == {"a": False, "b": True}
 
     def test_map_values_list(self):
-        result = jq_eval([1, 2, 3], "map_values(. > 1)")
+        result = eval_one([1, 2, 3], "map_values(. > 1)")
         assert result == [False, True, True]
 
     def test_map_values_dict_arithmetic(self):
-        result = jq_eval({"x": 10, "y": 20}, 'map_values(type)')
+        result = eval_one({"x": 10, "y": 20}, 'map_values(type)')
         assert result == {"x": "number", "y": "number"}
 
 
 class TestJqHas:
 
     def test_has_present_key(self):
-        assert jq_eval({"name": "alice"}, 'has("name")') is True
+        assert eval_one({"name": "alice"}, 'has("name")') is True
 
     def test_has_absent_key(self):
-        assert jq_eval({"name": "alice"}, 'has("age")') is False
+        assert eval_one({"name": "alice"}, 'has("age")') is False
 
     def test_has_array_with_int_key(self):
         # In real jq, has() on arrays takes an integer index.
-        assert jq_eval([1, 2, 3], "has(1)") is True
-        assert jq_eval([1, 2, 3], "has(5)") is False
+        assert eval_one([1, 2, 3], "has(1)") is True
+        assert eval_one([1, 2, 3], "has(5)") is False
 
 
 class TestJqContains:
 
     def test_contains_string_in_string(self):
-        assert jq_eval("foobar", 'contains("foo")') is True
+        assert eval_one("foobar", 'contains("foo")') is True
 
     def test_contains_string_not_found(self):
-        assert jq_eval("foobar", 'contains("xyz")') is False
+        assert eval_one("foobar", 'contains("xyz")') is False
 
     def test_contains_element_requires_array_arg(self):
         # In real jq, contains(x) requires arg of same type.
         # For arrays, use contains([item]) — see test_contains_subarray.
         with pytest.raises(ValueError):
-            jq_eval([1, 2, 3], "contains(2)")
+            eval_one([1, 2, 3], "contains(2)")
 
     def test_contains_subarray(self):
-        assert jq_eval([1, 2, 3], "contains([1, 2])") is True
+        assert eval_one([1, 2, 3], "contains([1, 2])") is True
 
     def test_contains_subarray_not_found(self):
-        assert jq_eval([1, 2, 3], "contains([4, 5])") is False
+        assert eval_one([1, 2, 3], "contains([4, 5])") is False
 
 
 class TestJqComparisons:
 
     def test_eq_true(self):
-        assert jq_eval({"a": 1}, ".a == 1") is True
+        assert eval_one({"a": 1}, ".a == 1") is True
 
     def test_eq_false(self):
-        assert jq_eval({"a": 1}, ".a == 2") is False
+        assert eval_one({"a": 1}, ".a == 2") is False
 
     def test_neq_true(self):
-        assert jq_eval({"a": 1}, ".a != 2") is True
+        assert eval_one({"a": 1}, ".a != 2") is True
 
     def test_neq_false(self):
-        assert jq_eval({"a": 1}, ".a != 1") is False
+        assert eval_one({"a": 1}, ".a != 1") is False
 
     def test_gt(self):
-        assert jq_eval({"a": 5}, ".a > 3") is True
+        assert eval_one({"a": 5}, ".a > 3") is True
 
     def test_gt_false(self):
-        assert jq_eval({"a": 1}, ".a > 3") is False
+        assert eval_one({"a": 1}, ".a > 3") is False
 
     def test_lt(self):
-        assert jq_eval({"a": 1}, ".a < 3") is True
+        assert eval_one({"a": 1}, ".a < 3") is True
 
     def test_lt_false(self):
-        assert jq_eval({"a": 5}, ".a < 3") is False
+        assert eval_one({"a": 5}, ".a < 3") is False
 
     def test_gte(self):
-        assert jq_eval({"a": 3}, ".a >= 3") is True
+        assert eval_one({"a": 3}, ".a >= 3") is True
 
     def test_gte_false(self):
-        assert jq_eval({"a": 2}, ".a >= 3") is False
+        assert eval_one({"a": 2}, ".a >= 3") is False
 
     def test_lte(self):
-        assert jq_eval({"a": 3}, ".a <= 3") is True
+        assert eval_one({"a": 3}, ".a <= 3") is True
 
     def test_lte_false(self):
-        assert jq_eval({"a": 5}, ".a <= 3") is False
+        assert eval_one({"a": 5}, ".a <= 3") is False
 
     def test_string_eq(self):
-        assert jq_eval({"s": "hello"}, '.s == "hello"') is True
+        assert eval_one({"s": "hello"}, '.s == "hello"') is True
 
 
 class TestJqPipes:
@@ -253,61 +254,61 @@ class TestJqPipes:
     def test_pipe_with_iteration_and_select(self, backend):
         write_to_backend(backend, "/tmp/f.json",
                          b'[{"x": 1}, {"x": 5}, {"x": 10}]')
-        result = jq(backend, "/tmp/f.json", ".[] | select(.x > 3)")
+        result = jq_all(backend, "/tmp/f.json", ".[] | select(.x > 3)")
         assert result == [{"x": 5}, {"x": 10}]
 
     def test_pipe_keys_then_length(self):
-        result = jq_eval({"a": 1, "b": 2, "c": 3}, "keys | length")
+        result = eval_one({"a": 1, "b": 2, "c": 3}, "keys | length")
         assert result == 3
 
     def test_pipe_object_values_via_spread_then_sort(self):
         # Real jq: `values` returns the object as-is (it's the identity for
         # non-null). To get the object's values list, use [.[]].
-        result = jq_eval({"a": 3, "b": 1, "c": 2}, "[.[]] | sort")
+        result = eval_one({"a": 3, "b": 1, "c": 2}, "[.[]] | sort")
         assert result == [1, 2, 3]
 
     def test_pipe_map_then_select(self):
         data = [1, 2, 3, 4, 5]
-        result = jq_eval(data, "map(select(. > 2))")
+        result = eval_one(data, "map(select(. > 2))")
         assert result == [3, 4, 5]
 
 
 class TestJqArrayAccess:
 
     def test_index_access(self):
-        result = jq_eval({"items": ["a", "b", "c"]}, ".items[0]")
+        result = eval_one({"items": ["a", "b", "c"]}, ".items[0]")
         assert result == "a"
 
     def test_index_access_last(self):
-        result = jq_eval({"items": ["a", "b", "c"]}, ".items[2]")
+        result = eval_one({"items": ["a", "b", "c"]}, ".items[2]")
         assert result == "c"
 
     def test_nested_array_iteration(self, backend):
         write_to_backend(backend, "/tmp/f.json",
                          b'{"users": [{"name": "alice"}, {"name": "bob"}]}')
-        result = jq(backend, "/tmp/f.json", ".users[].name")
+        result = jq_all(backend, "/tmp/f.json", ".users[].name")
         assert result == ["alice", "bob"]
 
     def test_slice_from_start(self):
-        result = jq_eval([1, 2, 3, 4, 5], ".[:2]")
+        result = eval_one([1, 2, 3, 4, 5], ".[:2]")
         assert result == [1, 2]
 
     def test_slice_to_end(self):
-        result = jq_eval([1, 2, 3, 4, 5], ".[3:]")
+        result = eval_one([1, 2, 3, 4, 5], ".[3:]")
         assert result == [4, 5]
 
 
 class TestJqEdgeCases:
 
     def test_empty_object(self):
-        assert jq_eval({}, ".") == {}
+        assert eval_one({}, ".") == {}
 
     def test_empty_array(self):
-        assert jq_eval([], ".") == []
+        assert eval_one([], ".") == []
 
     def test_deeply_nested(self):
         data = {"a": {"b": {"c": {"d": 42}}}}
-        assert jq_eval(data, ".a.b.c.d") == 42
+        assert eval_one(data, ".a.b.c.d") == 42
 
     def test_unicode_content(self, backend):
         data = {"name": "café", "emoji": "hello"}
@@ -316,46 +317,46 @@ class TestJqEdgeCases:
         assert result == "café"
 
     def test_json_literal_number(self):
-        assert jq_eval({}, "42") == 42
+        assert eval_one({}, "42") == 42
 
     def test_json_literal_string(self):
-        assert jq_eval({}, '"hello"') == "hello"
+        assert eval_one({}, '"hello"') == "hello"
 
     def test_json_literal_array(self):
-        assert jq_eval({}, "[1, 2, 3]") == [1, 2, 3]
+        assert eval_one({}, "[1, 2, 3]") == [1, 2, 3]
 
     def test_length_of_string(self):
-        assert jq_eval("hello", "length") == 5
+        assert eval_one("hello", "length") == 5
 
     def test_length_of_dict(self):
-        assert jq_eval({"a": 1, "b": 2}, "length") == 2
+        assert eval_one({"a": 1, "b": 2}, "length") == 2
 
     def test_keys_of_array(self):
-        assert jq_eval(["a", "b", "c"], "keys") == [0, 1, 2]
+        assert eval_one(["a", "b", "c"], "keys") == [0, 1, 2]
 
     def test_string_interpolation_with_nested_expr(self):
         data = {"items": [1, 2, 3]}
-        result = jq_eval(data, '"count: \\(.items | length)"')
+        result = eval_one(data, '"count: \\(.items | length)"')
         assert result == "count: 3"
 
     def test_select_drops_non_matching(self):
-        assert jq_eval({"a": 1}, "select(.a > 10)") is JQ_EMPTY
+        assert jq_eval({"a": 1}, "select(.a > 10)") == []
 
     def test_map_requires_iterable(self):
         # Real jq: map(.) on a non-iterable raises ValueError.
         with pytest.raises(ValueError):
-            jq_eval(5, "map(.)")
+            eval_one(5, "map(.)")
 
     def test_missing_key_returns_null(self):
         # Real jq: missing keys silently return null (no exception).
-        assert jq_eval({"a": 1}, ".b") is None
+        assert eval_one({"a": 1}, ".b") is None
 
     def test_type_error_dot_on_list(self):
         with pytest.raises((TypeError, KeyError, ValueError)):
-            jq_eval([1, 2, 3], ".name")
+            eval_one([1, 2, 3], ".name")
 
     def test_try_catch_type_error(self):
-        result = jq_eval([1, 2], 'try .name catch "no key"')
+        result = eval_one([1, 2], 'try .name catch "no key"')
         assert result == "no key"
 
 
@@ -375,77 +376,77 @@ class TestJqComplex:
 
     def test_flatten_then_unique_then_sort(self):
         data = [[3, 1], [2, 1], [3, 2]]
-        result = jq_eval(data, "flatten | unique | sort")
+        result = eval_one(data, "flatten | unique | sort")
         assert result == [1, 2, 3]
 
     def test_map_length(self):
         data = ["hello", "hi", "hey"]
-        result = jq_eval(data, "map(length)")
+        result = eval_one(data, "map(length)")
         assert result == [5, 2, 3]
 
     def test_select_with_has(self):
         data = [{"name": "alice"}, {"age": 30}, {"name": "bob"}]
-        result = jq_eval(data, 'map(select(has("name")))')
+        result = eval_one(data, 'map(select(has("name")))')
         assert result == [{"name": "alice"}, {"name": "bob"}]
 
 
 class TestJqArithmetic:
 
     def test_add_numbers(self):
-        assert jq_eval({"a": 1, "b": 2}, ".a + .b") == 3
+        assert eval_one({"a": 1, "b": 2}, ".a + .b") == 3
 
     def test_subtract(self):
-        assert jq_eval({"a": 10, "b": 3}, ".a - .b") == 7
+        assert eval_one({"a": 10, "b": 3}, ".a - .b") == 7
 
     def test_multiply(self):
-        assert jq_eval({"a": 4, "b": 5}, ".a * .b") == 20
+        assert eval_one({"a": 4, "b": 5}, ".a * .b") == 20
 
     def test_divide(self):
-        assert jq_eval({"a": 10, "b": 2}, ".a / .b") == 5.0
+        assert eval_one({"a": 10, "b": 2}, ".a / .b") == 5.0
 
     def test_add_string_concat(self):
-        assert jq_eval({
+        assert eval_one({
             "a": "hello",
             "b": " world"
         }, ".a + .b") == "hello world"
 
     def test_add_literal_number(self):
-        assert jq_eval({"a": 1}, ".a + 10") == 11
+        assert eval_one({"a": 1}, ".a + 10") == 11
 
 
 class TestJqObjectConstruction:
 
     def test_object_construction(self):
         data = {"name": "alice", "age": 30}
-        result = jq_eval(data, "{name: .name}")
+        result = eval_one(data, "{name: .name}")
         assert result == {"name": "alice"}
 
     def test_object_construction_multiple_keys(self):
         data = {"x": 1, "y": 2, "z": 3}
-        result = jq_eval(data, "{a: .x, b: .y}")
+        result = eval_one(data, "{a: .x, b: .y}")
         assert result == {"a": 1, "b": 2}
 
 
 class TestJqAlternative:
 
     def test_alternative_with_null(self):
-        assert jq_eval({"a": None}, '.a // "default"') == "default"
+        assert eval_one({"a": None}, '.a // "default"') == "default"
 
     def test_alternative_with_value(self):
-        assert jq_eval({"a": 42}, '.a // "default"') == 42
+        assert eval_one({"a": 42}, '.a // "default"') == 42
 
     def test_alternative_missing_key(self):
-        assert jq_eval({}, '.missing // "fallback"') == "fallback"
+        assert eval_one({}, '.missing // "fallback"') == "fallback"
 
 
 class TestJqIfThenElse:
 
     def test_if_then_else_true(self):
-        result = jq_eval({"x": 5}, 'if .x > 3 then "big" else "small" end')
+        result = eval_one({"x": 5}, 'if .x > 3 then "big" else "small" end')
         assert result == "big"
 
     def test_if_then_else_false(self):
-        result = jq_eval({"x": 1}, 'if .x > 3 then "big" else "small" end')
+        result = eval_one({"x": 1}, 'if .x > 3 then "big" else "small" end')
         assert result == "small"
 
 
@@ -453,12 +454,12 @@ class TestJqSortByGroupBy:
 
     def test_sort_by(self):
         data = [{"a": 3}, {"a": 1}, {"a": 2}]
-        result = jq_eval(data, "sort_by(.a)")
+        result = eval_one(data, "sort_by(.a)")
         assert result == [{"a": 1}, {"a": 2}, {"a": 3}]
 
     def test_group_by(self):
         data = [{"k": "a", "v": 1}, {"k": "b", "v": 2}, {"k": "a", "v": 3}]
-        result = jq_eval(data, "group_by(.k)")
+        result = eval_one(data, "group_by(.k)")
         assert result == [
             [{
                 "k": "a",
@@ -489,54 +490,54 @@ class TestJqBugFixes:
     def test_dot_key_on_list_raises(self):
         # Real jq raises ValueError "Cannot index array with string".
         with pytest.raises(ValueError):
-            jq_eval([1, 2, 3], ".name")
+            eval_one([1, 2, 3], ".name")
 
     def test_contains_dict_subset(self):
-        assert jq_eval({"a": 1, "b": 2}, 'contains({"a": 1})') is True
+        assert eval_one({"a": 1, "b": 2}, 'contains({"a": 1})') is True
 
     def test_contains_dict_missing_key(self):
-        assert jq_eval({"a": 1}, 'contains({"b": 2})') is False
+        assert eval_one({"a": 1}, 'contains({"b": 2})') is False
 
     def test_contains_dict_wrong_value(self):
-        assert jq_eval({"a": 1}, 'contains({"a": 2})') is False
+        assert eval_one({"a": 1}, 'contains({"a": 2})') is False
 
     def test_contains_dict_full_match(self):
-        assert jq_eval({"a": 1}, 'contains({"a": 1})') is True
+        assert eval_one({"a": 1}, 'contains({"a": 1})') is True
 
 
 class TestJqParensAndArrayConstruction:
 
     def test_parens_unwrap_single(self):
-        assert jq_eval({"items": [1, 2, 3]}, "(.items | length)") == 3
+        assert eval_one({"items": [1, 2, 3]}, "(.items | length)") == 3
 
     def test_parens_in_object_value(self):
-        result = jq_eval({"items": [1, 2, 3]},
-                         "{n: (.items | length), first: .items[0]}")
+        result = eval_one({"items": [1, 2, 3]},
+                          "{n: (.items | length), first: .items[0]}")
         assert result == {"n": 3, "first": 1}
 
     def test_array_construction_collects_spread(self):
         data = {"slides": [{"id": "a"}, {"id": "b"}, {"id": "c"}]}
-        assert jq_eval(data, "[.slides[].id]") == ["a", "b", "c"]
+        assert eval_one(data, "[.slides[].id]") == ["a", "b", "c"]
 
     def test_array_construction_wraps_single_value(self):
-        assert jq_eval({"x": 5}, "[.x]") == [5]
+        assert eval_one({"x": 5}, "[.x]") == [5]
 
     def test_object_with_array_literal_value_does_not_split_inside(self):
-        assert jq_eval({}, "{x: 1, y: [1,2,3]}") == {"x": 1, "y": [1, 2, 3]}
+        assert eval_one({}, "{x: 1, y: [1,2,3]}") == {"x": 1, "y": [1, 2, 3]}
 
     def test_object_with_nested_object_value(self):
-        result = jq_eval({"a": 1, "b": 2}, "{outer: {x: .a, y: .b}}")
+        result = eval_one({"a": 1, "b": 2}, "{outer: {x: .a, y: .b}}")
         assert result == {"outer": {"x": 1, "y": 2}}
 
     def test_join_separator(self):
-        assert jq_eval([1, 2, 3], 'join("-")') == "1-2-3"
+        assert eval_one([1, 2, 3], 'join("-")') == "1-2-3"
 
     def test_join_empty_separator(self):
-        assert jq_eval(["foo", "bar"], 'join("")') == "foobar"
+        assert eval_one(["foo", "bar"], 'join("")') == "foobar"
 
     def test_array_construction_then_join(self):
         data = {"slides": [{"id": "a"}, {"id": "b"}]}
-        assert jq_eval(data, '[.slides[].id] | join(",")') == "a,b"
+        assert eval_one(data, '[.slides[].id] | join(",")') == "a,b"
 
     def test_full_slides_summary_expression(self):
         data = {
@@ -597,7 +598,7 @@ class TestJqParensAndArrayConstruction:
                 '{type: .shape.shapeType, '
                 'text: [.shape.text.textElements[].textRun.content] '
                 '| join("")}]}]}')
-        assert jq_eval(data, expr) == {
+        assert eval_one(data, expr) == {
             "title":
             "Deck",
             "slideCount":
@@ -681,7 +682,7 @@ class TestJqRealLibjqExpressions:
     def test_user_query_with_select_textRun_then_join(self):
         expr = ('[.slides[].pageElements[].shape.text.textElements[] | '
                 'select(.textRun != null) | .textRun.content] | join("")')
-        assert jq_eval(self._slides_doc(), expr) == "Hello worldBye"
+        assert eval_one(self._slides_doc(), expr) == "Hello worldBye"
 
     def test_user_query_array_per_slide_then_join(self):
         expr = ('[.slides[] | '
@@ -689,7 +690,7 @@ class TestJqRealLibjqExpressions:
                 '| join("")]')
         # paragraphMarker has no textRun -> jq returns null; join treats null
         # as empty -> "Hello world" for s1, "Bye" for s2.
-        assert jq_eval(self._slides_doc(), expr) == ["Hello world", "Bye"]
+        assert eval_one(self._slides_doc(), expr) == ["Hello world", "Bye"]
 
     def test_user_query_full_summary_object(self):
         expr = ('{title: .title, '
@@ -699,7 +700,7 @@ class TestJqRealLibjqExpressions:
                 '{type: .shape.shapeType, '
                 'text: [.shape.text.textElements[].textRun.content] '
                 '| join("")}]}]}')
-        assert jq_eval(self._slides_doc(), expr) == {
+        assert eval_one(self._slides_doc(), expr) == {
             "title":
             "Deck",
             "slideCount":
@@ -725,43 +726,43 @@ class TestJqRealLibjqExpressions:
     def test_recurse_then_select(self):
         # `recurse` (..) is a real jq builtin the homegrown didn't have.
         data = {"a": 1, "b": {"c": 2, "d": {"e": 3}}}
-        result = jq_eval(data, "[.. | numbers] | sort")
+        result = eval_one(data, "[.. | numbers] | sort")
         assert result == [1, 2, 3]
 
     def test_string_split_join_round_trip(self):
-        assert jq_eval("a-b-c", 'split("-")') == ["a", "b", "c"]
-        assert jq_eval(["a", "b", "c"], 'join("-")') == "a-b-c"
+        assert eval_one("a-b-c", 'split("-")') == ["a", "b", "c"]
+        assert eval_one(["a", "b", "c"], 'join("-")') == "a-b-c"
 
     def test_alternative_operator_default(self):
         # `// "default"` falls back when LHS is null/false.
-        assert jq_eval({"a": None}, '.a // "fallback"') == "fallback"
-        assert jq_eval({"a": "real"}, '.a // "fallback"') == "real"
+        assert eval_one({"a": None}, '.a // "fallback"') == "fallback"
+        assert eval_one({"a": "real"}, '.a // "fallback"') == "real"
 
     def test_to_entries_from_entries(self):
-        result = jq_eval({"a": 1, "b": 2}, "to_entries")
+        result = eval_one({"a": 1, "b": 2}, "to_entries")
         assert result == [{"key": "a", "value": 1}, {"key": "b", "value": 2}]
-        result2 = jq_eval([{"key": "x", "value": 9}], "from_entries")
+        result2 = eval_one([{"key": "x", "value": 9}], "from_entries")
         assert result2 == {"x": 9}
 
     def test_string_endswith_startswith(self):
-        assert jq_eval("foobar", 'startswith("foo")') is True
-        assert jq_eval("foobar", 'endswith("bar")') is True
-        assert jq_eval("foobar", 'startswith("xyz")') is False
+        assert eval_one("foobar", 'startswith("foo")') is True
+        assert eval_one("foobar", 'endswith("bar")') is True
+        assert eval_one("foobar", 'startswith("xyz")') is False
 
     def test_test_regex(self):
-        assert jq_eval("hello world", 'test("w.rld")') is True
-        assert jq_eval("hello world", 'test("xyz")') is False
+        assert eval_one("hello world", 'test("w.rld")') is True
+        assert eval_one("hello world", 'test("xyz")') is False
 
     def test_walk_transform(self):
         # `walk` is a real jq builtin the homegrown didn't have.
         data = {"a": "FOO", "b": ["BAR", "BAZ"]}
-        result = jq_eval(
+        result = eval_one(
             data, 'walk(if type == "string" then ascii_downcase else . end)')
         assert result == {"a": "foo", "b": ["bar", "baz"]}
 
     def test_nested_object_with_paren_value(self):
         data = {"items": [1, 2, 3]}
-        result = jq_eval(
+        result = eval_one(
             data, "{count: (.items | length), max: (.items | max), "
             "sum: ([.items[]] | add)}")
         assert result == {"count": 3, "max": 3, "sum": 6}
@@ -783,14 +784,14 @@ class TestJqRealLibjqExpressions:
                 },
             ]
         }
-        result = jq_eval(
+        result = eval_one(
             data, "[.users[] | select(.active) | .name] | join(\", \")")
         assert result == "alice, carol"
 
-    def test_top_level_select_returns_empty_sentinel(self):
-        # Real jq: select(false) produces 0 outputs.
-        # Our adapter returns JQ_EMPTY so callers serialize as empty bytes.
-        assert jq_eval({"x": 5}, "select(.x > 100)") is JQ_EMPTY
+    def test_top_level_select_produces_no_output(self):
+        # Real jq: select(false) produces 0 outputs, which the caller
+        # serializes as empty bytes.
+        assert jq_eval({"x": 5}, "select(.x > 100)") == []
 
 
 class TestJqMemoryBackend:

--- a/python/tests/commands/builtin/jq/test_jq_examples.py
+++ b/python/tests/commands/builtin/jq/test_jq_examples.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from .conftest import EXAMPLE_JSON, EXAMPLE_JSONL, jq, write_to_backend
+from .conftest import EXAMPLE_JSON, EXAMPLE_JSONL, jq, jq_all, write_to_backend
 
 
 class TestJqExampleJson:
@@ -45,14 +45,14 @@ class TestJqExampleJson:
 
     def test_department_names(self, backend):
         self._load(backend)
-        result = jq(backend, "/tmp/example.json", ".departments[] | .name")
+        result = jq_all(backend, "/tmp/example.json", ".departments[] | .name")
         assert "Engineering" in result
         assert "Product" in result
 
     def test_nested_team_names(self, backend):
         self._load(backend)
-        result = jq(backend, "/tmp/example.json",
-                    ".departments[0].teams[] | .name")
+        result = jq_all(backend, "/tmp/example.json",
+                        ".departments[0].teams[] | .name")
         assert "Platform" in result
 
     def test_deep_member_access(self, backend):
@@ -134,8 +134,9 @@ class TestJqExampleJsonl:
 
     def test_select_queue_operations(self, backend):
         self._load(backend)
-        result = jq(backend, "/tmp/example.jsonl",
-                    '.[] | select(.type == "queue-operation") | .operation')
+        result = jq_all(
+            backend, "/tmp/example.jsonl",
+            '.[] | select(.type == "queue-operation") | .operation')
         assert "enqueue" in result
         assert "dequeue" in result
 

--- a/python/tests/commands/builtin/jq/test_stream.py
+++ b/python/tests/commands/builtin/jq/test_stream.py
@@ -25,7 +25,7 @@ from mirage.resource.ram import RAMResource
 from mirage.types import MountMode, PathSpec
 from mirage.workspace import Workspace
 
-from .conftest import (SAMPLE_JSONL, collect, jq, mem_ws, run_raw,
+from .conftest import (SAMPLE_JSONL, collect, jq, jq_all, mem_ws, run_raw,
                        write_to_backend)
 
 
@@ -45,7 +45,7 @@ class TestJqJsonl:
 
     def test_jsonl_file_select(self, backend):
         write_to_backend(backend, "/tmp/data.jsonl", SAMPLE_JSONL)
-        result = jq(backend, "/tmp/data.jsonl", ".[] | select(.age > 28)")
+        result = jq_all(backend, "/tmp/data.jsonl", ".[] | select(.age > 28)")
         assert len(result) == 2
         assert result[0]["name"] == "alice"
         assert result[1]["name"] == "carol"
@@ -57,7 +57,7 @@ class TestJqJsonl:
 
     def test_jsonl_file_iteration(self, backend):
         write_to_backend(backend, "/tmp/data.jsonl", SAMPLE_JSONL)
-        result = jq(backend, "/tmp/data.jsonl", ".[] | .name")
+        result = jq_all(backend, "/tmp/data.jsonl", ".[] | .name")
         assert result == ["alice", "bob", "carol"]
 
     def test_ndjson_extension(self, backend):

--- a/python/tests/core/jq/test_eval.py
+++ b/python/tests/core/jq/test_eval.py
@@ -12,38 +12,51 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.core.jq.eval import has_top_level_spread, jq_eval
+from mirage.core.jq.eval import jq_eval
 
 
-def test_top_level_spread_is_detected():
-    assert has_top_level_spread(".a[]")
-    assert has_top_level_spread(".[] | .name")
-
-
-def test_spread_inside_a_collector_is_not_top_level():
-    # `[.a[] | .t]` emits ONE array, so the caller must print one line.
-    assert not has_top_level_spread("[.a[] | .t]")
-    assert not has_top_level_spread('[["H"]] + [.[] | [.]]')
-
-
-def test_spread_inside_parens_is_not_top_level():
-    assert not has_top_level_spread("([.a[]] | length)")
-
-
-def test_bracket_pair_in_a_string_literal_is_not_a_spread():
-    assert not has_top_level_spread('.a | test("[]")')
-
-
-def test_index_and_slice_are_not_spreads():
-    assert not has_top_level_spread(".values[1:]")
-    assert not has_top_level_spread(".a[0]")
+def test_single_output_is_a_one_element_list():
+    assert jq_eval({"a": 1}, ".a") == [1]
 
 
 def test_collector_program_evaluates_to_a_single_value():
-    result = jq_eval({"a": [{"t": "x"}, {"t": "y"}]}, "[.a[] | .t]")
-    assert result == ["x", "y"]
+    # `[.a[] | .t]` emits ONE array, so the caller prints one line.
+    assert jq_eval({"a": [{
+        "t": "x"
+    }, {
+        "t": "y"
+    }]}, "[.a[] | .t]") == [["x", "y"]]
 
 
-def test_spread_program_evaluates_to_the_output_list():
-    result = jq_eval({"a": [1, 2, 3]}, ".a[]")
-    assert result == [1, 2, 3]
+def test_spread_program_evaluates_to_one_output_per_element():
+    assert jq_eval({"a": [1, 2, 3]}, ".a[]") == [1, 2, 3]
+
+
+def test_comma_is_two_outputs_not_one_array():
+    assert jq_eval({"a": 1, "b": 2}, ".a, .b") == [1, 2]
+
+
+def test_comma_over_arrays_keeps_each_array_whole():
+    assert jq_eval({"a": 1, "b": 2}, "[.a], [.b]") == [[1], [2]]
+
+
+def test_multi_output_without_a_bracket_pair():
+    # `range` and `..` spread with no `[]` anywhere in the program.
+    assert jq_eval(None, "range(3)") == [0, 1, 2]
+    assert jq_eval({"a": 1}, "..") == [{"a": 1}, 1]
+
+
+def test_bracket_pair_inside_a_string_literal_is_one_output():
+    assert jq_eval({"a": "x[]y"}, '.a | contains("[]")') == [True]
+
+
+def test_zero_outputs_is_an_empty_list():
+    assert jq_eval({"x": 1}, "select(.x > 100)") == []
+    assert jq_eval({}, "empty") == []
+
+
+def test_optional_spread_over_a_missing_field_is_empty():
+    """Reproducer for the 'jq: DropItem' regression: an `[]?` over a
+    missing field used to leak the internal sentinel exception."""
+    msg = {"id": "x", "subject": "hi", "body_text": "..."}
+    assert jq_eval(msg, ".attachments[]?") == []

--- a/python/tests/core/jq/test_format.py
+++ b/python/tests/core/jq/test_format.py
@@ -12,48 +12,48 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.core.jq import JQ_EMPTY, format_jq_output, jq_eval
+from mirage.core.jq import format_jq_output, jq_eval
 
 
-def test_format_jq_empty_sentinel_is_empty_bytes():
-    assert format_jq_output(JQ_EMPTY, raw=False, compact=False,
-                            spread=False) == b""
-    assert format_jq_output(JQ_EMPTY, raw=True, compact=True,
-                            spread=True) == b""
+def test_format_jq_no_outputs_is_empty_bytes():
+    assert format_jq_output([], raw=False, compact=False) == b""
+    assert format_jq_output([], raw=True, compact=True) == b""
 
 
 def test_format_jq_single_value_compact():
-    assert format_jq_output({"a": 1}, raw=False, compact=True,
-                            spread=False) == b'{"a":1}\n'
+    assert format_jq_output([{
+        "a": 1
+    }], raw=False, compact=True) == b'{"a":1}\n'
+
+
+def test_format_jq_single_value_indents_by_default():
+    assert format_jq_output([{
+        "a": 1
+    }], raw=False, compact=False) == b'{\n  "a": 1\n}\n'
 
 
 def test_format_jq_raw_string():
-    assert format_jq_output("hello", raw=True, compact=True,
-                            spread=False) == b"hello\n"
+    assert format_jq_output(["hello"], raw=True, compact=True) == b"hello\n"
 
 
-def test_format_jq_spread_serializes_each_item():
-    out = format_jq_output([1, 2, 3], raw=False, compact=True, spread=True)
-    assert out == b"1\n2\n3\n"
+def test_format_jq_raw_leaves_non_strings_as_json():
+    assert format_jq_output(["a", 1], raw=True, compact=True) == b"a\n1\n"
 
 
-def test_format_jq_spread_off_keeps_array_as_one_value():
-    out = format_jq_output([1, 2, 3], raw=False, compact=True, spread=False)
+def test_format_jq_prints_one_line_per_output():
+    assert format_jq_output([1, 2, 3], raw=False, compact=True) == b"1\n2\n3\n"
+
+
+def test_format_jq_one_array_output_stays_one_line():
+    out = format_jq_output([[1, 2, 3]], raw=False, compact=True)
     assert out == b"[1,2,3]\n"
 
 
-def test_attachments_missing_returns_empty():
-    """Reproducer for the 'jq: DropItem' regression: an `[]?` over a
-    missing field used to leak the internal sentinel exception. Now it
-    must serialize to empty output."""
-    msg = {"id": "x", "subject": "hi", "body_text": "..."}
-    result = jq_eval(msg, ".attachments[]?")
-    assert result is JQ_EMPTY
-    assert format_jq_output(result, raw=True, compact=True, spread=True) == b""
+def test_select_no_match_formats_to_nothing():
+    outputs = jq_eval({"x": 1}, "select(.x > 100)")
+    assert format_jq_output(outputs, raw=False, compact=True) == b""
 
 
-def test_select_no_match_returns_empty():
-    result = jq_eval({"x": 1}, "select(.x > 100)")
-    assert result is JQ_EMPTY
-    assert format_jq_output(result, raw=False, compact=True,
-                            spread=False) == b""
+def test_comma_formats_one_value_per_line():
+    outputs = jq_eval({"a": "alice", "b": 30}, ".a, .b")
+    assert format_jq_output(outputs, raw=True, compact=True) == b"alice\n30\n"

--- a/python/tests/core/jq/test_stream.py
+++ b/python/tests/core/jq/test_stream.py
@@ -90,3 +90,17 @@ async def test_eval_jsonl_stream_raw_unquotes_strings():
     source = _lines(b'{"msg":"hello"}\n', b'{"msg":"world"}\n')
     out = await _collect(eval_jsonl_stream(source, ".[].msg", raw=True))
     assert out == ["hello", "world"]
+
+
+@pytest.mark.asyncio
+async def test_eval_jsonl_stream_prints_every_output_of_a_line():
+    source = _lines(b'{"a":1,"b":2}\n', b'{"a":3,"b":4}\n')
+    out = await _collect(eval_jsonl_stream(source, ".[] | .a, .b"))
+    assert out == ["1", "2", "3", "4"]
+
+
+@pytest.mark.asyncio
+async def test_eval_jsonl_stream_drops_lines_with_no_output():
+    source = _lines(b'{"id":1}\n', b'{"id":2}\n', b'{"id":3}\n')
+    out = await _collect(eval_jsonl_stream(source, ".[] | select(.id > 2)"))
+    assert out == ['{"id":3}']

--- a/typescript/packages/core/src/commands/builtin/generic/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/jq.ts
@@ -16,7 +16,6 @@ import {
   concatBytes,
   evalJsonlStream,
   formatJqOutput,
-  hasTopLevelSpread,
   isJsonlPath,
   isStreamableJsonlExpr,
   jqEval,
@@ -40,10 +39,6 @@ export async function jqGeneric(
   const raw = opts.flags.r === true
   const compact = opts.flags.c === true
   const slurp = opts.flags.s === true
-  // Must match the arity rule jqEval used: a nested `[]` inside a
-  // collector still yields one output, so a substring test would
-  // explode a single array one element per line.
-  const spread = hasTopLevelSpread(expression)
 
   if (paths.length > 0) {
     const first = paths[0]
@@ -56,16 +51,16 @@ export async function jqGeneric(
       const bytes = await materialize(stream(p))
       const docs = parseJsonDocs(bytes)
       if (slurp) {
-        const result = await jqEval(docs, expression.trim())
-        outputs.push(formatJqOutput(result, raw, compact, spread))
+        const values = await jqEval(docs, expression.trim())
+        outputs.push(formatJqOutput(values, raw, compact))
         continue
       }
       // jq applies the program to every document in the stream, so a
       // multi-value file evaluates per document whatever it is named;
       // only slurp collapses the stream into one array.
       for (const doc of docs) {
-        const result = await jqEval(doc, expression.trim())
-        outputs.push(formatJqOutput(result, raw, compact, spread))
+        const values = await jqEval(doc, expression.trim())
+        outputs.push(formatJqOutput(values, raw, compact))
       }
     }
     const out: ByteSource = concatBytes(outputs)
@@ -77,14 +72,14 @@ export async function jqGeneric(
   const stdinDocs = parseJsonDocs(stdinBytes)
   if (slurp) {
     const slurped = await jqEval(stdinDocs, expression.trim())
-    return [formatJqOutput(slurped, raw, compact, spread), new IOResult()]
+    return [formatJqOutput(slurped, raw, compact), new IOResult()]
   }
   // Same stream rule as the path branch: piped input is a stream of
   // values, so each document is evaluated on its own.
   const stdinOut: Uint8Array[] = []
   for (const doc of stdinDocs) {
-    const result = await jqEval(doc, expression.trim())
-    stdinOut.push(formatJqOutput(result, raw, compact, spread))
+    const values = await jqEval(doc, expression.trim())
+    stdinOut.push(formatJqOutput(values, raw, compact))
   }
   return [concatBytes(stdinOut), new IOResult()]
 }

--- a/typescript/packages/core/src/core/jq/eval.test.ts
+++ b/typescript/packages/core/src/core/jq/eval.test.ts
@@ -13,24 +13,36 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { hasTopLevelSpread, jqEval } from './eval.ts'
-import { JQ_EMPTY } from './format.ts'
+import { jqEval } from './eval.ts'
+
+/**
+ * Evaluate expr and return its single output.
+ *
+ * jqEval is arity-preserving, so a program that emits one value still comes
+ * back as a one-element list. Tests of single-valued programs go through
+ * here, which asserts the arity instead of assuming it.
+ */
+async function evalOne(obj: unknown, expr: string): Promise<unknown> {
+  const outputs = await jqEval(obj, expr)
+  expect(outputs).toHaveLength(1)
+  return outputs[0]
+}
 
 describe('jq eval (libjq adapter)', () => {
   it('identity', async () => {
-    expect(await jqEval({ a: 1 }, '.')).toEqual({ a: 1 })
+    expect(await evalOne({ a: 1 }, '.')).toEqual({ a: 1 })
   })
 
   it('dot access', async () => {
-    expect(await jqEval({ name: 'alice' }, '.name')).toBe('alice')
+    expect(await evalOne({ name: 'alice' }, '.name')).toBe('alice')
   })
 
   it('nested dot access', async () => {
-    expect(await jqEval({ a: { b: { c: 42 } } }, '.a.b.c')).toBe(42)
+    expect(await evalOne({ a: { b: { c: 42 } } }, '.a.b.c')).toBe(42)
   })
 
   it('array index', async () => {
-    expect(await jqEval([10, 20, 30], '.[1]')).toBe(20)
+    expect(await evalOne([10, 20, 30], '.[1]')).toBe(20)
   })
 
   it('array spread with map-like pipe', async () => {
@@ -39,30 +51,30 @@ describe('jq eval (libjq adapter)', () => {
   })
 
   it('length', async () => {
-    expect(await jqEval([1, 2, 3], 'length')).toBe(3)
-    expect(await jqEval('hello', 'length')).toBe(5)
-    expect(await jqEval({ a: 1, b: 2 }, 'length')).toBe(2)
+    expect(await evalOne([1, 2, 3], 'length')).toBe(3)
+    expect(await evalOne('hello', 'length')).toBe(5)
+    expect(await evalOne({ a: 1, b: 2 }, 'length')).toBe(2)
   })
 
   it('keys', async () => {
-    expect(await jqEval({ c: 1, a: 2, b: 3 }, 'keys')).toEqual(['a', 'b', 'c'])
+    expect(await evalOne({ c: 1, a: 2, b: 3 }, 'keys')).toEqual(['a', 'b', 'c'])
   })
 
   it('map with identity', async () => {
-    expect(await jqEval([1, 2, 3], 'map(.)')).toEqual([1, 2, 3])
+    expect(await evalOne([1, 2, 3], 'map(.)')).toEqual([1, 2, 3])
   })
 
   it('map with type', async () => {
-    expect(await jqEval([1, 'a', null], 'map(type)')).toEqual(['number', 'string', 'null'])
+    expect(await evalOne([1, 'a', null], 'map(type)')).toEqual(['number', 'string', 'null'])
   })
 
   it('select filters', async () => {
-    expect(await jqEval([1, 2, 3, 4], 'map(select(. > 2))')).toEqual([3, 4])
+    expect(await evalOne([1, 2, 3, 4], 'map(select(. > 2))')).toEqual([3, 4])
   })
 
   it('sort_by', async () => {
     const data = [{ n: 3 }, { n: 1 }, { n: 2 }]
-    expect(await jqEval(data, 'sort_by(.n)')).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }])
+    expect(await evalOne(data, 'sort_by(.n)')).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }])
   })
 
   it('group_by', async () => {
@@ -71,7 +83,7 @@ describe('jq eval (libjq adapter)', () => {
       { kind: 'b', v: 2 },
       { kind: 'a', v: 3 },
     ]
-    expect(await jqEval(data, 'group_by(.kind)')).toEqual([
+    expect(await evalOne(data, 'group_by(.kind)')).toEqual([
       [
         { kind: 'a', v: 1 },
         { kind: 'a', v: 3 },
@@ -82,25 +94,25 @@ describe('jq eval (libjq adapter)', () => {
 
   it('object construction', async () => {
     const data = { name: 'alice', age: 30 }
-    expect(await jqEval(data, '{name, age}')).toEqual({ name: 'alice', age: 30 })
+    expect(await evalOne(data, '{name, age}')).toEqual({ name: 'alice', age: 30 })
   })
 
   it('has', async () => {
-    expect(await jqEval({ a: 1 }, 'has("a")')).toBe(true)
-    expect(await jqEval({ a: 1 }, 'has("b")')).toBe(false)
+    expect(await evalOne({ a: 1 }, 'has("a")')).toBe(true)
+    expect(await evalOne({ a: 1 }, 'has("b")')).toBe(false)
   })
 
   it('add', async () => {
-    expect(await jqEval([1, 2, 3], 'add')).toBe(6)
-    expect(await jqEval(['a', 'b'], 'add')).toBe('ab')
+    expect(await evalOne([1, 2, 3], 'add')).toBe(6)
+    expect(await evalOne(['a', 'b'], 'add')).toBe('ab')
   })
 
   it('unique', async () => {
-    expect(await jqEval([1, 2, 2, 3, 1], 'unique')).toEqual([1, 2, 3])
+    expect(await evalOne([1, 2, 2, 3, 1], 'unique')).toEqual([1, 2, 3])
   })
 
   it('reverse on array', async () => {
-    expect(await jqEval([1, 2, 3], 'reverse')).toEqual([3, 2, 1])
+    expect(await evalOne([1, 2, 3], 'reverse')).toEqual([3, 2, 1])
   })
 
   it('reverse on string raises (real jq is strict)', async () => {
@@ -108,147 +120,155 @@ describe('jq eval (libjq adapter)', () => {
   })
 
   it('string interpolation', async () => {
-    expect(await jqEval({ name: 'alice' }, '"hi \\(.name)"')).toBe('hi alice')
+    expect(await evalOne({ name: 'alice' }, '"hi \\(.name)"')).toBe('hi alice')
   })
 
   it('comparison', async () => {
-    expect(await jqEval({ n: 5 }, '.n > 3')).toBe(true)
-    expect(await jqEval({ n: 5 }, '.n == 5')).toBe(true)
+    expect(await evalOne({ n: 5 }, '.n > 3')).toBe(true)
+    expect(await evalOne({ n: 5 }, '.n == 5')).toBe(true)
   })
 
   it('pipe chains', async () => {
-    expect(await jqEval([{ n: 3 }, { n: 1 }], 'sort_by(.n) | .[0].n')).toBe(1)
+    expect(await evalOne([{ n: 3 }, { n: 1 }], 'sort_by(.n) | .[0].n')).toBe(1)
   })
 
   it('alt operator //', async () => {
-    expect(await jqEval({ a: null }, '.a // "default"')).toBe('default')
-    expect(await jqEval({ a: 'x' }, '.a // "default"')).toBe('x')
+    expect(await evalOne({ a: null }, '.a // "default"')).toBe('default')
+    expect(await evalOne({ a: 'x' }, '.a // "default"')).toBe('x')
   })
 
   it('if-then-else-end', async () => {
-    expect(await jqEval(5, 'if . > 3 then "big" else "small" end')).toBe('big')
-    expect(await jqEval(1, 'if . > 3 then "big" else "small" end')).toBe('small')
+    expect(await evalOne(5, 'if . > 3 then "big" else "small" end')).toBe('big')
+    expect(await evalOne(1, 'if . > 3 then "big" else "small" end')).toBe('small')
   })
 
   it('array slice', async () => {
-    expect(await jqEval([1, 2, 3, 4, 5], '.[1:3]')).toEqual([2, 3])
+    expect(await evalOne([1, 2, 3, 4, 5], '.[1:3]')).toEqual([2, 3])
   })
 
   it('type', async () => {
-    expect(await jqEval('s', 'type')).toBe('string')
-    expect(await jqEval([], 'type')).toBe('array')
-    expect(await jqEval({}, 'type')).toBe('object')
-    expect(await jqEval(null, 'type')).toBe('null')
+    expect(await evalOne('s', 'type')).toBe('string')
+    expect(await evalOne([], 'type')).toBe('array')
+    expect(await evalOne({}, 'type')).toBe('object')
+    expect(await evalOne(null, 'type')).toBe('null')
   })
 
   it('not (real jq: only null and false are falsy)', async () => {
-    expect(await jqEval(false, 'not')).toBe(true)
-    expect(await jqEval(null, 'not')).toBe(true)
-    expect(await jqEval(0, 'not')).toBe(false)
-    expect(await jqEval(1, 'not')).toBe(false)
-    expect(await jqEval([], 'not')).toBe(false)
+    expect(await evalOne(false, 'not')).toBe(true)
+    expect(await evalOne(null, 'not')).toBe(true)
+    expect(await evalOne(0, 'not')).toBe(false)
+    expect(await evalOne(1, 'not')).toBe(false)
+    expect(await evalOne([], 'not')).toBe(false)
   })
 
   it('empty drops item inside map', async () => {
-    expect(await jqEval([1, 2, 3], 'map(if . == 2 then empty else . end)')).toEqual([1, 3])
+    expect(await evalOne([1, 2, 3], 'map(if . == 2 then empty else . end)')).toEqual([1, 3])
+  })
+
+  it('empty produces no output at the top level', async () => {
+    expect(await jqEval({}, 'empty')).toEqual([])
   })
 })
 
 describe('jq eval — libjq-only features (regression suite)', () => {
   it('parens (.x | y)', async () => {
-    expect(await jqEval({ items: [1, 2, 3] }, '(.items | length)')).toBe(3)
+    expect(await evalOne({ items: [1, 2, 3] }, '(.items | length)')).toBe(3)
   })
 
   it('parens in object value', async () => {
-    expect(await jqEval({ items: [1, 2, 3] }, '{n: (.items | length), first: .items[0]}')).toEqual({
-      n: 3,
-      first: 1,
-    })
+    expect(await evalOne({ items: [1, 2, 3] }, '{n: (.items | length), first: .items[0]}')).toEqual(
+      {
+        n: 3,
+        first: 1,
+      },
+    )
   })
 
   it('array construction collects spread outputs', async () => {
     const data = { slides: [{ id: 'a' }, { id: 'b' }, { id: 'c' }] }
-    expect(await jqEval(data, '[.slides[].id]')).toEqual(['a', 'b', 'c'])
+    expect(await evalOne(data, '[.slides[].id]')).toEqual(['a', 'b', 'c'])
   })
 
   it('array construction wraps single value', async () => {
-    expect(await jqEval({ x: 5 }, '[.x]')).toEqual([5])
+    expect(await evalOne({ x: 5 }, '[.x]')).toEqual([5])
   })
 
   it('object literal value with comma inside list', async () => {
-    expect(await jqEval({}, '{x: 1, y: [1,2,3]}')).toEqual({ x: 1, y: [1, 2, 3] })
+    expect(await evalOne({}, '{x: 1, y: [1,2,3]}')).toEqual({ x: 1, y: [1, 2, 3] })
   })
 
   it('nested object construction', async () => {
-    expect(await jqEval({ a: 1, b: 2 }, '{outer: {x: .a, y: .b}}')).toEqual({
+    expect(await evalOne({ a: 1, b: 2 }, '{outer: {x: .a, y: .b}}')).toEqual({
       outer: { x: 1, y: 2 },
     })
   })
 
   it('join with separator', async () => {
-    expect(await jqEval(['a', 'b', 'c'], 'join("-")')).toBe('a-b-c')
+    expect(await evalOne(['a', 'b', 'c'], 'join("-")')).toBe('a-b-c')
   })
 
   it('join empty separator', async () => {
-    expect(await jqEval(['foo', 'bar'], 'join("")')).toBe('foobar')
+    expect(await evalOne(['foo', 'bar'], 'join("")')).toBe('foobar')
   })
 
   it('array construction then join', async () => {
     const data = { slides: [{ id: 'a' }, { id: 'b' }] }
-    expect(await jqEval(data, '[.slides[].id] | join(",")')).toBe('a,b')
+    expect(await evalOne(data, '[.slides[].id] | join(",")')).toBe('a,b')
   })
 
   it('recurse (..) with type filter', async () => {
     const data = { a: 1, b: { c: 2, d: { e: 3 } } }
-    expect(await jqEval(data, '[.. | numbers] | sort')).toEqual([1, 2, 3])
+    expect(await evalOne(data, '[.. | numbers] | sort')).toEqual([1, 2, 3])
   })
 
   it('split / join round trip', async () => {
-    expect(await jqEval('a-b-c', 'split("-")')).toEqual(['a', 'b', 'c'])
-    expect(await jqEval(['a', 'b', 'c'], 'join("-")')).toBe('a-b-c')
+    expect(await evalOne('a-b-c', 'split("-")')).toEqual(['a', 'b', 'c'])
+    expect(await evalOne(['a', 'b', 'c'], 'join("-")')).toBe('a-b-c')
   })
 
   it('to_entries / from_entries', async () => {
-    expect(await jqEval({ a: 1, b: 2 }, 'to_entries')).toEqual([
+    expect(await evalOne({ a: 1, b: 2 }, 'to_entries')).toEqual([
       { key: 'a', value: 1 },
       { key: 'b', value: 2 },
     ])
-    expect(await jqEval([{ key: 'x', value: 9 }], 'from_entries')).toEqual({ x: 9 })
+    expect(await evalOne([{ key: 'x', value: 9 }], 'from_entries')).toEqual({ x: 9 })
   })
 
   it('startswith / endswith', async () => {
-    expect(await jqEval('foobar', 'startswith("foo")')).toBe(true)
-    expect(await jqEval('foobar', 'endswith("bar")')).toBe(true)
-    expect(await jqEval('foobar', 'startswith("xyz")')).toBe(false)
+    expect(await evalOne('foobar', 'startswith("foo")')).toBe(true)
+    expect(await evalOne('foobar', 'endswith("bar")')).toBe(true)
+    expect(await evalOne('foobar', 'startswith("xyz")')).toBe(false)
   })
 
   it('test (regex)', async () => {
-    expect(await jqEval('hello world', 'test("w.rld")')).toBe(true)
-    expect(await jqEval('hello world', 'test("xyz")')).toBe(false)
+    expect(await evalOne('hello world', 'test("w.rld")')).toBe(true)
+    expect(await evalOne('hello world', 'test("xyz")')).toBe(false)
   })
 
   it('walk transform', async () => {
     const data = { a: 'FOO', b: ['BAR', 'BAZ'] }
-    expect(await jqEval(data, 'walk(if type == "string" then ascii_downcase else . end)')).toEqual({
-      a: 'foo',
-      b: ['bar', 'baz'],
-    })
+    expect(await evalOne(data, 'walk(if type == "string" then ascii_downcase else . end)')).toEqual(
+      {
+        a: 'foo',
+        b: ['bar', 'baz'],
+      },
+    )
   })
 
-  it('top-level select that drops everything returns JQ_EMPTY sentinel', async () => {
-    expect(await jqEval({ x: 5 }, 'select(.x > 100)')).toBe(JQ_EMPTY)
+  it('top-level select that drops everything produces no output', async () => {
+    expect(await jqEval({ x: 5 }, 'select(.x > 100)')).toEqual([])
   })
 
   it('try / .missing returns null (real jq: missing key is not an error)', async () => {
-    expect(await jqEval({}, 'try .missing.x catch "fb"')).toBeNull()
+    expect(await evalOne({}, 'try .missing.x catch "fb"')).toBeNull()
   })
 
   it('try / catch triggers on real error', async () => {
-    expect(await jqEval([1, 2, 3], 'try .name catch "fb"')).toBe('fb')
+    expect(await evalOne([1, 2, 3], 'try .name catch "fb"')).toBe('fb')
   })
 
   it('missing dict key returns null in real jq (no throw)', async () => {
-    expect(await jqEval({ a: 1 }, '.b')).toBeNull()
+    expect(await evalOne({ a: 1 }, '.b')).toBeNull()
   })
 
   it('dot key on array raises (real jq is strict)', async () => {
@@ -296,19 +316,19 @@ describe('jq eval — user expressions that broke the homegrown parser', () => {
   it('flat select(.textRun != null) then join', async () => {
     const expr =
       '[.slides[].pageElements[].shape.text.textElements[] | select(.textRun != null) | .textRun.content] | join("")'
-    expect(await jqEval(slidesDoc(), expr)).toBe('Hello worldBye')
+    expect(await evalOne(slidesDoc(), expr)).toBe('Hello worldBye')
   })
 
   it('per-slide [content] then join, collected', async () => {
     const expr =
       '[.slides[] | [.pageElements[].shape.text.textElements[].textRun.content] | join("")]'
-    expect(await jqEval(slidesDoc(), expr)).toEqual(['Hello world', 'Bye'])
+    expect(await evalOne(slidesDoc(), expr)).toEqual(['Hello world', 'Bye'])
   })
 
   it('full slides summary object with nested constructions', async () => {
     const expr =
       '{title: .title, slideCount: (.slides | length), slides: [.slides[] | {objectId, elements: [.pageElements[] | select(.shape != null) | {type: .shape.shapeType, text: [.shape.text.textElements[].textRun.content] | join("")}]}]}'
-    expect(await jqEval(slidesDoc(), expr)).toEqual({
+    expect(await evalOne(slidesDoc(), expr)).toEqual({
       title: 'Deck',
       slideCount: 2,
       slides: [
@@ -325,28 +345,25 @@ describe('jq eval — user expressions that broke the homegrown parser', () => {
   })
 })
 
-describe('hasTopLevelSpread', () => {
-  it('detects a top-level spread', () => {
-    expect(hasTopLevelSpread('.a[]')).toBe(true)
-    expect(hasTopLevelSpread('.[] | .name')).toBe(true)
+describe('jq eval — output arity', () => {
+  it('a comma is two outputs, not one array', async () => {
+    expect(await jqEval({ a: 1, b: 2 }, '.a, .b')).toEqual([1, 2])
   })
 
-  it('does not treat a spread inside a collector as top level', () => {
-    // `[.a[] | .t]` emits ONE array, so the caller must print one line.
-    expect(hasTopLevelSpread('[.a[] | .t]')).toBe(false)
-    expect(hasTopLevelSpread('[["H"]] + [.[] | [.]]')).toBe(false)
+  it('a comma over arrays keeps each array whole', async () => {
+    expect(await jqEval({ a: 1, b: 2 }, '[.a], [.b]')).toEqual([[1], [2]])
   })
 
-  it('does not treat a spread inside parens as top level', () => {
-    expect(hasTopLevelSpread('([.a[]] | length)')).toBe(false)
+  it('a collector emits one output that is an array', async () => {
+    expect(await jqEval({ a: [{ t: 'x' }, { t: 'y' }] }, '[.a[] | .t]')).toEqual([['x', 'y']])
   })
 
-  it('ignores a bracket pair inside a string literal', () => {
-    expect(hasTopLevelSpread('.a | test("[]")')).toBe(false)
+  it('spreads with no bracket pair in the program', async () => {
+    expect(await jqEval(null, 'range(3)')).toEqual([0, 1, 2])
+    expect(await jqEval({ a: 1 }, '..')).toEqual([{ a: 1 }, 1])
   })
 
-  it('does not treat an index or slice as a spread', () => {
-    expect(hasTopLevelSpread('.values[1:]')).toBe(false)
-    expect(hasTopLevelSpread('.a[0]')).toBe(false)
+  it('a bracket pair inside a string literal is one output', async () => {
+    expect(await jqEval({ a: 'x[]y' }, '.a | contains("[]")')).toEqual([true])
   })
 })

--- a/typescript/packages/core/src/core/jq/eval.ts
+++ b/typescript/packages/core/src/core/jq/eval.ts
@@ -13,41 +13,24 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import * as jqWasm from 'jq-wasm'
-import { JQ_EMPTY } from './format.ts'
 
 /**
- * Report whether a jq program spreads its input at the top level.
+ * Evaluate a jq expression against obj.
  *
- * A top-level `[]` means the program emits one output per element, so the
- * caller must print each on its own line. A `[]` nested inside a collector
- * (`[.a[] | .b]`) does not: that program emits a single array. Strings are
- * skipped so a literal "[]" never counts.
+ * A jq program is a stream transformer: it emits zero, one or many values,
+ * and jq prints each on its own line. That arity is preserved here rather
+ * than collapsed, so two outputs are never confused with one output that
+ * happens to be an array. `.a, .b` yields two values; `[.a, .b]` yields one.
+ *
+ * Returns every output value, in order. Empty when the program produces no
+ * output at all, which real jq reports as exit 0 with empty stdout.
  */
-export function hasTopLevelSpread(expr: string): boolean {
-  let depth = 0
-  let inStr = false
-  for (let i = 0; i < expr.length; i++) {
-    const ch = expr[i]
-    if (ch === '"' && (i === 0 || expr[i - 1] !== '\\')) {
-      inStr = !inStr
-      continue
-    }
-    if (inStr) continue
-    if (depth === 0 && ch === '[' && expr[i + 1] === ']') return true
-    if (ch === '(' || ch === '[' || ch === '{') depth += 1
-    else if (ch === ')' || ch === ']' || ch === '}') depth -= 1
-  }
-  return false
-}
-
-export async function jqEval(obj: unknown, expr: string): Promise<unknown> {
+export async function jqEval(obj: unknown, expr: string): Promise<unknown[]> {
   const result = await jqWasm.raw(JSON.stringify(obj), expr, ['-c'])
   if (result.exitCode !== 0) {
     throw new Error(result.stderr || `jq exited with code ${String(result.exitCode)}`)
   }
-  const lines = result.stdout === '' ? [] : result.stdout.split('\n').filter((l) => l !== '')
-  const outputs = lines.map((l) => JSON.parse(l) as unknown)
-  if (outputs.length === 0) return JQ_EMPTY
-  if (outputs.length === 1 && !hasTopLevelSpread(expr)) return outputs[0]
-  return outputs
+  if (result.stdout === '') return []
+  const lines = result.stdout.split('\n').filter((l) => l !== '')
+  return lines.map((l) => JSON.parse(l) as unknown)
 }

--- a/typescript/packages/core/src/core/jq/format.test.ts
+++ b/typescript/packages/core/src/core/jq/format.test.ts
@@ -14,45 +14,58 @@
 
 import { describe, expect, it } from 'vitest'
 import { jqEval } from './eval.ts'
-import { JQ_EMPTY, concatBytes, formatJqOutput } from './format.ts'
+import { concatBytes, formatJqOutput } from './format.ts'
 
 const DEC = new TextDecoder()
 
 describe('formatJqOutput', () => {
-  it('returns empty bytes for JQ_EMPTY sentinel', () => {
-    expect(formatJqOutput(JQ_EMPTY, false, false, false)).toEqual(new Uint8Array(0))
-    expect(formatJqOutput(JQ_EMPTY, true, true, true)).toEqual(new Uint8Array(0))
+  it('returns empty bytes when there are no outputs', () => {
+    expect(formatJqOutput([], false, false)).toEqual(new Uint8Array(0))
+    expect(formatJqOutput([], true, true)).toEqual(new Uint8Array(0))
   })
 
   it('serializes a single value compactly', () => {
-    expect(DEC.decode(formatJqOutput({ a: 1 }, false, true, false))).toBe('{"a":1}\n')
+    expect(DEC.decode(formatJqOutput([{ a: 1 }], false, true))).toBe('{"a":1}\n')
+  })
+
+  it('indents a single value by default', () => {
+    expect(DEC.decode(formatJqOutput([{ a: 1 }], false, false))).toBe('{\n  "a": 1\n}\n')
   })
 
   it('emits raw strings without JSON quoting when raw=true', () => {
-    expect(DEC.decode(formatJqOutput('hello', true, true, false))).toBe('hello\n')
+    expect(DEC.decode(formatJqOutput(['hello'], true, true))).toBe('hello\n')
   })
 
-  it('spreads top-level arrays into one line per item', () => {
-    expect(DEC.decode(formatJqOutput([1, 2, 3], false, true, true))).toBe('1\n2\n3\n')
+  it('leaves non-strings as JSON when raw=true', () => {
+    expect(DEC.decode(formatJqOutput(['a', 1], true, true))).toBe('a\n1\n')
   })
 
-  it('keeps array as one value when spread is false', () => {
-    expect(DEC.decode(formatJqOutput([1, 2, 3], false, true, false))).toBe('[1,2,3]\n')
+  it('prints one line per output', () => {
+    expect(DEC.decode(formatJqOutput([1, 2, 3], false, true))).toBe('1\n2\n3\n')
+  })
+
+  it('keeps a single array output on one line', () => {
+    expect(DEC.decode(formatJqOutput([[1, 2, 3]], false, true))).toBe('[1,2,3]\n')
+  })
+
+  it('prints one line per output of a comma program', async () => {
+    const outputs = await jqEval({ a: 'alice', b: 30 }, '.a, .b')
+    expect(DEC.decode(formatJqOutput(outputs, true, true))).toBe('alice\n30\n')
   })
 })
 
 describe('jq DropItem regression', () => {
-  it('zero-output expression returns JQ_EMPTY, not a thrown error', async () => {
+  it('zero-output expression yields no outputs, not a thrown error', async () => {
     const msg = { id: 'x', subject: 'hi', body_text: '...' }
-    const result = await jqEval(msg, '.attachments[]?')
-    expect(result).toBe(JQ_EMPTY)
-    expect(formatJqOutput(result, true, true, true)).toEqual(new Uint8Array(0))
+    const outputs = await jqEval(msg, '.attachments[]?')
+    expect(outputs).toEqual([])
+    expect(formatJqOutput(outputs, true, true)).toEqual(new Uint8Array(0))
   })
 
-  it('select with no match returns JQ_EMPTY', async () => {
-    const result = await jqEval({ x: 1 }, 'select(.x > 100)')
-    expect(result).toBe(JQ_EMPTY)
-    expect(formatJqOutput(result, false, true, false)).toEqual(new Uint8Array(0))
+  it('select with no match yields no outputs', async () => {
+    const outputs = await jqEval({ x: 1 }, 'select(.x > 100)')
+    expect(outputs).toEqual([])
+    expect(formatJqOutput(outputs, false, true)).toEqual(new Uint8Array(0))
   })
 })
 

--- a/typescript/packages/core/src/core/jq/format.ts
+++ b/typescript/packages/core/src/core/jq/format.ts
@@ -12,8 +12,6 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export const JQ_EMPTY: unique symbol = Symbol('JQ_EMPTY')
-
 const ENC = new TextEncoder()
 
 function formatOne(value: unknown, raw: boolean, compact: boolean): Uint8Array {
@@ -34,17 +32,13 @@ export function concatBytes(parts: readonly Uint8Array[]): Uint8Array {
   return out
 }
 
+/** Render every output of a jq program, one per line. */
 export function formatJqOutput(
-  result: unknown,
+  outputs: readonly unknown[],
   raw: boolean,
   compact: boolean,
-  spread: boolean,
 ): Uint8Array {
-  if (result === JQ_EMPTY) return new Uint8Array(0)
-  if (spread && Array.isArray(result)) {
-    const parts: Uint8Array[] = []
-    for (const item of result) parts.push(formatOne(item, raw, compact))
-    return concatBytes(parts)
-  }
-  return formatOne(result, raw, compact)
+  const parts: Uint8Array[] = []
+  for (const value of outputs) parts.push(formatOne(value, raw, compact))
+  return concatBytes(parts)
 }

--- a/typescript/packages/core/src/core/jq/index.ts
+++ b/typescript/packages/core/src/core/jq/index.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-export { hasTopLevelSpread, jqEval } from './eval.ts'
+export { jqEval } from './eval.ts'
 export { concatBytes, formatJqOutput } from './format.ts'
 export {
   evalJsonlStream,

--- a/typescript/packages/core/src/core/jq/stream.test.ts
+++ b/typescript/packages/core/src/core/jq/stream.test.ts
@@ -13,9 +13,21 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { parseJsonAuto, parseJsonDocs } from './stream.ts'
+import { evalJsonlStream, parseJsonAuto, parseJsonDocs } from './stream.ts'
 
 const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+async function* lines(...items: string[]): AsyncIterable<Uint8Array> {
+  await Promise.resolve()
+  for (const item of items) yield ENC.encode(item)
+}
+
+async function collect(stream: AsyncIterable<Uint8Array>): Promise<string[]> {
+  const out: string[] = []
+  for await (const chunk of stream) out.push(DEC.decode(chunk).replace(/\n$/, ''))
+  return out
+}
 
 describe('parseJsonAuto', () => {
   it('throws clear error on empty input', () => {
@@ -63,5 +75,27 @@ describe('parseJsonDocs', () => {
 
   it('reports the whole-document error on garbage', () => {
     expect(() => parseJsonDocs(ENC.encode('this is not json'))).toThrow(/JSON|json/)
+  })
+})
+
+describe('evalJsonlStream', () => {
+  it('maps each line through the per-item program', async () => {
+    const source = lines('{"msg":"hello"}\n', '{"msg":"world"}\n')
+    expect(await collect(evalJsonlStream(source, '.[].msg'))).toEqual(['"hello"', '"world"'])
+  })
+
+  it('unquotes strings when raw', async () => {
+    const source = lines('{"msg":"hello"}\n', '{"msg":"world"}\n')
+    expect(await collect(evalJsonlStream(source, '.[].msg', true))).toEqual(['hello', 'world'])
+  })
+
+  it('prints every output of a line', async () => {
+    const source = lines('{"a":1,"b":2}\n', '{"a":3,"b":4}\n')
+    expect(await collect(evalJsonlStream(source, '.[] | .a, .b'))).toEqual(['1', '2', '3', '4'])
+  })
+
+  it('drops lines with no output', async () => {
+    const source = lines('{"id":1}\n', '{"id":2}\n', '{"id":3}\n')
+    expect(await collect(evalJsonlStream(source, '.[] | select(.id > 2)'))).toEqual(['{"id":3}'])
   })
 })

--- a/typescript/packages/core/src/core/jq/stream.ts
+++ b/typescript/packages/core/src/core/jq/stream.ts
@@ -13,7 +13,6 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { AsyncLineIterator } from '../../io/async_line_iterator.ts'
-import { JQ_EMPTY } from './format.ts'
 
 const DEC = new TextDecoder('utf-8', { fatal: false })
 const WHITESPACE = /\s/
@@ -142,9 +141,9 @@ export async function* evalJsonlStream(
     const text = DEC.decode(lineBytes).trim()
     if (text === '') continue
     const obj: unknown = JSON.parse(text)
-    const result = await jqEval(obj, perItem)
-    if (result === JQ_EMPTY) continue
-    const line = raw && typeof result === 'string' ? result : JSON.stringify(result)
-    yield ENC.encode(line + '\n')
+    for (const value of await jqEval(obj, perItem)) {
+      const line = raw && typeof value === 'string' ? value : JSON.stringify(value)
+      yield ENC.encode(line + '\n')
+    }
   }
 }


### PR DESCRIPTION
## The bug

`jq_eval` / `jqEval` collapsed a program's output stream into a single value: one output returned bare, many returned as a *list*, zero as a `JQ_EMPTY` sentinel. A list of outputs is indistinguishable from one output that happens to be an array, so the printer recovered the difference from the program text: `has_top_level_spread` / `hasTopLevelSpread` scanned for a `[]` at bracket depth 0.

The text cannot answer that question. Any multi-output program with no literal `[]` printed a JSON array instead of one line per value:

| program | mirage before | GNU jq |
| --- | --- | --- |
| `jq -r '.a, .b'` | `[1,2]` | `1` / `2` |
| `jq -c 'range(3)'` | `[0,1,2]` | `0` / `1` / `2` |
| `jq -c '..'` | `[{...},"alice",30]` | three lines |

Neither libjq nor jq-wasm was wrong. Both returned the right arity and it was discarded immediately after the call. In TypeScript the correct output was already the string `"1\n2\n"` in `result.stdout`, then split, parsed, collapsed, and re-derived from the program text.

## The fix

`jq_eval` returns every output in order, `format_jq_output` prints one per line, and the heuristic plus both `JQ_EMPTY` sentinels are deleted (an empty list means no output). `eval_jsonl_stream` loops the outputs of each line as well. `[.a, .b]` still emits one value and prints one line, now for the right reason.

## Tests

`integ/unix/jq/comma.json`, 12 cases (seq 700000-700011): comma under `-c` / `-r` / default pretty-printing, comma over arrays vs a collector, per-document and slurped, `range`, `..`, through a pipe, from stdin, and over the jsonl stream path.

Expected output is pinned against GNU jq 1.7 in `debian:stable-slim`, not written from memory.

With arity preserved, `jq_eval(x, ".a")` returns `[1]`, and about 130 existing assertions read `== 1`. Instead of adding `[0]` everywhere, the unit tests go through `eval_one` / `evalOne` helpers that assert `len(outputs) == 1` and return it. That turned the migration into a detector: it flagged 13 tests whose programs were genuinely multi-output, and each moved to the arity-preserving call with its expected list unchanged.

`docs/home/bash.mdx` documented the old rule and is updated.

## Verification

- pre-commit clean and stable across a second run
- full Python suite exit 0, zero FAILED/ERROR
- TS core 5646, node 2000, browser 181, agents 175, server 210, cli 92, all passing; `pnpm -r typecheck` clean
- integ 3979 passed / 0 failed on both the python and typescript hosts for ram+disk, plus 1920 on redis
- no spec drift from either generator

## Known divergence, left alone

The `.jsonl` streaming fast path (taken when the path ends `.jsonl`/`.ndjson` and the program starts `.[]`) treats the file as one array and always prints compact, ignoring the absence of `-c`. GNU jq would read each line as its own document. That array premise is already pinned by `jq_jsonl_chain` (seq 28), so the streaming case here is pinned with `-c` rather than quietly encoding the pretty-print behavior either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)