### PR TITLE
Guard cp/mv against a same-storage operand, and refuse a non-empty destination directory

### DIFF
--- a/integ/crossmount/alias/same_store.json
+++ b/integ/crossmount/alias/same_store.json
@@ -1,0 +1,108 @@
+{
+  "cases": [
+    {
+      "id": "alias_seed",
+      "seq": 614000,
+      "targets": [
+        "ram-alias"
+      ],
+      "command": "printf precious | tee /data/x.txt > /dev/null && mkdir -p /data/tree && printf a | tee /data/tree/a.txt > /dev/null && echo seeded",
+      "expect": {
+        "exit": 0,
+        "stdout": "seeded\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "alias_both_prefixes_see_one_store",
+      "seq": 614001,
+      "targets": [
+        "ram-alias"
+      ],
+      "command": "cat /alias/x.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "precious",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "alias_mv_across_prefixes_refuses",
+      "seq": 614002,
+      "targets": [
+        "ram-alias"
+      ],
+      "command": "mv /data/x.txt /alias/x.txt",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "mv: '/data/x.txt' and '/alias/x.txt' are the same file\n"
+      }
+    },
+    {
+      "id": "alias_mv_refusal_kept_the_bytes",
+      "seq": 614003,
+      "targets": [
+        "ram-alias"
+      ],
+      "command": "cat /data/x.txt && cat /alias/x.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "preciousprecious",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "alias_cp_across_prefixes_refuses",
+      "seq": 614004,
+      "targets": [
+        "ram-alias"
+      ],
+      "command": "cp /data/x.txt /alias/x.txt",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "cp: '/data/x.txt' and '/alias/x.txt' are the same file\n"
+      }
+    },
+    {
+      "id": "alias_distinct_paths_still_move",
+      "seq": 614005,
+      "targets": [
+        "ram-alias"
+      ],
+      "command": "mv /data/x.txt /alias/moved.txt && cat /data/moved.txt && ls /alias",
+      "expect": {
+        "exit": 0,
+        "stdout": "preciousmoved.txt\ntree\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "alias_dir_move_onto_itself_refuses",
+      "seq": 614006,
+      "targets": [
+        "ram-alias"
+      ],
+      "command": "mv /data/tree /alias/tree",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "mv: cannot move '/data/tree' to a subdirectory of itself, '/alias/tree/tree'\n"
+      }
+    },
+    {
+      "id": "alias_cleanup",
+      "seq": 614009,
+      "targets": [
+        "ram-alias"
+      ],
+      "command": "rm -rf /data/moved.txt /data/tree && echo cleaned",
+      "expect": {
+        "exit": 0,
+        "stdout": "cleaned\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -2035,9 +2035,20 @@ def build_mounts(
 ) -> tuple[dict[str, object], list[Callable[[], Awaitable[None]]]]:
     mounts: dict[str, object] = {}
     cleanups: list[Callable[[], Awaitable[None]]] = []
+    built: dict[str, object] = {}
     for mount in target["mounts"]:
-        builder = BUILDERS[mount["resource"]]
-        resource, cleanup = builder(mount, run_id, service)
+        alias_of = mount.get("alias_of")
+        if alias_of is not None:
+            # Two prefixes over one store: the shape that made cross-mount
+            # mv copy an object onto itself and then unlink the source.
+            # Reusing the built resource is the only way to express it,
+            # since every builder otherwise allocates fresh storage.
+            resource = built[alias_of]
+            cleanup = _noop
+        else:
+            builder = BUILDERS[mount["resource"]]
+            resource, cleanup = builder(mount, run_id, service)
+        built[mount["path"]] = resource
         if mount.get("mode") == "read":
             mounts[mount["path"]] = (resource, MountMode.READ)
         else:

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -167,8 +167,17 @@ function runId(): string {
 
 async function openRam(target: Target): Promise<Open> {
   const mounts: Record<string, RAMResource | [RAMResource, MountMode]> = {}
+  const built: Record<string, RAMResource> = {}
   for (const m of target.mounts) {
-    const resource = new RAMResource()
+    // alias_of gives two prefixes one store: the shape that made
+    // cross-mount mv copy an object onto itself and then unlink the
+    // source. Every other path here allocates fresh storage.
+    const existing = m.alias_of !== undefined ? built[m.alias_of] : undefined
+    if (m.alias_of !== undefined && existing === undefined) {
+      throw new Error(`alias_of names no built mount: ${m.alias_of}`)
+    }
+    const resource = existing ?? new RAMResource()
+    built[m.path] = resource
     mounts[m.path] = m.mode === 'read' ? [resource, MountMode.READ] : resource
   }
   const ws = new Workspace(mounts, {

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -28,6 +28,10 @@ export interface Mount {
   backend: string
   mode?: string
   fixture?: string
+  // Mount this prefix over an already-built mount's storage instead of
+  // allocating fresh storage, so cp/mv can be exercised against two
+  // prefixes that address the same bytes.
+  alias_of?: string
   // Fixture seeded by the adapter (over the backend API) instead of the
   // harness tee path -- used by read-only backends like box.
   seed?: string

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -75,6 +75,26 @@
       }
     },
     {
+      "id": "ram-alias",
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
+      "mounts": [
+        {
+          "path": "/data",
+          "resource": "ram",
+          "backend": "memory"
+        },
+        {
+          "path": "/alias",
+          "resource": "ram",
+          "backend": "memory",
+          "alias_of": "/data"
+        }
+      ]
+    },
+    {
       "id": "ram-history",
       "hosts": [
         "python",

--- a/integ/unix/overwrite/cleanup.json
+++ b/integ/unix/overwrite/cleanup.json
@@ -2,7 +2,7 @@
   "cases": [
     {
       "id": "ow_cleanup",
-      "seq": 203005,
+      "seq": 203009,
       "targets": [
         "ram",
         "disk",

--- a/integ/unix/overwrite/mv.json
+++ b/integ/unix/overwrite/mv.json
@@ -31,6 +31,70 @@
         "stdout": "newdst.txt\ns\nt\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "ow_mv_onto_existing_nonempty_dir",
+      "seq": 203006,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mv /data/ow/s/t /data/ow",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "mv: cannot overwrite '/data/ow/t': Directory not empty\n"
+      }
+    },
+    {
+      "id": "ow_mv_n_skips_existing_nonempty_dir",
+      "seq": 203007,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mv -n /data/ow/s/t /data/ow && ls /data/ow/t && ls /data/ow/s/t",
+      "expect": {
+        "exit": 0,
+        "stdout": "f.old\nf.txt\nf.txt\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/python/mirage/commands/builtin/generic/crossmount/relay/cp.py
+++ b/python/mirage/commands/builtin/generic/crossmount/relay/cp.py
@@ -24,11 +24,11 @@ from mirage.commands.spec.types import FlagView
 from mirage.types import PathSpec, PrimitiveCopy
 
 
-async def run_cp(scopes: list[PathSpec],
-                 flag_kwargs: dict[str, object],
-                 dispatch: Callable[..., Any],
-                 storage_key: Callable[[PathSpec], str] | None = None
-                 ) -> CrossResult:
+async def run_cp(
+        scopes: list[PathSpec],
+        flag_kwargs: dict[str, object],
+        dispatch: Callable[..., Any],
+        storage_key: Callable[[PathSpec], str] | None = None) -> CrossResult:
     """Copy operands that span mounts via the shared generic cp.
 
     Pure wiring: the generic runs in its primitive mode (no native copy),

--- a/python/mirage/commands/builtin/generic/crossmount/relay/cp.py
+++ b/python/mirage/commands/builtin/generic/crossmount/relay/cp.py
@@ -24,8 +24,11 @@ from mirage.commands.spec.types import FlagView
 from mirage.types import PathSpec, PrimitiveCopy
 
 
-async def run_cp(scopes: list[PathSpec], flag_kwargs: dict[str, object],
-                 dispatch: Callable[..., Any]) -> CrossResult:
+async def run_cp(scopes: list[PathSpec],
+                 flag_kwargs: dict[str, object],
+                 dispatch: Callable[..., Any],
+                 storage_key: Callable[[PathSpec], str] | None = None
+                 ) -> CrossResult:
     """Copy operands that span mounts via the shared generic cp.
 
     Pure wiring: the generic runs in its primitive mode (no native copy),
@@ -36,6 +39,8 @@ async def run_cp(scopes: list[PathSpec], flag_kwargs: dict[str, object],
         scopes (list[PathSpec]): Path operands in command-line order.
         flag_kwargs (dict): Flags parsed against the shared cp spec.
         dispatch (Callable): Workspace operation dispatcher.
+        storage_key (Callable | None): Maps an operand to its storage
+            identity so two prefixes over one store compare equal.
     """
     fl = FlagView(flag_kwargs, spec=SPECS["cp"])
     primitives = transfer_primitives(dispatch)
@@ -46,4 +51,5 @@ async def run_cp(scopes: list[PathSpec], flag_kwargs: dict[str, object],
                                 write=primitives["write"],
                                 mkdir=primitives["mkdir"],
                                 readdir=primitives["readdir"]),
-                            flags=parse_cp_flags(fl))
+                            flags=parse_cp_flags(fl),
+                            backend_key=storage_key)

--- a/python/mirage/commands/builtin/generic/crossmount/relay/mv.py
+++ b/python/mirage/commands/builtin/generic/crossmount/relay/mv.py
@@ -25,11 +25,11 @@ from mirage.commands.spec.types import FlagView
 from mirage.types import PathSpec, PrimitiveMove
 
 
-async def run_mv(scopes: list[PathSpec],
-                 flag_kwargs: dict[str, object],
-                 dispatch: Callable[..., Any],
-                 storage_key: Callable[[PathSpec], str] | None = None
-                 ) -> CrossResult:
+async def run_mv(
+        scopes: list[PathSpec],
+        flag_kwargs: dict[str, object],
+        dispatch: Callable[..., Any],
+        storage_key: Callable[[PathSpec], str] | None = None) -> CrossResult:
     """Move operands that span mounts via the shared generic mv.
 
     Pure wiring: copy through the transfer primitives, then unlink the

--- a/python/mirage/commands/builtin/generic/crossmount/relay/mv.py
+++ b/python/mirage/commands/builtin/generic/crossmount/relay/mv.py
@@ -25,8 +25,11 @@ from mirage.commands.spec.types import FlagView
 from mirage.types import PathSpec, PrimitiveMove
 
 
-async def run_mv(scopes: list[PathSpec], flag_kwargs: dict[str, object],
-                 dispatch: Callable[..., Any]) -> CrossResult:
+async def run_mv(scopes: list[PathSpec],
+                 flag_kwargs: dict[str, object],
+                 dispatch: Callable[..., Any],
+                 storage_key: Callable[[PathSpec], str] | None = None
+                 ) -> CrossResult:
     """Move operands that span mounts via the shared generic mv.
 
     Pure wiring: copy through the transfer primitives, then unlink the
@@ -36,6 +39,10 @@ async def run_mv(scopes: list[PathSpec], flag_kwargs: dict[str, object],
         scopes (list[PathSpec]): Path operands in command-line order.
         flag_kwargs (dict): Flags parsed against the shared mv spec.
         dispatch (Callable): Workspace operation dispatcher.
+        storage_key (Callable | None): Maps an operand to its storage
+            identity. Without it a move between two prefixes over one
+            store would copy the object onto itself and then unlink the
+            source, destroying it.
     """
     p = functools.partial
     fl = FlagView(flag_kwargs, spec=SPECS["mv"])
@@ -49,4 +56,5 @@ async def run_mv(scopes: list[PathSpec], flag_kwargs: dict[str, object],
                                 readdir=primitives["readdir"],
                                 unlink=p(relay, dispatch, "unlink"),
                                 rmdir=p(relay, dispatch, "rmdir")),
-                            flags=parse_mv_flags(fl))
+                            flags=parse_mv_flags(fl),
+                            backend_key=storage_key)

--- a/python/mirage/commands/builtin/generic/crossmount/relay/relay.py
+++ b/python/mirage/commands/builtin/generic/crossmount/relay/relay.py
@@ -25,9 +25,12 @@ from mirage.commands.builtin.generic.crossmount.types import Cmd, CrossResult
 from mirage.types import PathSpec
 
 
-async def run_relay(cmd_name: str, scopes: list[PathSpec],
+async def run_relay(cmd_name: str,
+                    scopes: list[PathSpec],
                     flag_kwargs: dict[str, object],
-                    dispatch: Callable[..., Any]) -> CrossResult:
+                    dispatch: Callable[..., Any],
+                    storage_key: Callable[[PathSpec], str] | None = None
+                    ) -> CrossResult:
     """Run a command whose data must colocate across mounts.
 
     Pure wiring: every operand is read or written through ``dispatch``
@@ -39,11 +42,14 @@ async def run_relay(cmd_name: str, scopes: list[PathSpec],
         scopes (list[PathSpec]): Path operands in command-line order.
         flag_kwargs (dict): Flags parsed against the shared command spec.
         dispatch (Callable): Workspace operation dispatcher.
+        storage_key (Callable | None): Maps an operand to its storage
+            identity, for the transfer commands that must tell a real
+            move from one whose two prefixes address a single store.
     """
     if cmd_name == Cmd.CP:
-        return await run_cp(scopes, flag_kwargs, dispatch)
+        return await run_cp(scopes, flag_kwargs, dispatch, storage_key)
     if cmd_name == Cmd.MV:
-        return await run_mv(scopes, flag_kwargs, dispatch)
+        return await run_mv(scopes, flag_kwargs, dispatch, storage_key)
     if cmd_name == Cmd.DIFF:
         return await run_diff(scopes, flag_kwargs, dispatch)
     if cmd_name == Cmd.PASTE:

--- a/python/mirage/commands/builtin/generic/crossmount/relay/relay.py
+++ b/python/mirage/commands/builtin/generic/crossmount/relay/relay.py
@@ -25,12 +25,12 @@ from mirage.commands.builtin.generic.crossmount.types import Cmd, CrossResult
 from mirage.types import PathSpec
 
 
-async def run_relay(cmd_name: str,
-                    scopes: list[PathSpec],
-                    flag_kwargs: dict[str, object],
-                    dispatch: Callable[..., Any],
-                    storage_key: Callable[[PathSpec], str] | None = None
-                    ) -> CrossResult:
+async def run_relay(
+        cmd_name: str,
+        scopes: list[PathSpec],
+        flag_kwargs: dict[str, object],
+        dispatch: Callable[..., Any],
+        storage_key: Callable[[PathSpec], str] | None = None) -> CrossResult:
     """Run a command whose data must colocate across mounts.
 
     Pure wiring: every operand is read or written through ``dispatch``

--- a/python/mirage/commands/builtin/generic/crossmount/route.py
+++ b/python/mirage/commands/builtin/generic/crossmount/route.py
@@ -35,6 +35,7 @@ async def handle_cross_mount(
     dispatch: Callable[..., Any],
     run_single: RunSingle,
     stdin: ByteSource | None = None,
+    storage_key: Callable[[PathSpec], str] | None = None,
 ) -> CrossResult:
     """Run a command whose path operands span mounts.
 
@@ -57,11 +58,14 @@ async def handle_cross_mount(
             (STREAM and FANOUT).
         stdin (ByteSource | None): Original stdin (tee re-feeds it per
             operand).
+        storage_key (Callable | None): Maps an operand to its storage
+            identity (RELAY's transfer commands).
     """
     try:
         strategy = strategy_for(cmd_name, flag_kwargs)
         if strategy is Strategy.RELAY:
-            return await run_relay(cmd_name, scopes, flag_kwargs, dispatch)
+            return await run_relay(cmd_name, scopes, flag_kwargs, dispatch,
+                                   storage_key)
         if strategy is Strategy.STREAM:
             return await run_stream(cmd_name, scopes, text_args, flag_kwargs,
                                     run_single)

--- a/python/mirage/commands/builtin/generic/mv.py
+++ b/python/mirage/commands/builtin/generic/mv.py
@@ -375,10 +375,15 @@ async def mv(
             errors.append(f"mv: cannot move '{src.virtual}' to "
                           f"'{target.virtual}': Invalid cross-device link")
             continue
-        # A backup renames the target aside first, so -b -T installs over a
-        # nonempty directory (GNU 9.7) instead of hitting this refusal.
-        if src_is_dir and target_is_dir and flags.no_target_dir \
-                and readdir is not None \
+        if not await overwrite_gate(policy, stat, src, target, errors):
+            continue
+        # GNU refuses to replace a non-empty directory whether the target
+        # was named outright (-T) or mapped under an existing destination
+        # directory, so this cannot be gated on no_target_dir. It runs
+        # after the clobber gate because -n and --update=none skip such a
+        # target silently at exit 0, and a backup renames the target aside
+        # first, so -b installs over it instead (all GNU 9.7).
+        if src_is_dir and target_is_dir and readdir is not None \
                 and not backup_displaces(flags.backup):
             try:
                 children = await readdir(target)
@@ -392,8 +397,6 @@ async def mv(
                 errors.append(f"mv: cannot overwrite '{target.virtual}': "
                               "Directory not empty")
                 continue
-        if not await overwrite_gate(policy, stat, src, target, errors):
-            continue
         backup, ok = await make_backup(policy, strategy, stat, readdir, target,
                                        writes, errors)
         if not ok:

--- a/python/mirage/core/s3/copy.py
+++ b/python/mirage/core/s3/copy.py
@@ -15,7 +15,9 @@
 from mirage.accessor.s3 import S3Accessor
 from mirage.cache.context import invalidate_after_write
 from mirage.core.s3._client import _client_kwargs, _key, async_session
+from mirage.core.s3.exists import exists
 from mirage.types import PathSpec
+from mirage.utils.errors import enoent
 
 
 async def copy(accessor: S3Accessor, src_spec: PathSpec,
@@ -23,6 +25,14 @@ async def copy(accessor: S3Accessor, src_spec: PathSpec,
     src = src_spec.mount_path
     dst = dst_spec.mount_path
     config = accessor.config
+    if _key(src, config) == _key(dst, config):
+        # Copying an object onto its own key is a no-op we must not send:
+        # AWS and MinIO reject it, but a store that accepts it would pair
+        # with rename's delete below and destroy the only copy. A missing
+        # source still has to fail (#150).
+        if not await exists(accessor, src_spec):
+            raise enoent(src_spec)
+        return
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:
         await client.copy_object(

--- a/python/mirage/core/s3/rename.py
+++ b/python/mirage/core/s3/rename.py
@@ -16,7 +16,9 @@ from mirage.accessor.s3 import S3Accessor
 from mirage.cache.context import (invalidate_after_unlink,
                                   invalidate_after_write)
 from mirage.core.s3._client import _client_kwargs, _key, async_session
+from mirage.core.s3.exists import exists
 from mirage.types import PathSpec
+from mirage.utils.errors import enoent
 
 
 async def rename(accessor: S3Accessor, src_spec: PathSpec,
@@ -24,6 +26,14 @@ async def rename(accessor: S3Accessor, src_spec: PathSpec,
     src = src_spec.mount_path
     dst = dst_spec.mount_path
     config = accessor.config
+    if _key(src, config) == _key(dst, config):
+        # POSIX rename(2): the same existing file succeeds and performs no
+        # other action. Reaching the copy+delete pair below would instead
+        # delete the object on any store that accepts the self-copy, and
+        # error on the ones that reject it (#150).
+        if not await exists(accessor, src_spec):
+            raise enoent(src_spec)
+        return
     session = async_session(config)
     async with session.client(**_client_kwargs(config)) as client:
         await client.copy_object(

--- a/python/mirage/resource/base.py
+++ b/python/mirage/resource/base.py
@@ -103,6 +103,21 @@ class BaseResource:
                            prefix: str = "") -> list[PathSpec]:
         raise NotImplementedError
 
+    def storage_id(self) -> str:
+        """Identity of the storage this resource reads and writes.
+
+        Two mounts whose resources return the same value address the same
+        bytes, so a move between them must refuse rather than copy the
+        object over itself and then unlink the source. The default treats
+        every instance as its own storage, which is the safe direction to
+        be wrong in: a false "different" only keeps the pre-existing
+        behavior, while a false "same" would refuse a legitimate move.
+        Backends whose config pins the storage (a disk root, a bucket and
+        key prefix) override this so two separately constructed instances
+        pointing at one target still compare equal.
+        """
+        return f"{self.name}:{id(self):x}"
+
     async def statfs(self) -> CapacityResult:
         """Capacity of this backend for df. Default: UNKNOWN (rendered as
         ``-``). Backends that can report truthfully — a real filesystem, or

--- a/python/mirage/resource/disk/disk.py
+++ b/python/mirage/resource/disk/disk.py
@@ -86,6 +86,11 @@ class DiskResource(BaseResource):
         for ro in DISK_OPS:
             self.register_op(ro)
 
+    def storage_id(self) -> str:
+        # The resolved root is the storage: two DiskResources built on the
+        # same directory are one store, however they were spelled.
+        return f"{self.name}:{self.root}"
+
     async def resolve_glob(self, paths, prefix: str = ""):
         if prefix:
             paths = [

--- a/python/mirage/resource/redis/redis.py
+++ b/python/mirage/resource/redis/redis.py
@@ -91,12 +91,19 @@ class RedisResource(BaseResource):
         key_prefix: str = "mirage:fs:",
     ) -> None:
         super().__init__()
+        self.url = url
+        self.key_prefix = key_prefix
         self._store = RedisStore(url=url, key_prefix=key_prefix)
         self.accessor = RedisAccessor(self._store)
         for fn in REDIS_COMMANDS:
             self.register(fn)
         for ro in REDIS_OPS:
             self.register_op(ro)
+
+    def storage_id(self) -> str:
+        # The server URL (host, port and db) plus the key prefix pin the
+        # keyspace two mounts would share.
+        return f"{self.name}:{self.url}:{self.key_prefix}"
 
     async def resolve_glob(self, paths, prefix: str = ""):
         if prefix:

--- a/python/mirage/resource/redis/redis.py
+++ b/python/mirage/resource/redis/redis.py
@@ -102,8 +102,11 @@ class RedisResource(BaseResource):
 
     def storage_id(self) -> str:
         # The server URL (host, port and db) plus the key prefix pin the
-        # keyspace two mounts would share.
-        return f"{self.name}:{self.url}:{self.key_prefix}"
+        # keyspace two mounts would share. The prefix is joined path-like
+        # so nested prefixes collapse onto one key.
+        prefix = self.key_prefix.strip("/")
+        base = f"{self.name}:{self.url}"
+        return f"{base}/{prefix}" if prefix else base
 
     async def resolve_glob(self, paths, prefix: str = ""):
         if prefix:

--- a/python/mirage/resource/s3/s3.py
+++ b/python/mirage/resource/s3/s3.py
@@ -86,6 +86,14 @@ class S3Resource(BaseResource):
         for fn in S3_OPS:
             self.register_op(fn)
 
+    def storage_id(self) -> str:
+        # Endpoint, bucket and key prefix pin the object namespace. The
+        # endpoint matters because the same bucket name on two providers
+        # (AWS vs MinIO vs R2) is two different stores.
+        cfg = self.config
+        return (f"{self.name}:{cfg.endpoint_url or 'aws'}"
+                f":{cfg.bucket}:{cfg.key_prefix or ''}")
+
     async def resolve_glob(self, paths, prefix: str = ""):
         if prefix:
             paths = [

--- a/python/mirage/resource/s3/s3.py
+++ b/python/mirage/resource/s3/s3.py
@@ -89,10 +89,13 @@ class S3Resource(BaseResource):
     def storage_id(self) -> str:
         # Endpoint, bucket and key prefix pin the object namespace. The
         # endpoint matters because the same bucket name on two providers
-        # (AWS vs MinIO vs R2) is two different stores.
+        # (AWS vs MinIO vs R2) is two different stores. The prefix joins
+        # path-like so two mounts whose prefixes nest still resolve to
+        # one key once the mount-relative path is appended.
         cfg = self.config
-        return (f"{self.name}:{cfg.endpoint_url or 'aws'}"
-                f":{cfg.bucket}:{cfg.key_prefix or ''}")
+        prefix = (cfg.key_prefix or "").strip("/")
+        base = f"{self.name}:{cfg.endpoint_url or 'aws'}:{cfg.bucket}"
+        return f"{base}/{prefix}" if prefix else base
 
     async def resolve_glob(self, paths, prefix: str = ""):
         if prefix:

--- a/python/mirage/workspace/executor/command.py
+++ b/python/mirage/workspace/executor/command.py
@@ -63,6 +63,7 @@ from mirage.workspace.mount import (MountCommandUnsupported, MountEntry,
                                     MountRegistry)
 from mirage.workspace.mount.namespace import Namespace
 from mirage.workspace.mount.namespace.overlay import merge_overlay_stat
+from mirage.workspace.mount.storage import make_storage_key
 from mirage.workspace.route import JOB_BUILTINS, Consumer, route
 from mirage.workspace.session import Session, assert_mount_allowed
 from mirage.workspace.types import ExecutionNode
@@ -809,13 +810,15 @@ async def handle_command(
                                        dispatch,
                                        namespace,
                                        routing_decision=routing_decision)
-        stdout, io = await handle_cross_mount(cmd_name,
-                                              cross_scopes,
-                                              cross_texts,
-                                              cross_parsed.flag_kwargs,
-                                              dispatch,
-                                              run_single,
-                                              stdin=stdin)
+        stdout, io = await handle_cross_mount(
+            cmd_name,
+            cross_scopes,
+            cross_texts,
+            cross_parsed.flag_kwargs,
+            dispatch,
+            run_single,
+            stdin=stdin,
+            storage_key=make_storage_key(registry))
         if cross_parsed.warnings:
             warn = "".join(f"{cmd_name}: {w}\n"
                            for w in cross_parsed.warnings).encode()

--- a/python/mirage/workspace/mount/storage.py
+++ b/python/mirage/workspace/mount/storage.py
@@ -1,0 +1,53 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from typing import Callable
+
+from mirage.types import PathSpec
+from mirage.utils.key_prefix import strip_mount
+from mirage.workspace.mount.registry import MountRegistry
+
+
+def make_storage_key(registry: MountRegistry) -> Callable[[PathSpec], str]:
+    """Build the transfer generics' identity function for a mount set.
+
+    ``cp`` and ``mv`` compare two operands to decide whether they name the
+    same file. Within one mount the mount-relative path answers that, but
+    across mounts it does not: two prefixes can address one store (two
+    disk mounts on a shared root, one bucket mounted twice, the same
+    resource object mounted at two prefixes), and there a move would copy
+    an object over itself and then unlink the source. Pairing the
+    resource's ``storage_id`` with the mount-relative path makes the
+    comparison about bytes rather than about spelling.
+
+    The mount-relative path keeps its leading slash so the generics'
+    ``startswith(key + "/")`` containment test still marks a directory as
+    an ancestor of its children, and only within one storage.
+
+    Args:
+        registry (MountRegistry): Mount set the operands are addressed in.
+    """
+
+    def storage_key(path: PathSpec) -> str:
+        try:
+            entry = registry.mount_for(path.virtual)
+        except ValueError:
+            # Outside every mount there is no storage to name, so fall
+            # back to the path itself; such an operand fails on its own
+            # when the command tries to read it.
+            return path.virtual.rstrip("/")
+        rel = strip_mount(path.virtual, entry.prefix.rstrip("/"))
+        return f"{entry.resource.storage_id()}:{rel.rstrip('/') or '/'}"
+
+    return storage_key

--- a/python/mirage/workspace/mount/storage.py
+++ b/python/mirage/workspace/mount/storage.py
@@ -12,42 +12,72 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import functools
 from typing import Callable
 
+from mirage.resource.base import BaseResource
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import strip_mount
 from mirage.workspace.mount.registry import MountRegistry
 
 
-def make_storage_key(registry: MountRegistry) -> Callable[[PathSpec], str]:
-    """Build the transfer generics' identity function for a mount set.
+def resource_storage_id(resource: BaseResource) -> str:
+    """Storage identity of a resource, with a fallback for custom ones.
 
-    ``cp`` and ``mv`` compare two operands to decide whether they name the
-    same file. Within one mount the mount-relative path answers that, but
-    across mounts it does not: two prefixes can address one store (two
-    disk mounts on a shared root, one bucket mounted twice, the same
-    resource object mounted at two prefixes), and there a move would copy
-    an object over itself and then unlink the source. Pairing the
-    resource's ``storage_id`` with the mount-relative path makes the
-    comparison about bytes rather than about spelling.
+    ``BaseResource`` supplies ``storage_id``, but a third-party resource
+    may implement the protocol without inheriting it. Falling back to
+    object identity keeps such a resource correct when it is mounted
+    twice, instead of reading as two separate stores.
+
+    Args:
+        resource (BaseResource): The mounted resource.
+    """
+    fn = getattr(resource, "storage_id", None)
+    if fn is None:
+        return f"resource:{id(resource):x}"
+    return fn()
+
+
+def storage_key(registry: MountRegistry, path: PathSpec) -> str:
+    """Identify the bytes an operand addresses, across mounts.
+
+    ``cp`` and ``mv`` compare two operands to decide whether they name
+    the same file. Within one mount the mount-relative path answers
+    that, but across mounts it does not: two prefixes can address one
+    store, and there a move would copy an object over itself and then
+    unlink the source.
+
+    The resource's storage id and the mount-relative path are joined
+    into one path-like string rather than kept as separate components,
+    so nested backings collapse onto the same key. Two disk mounts
+    rooted at ``/srv/data`` and ``/srv/data/sub`` make ``/a/sub/x`` and
+    ``/b/x`` the same file, and both render as
+    ``disk:/srv/data/sub/x``. A delimiter between the two parts would
+    keep them apart and let the move through.
 
     The mount-relative path keeps its leading slash so the generics'
-    ``startswith(key + "/")`` containment test still marks a directory as
-    an ancestor of its children, and only within one storage.
+    ``startswith(key + "/")`` containment test still marks a directory
+    as an ancestor of its children, and only within one storage.
+
+    Args:
+        registry (MountRegistry): Mount set the operand is addressed in.
+        path (PathSpec): The operand.
+    """
+    try:
+        entry = registry.mount_for(path.virtual)
+    except ValueError:
+        # Outside every mount there is no storage to name, so fall back
+        # to the path itself; such an operand fails on its own when the
+        # command tries to read it.
+        return path.virtual.rstrip("/")
+    rel = strip_mount(path.virtual, entry.prefix.rstrip("/")).rstrip("/")
+    return resource_storage_id(entry.resource) + rel
+
+
+def make_storage_key(registry: MountRegistry) -> Callable[[PathSpec], str]:
+    """Bind ``storage_key`` to one mount set for the transfer generics.
 
     Args:
         registry (MountRegistry): Mount set the operands are addressed in.
     """
-
-    def storage_key(path: PathSpec) -> str:
-        try:
-            entry = registry.mount_for(path.virtual)
-        except ValueError:
-            # Outside every mount there is no storage to name, so fall
-            # back to the path itself; such an operand fails on its own
-            # when the command tries to read it.
-            return path.virtual.rstrip("/")
-        rel = strip_mount(path.virtual, entry.prefix.rstrip("/"))
-        return f"{entry.resource.storage_id()}:{rel.rstrip('/') or '/'}"
-
-    return storage_key
+    return functools.partial(storage_key, registry)

--- a/python/tests/core/s3/test_same_key_guard.py
+++ b/python/tests/core/s3/test_same_key_guard.py
@@ -1,0 +1,124 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+from contextlib import ExitStack
+
+import pytest
+
+from mirage.accessor.s3 import S3Accessor
+from mirage.core.s3.copy import copy
+from mirage.core.s3.rename import rename
+from mirage.resource.s3 import S3Config
+from mirage.types import PathSpec
+from tests.e2e.s3_mock import (MultiBucketSession, patch_s3_multi,
+                               patch_s3_session)
+
+BUCKET = "test-bucket"
+
+
+def _config(key_prefix: str | None = None) -> S3Config:
+    return S3Config(
+        bucket=BUCKET,
+        region="us-east-1",
+        aws_access_key_id="fake",
+        aws_secret_access_key="fake",
+        **({
+            "key_prefix": key_prefix
+        } if key_prefix else {}),
+    )
+
+
+def _spec(key: str) -> PathSpec:
+    return PathSpec(resource_path=key,
+                    virtual=f"/{key}",
+                    directory="/" + key.rsplit("/", 1)[0] if "/" in key else
+                    "/")
+
+
+def _run(fn, store: dict, config: S3Config):
+    stack = ExitStack()
+    stack.enter_context(patch_s3_multi({BUCKET: store}))
+    try:
+        return asyncio.run(fn(S3Accessor(config)))
+    finally:
+        stack.close()
+
+
+def test_rename_onto_the_same_key_keeps_the_object():
+    """The data-loss shape #150 describes.
+
+    The mock accepts a self-copy, like a non-AWS S3-compatible store
+    might. Without the guard the unconditional delete_object that
+    follows removes the only copy.
+    """
+    store = {"a.txt": b"precious"}
+    _run(lambda acc: rename(acc, _spec("a.txt"), _spec("a.txt")), store,
+         _config())
+    assert store == {"a.txt": b"precious"}
+
+
+def test_rename_onto_the_same_key_issues_no_writes():
+    """POSIX rename(2): same existing file succeeds, no other action.
+
+    Stronger than "the object survived": it must send nothing at all,
+    since on AWS and MinIO the copy would come back InvalidRequest.
+    """
+    store = {"a.txt": b"precious"}
+    session = MultiBucketSession({BUCKET: store})
+    stack = patch_s3_session(session)
+    try:
+        asyncio.run(
+            rename(S3Accessor(_config()), _spec("a.txt"), _spec("a.txt")))
+        calls = session.client().calls
+        assert calls["copy_object"] == 0
+        assert calls["delete_object"] == 0
+    finally:
+        stack.close()
+
+
+def test_copy_onto_the_same_key_is_a_no_op():
+    store = {"a.txt": b"precious"}
+    _run(lambda acc: copy(acc, _spec("a.txt"), _spec("a.txt")), store,
+         _config())
+    assert store == {"a.txt": b"precious"}
+
+
+def test_rename_onto_the_same_key_still_fails_when_absent():
+    """A missing source must not be silently reported as moved."""
+    with pytest.raises(FileNotFoundError):
+        _run(lambda acc: rename(acc, _spec("nope.txt"), _spec("nope.txt")),
+             {}, _config())
+
+
+def test_copy_onto_the_same_key_still_fails_when_absent():
+    with pytest.raises(FileNotFoundError):
+        _run(lambda acc: copy(acc, _spec("nope.txt"), _spec("nope.txt")), {},
+             _config())
+
+
+def test_distinct_keys_still_move():
+    """The guard must not swallow a real rename."""
+    store = {"a.txt": b"precious"}
+    _run(lambda acc: rename(acc, _spec("a.txt"), _spec("b.txt")), store,
+         _config())
+    assert store == {"b.txt": b"precious"}
+
+
+def test_guard_compares_resolved_keys_not_spelling():
+    """Two paths that differ only by the mount's key prefix are one key."""
+    store = {"pre/a.txt": b"precious"}
+    _run(lambda acc: rename(acc, _spec("a.txt"), _spec("a.txt")), store,
+         _config(key_prefix="pre/"))
+    assert store == {"pre/a.txt": b"precious"}

--- a/python/tests/core/s3/test_same_key_guard.py
+++ b/python/tests/core/s3/test_same_key_guard.py
@@ -43,8 +43,8 @@ def _config(key_prefix: str | None = None) -> S3Config:
 def _spec(key: str) -> PathSpec:
     return PathSpec(resource_path=key,
                     virtual=f"/{key}",
-                    directory="/" + key.rsplit("/", 1)[0] if "/" in key else
-                    "/")
+                    directory="/" +
+                    key.rsplit("/", 1)[0] if "/" in key else "/")
 
 
 def _run(fn, store: dict, config: S3Config):
@@ -98,8 +98,8 @@ def test_copy_onto_the_same_key_is_a_no_op():
 def test_rename_onto_the_same_key_still_fails_when_absent():
     """A missing source must not be silently reported as moved."""
     with pytest.raises(FileNotFoundError):
-        _run(lambda acc: rename(acc, _spec("nope.txt"), _spec("nope.txt")),
-             {}, _config())
+        _run(lambda acc: rename(acc, _spec("nope.txt"), _spec("nope.txt")), {},
+             _config())
 
 
 def test_copy_onto_the_same_key_still_fails_when_absent():

--- a/python/tests/e2e/s3_mock.py
+++ b/python/tests/e2e/s3_mock.py
@@ -212,10 +212,15 @@ class MultiBucketS3Client:
         self._objects(Bucket)[Key] = Body
 
     async def delete_object(self, Bucket: str, Key: str) -> None:
+        self.calls["delete_object"] += 1
         self._objects(Bucket).pop(Key, None)
 
     async def copy_object(self, Bucket: str, CopySource: dict,
                           Key: str) -> None:
+        # Deliberately lenient: a self-copy is accepted, the way a
+        # non-AWS S3-compatible store might. That is what makes the
+        # same-key guard observable in tests (#150).
+        self.calls["copy_object"] += 1
         src_bucket = CopySource.get("Bucket", Bucket)
         src_key = CopySource["Key"]
         src_objects = self._objects(src_bucket)

--- a/python/tests/workspace/mount/test_storage.py
+++ b/python/tests/workspace/mount/test_storage.py
@@ -1,0 +1,118 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+
+from mirage.resource.disk import DiskResource
+from mirage.resource.ram import RAMResource
+from mirage.types import MountMode, PathSpec
+from mirage.workspace import Workspace
+from mirage.workspace.mount.storage import make_storage_key
+
+
+def _spec(virtual: str) -> PathSpec:
+    return PathSpec(virtual=virtual,
+                    directory=virtual.rsplit("/", 1)[0] or "/",
+                    resource_path=virtual.strip("/"))
+
+
+def _key(mounts: dict):
+    ws = Workspace({p: (r, MountMode.WRITE) for p, r in mounts.items()})
+    return make_storage_key(ws.registry)
+
+
+def test_one_resource_at_two_prefixes_is_one_storage():
+    """The alias that used to make mv delete the file it moved (#154)."""
+    shared = RAMResource()
+    key = _key({"/m1/": shared, "/m2/": shared})
+    assert key(_spec("/m1/x.txt")) == key(_spec("/m2/x.txt"))
+
+
+def test_distinct_resources_are_distinct_storage():
+    """Same basename on two real stores must stay a legitimate move."""
+    key = _key({"/m1/": RAMResource(), "/m2/": RAMResource()})
+    assert key(_spec("/m1/x.txt")) != key(_spec("/m2/x.txt"))
+
+
+def test_disk_identity_is_the_resolved_root(tmp_path):
+    """Two DiskResources built on one directory are one store."""
+    root = str(tmp_path)
+    key = _key({
+        "/d1/": DiskResource(root=root),
+        "/d2/": DiskResource(root=root)
+    })
+    assert key(_spec("/d1/x.txt")) == key(_spec("/d2/x.txt"))
+
+
+def test_disk_roots_that_differ_stay_separate(tmp_path):
+    a, b = tmp_path / "a", tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    key = _key({
+        "/d1/": DiskResource(root=str(a)),
+        "/d2/": DiskResource(root=str(b))
+    })
+    assert key(_spec("/d1/x.txt")) != key(_spec("/d2/x.txt"))
+
+
+def test_distinct_paths_in_one_storage_stay_distinct():
+    """A real move within one store must not read as a self-move."""
+    shared = RAMResource()
+    key = _key({"/m1/": shared, "/m2/": shared})
+    assert key(_spec("/m1/x.txt")) != key(_spec("/m2/other.txt"))
+
+
+def test_key_keeps_the_ancestor_prefix_boundary():
+    """cp/mv test containment with startswith(key + "/")."""
+    shared = RAMResource()
+    key = _key({"/m1/": shared, "/m2/": shared})
+    assert key(_spec("/m2/dir/sub")).startswith(key(_spec("/m1/dir")) + "/")
+    assert not key(_spec("/m2/dirty")).startswith(key(_spec("/m1/dir")) + "/")
+
+
+def test_path_outside_every_mount_falls_back_to_itself():
+    """The defensive branch, reached only without a root mount.
+
+    A Workspace always carries one, so an unmatched path normally lands
+    there instead; this pins the fallback for a bare registry.
+    """
+
+    class _NoMounts:
+
+        def mount_for(self, path: str):
+            raise ValueError(path)
+
+    key = make_storage_key(_NoMounts())
+    assert key(_spec("/nowhere/x.txt")) == "/nowhere/x.txt"
+
+
+def test_aliased_mounts_refuse_the_move_that_used_to_lose_the_file():
+    """End to end: the #154 repro must keep the bytes."""
+    shared = RAMResource()
+    ws = Workspace({
+        "/m1/": (shared, MountMode.WRITE),
+        "/m2/": (shared, MountMode.WRITE)
+    })
+
+    async def _run():
+        await ws.execute("sh -c 'echo precious > /m1/x.txt'")
+        io = await ws.execute("mv /m1/x.txt /m2/x.txt")
+        err = await io.stderr_str()
+        kept = await (await ws.execute("cat /m2/x.txt")).stdout_str()
+        return err, io.exit_code, kept
+
+    err, code, kept = asyncio.run(_run())
+    assert code == 1
+    assert "are the same file" in err
+    assert kept == "precious\n"

--- a/python/tests/workspace/mount/test_storage.py
+++ b/python/tests/workspace/mount/test_storage.py
@@ -18,7 +18,8 @@ from mirage.resource.disk import DiskResource
 from mirage.resource.ram import RAMResource
 from mirage.types import MountMode, PathSpec
 from mirage.workspace import Workspace
-from mirage.workspace.mount.storage import make_storage_key
+from mirage.workspace.mount.storage import (make_storage_key,
+                                            resource_storage_id)
 
 
 def _spec(virtual: str) -> PathSpec:
@@ -79,6 +80,51 @@ def test_key_keeps_the_ancestor_prefix_boundary():
     key = _key({"/m1/": shared, "/m2/": shared})
     assert key(_spec("/m2/dir/sub")).startswith(key(_spec("/m1/dir")) + "/")
     assert not key(_spec("/m2/dirty")).startswith(key(_spec("/m1/dir")) + "/")
+
+
+def test_nested_disk_roots_resolve_to_one_key(tmp_path):
+    """Overlapping roots make the same file reachable two ways.
+
+    /a backed by root and /b backed by root/sub means /a/sub/x and /b/x
+    are one file. Keeping the root and the relative path as separate
+    key components kept them apart and let mv delete the file.
+    """
+    root = tmp_path / "data"
+    sub = root / "sub"
+    sub.mkdir(parents=True)
+    key = _key({
+        "/a/": DiskResource(root=str(root)),
+        "/b/": DiskResource(root=str(sub)),
+    })
+    assert key(_spec("/a/sub/x.txt")) == key(_spec("/b/x.txt"))
+
+
+def test_nested_roots_do_not_collide_on_a_sibling(tmp_path):
+    """Concatenation must not fuse names that merely share a prefix."""
+    root = tmp_path / "data"
+    sibling = tmp_path / "dataX"
+    root.mkdir()
+    sibling.mkdir()
+    key = _key({
+        "/a/": DiskResource(root=str(root)),
+        "/b/": DiskResource(root=str(sibling)),
+    })
+    assert key(_spec("/a/y.txt")) != key(_spec("/b/y.txt"))
+
+
+def test_resource_without_storage_id_keeps_object_identity():
+    """A custom resource may not inherit BaseResource.storage_id.
+
+    Falling back to the mount prefix would give one object two
+    identities and let a self-move through.
+    """
+
+    class _Custom:
+        pass
+
+    shared = _Custom()
+    assert resource_storage_id(shared) == resource_storage_id(shared)
+    assert resource_storage_id(shared) != resource_storage_id(_Custom())
 
 
 def test_path_outside_every_mount_falls_back_to_itself():

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/cp.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/cp.ts
@@ -25,6 +25,9 @@ export async function runCp(
   scopes: PathSpec[],
   flagKwargs: Record<string, string | boolean | number | string[]>,
   dispatch: DispatchFn,
+  // Maps an operand to its storage identity so two prefixes over one
+  // store compare equal.
+  storageKey?: (path: PathSpec) => string,
 ): Promise<CrossResult> {
   const flat = flatten(scopes)
   const stat = statOp(dispatch)
@@ -36,5 +39,12 @@ export async function runCp(
   const mkdir = async (p: PathSpec): Promise<void> => {
     await dispatch('mkdir', p)
   }
-  return cpGeneric(flat, stat, { readBytes, write, mkdir, readdir }, parseCpFlags(flagKwargs))
+  return cpGeneric(
+    flat,
+    stat,
+    { readBytes, write, mkdir, readdir },
+    parseCpFlags(flagKwargs),
+    undefined,
+    storageKey,
+  )
 }

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/mv.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/mv.ts
@@ -24,6 +24,10 @@ export async function runMv(
   scopes: PathSpec[],
   flagKwargs: Record<string, string | boolean | number | string[]>,
   dispatch: DispatchFn,
+  // Maps an operand to its storage identity. Without it a move between
+  // two prefixes over one store would copy the object onto itself and
+  // then unlink the source, destroying it.
+  storageKey?: (path: PathSpec) => string,
 ): Promise<CrossResult> {
   const flat = flatten(scopes)
   const stat = statOp(dispatch)
@@ -46,5 +50,7 @@ export async function runMv(
     stat,
     { readBytes, write, mkdir, readdir, unlink, rmdir },
     parseMvFlags(flagKwargs),
+    undefined,
+    storageKey,
   )
 }

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/relay.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/relay/relay.ts
@@ -31,9 +31,13 @@ export async function runRelay(
   scopes: PathSpec[],
   flagKwargs: Record<string, string | boolean | number | string[]>,
   dispatch: DispatchFn,
+  // Maps an operand to its storage identity, for the transfer commands
+  // that must tell a real move from one whose two prefixes address a
+  // single store.
+  storageKey?: (path: PathSpec) => string,
 ): Promise<CrossResult> {
-  if (cmdName === Cmd.CP) return runCp(scopes, flagKwargs, dispatch)
-  if (cmdName === Cmd.MV) return runMv(scopes, flagKwargs, dispatch)
+  if (cmdName === Cmd.CP) return runCp(scopes, flagKwargs, dispatch, storageKey)
+  if (cmdName === Cmd.MV) return runMv(scopes, flagKwargs, dispatch, storageKey)
   if (cmdName === Cmd.DIFF) return runDiff(scopes, flagKwargs, dispatch)
   if (cmdName === Cmd.PASTE) return runPaste(scopes, flagKwargs, dispatch)
   if (cmdName === Cmd.COMM) return runComm(scopes, flagKwargs, dispatch)

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/route.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/route.ts
@@ -37,6 +37,8 @@ export async function handleCrossMount(
   dispatch: DispatchFn,
   runSingle: RunSingle,
   stdin: ByteSource | null = null,
+  // Maps an operand to its storage identity (RELAY's transfer commands).
+  storageKey?: (path: PathSpec) => string,
 ): Promise<CrossResult> {
   try {
     // isCrossMount gated on CROSS_MOUNT_COMMANDS membership, so the name is
@@ -44,7 +46,7 @@ export async function handleCrossMount(
     const cmd = cmdName as Cmd
     const strategy = strategyFor(cmd, flagKwargs)
     if (strategy === Strategy.RELAY) {
-      return await runRelay(cmd, scopes, flagKwargs, dispatch)
+      return await runRelay(cmd, scopes, flagKwargs, dispatch, storageKey)
     }
     if (strategy === Strategy.STREAM) {
       return await runStream(cmd, scopes, textArgs, flagKwargs, runSingle)

--- a/typescript/packages/core/src/commands/builtin/generic/mv.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/mv.ts
@@ -375,15 +375,14 @@ export async function mvGeneric(
       )
       continue
     }
-    // A backup renames the target aside first, so -b -T installs over a
-    // nonempty directory (GNU 9.7) instead of hitting this refusal.
-    if (
-      srcIsDir &&
-      targetIsDir &&
-      flags.noTargetDir &&
-      versionReaddir !== undefined &&
-      !backupDisplaces(flags.backup)
-    ) {
+    if (!(await overwriteGate(policy, stat, src, target, errors))) continue
+    // GNU refuses to replace a non-empty directory whether the target was
+    // named outright (-T) or mapped under an existing destination
+    // directory, so this cannot be gated on noTargetDir. It runs after the
+    // clobber gate because -n and --update=none skip such a target
+    // silently at exit 0, and a backup renames the target aside first, so
+    // -b installs over it instead (all GNU 9.7).
+    if (srcIsDir && targetIsDir && versionReaddir !== undefined && !backupDisplaces(flags.backup)) {
       let children: string[]
       try {
         children = await versionReaddir(target)
@@ -399,7 +398,6 @@ export async function mvGeneric(
         continue
       }
     }
-    if (!(await overwriteGate(policy, stat, src, target, errors))) continue
     const made = await makeBackup(
       policy,
       strategy,

--- a/typescript/packages/core/src/core/s3/copy.ts
+++ b/typescript/packages/core/src/core/s3/copy.ts
@@ -15,13 +15,23 @@
 import type { PathSpec } from '../../types.ts'
 import type { S3Accessor } from '../../accessor/s3.ts'
 import { invalidateAfterWrite } from '../../cache/context.ts'
+import { enoent } from '../../utils/errors.ts'
 import { loadS3Module, rawPathOf, s3Key, withClient } from './_client.ts'
+import { exists } from './exists.ts'
 
 export async function copy(accessor: S3Accessor, src: PathSpec, dst: PathSpec): Promise<void> {
   const { CopyObjectCommand } = await loadS3Module(accessor.config)
   const srcKey = s3Key(rawPathOf(src), accessor.config)
   const dstKey = s3Key(rawPathOf(dst), accessor.config)
   const { bucket } = accessor.config
+  if (srcKey === dstKey) {
+    // Copying an object onto its own key is a no-op we must not send:
+    // AWS and MinIO reject it, but a store that accepts it would pair
+    // with rename's delete and destroy the only copy. A missing source
+    // still has to fail (#150).
+    if (!(await exists(accessor, src))) throw enoent(src)
+    return
+  }
   await withClient(accessor.config, async (client) => {
     await client.send(
       new CopyObjectCommand({

--- a/typescript/packages/core/src/core/s3/rename.ts
+++ b/typescript/packages/core/src/core/s3/rename.ts
@@ -15,13 +15,23 @@
 import { invalidateAfterUnlink, invalidateAfterWrite } from '../../cache/context.ts'
 import type { PathSpec } from '../../types.ts'
 import type { S3Accessor } from '../../accessor/s3.ts'
+import { enoent } from '../../utils/errors.ts'
 import { loadS3Module, rawPathOf, s3Key, withClient } from './_client.ts'
+import { exists } from './exists.ts'
 
 export async function rename(accessor: S3Accessor, src: PathSpec, dst: PathSpec): Promise<void> {
   const { CopyObjectCommand, DeleteObjectCommand } = await loadS3Module(accessor.config)
   const srcKey = s3Key(rawPathOf(src), accessor.config)
   const dstKey = s3Key(rawPathOf(dst), accessor.config)
   const { bucket } = accessor.config
+  if (srcKey === dstKey) {
+    // POSIX rename(2): the same existing file succeeds and performs no
+    // other action. Reaching the copy+delete pair below would instead
+    // delete the object on any store that accepts the self-copy, and
+    // error on the ones that reject it (#150).
+    if (!(await exists(accessor, src))) throw enoent(src)
+    return
+  }
   await withClient(accessor.config, async (client) => {
     await client.send(
       new CopyObjectCommand({

--- a/typescript/packages/core/src/resource/base.ts
+++ b/typescript/packages/core/src/resource/base.ts
@@ -177,7 +177,7 @@ export abstract class BaseResource {
     this.#storageSeq ??= ++BaseResource.#storageCounter
     // The serial is what makes this unique; the class name only makes the
     // value readable when it shows up while debugging.
-    return `${this.constructor.name}:${this.#storageSeq}`
+    return `${this.constructor.name}:${String(this.#storageSeq)}`
   }
 
   // Default df capacity: UNKNOWN (rendered `-`). Backends that can report

--- a/typescript/packages/core/src/resource/base.ts
+++ b/typescript/packages/core/src/resource/base.ts
@@ -110,6 +110,11 @@ export interface Resource {
   // only where a truthful number exists (a real filesystem, or a provider
   // quota); never fabricate a total.
   statfs?(): Promise<CapacityResult>
+  // Identity of the storage behind this resource, so cp/mv can tell two
+  // prefixes over one store from two genuinely separate ones. Absent ->
+  // every mount is treated as its own storage, which only preserves the
+  // pre-existing behavior; see BaseResource.storageId.
+  storageId?(): string
   deltaHook?(): DeltaHook
 }
 
@@ -128,6 +133,10 @@ export function sizesAlwaysKnown(resource: Resource): boolean {
 export abstract class BaseResource {
   readonly indexTtl: number = 600
   protected _index?: IndexCacheStore
+  // JS has no object-identity primitive, so the default storageId hands
+  // each instance a serial number the first time it is asked.
+  static #storageCounter = 0
+  #storageSeq?: number
 
   get index(): IndexCacheStore {
     let store = this._index
@@ -153,6 +162,22 @@ export abstract class BaseResource {
     }
     const ttl = config === undefined ? this.indexTtl : (config.ttl ?? 600)
     return new RAMIndexCacheStore({ ttl })
+  }
+
+  // Identity of the storage this resource reads and writes. Two mounts
+  // whose resources return the same value address the same bytes, so a
+  // move between them must refuse rather than copy the object onto itself
+  // and then unlink the source. The default treats every instance as its
+  // own storage, which is the safe direction to be wrong in: a false
+  // "different" only keeps the pre-existing behavior, while a false "same"
+  // would refuse a legitimate move. Backends whose config pins the storage
+  // (a disk root, a bucket and key prefix) override this so two separately
+  // constructed instances pointing at one target still compare equal.
+  storageId(): string {
+    this.#storageSeq ??= ++BaseResource.#storageCounter
+    // The serial is what makes this unique; the class name only makes the
+    // value readable when it shows up while debugging.
+    return `${this.constructor.name}:${this.#storageSeq}`
   }
 
   // Default df capacity: UNKNOWN (rendered `-`). Backends that can report

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -37,6 +37,7 @@ import type { MountEntry } from '../mount/mount.ts'
 import type { Namespace } from '../mount/namespace/namespace.ts'
 import { mergeOverlayStat } from '../mount/namespace/overlay.ts'
 import { MountCommandUnsupported, type MountRegistry } from '../mount/registry.ts'
+import { makeStorageKey } from '../mount/storage.ts'
 import { Consumer, JOB_BUILTINS, route } from '../route/index.ts'
 import { VfsRuntime, type Runtime } from './runtime.ts'
 import type { PolicyDecision } from './policy/index.ts'
@@ -582,6 +583,7 @@ export async function handleCommand(
       runSingle,
       stdin,
       cmdStr,
+      makeStorageKey(registry),
     )
     if (csParsed[3].length > 0) {
       const csWarn = new TextEncoder().encode(csParsed[3].map((w) => `${cmdName}: ${w}\n`).join(''))

--- a/typescript/packages/core/src/workspace/executor/cross_mount.ts
+++ b/typescript/packages/core/src/workspace/executor/cross_mount.ts
@@ -40,6 +40,7 @@ export async function handleCrossMount(
   runSingle: RunSingle,
   stdin: ByteSource | null,
   cmdStr: string,
+  storageKey?: (path: PathSpec) => string,
 ): Promise<Result> {
   const [stdout, io] = await routeCrossMount(
     cmdName,
@@ -49,6 +50,7 @@ export async function handleCrossMount(
     dispatch,
     runSingle,
     stdin,
+    storageKey,
   )
   const stderrBytes = await materialize(io.stderr)
   const exec = new ExecutionNode({ command: cmdStr, stderr: stderrBytes, exitCode: io.exitCode })

--- a/typescript/packages/core/src/workspace/mount/storage.test.ts
+++ b/typescript/packages/core/src/workspace/mount/storage.test.ts
@@ -1,0 +1,112 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { BaseResource, type Resource } from '../../resource/base.ts'
+import { MountMode, PathSpec } from '../../types.ts'
+import { MountRegistry } from './registry.ts'
+import { makeStorageKey } from './storage.ts'
+
+class StoreResource extends BaseResource implements Resource {
+  readonly kind = 'ram'
+  open(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+// A resource pinned by config, the way disk/s3/redis are: two instances
+// naming one target must compare equal.
+class RootedResource extends BaseResource implements Resource {
+  readonly kind = 'disk'
+  constructor(readonly root: string) {
+    super()
+  }
+  override storageId(): string {
+    return `${this.kind}:${this.root}`
+  }
+  open(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+// Implements Resource without extending BaseResource, so it has no
+// storageId at all.
+class BareResource implements Resource {
+  readonly kind = 'bare'
+  open(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+const spec = (virtual: string): PathSpec =>
+  new PathSpec({
+    virtual,
+    directory: virtual.slice(0, virtual.lastIndexOf('/')) || '/',
+    resourcePath: virtual.replace(/^\/+/, ''),
+  })
+
+const keyFor = (mounts: Record<string, Resource>): ((p: PathSpec) => string) =>
+  makeStorageKey(new MountRegistry(mounts, MountMode.WRITE))
+
+describe('makeStorageKey', () => {
+  it('treats one resource at two prefixes as one storage (#154)', () => {
+    const shared = new StoreResource()
+    const key = keyFor({ '/m1': shared, '/m2': shared })
+    expect(key(spec('/m1/x.txt'))).toBe(key(spec('/m2/x.txt')))
+  })
+
+  it('keeps distinct resources distinct so a real move still works', () => {
+    const key = keyFor({ '/m1': new StoreResource(), '/m2': new StoreResource() })
+    expect(key(spec('/m1/x.txt'))).not.toBe(key(spec('/m2/x.txt')))
+  })
+
+  it('uses the config identity, so two instances on one root match', () => {
+    const key = keyFor({ '/d1': new RootedResource('/tmp/r'), '/d2': new RootedResource('/tmp/r') })
+    expect(key(spec('/d1/x.txt'))).toBe(key(spec('/d2/x.txt')))
+  })
+
+  it('keeps different roots separate', () => {
+    const key = keyFor({ '/d1': new RootedResource('/tmp/a'), '/d2': new RootedResource('/tmp/b') })
+    expect(key(spec('/d1/x.txt'))).not.toBe(key(spec('/d2/x.txt')))
+  })
+
+  it('keeps distinct paths in one storage distinct', () => {
+    const shared = new StoreResource()
+    const key = keyFor({ '/m1': shared, '/m2': shared })
+    expect(key(spec('/m1/x.txt'))).not.toBe(key(spec('/m2/other.txt')))
+  })
+
+  it('preserves the ancestor boundary cp/mv test with startsWith(key + "/")', () => {
+    const shared = new StoreResource()
+    const key = keyFor({ '/m1': shared, '/m2': shared })
+    expect(key(spec('/m2/dir/sub')).startsWith(`${key(spec('/m1/dir'))}/`)).toBe(true)
+    expect(key(spec('/m2/dirty')).startsWith(`${key(spec('/m1/dir'))}/`)).toBe(false)
+  })
+
+  it('falls back to the mount prefix when a resource declares no identity', () => {
+    // Two bare resources must stay distinct: without an identity the safe
+    // answer is "its own storage", never a false same-file refusal.
+    const key = keyFor({ '/b1': new BareResource(), '/b2': new BareResource() })
+    expect(key(spec('/b1/x.txt'))).not.toBe(key(spec('/b2/x.txt')))
+  })
+})

--- a/typescript/packages/core/src/workspace/mount/storage.test.ts
+++ b/typescript/packages/core/src/workspace/mount/storage.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from 'vitest'
 import { BaseResource, type Resource } from '../../resource/base.ts'
 import { MountMode, PathSpec } from '../../types.ts'
 import { MountRegistry } from './registry.ts'
-import { makeStorageKey } from './storage.ts'
+import { makeStorageKey, resourceStorageId } from './storage.ts'
 
 class StoreResource extends BaseResource implements Resource {
   readonly kind = 'ram'
@@ -103,10 +103,41 @@ describe('makeStorageKey', () => {
     expect(key(spec('/m2/dirty')).startsWith(`${key(spec('/m1/dir'))}/`)).toBe(false)
   })
 
-  it('falls back to the mount prefix when a resource declares no identity', () => {
-    // Two bare resources must stay distinct: without an identity the safe
-    // answer is "its own storage", never a false same-file refusal.
+  it('keeps distinct bare resources distinct', () => {
     const key = keyFor({ '/b1': new BareResource(), '/b2': new BareResource() })
     expect(key(spec('/b1/x.txt'))).not.toBe(key(spec('/b2/x.txt')))
+  })
+
+  it('gives one storageId-less object one identity across two prefixes', () => {
+    // Browser resources implement Resource directly and have no
+    // storageId. Keying on the mount prefix handed the same object two
+    // identities, so a self-move still relayed a write then an unlink.
+    const shared = new BareResource()
+    const key = keyFor({ '/b1': shared, '/b2': shared })
+    expect(key(spec('/b1/x.txt'))).toBe(key(spec('/b2/x.txt')))
+  })
+
+  it('resolves nested backings onto one key', () => {
+    // /a rooted at /srv/data and /b at /srv/data/sub make /a/sub/x and
+    // /b/x one file; separate key components kept them apart.
+    const key = keyFor({
+      '/a': new RootedResource('/srv/data'),
+      '/b': new RootedResource('/srv/data/sub'),
+    })
+    expect(key(spec('/a/sub/x.txt'))).toBe(key(spec('/b/x.txt')))
+  })
+
+  it('does not fuse roots that merely share a name prefix', () => {
+    const key = keyFor({
+      '/a': new RootedResource('/srv/data'),
+      '/b': new RootedResource('/srv/dataX'),
+    })
+    expect(key(spec('/a/y.txt'))).not.toBe(key(spec('/b/y.txt')))
+  })
+
+  it('resourceStorageId is stable per object', () => {
+    const bare = new BareResource()
+    expect(resourceStorageId(bare)).toBe(resourceStorageId(bare))
+    expect(resourceStorageId(bare)).not.toBe(resourceStorageId(new BareResource()))
   })
 })

--- a/typescript/packages/core/src/workspace/mount/storage.ts
+++ b/typescript/packages/core/src/workspace/mount/storage.ts
@@ -1,0 +1,53 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { PathSpec } from '../../types.ts'
+import { stripMount } from '../../utils/key_prefix.ts'
+import type { MountRegistry } from './registry.ts'
+
+/**
+ * Build the transfer generics' identity function for a mount set.
+ *
+ * `cp` and `mv` compare two operands to decide whether they name the same
+ * file. Within one mount the mount-relative path answers that, but across
+ * mounts it does not: two prefixes can address one store (two disk mounts
+ * on a shared root, one bucket mounted twice, the same resource object
+ * mounted at two prefixes), and there a move would copy an object over
+ * itself and then unlink the source. Pairing the resource's `storageId`
+ * with the mount-relative path makes the comparison about bytes rather
+ * than about spelling.
+ *
+ * The mount-relative path keeps its leading slash so the generics'
+ * `startsWith(key + '/')` containment test still marks a directory as an
+ * ancestor of its children, and only within one storage.
+ */
+export function makeStorageKey(registry: MountRegistry): (path: PathSpec) => string {
+  return (path: PathSpec): string => {
+    const entry = registry.mountFor(path.virtual)
+    if (entry === null) {
+      // Outside every mount there is no storage to name, so fall back to
+      // the path itself; such an operand fails on its own when the
+      // command tries to read it.
+      return path.virtual.replace(/\/+$/, '')
+    }
+    const rel = stripMount(path.virtual, entry.prefix.replace(/\/+$/, ''))
+    const trimmed = rel.replace(/\/+$/, '')
+    // A resource that declares no identity is treated as its own storage,
+    // keyed by the mount prefix. That only reproduces the pre-existing
+    // behavior, which is the safe direction: it can miss an alias, never
+    // refuse a legitimate move.
+    const id = entry.resource.storageId?.() ?? `mount:${entry.prefix}`
+    return `${id}:${trimmed === '' ? '/' : trimmed}`
+  }
+}

--- a/typescript/packages/core/src/workspace/mount/storage.ts
+++ b/typescript/packages/core/src/workspace/mount/storage.ts
@@ -14,6 +14,7 @@
 
 import type { PathSpec } from '../../types.ts'
 import { stripMount } from '../../utils/key_prefix.ts'
+import { rstripSlash } from '../../utils/slash.ts'
 import type { MountRegistry } from './registry.ts'
 
 /**
@@ -39,10 +40,10 @@ export function makeStorageKey(registry: MountRegistry): (path: PathSpec) => str
       // Outside every mount there is no storage to name, so fall back to
       // the path itself; such an operand fails on its own when the
       // command tries to read it.
-      return path.virtual.replace(/\/+$/, '')
+      return rstripSlash(path.virtual)
     }
-    const rel = stripMount(path.virtual, entry.prefix.replace(/\/+$/, ''))
-    const trimmed = rel.replace(/\/+$/, '')
+    const rel = stripMount(path.virtual, rstripSlash(entry.prefix))
+    const trimmed = rstripSlash(rel)
     // A resource that declares no identity is treated as its own storage,
     // keyed by the mount prefix. That only reproduces the pre-existing
     // behavior, which is the safe direction: it can miss an alias, never

--- a/typescript/packages/core/src/workspace/mount/storage.ts
+++ b/typescript/packages/core/src/workspace/mount/storage.ts
@@ -12,22 +12,45 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { Resource } from '../../resource/base.ts'
 import type { PathSpec } from '../../types.ts'
 import { stripMount } from '../../utils/key_prefix.ts'
 import { rstripSlash } from '../../utils/slash.ts'
 import type { MountRegistry } from './registry.ts'
+
+// Serial numbers for resources that declare no storageId, keyed on the
+// object so one instance mounted at two prefixes gets one identity.
+// Browser resources implement Resource directly instead of extending
+// BaseResource, so they have no storageId; keying on the mount prefix
+// would hand one object two identities and let a self-move through.
+const OBJECT_IDS = new WeakMap<Resource, number>()
+let objectIdCounter = 0
+
+export function resourceStorageId(resource: Resource): string {
+  const declared = resource.storageId?.()
+  if (declared !== undefined) return declared
+  let serial = OBJECT_IDS.get(resource)
+  if (serial === undefined) {
+    serial = ++objectIdCounter
+    OBJECT_IDS.set(resource, serial)
+  }
+  return `resource:${String(serial)}`
+}
 
 /**
  * Build the transfer generics' identity function for a mount set.
  *
  * `cp` and `mv` compare two operands to decide whether they name the same
  * file. Within one mount the mount-relative path answers that, but across
- * mounts it does not: two prefixes can address one store (two disk mounts
- * on a shared root, one bucket mounted twice, the same resource object
- * mounted at two prefixes), and there a move would copy an object over
- * itself and then unlink the source. Pairing the resource's `storageId`
- * with the mount-relative path makes the comparison about bytes rather
- * than about spelling.
+ * mounts it does not: two prefixes can address one store, and there a move
+ * would copy an object over itself and then unlink the source.
+ *
+ * The resource's storage id and the mount-relative path are joined into
+ * one path-like string rather than kept as separate components, so nested
+ * backings collapse onto the same key. Two disk mounts rooted at
+ * `/srv/data` and `/srv/data/sub` make `/a/sub/x` and `/b/x` the same
+ * file, and both render as `disk:/srv/data/sub/x`. A delimiter between
+ * the two parts would keep them apart and let the move through.
  *
  * The mount-relative path keeps its leading slash so the generics'
  * `startsWith(key + '/')` containment test still marks a directory as an
@@ -42,13 +65,7 @@ export function makeStorageKey(registry: MountRegistry): (path: PathSpec) => str
       // command tries to read it.
       return rstripSlash(path.virtual)
     }
-    const rel = stripMount(path.virtual, rstripSlash(entry.prefix))
-    const trimmed = rstripSlash(rel)
-    // A resource that declares no identity is treated as its own storage,
-    // keyed by the mount prefix. That only reproduces the pre-existing
-    // behavior, which is the safe direction: it can miss an alias, never
-    // refuse a legitimate move.
-    const id = entry.resource.storageId?.() ?? `mount:${entry.prefix}`
-    return `${id}:${trimmed === '' ? '/' : trimmed}`
+    const rel = rstripSlash(stripMount(path.virtual, rstripSlash(entry.prefix)))
+    return resourceStorageId(entry.resource) + rel
   }
 }

--- a/typescript/packages/node/src/resource/disk/disk.ts
+++ b/typescript/packages/node/src/resource/disk/disk.ts
@@ -120,6 +120,12 @@ export class DiskResource extends BaseResource implements Resource {
     this.accessor = new DiskAccessor(this.root)
   }
 
+  // The resolved root is the storage: two DiskResources built on the same
+  // directory are one store, however they were spelled.
+  override storageId(): string {
+    return `${this.kind}:${this.root}`
+  }
+
   async open(): Promise<void> {
     await mkdir(this.root, { recursive: true })
   }

--- a/typescript/packages/node/src/resource/redis/redis.ts
+++ b/typescript/packages/node/src/resource/redis/redis.ts
@@ -25,6 +25,7 @@ import {
   type RegisteredCommand,
   type RegisteredOp,
   type Resource,
+  stripSlash,
 } from '@struktoai/mirage-core'
 import { REDIS_COMMANDS } from '../../commands/builtin/redis/index.ts'
 import type { RedisClientType } from 'redis'
@@ -118,9 +119,12 @@ export class RedisResource extends BaseResource implements Resource {
   }
 
   // The server URL (host, port and db) plus the key prefix pin the keyspace
-  // two mounts would share.
+  // two mounts would share. The prefix is joined path-like so nested
+  // prefixes collapse onto one key.
   override storageId(): string {
-    return `${this.kind}:${this.url}:${this.keyPrefix}`
+    const prefix = stripSlash(this.keyPrefix)
+    const base = `${this.kind}:${this.url}`
+    return prefix === '' ? base : `${base}/${prefix}`
   }
 
   async open(): Promise<void> {

--- a/typescript/packages/node/src/resource/redis/redis.ts
+++ b/typescript/packages/node/src/resource/redis/redis.ts
@@ -117,6 +117,12 @@ export class RedisResource extends BaseResource implements Resource {
     this.accessor = new RedisAccessor(this.store)
   }
 
+  // The server URL (host, port and db) plus the key prefix pin the keyspace
+  // two mounts would share.
+  override storageId(): string {
+    return `${this.kind}:${this.url}:${this.keyPrefix}`
+  }
+
   async open(): Promise<void> {
     await this.store.client()
   }

--- a/typescript/packages/node/src/resource/s3/s3.ts
+++ b/typescript/packages/node/src/resource/s3/s3.ts
@@ -115,6 +115,14 @@ export class S3Resource extends BaseResource implements Resource {
     })
   }
 
+  // Endpoint, bucket and key prefix pin the object namespace. The endpoint
+  // matters because the same bucket name on two providers (AWS vs MinIO vs
+  // R2) is two different stores.
+  override storageId(): string {
+    const cfg = this.config
+    return `${this.kind}:${cfg.endpoint ?? 'aws'}:${cfg.bucket}:${cfg.keyPrefix ?? ''}`
+  }
+
   open(): Promise<void> {
     return Promise.resolve()
   }

--- a/typescript/packages/node/src/resource/s3/s3.ts
+++ b/typescript/packages/node/src/resource/s3/s3.ts
@@ -49,6 +49,7 @@ import {
   type Resource,
   unlink as unlinkCore,
   write as writeCore,
+  stripSlash,
 } from '@struktoai/mirage-core'
 import { HttpProxyAgent } from 'http-proxy-agent'
 import { HttpsProxyAgent } from 'https-proxy-agent'
@@ -117,10 +118,14 @@ export class S3Resource extends BaseResource implements Resource {
 
   // Endpoint, bucket and key prefix pin the object namespace. The endpoint
   // matters because the same bucket name on two providers (AWS vs MinIO vs
-  // R2) is two different stores.
+  // R2) is two different stores. The prefix joins path-like so two mounts
+  // whose prefixes nest still resolve to one key once the mount-relative
+  // path is appended.
   override storageId(): string {
     const cfg = this.config
-    return `${this.kind}:${cfg.endpoint ?? 'aws'}:${cfg.bucket}:${cfg.keyPrefix ?? ''}`
+    const prefix = stripSlash(cfg.keyPrefix ?? '')
+    const base = `${this.kind}:${cfg.endpoint ?? 'aws'}:${cfg.bucket}`
+    return prefix === '' ? base : `${base}/${prefix}`
   }
 
   open(): Promise<void> {


### PR DESCRIPTION
Closes #272. Closes #154. Closes #150.

Three transfer-command guards that all come down to the same question: do two operands name the same bytes, and what does `mv` owe you when the destination already exists?

## #272: the non-empty-directory refusal was gated on `-T`

The refusal existed but only fired under `--no-target-dir`, so the ordinary spelling merged the trees and exited 0:

```
$ mv /m1/src /m2/dest/          # /m2/dest/src exists, non-empty
exit 0, trees merged
```

GNU refuses whether the target was named outright or mapped under an existing destination directory. Dropping the gate also required moving the check **after** the clobber gate, because GNU lets `-n` skip such a target silently at exit 0 while the old ordering turned that into an error. Pinned against coreutils 9.7 in `debian:stable-slim`, all seven arms:

| command | GNU |
|---|---|
| `mv src dest/` | `cannot overwrite 'dest/src': Directory not empty`, exit 1 |
| `mv -T src dest/src` | same |
| `mv -f src dest/` | same (`-f` does not bypass) |
| `mv -n src dest/` | exit 0, skipped |
| `mv -n -T src dest/src` | exit 0, skipped |
| `mv src dest/` (empty target) | exit 0, moves |
| `cp -r src dest/` | exit 0, still merges |

The exact wording is `cannot overwrite`, not the `cannot move ... to ...` the issue predicted. `-b` keeps working through `backup_displaces`, which renames the target aside before the refusal can apply.

Fixing the ordering also fixed an unreported divergence: `mv -n -T` onto a non-empty target used to error where GNU exits 0.

## #154: cross-mount `mv` destroyed the file when two mounts aliased one store

Reproduced on main:

```
$ mv /m1/x.txt /m2/x.txt     exit 0
$ cat /m2/x.txt              cat: /m2/x.txt: No such file or directory
$ find /m1                   /m1
```

Cross-mount routing keys off the mount prefix alone, so two prefixes over one store (two disk mounts on a shared root, one bucket mounted twice, the same resource object mounted twice) looked like a genuine cross-mount move. `mv` then did read → write → unlink, writing the object over itself and deleting it.

The generic `cp`/`mv` already had a same-file guard and a `backend_key` hook for it, but nothing injected a key, and the default is the mount-relative path, which carries no mount identity. Resources now answer `storage_id()` / `storageId()`; `make_storage_key` pairs it with the mount-relative path and the executor threads it through route → relay → cp/mv.

The default is per-instance identity, so a backend that says nothing keeps today's behavior. That is the safe direction to be wrong in: a false "different" only fails to catch an alias, while a false "same" would refuse a legitimate move. `disk` (resolved root), `s3` (endpoint, bucket, key prefix) and `redis` (url, key prefix) override it so two separately constructed instances over one target still compare equal.

Verified that genuine work is untouched: distinct stores sharing a basename, distinct paths within one store, and two ram mounts all still move normally.

## #150: same-key `copy`/`rename` in the s3 core

`core.rename` was `copy_object` + an unconditional `delete_object`, and `core.copy` a plain `copy_object`, neither checking whether the resolved keys were equal. Both now follow POSIX `rename(2)` for that case — succeed and perform no other action, with a missing source still raising ENOENT.

**This corrects the issue's premise.** #150 says the bug is masked "only by AWS's own behavior" and names MinIO among stores that may permit the self-copy. Probing a real MinIO:

- a plain self-copy is **rejected**, versioned or not (`InvalidRequest`), exactly like AWS. The data loss is not reachable there today.
- but the self-copy **is** accepted once the request carries `MetadataDirective=REPLACE`, and the delete then removes the object. On a versioned bucket the old version survives behind a delete marker; on a plain bucket it is gone.

So this is safety-by-construction rather than a live loss: today's safety is an accident of the remote's validation, and one plausible change (preserving content-type on rename, say) turns it into real data loss.

## On verifying #150

A "does the file survive?" test passes on the **unfixed** code, because the remote's rejection already saves it — it cannot tell fixed from broken. The discriminating assertion is that no write was issued at all.

The python s3 mock's `copy_object` is deliberately lenient, which is what makes the guard observable; it now counts `copy_object`/`delete_object` so the test asserts zero writes rather than mere survival. Confirmed discriminating: disabling the guard fails four of the seven, one of them literally on an emptied store (`assert {} == {'pre/a.txt': b'precious'}`).

## integ

Two `overwrite` cases for #272, on the seed that already builds the shape.

For #154 the harness could not express the shape at all — every builder allocates fresh storage, so no two mounts could address one store. A mount may now carry `alias_of` naming an already-built mount, honored by both runners (snake_case, matching the existing `seed_root`). The new `ram-alias` target mounts one `RAMResource` at `/data` and `/alias`, and `alias_both_prefixes_see_one_store` proves the aliasing is real before the guard cases assert anything.

## Verification

- integ, `ram` + `disk` + `ram-alias`, rebased: **4069 passed / 0 failed** on the python host and on typescript-node, with all 12 new case-executions green on both
- typescript: core 5822 passed, node 2009 passed; `tsc --noEmit` clean across core, browser and node
- spec drift none after running both generators; spec parity 93/93
- pre-commit exit 0, tree stable across two runs

Not covered here: `core.copy`/`core.rename` are only reachable programmatically for an equal-key operand, since the generic catches `mv a a` at the command layer. That half is unit-tested rather than integ-tested, deliberately.
