### PR TITLE
Runtime and policy sweep 4: interruptible pyodide, killable monty, prototype-safe shell records

### DIFF
--- a/docs/typescript/runtime/python.mdx
+++ b/docs/typescript/runtime/python.mdx
@@ -109,9 +109,13 @@ central point. A run that exceeds `timeout_seconds` answers with exit
 other command; `max_bytes` and `max_lines` cap its output the same
 way. There is no python3-specific limit surface.
 
-One caveat: the guard bounds how long a run may *answer*, not the
-interpreter itself. A run that ignores the deadline keeps its
-interpreter busy in the background until it finishes (monty runs on a
-crash-isolated worker; pyodide shares the event loop, so prefer monty
-for untrusted code). Give untrusted code a finite workload, or run it
-behind a sandboxed deployment.
+The deadline stops the interpreter, not just the answer. Monty's
+worker process is SIGKILLed when its run trips the deadline (or a
+background job is killed), so a runaway loop never keeps burning.
+Pyodide shares the event loop with the workspace, so the runtime arms
+its interrupt buffer from a watchdog thread: the guest gets a
+`KeyboardInterrupt` at the deadline and the run answers 124 even for
+a busy `while True` loop. The watchdog needs `SharedArrayBuffer`
+(always present in Node; in a browser only on cross-origin isolated
+pages) — without it, a busy pyodide loop blocks the event loop until
+it finishes, so prefer monty for untrusted code there.

--- a/integ/bash/command/proto.json
+++ b/integ/bash/command/proto.json
@@ -1,0 +1,159 @@
+{
+  "cases": [
+    {
+      "id": "proto_name_command_not_found",
+      "seq": 503150,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "toString 2>&1; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "toString: command not found\nrc=127\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "proto_name_command_v_misses",
+      "seq": 503151,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "command -v toString; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rc=1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "proto_name_prefix_assign_no_leak",
+      "seq": 503152,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "X=7 toString 2>/dev/null; echo \"[$X]\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "[]\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "proto_name_variable",
+      "seq": 503153,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "__proto__=5; echo \"[$__proto__]\"; unset __proto__; echo \"[$__proto__]\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "[5]\n[]\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "proto_name_function",
+      "seq": 503154,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "toString() { echo ran; }; toString; unset -f toString; toString 2>&1; echo rc=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "ran\ntoString: command not found\nrc=127\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/typescript/packages/core/src/commands/spec/builtins.ts
+++ b/typescript/packages/core/src/commands/spec/builtins.ts
@@ -20,7 +20,7 @@ export function specOf(name: string): CommandSpec {
   return spec
 }
 
-export const BUILTIN_SPECS: Readonly<Record<string, CommandSpec>> = Object.freeze({
+const SPEC_TABLE: Record<string, CommandSpec> = {
   ls: new CommandSpec({
     options: [
       new Option({ short: '-l' }),
@@ -1159,4 +1159,11 @@ export const BUILTIN_SPECS: Readonly<Record<string, CommandSpec>> = Object.freez
     ],
     rest: new Operand({ kind: OperandKind.PATH }),
   }),
-})
+}
+
+// Null prototype: command names are script-controlled, so a name like
+// `toString` must miss instead of resolving an `Object.prototype`
+// member as a spec.
+export const BUILTIN_SPECS: Readonly<Record<string, CommandSpec>> = Object.freeze(
+  Object.setPrototypeOf(SPEC_TABLE, null) as Record<string, CommandSpec>,
+)

--- a/typescript/packages/core/src/workspace/command_timeout.test.ts
+++ b/typescript/packages/core/src/workspace/command_timeout.test.ts
@@ -114,7 +114,8 @@ describe('command timeout', () => {
 
 // python3 is guarded like any other command: the same safeguard surface,
 // the same enforcement point, exit 124. ~2s of interpreter work against a
-// 0.25s budget; monty's worker finishes in the background before close.
+// 0.25s budget; the deadline SIGKILLs monty's worker, so close() never
+// waits on it.
 const SLOW_SCRIPT = "printf 'n = 0\\nfor i in range(100000000):\\n    n = n + 1\\n' > /data/slow.py"
 
 describe('python3 command timeout', () => {
@@ -201,6 +202,47 @@ describe('python3 command timeout', () => {
       expect(r.exitCode).toBe(124)
       expect(probe.aborted).toBe(true)
     } finally {
+      await ws.close()
+    }
+  }, 60_000)
+
+  it('a busy pyodide loop trips the safeguard instead of wedging the event loop', async () => {
+    const ram = new RAMResource()
+    const registry = new OpsRegistry()
+    registry.registerResource(ram)
+    const ws = new Workspace(
+      { '/data': ram },
+      {
+        mode: MountMode.EXEC,
+        ops: registry,
+        shellParser: parser,
+        runtimes: ['pyodide', 'vfs'],
+        commandSafeguards: {
+          '/data': { python3: new CommandSafeguard({ timeoutSeconds: 0.5 }) },
+        },
+      },
+    )
+    try {
+      const started = Date.now()
+      const r = await ws.execute('cd /data && python3 -c "while True: pass"')
+      expect(r.exitCode).toBe(124)
+      expect(DEC.decode(r.stderr)).toContain('timed out')
+      expect(Date.now() - started).toBeLessThan(60_000)
+    } finally {
+      await ws.close()
+    }
+  }, 120_000)
+
+  it('a busy monty loop trips the safeguard and the worker is reclaimed', async () => {
+    const ws = buildPyWs({
+      '/data': { python3: new CommandSafeguard({ timeoutSeconds: 0.25 }) },
+    })
+    try {
+      const r = await ws.execute('cd /data && python3 -c "while True: pass"')
+      expect(r.exitCode).toBe(124)
+      expect(DEC.decode(r.stderr)).toContain('python3: timed out after 0.25s')
+    } finally {
+      // close() must not hang on the killed worker's session.
       await ws.close()
     }
   }, 60_000)

--- a/typescript/packages/core/src/workspace/execute.test.ts
+++ b/typescript/packages/core/src/workspace/execute.test.ts
@@ -337,3 +337,54 @@ describe('glob rule: resolved by whoever consumes the word, exactly once', () =>
     await ws.close()
   })
 })
+
+// Shell names are script-controlled, so a name colliding with an
+// `Object.prototype` member must behave exactly like any other name:
+// session records and lookup tables are null-prototype (ownRecord,
+// SPEC_TABLE) and the seams read own entries only. Python's dicts get
+// this for free; these pins keep the TypeScript side honest.
+describe('Object.prototype-colliding names', () => {
+  it('an unknown command named toString is command-not-found, exit 127', async () => {
+    const { ws } = buildWorkspace()
+    const res = await ws.execute('toString')
+    expect(res.exitCode).toBe(127)
+    expect(new TextDecoder().decode(res.stderr)).toContain('toString: command not found')
+    await ws.close()
+  })
+
+  it('command -v and type do not report prototype members as functions', async () => {
+    const { ws } = buildWorkspace()
+    const v = await ws.execute('command -v toString')
+    expect(v.exitCode).toBe(1)
+    expect(new TextDecoder().decode(v.stdout)).toBe('')
+    const t = await ws.execute('type constructor')
+    expect(t.exitCode).toBe(1)
+    await ws.close()
+  })
+
+  it('a prefix assignment on an unknown command does not leak into the session', async () => {
+    const { ws } = buildWorkspace()
+    await ws.execute('X=7 toString')
+    const res = await ws.execute('echo "[$X]"')
+    expect(new TextDecoder().decode(res.stdout)).toBe('[]\n')
+    await ws.close()
+  })
+
+  it('__proto__ is an ordinary shell variable', async () => {
+    const { ws } = buildWorkspace()
+    const res = await ws.execute('__proto__=5; echo "[$__proto__]"')
+    expect(new TextDecoder().decode(res.stdout)).toBe('[5]\n')
+    const unset = await ws.execute('__proto__=5; unset __proto__; echo "[$__proto__]"')
+    expect(new TextDecoder().decode(unset.stdout)).toBe('[]\n')
+    await ws.close()
+  })
+
+  it('a shell function named toString defines, runs, and unsets', async () => {
+    const { ws } = buildWorkspace()
+    const res = await ws.execute('toString() { echo ran; }; toString')
+    expect(new TextDecoder().decode(res.stdout)).toBe('ran\n')
+    const gone = await ws.execute('toString() { echo ran; }; unset -f toString; toString')
+    expect(gone.exitCode).toBe(127)
+    await ws.close()
+  })
+})

--- a/typescript/packages/core/src/workspace/executor/builtins.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins.test.ts
@@ -463,7 +463,9 @@ describe('handlePrintf', () => {
     const s = new Session({ sessionId: 'test' })
     expect(handlePrintf(['-v', '__proto__[0]', 'hi'], s)[1].exitCode).toBe(0)
     expect(Object.hasOwn(s.arrays, '__proto__')).toBe(true)
-    expect(Object.getPrototypeOf(s.arrays)).toBe(Object.prototype)
+    // Session records are null-prototype (ownRecord), so there is no
+    // prototype to corrupt in the first place.
+    expect(Object.getPrototypeOf(s.arrays)).toBe(null)
     expect(({} as Record<string, unknown>)[0]).toBeUndefined()
   })
 

--- a/typescript/packages/core/src/workspace/executor/builtins/vars.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/vars.ts
@@ -24,7 +24,7 @@ import { SET_FLAG_TO_OPTION } from '../../../shell/types.ts'
 import type { Namespace } from '../../mount/namespace/namespace.ts'
 import { arrayExtent, arrayUnset } from '../../../shell/array.ts'
 import { arrayIndex } from '../../expand/variable.ts'
-import { sessionEntry } from '../../session/session.ts'
+import { ownRecord, sessionEntry } from '../../session/session.ts'
 import type { Session } from '../../session/session.ts'
 import { ExecutionNode } from '../../types.ts'
 import { ReturnSignal } from '../command.ts'
@@ -315,7 +315,7 @@ export async function handleEnv(
 
   const dropSet = new Set(unset)
   const source = ignoreEnv ? {} : session.env
-  const base: Record<string, string> = {}
+  const base: Record<string, string> = ownRecord()
   for (const [k, v] of Object.entries(source)) {
     if (!dropSet.has(k)) base[k] = v
   }

--- a/typescript/packages/core/src/workspace/executor/pipes.ts
+++ b/typescript/packages/core/src/workspace/executor/pipes.ts
@@ -22,7 +22,7 @@ import type { CallStack } from '../../shell/call_stack.ts'
 import { ExitSignal } from '../../shell/errors.ts'
 import { ERREXIT_EXEMPT_TYPES, NodeType as NT } from '../../shell/types.ts'
 import type { JobTable } from '../../shell/job_table.ts'
-import type { Session } from '../session/session.ts'
+import { ownRecord, type Session } from '../session/session.ts'
 import type { TSNodeLike } from '../expand/variable.ts'
 import { ExecutionNode } from '../types.ts'
 import { type ExecuteNodeFn, handleBackground } from './jobs.ts'
@@ -256,12 +256,12 @@ export async function handleSubshell(
   agentId: string | null = null,
 ): Promise<Result> {
   const savedCwd = session.cwd
-  const savedEnv = { ...session.env }
+  const savedEnv = ownRecord(session.env)
   const savedOptions = { ...session.shellOptions }
   const savedReadonly = new Set(session.readonlyVars)
-  const savedArrays: Record<string, ShellArray> = {}
+  const savedArrays: Record<string, ShellArray> = ownRecord()
   for (const [k, v] of Object.entries(session.arrays)) savedArrays[k] = [...v]
-  const savedFunctions = { ...session.functions }
+  const savedFunctions = ownRecord(session.functions)
   const savedPositional = [...session.positionalArgs]
   const savedLastBgJob = session.lastBgJobId
   const savedGetoptsPos = session.getoptsPos

--- a/typescript/packages/core/src/workspace/executor/policy/decide.ts
+++ b/typescript/packages/core/src/workspace/executor/policy/decide.ts
@@ -242,7 +242,11 @@ export async function decideLine(
         })
       }
       return {
-        bindings: { ...staticBindings, ...overlay },
+        bindings: Object.assign(
+          Object.create(null) as Record<string, Runtime>,
+          staticBindings,
+          overlay,
+        ),
         fallback: catchAll(entries),
       }
     }
@@ -254,8 +258,12 @@ export async function decideLine(
     if (wants) willing.push(entry)
   }
   // Every captured command resolves: to its first willing capturer, or
-  // to null (all capturers refused -> admission failure).
-  const bindings: Record<string, Runtime | null> = {}
+  // to null (all capturers refused -> admission failure). Null
+  // prototype: captures are arbitrary command names.
+  const bindings: Record<string, Runtime | null> = Object.create(null) as Record<
+    string,
+    Runtime | null
+  >
   for (const entry of entries) {
     for (const command of entry.captures) bindings[command] = null
   }

--- a/typescript/packages/core/src/workspace/executor/policy/safeguard.test.ts
+++ b/typescript/packages/core/src/workspace/executor/policy/safeguard.test.ts
@@ -101,3 +101,11 @@ describe('resolveAcrossMounts', () => {
     expect(merged?.maxLines).toBe(10)
   })
 })
+
+describe('prototype-colliding command names', () => {
+  it('falls through to the fallback instead of an Object.prototype member', () => {
+    const sg = resolveSafeguard('toString')
+    expect(sg).toBe(FALLBACK_SAFEGUARD)
+    expect(resolveSafeguard('constructor')).toBe(FALLBACK_SAFEGUARD)
+  })
+})

--- a/typescript/packages/core/src/workspace/executor/policy/safeguard.ts
+++ b/typescript/packages/core/src/workspace/executor/policy/safeguard.ts
@@ -17,14 +17,20 @@ import { CommandSafeguard } from '../../../types.ts'
 const DEFAULT_MAX_LINES = 2000
 const DEFAULT_TIMEOUT_SECONDS = 600
 
-export const DEFAULT_COMMAND_SAFEGUARDS: Record<string, CommandSafeguard> = Object.fromEntries(
-  ['cat', 'grep', 'rg', 'head', 'tail'].map((name) => [
-    name,
-    new CommandSafeguard({
-      maxLines: DEFAULT_MAX_LINES,
-      timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
-    }),
-  ]),
+// Null prototype: command names are script-controlled, so a name like
+// `toString` must fall through to the fallback instead of resolving an
+// `Object.prototype` member as a safeguard.
+export const DEFAULT_COMMAND_SAFEGUARDS: Record<string, CommandSafeguard> = Object.assign(
+  Object.create(null) as Record<string, CommandSafeguard>,
+  Object.fromEntries(
+    ['cat', 'grep', 'rg', 'head', 'tail'].map((name) => [
+      name,
+      new CommandSafeguard({
+        maxLines: DEFAULT_MAX_LINES,
+        timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
+      }),
+    ]),
+  ),
 )
 
 export const FALLBACK_SAFEGUARD = new CommandSafeguard({ timeoutSeconds: DEFAULT_TIMEOUT_SECONDS })

--- a/typescript/packages/core/src/workspace/executor/python/interrupt.ts
+++ b/typescript/packages/core/src/workspace/executor/python/interrupt.ts
@@ -51,7 +51,10 @@ interface WatchdogPort {
 }
 
 // The watchdog body, identical logic in both hosts: one pending
-// countdown at a time, generation-checked at the deadline.
+// countdown at a time, generation-checked at the deadline. The reason
+// cell is stored BEFORE the interrupt cell: the interrupt write can
+// wake pyodide immediately, and disarm() must never observe the trip
+// without its reason (it would report a timeout as a plain failure).
 const WATCHDOG_BODY = `
 let timer = null;
 function onMessage(msg) {
@@ -61,8 +64,8 @@ function onMessage(msg) {
     const gen = msg.gen;
     timer = setTimeout(() => {
       if (Atomics.load(cells, 2) === gen) {
-        Atomics.store(cells, 0, 2);
         Atomics.store(cells, 1, 1);
+        Atomics.store(cells, 0, 2);
       }
     }, msg.delayMs);
   }
@@ -89,7 +92,9 @@ async function createNodeWatchdog(): Promise<WatchdogPort | null> {
     // The watchdog must never keep the process alive on its own.
     worker.unref()
     return {
-      post: (message) => worker.postMessage(message),
+      post: (message) => {
+        worker.postMessage(message)
+      },
       terminate: () => void worker.terminate(),
     }
   } catch {

--- a/typescript/packages/core/src/workspace/executor/python/interrupt.ts
+++ b/typescript/packages/core/src/workspace/executor/python/interrupt.ts
@@ -1,0 +1,171 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+/**
+ * Deadline interruption for pyodide, which executes on THIS thread: a
+ * busy guest loop blocks the event loop, so no timer here can ever
+ * fire (the quickjs runtime has an in-VM interrupt hook for this;
+ * pyodide only reads a SharedArrayBuffer via setInterruptBuffer). A
+ * tiny watchdog worker owns the countdown instead: it writes SIGINT
+ * (2) into the shared interrupt cell at the deadline, pyodide's
+ * interpreter loop sees it mid-execution and raises KeyboardInterrupt,
+ * and the run reports which trip happened through the second cell.
+ *
+ * Cells (Int32Array over one SharedArrayBuffer): [0] the pyodide
+ * interrupt cell (pyodide resets it to 0 when it fires), [1] why the
+ * trip happened (1 deadline, 2 kill signal), [2] the arm generation,
+ * which the watchdog re-checks at the deadline so a countdown
+ * cancelled just as it fires cannot poison the next run.
+ *
+ * Environments without SharedArrayBuffer or workers (a browser page
+ * that is not cross-origin isolated) get null: runs stay unbounded
+ * there, exactly the pre-interrupt behavior.
+ */
+
+interface ArmedInterrupt {
+  /** Stop the countdown; report the trip, once (idempotent: null after). */
+  disarm(): 'deadline' | 'signal' | null
+}
+
+export interface PyodideInterrupter {
+  /** The view to hand to pyodide.setInterruptBuffer, once. */
+  readonly view: Int32Array
+  arm(timeoutSeconds: number | null, signal?: AbortSignal): ArmedInterrupt
+  close(): void
+}
+
+interface WatchdogPort {
+  post(message: object): void
+  terminate(): void
+}
+
+// The watchdog body, identical logic in both hosts: one pending
+// countdown at a time, generation-checked at the deadline.
+const WATCHDOG_BODY = `
+let timer = null;
+function onMessage(msg) {
+  if (timer !== null) { clearTimeout(timer); timer = null; }
+  if (msg.delayMs != null) {
+    const cells = new Int32Array(msg.buffer);
+    const gen = msg.gen;
+    timer = setTimeout(() => {
+      if (Atomics.load(cells, 2) === gen) {
+        Atomics.store(cells, 0, 2);
+        Atomics.store(cells, 1, 1);
+      }
+    }, msg.delayMs);
+  }
+}
+`
+
+const NODE_WATCHDOG = `${WATCHDOG_BODY}
+require('node:worker_threads').parentPort.on('message', onMessage);
+`
+
+const BROWSER_WATCHDOG = `${WATCHDOG_BODY}
+self.onmessage = (event) => { onMessage(event.data); };
+`
+
+function isNode(): boolean {
+  const proc = (globalThis as { process?: { versions?: Record<string, string> } }).process
+  return typeof proc?.versions?.node === 'string'
+}
+
+async function createNodeWatchdog(): Promise<WatchdogPort | null> {
+  try {
+    const { Worker } = await import('node:worker_threads')
+    const worker = new Worker(NODE_WATCHDOG, { eval: true })
+    // The watchdog must never keep the process alive on its own.
+    worker.unref()
+    return {
+      post: (message) => worker.postMessage(message),
+      terminate: () => void worker.terminate(),
+    }
+  } catch {
+    // No worker_threads (exotic host): degrade to unbounded runs.
+    return null
+  }
+}
+
+function createBrowserWatchdog(): WatchdogPort | null {
+  if (typeof Worker === 'undefined' || typeof Blob === 'undefined') return null
+  const url = URL.createObjectURL(new Blob([BROWSER_WATCHDOG], { type: 'text/javascript' }))
+  try {
+    const worker = new Worker(url)
+    return {
+      post: (message) => {
+        worker.postMessage(message)
+      },
+      terminate: () => {
+        worker.terminate()
+      },
+    }
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+}
+
+export async function createPyodideInterrupter(): Promise<PyodideInterrupter | null> {
+  if (typeof SharedArrayBuffer === 'undefined') return null
+  const watchdog = isNode() ? await createNodeWatchdog() : createBrowserWatchdog()
+  if (watchdog === null) return null
+  const shared = new SharedArrayBuffer(12)
+  const cells = new Int32Array(shared)
+  let generation = 0
+  return {
+    view: cells,
+    arm(timeoutSeconds: number | null, signal?: AbortSignal): ArmedInterrupt {
+      generation += 1
+      Atomics.store(cells, 0, 0)
+      Atomics.store(cells, 1, 0)
+      Atomics.store(cells, 2, generation)
+      if (timeoutSeconds !== null && timeoutSeconds > 0) {
+        watchdog.post({ buffer: shared, delayMs: timeoutSeconds * 1000, gen: generation })
+      }
+      let removeAbort: (() => void) | null = null
+      if (signal !== undefined) {
+        const onAbort = (): void => {
+          Atomics.store(cells, 1, 2)
+          Atomics.store(cells, 0, 2)
+        }
+        if (signal.aborted) {
+          onAbort()
+        } else {
+          signal.addEventListener('abort', onAbort, { once: true })
+          removeAbort = () => {
+            signal.removeEventListener('abort', onAbort)
+          }
+        }
+      }
+      let done = false
+      return {
+        disarm: (): 'deadline' | 'signal' | null => {
+          if (done) return null
+          done = true
+          generation += 1
+          Atomics.store(cells, 2, generation)
+          watchdog.post({ cancel: true })
+          if (removeAbort !== null) removeAbort()
+          const why = Atomics.load(cells, 1)
+          Atomics.store(cells, 0, 0)
+          Atomics.store(cells, 1, 0)
+          return why === 1 ? 'deadline' : why === 2 ? 'signal' : null
+        },
+      }
+    },
+    close(): void {
+      watchdog.terminate()
+    },
+  }
+}

--- a/typescript/packages/core/src/workspace/executor/python/loader.ts
+++ b/typescript/packages/core/src/workspace/executor/python/loader.ts
@@ -46,6 +46,7 @@ export interface PyodideInterface {
   loadPackagesFromImports?: (code: string, options?: Record<string, unknown>) => Promise<unknown>
   registerJsModule: (name: string, module: unknown) => void
   unregisterJsModule?: (name: string) => void
+  setInterruptBuffer?: (buffer: Int32Array | Uint8Array) => void
   FS: PyodideFS
 }
 

--- a/typescript/packages/core/src/workspace/executor/python/runtime_monty.test.ts
+++ b/typescript/packages/core/src/workspace/executor/python/runtime_monty.test.ts
@@ -99,6 +99,29 @@ describe('MontyRuntime', () => {
     expect(text(result.stderr)).toContain('SyntaxError')
   }, 30_000)
 
+  it('a deadline SIGKILLs the busy worker and reports exit 124', async () => {
+    const rt = make()
+    await expect(
+      rt.run({ code: 'while True: pass', args: [], env: {}, stdin: null, timeoutSeconds: 0.3 }),
+    ).rejects.toThrow(/monty: timed out after 0.3s/)
+  }, 30_000)
+
+  it('an aborted signal SIGKILLs the busy worker and reports exit 1', async () => {
+    const rt = make()
+    const ctrl = new AbortController()
+    setTimeout(() => {
+      ctrl.abort()
+    }, 200)
+    const result = await rt.run({
+      code: 'while True: pass',
+      args: [],
+      env: {},
+      stdin: null,
+      signal: ctrl.signal,
+    })
+    expect(result.exitCode).toBe(1)
+  }, 30_000)
+
   it('runtime errors keep prior stdout', async () => {
     const result = await run(make(), "print('before')\n1/0")
     expect(result.exitCode).toBe(1)

--- a/typescript/packages/core/src/workspace/executor/python/runtimes/monty.ts
+++ b/typescript/packages/core/src/workspace/executor/python/runtimes/monty.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { CommandTimeoutError } from '../../../../commands/builtin/utils/safeguard.ts'
 import { Runtime } from '../../runtime.ts'
 import { EvalError } from '../../runtime_errors.ts'
 import { EVALUATOR, type Evaluator } from '../../runtime_mixin.ts'
@@ -35,6 +36,7 @@ export class MontyUnavailableError extends Error {
 // Structural views of @pydantic/monty so its types never leak into our
 // public .d.ts (the package is an optional peer dependency).
 interface MontySessionLike {
+  readonly workerPid?: number
   feedRun(code: string, options?: Record<string, unknown>): Promise<unknown>
   close(): Promise<void>
 }
@@ -58,6 +60,40 @@ interface MontyDisplayableError extends Error {
 interface MirageEntryLike {
   path: string
   isDir: boolean
+}
+
+// One-shot eval is bounded like quickjs's: nothing above the runtime
+// can stop a hung guest, so the runtime owns its own interrupt.
+const EVAL_INTERRUPT_SECONDS = 10
+
+const INTERRUPTED = Symbol('interrupted')
+
+interface RunInterruption {
+  promise: Promise<typeof INTERRUPTED>
+  timedOut: { value: boolean }
+  dispose: () => void
+}
+
+/**
+ * Hard-stop one monty worker. The binding offers no cancel: feedRun
+ * has no signal and session.close() waits for the in-flight turn
+ * (probed live), so the only way to stop a busy guest is to kill its
+ * worker process — which poisons the session (the pool discards and
+ * replaces the worker) and settles the pending feedRun. The pid is
+ * only readable while the session is idle, so callers capture it
+ * before feeding. Python needs none of this: cancelling run_async
+ * halts the interpreter.
+ */
+function killWorker(pid: number | undefined): void {
+  if (pid === undefined) return
+  const proc = (globalThis as { process?: { kill?: (pid: number, signal?: string) => void } })
+    .process
+  if (typeof proc?.kill !== 'function') return
+  try {
+    proc.kill(pid, 'SIGKILL')
+  } catch {
+    // the worker may already have exited; nothing left to reclaim
+  }
 }
 
 function displayError(err: unknown): string {
@@ -120,10 +156,63 @@ export class MontyRuntime extends Runtime implements Evaluator {
   async run(args: RunArgs): Promise<RunResult> {
     const pool = await this.ensurePool()
     const session = await pool.checkout()
+    // Monty executes on its own worker process, so the event loop stays
+    // live to observe the safeguard deadline and the kill signal; a trip
+    // SIGKILLs the worker (see killWorker). Deadline -> exit 124 via
+    // CommandTimeoutError, kill -> exit 1 like the local runtime.
+    const workerPid = session.workerPid
+    const interruption = this.installInterruption(args.signal, args.timeoutSeconds)
     try {
-      return await this.feedOne(session, args.code, args)
+      const run = this.feedOne(session, args.code, args)
+      const winner = await Promise.race([run, interruption.promise])
+      if (winner !== INTERRUPTED) return winner
+      run.catch(() => undefined)
+      killWorker(workerPid)
+      if (interruption.timedOut.value && args.timeoutSeconds !== undefined) {
+        throw new CommandTimeoutError(this.name, args.timeoutSeconds)
+      }
+      return { stdout: new Uint8Array(), stderr: null, exitCode: 1 }
     } finally {
+      interruption.dispose()
       await session.close()
+    }
+  }
+
+  private installInterruption(
+    signal: AbortSignal | undefined,
+    timeoutSeconds: number | undefined,
+  ): RunInterruption {
+    const timedOut = { value: false }
+    let timer: ReturnType<typeof setTimeout> | null = null
+    let removeAbort: (() => void) | null = null
+    const promise = new Promise<typeof INTERRUPTED>((resolve) => {
+      if (timeoutSeconds !== undefined && timeoutSeconds > 0) {
+        timer = setTimeout(() => {
+          timedOut.value = true
+          resolve(INTERRUPTED)
+        }, timeoutSeconds * 1000)
+      }
+      if (signal !== undefined) {
+        if (signal.aborted) {
+          resolve(INTERRUPTED)
+          return
+        }
+        const onAbort = (): void => {
+          resolve(INTERRUPTED)
+        }
+        signal.addEventListener('abort', onAbort, { once: true })
+        removeAbort = () => {
+          signal.removeEventListener('abort', onAbort)
+        }
+      }
+    })
+    return {
+      promise,
+      timedOut,
+      dispose: () => {
+        if (timer !== null) clearTimeout(timer)
+        if (removeAbort !== null) removeAbort()
+      },
     }
   }
 
@@ -165,8 +254,25 @@ export class MontyRuntime extends Runtime implements Evaluator {
       os: this.buildOsCallback(module, {}),
     }
     const enc = new TextEncoder()
+    // One-shot evals get the quickjs-style 10s bound (the policy layer
+    // above times out but cannot stop the worker; SIGKILLing it does).
+    // Console sessions stay unbounded, matching python where
+    // cancellation is ambient.
+    const workerPid = session.workerPid
+    const interruption =
+      opts.session === undefined
+        ? this.installInterruption(undefined, EVAL_INTERRUPT_SECONDS)
+        : null
     try {
-      const value = toEvalValue(await session.feedRun(code, options))
+      const fed = session.feedRun(code, options)
+      const winner =
+        interruption !== null ? await Promise.race([fed, interruption.promise]) : await fed
+      if (winner === INTERRUPTED) {
+        fed.catch(() => undefined)
+        killWorker(workerPid)
+        throw new EvalError(`monty eval timed out after ${String(EVAL_INTERRUPT_SECONDS)}s`)
+      }
+      const value = toEvalValue(winner)
       return {
         value,
         stdout: enc.encode(out.join('')),
@@ -216,6 +322,7 @@ export class MontyRuntime extends Runtime implements Evaluator {
       }
       throw caught
     } finally {
+      interruption?.dispose()
       if (opts.session === undefined) await session.close()
     }
   }
@@ -301,8 +408,10 @@ export class MontyRuntime extends Runtime implements Evaluator {
     const notHandled = module.NOT_HANDLED
     return (name: string, args: unknown[]): unknown => {
       if (name === 'os.getenv') {
+        // hasOwn, not `in`: the guest picks the key, so a name like
+        // `toString` must miss instead of leaking a host function.
         const key = String(args[0])
-        if (key in env) return env[key]
+        if (Object.hasOwn(env, key)) return env[key]
         return args.length > 1 ? args[1] : null
       }
       if (bridge === null) return notHandled

--- a/typescript/packages/core/src/workspace/executor/python/runtimes/pyodide.ts
+++ b/typescript/packages/core/src/workspace/executor/python/runtimes/pyodide.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { CommandTimeoutError } from '../../../../commands/builtin/utils/safeguard.ts'
 import { Runtime } from '../../runtime.ts'
 import { EvalError } from '../../runtime_errors.ts'
 import { EVALUATOR, type Evaluator } from '../../runtime_mixin.ts'
@@ -23,6 +24,7 @@ import type {
   RunResult,
   RuntimeOptions,
 } from '../../runtime_types.ts'
+import { createPyodideInterrupter, type PyodideInterrupter } from '../interrupt.ts'
 import { loadPyodideRuntime, type PyodideInterface } from '../loader.ts'
 import {
   createMirageBridge,
@@ -112,6 +114,11 @@ const PYODIDE_CONFIG_KEYS: readonly string[] = [
   'home',
 ]
 
+// One-shot eval is bounded like quickjs's: nothing above the runtime
+// can stop a hung guest on this thread, so the runtime owns its own
+// interrupt. Console (repl) sessions stay unbounded, matching python.
+const EVAL_INTERRUPT_SECONDS = 10
+
 export class PyodideRuntime extends Runtime implements Evaluator {
   readonly name = PYODIDE_RUNTIME
   readonly [EVALUATOR] = true as const
@@ -128,6 +135,11 @@ export class PyodideRuntime extends Runtime implements Evaluator {
   private listMounts: () => string[] = () => []
   private readonly home: string | null
   private bridge: MirageBridge | null = null
+  // The guest executes on this event loop, so only the watchdog-backed
+  // interrupt buffer can stop a busy loop (see interrupt.ts); null
+  // where SharedArrayBuffer/workers are unavailable (runs unbounded).
+  private interrupter: PyodideInterrupter | null = null
+  private interrupterTried = false
 
   constructor(options: RuntimeOptions<PyodideConfig> = {}) {
     super(options, PyodideRuntime.commands, PYODIDE_CONFIG_KEYS)
@@ -183,8 +195,12 @@ export class PyodideRuntime extends Runtime implements Evaluator {
     const inputsPy = pyodide.toPy(opts.inputs ?? {})
     pyodide.globals.set('_user_code', code)
     pyodide.globals.set('_eval_inputs', inputsPy)
+    const armed = this.interrupter !== null ? this.interrupter.arm(EVAL_INTERRUPT_SECONDS) : null
     try {
       await pyodide.runPythonAsync(PYTHON_EVAL_WRAPPER)
+      if (armed?.disarm() === 'deadline') {
+        throw new EvalError(`pyodide eval timed out after ${String(EVAL_INTERRUPT_SECONDS)}s`)
+      }
       const resultProxy = pyodide.globals.get('_eval_result') as
         | {
             toJs?: (opts?: Record<string, unknown>) => unknown
@@ -211,7 +227,15 @@ export class PyodideRuntime extends Runtime implements Evaluator {
         exitCode: 0,
         status: 'complete',
       }
+    } catch (err) {
+      if (armed?.disarm() === 'deadline') {
+        throw new EvalError(`pyodide eval timed out after ${String(EVAL_INTERRUPT_SECONDS)}s`, {
+          cause: err,
+        })
+      }
+      throw err
     } finally {
+      armed?.disarm()
       pyodide.globals.delete?.('_user_code')
       pyodide.globals.delete?.('_eval_inputs')
       pyodide.globals.delete?.('_eval_result')
@@ -234,12 +258,23 @@ export class PyodideRuntime extends Runtime implements Evaluator {
     this.pyodide = null
     this.initPromise = null
     this.bridge = null
+    this.interrupter?.close()
+    this.interrupter = null
+    this.interrupterTried = false
+  }
+
+  private async wireInterruptIfNeeded(pyodide: PyodideInterface): Promise<void> {
+    if (this.interrupterTried || pyodide.setInterruptBuffer === undefined) return
+    this.interrupterTried = true
+    this.interrupter = await createPyodideInterrupter()
+    if (this.interrupter !== null) pyodide.setInterruptBuffer(this.interrupter.view)
   }
 
   private async ensureLoaded(): Promise<PyodideInterface> {
     if (this.pyodide !== null) {
       if (this.bootstrapPromise !== null) await this.bootstrapPromise
       await this.wireBridgeIfNeeded(this.pyodide)
+      await this.wireInterruptIfNeeded(this.pyodide)
       return this.pyodide
     }
     this.initPromise ??= loadPyodideRuntime(this.home ?? undefined)
@@ -260,6 +295,7 @@ export class PyodideRuntime extends Runtime implements Evaluator {
       await this.bootstrapPromise
     }
     await this.wireBridgeIfNeeded(this.pyodide)
+    await this.wireInterruptIfNeeded(this.pyodide)
     return this.pyodide
   }
 
@@ -302,8 +338,18 @@ export class PyodideRuntime extends Runtime implements Evaluator {
     pyodide.globals.set('_stdin_bytes', stdinBytes)
     pyodide.globals.set('_user_globals', userGlobalsPy)
 
+    // Deadline trip -> exit 124 via CommandTimeoutError; a kill signal
+    // raises KeyboardInterrupt in the guest, whose wrapper-reported
+    // exit code (1) stands, like the local runtime's killed child.
+    const armed =
+      this.interrupter !== null
+        ? this.interrupter.arm(args.timeoutSeconds ?? null, args.signal)
+        : null
     try {
       await pyodide.runPythonAsync(PYTHON_WRAPPER)
+      if (armed?.disarm() === 'deadline' && args.timeoutSeconds !== undefined) {
+        throw new CommandTimeoutError(this.name, args.timeoutSeconds)
+      }
       const resultProxy = pyodide.globals.get('_result') as
         | {
             toJs?: (opts?: Record<string, unknown>) => unknown
@@ -327,7 +373,15 @@ export class PyodideRuntime extends Runtime implements Evaluator {
         stderr: bridgeStderr(arr[1]),
         exitCode: arr[2],
       }
+    } catch (err) {
+      // The interrupt can also fire between wrapper statements, where
+      // KeyboardInterrupt escapes as a rejection instead of a result.
+      if (armed?.disarm() === 'deadline' && args.timeoutSeconds !== undefined) {
+        throw new CommandTimeoutError(this.name, args.timeoutSeconds)
+      }
+      throw err
     } finally {
+      armed?.disarm()
       pyodide.globals.delete?.('_user_code')
       pyodide.globals.delete?.('_argv')
       pyodide.globals.delete?.('_merged_env')

--- a/typescript/packages/core/src/workspace/executor/runtime.test.ts
+++ b/typescript/packages/core/src/workspace/executor/runtime.test.ts
@@ -84,6 +84,28 @@ describe('bindCommands', () => {
       /duplicate runtime entry: 'fake'/,
     )
   })
+
+  it('captures named after Object.prototype members bind like any other', () => {
+    class ProtoRuntime extends Runtime {
+      readonly name = 'proto'
+
+      constructor() {
+        super({ captures: ['toString', 'constructor'] })
+      }
+
+      run(_args: RunArgs): Promise<RunResult> {
+        return Promise.resolve({ stdout: new Uint8Array(), stderr: new Uint8Array(), exitCode: 0 })
+      }
+    }
+    const rt = new ProtoRuntime()
+    const bindings = bindCommands([rt, new VfsRuntime()])
+    // A helper defeats TS resolving `.toString` to the Object method.
+    const bound = (record: Record<string, Runtime>, name: string): Runtime | undefined =>
+      record[name]
+    expect(bound(bindings, 'toString')).toBe(rt)
+    expect(bound(bindings, 'constructor')).toBe(rt)
+    expect(bound(runtimeBindingsFor([rt], 'proto'), 'toString')).toBe(rt)
+  })
 })
 
 describe('buildRuntime option validation', () => {

--- a/typescript/packages/core/src/workspace/executor/runtime.ts
+++ b/typescript/packages/core/src/workspace/executor/runtime.ts
@@ -235,7 +235,8 @@ export function runtimeBindingsFor(
   }
   for (const entry of entries) {
     if (entry.name === name) {
-      const bindings: Record<string, Runtime> = {}
+      // Null prototype: captures are arbitrary command names.
+      const bindings: Record<string, Runtime> = Object.create(null) as Record<string, Runtime>
       for (const command of entry.captures) bindings[command] = entry
       return bindings
     }
@@ -254,7 +255,9 @@ export function runtimeBindingsFor(
  * config mistake.
  */
 export function bindCommands(entries: readonly Runtime[]): Record<string, Runtime> {
-  const bindings: Record<string, Runtime> = {}
+  // Null prototype: captures are arbitrary command names, so a capture
+  // like `toString` must bind instead of reading as already-present.
+  const bindings: Record<string, Runtime> = Object.create(null) as Record<string, Runtime>
   const seen = new Set<string>()
   for (const entry of entries) {
     if (seen.has(entry.name)) {

--- a/typescript/packages/core/src/workspace/executor/runtime_table.ts
+++ b/typescript/packages/core/src/workspace/executor/runtime_table.ts
@@ -22,12 +22,18 @@ import { QuickJsRuntime } from './js/quickjs.ts'
 // is derived from each class's captures, never hand-maintained.
 export const RUNTIMES = [PyodideRuntime, MontyRuntime, QuickJsRuntime] as const
 
-const NAMED: Record<string, new (options?: RuntimeOptions<never>) => Runtime> = {
-  pyodide: PyodideRuntime,
-  monty: MontyRuntime,
-  quickjs: QuickJsRuntime,
-  vfs: VfsRuntime,
-}
+// Null prototype: runtime names come from config, and a name like
+// `constructor` must miss instead of resolving an `Object.prototype`
+// member as a runtime class.
+const NAMED: Record<string, new (options?: RuntimeOptions<never>) => Runtime> = Object.assign(
+  Object.create(null) as Record<string, new (options?: RuntimeOptions<never>) => Runtime>,
+  {
+    pyodide: PyodideRuntime,
+    monty: MontyRuntime,
+    quickjs: QuickJsRuntime,
+    vfs: VfsRuntime,
+  },
+)
 
 /** The runtime classes that capture a command, preference order. */
 export function candidates(command: string): (typeof RUNTIMES)[number][] {

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -223,7 +223,8 @@ export class MountEntry {
   }
 
   filetypeHandlers(cmdName: string): Record<string, CommandFn> {
-    const fns: Record<string, CommandFn> = {}
+    // Null prototype: filetype names are registration-controlled.
+    const fns: Record<string, CommandFn> = Object.create(null) as Record<string, CommandFn>
     for (const [key, rc] of this.cmds) {
       if (rc.name === cmdName && rc.filetype !== null) {
         if (!(rc.filetype in fns)) fns[rc.filetype] = rc.fn

--- a/typescript/packages/core/src/workspace/session/manager.ts
+++ b/typescript/packages/core/src/workspace/session/manager.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { Session } from './session.ts'
+import { ownRecord, Session } from './session.ts'
 import { RAMSessionStore } from './ram.ts'
 import { CAS_MAX_RETRIES, generationOf, type SessionFields, type SessionStore } from './store.ts'
 import type { MountMode } from '../../types.ts'
@@ -92,7 +92,7 @@ export class SessionManager {
   }
 
   set env(value: Record<string, string>) {
-    this.defaultSession().env = value
+    this.defaultSession().env = ownRecord(value)
   }
 
   /**

--- a/typescript/packages/core/src/workspace/session/session.test.ts
+++ b/typescript/packages/core/src/workspace/session/session.test.ts
@@ -141,3 +141,26 @@ describe('Session.fork', () => {
     expect(original.arrays.A).toEqual(['1'])
   })
 })
+
+describe('ownRecord', () => {
+  it('session records treat prototype-colliding names as ordinary keys', () => {
+    const session = new Session({ sessionId: 's' })
+    session.env.__proto__ = '5'
+    expect(session.env.__proto__).toBe('5')
+    expect(Object.getPrototypeOf(session.env)).toBe(null)
+    // A helper defeats TS resolving `.toString` to the Object method.
+    const read = (record: Record<string, string>, name: string): string | undefined => record[name]
+    expect(read(session.env, 'toString')).toBeUndefined()
+    expect('toString' in session.functions).toBe(false)
+  })
+
+  it('fork keeps the null prototype and copies prototype-named entries', () => {
+    const session = new Session({ sessionId: 's' })
+    session.env.__proto__ = '5'
+    const forked = session.fork()
+    expect(forked.env.__proto__).toBe('5')
+    expect(Object.getPrototypeOf(forked.env)).toBe(null)
+    forked.env.__proto__ = '6'
+    expect(session.env.__proto__).toBe('5')
+  })
+})

--- a/typescript/packages/core/src/workspace/session/session.ts
+++ b/typescript/packages/core/src/workspace/session/session.ts
@@ -42,6 +42,19 @@ export function setSessionEntry<T>(record: Record<string, T>, name: string, valu
   })
 }
 
+/**
+ * A copy of `record` with a null prototype. Session records (env,
+ * functions, arrays) hold script-controlled names, so they must not
+ * inherit from `Object.prototype`: on a plain object, reading a name
+ * like `toString` hands back an inherited function and assigning
+ * `__proto__` runs the inherited setter instead of storing the value.
+ * With no prototype, every name is an ordinary key. Python's dicts
+ * need no equivalent.
+ */
+export function ownRecord<T>(record?: Record<string, T>): Record<string, T> {
+  return Object.assign(Object.create(null) as Record<string, T>, record)
+}
+
 export interface SessionInit {
   sessionId: string
   cwd?: string
@@ -122,14 +135,14 @@ export class Session {
     this.sessionId = init.sessionId
     this.errexitImmune = false
     this.cwd = init.cwd ?? '/'
-    this.env = init.env ?? {}
+    this.env = ownRecord(init.env)
     this.createdAt = init.createdAt ?? Date.now() / 1000
-    this.functions = init.functions ?? {}
+    this.functions = ownRecord(init.functions)
     this.lastExitCode = init.lastExitCode ?? 0
     this.positionalArgs = init.positionalArgs ?? []
     this.shellOptions = init.shellOptions ?? {}
     this.readonlyVars = init.readonlyVars ?? new Set()
-    this.arrays = init.arrays ?? {}
+    this.arrays = ownRecord(init.arrays)
     this.mountModes = init.mountModes ?? null
     this.generation = init.generation ?? 0
     this.pipelineTimeoutSeconds = init.pipelineTimeoutSeconds ?? null

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -543,7 +543,11 @@ export class Workspace {
         })
       }
       return {
-        bindings: { ...this.runtimeBindings, ...overlay },
+        bindings: Object.assign(
+          Object.create(null) as Record<string, Runtime>,
+          this.runtimeBindings,
+          overlay,
+        ),
         fallback: catchAll(this.runtimeEntries),
       }
     }

--- a/typescript/packages/node/src/workspace/runtime/docker/runtime.test.ts
+++ b/typescript/packages/node/src/workspace/runtime/docker/runtime.test.ts
@@ -12,6 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { buildRuntime } from '@struktoai/mirage-core'
 import { describe, expect, it } from 'vitest'
 import type { RuntimeOptions } from '@struktoai/mirage-core'
@@ -103,5 +106,29 @@ describe('DockerRuntime', () => {
     const runtime = buildRuntime('docker', { config: { container: 'cid-42' } })
     expect(runtime).toBeInstanceOf(DockerRuntime)
     expect(runtime.captures).toEqual(['*'])
+  })
+})
+
+// The real spawn path: a container command that exits without draining
+// its stdin EPIPEs the pipe. Without the stdin error guard the stream's
+// unhandled 'error' event crashes the whole process (python suppresses
+// the matching BrokenPipeError inside communicate()). A fake `docker`
+// on PATH that ignores stdin reproduces it against the real spawn.
+describe.skipIf(process.platform === 'win32')('DockerRuntime stdin EPIPE', () => {
+  it('a command that ignores a large stdin resolves instead of crashing', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'fake-docker-'))
+    const fake = join(dir, 'docker')
+    await writeFile(fake, '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+    const savedPath = process.env.PATH
+    process.env.PATH = `${dir}:${savedPath ?? ''}`
+    try {
+      const runtime = new DockerRuntime({ config: { container: 'cid-42' } })
+      const big = new Uint8Array(4 * 1024 * 1024)
+      const result = await runtime.execLine('head -1', big, {}, '/')
+      expect(result.exitCode).toBe(0)
+    } finally {
+      process.env.PATH = savedPath
+      await rm(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/typescript/packages/node/src/workspace/runtime/docker/runtime.ts
+++ b/typescript/packages/node/src/workspace/runtime/docker/runtime.ts
@@ -66,6 +66,12 @@ export class DockerRuntime extends RemoteSandbox<DockerConfig> {
           code: code ?? 1,
         })
       })
+      // EPIPE means the container command exited without draining its
+      // stdin (`head`-like); python's communicate() suppresses the
+      // matching BrokenPipeError, so it is not an error here either.
+      child.stdin.on('error', (error: NodeJS.ErrnoException) => {
+        if (error.code !== 'EPIPE') reject(error)
+      })
       if (stdin !== null) child.stdin.write(stdin)
       child.stdin.end()
     })


### PR DESCRIPTION
Round 4 of the runtime/policy sweep. All four fixes are TypeScript-only; python already had each protection and is untouched.

- **A busy pyodide loop wedged the whole workspace forever.** Pyodide executes on the event loop, so `python3 -c 'while True: pass'` starved the safeguard timer itself. A new `executor/python/interrupt.ts` arms pyodide's interrupt buffer from a watchdog worker (worker_threads in node, Blob worker in browser, generation-checked so a cancelled countdown cannot poison the next run): deadline -> KeyboardInterrupt in the guest -> exit 124; one-shot eval bounded at 10s like quickjs. Without SharedArrayBuffer it degrades to the old behavior (documented).
- **Names colliding with `Object.prototype` members broke the shell.** `toString` as a command hit an internal error instead of 127, `command -v toString` answered 0, `X=7 toString` leaked X into the session, `__proto__=5` silently vanished, and the safeguard table returned `Object.prototype.toString` as a "safeguard" (a `setTimeout(NaN)`). Session records (env/functions/arrays) and the static tables (BUILTIN_SPECS, runtime NAMED, safeguard defaults, binding maps) are now null-prototype via `ownRecord`, with `Object.hasOwn` at the guest-reachable monty `os.getenv`. Pinned by `integ/bash/command/proto.json` on both hosts.
- **`kill %1` / timeouts left monty workers burning.** The JS binding has no cancel and `session.close()` waits out the in-flight turn (probed live), so a deadline or kill now SIGKILLs the worker process (pid captured before feeding), which poisons the session and settles the run: timeout -> 124, kill -> exit 1, mirroring python's future cancellation.
- **The docker runtime could crash the host process.** A container command exiting without draining its stdin raised an unhandled EPIPE stream error; the same guard the local runtime carries (python's `communicate()` suppresses the matching BrokenPipeError) now applies, with a real-spawn test against a PATH-faked docker.

Verified: core 5651/5651, node 2001 passed, integ ram battery 1990/1990 on both hosts, pre-commit stable twice; busy-loop and prototype-name repros re-run against the built dists.