### PR TITLE
fix(safeguard): a null override must not shadow the serving mount's table

### DIFF
--- a/typescript/packages/core/src/workspace/mount/mount.test.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.test.ts
@@ -21,7 +21,7 @@ import type { Accessor } from '../../accessor/base.ts'
 import { revisionFor } from '../../observe/context.ts'
 import type { RegisteredOp } from '../../ops/registry.ts'
 import type { Resource } from '../../resource/base.ts'
-import { MountMode, PathSpec } from '../../types.ts'
+import { CommandSafeguard, MountMode, PathSpec } from '../../types.ts'
 import { MountEntry } from './mount.ts'
 
 class StubResource implements Resource {
@@ -206,6 +206,23 @@ describe('Mount.executeCmd', () => {
     m.register(cmd)
     await m.executeCmd('cat', [PathSpec.fromStrPath('/ram/hello.txt')], [], {})
     expect(seenPrefix).toBe('/ram')
+  })
+
+  it('a null safeguardOverride does not shadow the mount own table', async () => {
+    // The override carries the origin mount's cap across a warm-cache
+    // redirect; a path-less command from an unmounted cwd resolves no
+    // origin and passes null, which must fall through to the serving
+    // mount's command_safeguards (python always reads the serving
+    // mount's own table).
+    const m = makeMount()
+    m.commandSafeguards.set('cat', new CommandSafeguard({ timeoutSeconds: 0.05 }))
+    const hang: CommandFn = () => new Promise(() => undefined)
+    const [cmd] = command({ name: 'cat', resource: 'ram', spec: BASIC_SPEC, fn: hang })
+    if (cmd === undefined) throw new Error('missing')
+    m.register(cmd)
+    await expect(
+      m.executeCmd('cat', [PathSpec.fromStrPath('/x.txt')], [], {}, { safeguardOverride: null }),
+    ).rejects.toThrow(/cat: timed out after 0.05s/)
   })
 })
 

--- a/typescript/packages/core/src/workspace/mount/mount.test.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.test.ts
@@ -38,6 +38,7 @@ const BASIC_SPEC = new CommandSpec({ rest: new Operand({ kind: OperandKind.PATH 
 
 const OK_CMD: CommandFn = () => [null, new IOResult({ exitCode: 0 })]
 const OK_CMD_STDOUT: CommandFn = () => [new TextEncoder().encode('ok'), new IOResult()]
+const HANG_CMD: CommandFn = () => new Promise(() => undefined)
 
 function makeMount(mode: MountMode = MountMode.WRITE): MountEntry {
   return new MountEntry({ prefix: '/ram/', resource: new StubResource(), mode })
@@ -216,8 +217,7 @@ describe('Mount.executeCmd', () => {
     // mount's own table).
     const m = makeMount()
     m.commandSafeguards.set('cat', new CommandSafeguard({ timeoutSeconds: 0.05 }))
-    const hang: CommandFn = () => new Promise(() => undefined)
-    const [cmd] = command({ name: 'cat', resource: 'ram', spec: BASIC_SPEC, fn: hang })
+    const [cmd] = command({ name: 'cat', resource: 'ram', spec: BASIC_SPEC, fn: HANG_CMD })
     if (cmd === undefined) throw new Error('missing')
     m.register(cmd)
     await expect(

--- a/typescript/packages/core/src/workspace/mount/mount.ts
+++ b/typescript/packages/core/src/workspace/mount/mount.ts
@@ -475,13 +475,17 @@ export class MountEntry {
               // mount-resolved timeout must also bound the command
               // body: eager commands do their work inside cmd.fn,
               // where the stream-consumption guard never runs.
+              // safeguardOverride carries the origin mount's cap across
+              // a warm-cache redirect; a null one is "no opinion" and
+              // must not shadow the serving mount's own table (a
+              // path-less command with cwd outside every mount resolves
+              // no origin, but the serving mount's cap still applies —
+              // python always reads the serving mount).
               const resolvedSafeguard = resolveSafeguard(
                 cmdName,
                 [],
                 cmd.safeguard,
-                opts.safeguardOverride !== undefined
-                  ? opts.safeguardOverride
-                  : (this.commandSafeguards.get(cmdName) ?? null),
+                opts.safeguardOverride ?? this.commandSafeguards.get(cmdName) ?? null,
               )
               const cmdTimeout =
                 resolvedSafeguard !== null ? resolvedSafeguard.timeoutSeconds : null


### PR DESCRIPTION
Round-5 follow-up to #669. The `safeguardOverride` channel exists to carry the origin mount's per-command cap across a warm-cache redirect (#3b3739108). But the caller computes it as null when a path-less command runs from a cwd outside every mount, and mount.ts treated that explicit null as authoritative — shadowing the serving mount's own `commandSafeguards` table. Python always resolves from the serving mount's table, so the null now falls through to it (`??`), restoring parity. Pinned with a mount-level test: a hanging registered command with a mount cap and a null override times out instead of hanging.