### PR TITLE
feat(spec): mirror argparse: aliases, long-option abbreviation, typed int values

### DIFF
--- a/python/mirage/commands/cli/compile.py
+++ b/python/mirage/commands/cli/compile.py
@@ -38,6 +38,10 @@ def validate_cli(node: "CLISpec") -> None:
     if not node.name or any(ch.isspace() for ch in node.name):
         raise ValueError(
             f"cli name {node.name!r} must be a single non-empty word")
+    for alias in node.aliases:
+        if not alias or any(ch.isspace() for ch in alias):
+            raise ValueError(f"cli {node.name!r}: alias {alias!r} must be "
+                             f"a single non-empty word")
     if node.fn is not None and node.subcommands:
         raise ValueError(
             f"cli {node.name!r}: a node takes fn or subcommands, not both")
@@ -47,12 +51,15 @@ def validate_cli(node: "CLISpec") -> None:
         raise ValueError(
             f"cli {node.name!r}: a group's operand is its subcommand "
             f"word; positional/rest belong on leaves")
+    # Names and aliases share one sibling namespace (argparse refuses a
+    # conflicting subparser alias the same way).
     seen: set[str] = set()
     for child in node.subcommands:
-        if child.name in seen:
-            raise ValueError(f"cli {node.name!r}: duplicate subcommand "
-                             f"{child.name!r}")
-        seen.add(child.name)
+        for word in (child.name, ) + child.aliases:
+            if word in seen:
+                raise ValueError(f"cli {node.name!r}: duplicate subcommand "
+                                 f"{word!r}")
+            seen.add(word)
         if child.config_model is not None:
             raise ValueError(
                 f"cli {node.name!r}: subcommand {child.name!r} declares "

--- a/python/mirage/commands/cli/types.py
+++ b/python/mirage/commands/cli/types.py
@@ -47,6 +47,13 @@ class CLISpec(CommandSpec):
     Args:
         name (str): the word at this level: argparse's ``prog`` for a
             root, ``add_parser`` name for a subcommand.
+        aliases (tuple[str, ...]): alternate words that resolve to this
+            subcommand (argparse ``add_parser(..., aliases=[...])``).
+            Rendered as ``name (alias, ...)`` in the parent's Commands
+            listing; the walk records the canonical ``name`` in its
+            path, so help and errors attribute to the canonical word
+            (argparse prog semantics). Inert on a root: the installed
+            head word is the only way in.
         fn (Callable | None): leaf handler (argparse
             ``set_defaults(func=...)``), called as
             ``fn(config, paths, *texts, **flags)`` where ``config`` is the
@@ -64,6 +71,7 @@ class CLISpec(CommandSpec):
             ``register_cli``; also the redaction schema for snapshots.
     """
     name: str = ""
+    aliases: tuple[str, ...] = ()
     fn: Callable[..., Any] | None = None
     subcommands: tuple["CLISpec", ...] = ()
     write: bool = False
@@ -87,8 +95,9 @@ class WalkResult:
     Args:
         leaf (CLISpec | None): resolved verb node, None for a rendered
             outcome.
-        path (tuple[str, ...]): words consumed below the head, including
-            the leaf name.
+        path (tuple[str, ...]): canonical subcommand names consumed below
+            the head, including the leaf name (an alias records the name
+            it resolves to, argparse prog semantics).
         group_flags (dict): flags consumed at group levels, keyed by
             canonical dashed spelling like ParsedArgs.flags.
         argv (tuple[str, ...]): remaining tokens for the leaf's spec.

--- a/python/mirage/commands/cli/walk.py
+++ b/python/mirage/commands/cli/walk.py
@@ -18,8 +18,21 @@ from dataclasses import replace
 from mirage.commands.cli.constants import USAGE_EXIT
 from mirage.commands.cli.types import CLISpec, FlagBag, WalkResult
 from mirage.commands.config import HELP_OPTION
-from mirage.commands.spec.compile import CompiledSpec, compile_spec
+from mirage.commands.spec.compile import (CompiledSpec, compile_spec,
+                                          expand_long)
+from mirage.commands.spec.constants import INT_VALUE
 from mirage.commands.spec.help import render_help
+
+
+def _verb_display(child: CLISpec) -> str:
+    """A subcommand's row label: ``name (alias, ...)`` like argparse.
+
+    Args:
+        child (CLISpec): the subcommand node.
+    """
+    if child.aliases:
+        return f"{child.name} ({', '.join(child.aliases)})"
+    return child.name
 
 
 def node_help(name: str, node: CLISpec) -> str:
@@ -36,7 +49,7 @@ def node_help(name: str, node: CLISpec) -> str:
             renders its own spelling.
         node (CLISpec): the group node.
     """
-    rows = [(child.name, child.description or "")
+    rows = [(_verb_display(child), child.description or "")
             for child in node.subcommands]
     # --help is a registered option everywhere (argparse add_help, click
     # add_help_option, withHelpSupport for leaves), so the listing shows
@@ -156,6 +169,28 @@ def _match_short(
     return None
 
 
+def _expand_group_long(node: CLISpec, cs: CompiledSpec,
+                       spelling: str) -> tuple[str, ...]:
+    """Prefix-expand a long spelling at a group level.
+
+    The declared tables match first; the injected ``--help`` joins the
+    candidate pool when the node does not declare its own, because it is
+    a registered option everywhere else (argparse and getopt_long both
+    expand ``--hel`` to it).
+
+    Args:
+        node (CLISpec): the group node being parsed.
+        cs (CompiledSpec): the node's compiled tables.
+        spelling (str): the typed long spelling, without any ``=value``.
+    """
+    candidates = expand_long(cs, spelling)
+    if ("--help".startswith(spelling) and len(spelling) > 2
+            and "--help" not in candidates
+            and not any(option.long == "--help" for option in node.options)):
+        candidates = candidates + ("--help", )
+    return candidates
+
+
 def _finish_node(name: str, node: CLISpec, cs: CompiledSpec,
                  flags: FlagBag) -> WalkResult | None:
     """Apply a node's declarative option rules after its scan.
@@ -176,6 +211,17 @@ def _finish_node(name: str, node: CLISpec, cs: CompiledSpec,
                 flags[dest] = [default]
             else:
                 flags[dest] = default
+    # Int-typed values before choices, argparse's order; wording is
+    # git's parse-options refusal (`--depth` on a non-integer).
+    for dest in cs.int_dests:
+        value = flags.get(dest)
+        candidates = value if isinstance(
+            value, list) else ([value] if isinstance(value, str) else [])
+        for part in candidates:
+            if not INT_VALUE.match(part):
+                return _usage_error(
+                    name, node,
+                    f"error: option '{dest}' expects a numerical value")
     for dest, allowed in cs.choices_by_dest.items():
         value = flags.get(dest)
         candidates = value if isinstance(
@@ -232,6 +278,19 @@ def walk(head: str, spec: CLISpec, argv: Sequence[str]) -> WalkResult:
                 continue
             if not options_ended and token.startswith("--"):
                 spelling, eq, attached = token.partition("=")
+                # getopt_long: an exact spelling wins; otherwise a unique
+                # prefix expands (git status --porcel) and an ambiguous
+                # one is refused with every possibility (git wording).
+                if spelling not in cs.dest and spelling != "--help":
+                    candidates = _expand_group_long(node, cs, spelling)
+                    if len(candidates) == 1:
+                        spelling = candidates[0]
+                    elif len(candidates) > 1:
+                        possible = " or ".join(candidates)
+                        return _usage_error(
+                            name, node,
+                            f"error: ambiguous option: {spelling[2:]} "
+                            f"(could be {possible})")
                 # Optional-value longs sit in BOTH long_bool_spellings and
                 # long_optional_spellings, so the optional test runs first
                 # or --color=auto would be refused as taking no value.
@@ -308,12 +367,15 @@ def walk(head: str, spec: CLISpec, argv: Sequence[str]) -> WalkResult:
             refused = _finish_node(name, node, cs, flags)
             if refused is not None:
                 return refused
-            child = next((c for c in node.subcommands if c.name == token),
-                         None)
+            # An alias resolves to its canonical node; the path records
+            # the canonical name (argparse prog attribution: errors under
+            # `gws co` render as `gws checkout`).
+            child = next((c for c in node.subcommands
+                          if token == c.name or token in c.aliases), None)
             if child is None:
                 return _unknown_verb(head, name, token)
             node = child
-            path = path + (token, )
+            path = path + (child.name, )
             i += 1
             descended = True
             break

--- a/python/mirage/commands/spec/compile.py
+++ b/python/mirage/commands/spec/compile.py
@@ -57,6 +57,10 @@ class CompiledSpec:
         long_spellings (tuple[str, ...]): every long spelling in
             declaration order (the order GNU's ambiguity refusal lists
             possibilities), for getopt_long prefix expansion.
+        long_signatures (dict[str, str]): behavior signature per long
+            spelling. Prefix candidates whose signatures all match are
+            one option in glibc's eyes (same action struct), so the
+            prefix resolves instead of refusing as ambiguous.
         int_dests (frozenset[str]): canonical spellings of int-typed
             options; the parser refuses a non-integer value at parse
             time (argparse ``type=int``).
@@ -80,6 +84,7 @@ class CompiledSpec:
     long_value_spellings: frozenset[str] = frozenset()
     long_optional_spellings: frozenset[str] = frozenset()
     long_spellings: tuple[str, ...] = ()
+    long_signatures: dict[str, str] = field(default_factory=dict)
     int_dests: frozenset[str] = frozenset()
     kind_of: dict[str, OperandKind] = field(default_factory=dict)
     kind_by_dest: dict[str, OperandKind] = field(default_factory=dict)
@@ -106,12 +111,14 @@ def expand_long(cs: CompiledSpec, spelling: str) -> tuple[str, ...]:
 
     An exact declared spelling always wins (GNU: ``--binary`` never
     trips over ``--binary-files``); otherwise the candidates are every
-    declared long the typed spelling prefixes, deduped by dest because
-    glibc treats several spellings of one option as unambiguous
-    (``grep --colo`` resolves despite ``--color``/``--colour``). The
-    result length tells the caller everything: 0 unknown, 1 match, 2+
-    ambiguous (candidates in declaration order, the order GNU lists
-    possibilities).
+    declared long the typed spelling prefixes. Candidates whose behavior
+    signatures all match count as one option, the way glibc treats
+    several table entries with one action struct (``grep --colo``
+    resolves despite ``--color``/``--colour`` being separate entries),
+    and the prefix resolves to the first. The result length tells the
+    caller everything: 0 unknown, 1 match, 2+ ambiguous (every matching
+    spelling in declaration order, the order GNU lists possibilities,
+    synonyms included like GNU's own listing).
 
     Args:
         cs (CompiledSpec): compiled tables to match against.
@@ -121,15 +128,14 @@ def expand_long(cs: CompiledSpec, spelling: str) -> tuple[str, ...]:
         return (spelling, )
     if len(spelling) <= 2:
         return ()
-    matches: list[str] = []
-    seen: set[str] = set()
-    for declared in cs.long_spellings:
-        if declared.startswith(spelling):
-            dest = cs.dest_of(declared)
-            if dest not in seen:
-                seen.add(dest)
-                matches.append(declared)
-    return tuple(matches)
+    matches = tuple(declared for declared in cs.long_spellings
+                    if declared.startswith(spelling))
+    if not matches:
+        return ()
+    signatures = {cs.long_signatures[declared] for declared in matches}
+    if len(signatures) == 1:
+        return (matches[0], )
+    return matches
 
 
 @lru_cache(maxsize=512)
@@ -146,6 +152,7 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
     long_value_spellings: set[str] = set()
     long_optional_spellings: set[str] = set()
     long_spellings: list[str] = []
+    long_signatures: dict[str, str] = {}
     int_dests: set[str] = set()
     kind_of: dict[str, OperandKind] = {}
     kind_by_dest: dict[str, OperandKind] = {}
@@ -214,6 +221,12 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
                     numeric_dest = canonical
         if opt.long:
             long_spellings.append(opt.long)
+            # Everything parsing-relevant except the spellings and the
+            # help text: two options that agree here are one action.
+            long_signatures[opt.long] = "|".join(
+                (opt.value_kind.value, str(opt.value_optional),
+                 str(opt.multiple), str(opt.count), ",".join(opt.choices),
+                 str(opt.required), str(opt.default), opt.type))
             if opt.value_kind == OperandKind.NONE:
                 long_bool_spellings.add(opt.long)
             elif opt.value_optional:
@@ -239,6 +252,7 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
         long_value_spellings=frozenset(long_value_spellings),
         long_optional_spellings=frozenset(long_optional_spellings),
         long_spellings=tuple(long_spellings),
+        long_signatures=long_signatures,
         int_dests=frozenset(int_dests),
         kind_of=kind_of,
         kind_by_dest=kind_by_dest,

--- a/python/mirage/commands/spec/compile.py
+++ b/python/mirage/commands/spec/compile.py
@@ -15,6 +15,7 @@
 from dataclasses import dataclass, field
 from functools import lru_cache
 
+from mirage.commands.spec.constants import INT_VALUE
 from mirage.commands.spec.types import CommandSpec, OperandKind
 
 
@@ -53,6 +54,12 @@ class CompiledSpec:
         count_dests (frozenset[str]): canonical spellings of boolean
             flags whose occurrences accumulate into an int (click count,
             ``-vvv``).
+        long_spellings (tuple[str, ...]): every long spelling in
+            declaration order (the order GNU's ambiguity refusal lists
+            possibilities), for getopt_long prefix expansion.
+        int_dests (frozenset[str]): canonical spellings of int-typed
+            options; the parser refuses a non-integer value at parse
+            time (argparse ``type=int``).
         choices_by_dest (dict[str, tuple[str, ...]]): allowed values per
             canonical spelling, in declaration order (the order GNU's
             ARGMATCH refusal lists them).
@@ -72,6 +79,8 @@ class CompiledSpec:
     long_bool_spellings: frozenset[str] = frozenset()
     long_value_spellings: frozenset[str] = frozenset()
     long_optional_spellings: frozenset[str] = frozenset()
+    long_spellings: tuple[str, ...] = ()
+    int_dests: frozenset[str] = frozenset()
     kind_of: dict[str, OperandKind] = field(default_factory=dict)
     kind_by_dest: dict[str, OperandKind] = field(default_factory=dict)
     dest: dict[str, str] = field(default_factory=dict)
@@ -92,6 +101,37 @@ class CompiledSpec:
         return self.dest.get(spelling, spelling)
 
 
+def expand_long(cs: CompiledSpec, spelling: str) -> tuple[str, ...]:
+    """getopt_long prefix matching for a long spelling.
+
+    An exact declared spelling always wins (GNU: ``--binary`` never
+    trips over ``--binary-files``); otherwise the candidates are every
+    declared long the typed spelling prefixes, deduped by dest because
+    glibc treats several spellings of one option as unambiguous
+    (``grep --colo`` resolves despite ``--color``/``--colour``). The
+    result length tells the caller everything: 0 unknown, 1 match, 2+
+    ambiguous (candidates in declaration order, the order GNU lists
+    possibilities).
+
+    Args:
+        cs (CompiledSpec): compiled tables to match against.
+        spelling (str): the typed long spelling, without any ``=value``.
+    """
+    if spelling in cs.dest:
+        return (spelling, )
+    if len(spelling) <= 2:
+        return ()
+    matches: list[str] = []
+    seen: set[str] = set()
+    for declared in cs.long_spellings:
+        if declared.startswith(spelling):
+            dest = cs.dest_of(declared)
+            if dest not in seen:
+                seen.add(dest)
+                matches.append(declared)
+    return tuple(matches)
+
+
 @lru_cache(maxsize=512)
 def compile_spec(spec: CommandSpec) -> CompiledSpec:
     """Lower a CommandSpec into parser lookup tables.
@@ -105,6 +145,8 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
     long_bool_spellings: set[str] = set()
     long_value_spellings: set[str] = set()
     long_optional_spellings: set[str] = set()
+    long_spellings: list[str] = []
+    int_dests: set[str] = set()
     kind_of: dict[str, OperandKind] = {}
     kind_by_dest: dict[str, OperandKind] = {}
     dest: dict[str, str] = {}
@@ -130,6 +172,14 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
                 and opt.default not in opt.choices):
             raise ValueError(f"option {canonical!r}: default "
                              f"{opt.default!r} is not one of its choices")
+        if opt.type == "int":
+            if opt.value_kind == OperandKind.NONE:
+                raise ValueError(f"option {canonical!r}: type 'int' "
+                                 "requires a value flag")
+            if opt.default is not None and not INT_VALUE.match(opt.default):
+                raise ValueError(f"option {canonical!r}: default "
+                                 f"{opt.default!r} is not an integer")
+            int_dests.add(canonical)
         if opt.short:
             dest[opt.short] = canonical
         if opt.long:
@@ -163,6 +213,7 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
                 if opt.numeric_shorthand:
                     numeric_dest = canonical
         if opt.long:
+            long_spellings.append(opt.long)
             if opt.value_kind == OperandKind.NONE:
                 long_bool_spellings.add(opt.long)
             elif opt.value_optional:
@@ -187,6 +238,8 @@ def compile_spec(spec: CommandSpec) -> CompiledSpec:
         long_bool_spellings=frozenset(long_bool_spellings),
         long_value_spellings=frozenset(long_value_spellings),
         long_optional_spellings=frozenset(long_optional_spellings),
+        long_spellings=tuple(long_spellings),
+        int_dests=frozenset(int_dests),
         kind_of=kind_of,
         kind_by_dest=kind_by_dest,
         dest=dest,

--- a/python/mirage/commands/spec/constants.py
+++ b/python/mirage/commands/spec/constants.py
@@ -20,6 +20,11 @@ AMBIGUOUS_NAMES = {"l": "args_l", "O": "args_O", "I": "args_I", "1": "args_1"}
 # cluster or a path.
 NUMERIC_SHORT = re.compile(r"^-\d+$")
 
+# Value shape accepted by an int-typed option: optional sign plus digits,
+# the portable core of Python int() and argparse (no whitespace, no
+# underscores, so both languages accept exactly the same strings).
+INT_VALUE = re.compile(r"^[+-]?\d+$")
+
 # GNU usage-error exit codes, pinned against debian coreutils/grep/diffutils
 # (plus ripgrep and jq upstream docs). Everything else exits 1. Keys are
 # plain strings, not CommandName members: types.py (the enum's home)

--- a/python/mirage/commands/spec/parser.py
+++ b/python/mirage/commands/spec/parser.py
@@ -145,6 +145,7 @@ def parse_command(
     warnings: list[str] = []
     invalid_options: list[str] = []
     ambiguous_options: list[tuple[str, tuple[str, ...]]] = []
+    option_error_kinds: list[str] = []
     needs_value_options: list[str] = []
     # Free-text commands (echo/python/bash-style TEXT rest) keep unknown
     # dash tokens verbatim; elsewhere they are dropped with a warning so a
@@ -182,6 +183,7 @@ def parse_command(
                     spelling = expansions[0]
                 elif len(expansions) > 1:
                     ambiguous_options.append((typed, expansions))
+                    option_error_kinds.append("ambiguous")
                     i += 1
                     continue
             etok = spelling if eq == -1 else spelling + tok[eq:]
@@ -205,6 +207,7 @@ def parse_command(
                     raw_indices.append(orig_indices[i])
                 else:
                     invalid_options.append(tok)
+                    option_error_kinds.append("invalid")
                 i += 1
             continue
 
@@ -293,6 +296,7 @@ def parse_command(
                         bad = ch
                         break
                 invalid_options.append(bad)
+                option_error_kinds.append("invalid")
             i += 1
             continue
 
@@ -399,6 +403,7 @@ def parse_command(
         word_kinds=word_kinds,
         invalid_options=invalid_options,
         ambiguous_options=ambiguous_options,
+        option_error_kinds=option_error_kinds,
         needs_value_options=needs_value_options,
         invalid_value_options=invalid_value_options,
         invalid_int_options=invalid_int_options,

--- a/python/mirage/commands/spec/parser.py
+++ b/python/mirage/commands/spec/parser.py
@@ -12,8 +12,10 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.commands.spec.compile import CompiledSpec, compile_spec
-from mirage.commands.spec.constants import NUMERIC_SHORT, flag_kwarg_name
+from mirage.commands.spec.compile import (CompiledSpec, compile_spec,
+                                          expand_long)
+from mirage.commands.spec.constants import (INT_VALUE, NUMERIC_SHORT,
+                                            flag_kwarg_name)
 from mirage.commands.spec.types import CommandSpec, OperandKind, ParsedArgs
 from mirage.utils.path import resolve_path
 
@@ -142,6 +144,7 @@ def parse_command(
     word_kinds: list[OperandKind | None] = [None] * len(argv)
     warnings: list[str] = []
     invalid_options: list[str] = []
+    ambiguous_options: list[tuple[str, tuple[str, ...]]] = []
     needs_value_options: list[str] = []
     # Free-text commands (echo/python/bash-style TEXT rest) keep unknown
     # dash tokens verbatim; elsewhere they are dropped with a warning so a
@@ -165,22 +168,38 @@ def parse_command(
             continue
 
         if tok.startswith("--"):
-            if tok in cs.long_bool_spellings:
-                _set_bool_flag(flags, cs, tok)
+            # getopt_long: an exact spelling always wins; otherwise an
+            # unambiguous prefix expands to its declared spelling
+            # (grep --rec) and an ambiguous one is refused with every
+            # possibility. Free-text commands keep exact-only matching:
+            # their unknown dash tokens are operands, not typos.
+            eq = tok.find("=")
+            typed = tok if eq == -1 else tok[:eq]
+            spelling = typed
+            if typed not in cs.dest and not lenient_dash_operands:
+                expansions = expand_long(cs, typed)
+                if len(expansions) == 1:
+                    spelling = expansions[0]
+                elif len(expansions) > 1:
+                    ambiguous_options.append((typed, expansions))
+                    i += 1
+                    continue
+            etok = spelling if eq == -1 else spelling + tok[eq:]
+            if etok in cs.long_bool_spellings:
+                _set_bool_flag(flags, cs, etok)
                 i += 1
-            elif (tok in cs.long_value_spellings
+            elif (etok in cs.long_value_spellings
                   and i + 1 < len(filtered_argv)):
-                _set_value_flag(flags, cs, tok, filtered_argv[i + 1])
-                word_kinds[orig_indices[i + 1]] = cs.kind_of[tok]
+                _set_value_flag(flags, cs, etok, filtered_argv[i + 1])
+                word_kinds[orig_indices[i + 1]] = cs.kind_of[etok]
                 i += 2
             else:
-                eq = tok.find("=")
-                if eq != -1 and (tok[:eq] in cs.long_value_spellings
-                                 or tok[:eq] in cs.long_optional_spellings):
-                    _set_value_flag(flags, cs, tok[:eq], tok[eq + 1:])
-                elif tok in cs.long_value_spellings:
+                if eq != -1 and (spelling in cs.long_value_spellings
+                                 or spelling in cs.long_optional_spellings):
+                    _set_value_flag(flags, cs, spelling, tok[eq + 1:])
+                elif etok in cs.long_value_spellings:
                     # Declared value flag at end of line with no argument.
-                    needs_value_options.append(tok)
+                    needs_value_options.append(etok)
                 elif lenient_dash_operands:
                     raw_args.append(tok)
                     raw_indices.append(orig_indices[i])
@@ -292,6 +311,18 @@ def parse_command(
             else:
                 flags[dest_name] = default
 
+    # Int-typed values are refused before choices, argparse's order
+    # (type conversion runs before the choices test). The bare boolean
+    # form of an optional-value flag is exempt, like choices.
+    invalid_int_options: list[tuple[str, str]] = []
+    for dest_name in cs.int_dests:
+        value = flags.get(dest_name)
+        candidates = value if isinstance(
+            value, list) else ([value] if isinstance(value, str) else [])
+        for part in candidates:
+            if not INT_VALUE.match(part):
+                invalid_int_options.append((dest_name, part))
+
     invalid_value_options: list[tuple[str, str, tuple[str, ...]]] = []
     for dest_name, allowed in cs.choices_by_dest.items():
         value = flags.get(dest_name)
@@ -367,8 +398,10 @@ def parse_command(
         warnings=warnings,
         word_kinds=word_kinds,
         invalid_options=invalid_options,
+        ambiguous_options=ambiguous_options,
         needs_value_options=needs_value_options,
         invalid_value_options=invalid_value_options,
+        invalid_int_options=invalid_int_options,
         missing_required_options=missing_required_options,
     )
 

--- a/python/mirage/commands/spec/types.py
+++ b/python/mirage/commands/spec/types.py
@@ -250,6 +250,12 @@ class ParsedArgs:
     ambiguous_options: list[tuple[str,
                                   tuple[str,
                                         ...]]] = field(default_factory=list)
+    # "invalid" / "ambiguous" tags in scan encounter order, so the refusal
+    # names the FIRST offending token like GNU (grep --c --bogus reports
+    # --c; reversed reports --bogus). needs_value is absent by
+    # construction: it only fires on the line's final token, so it can
+    # never precede another scan error.
+    option_error_kinds: list[str] = field(default_factory=list)
     needs_value_options: list[str] = field(default_factory=list)
     invalid_value_options: list[tuple[str, str, tuple[str, ...]]] = field(
         default_factory=list)

--- a/python/mirage/commands/spec/types.py
+++ b/python/mirage/commands/spec/types.py
@@ -15,7 +15,7 @@
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import Enum, StrEnum
-from typing import Any
+from typing import Any, Literal
 
 from mirage.commands.spec.constants import flag_kwarg_name
 
@@ -93,6 +93,16 @@ class Option:
             if it had been typed (a PATH default resolves and routes, a
             defaulted value must satisfy choices). Presence of a default
             always satisfies ``required``.
+        type (Literal["str", "int"]): argparse ``type=`` as data. "int"
+            makes the parser refuse a non-integer value at parse time
+            (argparse's ``invalid int value``; the walk uses git's
+            ``expects a numerical value``), before the command runs. The
+            accepted shape is an optional sign plus digits, the portable
+            core of Python ``int()`` and argparse. The bag still holds
+            the string: commands read it through ``FlagView.as_int``,
+            the established mirage convention. Builtins whose GNU tool
+            words its own numeric refusal (``head: invalid number of
+            lines``) keep ``"str"`` and validate in the command.
         description (str | None): help text.
     """
     short: str | None = None
@@ -106,6 +116,7 @@ class Option:
     choices: tuple[str, ...] = ()
     required: bool = False
     default: str | None = None
+    type: Literal["str", "int"] = "str"
     description: str | None = None
 
 
@@ -229,13 +240,20 @@ class ParsedArgs:
     word_kinds: list[OperandKind | None] = field(default_factory=list)
     # GNU-shaped option errors, reported (never raised) by the parser:
     # undeclared options ('--bogus' or the offending cluster char 'Y'),
-    # declared value flags that ran out of line ('--max-depth', 'm'),
-    # values outside a declared choices set (canonical spelling, value,
-    # allowed values), and absent required options (canonical spelling).
+    # abbreviated longs matching several options (typed prefix, matched
+    # spellings in declaration order), declared value flags that ran out
+    # of line ('--max-depth', 'm'), values outside a declared choices set
+    # (canonical spelling, value, allowed values), non-integer values on
+    # int-typed options (canonical spelling, value), and absent required
+    # options (canonical spelling).
     invalid_options: list[str] = field(default_factory=list)
+    ambiguous_options: list[tuple[str,
+                                  tuple[str,
+                                        ...]]] = field(default_factory=list)
     needs_value_options: list[str] = field(default_factory=list)
     invalid_value_options: list[tuple[str, str, tuple[str, ...]]] = field(
         default_factory=list)
+    invalid_int_options: list[tuple[str, str]] = field(default_factory=list)
     missing_required_options: list[str] = field(default_factory=list)
 
     def paths(self) -> list[str]:

--- a/python/mirage/commands/spec/usage.py
+++ b/python/mirage/commands/spec/usage.py
@@ -52,6 +52,47 @@ def unknown_option_error(cmd_name: str, token: str) -> tuple[bytes, int]:
     return (line + hint).encode(), usage_exit_code(cmd_name)
 
 
+def ambiguous_option_error(cmd_name: str, token: str,
+                           candidates: tuple[str, ...]) -> tuple[bytes, int]:
+    """getopt_long refusal for an abbreviated long matching several options.
+
+    Shape pinned against real GNU (``grep --c``): the typed spelling,
+    then every possibility quoted in declaration order on one line. The
+    per-tool usage dump GNU appends is deliberately omitted, like
+    unknown_option_error.
+
+    Args:
+        cmd_name (str): command name for the message and exit code.
+        token (str): the typed abbreviated spelling ('--c').
+        candidates (tuple[str, ...]): matching declared spellings in
+            declaration order.
+    """
+    listed = " ".join(f"'{c}'" for c in candidates)
+    line = (f"{cmd_name}: option '{token}' is ambiguous; "
+            f"possibilities: {listed}\n")
+    hint = f"Try '{cmd_name} --help' for more information.\n"
+    return (line + hint).encode(), usage_exit_code(cmd_name)
+
+
+def invalid_int_error(cmd_name: str, option: str,
+                      value: str) -> tuple[bytes, int]:
+    """Refusal for a non-integer value on an int-typed option.
+
+    No GNU tool declares types through getopt (each words its own
+    refusal, e.g. ``head: invalid number of lines``), so this mirrors
+    argparse's ``invalid int value: 'abc'`` with the option attributed
+    the way invalid_argument_error does.
+
+    Args:
+        cmd_name (str): command name for the message and exit code.
+        option (str): canonical dashed spelling ('--port').
+        value (str): the rejected value.
+    """
+    line = f"{cmd_name}: invalid int value: '{value}' for '{option}'\n"
+    hint = f"Try '{cmd_name} --help' for more information.\n"
+    return (line + hint).encode(), usage_exit_code(cmd_name)
+
+
 def missing_value_error(cmd_name: str, token: str) -> tuple[bytes, int]:
     """GNU-shaped error for a declared value flag with no argument left.
 

--- a/python/mirage/workspace/executor/command/flags.py
+++ b/python/mirage/workspace/executor/command/flags.py
@@ -131,18 +131,16 @@ def parse_flags(
                 paths.append(scope)
             else:
                 texts.append(value)
-        return ParsedCommand(paths, texts, flag_kwargs, parsed.warnings,
-                             parsed.invalid_options,
-                             parsed.ambiguous_options,
-                             parsed.needs_value_options,
-                             parsed.invalid_value_options,
-                             parsed.invalid_int_options,
-                             parsed.missing_required_options)
+        return ParsedCommand(
+            paths, texts, flag_kwargs, parsed.warnings, parsed.invalid_options,
+            parsed.ambiguous_options, parsed.option_error_kinds,
+            parsed.needs_value_options, parsed.invalid_value_options,
+            parsed.invalid_int_options, parsed.missing_required_options)
 
     # No spec: separate by type
     paths = [item for item in parts if isinstance(item, PathSpec)]
     texts = [item for item in parts if not isinstance(item, PathSpec)]
-    return ParsedCommand(paths, texts, {}, [], [], [], [], [], [], [])
+    return ParsedCommand(paths, texts, {}, [], [], [], [], [], [], [], [])
 
 
 def option_error(cmd_name: str,
@@ -158,6 +156,13 @@ def option_error(cmd_name: str,
     """
     if cmd_name == "find":
         return None
+    # Scan-order between unknown and ambiguous options: GNU stops at the
+    # first offending token, so `grep --c --bogus` reports the ambiguity
+    # and the reversed line reports --bogus.
+    if (parsed.option_error_kinds
+            and parsed.option_error_kinds[0] == "ambiguous"):
+        token, candidates = parsed.ambiguous_options[0]
+        return ambiguous_option_error(cmd_name, token, candidates)
     if parsed.invalid_options:
         return unknown_option_error(cmd_name, parsed.invalid_options[0])
     if parsed.ambiguous_options:

--- a/python/mirage/workspace/executor/command/flags.py
+++ b/python/mirage/workspace/executor/command/flags.py
@@ -14,10 +14,9 @@
 
 from mirage.commands.spec import (CommandSpec, OperandKind, flag_kwarg_name,
                                   parse_command, parse_to_kwargs)
-from mirage.commands.spec.usage import (invalid_argument_error,
-                                        missing_required_error,
-                                        missing_value_error,
-                                        unknown_option_error)
+from mirage.commands.spec.usage import (  # yapf: disable
+    ambiguous_option_error, invalid_argument_error, invalid_int_error,
+    missing_required_error, missing_value_error, unknown_option_error)
 from mirage.types import PathSpec
 from mirage.workspace.executor.command.types import ParsedCommand
 
@@ -134,14 +133,16 @@ def parse_flags(
                 texts.append(value)
         return ParsedCommand(paths, texts, flag_kwargs, parsed.warnings,
                              parsed.invalid_options,
+                             parsed.ambiguous_options,
                              parsed.needs_value_options,
                              parsed.invalid_value_options,
+                             parsed.invalid_int_options,
                              parsed.missing_required_options)
 
     # No spec: separate by type
     paths = [item for item in parts if isinstance(item, PathSpec)]
     texts = [item for item in parts if not isinstance(item, PathSpec)]
-    return ParsedCommand(paths, texts, {}, [], [], [], [], [])
+    return ParsedCommand(paths, texts, {}, [], [], [], [], [], [], [])
 
 
 def option_error(cmd_name: str,
@@ -159,11 +160,17 @@ def option_error(cmd_name: str,
         return None
     if parsed.invalid_options:
         return unknown_option_error(cmd_name, parsed.invalid_options[0])
+    if parsed.ambiguous_options:
+        token, candidates = parsed.ambiguous_options[0]
+        return ambiguous_option_error(cmd_name, token, candidates)
     if parsed.needs_value_options:
         return missing_value_error(cmd_name, parsed.needs_value_options[0])
     if parsed.invalid_value_options:
         option, value, choices = parsed.invalid_value_options[0]
         return invalid_argument_error(cmd_name, option, value, choices)
+    if parsed.invalid_int_options:
+        option, value = parsed.invalid_int_options[0]
+        return invalid_int_error(cmd_name, option, value)
     if parsed.missing_required_options:
         return missing_required_error(cmd_name,
                                       parsed.missing_required_options[0])

--- a/python/mirage/workspace/executor/command/types.py
+++ b/python/mirage/workspace/executor/command/types.py
@@ -46,6 +46,8 @@ class ParsedCommand(NamedTuple):
     flag_kwargs: dict[str, object]
     warnings: list[str]
     invalid_options: list[str]
+    ambiguous_options: list[tuple[str, tuple[str, ...]]]
     needs_value_options: list[str]
     invalid_value_options: list[tuple[str, str, tuple[str, ...]]]
+    invalid_int_options: list[tuple[str, str]]
     missing_required_options: list[str]

--- a/python/mirage/workspace/executor/command/types.py
+++ b/python/mirage/workspace/executor/command/types.py
@@ -47,6 +47,7 @@ class ParsedCommand(NamedTuple):
     warnings: list[str]
     invalid_options: list[str]
     ambiguous_options: list[tuple[str, tuple[str, ...]]]
+    option_error_kinds: list[str]
     needs_value_options: list[str]
     invalid_value_options: list[tuple[str, str, tuple[str, ...]]]
     invalid_int_options: list[tuple[str, str]]

--- a/python/tests/commands/cli/test_compile.py
+++ b/python/tests/commands/cli/test_compile.py
@@ -108,3 +108,19 @@ def test_sibling_leaves_may_share_option_spellings():
         ),
     )
     assert len(tree.subcommands) == 2
+
+
+def test_alias_shares_the_sibling_namespace():
+    with pytest.raises(ValueError, match="duplicate subcommand 'co'"):
+        CLISpec(name="tool",
+                subcommands=(CLISpec(name="checkout",
+                                     aliases=("co", ),
+                                     fn=_verb), CLISpec(name="co", fn=_verb)))
+
+
+def test_alias_must_be_a_single_word():
+    with pytest.raises(ValueError, match="alias 'c o'"):
+        CLISpec(name="tool",
+                subcommands=(CLISpec(name="checkout",
+                                     aliases=("c o", ),
+                                     fn=_verb), ))

--- a/python/tests/commands/cli/test_walk.py
+++ b/python/tests/commands/cli/test_walk.py
@@ -234,3 +234,72 @@ def test_multichar_short_at_group_level():
     starved = walk("tool", tree, ["-name"])
     assert starved.exit_code == 129
     assert starved.output.startswith(b"error: option '-name' requires a value")
+
+
+def test_alias_resolves_to_the_canonical_verb():
+    tree = CLISpec(
+        name="tool",
+        subcommands=(CLISpec(name="checkout",
+                             aliases=("co", ),
+                             description="Switch branches",
+                             fn=_verb), ),
+    )
+    result = walk("tool", tree, ["co", "x"])
+    assert result.leaf is not None
+    assert result.path == ("checkout", )
+    assert result.argv == ("x", )
+
+
+def test_alias_renders_beside_the_canonical_name():
+    tree = CLISpec(
+        name="tool",
+        subcommands=(CLISpec(name="checkout",
+                             aliases=("co", "cout"),
+                             description="Switch branches",
+                             fn=_verb), ),
+    )
+    listing = walk("tool", tree, [])
+    assert b"  checkout (co, cout)  Switch branches" in listing.output
+
+
+def test_group_long_prefix_expands_like_git():
+    result = walk("gws", _tree(), ["--verb", "--verb", "gmail", "send"])
+    assert result.leaf is not None
+    assert result.group_flags["--verbose"] == 2
+
+
+def test_group_ambiguous_prefix_uses_git_wording():
+    tree = CLISpec(
+        name="tool",
+        options=(Option(long="--context",
+                        value_kind=OperandKind.TEXT), Option(long="--count")),
+        subcommands=(CLISpec(name="run", fn=_verb), ),
+    )
+    result = walk("tool", tree, ["--co", "run"])
+    assert result.exit_code == 129
+    assert result.output.startswith(
+        b"error: ambiguous option: co (could be --context or --count)")
+
+
+def test_help_prefix_reaches_the_injected_help():
+    full = walk("gws", _tree(), ["--help"])
+    abbreviated = walk("gws", _tree(), ["--hel"])
+    assert abbreviated.exit_code == 0
+    assert abbreviated.output == full.output
+
+
+def test_int_typed_group_option_uses_git_wording():
+    tree = CLISpec(
+        name="tool",
+        options=(Option(long="--depth",
+                        value_kind=OperandKind.TEXT,
+                        type="int"), ),
+        subcommands=(CLISpec(name="run", fn=_verb), ),
+    )
+    bad = walk("tool", tree, ["--depth", "x", "run"])
+    assert bad.exit_code == 129
+    assert bad.output.startswith(
+        b"error: option '--depth' expects a numerical value")
+    ok = walk("tool", tree, ["--depth", "-3", "run"])
+    assert ok.leaf is not None
+    assert ok.group_flags == {"--depth": "-3"}

--- a/python/tests/commands/spec/test_compile.py
+++ b/python/tests/commands/spec/test_compile.py
@@ -12,7 +12,9 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.commands.spec.compile import compile_spec
+import pytest
+
+from mirage.commands.spec.compile import compile_spec, expand_long
 from mirage.commands.spec.types import (CommandSpec, Operand, OperandKind,
                                         Option)
 
@@ -125,3 +127,31 @@ def test_default_outside_choices_is_a_spec_error():
         assert "not one of its choices" in str(exc)
     else:
         raise AssertionError("expected ValueError")
+
+
+def test_type_int_requires_a_value_flag():
+    with pytest.raises(ValueError, match="requires a value flag"):
+        compile_spec(
+            CommandSpec(options=(Option(long="--fast", type="int"), )))
+
+
+def test_type_int_default_must_be_an_integer():
+    with pytest.raises(ValueError, match="is not an integer"):
+        compile_spec(
+            CommandSpec(options=(Option(long="--port",
+                                        value_kind=OperandKind.TEXT,
+                                        type="int",
+                                        default="auto"), )))
+
+
+def test_expand_long_exact_prefix_ambiguous_and_unknown():
+    cs = compile_spec(
+        CommandSpec(options=(
+            Option(long="--binary"),
+            Option(long="--binary-files", value_kind=OperandKind.TEXT),
+            Option(long="--count"))))
+    assert expand_long(cs, "--binary") == ("--binary", )
+    assert expand_long(cs, "--bin") == ("--binary", "--binary-files")
+    assert expand_long(cs, "--co") == ("--count", )
+    assert expand_long(cs, "--zz") == ()
+    assert expand_long(cs, "--") == ()

--- a/python/tests/commands/spec/test_parser.py
+++ b/python/tests/commands/spec/test_parser.py
@@ -431,3 +431,73 @@ def test_multiple_default_lands_as_one_element_list():
     assert parsed.path_flag_values == ["/data/cfg.txt"]
     typed = parse_command(spec, ["-f", "a", "-f", "b"], "/data")
     assert typed.flags["--file"] == ["/data/a", "/data/b"]
+
+
+def test_unique_long_prefix_expands_like_getopt_long():
+    spec = CommandSpec(options=(Option(long="--recursive"),
+                                Option(long="--count")))
+    parsed = parse_command(spec, ["--rec", "x"], "/")
+    assert parsed.flags["--recursive"] is True
+    assert parsed.invalid_options == []
+    assert parsed.ambiguous_options == []
+
+
+def test_ambiguous_long_prefix_reports_possibilities_in_order():
+    spec = CommandSpec(options=(
+        Option(long="--context", value_kind=OperandKind.TEXT),
+        Option(
+            long="--color", value_optional=True, value_kind=OperandKind.TEXT),
+        Option(long="--count")))
+    parsed = parse_command(spec, ["--c"], "/")
+    assert parsed.ambiguous_options == [("--c", ("--context", "--color",
+                                                 "--count"))]
+    assert parsed.invalid_options == []
+
+
+def test_exact_long_wins_over_a_longer_spelling():
+    spec = CommandSpec(
+        options=(Option(long="--binary"),
+                 Option(long="--binary-files", value_kind=OperandKind.TEXT)))
+    parsed = parse_command(spec, ["--binary"], "/")
+    assert parsed.flags["--binary"] is True
+    assert parsed.ambiguous_options == []
+
+
+def test_abbreviated_long_carries_an_attached_value():
+    spec = CommandSpec(options=(Option(
+        long="--color", value_optional=True, value_kind=OperandKind.TEXT), ))
+    parsed = parse_command(spec, ["--colo=never"], "/")
+    assert parsed.flags["--color"] == "never"
+
+
+def test_abbreviated_value_long_takes_the_next_word():
+    spec = CommandSpec(
+        options=(Option(long="--exclude", value_kind=OperandKind.TEXT), ))
+    parsed = parse_command(spec, ["--excl", "tmp"], "/")
+    assert parsed.flags["--exclude"] == "tmp"
+
+
+def test_free_text_commands_keep_exact_only_long_matching():
+    spec = CommandSpec(options=(Option(long="--verbose"), ),
+                       rest=Operand(kind=OperandKind.TEXT))
+    parsed = parse_command(spec, ["--verb", "hi"], "/")
+    assert "--verbose" not in parsed.flags
+    assert parsed.texts() == ["--verb", "hi"]
+
+
+def test_int_typed_value_is_reported_not_raised():
+    spec = CommandSpec(options=(
+        Option(long="--port", value_kind=OperandKind.TEXT, type="int"), ))
+    parsed = parse_command(spec, ["--port", "abc"], "/")
+    assert parsed.invalid_int_options == [("--port", "abc")]
+    ok = parse_command(spec, ["--port", "-42"], "/")
+    assert ok.invalid_int_options == []
+    assert ok.flags["--port"] == "-42"
+
+
+def test_int_typed_multiple_checks_every_value():
+    spec = CommandSpec(options=(Option(
+        long="--id", value_kind=OperandKind.TEXT, multiple=True, type="int"),
+                                ))
+    parsed = parse_command(spec, ["--id", "1", "--id", "x"], "/")
+    assert parsed.invalid_int_options == [("--id", "x")]

--- a/python/tests/commands/spec/test_parser.py
+++ b/python/tests/commands/spec/test_parser.py
@@ -501,3 +501,35 @@ def test_int_typed_multiple_checks_every_value():
                                 ))
     parsed = parse_command(spec, ["--id", "1", "--id", "x"], "/")
     assert parsed.invalid_int_options == [("--id", "x")]
+
+
+def test_synonym_spellings_resolve_a_shared_prefix_like_glibc():
+    parsed = parse_command(SPECS["grep"], ["--colo", "pat", "/a.txt"], "/")
+    assert parsed.ambiguous_options == []
+    assert parsed.flags["--color"] is True
+    attached = parse_command(SPECS["grep"], ["--colo=never", "pat", "/a.txt"],
+                             "/")
+    assert attached.flags["--color"] == "never"
+
+
+def test_ambiguity_lists_synonyms_like_gnu():
+    spec = CommandSpec(options=(
+        Option(long="--context", value_kind=OperandKind.TEXT),
+        Option(
+            long="--color", value_optional=True, value_kind=OperandKind.TEXT),
+        Option(
+            long="--colour", value_optional=True, value_kind=OperandKind.TEXT),
+        Option(long="--count")))
+    parsed = parse_command(spec, ["--c"], "/")
+    assert parsed.ambiguous_options == [("--c", ("--context", "--color",
+                                                 "--colour", "--count"))]
+
+
+def test_option_error_kinds_keep_scan_order():
+    spec = CommandSpec(
+        options=(Option(long="--context", value_kind=OperandKind.TEXT),
+                 Option(long="--count")))
+    parsed = parse_command(spec, ["--c", "--bogus"], "/")
+    assert parsed.option_error_kinds == ["ambiguous", "invalid"]
+    flipped = parse_command(spec, ["--bogus", "--c"], "/")
+    assert flipped.option_error_kinds == ["invalid", "ambiguous"]

--- a/python/tests/commands/spec/test_usage.py
+++ b/python/tests/commands/spec/test_usage.py
@@ -1,8 +1,7 @@
-from mirage.commands.spec.usage import (extra_operand_error,
-                                        invalid_argument_error,
-                                        missing_required_error,
-                                        missing_value_error,
-                                        unknown_option_error, usage_exit_code)
+from mirage.commands.spec.usage import (  # yapf: disable
+    ambiguous_option_error, extra_operand_error, invalid_argument_error,
+    invalid_int_error, missing_required_error, missing_value_error,
+    unknown_option_error, usage_exit_code)
 
 
 def test_exit_codes_match_gnu():
@@ -78,4 +77,20 @@ def test_missing_required_names_the_canonical_spelling():
     stderr, code = missing_required_error("mycmd", "--out")
     assert stderr == (b"mycmd: option '--out' is required\n"
                       b"Try 'mycmd --help' for more information.\n")
+    assert code == 1
+
+
+def test_ambiguous_option_matches_gnu_shape():
+    out, code = ambiguous_option_error("grep", "--c",
+                                       ("--context", "--color", "--count"))
+    assert out == (b"grep: option '--c' is ambiguous; possibilities: "
+                   b"'--context' '--color' '--count'\n"
+                   b"Try 'grep --help' for more information.\n")
+    assert code == 2
+
+
+def test_invalid_int_mirrors_argparse_wording():
+    out, code = invalid_int_error("mycli", "--port", "abc")
+    assert out == (b"mycli: invalid int value: 'abc' for '--port'\n"
+                   b"Try 'mycli --help' for more information.\n")
     assert code == 1

--- a/python/tests/workspace/executor/command/test_flags.py
+++ b/python/tests/workspace/executor/command/test_flags.py
@@ -13,7 +13,8 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.commands.spec import SPECS
-from mirage.workspace.executor.command.flags import (parse_flags,
+from mirage.commands.spec.types import CommandSpec, OperandKind, Option
+from mirage.workspace.executor.command.flags import (option_error, parse_flags,
                                                      synthesize_path_spec)
 
 
@@ -43,3 +44,17 @@ def test_classified_path_wins_over_synthesis():
     path = synthesize_path_spec("/data/a.txt")
     parsed = parse_flags([path], SPECS["cat"], "cat", "/")
     assert parsed.paths[0] is path
+
+
+def test_option_error_reports_the_first_scan_error_like_gnu():
+    spec = CommandSpec(
+        options=(Option(long="--context", value_kind=OperandKind.TEXT),
+                 Option(long="--count")))
+    ambiguous_first = parse_flags(["--c", "--bogus", "x"], spec, "grep", "/")
+    refusal = option_error("grep", ambiguous_first)
+    assert refusal is not None
+    assert refusal[0].startswith(b"grep: option '--c' is ambiguous")
+    invalid_first = parse_flags(["--bogus", "--c", "x"], spec, "grep", "/")
+    refusal = option_error("grep", invalid_first)
+    assert refusal is not None
+    assert refusal[0].startswith(b"grep: unrecognized option '--bogus'")

--- a/spec/python/general/awk.json
+++ b/spec/python/general/awk.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     }

--- a/spec/python/general/base64.json
+++ b/spec/python/general/base64.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-D",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/basename.json
+++ b/spec/python/general/basename.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/bash.json
+++ b/spec/python/general/bash.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -64,6 +67,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -78,6 +82,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -92,6 +97,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -106,6 +112,7 @@
       "required": false,
       "short": "-x",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -120,6 +127,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -134,6 +142,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -148,6 +157,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -162,6 +172,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/bc.json
+++ b/spec/python/general/bc.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/cat.json
+++ b/spec/python/general/cat.json
@@ -276,6 +276,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +291,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +306,7 @@
       "required": false,
       "short": "-E",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +321,7 @@
       "required": false,
       "short": "-T",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +336,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +351,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +366,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +381,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +396,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -402,6 +411,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/chgrp.json
+++ b/spec/python/general/chgrp.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -64,6 +67,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/chmod.json
+++ b/spec/python/general/chmod.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/chown.json
+++ b/spec/python/general/chown.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -64,6 +67,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/cmp.json
+++ b/spec/python/general/cmp.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/column.json
+++ b/spec/python/general/column.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/comm.json
+++ b/spec/python/general/comm.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-1",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-2",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-3",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +374,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/cp.json
+++ b/spec/python/general/cp.json
@@ -115,6 +115,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -129,6 +130,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -143,6 +145,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +160,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +175,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -185,6 +190,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -199,6 +205,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -213,6 +220,7 @@
       "required": false,
       "short": "-u",
       "short_value": false,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -227,6 +235,7 @@
       "required": false,
       "short": "-b",
       "short_value": false,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -241,6 +250,7 @@
       "required": false,
       "short": "-S",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -255,6 +265,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -269,6 +280,7 @@
       "required": false,
       "short": "-T",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +295,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/csplit.json
+++ b/spec/python/general/csplit.json
@@ -122,6 +122,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -136,6 +137,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -150,6 +152,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -164,6 +167,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -178,6 +182,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -192,6 +197,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -206,6 +212,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -220,6 +227,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/curl.json
+++ b/spec/python/general/curl.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -57,6 +59,7 @@
       "required": false,
       "short": "-X",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -71,6 +74,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -85,6 +89,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -99,6 +104,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -113,6 +119,7 @@
       "required": false,
       "short": "-L",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -127,6 +134,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -141,6 +149,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -155,6 +164,7 @@
       "required": false,
       "short": "-S",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/cut.json
+++ b/spec/python/general/cut.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +374,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +389,7 @@
       "required": false,
       "short": "-O",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -395,6 +404,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -409,6 +419,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -423,6 +434,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -437,6 +449,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/date.json
+++ b/spec/python/general/date.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -57,6 +59,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -71,6 +74,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/df.json
+++ b/spec/python/general/df.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -64,6 +67,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -78,6 +82,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -92,6 +97,7 @@
       "required": false,
       "short": "-T",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -106,6 +112,7 @@
       "required": false,
       "short": "-P",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -120,6 +127,7 @@
       "required": false,
       "short": "-B",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/diff.json
+++ b/spec/python/general/diff.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/dirname.json
+++ b/spec/python/general/dirname.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/du.json
+++ b/spec/python/general/du.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/echo.json
+++ b/spec/python/general/echo.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/expand.json
+++ b/spec/python/general/expand.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/file.json
+++ b/spec/python/general/file.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/find.json
+++ b/spec/python/general/find.json
@@ -279,6 +279,7 @@
       "required": false,
       "short": "-name",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -293,6 +294,7 @@
       "required": false,
       "short": "-type",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -307,6 +309,7 @@
       "required": false,
       "short": "-maxdepth",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -321,6 +324,7 @@
       "required": false,
       "short": "-size",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -335,6 +339,7 @@
       "required": false,
       "short": "-mtime",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -349,6 +354,7 @@
       "required": false,
       "short": "-iname",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -363,6 +369,7 @@
       "required": false,
       "short": "-path",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -377,6 +384,7 @@
       "required": false,
       "short": "-mindepth",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -391,6 +399,7 @@
       "required": false,
       "short": "-print",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -405,6 +414,7 @@
       "required": false,
       "short": "-print0",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -419,6 +429,7 @@
       "required": false,
       "short": "-delete",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -433,6 +444,7 @@
       "required": false,
       "short": "-depth",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -447,6 +459,7 @@
       "required": false,
       "short": "-prune",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -461,6 +474,7 @@
       "required": false,
       "short": "-ls",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -475,6 +489,7 @@
       "required": false,
       "short": "-empty",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -489,6 +504,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -503,6 +519,7 @@
       "required": false,
       "short": "-or",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -517,6 +534,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -531,6 +549,7 @@
       "required": false,
       "short": "-and",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -545,6 +564,7 @@
       "required": false,
       "short": "-not",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/fmt.json
+++ b/spec/python/general/fmt.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-g",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/fold.json
+++ b/spec/python/general/fold.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/grep.json
+++ b/spec/python/general/grep.json
@@ -276,6 +276,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +291,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +306,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +321,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +336,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +351,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +366,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +381,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +396,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -402,6 +411,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -416,6 +426,7 @@
       "required": false,
       "short": "-E",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -430,6 +441,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -444,6 +456,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -458,6 +471,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -472,6 +486,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -486,6 +501,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -500,6 +516,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -514,6 +531,7 @@
       "required": false,
       "short": "-B",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -528,6 +546,7 @@
       "required": false,
       "short": "-C",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -542,6 +561,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -556,6 +576,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -570,6 +591,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -584,6 +606,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -598,6 +621,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/gunzip.json
+++ b/spec/python/general/gunzip.json
@@ -122,6 +122,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -136,6 +137,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -150,6 +152,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -164,6 +167,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/gzip.json
+++ b/spec/python/general/gzip.json
@@ -122,6 +122,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -136,6 +137,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -150,6 +152,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -164,6 +167,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -178,6 +182,7 @@
       "required": false,
       "short": "-1",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -192,6 +197,7 @@
       "required": false,
       "short": "-2",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -206,6 +212,7 @@
       "required": false,
       "short": "-3",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -220,6 +227,7 @@
       "required": false,
       "short": "-4",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -234,6 +242,7 @@
       "required": false,
       "short": "-5",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -248,6 +257,7 @@
       "required": false,
       "short": "-6",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -262,6 +272,7 @@
       "required": false,
       "short": "-7",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -276,6 +287,7 @@
       "required": false,
       "short": "-8",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +302,7 @@
       "required": false,
       "short": "-9",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/head.json
+++ b/spec/python/general/head.json
@@ -276,6 +276,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -290,6 +291,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +306,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +321,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +336,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +351,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/history.json
+++ b/spec/python/general/history.json
@@ -31,6 +31,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -45,6 +46,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -59,6 +61,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -73,6 +76,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -87,6 +91,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +106,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -115,6 +121,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -129,6 +136,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/iconv.json
+++ b/spec/python/general/iconv.json
@@ -122,6 +122,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -136,6 +137,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -150,6 +152,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -164,6 +167,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     }

--- a/spec/python/general/join.json
+++ b/spec/python/general/join.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-1",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-2",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -367,6 +374,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +389,7 @@
       "required": false,
       "short": "-j",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -395,6 +404,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -409,6 +419,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -423,6 +434,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -437,6 +449,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/jq.json
+++ b/spec/python/general/jq.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/js.json
+++ b/spec/python/general/js.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/ln.json
+++ b/spec/python/general/ln.json
@@ -122,6 +122,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -136,6 +137,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -150,6 +152,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -164,6 +167,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/look.json
+++ b/spec/python/general/look.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/ls.json
+++ b/spec/python/general/ls.json
@@ -276,6 +276,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +291,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +306,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +321,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +336,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +351,7 @@
       "required": false,
       "short": "-S",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +366,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +381,7 @@
       "required": false,
       "short": "-1",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +396,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -402,6 +411,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -416,6 +426,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -430,6 +441,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     }

--- a/spec/python/general/md5sum.json
+++ b/spec/python/general/md5sum.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +374,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +389,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -395,6 +404,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/mkdir.json
+++ b/spec/python/general/mkdir.json
@@ -122,6 +122,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -136,6 +137,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -150,6 +152,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -164,6 +167,7 @@
       "required": false,
       "short": "-Z",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     }

--- a/spec/python/general/mktemp.json
+++ b/spec/python/general/mktemp.json
@@ -122,6 +122,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -136,6 +137,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -150,6 +152,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": true
     },
@@ -164,6 +167,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -178,6 +182,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -192,6 +197,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -206,6 +212,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/mv.json
+++ b/spec/python/general/mv.json
@@ -115,6 +115,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -129,6 +130,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -143,6 +145,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +160,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +175,7 @@
       "required": false,
       "short": "-u",
       "short_value": false,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -185,6 +190,7 @@
       "required": false,
       "short": "-b",
       "short_value": false,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -199,6 +205,7 @@
       "required": false,
       "short": "-S",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -213,6 +220,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -227,6 +235,7 @@
       "required": false,
       "short": "-T",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +250,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +265,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +280,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/nl.json
+++ b/spec/python/general/nl.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +374,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -381,6 +389,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -395,6 +404,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -409,6 +419,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/node.json
+++ b/spec/python/general/node.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/numfmt.json
+++ b/spec/python/general/numfmt.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/od.json
+++ b/spec/python/general/od.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-j",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-N",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/paste.json
+++ b/spec/python/general/paste.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/patch.json
+++ b/spec/python/general/patch.json
@@ -122,6 +122,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -136,6 +137,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -150,6 +152,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -164,6 +167,7 @@
       "required": false,
       "short": "-N",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/pwd.json
+++ b/spec/python/general/pwd.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-P",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-L",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/python.json
+++ b/spec/python/general/python.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/python3.json
+++ b/spec/python/general/python3.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/readlink.json
+++ b/spec/python/general/readlink.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/realpath.json
+++ b/spec/python/general/realpath.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/rg.json
+++ b/spec/python/general/rg.json
@@ -276,6 +276,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +291,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +306,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +321,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +336,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +351,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +366,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +381,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +396,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -402,6 +411,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -416,6 +426,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -430,6 +441,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -444,6 +456,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -458,6 +471,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -472,6 +486,7 @@
       "required": false,
       "short": "-B",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -486,6 +501,7 @@
       "required": false,
       "short": "-C",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -500,6 +516,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -514,6 +531,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -528,6 +546,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -542,6 +561,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     }

--- a/spec/python/general/rm.json
+++ b/spec/python/general/rm.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -185,6 +188,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -199,6 +203,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -213,6 +218,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -227,6 +233,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +248,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +263,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +278,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/rmdir.json
+++ b/spec/python/general/rmdir.json
@@ -115,6 +115,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/search.json
+++ b/spec/python/general/search.json
@@ -52,6 +52,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -66,6 +67,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -80,6 +82,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/sed.json
+++ b/spec/python/general/sed.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-E",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/seq.json
+++ b/spec/python/general/seq.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -57,6 +59,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/sha1sum.json
+++ b/spec/python/general/sha1sum.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +374,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +389,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -395,6 +404,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/sha256sum.json
+++ b/spec/python/general/sha256sum.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +374,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +389,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -395,6 +404,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/sha384sum.json
+++ b/spec/python/general/sha384sum.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +374,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +389,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -395,6 +404,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/sha512sum.json
+++ b/spec/python/general/sha512sum.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +374,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +389,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -395,6 +404,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/shuf.json
+++ b/spec/python/general/shuf.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     }

--- a/spec/python/general/sort.json
+++ b/spec/python/general/sort.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +374,7 @@
       "required": false,
       "short": "-V",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +389,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -395,6 +404,7 @@
       "required": false,
       "short": "-M",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -409,6 +419,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -423,6 +434,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -437,6 +449,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -451,6 +464,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -465,6 +479,7 @@
       "required": false,
       "short": "-g",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -479,6 +494,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -493,6 +509,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -507,6 +524,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -521,6 +539,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/split.json
+++ b/spec/python/general/split.json
@@ -122,6 +122,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -136,6 +137,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -150,6 +152,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -164,6 +167,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -178,6 +182,7 @@
       "required": false,
       "short": "-x",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -192,6 +197,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -206,6 +212,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -220,6 +227,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/stat.json
+++ b/spec/python/general/stat.json
@@ -276,6 +276,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -290,6 +291,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/strings.json
+++ b/spec/python/general/strings.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/tac.json
+++ b/spec/python/general/tac.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/tail.json
+++ b/spec/python/general/tail.json
@@ -276,6 +276,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -290,6 +291,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +306,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +321,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +336,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/tar.json
+++ b/spec/python/general/tar.json
@@ -122,6 +122,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -136,6 +137,7 @@
       "required": false,
       "short": "-x",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -150,6 +152,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -164,6 +167,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -178,6 +182,7 @@
       "required": false,
       "short": "-j",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -192,6 +197,7 @@
       "required": false,
       "short": "-J",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -206,6 +212,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -220,6 +227,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -234,6 +242,7 @@
       "required": false,
       "short": "-C",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -248,6 +257,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -262,6 +272,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/tee.json
+++ b/spec/python/general/tee.json
@@ -122,6 +122,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -136,6 +137,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -150,6 +152,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -169,6 +172,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     }

--- a/spec/python/general/touch.json
+++ b/spec/python/general/touch.json
@@ -122,6 +122,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -136,6 +137,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -150,6 +152,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/tr.json
+++ b/spec/python/general/tr.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-C",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/tree.json
+++ b/spec/python/general/tree.json
@@ -276,6 +276,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +291,7 @@
       "required": false,
       "short": "-L",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +306,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -318,6 +321,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +336,7 @@
       "required": false,
       "short": "-P",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/truncate.json
+++ b/spec/python/general/truncate.json
@@ -101,6 +101,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/unexpand.json
+++ b/spec/python/general/unexpand.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/uniq.json
+++ b/spec/python/general/uniq.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-D",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -367,6 +374,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -381,6 +389,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -395,6 +404,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -409,6 +419,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/unzip.json
+++ b/spec/python/general/unzip.json
@@ -122,6 +122,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -136,6 +137,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -150,6 +152,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -164,6 +167,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -178,6 +182,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -192,6 +197,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/wc.json
+++ b/spec/python/general/wc.json
@@ -276,6 +276,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +291,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +306,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +321,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +336,7 @@
       "required": false,
       "short": "-L",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +351,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/python/general/wget.json
+++ b/spec/python/general/wget.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-O",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -57,6 +59,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/xxd.json
+++ b/spec/python/general/xxd.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-g",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/zgrep.json
+++ b/spec/python/general/zgrep.json
@@ -269,6 +269,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +284,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +299,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +314,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +329,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +344,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -353,6 +359,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -367,6 +374,7 @@
       "required": false,
       "short": "-E",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +389,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -395,6 +404,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -409,6 +419,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -423,6 +434,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -437,6 +449,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -451,6 +464,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -465,6 +479,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/python/general/zip.json
+++ b/spec/python/general/zip.json
@@ -122,6 +122,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -136,6 +137,7 @@
       "required": false,
       "short": "-j",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -150,6 +152,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/awk.json
+++ b/spec/typescript/browser/general/awk.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/base64.json
+++ b/spec/typescript/browser/general/base64.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-D",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/basename.json
+++ b/spec/typescript/browser/general/basename.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/bash.json
+++ b/spec/typescript/browser/general/bash.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -64,6 +67,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -78,6 +82,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -92,6 +97,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -106,6 +112,7 @@
       "required": false,
       "short": "-x",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -120,6 +127,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -134,6 +142,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -148,6 +157,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -162,6 +172,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/bc.json
+++ b/spec/typescript/browser/general/bc.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/cat.json
+++ b/spec/typescript/browser/general/cat.json
@@ -234,6 +234,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -248,6 +249,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -262,6 +264,7 @@
       "required": false,
       "short": "-E",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -276,6 +279,7 @@
       "required": false,
       "short": "-T",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +294,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +309,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +324,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +339,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +354,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +369,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/chgrp.json
+++ b/spec/typescript/browser/general/chgrp.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -64,6 +67,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/chmod.json
+++ b/spec/typescript/browser/general/chmod.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/chown.json
+++ b/spec/typescript/browser/general/chown.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -64,6 +67,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/cmp.json
+++ b/spec/typescript/browser/general/cmp.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/column.json
+++ b/spec/typescript/browser/general/column.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/comm.json
+++ b/spec/typescript/browser/general/comm.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-1",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-2",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-3",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +332,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/cp.json
+++ b/spec/typescript/browser/general/cp.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -129,6 +132,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -143,6 +147,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +162,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +177,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -185,6 +192,7 @@
       "required": false,
       "short": "-u",
       "short_value": false,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -199,6 +207,7 @@
       "required": false,
       "short": "-b",
       "short_value": false,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -213,6 +222,7 @@
       "required": false,
       "short": "-S",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -227,6 +237,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -241,6 +252,7 @@
       "required": false,
       "short": "-T",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +267,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/csplit.json
+++ b/spec/typescript/browser/general/csplit.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -129,6 +132,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -143,6 +147,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +162,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +177,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -185,6 +192,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/curl.json
+++ b/spec/typescript/browser/general/curl.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -57,6 +59,7 @@
       "required": false,
       "short": "-X",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -71,6 +74,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -85,6 +89,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -99,6 +104,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -113,6 +119,7 @@
       "required": false,
       "short": "-L",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -127,6 +134,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -141,6 +149,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -155,6 +164,7 @@
       "required": false,
       "short": "-S",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/cut.json
+++ b/spec/typescript/browser/general/cut.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +332,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +347,7 @@
       "required": false,
       "short": "-O",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -353,6 +362,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -367,6 +377,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +392,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -395,6 +407,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/date.json
+++ b/spec/typescript/browser/general/date.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -57,6 +59,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -71,6 +74,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/df.json
+++ b/spec/typescript/browser/general/df.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -64,6 +67,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -78,6 +82,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -92,6 +97,7 @@
       "required": false,
       "short": "-T",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -106,6 +112,7 @@
       "required": false,
       "short": "-P",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -120,6 +127,7 @@
       "required": false,
       "short": "-B",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/diff.json
+++ b/spec/typescript/browser/general/diff.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/dirname.json
+++ b/spec/typescript/browser/general/dirname.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/du.json
+++ b/spec/typescript/browser/general/du.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/echo.json
+++ b/spec/typescript/browser/general/echo.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/expand.json
+++ b/spec/typescript/browser/general/expand.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/file.json
+++ b/spec/typescript/browser/general/file.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/find.json
+++ b/spec/typescript/browser/general/find.json
@@ -237,6 +237,7 @@
       "required": false,
       "short": "-name",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -251,6 +252,7 @@
       "required": false,
       "short": "-type",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -265,6 +267,7 @@
       "required": false,
       "short": "-maxdepth",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -279,6 +282,7 @@
       "required": false,
       "short": "-size",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -293,6 +297,7 @@
       "required": false,
       "short": "-mtime",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -307,6 +312,7 @@
       "required": false,
       "short": "-iname",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -321,6 +327,7 @@
       "required": false,
       "short": "-path",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -335,6 +342,7 @@
       "required": false,
       "short": "-mindepth",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -349,6 +357,7 @@
       "required": false,
       "short": "-print",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -363,6 +372,7 @@
       "required": false,
       "short": "-print0",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -377,6 +387,7 @@
       "required": false,
       "short": "-delete",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -391,6 +402,7 @@
       "required": false,
       "short": "-depth",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -405,6 +417,7 @@
       "required": false,
       "short": "-prune",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -419,6 +432,7 @@
       "required": false,
       "short": "-ls",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -433,6 +447,7 @@
       "required": false,
       "short": "-empty",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -447,6 +462,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -461,6 +477,7 @@
       "required": false,
       "short": "-or",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -475,6 +492,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -489,6 +507,7 @@
       "required": false,
       "short": "-and",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -503,6 +522,7 @@
       "required": false,
       "short": "-not",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/fmt.json
+++ b/spec/typescript/browser/general/fmt.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-g",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/fold.json
+++ b/spec/typescript/browser/general/fold.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/grep.json
+++ b/spec/typescript/browser/general/grep.json
@@ -234,6 +234,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -248,6 +249,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -262,6 +264,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -276,6 +279,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +294,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +309,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +324,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +339,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +354,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +369,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +384,7 @@
       "required": false,
       "short": "-E",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +399,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -402,6 +414,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -416,6 +429,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -430,6 +444,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -444,6 +459,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -458,6 +474,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -472,6 +489,7 @@
       "required": false,
       "short": "-B",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -486,6 +504,7 @@
       "required": false,
       "short": "-C",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -500,6 +519,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -514,6 +534,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -528,6 +549,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -542,6 +564,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -556,6 +579,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/gunzip.json
+++ b/spec/typescript/browser/general/gunzip.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -129,6 +132,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/gzip.json
+++ b/spec/typescript/browser/general/gzip.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -129,6 +132,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -143,6 +147,7 @@
       "required": false,
       "short": "-1",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +162,7 @@
       "required": false,
       "short": "-2",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +177,7 @@
       "required": false,
       "short": "-3",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -185,6 +192,7 @@
       "required": false,
       "short": "-4",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -199,6 +207,7 @@
       "required": false,
       "short": "-5",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -213,6 +222,7 @@
       "required": false,
       "short": "-6",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -227,6 +237,7 @@
       "required": false,
       "short": "-7",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +252,7 @@
       "required": false,
       "short": "-8",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +267,7 @@
       "required": false,
       "short": "-9",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/head.json
+++ b/spec/typescript/browser/general/head.json
@@ -234,6 +234,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -248,6 +249,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -262,6 +264,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -276,6 +279,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +294,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +309,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/history.json
+++ b/spec/typescript/browser/general/history.json
@@ -31,6 +31,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -45,6 +46,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -59,6 +61,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -73,6 +76,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -87,6 +91,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +106,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -115,6 +121,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -129,6 +136,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/iconv.json
+++ b/spec/typescript/browser/general/iconv.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -129,6 +132,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/join.json
+++ b/spec/typescript/browser/general/join.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-1",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-2",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -325,6 +332,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +347,7 @@
       "required": false,
       "short": "-j",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -353,6 +362,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +377,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +392,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -395,6 +407,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/jq.json
+++ b/spec/typescript/browser/general/jq.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/js.json
+++ b/spec/typescript/browser/general/js.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/ln.json
+++ b/spec/typescript/browser/general/ln.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -129,6 +132,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/look.json
+++ b/spec/typescript/browser/general/look.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/ls.json
+++ b/spec/typescript/browser/general/ls.json
@@ -234,6 +234,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -248,6 +249,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -262,6 +264,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -276,6 +279,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +294,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +309,7 @@
       "required": false,
       "short": "-S",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +324,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +339,7 @@
       "required": false,
       "short": "-1",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +354,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +369,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +384,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +399,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     }

--- a/spec/typescript/browser/general/md5sum.json
+++ b/spec/typescript/browser/general/md5sum.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +332,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +347,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +362,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/mkdir.json
+++ b/spec/typescript/browser/general/mkdir.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -129,6 +132,7 @@
       "required": false,
       "short": "-Z",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     }

--- a/spec/typescript/browser/general/mktemp.json
+++ b/spec/typescript/browser/general/mktemp.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": true
     },
@@ -129,6 +132,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -143,6 +147,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +162,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +177,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/mv.json
+++ b/spec/typescript/browser/general/mv.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -129,6 +132,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -143,6 +147,7 @@
       "required": false,
       "short": "-u",
       "short_value": false,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -157,6 +162,7 @@
       "required": false,
       "short": "-b",
       "short_value": false,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -171,6 +177,7 @@
       "required": false,
       "short": "-S",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -185,6 +192,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -199,6 +207,7 @@
       "required": false,
       "short": "-T",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -213,6 +222,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -227,6 +237,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +252,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/nl.json
+++ b/spec/typescript/browser/general/nl.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +332,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -339,6 +347,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -353,6 +362,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -367,6 +377,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/node.json
+++ b/spec/typescript/browser/general/node.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/numfmt.json
+++ b/spec/typescript/browser/general/numfmt.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/od.json
+++ b/spec/typescript/browser/general/od.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-j",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-N",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/paste.json
+++ b/spec/typescript/browser/general/paste.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/patch.json
+++ b/spec/typescript/browser/general/patch.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -129,6 +132,7 @@
       "required": false,
       "short": "-N",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/pwd.json
+++ b/spec/typescript/browser/general/pwd.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-P",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-L",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/python.json
+++ b/spec/typescript/browser/general/python.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/python3.json
+++ b/spec/typescript/browser/general/python3.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/readlink.json
+++ b/spec/typescript/browser/general/readlink.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/realpath.json
+++ b/spec/typescript/browser/general/realpath.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/rg.json
+++ b/spec/typescript/browser/general/rg.json
@@ -234,6 +234,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -248,6 +249,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -262,6 +264,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -276,6 +279,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +294,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +309,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +324,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +339,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +354,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +369,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +384,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -388,6 +399,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -402,6 +414,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -416,6 +429,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -430,6 +444,7 @@
       "required": false,
       "short": "-B",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -444,6 +459,7 @@
       "required": false,
       "short": "-C",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -458,6 +474,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -472,6 +489,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -486,6 +504,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -500,6 +519,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     }

--- a/spec/typescript/browser/general/rm.json
+++ b/spec/typescript/browser/general/rm.json
@@ -108,6 +108,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -122,6 +123,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -136,6 +138,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -150,6 +153,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -164,6 +168,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -178,6 +183,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -192,6 +198,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -206,6 +213,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -220,6 +228,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -234,6 +243,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/rmdir.json
+++ b/spec/typescript/browser/general/rmdir.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/search.json
+++ b/spec/typescript/browser/general/search.json
@@ -52,6 +52,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -66,6 +67,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -80,6 +82,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/sed.json
+++ b/spec/typescript/browser/general/sed.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-E",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/seq.json
+++ b/spec/typescript/browser/general/seq.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -57,6 +59,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/sha1sum.json
+++ b/spec/typescript/browser/general/sha1sum.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +332,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +347,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +362,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/sha256sum.json
+++ b/spec/typescript/browser/general/sha256sum.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +332,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +347,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +362,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/sha384sum.json
+++ b/spec/typescript/browser/general/sha384sum.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +332,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +347,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +362,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/sha512sum.json
+++ b/spec/typescript/browser/general/sha512sum.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +332,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +347,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +362,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/shuf.json
+++ b/spec/typescript/browser/general/shuf.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/sort.json
+++ b/spec/typescript/browser/general/sort.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +332,7 @@
       "required": false,
       "short": "-V",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +347,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +362,7 @@
       "required": false,
       "short": "-M",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +377,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +392,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -395,6 +407,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -409,6 +422,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -423,6 +437,7 @@
       "required": false,
       "short": "-g",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -437,6 +452,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -451,6 +467,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -465,6 +482,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -479,6 +497,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/split.json
+++ b/spec/typescript/browser/general/split.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -129,6 +132,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -143,6 +147,7 @@
       "required": false,
       "short": "-x",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -157,6 +162,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -171,6 +177,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -185,6 +192,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/stat.json
+++ b/spec/typescript/browser/general/stat.json
@@ -234,6 +234,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -248,6 +249,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/strings.json
+++ b/spec/typescript/browser/general/strings.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/tac.json
+++ b/spec/typescript/browser/general/tac.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/tail.json
+++ b/spec/typescript/browser/general/tail.json
@@ -234,6 +234,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -248,6 +249,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -262,6 +264,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -276,6 +279,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +294,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/tar.json
+++ b/spec/typescript/browser/general/tar.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-x",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -129,6 +132,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -143,6 +147,7 @@
       "required": false,
       "short": "-j",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +162,7 @@
       "required": false,
       "short": "-J",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +177,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -185,6 +192,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -199,6 +207,7 @@
       "required": false,
       "short": "-C",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -213,6 +222,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -227,6 +237,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/tee.json
+++ b/spec/typescript/browser/general/tee.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -134,6 +137,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     }

--- a/spec/typescript/browser/general/touch.json
+++ b/spec/typescript/browser/general/touch.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/tr.json
+++ b/spec/typescript/browser/general/tr.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-C",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/tree.json
+++ b/spec/typescript/browser/general/tree.json
@@ -234,6 +234,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -248,6 +249,7 @@
       "required": false,
       "short": "-L",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -262,6 +264,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -276,6 +279,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +294,7 @@
       "required": false,
       "short": "-P",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/truncate.json
+++ b/spec/typescript/browser/general/truncate.json
@@ -73,6 +73,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/unexpand.json
+++ b/spec/typescript/browser/general/unexpand.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/uniq.json
+++ b/spec/typescript/browser/general/uniq.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-D",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -325,6 +332,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -339,6 +347,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +362,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -367,6 +377,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/unzip.json
+++ b/spec/typescript/browser/general/unzip.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -129,6 +132,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -143,6 +147,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +162,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/wc.json
+++ b/spec/typescript/browser/general/wc.json
@@ -234,6 +234,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -248,6 +249,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -262,6 +264,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -276,6 +279,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +294,7 @@
       "required": false,
       "short": "-L",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +309,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/wget.json
+++ b/spec/typescript/browser/general/wget.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-O",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -57,6 +59,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/xxd.json
+++ b/spec/typescript/browser/general/xxd.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-g",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/zgrep.json
+++ b/spec/typescript/browser/general/zgrep.json
@@ -227,6 +227,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +242,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +257,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +272,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +287,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +302,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +317,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -325,6 +332,7 @@
       "required": false,
       "short": "-E",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +347,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +362,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +377,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +392,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -395,6 +407,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -409,6 +422,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -423,6 +437,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/browser/general/zip.json
+++ b/spec/typescript/browser/general/zip.json
@@ -87,6 +87,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +102,7 @@
       "required": false,
       "short": "-j",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -115,6 +117,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/awk.json
+++ b/spec/typescript/node/general/awk.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     }

--- a/spec/typescript/node/general/base64.json
+++ b/spec/typescript/node/general/base64.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-D",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/basename.json
+++ b/spec/typescript/node/general/basename.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/bash.json
+++ b/spec/typescript/node/general/bash.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -64,6 +67,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -78,6 +82,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -92,6 +97,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -106,6 +112,7 @@
       "required": false,
       "short": "-x",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -120,6 +127,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -134,6 +142,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -148,6 +157,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -162,6 +172,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/bc.json
+++ b/spec/typescript/node/general/bc.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/cat.json
+++ b/spec/typescript/node/general/cat.json
@@ -297,6 +297,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +312,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +327,7 @@
       "required": false,
       "short": "-E",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +342,7 @@
       "required": false,
       "short": "-T",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +357,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +372,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +387,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -395,6 +402,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -409,6 +417,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -423,6 +432,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/chgrp.json
+++ b/spec/typescript/node/general/chgrp.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -64,6 +67,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/chmod.json
+++ b/spec/typescript/node/general/chmod.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/chown.json
+++ b/spec/typescript/node/general/chown.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -64,6 +67,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/cmp.json
+++ b/spec/typescript/node/general/cmp.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/column.json
+++ b/spec/typescript/node/general/column.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/comm.json
+++ b/spec/typescript/node/general/comm.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-1",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-2",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-3",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +395,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/cp.json
+++ b/spec/typescript/node/general/cp.json
@@ -115,6 +115,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -129,6 +130,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -143,6 +145,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +160,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +175,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -185,6 +190,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -199,6 +205,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -213,6 +220,7 @@
       "required": false,
       "short": "-u",
       "short_value": false,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -227,6 +235,7 @@
       "required": false,
       "short": "-b",
       "short_value": false,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -241,6 +250,7 @@
       "required": false,
       "short": "-S",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -255,6 +265,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -269,6 +280,7 @@
       "required": false,
       "short": "-T",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +295,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/csplit.json
+++ b/spec/typescript/node/general/csplit.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -185,6 +188,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -199,6 +203,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -213,6 +218,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -227,6 +233,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +248,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/curl.json
+++ b/spec/typescript/node/general/curl.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -57,6 +59,7 @@
       "required": false,
       "short": "-X",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -71,6 +74,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -85,6 +89,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -99,6 +104,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -113,6 +119,7 @@
       "required": false,
       "short": "-L",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -127,6 +134,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -141,6 +149,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -155,6 +164,7 @@
       "required": false,
       "short": "-S",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/cut.json
+++ b/spec/typescript/node/general/cut.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +395,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -402,6 +410,7 @@
       "required": false,
       "short": "-O",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -416,6 +425,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -430,6 +440,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -444,6 +455,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -458,6 +470,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/date.json
+++ b/spec/typescript/node/general/date.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -57,6 +59,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -71,6 +74,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/df.json
+++ b/spec/typescript/node/general/df.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -50,6 +52,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -64,6 +67,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -78,6 +82,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -92,6 +97,7 @@
       "required": false,
       "short": "-T",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -106,6 +112,7 @@
       "required": false,
       "short": "-P",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -120,6 +127,7 @@
       "required": false,
       "short": "-B",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/diff.json
+++ b/spec/typescript/node/general/diff.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/dirname.json
+++ b/spec/typescript/node/general/dirname.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/du.json
+++ b/spec/typescript/node/general/du.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/echo.json
+++ b/spec/typescript/node/general/echo.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/expand.json
+++ b/spec/typescript/node/general/expand.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/file.json
+++ b/spec/typescript/node/general/file.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/find.json
+++ b/spec/typescript/node/general/find.json
@@ -300,6 +300,7 @@
       "required": false,
       "short": "-name",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -314,6 +315,7 @@
       "required": false,
       "short": "-type",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -328,6 +330,7 @@
       "required": false,
       "short": "-maxdepth",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -342,6 +345,7 @@
       "required": false,
       "short": "-size",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -356,6 +360,7 @@
       "required": false,
       "short": "-mtime",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -370,6 +375,7 @@
       "required": false,
       "short": "-iname",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -384,6 +390,7 @@
       "required": false,
       "short": "-path",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -398,6 +405,7 @@
       "required": false,
       "short": "-mindepth",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -412,6 +420,7 @@
       "required": false,
       "short": "-print",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -426,6 +435,7 @@
       "required": false,
       "short": "-print0",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -440,6 +450,7 @@
       "required": false,
       "short": "-delete",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -454,6 +465,7 @@
       "required": false,
       "short": "-depth",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -468,6 +480,7 @@
       "required": false,
       "short": "-prune",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -482,6 +495,7 @@
       "required": false,
       "short": "-ls",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -496,6 +510,7 @@
       "required": false,
       "short": "-empty",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -510,6 +525,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -524,6 +540,7 @@
       "required": false,
       "short": "-or",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -538,6 +555,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -552,6 +570,7 @@
       "required": false,
       "short": "-and",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -566,6 +585,7 @@
       "required": false,
       "short": "-not",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/fmt.json
+++ b/spec/typescript/node/general/fmt.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-g",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/fold.json
+++ b/spec/typescript/node/general/fold.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/grep.json
+++ b/spec/typescript/node/general/grep.json
@@ -297,6 +297,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +312,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +327,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +342,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +357,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +372,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +387,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -395,6 +402,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -409,6 +417,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -423,6 +432,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -437,6 +447,7 @@
       "required": false,
       "short": "-E",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -451,6 +462,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -465,6 +477,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -479,6 +492,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -493,6 +507,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -507,6 +522,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -521,6 +537,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -535,6 +552,7 @@
       "required": false,
       "short": "-B",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -549,6 +567,7 @@
       "required": false,
       "short": "-C",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -563,6 +582,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -577,6 +597,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -591,6 +612,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -605,6 +627,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -619,6 +642,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/gunzip.json
+++ b/spec/typescript/node/general/gunzip.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -185,6 +188,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/gzip.json
+++ b/spec/typescript/node/general/gzip.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -185,6 +188,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -199,6 +203,7 @@
       "required": false,
       "short": "-1",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -213,6 +218,7 @@
       "required": false,
       "short": "-2",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -227,6 +233,7 @@
       "required": false,
       "short": "-3",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +248,7 @@
       "required": false,
       "short": "-4",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +263,7 @@
       "required": false,
       "short": "-5",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +278,7 @@
       "required": false,
       "short": "-6",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -283,6 +293,7 @@
       "required": false,
       "short": "-7",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -297,6 +308,7 @@
       "required": false,
       "short": "-8",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +323,7 @@
       "required": false,
       "short": "-9",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/head.json
+++ b/spec/typescript/node/general/head.json
@@ -297,6 +297,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +312,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -325,6 +327,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +342,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +357,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +372,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/history.json
+++ b/spec/typescript/node/general/history.json
@@ -31,6 +31,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -45,6 +46,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -59,6 +61,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -73,6 +76,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -87,6 +91,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -101,6 +106,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -115,6 +121,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -129,6 +136,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/iconv.json
+++ b/spec/typescript/node/general/iconv.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -185,6 +188,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     }

--- a/spec/typescript/node/general/join.json
+++ b/spec/typescript/node/general/join.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-1",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-2",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -388,6 +395,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -402,6 +410,7 @@
       "required": false,
       "short": "-j",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -416,6 +425,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -430,6 +440,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -444,6 +455,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -458,6 +470,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/jq.json
+++ b/spec/typescript/node/general/jq.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/js.json
+++ b/spec/typescript/node/general/js.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/ln.json
+++ b/spec/typescript/node/general/ln.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -185,6 +188,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/look.json
+++ b/spec/typescript/node/general/look.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/ls.json
+++ b/spec/typescript/node/general/ls.json
@@ -297,6 +297,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +312,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +327,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +342,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +357,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +372,7 @@
       "required": false,
       "short": "-S",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +387,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -395,6 +402,7 @@
       "required": false,
       "short": "-1",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -409,6 +417,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -423,6 +432,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -437,6 +447,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -451,6 +462,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     }

--- a/spec/typescript/node/general/md5sum.json
+++ b/spec/typescript/node/general/md5sum.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +395,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -402,6 +410,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -416,6 +425,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/mkdir.json
+++ b/spec/typescript/node/general/mkdir.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -185,6 +188,7 @@
       "required": false,
       "short": "-Z",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     }

--- a/spec/typescript/node/general/mktemp.json
+++ b/spec/typescript/node/general/mktemp.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": true
     },
@@ -185,6 +188,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -199,6 +203,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -213,6 +218,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -227,6 +233,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/mv.json
+++ b/spec/typescript/node/general/mv.json
@@ -115,6 +115,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -129,6 +130,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -143,6 +145,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +160,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +175,7 @@
       "required": false,
       "short": "-u",
       "short_value": false,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -185,6 +190,7 @@
       "required": false,
       "short": "-b",
       "short_value": false,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -199,6 +205,7 @@
       "required": false,
       "short": "-S",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -213,6 +220,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -227,6 +235,7 @@
       "required": false,
       "short": "-T",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +250,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -255,6 +265,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -269,6 +280,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/nl.json
+++ b/spec/typescript/node/general/nl.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +395,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -402,6 +410,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -416,6 +425,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -430,6 +440,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/node.json
+++ b/spec/typescript/node/general/node.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/numfmt.json
+++ b/spec/typescript/node/general/numfmt.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/od.json
+++ b/spec/typescript/node/general/od.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-j",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-N",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/paste.json
+++ b/spec/typescript/node/general/paste.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/patch.json
+++ b/spec/typescript/node/general/patch.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -185,6 +188,7 @@
       "required": false,
       "short": "-N",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/pwd.json
+++ b/spec/typescript/node/general/pwd.json
@@ -22,6 +22,7 @@
       "required": false,
       "short": "-P",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -36,6 +37,7 @@
       "required": false,
       "short": "-L",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/python.json
+++ b/spec/typescript/node/general/python.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/python3.json
+++ b/spec/typescript/node/general/python3.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/readlink.json
+++ b/spec/typescript/node/general/readlink.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/realpath.json
+++ b/spec/typescript/node/general/realpath.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/rg.json
+++ b/spec/typescript/node/general/rg.json
@@ -297,6 +297,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +312,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +327,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +342,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +357,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +372,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -381,6 +387,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -395,6 +402,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -409,6 +417,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -423,6 +432,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -437,6 +447,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -451,6 +462,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -465,6 +477,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -479,6 +492,7 @@
       "required": false,
       "short": "-A",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -493,6 +507,7 @@
       "required": false,
       "short": "-B",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -507,6 +522,7 @@
       "required": false,
       "short": "-C",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -521,6 +537,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -535,6 +552,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -549,6 +567,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -563,6 +582,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     }

--- a/spec/typescript/node/general/rm.json
+++ b/spec/typescript/node/general/rm.json
@@ -164,6 +164,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -178,6 +179,7 @@
       "required": false,
       "short": "-R",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -192,6 +194,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -206,6 +209,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -220,6 +224,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -234,6 +239,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -248,6 +254,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -262,6 +269,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -276,6 +284,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -290,6 +299,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/rmdir.json
+++ b/spec/typescript/node/general/rmdir.json
@@ -115,6 +115,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/search.json
+++ b/spec/typescript/node/general/search.json
@@ -52,6 +52,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -66,6 +67,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -80,6 +82,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/sed.json
+++ b/spec/typescript/node/general/sed.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-E",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/seq.json
+++ b/spec/typescript/node/general/seq.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -57,6 +59,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/sha1sum.json
+++ b/spec/typescript/node/general/sha1sum.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +395,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -402,6 +410,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -416,6 +425,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/sha256sum.json
+++ b/spec/typescript/node/general/sha256sum.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +395,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -402,6 +410,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -416,6 +425,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/sha384sum.json
+++ b/spec/typescript/node/general/sha384sum.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +395,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -402,6 +410,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -416,6 +425,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/sha512sum.json
+++ b/spec/typescript/node/general/sha512sum.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +395,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -402,6 +410,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -416,6 +425,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/shuf.json
+++ b/spec/typescript/node/general/shuf.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     }

--- a/spec/typescript/node/general/sort.json
+++ b/spec/typescript/node/general/sort.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-k",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -388,6 +395,7 @@
       "required": false,
       "short": "-V",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -402,6 +410,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -416,6 +425,7 @@
       "required": false,
       "short": "-M",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -430,6 +440,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -444,6 +455,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -458,6 +470,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -472,6 +485,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -486,6 +500,7 @@
       "required": false,
       "short": "-g",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -500,6 +515,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -514,6 +530,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -528,6 +545,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -542,6 +560,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/split.json
+++ b/spec/typescript/node/general/split.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -185,6 +188,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -199,6 +203,7 @@
       "required": false,
       "short": "-x",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -213,6 +218,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -227,6 +233,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -241,6 +248,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/stat.json
+++ b/spec/typescript/node/general/stat.json
@@ -297,6 +297,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +312,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/strings.json
+++ b/spec/typescript/node/general/strings.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/tac.json
+++ b/spec/typescript/node/general/tac.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-b",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/tail.json
+++ b/spec/typescript/node/general/tail.json
@@ -297,6 +297,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -311,6 +312,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -325,6 +327,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +342,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +357,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/tar.json
+++ b/spec/typescript/node/general/tar.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-x",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -185,6 +188,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -199,6 +203,7 @@
       "required": false,
       "short": "-j",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -213,6 +218,7 @@
       "required": false,
       "short": "-J",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -227,6 +233,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -241,6 +248,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -255,6 +263,7 @@
       "required": false,
       "short": "-C",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -269,6 +278,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -283,6 +293,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/tee.json
+++ b/spec/typescript/node/general/tee.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -190,6 +193,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     }

--- a/spec/typescript/node/general/touch.json
+++ b/spec/typescript/node/general/touch.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/tr.json
+++ b/spec/typescript/node/general/tr.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-C",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/tree.json
+++ b/spec/typescript/node/general/tree.json
@@ -297,6 +297,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +312,7 @@
       "required": false,
       "short": "-L",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -325,6 +327,7 @@
       "required": false,
       "short": "-I",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -339,6 +342,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +357,7 @@
       "required": false,
       "short": "-P",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/truncate.json
+++ b/spec/typescript/node/general/truncate.json
@@ -101,6 +101,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/unexpand.json
+++ b/spec/typescript/node/general/unexpand.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-a",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/uniq.json
+++ b/spec/typescript/node/general/uniq.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-D",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": true
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -388,6 +395,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -402,6 +410,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -416,6 +425,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -430,6 +440,7 @@
       "required": false,
       "short": "-z",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/unzip.json
+++ b/spec/typescript/node/general/unzip.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": "-d",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -185,6 +188,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -199,6 +203,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -213,6 +218,7 @@
       "required": false,
       "short": "-t",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/wc.json
+++ b/spec/typescript/node/general/wc.json
@@ -297,6 +297,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -311,6 +312,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -325,6 +327,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -339,6 +342,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -353,6 +357,7 @@
       "required": false,
       "short": "-L",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -367,6 +372,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     }

--- a/spec/typescript/node/general/wget.json
+++ b/spec/typescript/node/general/wget.json
@@ -29,6 +29,7 @@
       "required": false,
       "short": "-O",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -43,6 +44,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -57,6 +59,7 @@
       "required": false,
       "short": null,
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/xxd.json
+++ b/spec/typescript/node/general/xxd.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-p",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-s",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-g",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": "-u",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/zgrep.json
+++ b/spec/typescript/node/general/zgrep.json
@@ -290,6 +290,7 @@
       "required": false,
       "short": "-i",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -304,6 +305,7 @@
       "required": false,
       "short": "-c",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -318,6 +320,7 @@
       "required": false,
       "short": "-l",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -332,6 +335,7 @@
       "required": false,
       "short": "-n",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -346,6 +350,7 @@
       "required": false,
       "short": "-v",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -360,6 +365,7 @@
       "required": false,
       "short": "-e",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -374,6 +380,7 @@
       "required": false,
       "short": "-f",
       "short_value": true,
+      "type": "str",
       "value_kind": "path",
       "value_optional": false
     },
@@ -388,6 +395,7 @@
       "required": false,
       "short": "-E",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -402,6 +410,7 @@
       "required": false,
       "short": "-F",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -416,6 +425,7 @@
       "required": false,
       "short": "-H",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -430,6 +440,7 @@
       "required": false,
       "short": "-h",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -444,6 +455,7 @@
       "required": false,
       "short": "-m",
       "short_value": true,
+      "type": "str",
       "value_kind": "text",
       "value_optional": false
     },
@@ -458,6 +470,7 @@
       "required": false,
       "short": "-o",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -472,6 +485,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -486,6 +500,7 @@
       "required": false,
       "short": "-w",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/spec/typescript/node/general/zip.json
+++ b/spec/typescript/node/general/zip.json
@@ -143,6 +143,7 @@
       "required": false,
       "short": "-r",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -157,6 +158,7 @@
       "required": false,
       "short": "-j",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     },
@@ -171,6 +173,7 @@
       "required": false,
       "short": "-q",
       "short_value": true,
+      "type": "str",
       "value_kind": "none",
       "value_optional": false
     }

--- a/typescript/packages/core/src/commands/cli/types.test.ts
+++ b/typescript/packages/core/src/commands/cli/types.test.ts
@@ -199,3 +199,28 @@ describe('CLISpec', () => {
     expect(Object.isFrozen(new CommandSpec({}))).toBe(true)
   })
 })
+
+describe('CLISpec aliases', () => {
+  it('shares one sibling namespace between names and aliases', () => {
+    expect(
+      () =>
+        new CLISpec({
+          name: 'tool',
+          subcommands: [
+            new CLISpec({ name: 'checkout', aliases: ['co'], fn: verb }),
+            new CLISpec({ name: 'co', fn: verb }),
+          ],
+        }),
+    ).toThrow(/duplicate subcommand 'co'/)
+  })
+
+  it('refuses a multi-word alias', () => {
+    expect(
+      () =>
+        new CLISpec({
+          name: 'tool',
+          subcommands: [new CLISpec({ name: 'checkout', aliases: ['c o'], fn: verb })],
+        }),
+    ).toThrow(/alias 'c o'/)
+  })
+})

--- a/typescript/packages/core/src/commands/cli/types.ts
+++ b/typescript/packages/core/src/commands/cli/types.ts
@@ -32,6 +32,7 @@ export type CLIVerbFn = (
 
 export interface CLISpecInit extends CommandSpecInit {
   name: string
+  aliases?: readonly string[]
   fn?: CLIVerbFn | null
   subcommands?: readonly CLISpec[]
   write?: boolean
@@ -58,6 +59,7 @@ export interface CLISpecInit extends CommandSpecInit {
  */
 export class CLISpec extends CommandSpec {
   readonly name: string
+  readonly aliases: readonly string[]
   readonly fn: CLIVerbFn | null
   readonly subcommands: readonly CLISpec[]
   readonly write: boolean
@@ -67,6 +69,7 @@ export class CLISpec extends CommandSpec {
   constructor(init: CLISpecInit) {
     super(init)
     this.name = init.name
+    this.aliases = Object.freeze([...(init.aliases ?? [])])
     this.fn = init.fn ?? null
     this.subcommands = Object.freeze([...(init.subcommands ?? [])])
     this.write = init.write ?? false
@@ -74,6 +77,11 @@ export class CLISpec extends CommandSpec {
     this.configModel = init.configModel ?? null
     if (this.name === '' || /\s/.test(this.name)) {
       throw new Error(`cli name '${this.name}' must be a single non-empty word`)
+    }
+    for (const alias of this.aliases) {
+      if (alias === '' || /\s/.test(alias)) {
+        throw new Error(`cli '${this.name}': alias '${alias}' must be a single non-empty word`)
+      }
     }
     if (this.fn !== null && this.subcommands.length > 0) {
       throw new Error(`cli '${this.name}': a node takes fn or subcommands, not both`)
@@ -87,12 +95,16 @@ export class CLISpec extends CommandSpec {
           'positional/rest belong on leaves',
       )
     }
+    // Names and aliases share one sibling namespace (argparse refuses a
+    // conflicting subparser alias the same way).
     const seen = new Set<string>()
     for (const child of this.subcommands) {
-      if (seen.has(child.name)) {
-        throw new Error(`cli '${this.name}': duplicate subcommand '${child.name}'`)
+      for (const word of [child.name, ...child.aliases]) {
+        if (seen.has(word)) {
+          throw new Error(`cli '${this.name}': duplicate subcommand '${word}'`)
+        }
+        seen.add(word)
       }
-      seen.add(child.name)
       if (child.configModel !== null) {
         throw new Error(
           `cli '${this.name}': subcommand '${child.name}' declares configModel; ` +

--- a/typescript/packages/core/src/commands/cli/walk.test.ts
+++ b/typescript/packages/core/src/commands/cli/walk.test.ts
@@ -256,3 +256,84 @@ describe('walk', () => {
     expect(ok.groupFlags).toEqual({ '--token': 't' })
   })
 })
+
+describe('walk argparse/git alignment', () => {
+  it('resolves an alias to its canonical verb', () => {
+    const spec = new CLISpec({
+      name: 'tool',
+      subcommands: [
+        new CLISpec({
+          name: 'checkout',
+          aliases: ['co'],
+          description: 'Switch branches',
+          fn: verb,
+        }),
+      ],
+    })
+    const result = walk('tool', spec, ['co', 'x'])
+    expect(result.leaf).not.toBeNull()
+    expect(result.path).toEqual(['checkout'])
+    expect(result.argv).toEqual(['x'])
+  })
+
+  it('renders aliases beside the canonical name', () => {
+    const spec = new CLISpec({
+      name: 'tool',
+      subcommands: [
+        new CLISpec({
+          name: 'checkout',
+          aliases: ['co', 'cout'],
+          description: 'Switch branches',
+          fn: verb,
+        }),
+      ],
+    })
+    const listing = walk('tool', spec, [])
+    expect(text(listing.output)).toContain('  checkout (co, cout)  Switch branches')
+  })
+
+  it('expands a unique group long prefix like git', () => {
+    const result = walk('gws', tree(), ['--verb', '--verb', 'gmail', 'send'])
+    expect(result.leaf).not.toBeNull()
+    expect(result.groupFlags['--verbose']).toBe(2)
+  })
+
+  it('refuses an ambiguous group prefix with git wording', () => {
+    const spec = new CLISpec({
+      name: 'tool',
+      options: [
+        new Option({ long: '--context', valueKind: OperandKind.TEXT }),
+        new Option({ long: '--count' }),
+      ],
+      subcommands: [new CLISpec({ name: 'run', fn: verb })],
+    })
+    const result = walk('tool', spec, ['--co', 'run'])
+    expect(result.exitCode).toBe(129)
+    expect(
+      text(result.output).startsWith('error: ambiguous option: co (could be --context or --count)'),
+    ).toBe(true)
+  })
+
+  it('reaches the injected help through a prefix', () => {
+    const full = walk('gws', tree(), ['--help'])
+    const abbreviated = walk('gws', tree(), ['--hel'])
+    expect(abbreviated.exitCode).toBe(0)
+    expect(abbreviated.output).toEqual(full.output)
+  })
+
+  it('refuses a non-integer int-typed group value with git wording', () => {
+    const spec = new CLISpec({
+      name: 'tool',
+      options: [new Option({ long: '--depth', valueKind: OperandKind.TEXT, type: 'int' })],
+      subcommands: [new CLISpec({ name: 'run', fn: verb })],
+    })
+    const bad = walk('tool', spec, ['--depth', 'x', 'run'])
+    expect(bad.exitCode).toBe(129)
+    expect(text(bad.output).startsWith("error: option '--depth' expects a numerical value")).toBe(
+      true,
+    )
+    const ok = walk('tool', spec, ['--depth', '-3', 'run'])
+    expect(ok.leaf).not.toBeNull()
+    expect(ok.groupFlags).toEqual({ '--depth': '-3' })
+  })
+})

--- a/typescript/packages/core/src/commands/cli/walk.ts
+++ b/typescript/packages/core/src/commands/cli/walk.ts
@@ -13,7 +13,8 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { HELP_OPTION } from '../config.ts'
-import { compileSpec, type CompiledSpec } from '../spec/compile.ts'
+import { compileSpec, type CompiledSpec, expandLong } from '../spec/compile.ts'
+import { INT_VALUE } from '../spec/constants.ts'
 import { renderHelp } from '../spec/help.ts'
 import { CommandSpec } from '../spec/types.ts'
 import { WalkResult, type CLISpec, type WalkFlagBag } from './types.ts'
@@ -21,6 +22,11 @@ import { WalkResult, type CLISpec, type WalkFlagBag } from './types.ts'
 import { USAGE_EXIT } from './constants.ts'
 
 const ENC = new TextEncoder()
+
+/** A subcommand's row label: `name (alias, ...)` like argparse. */
+function verbDisplay(child: CLISpec): string {
+  return child.aliases.length > 0 ? `${child.name} (${child.aliases.join(', ')})` : child.name
+}
 
 /**
  * A group node's help: the ordinary command help plus Commands rows.
@@ -31,7 +37,7 @@ const ENC = new TextEncoder()
  */
 export function nodeHelp(name: string, node: CLISpec): string {
   const rows: [string, string][] = node.subcommands.map((child) => [
-    child.name,
+    verbDisplay(child),
     child.description ?? '',
   ])
   // --help is a registered option everywhere (argparse add_help, click
@@ -136,6 +142,25 @@ function matchShort(
 }
 
 /**
+ * Prefix-expand a long spelling at a group level. The declared tables
+ * match first; the injected `--help` joins the candidate pool when the
+ * node does not declare its own, because it is a registered option
+ * everywhere else (argparse and getopt_long both expand `--hel` to it).
+ */
+function expandGroupLong(node: CLISpec, cs: CompiledSpec, spelling: string): readonly string[] {
+  const candidates = expandLong(cs, spelling)
+  if (
+    '--help'.startsWith(spelling) &&
+    spelling.length > 2 &&
+    !candidates.includes('--help') &&
+    !node.options.some((option) => option.long === '--help')
+  ) {
+    return [...candidates, '--help']
+  }
+  return candidates
+}
+
+/**
  * Apply a node's declarative option rules after its scan: defaults land as
  * if typed, then choices and required are enforced, the same order the
  * flat parser uses. Returns a rendered refusal or null when satisfied.
@@ -149,6 +174,17 @@ function finishNode(
   for (const [dest, value] of cs.defaults) {
     if (!(dest in flags)) {
       flags[dest] = cs.multipleDests.has(dest) ? [value] : value
+    }
+  }
+  // Int-typed values before choices, argparse's order; wording is git's
+  // parse-options refusal (`--depth` on a non-integer).
+  for (const dest of cs.intDests) {
+    const value = flags[dest]
+    const candidates = Array.isArray(value) ? value : typeof value === 'string' ? [value] : []
+    for (const part of candidates) {
+      if (!INT_VALUE.test(part)) {
+        return usageError(name, node, `error: option '${dest}' expects a numerical value`)
+      }
     }
   }
   for (const [dest, allowed] of cs.choicesByDest) {
@@ -204,8 +240,24 @@ export function walk(head: string, spec: CLISpec, argv: readonly string[]): Walk
       }
       if (!optionsEnded && token.startsWith('--')) {
         const eq = token.indexOf('=')
-        const spelling = eq === -1 ? token : token.slice(0, eq)
+        let spelling = eq === -1 ? token : token.slice(0, eq)
         const attached = eq === -1 ? null : token.slice(eq + 1)
+        // getopt_long: an exact spelling wins; otherwise a unique prefix
+        // expands (git status --porcel) and an ambiguous one is refused
+        // with every possibility (git wording).
+        if (!cs.dest.has(spelling) && spelling !== '--help') {
+          const candidates = expandGroupLong(node, cs, spelling)
+          if (candidates.length === 1) {
+            spelling = candidates[0] ?? spelling
+          } else if (candidates.length > 1) {
+            const possible = candidates.join(' or ')
+            return usageError(
+              name,
+              node,
+              `error: ambiguous option: ${spelling.slice(2)} (could be ${possible})`,
+            )
+          }
+        }
         // Optional-value longs sit in BOTH longBoolSpellings and
         // longOptionalSpellings, so the optional test runs first or
         // --color=auto would be refused as taking no value.
@@ -284,12 +336,15 @@ export function walk(head: string, spec: CLISpec, argv: readonly string[]): Walk
       }
       const refused = finishNode(name, node, cs, flags)
       if (refused !== null) return refused
-      const child = node.subcommands.find((c) => c.name === token)
+      // An alias resolves to its canonical node; the path records the
+      // canonical name (argparse prog attribution: errors under `gws co`
+      // render as `gws checkout`).
+      const child = node.subcommands.find((c) => c.name === token || c.aliases.includes(token))
       if (child === undefined) {
         return unknownVerb(head, name, token)
       }
       node = child
-      path = [...path, token]
+      path = [...path, child.name]
       i += 1
       descended = true
       break

--- a/typescript/packages/core/src/commands/spec/compile.test.ts
+++ b/typescript/packages/core/src/commands/spec/compile.test.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
-import { compileSpec } from './compile.ts'
+import { compileSpec, expandLong } from './compile.ts'
 import { CommandSpec, OperandKind, Option } from './types.ts'
 
 describe('compileSpec — count/choices/required/default tables', () => {
@@ -68,5 +68,49 @@ describe('compileSpec — count/choices/required/default tables', () => {
   it('caches per spec object', () => {
     const spec = new CommandSpec({ options: [new Option({ short: '-x' })] })
     expect(compileSpec(spec)).toBe(compileSpec(spec))
+  })
+})
+
+describe('type int validation', () => {
+  it('requires a value flag', () => {
+    expect(() =>
+      compileSpec(new CommandSpec({ options: [new Option({ long: '--fast', type: 'int' })] })),
+    ).toThrow(/requires a value flag/)
+  })
+
+  it('requires an integer default', () => {
+    expect(() =>
+      compileSpec(
+        new CommandSpec({
+          options: [
+            new Option({
+              long: '--port',
+              valueKind: OperandKind.TEXT,
+              type: 'int',
+              default: 'auto',
+            }),
+          ],
+        }),
+      ),
+    ).toThrow(/is not an integer/)
+  })
+})
+
+describe('expandLong', () => {
+  it('handles exact, prefix, ambiguous, and unknown spellings', () => {
+    const cs = compileSpec(
+      new CommandSpec({
+        options: [
+          new Option({ long: '--binary' }),
+          new Option({ long: '--binary-files', valueKind: OperandKind.TEXT }),
+          new Option({ long: '--count' }),
+        ],
+      }),
+    )
+    expect(expandLong(cs, '--binary')).toEqual(['--binary'])
+    expect(expandLong(cs, '--bin')).toEqual(['--binary', '--binary-files'])
+    expect(expandLong(cs, '--co')).toEqual(['--count'])
+    expect(expandLong(cs, '--zz')).toEqual([])
+    expect(expandLong(cs, '--')).toEqual([])
   })
 })

--- a/typescript/packages/core/src/commands/spec/compile.ts
+++ b/typescript/packages/core/src/commands/spec/compile.ts
@@ -46,6 +46,10 @@ export class CompiledSpec {
   /** Every long spelling in declaration order (the order GNU's ambiguity
    * refusal lists possibilities), for getopt_long prefix expansion. */
   readonly longSpellings: readonly string[]
+  /** Behavior signature per long spelling. Prefix candidates whose
+   * signatures all match are one option in glibc's eyes (same action
+   * struct), so the prefix resolves instead of refusing as ambiguous. */
+  readonly longSignatures: ReadonlyMap<string, string>
   /** Canonical spellings of int-typed options; the parser refuses a
    * non-integer value at parse time (argparse `type=int`). */
   readonly intDests: ReadonlySet<string>
@@ -84,6 +88,7 @@ export class CompiledSpec {
     longValueSpellings: ReadonlySet<string>
     longOptionalSpellings: ReadonlySet<string>
     longSpellings: readonly string[]
+    longSignatures: ReadonlyMap<string, string>
     intDests: ReadonlySet<string>
     kindOf: ReadonlyMap<string, OperandKind>
     kindByDest: ReadonlyMap<string, OperandKind>
@@ -103,6 +108,7 @@ export class CompiledSpec {
     this.longValueSpellings = fields.longValueSpellings
     this.longOptionalSpellings = fields.longOptionalSpellings
     this.longSpellings = fields.longSpellings
+    this.longSignatures = fields.longSignatures
     this.intDests = fields.intDests
     this.kindOf = fields.kindOf
     this.kindByDest = fields.kindByDest
@@ -136,6 +142,7 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
   const longValueSpellings = new Set<string>()
   const longOptionalSpellings = new Set<string>()
   const longSpellings: string[] = []
+  const longSignatures = new Map<string, string>()
   const intDests = new Set<string>()
   const kindOf = new Map<string, OperandKind>()
   const kindByDest = new Map<string, OperandKind>()
@@ -194,6 +201,21 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
     }
     if (opt.long !== null) {
       longSpellings.push(opt.long)
+      // Everything parsing-relevant except the spellings and the help
+      // text: two options that agree here are one action.
+      longSignatures.set(
+        opt.long,
+        [
+          opt.valueKind,
+          String(opt.valueOptional),
+          String(opt.multiple),
+          String(opt.count),
+          opt.choices.join(','),
+          String(opt.required),
+          String(opt.default),
+          opt.type,
+        ].join('|'),
+      )
       if (opt.valueKind === OperandKind.NONE) {
         longBoolSpellings.add(opt.long)
       } else if (opt.valueOptional) {
@@ -222,6 +244,7 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
     longValueSpellings,
     longOptionalSpellings,
     longSpellings,
+    longSignatures,
     intDests,
     kindOf,
     kindByDest,
@@ -243,25 +266,22 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
  *
  * An exact declared spelling always wins (GNU: `--binary` never trips
  * over `--binary-files`); otherwise the candidates are every declared
- * long the typed spelling prefixes, deduped by dest because glibc treats
- * several spellings of one option as unambiguous (`grep --colo` resolves
- * despite `--color`/`--colour`). The result length tells the caller
- * everything: 0 unknown, 1 match, 2+ ambiguous (candidates in
- * declaration order, the order GNU lists possibilities).
+ * long the typed spelling prefixes. Candidates whose behavior signatures
+ * all match count as one option, the way glibc treats several table
+ * entries with one action struct (`grep --colo` resolves despite
+ * `--color`/`--colour` being separate entries), and the prefix resolves
+ * to the first. The result length tells the caller everything: 0
+ * unknown, 1 match, 2+ ambiguous (every matching spelling in
+ * declaration order, the order GNU lists possibilities, synonyms
+ * included like GNU's own listing).
  */
 export function expandLong(cs: CompiledSpec, spelling: string): readonly string[] {
   if (cs.dest.has(spelling)) return [spelling]
   if (spelling.length <= 2) return []
-  const matches: string[] = []
-  const seen = new Set<string>()
-  for (const declared of cs.longSpellings) {
-    if (declared.startsWith(spelling)) {
-      const dest = cs.destOf(declared)
-      if (!seen.has(dest)) {
-        seen.add(dest)
-        matches.push(declared)
-      }
-    }
-  }
+  const matches = cs.longSpellings.filter((declared) => declared.startsWith(spelling))
+  const first = matches[0]
+  if (first === undefined) return []
+  const signatures = new Set(matches.map((declared) => cs.longSignatures.get(declared)))
+  if (signatures.size === 1) return [first]
   return matches
 }

--- a/typescript/packages/core/src/commands/spec/compile.ts
+++ b/typescript/packages/core/src/commands/spec/compile.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { INT_VALUE } from './constants.ts'
 import { type CommandSpec, OperandKind } from './types.ts'
 
 /**
@@ -42,6 +43,12 @@ export class CompiledSpec {
   /** Long spellings whose value only attaches via `=` (GNU optional
    * argument). */
   readonly longOptionalSpellings: ReadonlySet<string>
+  /** Every long spelling in declaration order (the order GNU's ambiguity
+   * refusal lists possibilities), for getopt_long prefix expansion. */
+  readonly longSpellings: readonly string[]
+  /** Canonical spellings of int-typed options; the parser refuses a
+   * non-integer value at parse time (argparse `type=int`). */
+  readonly intDests: ReadonlySet<string>
   /** Value kind per spelling (parse-time lookup). */
   readonly kindOf: ReadonlyMap<string, OperandKind>
   /** Value kind per canonical spelling, for post-parse PATH/TEXT value
@@ -76,6 +83,8 @@ export class CompiledSpec {
     longBoolSpellings: ReadonlySet<string>
     longValueSpellings: ReadonlySet<string>
     longOptionalSpellings: ReadonlySet<string>
+    longSpellings: readonly string[]
+    intDests: ReadonlySet<string>
     kindOf: ReadonlyMap<string, OperandKind>
     kindByDest: ReadonlyMap<string, OperandKind>
     dest: ReadonlyMap<string, string>
@@ -93,6 +102,8 @@ export class CompiledSpec {
     this.longBoolSpellings = fields.longBoolSpellings
     this.longValueSpellings = fields.longValueSpellings
     this.longOptionalSpellings = fields.longOptionalSpellings
+    this.longSpellings = fields.longSpellings
+    this.intDests = fields.intDests
     this.kindOf = fields.kindOf
     this.kindByDest = fields.kindByDest
     this.dest = fields.dest
@@ -124,6 +135,8 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
   const longBoolSpellings = new Set<string>()
   const longValueSpellings = new Set<string>()
   const longOptionalSpellings = new Set<string>()
+  const longSpellings: string[] = []
+  const intDests = new Set<string>()
   const kindOf = new Map<string, OperandKind>()
   const kindByDest = new Map<string, OperandKind>()
   const dest = new Map<string, string>()
@@ -145,6 +158,15 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
     }
     if (opt.choices.length > 0 && opt.default !== null && !opt.choices.includes(opt.default)) {
       throw new Error(`option '${canonical}': default '${opt.default}' is not one of its choices`)
+    }
+    if (opt.type === 'int') {
+      if (opt.valueKind === OperandKind.NONE) {
+        throw new Error(`option '${canonical}': type 'int' requires a value flag`)
+      }
+      if (opt.default !== null && !INT_VALUE.test(opt.default)) {
+        throw new Error(`option '${canonical}': default '${opt.default}' is not an integer`)
+      }
+      intDests.add(canonical)
     }
     if (opt.short !== null) dest.set(opt.short, canonical)
     if (opt.long !== null) dest.set(opt.long, canonical)
@@ -171,6 +193,7 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
       }
     }
     if (opt.long !== null) {
+      longSpellings.push(opt.long)
       if (opt.valueKind === OperandKind.NONE) {
         longBoolSpellings.add(opt.long)
       } else if (opt.valueOptional) {
@@ -198,6 +221,8 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
     longBoolSpellings,
     longValueSpellings,
     longOptionalSpellings,
+    longSpellings,
+    intDests,
     kindOf,
     kindByDest,
     dest,
@@ -211,4 +236,32 @@ export function compileSpec(spec: CommandSpec): CompiledSpec {
   })
   CACHE.set(spec, compiled)
   return compiled
+}
+
+/**
+ * getopt_long prefix matching for a long spelling.
+ *
+ * An exact declared spelling always wins (GNU: `--binary` never trips
+ * over `--binary-files`); otherwise the candidates are every declared
+ * long the typed spelling prefixes, deduped by dest because glibc treats
+ * several spellings of one option as unambiguous (`grep --colo` resolves
+ * despite `--color`/`--colour`). The result length tells the caller
+ * everything: 0 unknown, 1 match, 2+ ambiguous (candidates in
+ * declaration order, the order GNU lists possibilities).
+ */
+export function expandLong(cs: CompiledSpec, spelling: string): readonly string[] {
+  if (cs.dest.has(spelling)) return [spelling]
+  if (spelling.length <= 2) return []
+  const matches: string[] = []
+  const seen = new Set<string>()
+  for (const declared of cs.longSpellings) {
+    if (declared.startsWith(spelling)) {
+      const dest = cs.destOf(declared)
+      if (!seen.has(dest)) {
+        seen.add(dest)
+        matches.push(declared)
+      }
+    }
+  }
+  return matches
 }

--- a/typescript/packages/core/src/commands/spec/constants.ts
+++ b/typescript/packages/core/src/commands/spec/constants.ts
@@ -35,6 +35,11 @@ export function flagKwargName(flag: string): string {
 
 export const NUMERIC_SHORT = /^-\d+$/
 
+// Value shape accepted by an int-typed option: optional sign plus digits,
+// the portable core of Python int() and argparse (no whitespace, no
+// underscores, so both languages accept exactly the same strings).
+export const INT_VALUE = /^[+-]?\d+$/
+
 // GNU usage-error exit codes, pinned against debian coreutils/grep/diffutils
 // (plus ripgrep and jq upstream docs). Everything else exits 1.
 // Commands whose `Try '--help'` hint line is prefixed with the command

--- a/typescript/packages/core/src/commands/spec/parser.test.ts
+++ b/typescript/packages/core/src/commands/spec/parser.test.ts
@@ -778,3 +778,46 @@ describe('int-typed values', () => {
     expect(parsed.invalidIntOptions).toEqual([['--id', 'x']])
   })
 })
+
+describe('synonym long spellings', () => {
+  it('resolves a shared prefix like glibc', () => {
+    const grep = specOf('grep')
+    const parsed = parseCommand(grep, ['--colo', 'pat', '/a.txt'], '/')
+    expect(parsed.ambiguousOptions).toEqual([])
+    expect(parsed.flags['--color']).toBe(true)
+    const attached = parseCommand(grep, ['--colo=never', 'pat', '/a.txt'], '/')
+    expect(attached.flags['--color']).toBe('never')
+  })
+
+  it('lists synonyms in an ambiguity like GNU', () => {
+    const spec = new CommandSpec({
+      options: [
+        new Option({ long: '--context', valueKind: OperandKind.TEXT }),
+        new Option({ long: '--color', valueOptional: true, valueKind: OperandKind.TEXT }),
+        new Option({ long: '--colour', valueOptional: true, valueKind: OperandKind.TEXT }),
+        new Option({ long: '--count' }),
+      ],
+    })
+    const parsed = parseCommand(spec, ['--c'], '/')
+    expect(parsed.ambiguousOptions).toEqual([
+      ['--c', ['--context', '--color', '--colour', '--count']],
+    ])
+  })
+
+  it('keeps scan order in optionErrorKinds', () => {
+    const spec = new CommandSpec({
+      options: [
+        new Option({ long: '--context', valueKind: OperandKind.TEXT }),
+        new Option({ long: '--count' }),
+      ],
+    })
+    expect(parseCommand(spec, ['--c', '--bogus'], '/').optionErrorKinds).toEqual([
+      'ambiguous',
+      'invalid',
+    ])
+    expect(parseCommand(spec, ['--bogus', '--c'], '/').optionErrorKinds).toEqual([
+      'invalid',
+      'ambiguous',
+    ])
+  })
+})

--- a/typescript/packages/core/src/commands/spec/parser.test.ts
+++ b/typescript/packages/core/src/commands/spec/parser.test.ts
@@ -697,3 +697,84 @@ describe('multiple + default', () => {
     expect(typed.flags['--file']).toEqual(['/data/a', '/data/b'])
   })
 })
+
+describe('long-option abbreviation', () => {
+  it('expands a unique prefix like getopt_long', () => {
+    const spec = new CommandSpec({
+      options: [new Option({ long: '--recursive' }), new Option({ long: '--count' })],
+    })
+    const parsed = parseCommand(spec, ['--rec', 'x'], '/')
+    expect(parsed.flags['--recursive']).toBe(true)
+    expect(parsed.invalidOptions).toEqual([])
+    expect(parsed.ambiguousOptions).toEqual([])
+  })
+
+  it('reports ambiguous prefixes with possibilities in declaration order', () => {
+    const spec = new CommandSpec({
+      options: [
+        new Option({ long: '--context', valueKind: OperandKind.TEXT }),
+        new Option({ long: '--color', valueOptional: true, valueKind: OperandKind.TEXT }),
+        new Option({ long: '--count' }),
+      ],
+    })
+    const parsed = parseCommand(spec, ['--c'], '/')
+    expect(parsed.ambiguousOptions).toEqual([['--c', ['--context', '--color', '--count']]])
+    expect(parsed.invalidOptions).toEqual([])
+  })
+
+  it('lets an exact long win over a longer spelling', () => {
+    const spec = new CommandSpec({
+      options: [
+        new Option({ long: '--binary' }),
+        new Option({ long: '--binary-files', valueKind: OperandKind.TEXT }),
+      ],
+    })
+    const parsed = parseCommand(spec, ['--binary'], '/')
+    expect(parsed.flags['--binary']).toBe(true)
+    expect(parsed.ambiguousOptions).toEqual([])
+  })
+
+  it('carries attached and detached values through abbreviation', () => {
+    const spec = new CommandSpec({
+      options: [
+        new Option({ long: '--color', valueOptional: true, valueKind: OperandKind.TEXT }),
+        new Option({ long: '--exclude', valueKind: OperandKind.TEXT }),
+      ],
+    })
+    expect(parseCommand(spec, ['--colo=never'], '/').flags['--color']).toBe('never')
+    expect(parseCommand(spec, ['--excl', 'tmp'], '/').flags['--exclude']).toBe('tmp')
+  })
+
+  it('keeps exact-only matching for free-text commands', () => {
+    const spec = new CommandSpec({
+      options: [new Option({ long: '--verbose' })],
+      rest: new Operand({ kind: OperandKind.TEXT }),
+    })
+    const parsed = parseCommand(spec, ['--verb', 'hi'], '/')
+    expect(parsed.flags['--verbose']).toBeUndefined()
+    expect(parsed.texts()).toEqual(['--verb', 'hi'])
+  })
+})
+
+describe('int-typed values', () => {
+  it('reports a non-integer value, never throws', () => {
+    const spec = new CommandSpec({
+      options: [new Option({ long: '--port', valueKind: OperandKind.TEXT, type: 'int' })],
+    })
+    const parsed = parseCommand(spec, ['--port', 'abc'], '/')
+    expect(parsed.invalidIntOptions).toEqual([['--port', 'abc']])
+    const ok = parseCommand(spec, ['--port', '-42'], '/')
+    expect(ok.invalidIntOptions).toEqual([])
+    expect(ok.flags['--port']).toBe('-42')
+  })
+
+  it('checks every value of a multiple flag', () => {
+    const spec = new CommandSpec({
+      options: [
+        new Option({ long: '--id', valueKind: OperandKind.TEXT, multiple: true, type: 'int' }),
+      ],
+    })
+    const parsed = parseCommand(spec, ['--id', '1', '--id', 'x'], '/')
+    expect(parsed.invalidIntOptions).toEqual([['--id', 'x']])
+  })
+})

--- a/typescript/packages/core/src/commands/spec/parser.ts
+++ b/typescript/packages/core/src/commands/spec/parser.ts
@@ -13,8 +13,8 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { resolvePath } from '../../utils/path.ts'
-import { type CompiledSpec, compileSpec } from './compile.ts'
-import { flagKwargName, NUMERIC_SHORT } from './constants.ts'
+import { type CompiledSpec, compileSpec, expandLong } from './compile.ts'
+import { flagKwargName, INT_VALUE, NUMERIC_SHORT } from './constants.ts'
 import { type CommandSpec, OperandKind, ParsedArgs } from './types.ts'
 
 // Record a value flag occurrence under its canonical dest. Both spellings
@@ -130,6 +130,7 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
   const wordKinds: (OperandKind | null)[] = new Array<OperandKind | null>(argv.length).fill(null)
   const warnings: string[] = []
   const invalidOptions: string[] = []
+  const ambiguousOptions: [string, readonly string[]][] = []
   const needsValueOptions: string[] = []
   // Free-text commands (echo/python/bash-style TEXT rest) keep unknown dash
   // tokens verbatim; elsewhere they are dropped with a warning so a stray
@@ -161,24 +162,41 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
     }
 
     if (tok.startsWith('--')) {
-      if (cs.longBoolSpellings.has(tok)) {
-        setBoolFlag(flags, cs, tok)
+      // getopt_long: an exact spelling always wins; otherwise an
+      // unambiguous prefix expands to its declared spelling (grep --rec)
+      // and an ambiguous one is refused with every possibility.
+      // Free-text commands keep exact-only matching: their unknown dash
+      // tokens are operands, not typos.
+      const eqPos = tok.indexOf('=')
+      const typed = eqPos === -1 ? tok : tok.slice(0, eqPos)
+      let spelling = typed
+      if (!cs.dest.has(typed) && !lenientDashOperands) {
+        const candidates = expandLong(cs, typed)
+        if (candidates.length === 1) {
+          spelling = candidates[0] ?? typed
+        } else if (candidates.length > 1) {
+          ambiguousOptions.push([typed, candidates])
+          i += 1
+          continue
+        }
+      }
+      const etok = eqPos === -1 ? spelling : spelling + tok.slice(eqPos)
+      if (cs.longBoolSpellings.has(etok)) {
+        setBoolFlag(flags, cs, etok)
         i += 1
-      } else if (cs.longValueSpellings.has(tok) && i + 1 < filteredArgv.length) {
-        setValueFlag(flags, cs, tok, filteredArgv[i + 1] ?? '')
-        wordKinds[origIndices[i + 1] ?? -1] = cs.kindOf.get(tok) ?? null
+      } else if (cs.longValueSpellings.has(etok) && i + 1 < filteredArgv.length) {
+        setValueFlag(flags, cs, etok, filteredArgv[i + 1] ?? '')
+        wordKinds[origIndices[i + 1] ?? -1] = cs.kindOf.get(etok) ?? null
         i += 2
       } else {
-        const eq = tok.indexOf('=')
         if (
-          eq !== -1 &&
-          (cs.longValueSpellings.has(tok.slice(0, eq)) ||
-            cs.longOptionalSpellings.has(tok.slice(0, eq)))
+          eqPos !== -1 &&
+          (cs.longValueSpellings.has(spelling) || cs.longOptionalSpellings.has(spelling))
         ) {
-          setValueFlag(flags, cs, tok.slice(0, eq), tok.slice(eq + 1))
-        } else if (cs.longValueSpellings.has(tok)) {
+          setValueFlag(flags, cs, spelling, tok.slice(eqPos + 1))
+        } else if (cs.longValueSpellings.has(etok)) {
           // Declared value flag at end of line with no argument.
-          needsValueOptions.push(tok)
+          needsValueOptions.push(etok)
         } else if (lenientDashOperands) {
           rawArgs.push(tok)
           rawIndices.push(origIndices[i] ?? -1)
@@ -299,6 +317,18 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
     }
   }
 
+  // Int-typed values are refused before choices, argparse's order (type
+  // conversion runs before the choices test). The bare boolean form of
+  // an optional-value flag is exempt, like choices.
+  const invalidIntOptions: [string, string][] = []
+  for (const destName of cs.intDests) {
+    const value = flags[destName]
+    const candidates = Array.isArray(value) ? value : typeof value === 'string' ? [value] : []
+    for (const part of candidates) {
+      if (!INT_VALUE.test(part)) invalidIntOptions.push([destName, part])
+    }
+  }
+
   const invalidValueOptions: [string, string, readonly string[]][] = []
   for (const [destName, allowed] of cs.choicesByDest) {
     const value = flags[destName]
@@ -380,8 +410,10 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
     textFlagValues,
     warnings,
     invalidOptions,
+    ambiguousOptions,
     needsValueOptions,
     invalidValueOptions,
+    invalidIntOptions,
     missingRequiredOptions,
     wordKinds,
   })

--- a/typescript/packages/core/src/commands/spec/parser.ts
+++ b/typescript/packages/core/src/commands/spec/parser.ts
@@ -131,6 +131,7 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
   const warnings: string[] = []
   const invalidOptions: string[] = []
   const ambiguousOptions: [string, readonly string[]][] = []
+  const optionErrorKinds: string[] = []
   const needsValueOptions: string[] = []
   // Free-text commands (echo/python/bash-style TEXT rest) keep unknown dash
   // tokens verbatim; elsewhere they are dropped with a warning so a stray
@@ -176,6 +177,7 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
           spelling = candidates[0] ?? typed
         } else if (candidates.length > 1) {
           ambiguousOptions.push([typed, candidates])
+          optionErrorKinds.push('ambiguous')
           i += 1
           continue
         }
@@ -202,6 +204,7 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
           rawIndices.push(origIndices[i] ?? -1)
         } else {
           invalidOptions.push(tok)
+          optionErrorKinds.push('invalid')
         }
         i += 1
       }
@@ -297,6 +300,7 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
           }
         }
         invalidOptions.push(bad)
+        optionErrorKinds.push('invalid')
       }
       i += 1
       continue
@@ -411,6 +415,7 @@ export function parseCommand(spec: CommandSpec, argv: string[], cwd: string): Pa
     warnings,
     invalidOptions,
     ambiguousOptions,
+    optionErrorKinds,
     needsValueOptions,
     invalidValueOptions,
     invalidIntOptions,

--- a/typescript/packages/core/src/commands/spec/types.ts
+++ b/typescript/packages/core/src/commands/spec/types.ts
@@ -223,6 +223,7 @@ export interface ParsedArgsInit {
   wordKinds?: (OperandKind | null)[]
   invalidOptions?: string[]
   ambiguousOptions?: [string, readonly string[]][]
+  optionErrorKinds?: string[]
   needsValueOptions?: string[]
   invalidValueOptions?: [string, string, readonly string[]][]
   invalidIntOptions?: [string, string][]
@@ -248,6 +249,12 @@ export class ParsedArgs {
   // options (canonical spelling).
   readonly invalidOptions: string[]
   readonly ambiguousOptions: [string, readonly string[]][]
+  // "invalid" / "ambiguous" tags in scan encounter order, so the refusal
+  // names the FIRST offending token like GNU (grep --c --bogus reports
+  // --c; reversed reports --bogus). needsValue is absent by construction:
+  // it only fires on the line's final token, so it can never precede
+  // another scan error.
+  readonly optionErrorKinds: string[]
   readonly needsValueOptions: string[]
   readonly invalidValueOptions: [string, string, readonly string[]][]
   readonly invalidIntOptions: [string, string][]
@@ -264,6 +271,7 @@ export class ParsedArgs {
     this.wordKinds = init.wordKinds ?? []
     this.invalidOptions = init.invalidOptions ?? []
     this.ambiguousOptions = init.ambiguousOptions ?? []
+    this.optionErrorKinds = init.optionErrorKinds ?? []
     this.needsValueOptions = init.needsValueOptions ?? []
     this.invalidValueOptions = init.invalidValueOptions ?? []
     this.invalidIntOptions = init.invalidIntOptions ?? []

--- a/typescript/packages/core/src/commands/spec/types.ts
+++ b/typescript/packages/core/src/commands/spec/types.ts
@@ -102,6 +102,17 @@ export interface OptionInit {
    * choices). Presence of a default always satisfies `required`.
    */
   default?: string | null
+  /**
+   * argparse `type=` as data. "int" makes the parser refuse a non-integer
+   * value at parse time (argparse's `invalid int value`; the walk uses
+   * git's `expects a numerical value`), before the command runs. The
+   * accepted shape is an optional sign plus digits, the portable core of
+   * Python int() and argparse. The bag still holds the string: commands
+   * read it through FlagView.asInt, the established mirage convention.
+   * Builtins whose GNU tool words its own numeric refusal (`head: invalid
+   * number of lines`) keep "str" and validate in the command.
+   */
+  type?: 'str' | 'int'
   description?: string
 }
 
@@ -117,6 +128,7 @@ export class Option {
   readonly choices: readonly string[]
   readonly required: boolean
   readonly default: string | null
+  readonly type: 'str' | 'int'
   readonly description: string | null
 
   constructor(init: OptionInit = {}) {
@@ -131,6 +143,7 @@ export class Option {
     this.choices = init.choices ?? []
     this.required = init.required ?? false
     this.default = init.default ?? null
+    this.type = init.type ?? 'str'
     this.description = init.description ?? null
     Object.freeze(this)
   }
@@ -209,8 +222,10 @@ export interface ParsedArgsInit {
   warnings?: string[]
   wordKinds?: (OperandKind | null)[]
   invalidOptions?: string[]
+  ambiguousOptions?: [string, readonly string[]][]
   needsValueOptions?: string[]
   invalidValueOptions?: [string, string, readonly string[]][]
+  invalidIntOptions?: [string, string][]
   missingRequiredOptions?: string[]
 }
 
@@ -225,12 +240,17 @@ export class ParsedArgs {
   readonly wordKinds: (OperandKind | null)[]
   // GNU-shaped option errors, reported (never thrown) by the parser:
   // undeclared options ('--bogus' or the offending cluster char 'Y'),
-  // declared value flags that ran out of line ('--max-depth', 'm'),
-  // values outside a declared choices set (canonical spelling, value,
-  // allowed values), and absent required options (canonical spelling).
+  // abbreviated longs matching several options (typed prefix, matched
+  // spellings in declaration order), declared value flags that ran out
+  // of line ('--max-depth', 'm'), values outside a declared choices set
+  // (canonical spelling, value, allowed values), non-integer values on
+  // int-typed options (canonical spelling, value), and absent required
+  // options (canonical spelling).
   readonly invalidOptions: string[]
+  readonly ambiguousOptions: [string, readonly string[]][]
   readonly needsValueOptions: string[]
   readonly invalidValueOptions: [string, string, readonly string[]][]
+  readonly invalidIntOptions: [string, string][]
   readonly missingRequiredOptions: string[]
 
   constructor(init: ParsedArgsInit) {
@@ -243,8 +263,10 @@ export class ParsedArgs {
     this.warnings = init.warnings ?? []
     this.wordKinds = init.wordKinds ?? []
     this.invalidOptions = init.invalidOptions ?? []
+    this.ambiguousOptions = init.ambiguousOptions ?? []
     this.needsValueOptions = init.needsValueOptions ?? []
     this.invalidValueOptions = init.invalidValueOptions ?? []
+    this.invalidIntOptions = init.invalidIntOptions ?? []
     this.missingRequiredOptions = init.missingRequiredOptions ?? []
   }
 

--- a/typescript/packages/core/src/commands/spec/usage.test.ts
+++ b/typescript/packages/core/src/commands/spec/usage.test.ts
@@ -14,7 +14,9 @@
 
 import { describe, expect, it } from 'vitest'
 import {
+  ambiguousOptionError,
   extraOperandError,
+  invalidIntError,
   invalidArgumentError,
   missingRequiredError,
   missingValueError,
@@ -114,6 +116,28 @@ describe('missingRequiredError', () => {
     const [msg, code] = missingRequiredError('mycmd', '--out')
     expect(new TextDecoder().decode(msg)).toBe(
       "mycmd: option '--out' is required\nTry 'mycmd --help' for more information.\n",
+    )
+    expect(code).toBe(1)
+  })
+})
+
+describe('ambiguousOptionError', () => {
+  it('matches the GNU shape', () => {
+    const [msg, code] = ambiguousOptionError('grep', '--c', ['--context', '--color', '--count'])
+    expect(new TextDecoder().decode(msg)).toBe(
+      "grep: option '--c' is ambiguous; possibilities: '--context' '--color' '--count'\n" +
+        "Try 'grep --help' for more information.\n",
+    )
+    expect(code).toBe(2)
+  })
+})
+
+describe('invalidIntError', () => {
+  it('mirrors argparse wording', () => {
+    const [msg, code] = invalidIntError('mycli', '--port', 'abc')
+    expect(new TextDecoder().decode(msg)).toBe(
+      "mycli: invalid int value: 'abc' for '--port'\n" +
+        "Try 'mycli --help' for more information.\n",
     )
     expect(code).toBe(1)
   })

--- a/typescript/packages/core/src/commands/spec/usage.ts
+++ b/typescript/packages/core/src/commands/spec/usage.ts
@@ -46,6 +46,43 @@ export function unknownOptionError(cmdName: string, token: string): [Uint8Array,
   return [new TextEncoder().encode(line + hint), usageExitCode(cmdName)]
 }
 
+/**
+ * getopt_long refusal for an abbreviated long matching several options.
+ *
+ * Shape pinned against real GNU (`grep --c`): the typed spelling, then
+ * every possibility quoted in declaration order on one line. The
+ * per-tool usage dump GNU appends is deliberately omitted, like
+ * unknownOptionError.
+ */
+export function ambiguousOptionError(
+  cmdName: string,
+  token: string,
+  candidates: readonly string[],
+): [Uint8Array, number] {
+  const listed = candidates.map((c) => `'${c}'`).join(' ')
+  const line = `${cmdName}: option '${token}' is ambiguous; possibilities: ${listed}\n`
+  const hint = `Try '${cmdName} --help' for more information.\n`
+  return [new TextEncoder().encode(line + hint), usageExitCode(cmdName)]
+}
+
+/**
+ * Refusal for a non-integer value on an int-typed option.
+ *
+ * No GNU tool declares types through getopt (each words its own refusal,
+ * e.g. `head: invalid number of lines`), so this mirrors argparse's
+ * `invalid int value: 'abc'` with the option attributed the way
+ * invalidArgumentError does.
+ */
+export function invalidIntError(
+  cmdName: string,
+  option: string,
+  value: string,
+): [Uint8Array, number] {
+  const line = `${cmdName}: invalid int value: '${value}' for '${option}'\n`
+  const hint = `Try '${cmdName} --help' for more information.\n`
+  return [new TextEncoder().encode(line + hint), usageExitCode(cmdName)]
+}
+
 /** GNU-shaped error for a declared value flag with no argument left. */
 export function missingValueError(cmdName: string, token: string): [Uint8Array, number] {
   const line = token.startsWith('--')

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -218,6 +218,7 @@ export async function handleCommand(
       csParsed[7],
       csParsed[8],
       csParsed[9],
+      csParsed[10],
     )
     if (csRefusal !== null) {
       const [msg, code] = csRefusal
@@ -341,6 +342,7 @@ export async function handleCommand(
     parseWarnings,
     invalidOptions,
     ambiguousOptions,
+    optionErrorKinds,
     needsValueOptions,
     invalidValueOptions,
     invalidIntOptions,
@@ -350,6 +352,7 @@ export async function handleCommand(
     cmdName,
     invalidOptions,
     ambiguousOptions,
+    optionErrorKinds,
     needsValueOptions,
     invalidValueOptions,
     invalidIntOptions,

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -210,7 +210,15 @@ export async function handleCommand(
     const csParsed = parseFlags(parts.slice(1), SPECS[cmdName] ?? null, cmdName, session.cwd)
     const csFlags = csParsed[2]
     const csTexts = findExprTokens ?? csParsed[1]
-    const csRefusal = optionError(cmdName, csParsed[4], csParsed[5], csParsed[6], csParsed[7])
+    const csRefusal = optionError(
+      cmdName,
+      csParsed[4],
+      csParsed[5],
+      csParsed[6],
+      csParsed[7],
+      csParsed[8],
+      csParsed[9],
+    )
     if (csRefusal !== null) {
       const [msg, code] = csRefusal
       return [
@@ -332,15 +340,19 @@ export async function handleCommand(
     flagKwargs,
     parseWarnings,
     invalidOptions,
+    ambiguousOptions,
     needsValueOptions,
     invalidValueOptions,
+    invalidIntOptions,
     missingRequiredOptions,
   ] = parseFlags(parts.slice(1), mount.specFor(cmdName), cmdName, session.cwd)
   const refusal = optionError(
     cmdName,
     invalidOptions,
+    ambiguousOptions,
     needsValueOptions,
     invalidValueOptions,
+    invalidIntOptions,
     missingRequiredOptions,
   )
   if (refusal !== null) {

--- a/typescript/packages/core/src/workspace/executor/command/flags.test.ts
+++ b/typescript/packages/core/src/workspace/executor/command/flags.test.ts
@@ -16,7 +16,8 @@ import { describe, expect, it } from 'vitest'
 
 import { SPECS } from '../../../commands/spec/index.ts'
 import { PathSpec } from '../../../types.ts'
-import { parseFlags } from './flags.ts'
+import { CommandSpec, OperandKind, Option } from '../../../commands/spec/types.ts'
+import { optionError, parseFlags } from './flags.ts'
 
 function path(virtual: string): PathSpec {
   return new PathSpec({ virtual, directory: virtual, resourcePath: '', resolved: true })
@@ -44,5 +45,47 @@ describe('parseFlags', () => {
     const [paths] = parseFlags(['b.txt'], SPECS.cat ?? null, 'cat', '/data')
     expect(paths.length).toBe(1)
     expect(paths[0]?.resourcePath).toBe('')
+  })
+})
+
+describe('optionError scan order', () => {
+  it('reports the first scan error like GNU', () => {
+    const spec = new CommandSpec({
+      options: [
+        new Option({ long: '--context', valueKind: OperandKind.TEXT }),
+        new Option({ long: '--count' }),
+      ],
+    })
+    const dec = new TextDecoder()
+    const ambiguousFirst = parseFlags(['--c', '--bogus', 'x'], spec, 'grep', '/')
+    const refusal = optionError(
+      'grep',
+      ...([
+        ambiguousFirst[4],
+        ambiguousFirst[5],
+        ambiguousFirst[6],
+        ambiguousFirst[7],
+        ambiguousFirst[8],
+        ambiguousFirst[9],
+        ambiguousFirst[10],
+      ] as const),
+    )
+    expect(refusal).not.toBeNull()
+    expect(dec.decode(refusal?.[0]).startsWith("grep: option '--c' is ambiguous")).toBe(true)
+    const invalidFirst = parseFlags(['--bogus', '--c', 'x'], spec, 'grep', '/')
+    const flipped = optionError(
+      'grep',
+      ...([
+        invalidFirst[4],
+        invalidFirst[5],
+        invalidFirst[6],
+        invalidFirst[7],
+        invalidFirst[8],
+        invalidFirst[9],
+        invalidFirst[10],
+      ] as const),
+    )
+    expect(flipped).not.toBeNull()
+    expect(dec.decode(flipped?.[0]).startsWith("grep: unrecognized option '--bogus'")).toBe(true)
   })
 })

--- a/typescript/packages/core/src/workspace/executor/command/flags.ts
+++ b/typescript/packages/core/src/workspace/executor/command/flags.ts
@@ -14,7 +14,9 @@
 
 import { parseCommand, parseToKwargs } from '../../../commands/spec/parser.ts'
 import {
+  ambiguousOptionError,
   invalidArgumentError,
+  invalidIntError,
   missingRequiredError,
   missingValueError,
   unknownOptionError,
@@ -60,8 +62,10 @@ export function parseFlags(
   Record<string, string | boolean | number | string[]>,
   string[],
   string[],
+  [string, readonly string[]][],
   string[],
   [string, string, readonly string[]][],
+  [string, string][],
   string[],
 ] {
   const argv: string[] = parts.map((item) => (item instanceof PathSpec ? item.virtual : item))
@@ -103,8 +107,10 @@ export function parseFlags(
       flagKwargs,
       parsed.warnings,
       parsed.invalidOptions,
+      parsed.ambiguousOptions,
       parsed.needsValueOptions,
       parsed.invalidValueOptions,
+      parsed.invalidIntOptions,
       parsed.missingRequiredOptions,
     ]
   }
@@ -115,7 +121,7 @@ export function parseFlags(
     if (item instanceof PathSpec) paths.push(item)
     else texts.push(item)
   }
-  return [paths, texts, {}, [], [], [], [], []]
+  return [paths, texts, {}, [], [], [], [], [], [], []]
 }
 
 // GNU-shaped refusal for option errors the parser reported. find is
@@ -124,15 +130,21 @@ export function parseFlags(
 export function optionError(
   cmdName: string,
   invalid: readonly string[],
+  ambiguous: readonly [string, readonly string[]][],
   needsValue: readonly string[],
   invalidValue: readonly [string, string, readonly string[]][],
+  invalidInt: readonly [string, string][],
   missingRequired: readonly string[],
 ): [Uint8Array, number] | null {
   if (cmdName === 'find') return null
   if (invalid.length > 0) return unknownOptionError(cmdName, invalid[0] ?? '')
+  const ambiguousFirst = ambiguous[0]
+  if (ambiguousFirst !== undefined) return ambiguousOptionError(cmdName, ...ambiguousFirst)
   if (needsValue.length > 0) return missingValueError(cmdName, needsValue[0] ?? '')
   const badValue = invalidValue[0]
   if (badValue !== undefined) return invalidArgumentError(cmdName, ...badValue)
+  const badInt = invalidInt[0]
+  if (badInt !== undefined) return invalidIntError(cmdName, ...badInt)
   if (missingRequired.length > 0) return missingRequiredError(cmdName, missingRequired[0] ?? '')
   return null
 }

--- a/typescript/packages/core/src/workspace/executor/command/flags.ts
+++ b/typescript/packages/core/src/workspace/executor/command/flags.ts
@@ -64,6 +64,7 @@ export function parseFlags(
   string[],
   [string, readonly string[]][],
   string[],
+  string[],
   [string, string, readonly string[]][],
   [string, string][],
   string[],
@@ -108,6 +109,7 @@ export function parseFlags(
       parsed.warnings,
       parsed.invalidOptions,
       parsed.ambiguousOptions,
+      parsed.optionErrorKinds,
       parsed.needsValueOptions,
       parsed.invalidValueOptions,
       parsed.invalidIntOptions,
@@ -121,7 +123,7 @@ export function parseFlags(
     if (item instanceof PathSpec) paths.push(item)
     else texts.push(item)
   }
-  return [paths, texts, {}, [], [], [], [], [], [], []]
+  return [paths, texts, {}, [], [], [], [], [], [], [], []]
 }
 
 // GNU-shaped refusal for option errors the parser reported. find is
@@ -131,14 +133,21 @@ export function optionError(
   cmdName: string,
   invalid: readonly string[],
   ambiguous: readonly [string, readonly string[]][],
+  errorKinds: readonly string[],
   needsValue: readonly string[],
   invalidValue: readonly [string, string, readonly string[]][],
   invalidInt: readonly [string, string][],
   missingRequired: readonly string[],
 ): [Uint8Array, number] | null {
   if (cmdName === 'find') return null
-  if (invalid.length > 0) return unknownOptionError(cmdName, invalid[0] ?? '')
+  // Scan-order between unknown and ambiguous options: GNU stops at the
+  // first offending token, so `grep --c --bogus` reports the ambiguity
+  // and the reversed line reports --bogus.
   const ambiguousFirst = ambiguous[0]
+  if (errorKinds[0] === 'ambiguous' && ambiguousFirst !== undefined) {
+    return ambiguousOptionError(cmdName, ...ambiguousFirst)
+  }
+  if (invalid.length > 0) return unknownOptionError(cmdName, invalid[0] ?? '')
   if (ambiguousFirst !== undefined) return ambiguousOptionError(cmdName, ...ambiguousFirst)
   if (needsValue.length > 0) return missingValueError(cmdName, needsValue[0] ?? '')
   const badValue = invalidValue[0]

--- a/typescript/scripts/gen-specs.ts
+++ b/typescript/scripts/gen-specs.ts
@@ -159,6 +159,7 @@ function serializeOption(o: Option): Record<string, unknown> {
     required: o.required,
     short: o.short,
     short_value: o.shortValue,
+    type: o.type,
     value_kind: o.valueKind,
     value_optional: o.valueOptional,
   }


### PR DESCRIPTION
Mirrors three argparse/getopt_long behaviors into the spec machinery, per the alignment review of the CLI layer. Stacked on #685.

## Subcommand aliases (argparse `aliases=`)
- `CLISpec.aliases`: alternate words resolving to a subcommand; names and aliases share one sibling namespace (argparse's conflicting-alias refusal).
- The walk records the canonical name in `path`, so help and errors attribute to it (argparse prog semantics), and the Commands listing renders `checkout (co)`.

## Long-option abbreviation (getopt_long, argparse `allow_abbrev`)
- `expand_long` / `expandLong` in spec compile: exact spelling wins, a unique prefix expands, candidates dedupe by dest (glibc treats `--color`/`--colour` synonyms as unambiguous).
- Flat parser: unique prefixes work for every non-free-text command (`grep --rec`, `--colo=never`); ambiguous prefixes report `option '--c' is ambiguous; possibilities: ...` (pinned against GNU grep, exit per USAGE_EXIT). Free-text commands keep exact-only matching, since their unknown dash tokens are operands.
- Walk: group levels expand too (`gws --verb`), ambiguity uses git wording `error: ambiguous option: co (could be --context or --count)` at exit 129 (pinned against git 2.47.3 parse-options), and `--hel` reaches the injected `--help` like argparse.

## Typed values (argparse `type=int`)
- `Option.type: "str" | "int"` as data. Int-typed values are refused at parse time, before choices (argparse's order); the bag keeps the string and commands read it via `FlagView.as_int`, the existing convention.
- Flat parser wording mirrors argparse: `invalid int value: 'abc' for '--port'`; the walk uses git's `error: option '--port' expects a numerical value` (129). Compile refuses `type="int"` on boolean flags and non-integer defaults at import time.
- Builtins keep `type="str"`: GNU tools word their own numeric refusals (`head: invalid number of lines`), which stays in the commands.

Behavior pinned in docker (debian:stable-slim: GNU grep/head, git 2.47.3) and against argparse directly. Spec dumps regenerated in both languages (every Option now carries `type`); parity gate green.

Not mirrored: hidden subcommands, which argparse itself does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)