### PR TITLE
Recursive CLISpec atop CommandSpec

### DIFF
--- a/python/mirage/__init__.py
+++ b/python/mirage/__init__.py
@@ -16,6 +16,7 @@
 from mirage.resource.disk import DiskResource
 from mirage.resource.ram import RAMResource
 from mirage.commands.registry import command
+from mirage.commands.cli import CLISpec
 from mirage.types import FileStat, MountBackend, MountMode
 from mirage.workspace import (ExecutionNode, Workspace, WorkspaceRunner)
 from mirage.workspace.fuse import FuseManager
@@ -37,6 +38,7 @@ __all__ = [
     "Mount",
     "MountBackend",
     "MountMode",
+    "CLISpec",
     "command",
     "new_session_id",
     "new_workspace_id",

--- a/python/mirage/commands/cli/__init__.py
+++ b/python/mirage/commands/cli/__init__.py
@@ -1,0 +1,19 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.commands.cli.types import CLISpec
+
+__all__ = [
+    "CLISpec",
+]

--- a/python/mirage/commands/cli/compile.py
+++ b/python/mirage/commands/cli/compile.py
@@ -1,0 +1,58 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mirage.commands.cli.types import CLISpec
+
+
+def validate_cli(node: "CLISpec") -> None:
+    """Validate one CLISpec node at construction time.
+
+    Called from CLISpec.__post_init__, so a structurally invalid node
+    raises ValueError at import time, never at dispatch. Children were
+    validated by their own construction (a nested literal builds bottom
+    up), so each call checks one level: the name is a single word with no
+    whitespace, a node takes fn or subcommands (never both, never
+    neither), a group declares no positional/rest (its operand is the
+    subcommand word), child names are unique, and only a tree's root may
+    declare config_model.
+
+    Args:
+        node (CLISpec): the freshly constructed node.
+    """
+    if not node.name or any(ch.isspace() for ch in node.name):
+        raise ValueError(
+            f"cli name {node.name!r} must be a single non-empty word")
+    if node.fn is not None and node.subcommands:
+        raise ValueError(
+            f"cli {node.name!r}: a node takes fn or subcommands, not both")
+    if node.fn is None and not node.subcommands:
+        raise ValueError(
+            f"cli {node.name!r}: a node needs fn or subcommands")
+    if node.subcommands and (node.positional or node.rest is not None):
+        raise ValueError(
+            f"cli {node.name!r}: a group's operand is its subcommand "
+            f"word; positional/rest belong on leaves")
+    seen: set[str] = set()
+    for child in node.subcommands:
+        if child.name in seen:
+            raise ValueError(f"cli {node.name!r}: duplicate subcommand "
+                             f"{child.name!r}")
+        seen.add(child.name)
+        if child.config_model is not None:
+            raise ValueError(
+                f"cli {node.name!r}: subcommand {child.name!r} declares "
+                f"config_model; only the root of a tree may")

--- a/python/mirage/commands/cli/compile.py
+++ b/python/mirage/commands/cli/compile.py
@@ -40,8 +40,7 @@ def validate_cli(node: "CLISpec") -> None:
         raise ValueError(
             f"cli {node.name!r}: a node takes fn or subcommands, not both")
     if node.fn is None and not node.subcommands:
-        raise ValueError(
-            f"cli {node.name!r}: a node needs fn or subcommands")
+        raise ValueError(f"cli {node.name!r}: a node needs fn or subcommands")
     if node.subcommands and (node.positional or node.rest is not None):
         raise ValueError(
             f"cli {node.name!r}: a group's operand is its subcommand "

--- a/python/mirage/commands/cli/types.py
+++ b/python/mirage/commands/cli/types.py
@@ -17,6 +17,7 @@ from typing import Any, Callable
 
 from pydantic import BaseModel
 
+from mirage.commands.cli.compile import validate_cli
 from mirage.commands.spec.types import CommandSpec
 from mirage.types import CommandSafeguard
 
@@ -66,27 +67,4 @@ class CLISpec(CommandSpec):
     config_model: type[BaseModel] | None = None
 
     def __post_init__(self) -> None:
-        if not self.name or " " in self.name:
-            raise ValueError(
-                f"cli name {self.name!r} must be a single non-empty word")
-        if self.fn is not None and self.subcommands:
-            raise ValueError(
-                f"cli {self.name!r}: a node takes fn or subcommands, "
-                f"not both")
-        if self.fn is None and not self.subcommands:
-            raise ValueError(
-                f"cli {self.name!r}: a node needs fn or subcommands")
-        if self.subcommands and (self.positional or self.rest is not None):
-            raise ValueError(
-                f"cli {self.name!r}: a group's operand is its subcommand "
-                f"word; positional/rest belong on leaves")
-        seen: set[str] = set()
-        for child in self.subcommands:
-            if child.name in seen:
-                raise ValueError(f"cli {self.name!r}: duplicate subcommand "
-                                 f"{child.name!r}")
-            seen.add(child.name)
-            if child.config_model is not None:
-                raise ValueError(
-                    f"cli {self.name!r}: subcommand {child.name!r} declares "
-                    f"config_model; only the root of a tree may")
+        validate_cli(self)

--- a/python/mirage/commands/cli/types.py
+++ b/python/mirage/commands/cli/types.py
@@ -1,0 +1,92 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from pydantic import BaseModel
+
+from mirage.commands.spec.types import CommandSpec
+from mirage.types import CommandSafeguard
+
+
+@dataclass(frozen=True)
+class CLISpec(CommandSpec):
+    """One node of a program tree: argparse's parser/subparser as data.
+
+    A CLISpec IS a CommandSpec (click's Group-is-a-Command): it inherits
+    the grammar fields (``options``, ``positional``, ``rest``,
+    ``description``, ``epilog``) and adds identity, behavior, and nesting.
+    A leaf carries ``fn``; a group carries ``subcommands``; the root of an
+    installable program may carry ``config_model``. Every level of the
+    tree parses with the ordinary spec machinery because every level is a
+    CommandSpec.
+
+    Construction validates the node at import time: the name must be a
+    single word, a node takes ``fn`` or ``subcommands`` (never both,
+    never neither), a group declares no positional/rest (its operand is
+    the subcommand word), child names must be unique, and only a tree's
+    root may declare ``config_model``.
+
+    Args:
+        name (str): the word at this level: argparse's ``prog`` for a
+            root, ``add_parser`` name for a subcommand.
+        fn (Callable | None): leaf handler (argparse
+            ``set_defaults(func=...)``), called as
+            ``fn(config, paths, *texts, **flags)`` where ``config`` is the
+            installation's validated ``config_model`` instance (None when
+            the CLI declares no config). What the handler does with the
+            config: wrap it in an accessor, build its own client, or
+            ignore it, is the author's business.
+        subcommands (tuple[CLISpec, ...]): child nodes (argparse
+            ``add_subparsers().add_parser(...)``).
+        write (bool): leaf mutates backend state (policy classification).
+        safeguard (CommandSafeguard | None): safeguard category for the
+            leaf.
+        config_model (type[BaseModel] | None): root only. Pydantic model
+            validating an installation's config from YAML ``clis:`` or
+            ``register_cli``; also the redaction schema for snapshots.
+    """
+    name: str = ""
+    fn: Callable[..., Any] | None = None
+    subcommands: tuple["CLISpec", ...] = ()
+    write: bool = False
+    safeguard: CommandSafeguard | None = None
+    config_model: type[BaseModel] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name or " " in self.name:
+            raise ValueError(
+                f"cli name {self.name!r} must be a single non-empty word")
+        if self.fn is not None and self.subcommands:
+            raise ValueError(
+                f"cli {self.name!r}: a node takes fn or subcommands, "
+                f"not both")
+        if self.fn is None and not self.subcommands:
+            raise ValueError(
+                f"cli {self.name!r}: a node needs fn or subcommands")
+        if self.subcommands and (self.positional or self.rest is not None):
+            raise ValueError(
+                f"cli {self.name!r}: a group's operand is its subcommand "
+                f"word; positional/rest belong on leaves")
+        seen: set[str] = set()
+        for child in self.subcommands:
+            if child.name in seen:
+                raise ValueError(f"cli {self.name!r}: duplicate subcommand "
+                                 f"{child.name!r}")
+            seen.add(child.name)
+            if child.config_model is not None:
+                raise ValueError(
+                    f"cli {self.name!r}: subcommand {child.name!r} declares "
+                    f"config_model; only the root of a tree may")

--- a/python/tests/commands/cli/test_compile.py
+++ b/python/tests/commands/cli/test_compile.py
@@ -1,0 +1,77 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+from pydantic import BaseModel
+
+from mirage.commands.cli import CLISpec
+from mirage.commands.spec.types import Operand, OperandKind
+
+
+class _Config(BaseModel):
+    token: str = ""
+
+
+async def _verb(config, paths, *texts, **flags):
+    return None
+
+
+def test_name_must_be_a_single_word():
+    with pytest.raises(ValueError, match="single non-empty word"):
+        CLISpec(name="", fn=_verb)
+    with pytest.raises(ValueError, match="single non-empty word"):
+        CLISpec(name="gmail send", fn=_verb)
+    with pytest.raises(ValueError, match="single non-empty word"):
+        CLISpec(name="gmail\tsend", fn=_verb)
+    with pytest.raises(ValueError, match="single non-empty word"):
+        CLISpec(name="gmail\n", fn=_verb)
+
+
+def test_node_takes_fn_or_subcommands_not_both():
+    with pytest.raises(ValueError, match="not both"):
+        CLISpec(name="gws",
+                fn=_verb,
+                subcommands=(CLISpec(name="send", fn=_verb), ))
+
+
+def test_node_needs_fn_or_subcommands():
+    with pytest.raises(ValueError, match="needs fn or subcommands"):
+        CLISpec(name="gws")
+
+
+def test_group_declares_no_positional_or_rest():
+    with pytest.raises(ValueError, match="belong on leaves"):
+        CLISpec(name="gws",
+                positional=(Operand(kind=OperandKind.TEXT), ),
+                subcommands=(CLISpec(name="send", fn=_verb), ))
+    with pytest.raises(ValueError, match="belong on leaves"):
+        CLISpec(name="gws",
+                rest=Operand(kind=OperandKind.TEXT),
+                subcommands=(CLISpec(name="send", fn=_verb), ))
+
+
+def test_duplicate_subcommand_names_raise():
+    with pytest.raises(ValueError, match="duplicate subcommand 'send'"):
+        CLISpec(name="gws",
+                subcommands=(CLISpec(name="send",
+                                     fn=_verb), CLISpec(name="send",
+                                                        fn=_verb)))
+
+
+def test_config_model_is_root_only():
+    with pytest.raises(ValueError, match="only the root of a tree may"):
+        CLISpec(name="gws",
+                subcommands=(CLISpec(name="gmail",
+                                     fn=_verb,
+                                     config_model=_Config), ))

--- a/python/tests/commands/cli/test_types.py
+++ b/python/tests/commands/cli/test_types.py
@@ -40,12 +40,11 @@ def _tree() -> CLISpec:
                         CLISpec(name="send",
                                 fn=_verb,
                                 write=True,
-                                options=(Option(
-                                    short="-t",
-                                    long="--to",
-                                    value_kind=OperandKind.TEXT,
-                                    multiple=True,
-                                    required=True), ),
+                                options=(Option(short="-t",
+                                                long="--to",
+                                                value_kind=OperandKind.TEXT,
+                                                multiple=True,
+                                                required=True), ),
                                 rest=Operand(kind=OperandKind.TEXT)),
                         CLISpec(name="list", fn=_verb),
                     )),
@@ -118,8 +117,9 @@ def test_group_declares_no_positional_or_rest():
 def test_duplicate_subcommand_names_raise():
     with pytest.raises(ValueError, match="duplicate subcommand 'send'"):
         CLISpec(name="gws",
-                subcommands=(CLISpec(name="send", fn=_verb),
-                             CLISpec(name="send", fn=_verb)))
+                subcommands=(CLISpec(name="send",
+                                     fn=_verb), CLISpec(name="send",
+                                                        fn=_verb)))
 
 
 def test_config_model_is_root_only():

--- a/python/tests/commands/cli/test_types.py
+++ b/python/tests/commands/cli/test_types.py
@@ -1,0 +1,130 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+from pydantic import BaseModel
+
+from mirage.commands.cli import CLISpec
+from mirage.commands.spec.types import (CommandSpec, Operand, OperandKind,
+                                        Option)
+
+
+class _Config(BaseModel):
+    token: str = ""
+
+
+async def _verb(config, paths, *texts, **flags):
+    return None
+
+
+def _tree() -> CLISpec:
+    return CLISpec(
+        name="gws",
+        description="Google Workspace",
+        config_model=_Config,
+        subcommands=(
+            CLISpec(name="gmail",
+                    description="Gmail messages",
+                    subcommands=(
+                        CLISpec(name="send",
+                                fn=_verb,
+                                write=True,
+                                options=(Option(
+                                    short="-t",
+                                    long="--to",
+                                    value_kind=OperandKind.TEXT,
+                                    multiple=True,
+                                    required=True), ),
+                                rest=Operand(kind=OperandKind.TEXT)),
+                        CLISpec(name="list", fn=_verb),
+                    )),
+            CLISpec(name="docs",
+                    description="Google Docs",
+                    subcommands=(CLISpec(name="cat", fn=_verb), )),
+        ),
+    )
+
+
+def test_tree_builds_and_is_a_command_spec():
+    gws = _tree()
+    assert isinstance(gws, CommandSpec)
+    assert [child.name for child in gws.subcommands] == ["gmail", "docs"]
+    gmail = gws.subcommands[0]
+    send = gmail.subcommands[0]
+    assert send.write is True
+    assert send.fn is _verb
+    assert send.options[0].long == "--to"
+    assert gws.config_model is _Config
+    assert gmail.config_model is None
+
+
+def test_single_verb_cli_is_a_leaf_root():
+    curl_like = CLISpec(name="hello", fn=_verb)
+    assert curl_like.subcommands == ()
+    assert curl_like.write is False
+    assert curl_like.safeguard is None
+
+
+def test_group_may_carry_its_own_options():
+    tree = CLISpec(
+        name="git",
+        options=(Option(short="-C", value_kind=OperandKind.PATH), ),
+        subcommands=(CLISpec(name="status", fn=_verb), ),
+    )
+    assert tree.options[0].short == "-C"
+
+
+def test_name_must_be_a_single_word():
+    with pytest.raises(ValueError, match="single non-empty word"):
+        CLISpec(name="", fn=_verb)
+    with pytest.raises(ValueError, match="single non-empty word"):
+        CLISpec(name="gmail send", fn=_verb)
+
+
+def test_node_takes_fn_or_subcommands_not_both():
+    with pytest.raises(ValueError, match="not both"):
+        CLISpec(name="gws",
+                fn=_verb,
+                subcommands=(CLISpec(name="send", fn=_verb), ))
+
+
+def test_node_needs_fn_or_subcommands():
+    with pytest.raises(ValueError, match="needs fn or subcommands"):
+        CLISpec(name="gws")
+
+
+def test_group_declares_no_positional_or_rest():
+    with pytest.raises(ValueError, match="belong on leaves"):
+        CLISpec(name="gws",
+                positional=(Operand(kind=OperandKind.TEXT), ),
+                subcommands=(CLISpec(name="send", fn=_verb), ))
+    with pytest.raises(ValueError, match="belong on leaves"):
+        CLISpec(name="gws",
+                rest=Operand(kind=OperandKind.TEXT),
+                subcommands=(CLISpec(name="send", fn=_verb), ))
+
+
+def test_duplicate_subcommand_names_raise():
+    with pytest.raises(ValueError, match="duplicate subcommand 'send'"):
+        CLISpec(name="gws",
+                subcommands=(CLISpec(name="send", fn=_verb),
+                             CLISpec(name="send", fn=_verb)))
+
+
+def test_config_model_is_root_only():
+    with pytest.raises(ValueError, match="only the root of a tree may"):
+        CLISpec(name="gws",
+                subcommands=(CLISpec(name="gmail",
+                                     fn=_verb,
+                                     config_model=_Config), ))

--- a/python/tests/commands/cli/test_types.py
+++ b/python/tests/commands/cli/test_types.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import pytest
 from pydantic import BaseModel
 
 from mirage.commands.cli import CLISpec
@@ -82,49 +81,3 @@ def test_group_may_carry_its_own_options():
         subcommands=(CLISpec(name="status", fn=_verb), ),
     )
     assert tree.options[0].short == "-C"
-
-
-def test_name_must_be_a_single_word():
-    with pytest.raises(ValueError, match="single non-empty word"):
-        CLISpec(name="", fn=_verb)
-    with pytest.raises(ValueError, match="single non-empty word"):
-        CLISpec(name="gmail send", fn=_verb)
-
-
-def test_node_takes_fn_or_subcommands_not_both():
-    with pytest.raises(ValueError, match="not both"):
-        CLISpec(name="gws",
-                fn=_verb,
-                subcommands=(CLISpec(name="send", fn=_verb), ))
-
-
-def test_node_needs_fn_or_subcommands():
-    with pytest.raises(ValueError, match="needs fn or subcommands"):
-        CLISpec(name="gws")
-
-
-def test_group_declares_no_positional_or_rest():
-    with pytest.raises(ValueError, match="belong on leaves"):
-        CLISpec(name="gws",
-                positional=(Operand(kind=OperandKind.TEXT), ),
-                subcommands=(CLISpec(name="send", fn=_verb), ))
-    with pytest.raises(ValueError, match="belong on leaves"):
-        CLISpec(name="gws",
-                rest=Operand(kind=OperandKind.TEXT),
-                subcommands=(CLISpec(name="send", fn=_verb), ))
-
-
-def test_duplicate_subcommand_names_raise():
-    with pytest.raises(ValueError, match="duplicate subcommand 'send'"):
-        CLISpec(name="gws",
-                subcommands=(CLISpec(name="send",
-                                     fn=_verb), CLISpec(name="send",
-                                                        fn=_verb)))
-
-
-def test_config_model_is_root_only():
-    with pytest.raises(ValueError, match="only the root of a tree may"):
-        CLISpec(name="gws",
-                subcommands=(CLISpec(name="gmail",
-                                     fn=_verb,
-                                     config_model=_Config), ))

--- a/typescript/packages/core/src/commands/cli/types.test.ts
+++ b/typescript/packages/core/src/commands/cli/types.test.ts
@@ -1,0 +1,158 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { CommandSpec, Operand, OperandKind, Option } from '../spec/types.ts'
+import { CLISpec, type CLIVerbFn } from './types.ts'
+
+const verb: CLIVerbFn = () => null
+
+const configModel = (input: Record<string, unknown>) => input
+
+function tree(): CLISpec {
+  return new CLISpec({
+    name: 'gws',
+    description: 'Google Workspace',
+    configModel,
+    subcommands: [
+      new CLISpec({
+        name: 'gmail',
+        description: 'Gmail messages',
+        subcommands: [
+          new CLISpec({
+            name: 'send',
+            fn: verb,
+            write: true,
+            options: [
+              new Option({
+                short: '-t',
+                long: '--to',
+                valueKind: OperandKind.TEXT,
+                multiple: true,
+                required: true,
+              }),
+            ],
+            rest: new Operand({ kind: OperandKind.TEXT }),
+          }),
+          new CLISpec({ name: 'list', fn: verb }),
+        ],
+      }),
+      new CLISpec({
+        name: 'docs',
+        description: 'Google Docs',
+        subcommands: [new CLISpec({ name: 'cat', fn: verb })],
+      }),
+    ],
+  })
+}
+
+describe('CLISpec', () => {
+  it('builds a tree and is a CommandSpec', () => {
+    const gws = tree()
+    expect(gws).toBeInstanceOf(CommandSpec)
+    expect(gws.subcommands.map((child) => child.name)).toEqual(['gmail', 'docs'])
+    const gmail = gws.subcommands[0]!
+    const send = gmail.subcommands[0]!
+    expect(send.write).toBe(true)
+    expect(send.fn).toBe(verb)
+    expect(send.options[0]!.long).toBe('--to')
+    expect(gws.configModel).toBe(configModel)
+    expect(gmail.configModel).toBeNull()
+  })
+
+  it('allows a single-verb leaf root', () => {
+    const single = new CLISpec({ name: 'hello', fn: verb })
+    expect(single.subcommands).toEqual([])
+    expect(single.write).toBe(false)
+    expect(single.safeguard).toBeNull()
+  })
+
+  it('allows group-level options', () => {
+    const git = new CLISpec({
+      name: 'git',
+      options: [new Option({ short: '-C', valueKind: OperandKind.PATH })],
+      subcommands: [new CLISpec({ name: 'status', fn: verb })],
+    })
+    expect(git.options[0]!.short).toBe('-C')
+  })
+
+  it('rejects an empty or multi-word name', () => {
+    expect(() => new CLISpec({ name: '', fn: verb })).toThrow(/single non-empty word/)
+    expect(() => new CLISpec({ name: 'gmail send', fn: verb })).toThrow(/single non-empty word/)
+  })
+
+  it('rejects fn together with subcommands', () => {
+    expect(
+      () =>
+        new CLISpec({
+          name: 'gws',
+          fn: verb,
+          subcommands: [new CLISpec({ name: 'send', fn: verb })],
+        }),
+    ).toThrow(/not both/)
+  })
+
+  it('rejects a node with neither fn nor subcommands', () => {
+    expect(() => new CLISpec({ name: 'gws' })).toThrow(/needs fn or subcommands/)
+  })
+
+  it('rejects positional or rest on a group', () => {
+    expect(
+      () =>
+        new CLISpec({
+          name: 'gws',
+          positional: [new Operand({ kind: OperandKind.TEXT })],
+          subcommands: [new CLISpec({ name: 'send', fn: verb })],
+        }),
+    ).toThrow(/belong on leaves/)
+    expect(
+      () =>
+        new CLISpec({
+          name: 'gws',
+          rest: new Operand({ kind: OperandKind.TEXT }),
+          subcommands: [new CLISpec({ name: 'send', fn: verb })],
+        }),
+    ).toThrow(/belong on leaves/)
+  })
+
+  it('rejects duplicate subcommand names', () => {
+    expect(
+      () =>
+        new CLISpec({
+          name: 'gws',
+          subcommands: [
+            new CLISpec({ name: 'send', fn: verb }),
+            new CLISpec({ name: 'send', fn: verb }),
+          ],
+        }),
+    ).toThrow(/duplicate subcommand 'send'/)
+  })
+
+  it('rejects configModel below the root', () => {
+    expect(
+      () =>
+        new CLISpec({
+          name: 'gws',
+          subcommands: [new CLISpec({ name: 'gmail', fn: verb, configModel })],
+        }),
+    ).toThrow(/only the root of a tree may/)
+  })
+
+  it('stays frozen like every spec', () => {
+    const gws = tree()
+    expect(Object.isFrozen(gws)).toBe(true)
+    expect(Object.isFrozen(gws.subcommands)).toBe(true)
+    expect(Object.isFrozen(new CommandSpec({}))).toBe(true)
+  })
+})

--- a/typescript/packages/core/src/commands/cli/types.test.ts
+++ b/typescript/packages/core/src/commands/cli/types.test.ts
@@ -62,13 +62,13 @@ describe('CLISpec', () => {
     const gws = tree()
     expect(gws).toBeInstanceOf(CommandSpec)
     expect(gws.subcommands.map((child) => child.name)).toEqual(['gmail', 'docs'])
-    const gmail = gws.subcommands[0]!
-    const send = gmail.subcommands[0]!
-    expect(send.write).toBe(true)
-    expect(send.fn).toBe(verb)
-    expect(send.options[0]!.long).toBe('--to')
+    const gmail = gws.subcommands[0]
+    const send = gmail?.subcommands[0]
+    expect(send?.write).toBe(true)
+    expect(send?.fn).toBe(verb)
+    expect(send?.options[0]?.long).toBe('--to')
     expect(gws.configModel).toBe(configModel)
-    expect(gmail.configModel).toBeNull()
+    expect(gmail?.configModel).toBeNull()
   })
 
   it('allows a single-verb leaf root', () => {
@@ -84,7 +84,7 @@ describe('CLISpec', () => {
       options: [new Option({ short: '-C', valueKind: OperandKind.PATH })],
       subcommands: [new CLISpec({ name: 'status', fn: verb })],
     })
-    expect(git.options[0]!.short).toBe('-C')
+    expect(git.options[0]?.short).toBe('-C')
   })
 
   it('rejects an empty or multi-word name', () => {

--- a/typescript/packages/core/src/commands/cli/types.test.ts
+++ b/typescript/packages/core/src/commands/cli/types.test.ts
@@ -87,9 +87,11 @@ describe('CLISpec', () => {
     expect(git.options[0]?.short).toBe('-C')
   })
 
-  it('rejects an empty or multi-word name', () => {
+  it('rejects an empty, multi-word, or whitespace-bearing name', () => {
     expect(() => new CLISpec({ name: '', fn: verb })).toThrow(/single non-empty word/)
     expect(() => new CLISpec({ name: 'gmail send', fn: verb })).toThrow(/single non-empty word/)
+    expect(() => new CLISpec({ name: 'gmail\tsend', fn: verb })).toThrow(/single non-empty word/)
+    expect(() => new CLISpec({ name: 'gmail\n', fn: verb })).toThrow(/single non-empty word/)
   })
 
   it('rejects fn together with subcommands', () => {

--- a/typescript/packages/core/src/commands/cli/types.ts
+++ b/typescript/packages/core/src/commands/cli/types.ts
@@ -1,0 +1,104 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { CommandSafeguard, PathSpec } from '../../types.ts'
+import type { CommandFnResult, CommandOpts } from '../config.ts'
+import { CommandSpec, type CommandSpecInit } from '../spec/types.ts'
+
+/**
+ * Leaf handler of a CLISpec node, called with the installation's validated
+ * config (null when the CLI declares no config model). What the handler
+ * does with the config: wrap it in an accessor, build its own client, or
+ * ignore it, is the author's business.
+ */
+export type CLIVerbFn = (
+  config: unknown,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CommandOpts,
+) => Promise<CommandFnResult> | CommandFnResult
+
+export interface CLISpecInit extends CommandSpecInit {
+  name: string
+  fn?: CLIVerbFn | null
+  subcommands?: readonly CLISpec[]
+  write?: boolean
+  safeguard?: CommandSafeguard | null
+  configModel?: ((input: Record<string, unknown>) => unknown) | null
+}
+
+/**
+ * One node of a program tree: argparse's parser/subparser as data.
+ *
+ * A CLISpec IS a CommandSpec (click's Group-is-a-Command): it inherits the
+ * grammar fields (options, positional, rest, description, epilog) and adds
+ * identity, behavior, and nesting. A leaf carries `fn`; a group carries
+ * `subcommands`; the root of an installable program may carry
+ * `configModel` (the zod-backed `normalize*Config` shape resources already
+ * use, doubling as the redaction schema). Every level of the tree parses
+ * with the ordinary spec machinery because every level is a CommandSpec.
+ *
+ * The constructor validates the node at module-import time: the name must
+ * be a single word, a node takes `fn` or `subcommands` (never both, never
+ * neither), a group declares no positional/rest (its operand is the
+ * subcommand word), child names must be unique, and only a tree's root may
+ * declare `configModel`.
+ */
+export class CLISpec extends CommandSpec {
+  readonly name: string
+  readonly fn: CLIVerbFn | null
+  readonly subcommands: readonly CLISpec[]
+  readonly write: boolean
+  readonly safeguard: CommandSafeguard | null
+  readonly configModel: ((input: Record<string, unknown>) => unknown) | null
+
+  constructor(init: CLISpecInit) {
+    super(init)
+    this.name = init.name
+    this.fn = init.fn ?? null
+    this.subcommands = Object.freeze([...(init.subcommands ?? [])])
+    this.write = init.write ?? false
+    this.safeguard = init.safeguard ?? null
+    this.configModel = init.configModel ?? null
+    if (this.name === '' || this.name.includes(' ')) {
+      throw new Error(`cli name '${this.name}' must be a single non-empty word`)
+    }
+    if (this.fn !== null && this.subcommands.length > 0) {
+      throw new Error(`cli '${this.name}': a node takes fn or subcommands, not both`)
+    }
+    if (this.fn === null && this.subcommands.length === 0) {
+      throw new Error(`cli '${this.name}': a node needs fn or subcommands`)
+    }
+    if (this.subcommands.length > 0 && (this.positional.length > 0 || this.rest !== null)) {
+      throw new Error(
+        `cli '${this.name}': a group's operand is its subcommand word; ` +
+          'positional/rest belong on leaves',
+      )
+    }
+    const seen = new Set<string>()
+    for (const child of this.subcommands) {
+      if (seen.has(child.name)) {
+        throw new Error(`cli '${this.name}': duplicate subcommand '${child.name}'`)
+      }
+      seen.add(child.name)
+      if (child.configModel !== null) {
+        throw new Error(
+          `cli '${this.name}': subcommand '${child.name}' declares configModel; ` +
+            'only the root of a tree may',
+        )
+      }
+    }
+    Object.freeze(this)
+  }
+}

--- a/typescript/packages/core/src/commands/cli/types.ts
+++ b/typescript/packages/core/src/commands/cli/types.ts
@@ -71,7 +71,7 @@ export class CLISpec extends CommandSpec {
     this.write = init.write ?? false
     this.safeguard = init.safeguard ?? null
     this.configModel = init.configModel ?? null
-    if (this.name === '' || this.name.includes(' ')) {
+    if (this.name === '' || /\s/.test(this.name)) {
       throw new Error(`cli name '${this.name}' must be a single non-empty word`)
     }
     if (this.fn !== null && this.subcommands.length > 0) {

--- a/typescript/packages/core/src/commands/config.ts
+++ b/typescript/packages/core/src/commands/config.ts
@@ -191,18 +191,15 @@ function withHelpSupport(
   const extras: Option[] = []
   if (!hasHelp) extras.push(HELP_OPTION)
   if (!hasVersion) extras.push(VERSION_OPTION)
-  const init: ConstructorParameters<typeof CommandSpec>[0] = {
-    options: extras.length === 0 ? spec.options : [...spec.options, ...extras],
-    positional: spec.positional,
-    rest: spec.rest,
-    ignoreTokens: [...spec.ignoreTokens],
-  }
-  if (spec.description !== null) init.description = spec.description
-  // Python rebuilds via dataclasses.replace, which keeps every other field;
-  // this init is hand-listed, so a new CommandSpec field must be added here
-  // too or --help silently loses it.
-  if (spec.epilog !== null) init.epilog = spec.epilog
-  const newSpec = extras.length === 0 ? spec : new CommandSpec(init)
+  // Instance spread mirrors Python's dataclasses.replace: every CommandSpec
+  // field rides along, including ones added after this code was written.
+  // The prototype loss the lint warns about is the point: init wants a
+  // plain field bag, and the constructor rebuilds the class.
+  const newSpec =
+    extras.length === 0
+      ? spec
+      : // eslint-disable-next-line @typescript-eslint/no-misused-spread
+        new CommandSpec({ ...spec, options: [...spec.options, ...extras] })
   const helpText = renderHelp(name, newSpec)
   const versionText = versionLine(name)
   const wrappedFn: CommandFn = async (accessor, paths, texts, opts) => {

--- a/typescript/packages/core/src/commands/spec/types.ts
+++ b/typescript/packages/core/src/commands/spec/types.ts
@@ -162,13 +162,20 @@ export class Operand {
   }
 }
 
+/**
+ * Init accepts every CommandSpec instance field at its instance type
+ * (ignoreTokens as any iterable, description/epilog as null) so a spec
+ * instance can be spread into a new one: `new CommandSpec({...spec, ...})`
+ * is the TS mirror of Python's dataclasses.replace and carries fields
+ * added later without hand-listing them.
+ */
 export interface CommandSpecInit {
   options?: readonly Option[]
   positional?: readonly Operand[]
   rest?: Operand | null
-  ignoreTokens?: readonly string[]
-  description?: string
-  epilog?: string
+  ignoreTokens?: Iterable<string>
+  description?: string | null
+  epilog?: string | null
 }
 
 export class CommandSpec {
@@ -186,7 +193,9 @@ export class CommandSpec {
     this.ignoreTokens = new Set(init.ignoreTokens ?? [])
     this.description = init.description ?? null
     this.epilog = init.epilog ?? null
-    Object.freeze(this)
+    // A subclass (CLISpec) still has its own fields to assign, so only
+    // freeze here when constructed directly; subclasses freeze themselves.
+    if (new.target === CommandSpec) Object.freeze(this)
   }
 }
 

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -614,6 +614,7 @@ export {
   RegisteredCommand,
   type RegisteredCommandInit,
 } from './commands/config.ts'
+export { CLISpec, type CLISpecInit, type CLIVerbFn } from './commands/cli/types.ts'
 export {
   COMPOUND_EXTENSIONS,
   getExtension,


### PR DESCRIPTION
Phase 2 core of the CLI/resource separation: `CLISpec`, one node of a program tree, as a subclass of `CommandSpec` (argparse's parser/subparser as data, click's Group-is-a-Command). A leaf carries `fn`, a group carries `subcommands`, the root may carry `config_model`; grammar fields are inherited, so every tree level parses with the existing spec machinery, and group-level options need no special case.

- Python `mirage/commands/cli/types.py` + TS `commands/cli/types.ts`: the subclass with import-time validation (single-word name, fn XOR subcommands, no positional/rest on groups, unique child names, config_model root-only).
- Leaf handlers receive the installation's validated config instance: `fn(config, paths, *texts, **flags)`. No accessor factory; what the fn does with the config is the author's business.
- TS base accommodations: `CommandSpecInit` widened to instance types so `new CommandSpec({...spec, ...})` mirrors `dataclasses.replace` (fixes the hand-listed `withHelpSupport` rebuild that silently dropped new fields from `--help`), and `Object.freeze` guarded with `new.target` so the subclass can exist.
- `@command`, `RegisteredCommand`, and all builtin specs untouched.

Tests: 9 pytest + 10 vitest covering the tree build, group-level options, and each validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)