### PR TITLE
Add a typed, spec-validated FlagView to TypeScript

### DIFF
--- a/python/tests/commands/test_no_raw_flag_reads.py
+++ b/python/tests/commands/test_no_raw_flag_reads.py
@@ -1,0 +1,44 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import re
+from pathlib import Path
+
+# The spec layer builds the flag mapping, so it reads and writes it directly.
+# Everything downstream goes through FlagView or a typed parameter.
+COMMANDS = Path(__file__).resolve().parents[2] / "mirage" / "commands"
+EXEMPT = {"spec/parser.py", "spec/shell.py", "spec/types.py"}
+# Assignment is fine: crossmount fanout builds a bag to hand to the
+# sub-commands it dispatches. Only reads have to go through the view.
+RAW_READ = re.compile(r"\bflags\.get\(|\bflags\[[^\]]*\](?!\s*=[^=])")
+
+
+def test_commands_never_read_the_flag_bag_directly():
+    """Flags are read through FlagView or bound to a typed parameter.
+
+    Mirrors the TypeScript no-restricted-syntax rule banning `opts.flags`
+    in the generic commands. A raw read of a renamed or misspelled flag
+    yields None rather than failing, so nothing catches it: the spelling
+    has to be validated against the command's spec instead.
+    """
+    offenders = []
+    for path in sorted(COMMANDS.rglob("*.py")):
+        rel = path.relative_to(COMMANDS).as_posix()
+        if rel in EXEMPT:
+            continue
+        for number, line in enumerate(path.read_text().splitlines(), 1):
+            if RAW_READ.search(line):
+                offenders.append(f"{rel}:{number}: {line.strip()}")
+    assert not offenders, ("read flags through FlagView(flags, spec=SPECS[...]) "
+                          "or a typed parameter:\n" + "\n".join(offenders))

--- a/python/tests/commands/test_no_raw_flag_reads.py
+++ b/python/tests/commands/test_no_raw_flag_reads.py
@@ -40,5 +40,6 @@ def test_commands_never_read_the_flag_bag_directly():
         for number, line in enumerate(path.read_text().splitlines(), 1):
             if RAW_READ.search(line):
                 offenders.append(f"{rel}:{number}: {line.strip()}")
-    assert not offenders, ("read flags through FlagView(flags, spec=SPECS[...]) "
-                          "or a typed parameter:\n" + "\n".join(offenders))
+    assert not offenders, (
+        "read flags through FlagView(flags, spec=SPECS[...]) "
+        "or a typed parameter:\n" + "\n".join(offenders))

--- a/typescript/eslint.config.js
+++ b/typescript/eslint.config.js
@@ -30,5 +30,24 @@ export default tseslint.config(
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     },
   },
+  {
+    // Generic commands read flags only through FlagView, which is
+    // constructed with the command's spec and throws on a name the spec
+    // does not declare. Reaching into the bag directly reads a renamed or
+    // misspelled flag as false, which no test catches.
+    files: ['packages/core/src/commands/builtin/generic/*.ts'],
+    ignores: ['packages/core/src/commands/builtin/generic/*.test.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "MemberExpression[object.type='MemberExpression'][object.object.name='opts'][object.property.name='flags']",
+          message:
+            'Read flags through FlagView (new FlagView(opts.flags, specOf(name))), not opts.flags directly.',
+        },
+      ],
+    },
+  },
   prettierConfig,
 )

--- a/typescript/packages/core/src/commands/builtin/generic/awk.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/awk.ts
@@ -29,12 +29,10 @@ type Stream = (p: PathSpec) => AsyncIterable<Uint8Array>
 
 function parseFlags(opts: CommandOpts): AwkFlags {
   const fl = new FlagView(opts.flags, specOf('awk'))
-  const rawV = opts.flags.v
-  const assignments = Array.isArray(rawV) ? rawV : typeof rawV === 'string' ? [rawV] : []
-  const rawF = opts.flags.f
-  const programFiles = Array.isArray(rawF) ? rawF : typeof rawF === 'string' ? [rawF] : []
+  const assignments = fl.asList('v')
+  const programFiles = fl.asList('f')
   return {
-    fieldSeparator: (fl.asStr('F') ?? null),
+    fieldSeparator: fl.asStr('F') ?? null,
     assignments,
     programFiles,
   }

--- a/typescript/packages/core/src/commands/builtin/generic/awk.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/awk.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { mountKey, mountPrefixOf } from '../../../utils/key_prefix.ts'
 import { IOResult, materialize } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
@@ -26,12 +28,13 @@ const DEC = new TextDecoder('utf-8', { fatal: false })
 type Stream = (p: PathSpec) => AsyncIterable<Uint8Array>
 
 function parseFlags(opts: CommandOpts): AwkFlags {
+  const fl = new FlagView(opts.flags, specOf('awk'))
   const rawV = opts.flags.v
   const assignments = Array.isArray(rawV) ? rawV : typeof rawV === 'string' ? [rawV] : []
   const rawF = opts.flags.f
   const programFiles = Array.isArray(rawF) ? rawF : typeof rawF === 'string' ? [rawF] : []
   return {
-    fieldSeparator: typeof opts.flags.F === 'string' ? opts.flags.F : null,
+    fieldSeparator: (fl.asStr('F') ?? null),
     assignments,
     programFiles,
   }

--- a/typescript/packages/core/src/commands/builtin/generic/base64_cmd.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/base64_cmd.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, materialize } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import { decodeBase64, encodeBase64 } from '../../../utils/base64.ts'
@@ -58,11 +60,12 @@ export async function base64Generic(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('base64'))
   if (paths.length > 1) throw extraOperandError(CommandName.BASE64, paths[1]?.rawPath ?? '')
-  const decode = opts.flags.d === true || opts.flags.D === true || opts.flags.decode === true
-  const wrapValue = opts.flags.w ?? opts.flags.wrap
+  const decode = fl.asBool('d') || fl.asBool('D') || fl.asBool('decode')
+  const wrapValue = fl.asStr('w') ?? fl.asStr('wrap')
   const wrap = typeof wrapValue === 'string' ? Number.parseInt(wrapValue, 10) : null
-  const ignoreGarbage = opts.flags.i === true || opts.flags.ignore_garbage === true
+  const ignoreGarbage = fl.asBool('i') || fl.asBool('ignore_garbage')
   const cache: string[] = []
   let source: AsyncIterable<Uint8Array>
   if (paths.length > 0) {

--- a/typescript/packages/core/src/commands/builtin/generic/basename.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/basename.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult } from '../../../io/types.ts'
 import type { CommandFn } from '../../config.ts'
 import { gnuBasename } from '../../../utils/path.ts'
@@ -19,15 +21,16 @@ import { gnuBasename } from '../../../utils/path.ts'
 const ENC = new TextEncoder()
 
 export const basenameFn: CommandFn = (_accessor, _paths, texts, opts) => {
-  const suffixValue = opts.flags.s ?? opts.flags.suffix
+  const fl = new FlagView(opts.flags, specOf('basename'))
+  const suffixValue = fl.asStr('s') ?? fl.asStr('suffix')
   const suffix = typeof suffixValue === 'string' ? suffixValue : undefined
-  const multiple = opts.flags.a === true || opts.flags.multiple === true || suffix !== undefined
+  const multiple = fl.asBool('a') || fl.asBool('multiple') || suffix !== undefined
   const lines =
     suffix !== undefined
       ? texts.map((text) => gnuBasename(text, suffix))
       : texts.length === 2 && !multiple
         ? [gnuBasename(texts[0] ?? '', texts[1])]
         : texts.map((text) => gnuBasename(text))
-  const separator = opts.flags.z === true || opts.flags.zero === true ? '\0' : '\n'
+  const separator = fl.asBool('z') || fl.asBool('zero') ? '\0' : '\n'
   return [ENC.encode(lines.join(separator) + separator), new IOResult()]
 }

--- a/typescript/packages/core/src/commands/builtin/generic/checksum.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/checksum.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { mountKey, mountPrefixOf } from '../../../utils/key_prefix.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
@@ -45,11 +47,12 @@ function algorithmName(name: string): string {
 }
 
 function hashLine(digest: string, label: string, name: string, opts: CommandOpts): string {
-  const terminator = opts.flags.z === true || opts.flags.zero === true ? '\0' : '\n'
-  if (opts.flags.tag === true) {
+  const fl = new FlagView(opts.flags, specOf(name))
+  const terminator = fl.asBool('z') || fl.asBool('zero') ? '\0' : '\n'
+  if (fl.asBool('tag')) {
     return `${algorithmName(name)} (${label}) = ${digest}${terminator}`
   }
-  const marker = opts.flags.b === true || opts.flags.binary === true ? '*' : ' '
+  const marker = fl.asBool('b') || fl.asBool('binary') ? '*' : ' '
   return `${digest} ${marker}${label}${terminator}`
 }
 
@@ -69,6 +72,7 @@ async function checkFile(
   name: string,
   opts: CommandOpts,
 ): Promise<[Uint8Array | null, Uint8Array | null, number]> {
+  const fl = new FlagView(opts.flags, specOf(name))
   const data = DEC.decode(await materialize(stream(p)))
   const mountPrefix = mountPrefixOf(p.virtual, p.resourcePath)
   const output: string[] = []
@@ -87,23 +91,23 @@ async function checkFile(
     try {
       digest = await hashStream(stream(makePathSpec(filename, mountPrefix)), hasher)
     } catch (error) {
-      if (opts.flags.ignore_missing === true && isMissingError(error)) continue
-      if (opts.flags.status !== true) output.push(`${filename}: FAILED open or read`)
+      if (fl.asBool('ignore_missing') && isMissingError(error)) continue
+      if (!fl.asBool('status')) output.push(`${filename}: FAILED open or read`)
       failed = true
       continue
     }
     if (digest === expected) {
-      if (opts.flags.status !== true && opts.flags.quiet !== true) output.push(`${filename}: OK`)
+      if (!fl.asBool('status') && !fl.asBool('quiet')) output.push(`${filename}: OK`)
     } else {
-      if (opts.flags.status !== true) output.push(`${filename}: FAILED`)
+      if (!fl.asBool('status')) output.push(`${filename}: FAILED`)
       failed = true
     }
   }
-  if (malformed > 0 && (opts.flags.w === true || opts.flags.warn === true)) {
+  if (malformed > 0 && (fl.asBool('w') || fl.asBool('warn'))) {
     const count = malformed === 1 ? '1 line is' : `${String(malformed)} lines are`
     errors.push(`WARNING: ${count} improperly formatted`)
   }
-  if (malformed > 0 && opts.flags.strict === true) failed = true
+  if (malformed > 0 && fl.asBool('strict')) failed = true
   const stdout = output.length > 0 ? ENC.encode(`${output.join('\n')}\n`) : null
   const stderr = errors.length > 0 ? ENC.encode(`${errors.join('\n')}\n`) : null
   return [stdout, stderr, failed ? 1 : 0]
@@ -129,7 +133,8 @@ export async function checksumGeneric(
   hasher: Hasher,
   name: string,
 ): Promise<CommandFnResult> {
-  const check = opts.flags.c === true || opts.flags.check === true
+  const fl = new FlagView(opts.flags, specOf(name))
+  const check = fl.asBool('c') || fl.asBool('check')
   if (check && paths.length > 0) {
     const first = paths[0]
     if (first === undefined) return [null, new IOResult()]

--- a/typescript/packages/core/src/commands/builtin/generic/cmp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cmp.ts
@@ -58,13 +58,15 @@ export async function cmpGeneric(
     // unreadable operand) is exit 2.
     return [null, new IOResult({ exitCode: 2, stderr: formatFsError('cmp', err, paths) })]
   }
-  if (typeof opts.flags.i === 'string') {
-    const skip = Number.parseInt(opts.flags.i, 10)
+  const skipRaw = fl.asInt('i')
+  if (skipRaw !== undefined) {
+    const skip = skipRaw
     data1 = data1.slice(skip)
     data2 = data2.slice(skip)
   }
-  if (typeof opts.flags.n === 'string') {
-    const limit = Number.parseInt(opts.flags.n, 10)
+  const limitRaw = fl.asInt('n')
+  if (limitRaw !== undefined) {
+    const limit = limitRaw
     data1 = data1.slice(0, limit)
     data2 = data2.slice(0, limit)
   }

--- a/typescript/packages/core/src/commands/builtin/generic/cmp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/cmp.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandOpts } from '../../config.ts'
@@ -37,6 +39,7 @@ export async function cmpGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<[ByteSource | null, IOResult]> {
+  const fl = new FlagView(opts.flags, specOf('cmp'))
   if (paths.length > 2) throw extraOperandError(CommandName.CMP, paths[2]?.rawPath ?? '')
   if (paths.length < 2) {
     return [null, new IOResult({ exitCode: 2, stderr: ENC.encode('cmp: requires two paths\n') })]
@@ -66,8 +69,8 @@ export async function cmpGeneric(
     data2 = data2.slice(0, limit)
   }
   if (arraysEqual(data1, data2)) return [null, new IOResult()]
-  if (opts.flags.s === true) return [null, new IOResult({ exitCode: 1 })]
-  if (opts.flags.args_l === true) {
+  if (fl.asBool('s')) return [null, new IOResult({ exitCode: 1 })]
+  if (fl.asBool('args_l')) {
     const outLines: string[] = []
     const limit = Math.min(data1.byteLength, data2.byteLength)
     for (let idx = 0; idx < limit; idx++) {
@@ -84,7 +87,7 @@ export async function cmpGeneric(
       let line = 1
       for (let k = 0; k < idx; k++) if (data1[k] === 0x0a) line += 1
       let msg = `${p0.virtual} ${p1.virtual} differ: char ${String(idx + 1)}, line ${String(line)}`
-      if (opts.flags.b === true) {
+      if (fl.asBool('b')) {
         msg += ` is ${octal(data1[idx] ?? 0)} ${String.fromCharCode(data1[idx] ?? 0)} ${octal(data2[idx] ?? 0)} ${String.fromCharCode(data2[idx] ?? 0)}`
       }
       return [formatRecords([msg]), new IOResult({ exitCode: 1 })]

--- a/typescript/packages/core/src/commands/builtin/generic/column.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/column.ts
@@ -75,8 +75,8 @@ export async function columnGeneric(
 ): Promise<CommandFnResult> {
   const fl = new FlagView(opts.flags, specOf('column'))
   const tMode = fl.asBool('t')
-  const sFlag = (fl.asStr('s') ?? null)
-  const oFlag = (fl.asStr('o') ?? '  ')
+  const sFlag = fl.asStr('s') ?? null
+  const oFlag = fl.asStr('o') ?? '  '
   let raw: Uint8Array
   if (paths.length > 0) {
     const first = paths[0]

--- a/typescript/packages/core/src/commands/builtin/generic/column.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/column.ts
@@ -75,8 +75,8 @@ export async function columnGeneric(
 ): Promise<CommandFnResult> {
   const fl = new FlagView(opts.flags, specOf('column'))
   const tMode = fl.asBool('t')
-  const sFlag = typeof opts.flags.s === 'string' ? opts.flags.s : null
-  const oFlag = typeof opts.flags.o === 'string' ? opts.flags.o : '  '
+  const sFlag = (fl.asStr('s') ?? null)
+  const oFlag = (fl.asStr('o') ?? '  ')
   let raw: Uint8Array
   if (paths.length > 0) {
     const first = paths[0]

--- a/typescript/packages/core/src/commands/builtin/generic/column.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/column.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -71,7 +73,8 @@ export async function columnGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
-  const tMode = opts.flags.t === true
+  const fl = new FlagView(opts.flags, specOf('column'))
+  const tMode = fl.asBool('t')
   const sFlag = typeof opts.flags.s === 'string' ? opts.flags.s : null
   const oFlag = typeof opts.flags.o === 'string' ? opts.flags.o : '  '
   let raw: Uint8Array

--- a/typescript/packages/core/src/commands/builtin/generic/comm.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/comm.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -102,6 +104,7 @@ export async function commGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('comm'))
   if (paths.length > 2) throw extraOperandError(CommandName.COMM, paths[2]?.rawPath ?? '')
   if (paths.length < 2) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('comm: requires two paths\n') })]
@@ -111,15 +114,15 @@ export async function commGeneric(
   if (p1 === undefined || p2 === undefined) return [null, new IOResult()]
   const data1 = DEC.decode(await materialize(stream(p1)))
   const data2 = DEC.decode(await materialize(stream(p2)))
-  const zeroTerminated = opts.flags.z === true || opts.flags.zero_terminated === true
+  const zeroTerminated = fl.asBool('z') || fl.asBool('zero_terminated')
   const lines1 = zeroTerminated ? data1.replace(/\0$/, '').split('\0') : splitLinesNoTrailing(data1)
   const lines2 = zeroTerminated ? data2.replace(/\0$/, '').split('\0') : splitLinesNoTrailing(data2)
   let stderr = ''
-  if (opts.flags.check_order === true) {
+  if (fl.asBool('check_order')) {
     if (!isSorted(lines1)) stderr = 'comm: file 1 is not in sorted order\n'
     else if (!isSorted(lines2)) stderr = 'comm: file 2 is not in sorted order\n'
   }
-  const suppress1 = opts.flags.args_1 === true
+  const suppress1 = fl.asBool('args_1')
   const suppress2 = opts.flags['2'] === true
   const suppress3 = opts.flags['3'] === true
   const merged = commMerge(lines1, lines2)
@@ -132,7 +135,7 @@ export async function commGeneric(
     suppress3,
     delimiter,
     zeroTerminated ? '\0' : '\n',
-    opts.flags.total === true,
+    fl.asBool('total'),
   )
   const result: ByteSource = ENC.encode(output)
   return [

--- a/typescript/packages/core/src/commands/builtin/generic/comm.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/comm.ts
@@ -127,7 +127,7 @@ export async function commGeneric(
   const suppress3 = opts.flags['3'] === true
   const merged = commMerge(lines1, lines2)
   const delimiter =
-    typeof opts.flags.output_delimiter === 'string' ? opts.flags.output_delimiter : '\t'
+    (fl.asStr('output_delimiter') ?? '\t')
   const output = formatComm(
     merged,
     suppress1,

--- a/typescript/packages/core/src/commands/builtin/generic/comm.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/comm.ts
@@ -123,11 +123,10 @@ export async function commGeneric(
     else if (!isSorted(lines2)) stderr = 'comm: file 2 is not in sorted order\n'
   }
   const suppress1 = fl.asBool('args_1')
-  const suppress2 = opts.flags['2'] === true
-  const suppress3 = opts.flags['3'] === true
+  const suppress2 = fl.asBool('2')
+  const suppress3 = fl.asBool('3')
   const merged = commMerge(lines1, lines2)
-  const delimiter =
-    (fl.asStr('output_delimiter') ?? '\t')
+  const delimiter = fl.asStr('output_delimiter') ?? '\t'
   const output = formatComm(
     merged,
     suppress1,

--- a/typescript/packages/core/src/commands/builtin/generic/csplit.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/csplit.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { stripSlash } from '../../../utils/slash.ts'
 import { mountKey } from '../../../utils/key_prefix.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
@@ -101,21 +103,22 @@ export async function csplitGeneric(
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
 ): Promise<CommandFnResult> {
-  const prefixValue = opts.flags.f ?? opts.flags.prefix
+  const fl = new FlagView(opts.flags, specOf('csplit'))
+  const prefixValue = fl.asStr('f') ?? fl.asStr('prefix')
   const rawPrefix = typeof prefixValue === 'string' ? prefixValue : 'xx'
   const prefix = new PathSpec({
     virtual: rawPrefix,
     directory: rawPrefix,
     resourcePath: mountKey(rawPrefix, opts.mountPrefix ?? ''),
   }).mountPath
-  const digitsValue = opts.flags.n ?? opts.flags.digits
-  const suffixValue = opts.flags.b ?? opts.flags.suffix_format
+  const digitsValue = fl.asStr('n') ?? fl.asStr('digits')
+  const suffixValue = fl.asStr('b') ?? fl.asStr('suffix_format')
   const digits = typeof digitsValue === 'string' ? Number.parseInt(digitsValue, 10) : 2
   const suffixFormat = typeof suffixValue === 'string' ? suffixValue : null
-  const quiet = opts.flags.s === true || opts.flags.quiet === true || opts.flags.silent === true
-  const keep = opts.flags.k === true || opts.flags.keep_files === true
-  const suppressMatched = opts.flags.suppress_matched === true
-  const elideEmpty = opts.flags.z === true || opts.flags.elide_empty_files === true
+  const quiet = fl.asBool('s') || fl.asBool('quiet') || fl.asBool('silent')
+  const keep = fl.asBool('k') || fl.asBool('keep_files')
+  const suppressMatched = fl.asBool('suppress_matched')
+  const elideEmpty = fl.asBool('z') || fl.asBool('elide_empty_files')
   let raw: Uint8Array
   if (paths.length > 0) {
     const first = paths[0]

--- a/typescript/packages/core/src/commands/builtin/generic/diff.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/diff.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { mountKey, mountPrefixOf } from '../../../utils/key_prefix.ts'
 import { concat } from '../../../io/cachable_iterator.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
@@ -158,24 +160,25 @@ export async function diffGeneric(
   readdir?: Readdir,
   stat?: Stat,
 ): Promise<[ByteSource | null, IOResult]> {
+  const fl = new FlagView(opts.flags, specOf('diff'))
   if (paths.length > 2) throw extraOperandError(CommandName.DIFF, paths[2]?.rawPath ?? '')
   if (paths.length < 2) {
     return [null, new IOResult({ exitCode: 2, stderr: ENC.encode('diff: requires two paths\n') })]
   }
   const flags: DiffFlags = {
-    i: opts.flags.i === true,
-    w: opts.flags.w === true,
-    b: opts.flags.b === true,
-    e: opts.flags.e === true,
-    q: opts.flags.q === true,
-    u: opts.flags.u === true,
+    i: fl.asBool('i'),
+    w: fl.asBool('w'),
+    b: fl.asBool('b'),
+    e: fl.asBool('e'),
+    q: fl.asBool('q'),
+    u: fl.asBool('u'),
   }
   const p0 = paths[0]
   const p1 = paths[1]
   if (p0 === undefined || p1 === undefined) return [null, new IOResult()]
   let output: Uint8Array | undefined
   try {
-    if (opts.flags.r === true && readdir !== undefined && stat !== undefined) {
+    if (fl.asBool('r') && readdir !== undefined && stat !== undefined) {
       const bothDirs =
         (await stat(p0)).type === FileType.DIRECTORY && (await stat(p1)).type === FileType.DIRECTORY
       if (bothDirs) output = await diffDirs(readdir, stat, stream, p0, p1, flags)

--- a/typescript/packages/core/src/commands/builtin/generic/dirname.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/dirname.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult } from '../../../io/types.ts'
 import type { CommandFn } from '../../config.ts'
 import { gnuDirname } from '../../../utils/path.ts'
@@ -20,6 +22,7 @@ const ENC = new TextEncoder()
 
 export const dirnameFn: CommandFn = (_accessor, _paths, texts, opts) => {
   const lines = texts.map((t) => gnuDirname(t))
-  const separator = opts.flags.z === true || opts.flags.zero === true ? '\0' : '\n'
+  const fl = new FlagView(opts.flags, specOf('dirname'))
+  const separator = fl.asBool('z') || fl.asBool('zero') ? '\0' : '\n'
   return [ENC.encode(lines.join(separator) + separator), new IOResult()]
 }

--- a/typescript/packages/core/src/commands/builtin/generic/du.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/du.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { PathSpec } from '../../../types.ts'
 import type { CommandOpts } from '../../config.ts'
 import { UsageError } from '../../errors.ts'
@@ -88,9 +90,10 @@ const TRUNCATED_NOTE = 'du: walk stopped early: the reported sizes are incomplet
  * parsed. All three exit 1, du's usage-error code.
  */
 export function parseDuFlags(opts: CommandOpts): DuFlags {
-  const s = opts.flags.s === true
-  const a = opts.flags.a === true
-  const raw = opts.flags.max_depth ?? opts.flags.d
+  const fl = new FlagView(opts.flags, specOf('du'))
+  const s = fl.asBool('s')
+  const a = fl.asBool('a')
+  const raw = fl.asStr('max_depth') ?? fl.asStr('d')
   let maxDepth: number | null = null
   if (typeof raw === 'string') {
     maxDepth = parseDepth(raw)
@@ -116,8 +119,8 @@ export function parseDuFlags(opts: CommandOpts): DuFlags {
   return {
     s,
     a,
-    h: opts.flags.h === true,
-    c: opts.flags.c === true,
+    h: fl.asBool('h'),
+    c: fl.asBool('c'),
     maxDepth,
     ...(warning === undefined ? {} : { warning }),
   }

--- a/typescript/packages/core/src/commands/builtin/generic/expand.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/expand.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -66,9 +68,10 @@ export async function expandGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
-  const tabsValue = opts.flags.t ?? opts.flags.tabs
-  const tabsize = typeof tabsValue === 'string' ? Number.parseInt(tabsValue, 10) : 8
-  const leadingOnly = opts.flags.i === true || opts.flags.initial === true
+  const fl = new FlagView(opts.flags, specOf('expand'))
+  const tabsValue = fl.asStr('t') ?? fl.asStr('tabs')
+  const tabsize = tabsValue === undefined ? 8 : Number.parseInt(tabsValue, 10)
+  const leadingOnly = fl.asBool('i') || fl.asBool('initial')
   if (paths.length > 0) {
     // A missing operand is reported and skipped; the remaining operands
     // still expand (GNU expand).

--- a/typescript/packages/core/src/commands/builtin/generic/file.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/file.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { FileType, type FileStat, type PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -29,8 +31,9 @@ export async function fileGeneric(
   if (paths.length === 0) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('file: missing operand\n') })]
   }
-  const brief = opts.flags.b === true
-  const mime = opts.flags.i === true
+  const fl = new FlagView(opts.flags, specOf('file'))
+  const brief = fl.asBool('b')
+  const mime = fl.asBool('i')
   const lines: string[] = []
   for (const p of paths) {
     const s = await stat(p)

--- a/typescript/packages/core/src/commands/builtin/generic/find.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/find.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { isEnoent, modifiedTs } from '../../../core/generic/find.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { FindOptions } from '../../../resource/base.ts'
@@ -130,14 +132,15 @@ export async function findGeneric(
   find: (root: PathSpec, options: FindOptions) => Promise<string[]>,
   stat?: (spec: PathSpec) => Promise<FileStat>,
 ): Promise<CommandFnResult> {
-  const nameFlag = typeof opts.flags.name === 'string' ? opts.flags.name : null
-  const inameFlag = typeof opts.flags.iname === 'string' ? opts.flags.iname : null
-  const typeFlag = typeof opts.flags.type === 'string' ? opts.flags.type : null
-  const pathFlag = typeof opts.flags.path === 'string' ? opts.flags.path : null
-  const maxDepthFlag = typeof opts.flags.maxdepth === 'string' ? opts.flags.maxdepth : null
-  const minDepthFlag = typeof opts.flags.mindepth === 'string' ? opts.flags.mindepth : null
-  const sizeFlag = typeof opts.flags.size === 'string' ? opts.flags.size : null
-  const mtimeFlag = typeof opts.flags.mtime === 'string' ? opts.flags.mtime : null
+  const fl = new FlagView(opts.flags, specOf('find'))
+  const nameFlag = (fl.asStr('name') ?? null)
+  const inameFlag = (fl.asStr('iname') ?? null)
+  const typeFlag = (fl.asStr('type') ?? null)
+  const pathFlag = (fl.asStr('path') ?? null)
+  const maxDepthFlag = (fl.asStr('maxdepth') ?? null)
+  const minDepthFlag = (fl.asStr('mindepth') ?? null)
+  const sizeFlag = (fl.asStr('size') ?? null)
+  const mtimeFlag = (fl.asStr('mtime') ?? null)
   const targets =
     paths.length > 0
       ? paths
@@ -164,7 +167,7 @@ export async function findGeneric(
   if (badArg !== null) return invalidFindArg(badArg[0], badArg[1])
   const nameExclude = extractNotName(texts)
   const orNames = extractOrNames(nameFlag, texts)
-  const emptyFlag = opts.flags.empty === true
+  const emptyFlag = fl.asBool('empty')
   const expr = texts.length > 0 ? parseFindExpression(texts) : null
   // With a stat wired, the mtime window is applied by the overlay-
   // aware post-filter below, not pushed into the core: backend cores

--- a/typescript/packages/core/src/commands/builtin/generic/find.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/find.ts
@@ -133,14 +133,14 @@ export async function findGeneric(
   stat?: (spec: PathSpec) => Promise<FileStat>,
 ): Promise<CommandFnResult> {
   const fl = new FlagView(opts.flags, specOf('find'))
-  const nameFlag = (fl.asStr('name') ?? null)
-  const inameFlag = (fl.asStr('iname') ?? null)
-  const typeFlag = (fl.asStr('type') ?? null)
-  const pathFlag = (fl.asStr('path') ?? null)
-  const maxDepthFlag = (fl.asStr('maxdepth') ?? null)
-  const minDepthFlag = (fl.asStr('mindepth') ?? null)
-  const sizeFlag = (fl.asStr('size') ?? null)
-  const mtimeFlag = (fl.asStr('mtime') ?? null)
+  const nameFlag = fl.asStr('name') ?? null
+  const inameFlag = fl.asStr('iname') ?? null
+  const typeFlag = fl.asStr('type') ?? null
+  const pathFlag = fl.asStr('path') ?? null
+  const maxDepthFlag = fl.asStr('maxdepth') ?? null
+  const minDepthFlag = fl.asStr('mindepth') ?? null
+  const sizeFlag = fl.asStr('size') ?? null
+  const mtimeFlag = fl.asStr('mtime') ?? null
   const targets =
     paths.length > 0
       ? paths

--- a/typescript/packages/core/src/commands/builtin/generic/fmt.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/fmt.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -123,15 +125,16 @@ export async function fmtGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
-  const widthValue = opts.flags.w ?? opts.flags.width
-  const goalValue = opts.flags.g ?? opts.flags.goal
-  const prefixValue = opts.flags.p ?? opts.flags.prefix
+  const fl = new FlagView(opts.flags, specOf('fmt'))
+  const widthValue = fl.asStr('w') ?? fl.asStr('width')
+  const goalValue = fl.asStr('g') ?? fl.asStr('goal')
+  const prefixValue = fl.asStr('p') ?? fl.asStr('prefix')
   const width = typeof widthValue === 'string' ? Number.parseInt(widthValue, 10) : 75
   const goal = typeof goalValue === 'string' ? Number.parseInt(goalValue, 10) : null
   const prefix = typeof prefixValue === 'string' ? prefixValue : null
-  const splitOnly = opts.flags.s === true || opts.flags.split_only === true
-  const tagged = opts.flags.t === true || opts.flags.tagged_paragraph === true
-  const crown = opts.flags.c === true || opts.flags.crown_margin === true
+  const splitOnly = fl.asBool('s') || fl.asBool('split_only')
+  const tagged = fl.asBool('t') || fl.asBool('tagged_paragraph')
+  const crown = fl.asBool('c') || fl.asBool('crown_margin')
   if (paths.length > 0) {
     // A missing operand is reported and skipped; the remaining operands
     // still format (GNU fmt).

--- a/typescript/packages/core/src/commands/builtin/generic/fold.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/fold.ts
@@ -87,7 +87,7 @@ export async function foldGeneric(
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
   const fl = new FlagView(opts.flags, specOf('fold'))
-  const widthValue = opts.flags.w ?? opts.flags.width
+  const widthValue = fl.asStr('w') ?? fl.asStr('width')
   const width = typeof widthValue === 'string' ? Number.parseInt(widthValue, 10) : 80
   const breakSpaces = fl.asBool('s') || fl.asBool('spaces')
   const countBytes = fl.asBool('b') || fl.asBool('bytes')

--- a/typescript/packages/core/src/commands/builtin/generic/fold.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/fold.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -84,10 +86,11 @@ export async function foldGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('fold'))
   const widthValue = opts.flags.w ?? opts.flags.width
   const width = typeof widthValue === 'string' ? Number.parseInt(widthValue, 10) : 80
-  const breakSpaces = opts.flags.s === true || opts.flags.spaces === true
-  const countBytes = opts.flags.b === true || opts.flags.bytes === true
+  const breakSpaces = fl.asBool('s') || fl.asBool('spaces')
+  const countBytes = fl.asBool('b') || fl.asBool('bytes')
   if (paths.length > 0) {
     // A missing operand is reported and skipped; the remaining operands
     // still fold (GNU fold).

--- a/typescript/packages/core/src/commands/builtin/generic/grep.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/grep.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { mountKey, mountPrefixOf } from '../../../utils/key_prefix.ts'
 import { cacheAwareStream } from '../../../cache/read_through.ts'
 import { exitOnEmpty, quietMatch } from '../../../io/stream.ts'
@@ -118,6 +120,7 @@ export async function grepGeneric(
   readdir: Readdir,
   stream: Stream,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('grep'))
   stream = cacheAwareStream(stream)
   const resolution = await resolvePatternFromFlags(
     name,
@@ -142,7 +145,7 @@ export async function grepGeneric(
   }
   const f = parseFlags(opts.flags)
   if (resolution.neverMatch) f.fixedString = false
-  const recursive = opts.flags.r === true || opts.flags.R === true
+  const recursive = fl.asBool('r') || fl.asBool('R')
 
   if (paths.length > 0) {
     const first = paths[0]

--- a/typescript/packages/core/src/commands/builtin/generic/gunzip.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/gunzip.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { stripSlash } from '../../../utils/slash.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
@@ -49,9 +51,10 @@ export async function gunzipGeneric(
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
   unlink: (p: PathSpec) => Promise<void>,
 ): Promise<CommandFnResult> {
-  const keep = opts.flags.k === true
-  const stdoutMode = opts.flags.c === true
-  const testMode = opts.flags.t === true
+  const fl = new FlagView(opts.flags, specOf('gunzip'))
+  const keep = fl.asBool('k')
+  const stdoutMode = fl.asBool('c')
+  const testMode = fl.asBool('t')
 
   if (paths.length === 0) {
     let source: AsyncIterable<Uint8Array>

--- a/typescript/packages/core/src/commands/builtin/generic/gzip.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/gzip.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { stripSlash } from '../../../utils/slash.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
@@ -49,9 +51,10 @@ export async function gzipGeneric(
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
   unlink: (p: PathSpec) => Promise<void>,
 ): Promise<CommandFnResult> {
-  const decompress = opts.flags.d === true
-  const keep = opts.flags.k === true
-  const stdoutMode = opts.flags.c === true
+  const fl = new FlagView(opts.flags, specOf('gzip'))
+  const decompress = fl.asBool('d')
+  const keep = fl.asBool('k')
+  const stdoutMode = fl.asBool('c')
 
   if (paths.length === 0) {
     let source: AsyncIterable<Uint8Array>

--- a/typescript/packages/core/src/commands/builtin/generic/iconv.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/iconv.ts
@@ -114,8 +114,8 @@ export async function iconvGeneric(
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
 ): Promise<CommandFnResult> {
   const fl = new FlagView(opts.flags, specOf('iconv'))
-  const fromName = (fl.asStr('f') ?? 'utf-8')
-  const toName = (fl.asStr('t') ?? 'utf-8')
+  const fromName = fl.asStr('f') ?? 'utf-8'
+  const toName = fl.asStr('t') ?? 'utf-8'
   const fromEnc = normalizeEncoding(fromName)
   const toEnc = normalizeEncoding(toName)
   if (fromEnc === null) {
@@ -144,7 +144,7 @@ export async function iconvGeneric(
   }
   const decoded = decodeBytes(raw, fromEnc)
   const encoded = encodeText(decoded, toEnc)
-  const outPath = (fl.asStr('o') ?? null)
+  const outPath = fl.asStr('o') ?? null
   if (outPath !== null) {
     const spec = PathSpec.fromStrPath(outPath, mountKey(outPath, opts.mountPrefix ?? ''))
     await write(spec, encoded)

--- a/typescript/packages/core/src/commands/builtin/generic/iconv.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/iconv.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { mountKey } from '../../../utils/key_prefix.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
@@ -111,8 +113,9 @@ export async function iconvGeneric(
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
 ): Promise<CommandFnResult> {
-  const fromName = typeof opts.flags.f === 'string' ? opts.flags.f : 'utf-8'
-  const toName = typeof opts.flags.t === 'string' ? opts.flags.t : 'utf-8'
+  const fl = new FlagView(opts.flags, specOf('iconv'))
+  const fromName = (fl.asStr('f') ?? 'utf-8')
+  const toName = (fl.asStr('t') ?? 'utf-8')
   const fromEnc = normalizeEncoding(fromName)
   const toEnc = normalizeEncoding(toName)
   if (fromEnc === null) {
@@ -141,7 +144,7 @@ export async function iconvGeneric(
   }
   const decoded = decodeBytes(raw, fromEnc)
   const encoded = encodeText(decoded, toEnc)
-  const outPath = typeof opts.flags.o === 'string' ? opts.flags.o : null
+  const outPath = (fl.asStr('o') ?? null)
   if (outPath !== null) {
     const spec = PathSpec.fromStrPath(outPath, mountKey(outPath, opts.mountPrefix ?? ''))
     await write(spec, encoded)

--- a/typescript/packages/core/src/commands/builtin/generic/join.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/join.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -158,6 +160,7 @@ export async function joinGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('join'))
   if (paths.length > 2) throw extraOperandError(CommandName.JOIN, paths[2]?.rawPath ?? '')
   if (paths.length < 2) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('join: requires two paths\n') })]
@@ -172,19 +175,19 @@ export async function joinGeneric(
   const field2 =
     (commonField ??
       (typeof opts.flags['2'] === 'string' ? Number.parseInt(opts.flags['2'], 10) : 1)) - 1
-  const sep = typeof opts.flags.t === 'string' ? opts.flags.t : null
-  const aFlag = typeof opts.flags.a === 'string' ? opts.flags.a : null
-  const vFlag = typeof opts.flags.v === 'string' ? opts.flags.v : null
-  const eFlag = typeof opts.flags.e === 'string' ? opts.flags.e : null
-  const oFlag = typeof opts.flags.o === 'string' ? opts.flags.o : null
+  const sep = (fl.asStr('t') ?? null)
+  const aFlag = (fl.asStr('a') ?? null)
+  const vFlag = (fl.asStr('v') ?? null)
+  const eFlag = (fl.asStr('e') ?? null)
+  const oFlag = (fl.asStr('o') ?? null)
   const data1 = DEC.decode(await materialize(stream(p1)))
   const data2 = DEC.decode(await materialize(stream(p2)))
-  const zeroTerminated = opts.flags.z === true || opts.flags.zero_terminated === true
+  const zeroTerminated = fl.asBool('z') || fl.asBool('zero_terminated')
   const lines1 = zeroTerminated ? data1.replace(/\0$/, '').split('\0') : splitLinesNoTrailing(data1)
   const lines2 = zeroTerminated ? data2.replace(/\0$/, '').split('\0') : splitLinesNoTrailing(data2)
-  const ignoreCase = opts.flags.i === true || opts.flags.ignore_case === true
+  const ignoreCase = fl.asBool('i') || fl.asBool('ignore_case')
   const headerLines: string[] = []
-  if (opts.flags.header === true && lines1.length > 0 && lines2.length > 0) {
+  if (fl.asBool('header') && lines1.length > 0 && lines2.length > 0) {
     const first1 = splitFields(lines1.shift() ?? '', sep)
     const first2 = splitFields(lines2.shift() ?? '', sep)
     headerLines.push(
@@ -192,7 +195,7 @@ export async function joinGeneric(
     )
   }
   let stderr: Uint8Array | null = null
-  if (opts.flags.check_order === true && opts.flags.nocheck_order !== true) {
+  if (fl.asBool('check_order') && !fl.asBool('nocheck_order')) {
     if (!isSorted(lines1, field1, sep, ignoreCase)) {
       stderr = ENC.encode('join: file 1 is not in sorted order\n')
     } else if (!isSorted(lines2, field2, sep, ignoreCase)) {

--- a/typescript/packages/core/src/commands/builtin/generic/join.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/join.ts
@@ -168,18 +168,14 @@ export async function joinGeneric(
   const p1 = paths[0]
   const p2 = paths[1]
   if (p1 === undefined || p2 === undefined) return [null, new IOResult()]
-  const commonField = typeof opts.flags.j === 'string' ? Number.parseInt(opts.flags.j, 10) : null
-  const field1 =
-    (commonField ??
-      (typeof opts.flags.args_1 === 'string' ? Number.parseInt(opts.flags.args_1, 10) : 1)) - 1
-  const field2 =
-    (commonField ??
-      (typeof opts.flags['2'] === 'string' ? Number.parseInt(opts.flags['2'], 10) : 1)) - 1
-  const sep = (fl.asStr('t') ?? null)
-  const aFlag = (fl.asStr('a') ?? null)
-  const vFlag = (fl.asStr('v') ?? null)
-  const eFlag = (fl.asStr('e') ?? null)
-  const oFlag = (fl.asStr('o') ?? null)
+  const commonField = fl.asInt('j') ?? null
+  const field1 = (commonField ?? fl.asInt('args_1') ?? 1) - 1
+  const field2 = (commonField ?? fl.asInt('2') ?? 1) - 1
+  const sep = fl.asStr('t') ?? null
+  const aFlag = fl.asStr('a') ?? null
+  const vFlag = fl.asStr('v') ?? null
+  const eFlag = fl.asStr('e') ?? null
+  const oFlag = fl.asStr('o') ?? null
   const data1 = DEC.decode(await materialize(stream(p1)))
   const data2 = DEC.decode(await materialize(stream(p2)))
   const zeroTerminated = fl.asBool('z') || fl.asBool('zero_terminated')

--- a/typescript/packages/core/src/commands/builtin/generic/jq.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/jq.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import {
   concatBytes,
   evalJsonlStream,
@@ -36,9 +38,10 @@ export async function jqGeneric(
 ): Promise<CommandFnResult> {
   // GNU jq defaults the filter to "." when no expression is given
   const expression = texts[0] ?? '.'
-  const raw = opts.flags.r === true
-  const compact = opts.flags.c === true
-  const slurp = opts.flags.s === true
+  const fl = new FlagView(opts.flags, specOf('jq'))
+  const raw = fl.asBool('r')
+  const compact = fl.asBool('c')
+  const slurp = fl.asBool('s')
 
   if (paths.length > 0) {
     const first = paths[0]

--- a/typescript/packages/core/src/commands/builtin/generic/look.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/look.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -38,7 +40,8 @@ export async function lookGeneric(
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('look: missing prefix\n') })]
   }
   const prefix = texts[0] ?? ''
-  const caseInsensitive = opts.flags.f === true
+  const fl = new FlagView(opts.flags, specOf('look'))
+  const caseInsensitive = fl.asBool('f')
   let raw: Uint8Array
   if (paths.length > 0) {
     const first = paths[0]

--- a/typescript/packages/core/src/commands/builtin/generic/ls.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/ls.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { mountKey, mountPrefixOf } from '../../../utils/key_prefix.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { FileStat, FileType, PathSpec } from '../../../types.ts'
@@ -281,6 +283,7 @@ export async function lsGeneric(
   readdir: Readdir,
   stat: Stat,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('ls'))
   const targets: PathSpec[] =
     paths.length > 0
       ? paths
@@ -292,14 +295,14 @@ export async function lsGeneric(
             resourcePath: mountKey(opts.cwd, opts.mountPrefix ?? ''),
           }),
         ]
-  const long = opts.flags.args_l === true && opts.flags.args_1 !== true
-  const all = opts.flags.a === true || opts.flags.A === true
-  const human = opts.flags.h === true
-  const reverse = opts.flags.r === true
-  const classify = opts.flags.F === true
-  const recursive = opts.flags.R === true
-  const listDirItself = opts.flags.d === true
-  const sortBy: SortBy = opts.flags.t === true ? 'time' : opts.flags.S === true ? 'size' : 'name'
+  const long = fl.asBool('args_l') && !fl.asBool('args_1')
+  const all = fl.asBool('a') || fl.asBool('A')
+  const human = fl.asBool('h')
+  const reverse = fl.asBool('r')
+  const classify = fl.asBool('F')
+  const recursive = fl.asBool('R')
+  const listDirItself = fl.asBool('d')
+  const sortBy: SortBy = fl.asBool('t') ? 'time' : fl.asBool('S') ? 'size' : 'name'
   const warnings: LsWarning[] = []
   const lines: string[] = []
 

--- a/typescript/packages/core/src/commands/builtin/generic/mktemp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/mktemp.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -46,12 +48,13 @@ export async function mktempGeneric(
   mkdir: (p: PathSpec, parents?: boolean) => Promise<void>,
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('mktemp'))
   if (texts.length > 1) throw extraOperandError(CommandName.MKTEMP, texts[1] ?? '')
-  const tFlag = opts.flags.t === true
-  const directory = opts.flags.d === true || opts.flags.directory === true
-  const dryRun = opts.flags.u === true || opts.flags.dry_run === true
-  const suffix = typeof opts.flags.suffix === 'string' ? opts.flags.suffix : ''
-  const tmpdirValue: unknown = opts.flags.p ?? opts.flags.tmpdir
+  const tFlag = fl.asBool('t')
+  const directory = fl.asBool('d') || fl.asBool('directory')
+  const dryRun = fl.asBool('u') || fl.asBool('dry_run')
+  const suffix = (fl.asStr('suffix') ?? '')
+  const tmpdirValue: unknown = fl.raw('p') ?? fl.raw('tmpdir')
   const templateArg = texts[0]
   let template = templateArg !== undefined && templateArg !== '' ? templateArg : 'tmp.XXXXXXXXXX'
   let parent: string
@@ -83,7 +86,7 @@ export async function mktempGeneric(
   const path = `${rstripSlash(parent)}/${name}`
   if (!dryRun) {
     const mountPrefix = opts.mountPrefix ?? ''
-    const quiet = opts.flags.q === true || opts.flags.quiet === true
+    const quiet = fl.asBool('q') || fl.asBool('quiet')
     try {
       await mkdir(makePathSpec(parent, mountPrefix), true)
       if (directory) {

--- a/typescript/packages/core/src/commands/builtin/generic/mktemp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/mktemp.ts
@@ -53,7 +53,7 @@ export async function mktempGeneric(
   const tFlag = fl.asBool('t')
   const directory = fl.asBool('d') || fl.asBool('directory')
   const dryRun = fl.asBool('u') || fl.asBool('dry_run')
-  const suffix = (fl.asStr('suffix') ?? '')
+  const suffix = fl.asStr('suffix') ?? ''
   const tmpdirValue: unknown = fl.raw('p') ?? fl.raw('tmpdir')
   const templateArg = texts[0]
   let template = templateArg !== undefined && templateArg !== '' ? templateArg : 'tmp.XXXXXXXXXX'

--- a/typescript/packages/core/src/commands/builtin/generic/numfmt.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/numfmt.ts
@@ -110,9 +110,9 @@ export async function numfmtGeneric(
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
   const fl = new FlagView(opts.flags, specOf('numfmt'))
-  const toMode = (fl.asStr('to') ?? 'none')
-  const fromMode = (fl.asStr('from') ?? 'none')
-  const suffix = (fl.asStr('suffix') ?? '')
+  const toMode = fl.asStr('to') ?? 'none'
+  const fromMode = fl.asStr('from') ?? 'none'
+  const suffix = fl.asStr('suffix') ?? ''
   const grouping = fl.asBool('grouping')
   let output: string[]
   if (texts.length > 0) {

--- a/typescript/packages/core/src/commands/builtin/generic/numfmt.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/numfmt.ts
@@ -1,3 +1,5 @@
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, materialize } from '../../../io/types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { resolveSource } from '../utils/stream.ts'
@@ -107,10 +109,11 @@ export async function numfmtGeneric(
   texts: readonly string[],
   opts: CommandOpts,
 ): Promise<CommandFnResult> {
-  const toMode = typeof opts.flags.to === 'string' ? opts.flags.to : 'none'
-  const fromMode = typeof opts.flags.from === 'string' ? opts.flags.from : 'none'
-  const suffix = typeof opts.flags.suffix === 'string' ? opts.flags.suffix : ''
-  const grouping = opts.flags.grouping === true
+  const fl = new FlagView(opts.flags, specOf('numfmt'))
+  const toMode = (fl.asStr('to') ?? 'none')
+  const fromMode = (fl.asStr('from') ?? 'none')
+  const suffix = (fl.asStr('suffix') ?? '')
+  const grouping = fl.asBool('grouping')
   let output: string[]
   if (texts.length > 0) {
     output = texts.map((value) => convertField(value, toMode, fromMode, suffix, grouping))

--- a/typescript/packages/core/src/commands/builtin/generic/paste.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/paste.ts
@@ -70,7 +70,7 @@ export async function pasteGeneric(
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
   const fl = new FlagView(opts.flags, specOf('paste'))
-  const delimiterValue = opts.flags.d ?? opts.flags.delimiters
+  const delimiterValue = fl.asStr('d') ?? fl.asStr('delimiters')
   const delimiters = decodeDelimiters(typeof delimiterValue === 'string' ? delimiterValue : '\t')
   const serial = fl.asBool('s') || fl.asBool('serial')
   const zeroTerminated = fl.asBool('z') || fl.asBool('zero_terminated')

--- a/typescript/packages/core/src/commands/builtin/generic/paste.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/paste.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -67,10 +69,11 @@ export async function pasteGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('paste'))
   const delimiterValue = opts.flags.d ?? opts.flags.delimiters
   const delimiters = decodeDelimiters(typeof delimiterValue === 'string' ? delimiterValue : '\t')
-  const serial = opts.flags.s === true || opts.flags.serial === true
-  const zeroTerminated = opts.flags.z === true || opts.flags.zero_terminated === true
+  const serial = fl.asBool('s') || fl.asBool('serial')
+  const zeroTerminated = fl.asBool('z') || fl.asBool('zero_terminated')
   const fileLines: string[][] = []
   let stdinConsumed = false
   for (const p of paths) {

--- a/typescript/packages/core/src/commands/builtin/generic/patch.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/patch.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { mountKey, stripMount } from '../../../utils/key_prefix.ts'
 import { IOResult, materialize } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
@@ -154,10 +156,11 @@ export async function patchGeneric(
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('patch'))
   if (paths.length > 2) throw extraOperandError(CommandName.PATCH, paths[2]?.rawPath ?? '')
   const stripCount = typeof opts.flags.p === 'string' ? Number.parseInt(opts.flags.p, 10) : 0
-  const reverseMode = opts.flags.R === true
-  const forwardOnly = opts.flags.N === true
+  const reverseMode = fl.asBool('R')
+  const forwardOnly = fl.asBool('N')
   const iFlag = typeof opts.flags.i === 'string' ? opts.flags.i : null
   const mountPrefix = opts.mountPrefix ?? ''
   let patchData: Uint8Array | null = null

--- a/typescript/packages/core/src/commands/builtin/generic/patch.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/patch.ts
@@ -158,10 +158,10 @@ export async function patchGeneric(
 ): Promise<CommandFnResult> {
   const fl = new FlagView(opts.flags, specOf('patch'))
   if (paths.length > 2) throw extraOperandError(CommandName.PATCH, paths[2]?.rawPath ?? '')
-  const stripCount = typeof opts.flags.p === 'string' ? Number.parseInt(opts.flags.p, 10) : 0
+  const stripCount = fl.asInt('p') ?? 0
   const reverseMode = fl.asBool('R')
   const forwardOnly = fl.asBool('N')
-  const iFlag = (fl.asStr('i') ?? null)
+  const iFlag = fl.asStr('i') ?? null
   const mountPrefix = opts.mountPrefix ?? ''
   let patchData: Uint8Array | null = null
   if (iFlag !== null) {

--- a/typescript/packages/core/src/commands/builtin/generic/patch.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/patch.ts
@@ -161,7 +161,7 @@ export async function patchGeneric(
   const stripCount = typeof opts.flags.p === 'string' ? Number.parseInt(opts.flags.p, 10) : 0
   const reverseMode = fl.asBool('R')
   const forwardOnly = fl.asBool('N')
-  const iFlag = typeof opts.flags.i === 'string' ? opts.flags.i : null
+  const iFlag = (fl.asStr('i') ?? null)
   const mountPrefix = opts.mountPrefix ?? ''
   let patchData: Uint8Array | null = null
   if (iFlag !== null) {

--- a/typescript/packages/core/src/commands/builtin/generic/readlink.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/readlink.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { mountPrefixOf } from '../../../utils/key_prefix.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
@@ -43,8 +45,9 @@ export function readlinkGeneric(
   if (paths.length === 0) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('readlink: missing operand\n') })]
   }
-  const normalize = opts.flags.f === true || opts.flags.e === true || opts.flags.m === true
-  const noNewline = opts.flags.n === true
+  const fl = new FlagView(opts.flags, specOf('readlink'))
+  const normalize = fl.asBool('f') || fl.asBool('e') || fl.asBool('m')
+  const noNewline = fl.asBool('n')
   const results: string[] = []
   for (const p of paths) {
     let vp =

--- a/typescript/packages/core/src/commands/builtin/generic/realpath.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/realpath.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -47,7 +49,8 @@ export async function realpathGeneric(
   opts: CommandOpts,
   stat: (p: PathSpec) => Promise<unknown>,
 ): Promise<CommandFnResult> {
-  const requireExists = opts.flags.e === true
+  const fl = new FlagView(opts.flags, specOf('realpath'))
+  const requireExists = fl.asBool('e')
   const lines: string[] = []
   if (paths.length > 0) {
     for (const p of paths) {

--- a/typescript/packages/core/src/commands/builtin/generic/sed.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/sed.ts
@@ -36,10 +36,8 @@ export async function sedGeneric(
   // The script comes from -e expressions and -f script files (joined with
   // newlines, -e then -f as grep does) when any were given, otherwise from the
   // first positional operand.
-  const eVals = opts.flags.e
-  const eList = Array.isArray(eVals) ? eVals : typeof eVals === 'string' ? [eVals] : []
-  const fVals = opts.flags.f
-  const fList = Array.isArray(fVals) ? fVals : typeof fVals === 'string' ? [fVals] : []
+  const eList = fl.asList('e')
+  const fList = fl.asList('f')
   const scriptParts = [...eList]
   const firstPath = paths[0]
   const scriptPrefix =

--- a/typescript/packages/core/src/commands/builtin/generic/sed.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/sed.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { mountKey, mountPrefixOf } from '../../../utils/key_prefix.ts'
 import { fsErrorLine, isFsError } from '../../../utils/errors.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
@@ -30,6 +32,7 @@ export async function sedGeneric(
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('sed'))
   // The script comes from -e expressions and -f script files (joined with
   // newlines, -e then -f as grep does) when any were given, otherwise from the
   // first positional operand.
@@ -57,10 +60,10 @@ export async function sedGeneric(
   if (script === undefined) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('sed: missing script\n') })]
   }
-  const suppress = opts.flags.n === true
-  const inPlace = opts.flags.i === true
+  const suppress = fl.asBool('n')
+  const inPlace = fl.asBool('i')
   // -E / -r select Extended Regular Expressions; without them sed is BRE.
-  const extended = opts.flags.E === true || opts.flags.r === true
+  const extended = fl.asBool('E') || fl.asBool('r')
   let commands: SedCommand[]
   try {
     if (script.includes(';') || script.includes('{') || script.includes('\n')) {

--- a/typescript/packages/core/src/commands/builtin/generic/shuf.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/shuf.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
 import { mountKey } from '../../../utils/key_prefix.ts'
@@ -61,25 +63,24 @@ export async function shufGeneric(
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
 ): Promise<CommandFnResult> {
-  const countValue = opts.flags.n ?? opts.flags.head_count
-  const rangeValue = opts.flags.i ?? opts.flags.input_range
-  const outputValue = opts.flags.o ?? opts.flags.output
-  const nFlag = typeof countValue === 'string' ? Number.parseInt(countValue, 10) : null
-  const inputRange = typeof rangeValue === 'string' ? rangeValue : null
+  const fl = new FlagView(opts.flags, specOf('shuf'))
+  const countValue = fl.asStr('n') ?? fl.asStr('head_count')
+  const rangeValue = fl.asStr('i') ?? fl.asStr('input_range')
+  const outputValue = fl.asStr('o') ?? fl.asStr('output')
+  const nFlag = countValue === undefined ? null : Number.parseInt(countValue, 10)
+  const inputRange = rangeValue ?? null
   const output =
-    outputValue instanceof PathSpec
-      ? outputValue
-      : typeof outputValue === 'string'
-        ? new PathSpec({
-            virtual: outputValue,
-            directory: outputValue,
-            resourcePath: mountKey(outputValue, opts.mountPrefix ?? ''),
-            resolved: true,
-          })
-        : null
-  const echoMode = opts.flags.e === true || opts.flags.echo === true
-  const zeroSep = opts.flags.z === true || opts.flags.zero_terminated === true
-  const repeat = opts.flags.r === true || opts.flags.repeat === true
+    outputValue === undefined
+      ? null
+      : new PathSpec({
+          virtual: outputValue,
+          directory: outputValue,
+          resourcePath: mountKey(outputValue, opts.mountPrefix ?? ''),
+          resolved: true,
+        })
+  const echoMode = fl.asBool('e') || fl.asBool('echo')
+  const zeroSep = fl.asBool('z') || fl.asBool('zero_terminated')
+  const repeat = fl.asBool('r') || fl.asBool('repeat')
   const sep = zeroSep ? '\x00' : '\n'
 
   let items: string[]

--- a/typescript/packages/core/src/commands/builtin/generic/split.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/split.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { stripSlash } from '../../../utils/slash.ts'
 import { AsyncLineIterator } from '../../../io/async_line_iterator.ts'
 import { IOResult } from '../../../io/types.ts'
@@ -119,15 +121,16 @@ export async function splitGeneric(
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('split'))
   if (paths.length > 2) throw extraOperandError(CommandName.SPLIT, paths[2]?.rawPath ?? '')
   const prefixPath = paths.length >= 2 && paths[1] !== undefined ? paths[1].mountPath : 'x'
-  const linesValue = opts.flags.args_l ?? opts.flags.lines
-  const bytesValue = opts.flags.b ?? opts.flags.bytes
-  const numberValue = opts.flags.n ?? opts.flags.number
-  const lengthValue = opts.flags.a ?? opts.flags.suffix_length
-  const numericValue = opts.flags.d ?? opts.flags.numeric_suffixes
-  const hexValue = opts.flags.x ?? opts.flags.hex_suffixes
-  const separatorValue = opts.flags.t ?? opts.flags.separator
+  const linesValue = fl.asStr('args_l') ?? fl.asStr('lines')
+  const bytesValue = fl.asStr('b') ?? fl.asStr('bytes')
+  const numberValue = fl.asStr('n') ?? fl.asStr('number')
+  const lengthValue = fl.asStr('a') ?? fl.asStr('suffix_length')
+  const numericValue = fl.raw('d') ?? fl.raw('numeric_suffixes')
+  const hexValue = fl.raw('x') ?? fl.raw('hex_suffixes')
+  const separatorValue = fl.asStr('t') ?? fl.asStr('separator')
   const linesFlag = typeof linesValue === 'string' ? linesValue : null
   const bFlag = typeof bytesValue === 'string' ? bytesValue : null
   const nFlag = typeof numberValue === 'string' ? numberValue : null
@@ -141,7 +144,7 @@ export async function splitGeneric(
         ? Number.parseInt(hexValue, 10)
         : 0
   const additionalSuffix =
-    typeof opts.flags.additional_suffix === 'string' ? opts.flags.additional_suffix : ''
+    (fl.asStr('additional_suffix') ?? '')
   const separator =
     separatorValue === '\\0'
       ? 0

--- a/typescript/packages/core/src/commands/builtin/generic/split.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/split.ts
@@ -143,8 +143,7 @@ export async function splitGeneric(
       : typeof hexValue === 'string'
         ? Number.parseInt(hexValue, 10)
         : 0
-  const additionalSuffix =
-    (fl.asStr('additional_suffix') ?? '')
+  const additionalSuffix = fl.asStr('additional_suffix') ?? ''
   const separator =
     separatorValue === '\\0'
       ? 0

--- a/typescript/packages/core/src/commands/builtin/generic/stat.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/stat.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { FileType, type FileStat, type PathSpec } from '../../../types.ts'
 import { isoToEpoch } from '../../../utils/dates.ts'
@@ -204,15 +206,11 @@ export async function statGeneric(
   opts: CommandOpts,
   stat: (p: PathSpec) => Promise<FileStat>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('stat'))
   if (paths.length === 0) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('stat: missing operand\n') })]
   }
-  const fmt =
-    typeof opts.flags.c === 'string'
-      ? opts.flags.c
-      : typeof opts.flags.f === 'string'
-        ? opts.flags.f
-        : null
+  const fmt = fl.asStr('c') ?? fl.asStr('f') ?? null
   const lines: string[] = []
   let err = ''
   for (const p of paths) {

--- a/typescript/packages/core/src/commands/builtin/generic/strings.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/strings.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -45,7 +47,8 @@ export async function stringsGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
-  const minLen = typeof opts.flags.n === 'string' ? Number.parseInt(opts.flags.n, 10) : 4
+  const fl = new FlagView(opts.flags, specOf('strings'))
+  const minLen = fl.asInt('n') ?? 4
   // Each operand is scanned independently and the matches concatenate in
   // operand order, like GNU strings.
   if (paths.length > 0) {

--- a/typescript/packages/core/src/commands/builtin/generic/tac.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tac.ts
@@ -55,7 +55,7 @@ export async function tacGeneric(
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
   const fl = new FlagView(opts.flags, specOf('tac'))
-  const separatorValue = opts.flags.s ?? opts.flags.separator
+  const separatorValue = fl.asStr('s') ?? fl.asStr('separator')
   const separator = typeof separatorValue === 'string' ? separatorValue : '\n'
   const before = fl.asBool('b') || fl.asBool('before')
   const regex = fl.asBool('r') || fl.asBool('regex')

--- a/typescript/packages/core/src/commands/builtin/generic/tac.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tac.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -52,10 +54,11 @@ export async function tacGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('tac'))
   const separatorValue = opts.flags.s ?? opts.flags.separator
   const separator = typeof separatorValue === 'string' ? separatorValue : '\n'
-  const before = opts.flags.b === true || opts.flags.before === true
-  const regex = opts.flags.r === true || opts.flags.regex === true
+  const before = fl.asBool('b') || fl.asBool('before')
+  const regex = fl.asBool('r') || fl.asBool('regex')
   if (paths.length > 0) {
     // A missing operand is reported and skipped; the remaining operands
     // still reverse (GNU tac).

--- a/typescript/packages/core/src/commands/builtin/generic/tail.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tail.ts
@@ -46,8 +46,8 @@ export async function tailGeneric(
 ): Promise<CommandFnResult> {
   const fl = new FlagView(opts.flags, specOf('tail'))
   stream = cacheAwareStreamEager(stream)
-  const nRaw = typeof opts.flags.n === 'string' ? opts.flags.n : null
-  const cRaw = typeof opts.flags.c === 'string' ? opts.flags.c : null
+  const nRaw = (fl.asStr('n') ?? null)
+  const cRaw = (fl.asStr('c') ?? null)
   const numErr = numberFlagError('tail', nRaw, cRaw)
   if (numErr !== null) return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(numErr) })]
   const qFlag = fl.asBool('q')

--- a/typescript/packages/core/src/commands/builtin/generic/tail.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tail.ts
@@ -46,8 +46,8 @@ export async function tailGeneric(
 ): Promise<CommandFnResult> {
   const fl = new FlagView(opts.flags, specOf('tail'))
   stream = cacheAwareStreamEager(stream)
-  const nRaw = (fl.asStr('n') ?? null)
-  const cRaw = (fl.asStr('c') ?? null)
+  const nRaw = fl.asStr('n') ?? null
+  const cRaw = fl.asStr('c') ?? null
   const numErr = numberFlagError('tail', nRaw, cRaw)
   if (numErr !== null) return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(numErr) })]
   const qFlag = fl.asBool('q')

--- a/typescript/packages/core/src/commands/builtin/generic/tail.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tail.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { cacheAwareStreamEager } from '../../../cache/read_through.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
@@ -42,13 +44,14 @@ export async function tailGeneric(
   opts: CommandOpts,
   stream: Stream,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('tail'))
   stream = cacheAwareStreamEager(stream)
   const nRaw = typeof opts.flags.n === 'string' ? opts.flags.n : null
   const cRaw = typeof opts.flags.c === 'string' ? opts.flags.c : null
   const numErr = numberFlagError('tail', nRaw, cRaw)
   if (numErr !== null) return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(numErr) })]
-  const qFlag = opts.flags.q === true
-  const vFlag = opts.flags.v === true
+  const qFlag = fl.asBool('q')
+  const vFlag = fl.asBool('v')
   const [lines, plusMode] = parseN(nRaw)
   const bytesMode = cRaw !== null ? Number.parseInt(cRaw, 10) : null
 

--- a/typescript/packages/core/src/commands/builtin/generic/tar.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tar.ts
@@ -98,13 +98,10 @@ export async function tarGeneric(
       new IOResult({ exitCode: 1, stderr: ENC.encode('tar: bzip2/xz not supported\n') }),
     ]
   }
-  const fFlag = (fl.asStr('f') ?? null)
-  const CFlag = (fl.asStr('C') ?? null)
-  const stripN =
-    typeof opts.flags.strip_components === 'string'
-      ? Number.parseInt(opts.flags.strip_components, 10)
-      : 0
-  const exclude = (fl.asStr('exclude') ?? null)
+  const fFlag = fl.asStr('f') ?? null
+  const CFlag = fl.asStr('C') ?? null
+  const stripN = fl.asInt('strip_components') ?? 0
+  const exclude = fl.asStr('exclude') ?? null
   const mountPrefix = opts.mountPrefix ?? ''
   const archivePath = fFlag
   const destPath = CFlag ?? '/'

--- a/typescript/packages/core/src/commands/builtin/generic/tar.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tar.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { mountKey } from '../../../utils/key_prefix.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
@@ -48,9 +50,10 @@ function detectCompression(data: Uint8Array): Compression {
 }
 
 function compressionOf(opts: CommandOpts): Compression {
-  if (opts.flags.z === true) return 'gzip'
-  if (opts.flags.j === true) return 'bzip2'
-  if (opts.flags.J === true) return 'xz'
+  const fl = new FlagView(opts.flags, specOf('tar'))
+  if (fl.asBool('z')) return 'gzip'
+  if (fl.asBool('j')) return 'bzip2'
+  if (fl.asBool('J')) return 'xz'
   return null
 }
 
@@ -78,11 +81,12 @@ export async function tarGeneric(
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
   mkdir: (p: PathSpec) => Promise<void>,
 ): Promise<CommandFnResult> {
-  const create = opts.flags.c === true
-  const extract = opts.flags.x === true
-  const list = opts.flags.t === true
+  const fl = new FlagView(opts.flags, specOf('tar'))
+  const create = fl.asBool('c')
+  const extract = fl.asBool('x')
+  const list = fl.asBool('t')
   const compression = compressionOf(opts)
-  const verbose = opts.flags.v === true
+  const verbose = fl.asBool('v')
   // gzip is built in; bzip2 (-j) / xz (-J) need a codec registered by the
   // runtime package. Unregistered (e.g. browser core) -> not supported.
   if (
@@ -94,13 +98,13 @@ export async function tarGeneric(
       new IOResult({ exitCode: 1, stderr: ENC.encode('tar: bzip2/xz not supported\n') }),
     ]
   }
-  const fFlag = typeof opts.flags.f === 'string' ? opts.flags.f : null
-  const CFlag = typeof opts.flags.C === 'string' ? opts.flags.C : null
+  const fFlag = (fl.asStr('f') ?? null)
+  const CFlag = (fl.asStr('C') ?? null)
   const stripN =
     typeof opts.flags.strip_components === 'string'
       ? Number.parseInt(opts.flags.strip_components, 10)
       : 0
-  const exclude = typeof opts.flags.exclude === 'string' ? opts.flags.exclude : null
+  const exclude = (fl.asStr('exclude') ?? null)
   const mountPrefix = opts.mountPrefix ?? ''
   const archivePath = fFlag
   const destPath = CFlag ?? '/'

--- a/typescript/packages/core/src/commands/builtin/generic/tee.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tee.ts
@@ -17,6 +17,8 @@ import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
 import { fsErrorLine, isFsError } from '../../../utils/errors.ts'
 import { readStdinAsync } from '../utils/stream.ts'
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView, type FlagValue } from '../../spec/types.ts'
 
 const ENC = new TextEncoder()
 
@@ -26,10 +28,9 @@ export interface TeeOptions {
   append: boolean
 }
 
-export function parseTeeFlags(
-  flags: Record<string, string | boolean | string[]>,
-): TeeOptions | string {
-  const mode = flags.output_error
+export function parseTeeFlags(flags: Record<string, FlagValue>): TeeOptions | string {
+  const fl = new FlagView(flags, specOf('tee'))
+  const mode = fl.raw('output_error')
   if (typeof mode === 'string' && !OUTPUT_ERROR_MODES.includes(mode)) {
     const valid = OUTPUT_ERROR_MODES.map((m) => `  - '${m}'`).join('\n')
     return (
@@ -38,7 +39,7 @@ export function parseTeeFlags(
       "Try 'tee --help' for more information.\n"
     )
   }
-  return { append: flags.a === true || flags.append === true }
+  return { append: fl.asBool('a') || fl.asBool('append') }
 }
 
 export async function teeGeneric(

--- a/typescript/packages/core/src/commands/builtin/generic/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tree.ts
@@ -124,9 +124,9 @@ export async function treeGeneric(
             resourcePath: mountKey(opts.cwd, opts.mountPrefix ?? ''),
           }),
         ]
-  const depthRaw = (fl.asStr('L') ?? null)
-  const ignoreRaw = (fl.asStr('args_I') ?? null)
-  const matchRaw = (fl.asStr('P') ?? null)
+  const depthRaw = fl.asStr('L') ?? null
+  const ignoreRaw = fl.asStr('args_I') ?? null
+  const matchRaw = fl.asStr('P') ?? null
   const treeOpts: TreeOpts = {
     showHidden: fl.asBool('a'),
     maxDepth: depthRaw === null ? null : Number.parseInt(depthRaw, 10),

--- a/typescript/packages/core/src/commands/builtin/generic/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tree.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { mountKey, mountPrefixOf } from '../../../utils/key_prefix.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import { FileType, PathSpec, type FileStat } from '../../../types.ts'
@@ -110,6 +112,7 @@ export async function treeGeneric(
   readdir: (p: PathSpec) => Promise<string[]>,
   stat: (p: PathSpec) => Promise<FileStat>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('tree'))
   const targets =
     paths.length > 0
       ? paths
@@ -125,10 +128,10 @@ export async function treeGeneric(
   const ignoreRaw = typeof opts.flags.args_I === 'string' ? opts.flags.args_I : null
   const matchRaw = typeof opts.flags.P === 'string' ? opts.flags.P : null
   const treeOpts: TreeOpts = {
-    showHidden: opts.flags.a === true,
+    showHidden: fl.asBool('a'),
     maxDepth: depthRaw === null ? null : Number.parseInt(depthRaw, 10),
     ignorePattern: ignoreRaw,
-    dirsOnly: opts.flags.d === true,
+    dirsOnly: fl.asBool('d'),
     matchPattern: matchRaw,
   }
   const lines: string[] = []

--- a/typescript/packages/core/src/commands/builtin/generic/tree.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/tree.ts
@@ -124,9 +124,9 @@ export async function treeGeneric(
             resourcePath: mountKey(opts.cwd, opts.mountPrefix ?? ''),
           }),
         ]
-  const depthRaw = typeof opts.flags.L === 'string' ? opts.flags.L : null
-  const ignoreRaw = typeof opts.flags.args_I === 'string' ? opts.flags.args_I : null
-  const matchRaw = typeof opts.flags.P === 'string' ? opts.flags.P : null
+  const depthRaw = (fl.asStr('L') ?? null)
+  const ignoreRaw = (fl.asStr('args_I') ?? null)
+  const matchRaw = (fl.asStr('P') ?? null)
   const treeOpts: TreeOpts = {
     showHidden: fl.asBool('a'),
     maxDepth: depthRaw === null ? null : Number.parseInt(depthRaw, 10),

--- a/typescript/packages/core/src/commands/builtin/generic/unexpand.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/unexpand.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -71,10 +73,10 @@ export async function unexpandGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
-  const tabsValue = opts.flags.t ?? opts.flags.tabs
-  const tabsize = typeof tabsValue === 'string' ? Number.parseInt(tabsValue, 10) : 8
-  const allSpaces =
-    (opts.flags.a === true || opts.flags.all === true) && opts.flags.first_only !== true
+  const fl = new FlagView(opts.flags, specOf('unexpand'))
+  const tabsValue = fl.asStr('t') ?? fl.asStr('tabs')
+  const tabsize = tabsValue === undefined ? 8 : Number.parseInt(tabsValue, 10)
+  const allSpaces = (fl.asBool('a') || fl.asBool('all')) && !fl.asBool('first_only')
   if (paths.length > 0) {
     // A missing operand is reported and skipped; the remaining operands
     // still unexpand (GNU unexpand).

--- a/typescript/packages/core/src/commands/builtin/generic/unzip.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/unzip.ts
@@ -114,7 +114,7 @@ export async function unzipGeneric(
   const pipeMode = fl.asBool('p')
   const quiet = fl.asBool('q')
   const mountPrefix = mountPrefixOf(archivePath.virtual, archivePath.resourcePath)
-  const destRaw = (fl.asStr('d') ?? '/')
+  const destRaw = fl.asStr('d') ?? '/'
   const dest =
     mountPrefix !== '' && destRaw.startsWith(mountPrefix + '/')
       ? destRaw.slice(mountPrefix.length)

--- a/typescript/packages/core/src/commands/builtin/generic/unzip.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/unzip.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { mountPrefixOf } from '../../../utils/key_prefix.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
@@ -98,6 +100,7 @@ export async function unzipGeneric(
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
   mkdir: (p: PathSpec, parents?: boolean) => Promise<void>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('unzip'))
   if (paths.length === 0) {
     return [null, new IOResult({ exitCode: 1, stderr: ENC.encode('unzip: missing operand\n') })]
   }
@@ -106,12 +109,12 @@ export async function unzipGeneric(
   const data = await materialize(stream(archivePath))
   const entries = await readZipEntries(data)
 
-  const listMode = opts.flags.args_l === true
-  const testMode = opts.flags.t === true
-  const pipeMode = opts.flags.p === true
-  const quiet = opts.flags.q === true
+  const listMode = fl.asBool('args_l')
+  const testMode = fl.asBool('t')
+  const pipeMode = fl.asBool('p')
+  const quiet = fl.asBool('q')
   const mountPrefix = mountPrefixOf(archivePath.virtual, archivePath.resourcePath)
-  const destRaw = typeof opts.flags.d === 'string' ? opts.flags.d : '/'
+  const destRaw = (fl.asStr('d') ?? '/')
   const dest =
     mountPrefix !== '' && destRaw.startsWith(mountPrefix + '/')
       ? destRaw.slice(mountPrefix.length)

--- a/typescript/packages/core/src/commands/builtin/generic/xxd.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/xxd.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import type { CommandFnResult, CommandOpts } from '../../config.ts'
@@ -153,6 +155,7 @@ export async function xxdGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('xxd'))
   if (paths.length > 2) throw extraOperandError(CommandName.XXD, paths[2]?.rawPath ?? '')
   const cache: string[] = []
   let source: AsyncIterable<Uint8Array>
@@ -172,9 +175,9 @@ export async function xxdGeneric(
     const limit = limitFlag > 0 ? limitFlag : Number.MAX_SAFE_INTEGER
     source = applyLimits(source, skip, limit)
   }
-  const uppercase = opts.flags.u === true
-  if (opts.flags.r === true) return [xxdReverseStream(source), new IOResult({ cache })]
-  if (opts.flags.p === true) return [xxdPlainStream(source, uppercase), new IOResult({ cache })]
+  const uppercase = fl.asBool('u')
+  if (fl.asBool('r')) return [xxdReverseStream(source), new IOResult({ cache })]
+  if (fl.asBool('p')) return [xxdPlainStream(source, uppercase), new IOResult({ cache })]
   const cols = toInt(opts.flags.c) > 0 ? toInt(opts.flags.c) : 16
   const group = toInt(opts.flags.g) > 0 ? toInt(opts.flags.g) : 2
   return [xxdDumpStream(source, cols, group, uppercase), new IOResult({ cache })]

--- a/typescript/packages/core/src/commands/builtin/generic/xxd.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/xxd.ts
@@ -169,8 +169,8 @@ export async function xxdGeneric(
   }
   const toInt = (v: string | boolean | string[] | undefined): number =>
     typeof v === 'string' ? Number.parseInt(v, 10) : 0
-  const skip = toInt(opts.flags.s)
-  const limitFlag = toInt(opts.flags.args_l)
+  const skip = toInt(fl.raw('s'))
+  const limitFlag = toInt(fl.raw('args_l'))
   if (skip > 0 || limitFlag > 0) {
     const limit = limitFlag > 0 ? limitFlag : Number.MAX_SAFE_INTEGER
     source = applyLimits(source, skip, limit)
@@ -178,7 +178,7 @@ export async function xxdGeneric(
   const uppercase = fl.asBool('u')
   if (fl.asBool('r')) return [xxdReverseStream(source), new IOResult({ cache })]
   if (fl.asBool('p')) return [xxdPlainStream(source, uppercase), new IOResult({ cache })]
-  const cols = toInt(opts.flags.c) > 0 ? toInt(opts.flags.c) : 16
-  const group = toInt(opts.flags.g) > 0 ? toInt(opts.flags.g) : 2
+  const cols = toInt(fl.raw('c')) > 0 ? toInt(fl.raw('c')) : 16
+  const group = toInt(fl.raw('g')) > 0 ? toInt(fl.raw('g')) : 2
   return [xxdDumpStream(source, cols, group, uppercase), new IOResult({ cache })]
 }

--- a/typescript/packages/core/src/commands/builtin/generic/zgrep.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/zgrep.ts
@@ -129,7 +129,7 @@ export async function zgrepGeneric(
   const filesOnly = fl.asBool('args_l')
   const forceH = fl.asBool('H')
   const hideH = fl.asBool('h')
-  const maxCount = typeof opts.flags.m === 'string' ? Number.parseInt(opts.flags.m, 10) : null
+  const maxCount = fl.asInt('m') ?? null
   void extendedRegex
   const pattern = compilePattern(rawPattern, ignoreCase, fixedString, wholeWord)
 

--- a/typescript/packages/core/src/commands/builtin/generic/zgrep.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/zgrep.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import { gunzip } from '../../../utils/compress.ts'
@@ -92,6 +94,7 @@ export async function zgrepGeneric(
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('zgrep'))
   const resolution = await resolvePatternFromFlags(
     'zgrep',
     texts,
@@ -114,18 +117,18 @@ export async function zgrepGeneric(
     ]
   }
   const rawPattern = resolution.pattern
-  const extendedRegex = opts.flags.E === true
-  const fixedString = opts.flags.F === true && !neverMatch
-  const wholeWord = opts.flags.w === true
-  const ignoreCase = opts.flags.i === true
-  const invert = opts.flags.v === true
-  const countOnly = opts.flags.c === true
-  const lineNumbers = opts.flags.n === true
-  const onlyMatching = opts.flags.o === true
-  const quiet = opts.flags.q === true
-  const filesOnly = opts.flags.args_l === true
-  const forceH = opts.flags.H === true
-  const hideH = opts.flags.h === true
+  const extendedRegex = fl.asBool('E')
+  const fixedString = fl.asBool('F') && !neverMatch
+  const wholeWord = fl.asBool('w')
+  const ignoreCase = fl.asBool('i')
+  const invert = fl.asBool('v')
+  const countOnly = fl.asBool('c')
+  const lineNumbers = fl.asBool('n')
+  const onlyMatching = fl.asBool('o')
+  const quiet = fl.asBool('q')
+  const filesOnly = fl.asBool('args_l')
+  const forceH = fl.asBool('H')
+  const hideH = fl.asBool('h')
   const maxCount = typeof opts.flags.m === 'string' ? Number.parseInt(opts.flags.m, 10) : null
   void extendedRegex
   const pattern = compilePattern(rawPattern, ignoreCase, fixedString, wholeWord)

--- a/typescript/packages/core/src/commands/builtin/generic/zip_cmd.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/zip_cmd.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { specOf } from '../../spec/builtins.ts'
+import { FlagView } from '../../spec/types.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import type { PathSpec } from '../../../types.ts'
 import { deflateRaw } from '../../../utils/compress.ts'
@@ -142,6 +144,7 @@ export async function zipGeneric(
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
 ): Promise<CommandFnResult> {
+  const fl = new FlagView(opts.flags, specOf('zip'))
   if (paths.length < 2) {
     return [
       null,
@@ -154,8 +157,8 @@ export async function zipGeneric(
   const archivePath = paths[0]
   const filePaths = paths.slice(1)
   if (archivePath === undefined) return [null, new IOResult()]
-  const junkPaths = opts.flags.j === true
-  const quiet = opts.flags.q === true
+  const junkPaths = fl.asBool('j')
+  const quiet = fl.asBool('q')
 
   const items: ZipItem[] = []
   const outputLines: string[] = []

--- a/typescript/packages/core/src/commands/spec/constants.ts
+++ b/typescript/packages/core/src/commands/spec/constants.ts
@@ -21,6 +21,18 @@ export const AMBIGUOUS_NAMES: Readonly<Record<string, string>> = Object.freeze({
 
 // Numeric shorthand token like `-5` (head/tail count), never a flag
 // cluster or a path.
+/**
+ * Map a flag name to its dispatcher kwarg name.
+ *
+ * Mirrors Python's `flag_kwarg_name`. The dispatcher spells flags without
+ * their dashes and with dashes turned into underscores, so this is the one
+ * place that translation lives.
+ */
+export function flagKwargName(flag: string): string {
+  const clean = flag.replace(/^-+/, '').replaceAll('-', '_')
+  return AMBIGUOUS_NAMES[clean] ?? clean
+}
+
 export const NUMERIC_SHORT = /^-\d+$/
 
 // GNU usage-error exit codes, pinned against debian coreutils/grep/diffutils

--- a/typescript/packages/core/src/commands/spec/flag_view.test.ts
+++ b/typescript/packages/core/src/commands/spec/flag_view.test.ts
@@ -1,0 +1,80 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { specOf } from './builtins.ts'
+import { flagKwargName } from './constants.ts'
+import { CommandSpec, FlagView, OperandKind, Option, specFlagNames } from './types.ts'
+
+// Mirrors python/tests/commands/spec/test_types.py.
+
+describe('FlagView', () => {
+  it('reads each flag shape at its declared type', () => {
+    const fl = new FlagView({ i: true, m: '5', type: 'py', e: ['a', 'b'] })
+    expect(fl.asBool('i')).toBe(true)
+    expect(fl.asBool('v')).toBe(false)
+    expect(fl.asInt('m')).toBe(5)
+    expect(fl.asInt('A')).toBeUndefined()
+    expect(fl.asStr('type')).toBe('py')
+    expect(fl.asStr('glob')).toBeUndefined()
+    expect(fl.asList('e')).toEqual(['a', 'b'])
+    expect(fl.asList('f')).toEqual([])
+  })
+
+  it('coerces a single string to a one-element list', () => {
+    expect(new FlagView({ e: 'solo' }).asList('e')).toEqual(['solo'])
+  })
+
+  it('is lenient without a spec', () => {
+    const fl = new FlagView({ anything: true })
+    expect(fl.asBool('anything')).toBe(true)
+    expect(fl.asBool('missing')).toBe(false)
+  })
+
+  // The whole point of passing a spec: a missing key is otherwise
+  // indistinguishable from "flag not passed", so a typo reads as false.
+  it('rejects names the spec does not declare', () => {
+    const fl = new FlagView({ i: true }, specOf('grep'))
+    expect(fl.asBool('i')).toBe(true)
+    expect(() => fl.asBool('ignorecase')).toThrow(/ignorecase/)
+    expect(() => fl.asInt('max_count')).toThrow()
+    expect(() => fl.asList('patterns')).toThrow()
+  })
+
+  it('exposes the raw value for callers that validate it themselves', () => {
+    expect(new FlagView({ output_error: 'warn' }).raw('output_error')).toBe('warn')
+    expect(new FlagView({}).raw('output_error')).toBeUndefined()
+  })
+})
+
+describe('specFlagNames', () => {
+  it('includes short, long and disambiguated spellings', () => {
+    const spec = new CommandSpec({
+      options: [
+        new Option({ short: 'l' }),
+        new Option({ short: 'm', long: '--max-count', valueKind: OperandKind.TEXT }),
+        new Option({ long: '--hidden' }),
+      ],
+    })
+    expect([...specFlagNames(spec)].sort()).toEqual(['args_l', 'hidden', 'm', 'max_count'])
+  })
+})
+
+describe('flagKwargName', () => {
+  it('strips dashes and matches the dispatcher spelling', () => {
+    expect(flagKwargName('-i')).toBe('i')
+    expect(flagKwargName('--max-count')).toBe('max_count')
+    expect(flagKwargName('l')).toBe('args_l')
+  })
+})

--- a/typescript/packages/core/src/commands/spec/flag_view.test.ts
+++ b/typescript/packages/core/src/commands/spec/flag_view.test.ts
@@ -32,6 +32,23 @@ describe('FlagView', () => {
     expect(fl.asList('f')).toEqual([])
   })
 
+  // Python's as_int calls int(), which raises on a partial or junk value.
+  // parseInt would take the '5' out of '5x' and return NaN for 'abc', and
+  // NaN is still a number, so a bad value would flow on undetected.
+  it('rejects a value that is not wholly an integer', () => {
+    expect(() => new FlagView({ m: '5x' }).asInt('m')).toThrow(/expects an integer/)
+    expect(() => new FlagView({ m: 'abc' }).asInt('m')).toThrow(/expects an integer/)
+    expect(() => new FlagView({ m: '' }).asInt('m')).toThrow(/expects an integer/)
+    expect(() => new FlagView({ m: '1.5' }).asInt('m')).toThrow(/expects an integer/)
+  })
+
+  it('accepts the forms Python int() accepts', () => {
+    expect(new FlagView({ m: ' 42 ' }).asInt('m')).toBe(42)
+    expect(new FlagView({ m: '-7' }).asInt('m')).toBe(-7)
+    expect(new FlagView({ m: '+7' }).asInt('m')).toBe(7)
+    expect(new FlagView({ m: '1_0' }).asInt('m')).toBe(10)
+  })
+
   it('coerces a single string to a one-element list', () => {
     expect(new FlagView({ e: 'solo' }).asList('e')).toEqual(['solo'])
   })

--- a/typescript/packages/core/src/commands/spec/index.ts
+++ b/typescript/packages/core/src/commands/spec/index.ts
@@ -14,11 +14,13 @@
 
 export { BUILTIN_SPECS as SPECS, specOf } from './builtins.ts'
 
-export { AMBIGUOUS_NAMES } from './constants.ts'
+export { AMBIGUOUS_NAMES, flagKwargName } from './constants.ts'
 export { parseCommand, parseToKwargs } from './parser.ts'
 export {
   CommandSpec,
   type CommandSpecInit,
+  type FlagValue,
+  FlagView,
   Operand,
   type OperandInit,
   OperandKind,
@@ -26,4 +28,5 @@ export {
   type OptionInit,
   ParsedArgs,
   type ParsedArgsInit,
+  specFlagNames,
 } from './types.ts'

--- a/typescript/packages/core/src/commands/spec/parser.ts
+++ b/typescript/packages/core/src/commands/spec/parser.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { resolvePath } from '../../utils/path.ts'
-import { AMBIGUOUS_NAMES, NUMERIC_SHORT } from './constants.ts'
+import { flagKwargName, NUMERIC_SHORT } from './constants.ts'
 import { type CommandSpec, OperandKind, ParsedArgs } from './types.ts'
 
 // Copy a spelling's value onto its counterpart so the last one wins. GNU
@@ -426,9 +426,7 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
 export function parseToKwargs(parsed: ParsedArgs): Record<string, string | boolean | string[]> {
   const result: Record<string, string | boolean | string[]> = {}
   for (const [key, value] of Object.entries(parsed.flags)) {
-    let clean = key.replace(/^-+/, '').replaceAll('-', '_')
-    clean = AMBIGUOUS_NAMES[clean] ?? clean
-    result[clean] = value
+    result[flagKwargName(key)] = value
   }
   return result
 }

--- a/typescript/packages/core/src/commands/spec/types.ts
+++ b/typescript/packages/core/src/commands/spec/types.ts
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { flagKwargName } from './constants.ts'
+
 // Command names the spec layer references by value. Not a registry of
 // every command: only names that appear away from their own module
 // (usage message shapes, arity guards). Members are their plain string
@@ -213,5 +215,78 @@ export class ParsedArgs {
     fallback: string | boolean | string[] | null = null,
   ): string | boolean | string[] | null {
     return this.flags[name] ?? fallback
+  }
+}
+
+/**
+ * Collect the kwarg names a spec's options can produce.
+ *
+ * Mirrors Python's `spec_flag_names`.
+ */
+export function specFlagNames(spec: CommandSpec): ReadonlySet<string> {
+  const names = new Set<string>()
+  for (const option of spec.options) {
+    if (option.short !== null) names.add(flagKwargName(option.short))
+    if (option.long !== null) names.add(flagKwargName(option.long))
+  }
+  return names
+}
+
+export type FlagValue = string | boolean | string[]
+
+/**
+ * Typed read-only view over raw flag kwargs.
+ *
+ * Commands receive flags as an untyped record from the dispatcher; this
+ * view is the one sanctioned way to read them, replacing ad-hoc
+ * `flags.x === true` checks and typeof chains. Mirrors Python's
+ * `FlagView`.
+ *
+ * When constructed with a spec, reading a name the spec does not declare
+ * throws. A missing key is otherwise indistinguishable from "flag not
+ * passed", so a typo in the name would silently read as false/undefined.
+ */
+export class FlagView {
+  private readonly flags: Readonly<Record<string, FlagValue>>
+  private readonly allowed: ReadonlySet<string> | null
+
+  constructor(flags?: Readonly<Record<string, FlagValue>>, spec?: CommandSpec) {
+    this.flags = flags ?? {}
+    this.allowed = spec === undefined ? null : specFlagNames(spec)
+  }
+
+  private key(name: string): string {
+    if (this.allowed !== null && !this.allowed.has(name)) {
+      throw new Error(
+        `flag '${name}' is not declared by the command spec ` +
+          `(known: ${[...this.allowed].sort().join(', ')})`,
+      )
+    }
+    return name
+  }
+
+  asBool(name: string): boolean {
+    return this.flags[this.key(name)] === true
+  }
+
+  asInt(name: string): number | undefined {
+    const value = this.flags[this.key(name)]
+    return typeof value === 'string' ? Number.parseInt(value, 10) : undefined
+  }
+
+  asStr(name: string): string | undefined {
+    const value = this.flags[this.key(name)]
+    return typeof value === 'string' ? value : undefined
+  }
+
+  asList(name: string): string[] {
+    const value = this.flags[this.key(name)]
+    if (Array.isArray(value)) return value.filter((v) => typeof v === 'string')
+    if (typeof value === 'string') return [value]
+    return []
+  }
+
+  raw(name: string): FlagValue | undefined {
+    return this.flags[this.key(name)]
   }
 }

--- a/typescript/packages/core/src/commands/spec/types.ts
+++ b/typescript/packages/core/src/commands/spec/types.ts
@@ -271,7 +271,17 @@ export class FlagView {
 
   asInt(name: string): number | undefined {
     const value = this.flags[this.key(name)]
-    return typeof value === 'string' ? Number.parseInt(value, 10) : undefined
+    if (typeof value !== 'string') return undefined
+    // Python's int() is all-or-nothing: it accepts surrounding whitespace
+    // and underscore separators and raises on anything else. parseInt would
+    // instead take the numeric prefix of '5x' and hand back NaN for 'abc',
+    // and NaN still satisfies `number`, so a bad value would flow onward as
+    // a number rather than being rejected.
+    const text = value.trim()
+    if (!/^[+-]?\d+(?:_\d+)*$/.test(text)) {
+      throw new Error(`flag '${name}' expects an integer, got '${value}'`)
+    }
+    return Number.parseInt(text.replaceAll('_', ''), 10)
   }
 
   asStr(name: string): string | undefined {

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -159,6 +159,9 @@ export {
   AMBIGUOUS_NAMES,
   CommandSpec,
   type CommandSpecInit,
+  type FlagValue,
+  flagKwargName,
+  FlagView,
   Operand,
   type OperandInit,
   OperandKind,
@@ -168,6 +171,7 @@ export {
   type ParsedArgsInit,
   parseCommand,
   parseToKwargs,
+  specFlagNames,
   specOf,
   SPECS,
 } from './commands/spec/index.ts'


### PR DESCRIPTION
## Why

Python reads command flags through `FlagView`, which takes the command's spec and **throws** when asked for a name the spec does not declare. TypeScript had no equivalent: commands reached into the raw dispatcher bag with `flags.a === true`, so a name that no longer exists reads as `false` rather than failing.

That failure mode is silent, and it is worth seeing rather than taking on faith. Renaming `tee`'s `--append` to `--add` in the spec and running the suite both ways:

| `tee` reads flags via | Result |
|---|---|
| raw `flags.append` (before) | **7/7 tests pass, exit 0** while `--append` is a silent no-op |
| `FlagView` (after) | **39 tests fail** immediately |

## What

- `flagKwargName` in `constants.ts` — the dash-stripping rule `parseToKwargs` had inlined, now shared rather than duplicated in two places that could drift.
- `specFlagNames` and `FlagView` (`asBool` / `asInt` / `asStr` / `asList` / `raw`) in `types.ts`.
- `tee` migrated as the first consumer.

Placement mirrors Python exactly: `flag_kwarg_name` in `spec/constants.py`, `FlagView` and `spec_flag_names` in `spec/types.py`. Import direction checked for cycles: `constants.ts` imports nothing, so `types.ts -> constants.ts` is safe and matches Python.

## Deliberately not a sweep

56 generic commands still read flags raw. They are **not** migrated here, on purpose.

An audit of all 64 generic commands against their specs found **zero** undeclared reads today, so this is preventive, not a bug fix. And cli.md's Phase 1 (dest unification) removes the both-name reads (`fl.asBool('a') || fl.asBool('append')`) that a migration would write and then delete. 20 files currently hand-check both spellings, so sweeping now means touching them twice.

One gap worth recording for that work: `specFlagNames` currently returns **both** spellings (`tee` yields `['a', 'append', ...]`). When dest unification canonicalizes the parser output to the long name, `specFlagNames` has to canonicalize too, or a stale `asBool('a')` stays legal and silently returns false forever, reintroducing the exact failure this PR closes. Both languages have that behavior, so it has to change together or the #666 parity gate goes red.

## Verification

- 7 tests mirroring `python/tests/commands/spec/test_types.py` one for one, including the `args_l` disambiguation that confirms both languages' `AMBIGUOUS_NAMES` agree
- `tsc --noEmit` clean, eslint clean on changed files
- core: 542 files / 5,710 tests, exit 0