### PR TITLE
feat(cli): install registry, dispatch by name, and the YAML clis: section

### DIFF
--- a/python/mirage/__init__.py
+++ b/python/mirage/__init__.py
@@ -16,7 +16,7 @@
 from mirage.resource.disk import DiskResource
 from mirage.resource.ram import RAMResource
 from mirage.commands.registry import command
-from mirage.commands.cli import CLISpec
+from mirage.commands.cli import CLISpec, register_cli_spec
 from mirage.types import FileStat, MountBackend, MountMode
 from mirage.policy import (Action, CommandContext, Deny, GuardSpec, Policy)
 from mirage.workspace import (ExecutionNode, Workspace, WorkspaceRunner)
@@ -45,6 +45,7 @@ __all__ = [
     "MountBackend",
     "MountMode",
     "CLISpec",
+    "register_cli_spec",
     "command",
     "new_session_id",
     "new_workspace_id",

--- a/python/mirage/commands/cli/__init__.py
+++ b/python/mirage/commands/cli/__init__.py
@@ -12,12 +12,17 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from mirage.commands.cli.specs import (cli_spec_for, register_cli_spec,
+                                       unregister_cli_spec)
 from mirage.commands.cli.types import CLISpec, WalkResult
 from mirage.commands.cli.walk import node_help, walk
 
 __all__ = [
     "CLISpec",
     "WalkResult",
+    "cli_spec_for",
     "node_help",
+    "register_cli_spec",
+    "unregister_cli_spec",
     "walk",
 ]

--- a/python/mirage/commands/cli/specs.py
+++ b/python/mirage/commands/cli/specs.py
@@ -1,0 +1,55 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.commands.cli.types import CLISpec
+
+# Named CLISpec trees the YAML ``clis:`` section resolves against
+# (``cli: slack`` looks up "slack" here). Bundled programs register at
+# import time; user programs register through register_cli_spec before
+# the workspace loads.
+CLI_SPECS: dict[str, CLISpec] = {}
+
+
+def register_cli_spec(spec: CLISpec) -> None:
+    """Make a CLISpec resolvable by name from YAML.
+
+    Args:
+        spec (CLISpec): a program tree; its root ``name`` is the key.
+    """
+    if spec.name in CLI_SPECS:
+        raise ValueError(f"CLI spec {spec.name!r} is already registered")
+    CLI_SPECS[spec.name] = spec
+
+
+def unregister_cli_spec(name: str) -> None:
+    """Remove a named CLISpec from the YAML lookup.
+
+    Args:
+        name (str): the spec's root name.
+    """
+    if name not in CLI_SPECS:
+        raise KeyError(f"CLI spec {name!r} is not registered")
+    del CLI_SPECS[name]
+
+
+def cli_spec_for(name: str) -> CLISpec:
+    """Resolve a YAML ``cli:`` key to its registered tree, fail loud.
+
+    Args:
+        name (str): the spec's root name.
+    """
+    if name not in CLI_SPECS:
+        known = ", ".join(sorted(CLI_SPECS)) or "none registered"
+        raise ValueError(f"unknown cli {name!r} (known: {known})")
+    return CLI_SPECS[name]

--- a/python/mirage/commands/cli/types.py
+++ b/python/mirage/commands/cli/types.py
@@ -75,7 +75,11 @@ class CLISpec(CommandSpec):
     fn: Callable[..., Any] | None = None
     subcommands: tuple["CLISpec", ...] = ()
     write: bool = False
-    safeguard: CommandSafeguard | None = None
+    # hash=False: CommandSafeguard is a mutable dataclass, and the
+    # frozen CLISpec must stay hashable for compile_spec's per-spec
+    # cache. Equality still compares the field; only the hash skips it
+    # (a collision is legal, a TypeError is not).
+    safeguard: CommandSafeguard | None = field(default=None, hash=False)
     config_model: type[BaseModel] | None = None
 
     def __post_init__(self) -> None:

--- a/python/mirage/config.py
+++ b/python/mirage/config.py
@@ -238,6 +238,21 @@ class GuardBlock(BaseModel):
     paths: list[str] = Field(default_factory=list)
 
 
+class CLIBlock(BaseModel):
+    """One ``clis:`` entry: install a named CLISpec with its own config.
+
+    The section key is the installed head word; ``cli`` names the
+    registered spec tree; ``config`` validates through that spec's
+    ``config_model`` at install time (fail loud). A CLI never takes a
+    mode and never shares a mount's credentials: a binary has no mode,
+    the credential does.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    cli: str
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
 class MountBlock(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -358,6 +373,9 @@ class WorkspaceConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     mounts: dict[str, MountBlock]
+    # Installed CLIs, fully separate from mounts: key = installed head
+    # word, value names a registered CLISpec plus its own config.
+    clis: dict[str, CLIBlock] | None = None
     # The workspace's ordered runtime world: name strings or maps
     # with a name plus the uniform runtime options ({name: wasi,
     # config: {home: /opt/...}}). Unset = the default world.
@@ -432,6 +450,12 @@ class WorkspaceConfig(BaseModel):
                           commands=tuple(g.commands),
                           paths=tuple(g.paths)) for g in self.guards
             ]
+
+        if self.clis is not None:
+            kwargs["clis"] = {
+                name: (block.cli, dict(block.config))
+                for name, block in self.clis.items()
+            }
         return kwargs
 
     def kernel_mounts(self) -> dict[str, tuple[MountBackend, str | None]]:

--- a/python/mirage/workspace/cli/__init__.py
+++ b/python/mirage/workspace/cli/__init__.py
@@ -12,16 +12,10 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.workspace.names import (JOB_BUILTINS, NAMESPACE_COMMANDS,
-                                    NO_FOLLOW_COMMANDS, SHELL_NAMES,
-                                    UNSUPPORTED_BUILTINS)
+from mirage.workspace.cli.registry import CLIRegistry
+from mirage.workspace.cli.types import CLIInstall
 
-# The pools live in workspace/names.py (a leaf shared with the CLI
-# registry's collision rule); this module keeps route's public surface.
 __all__ = [
-    "JOB_BUILTINS",
-    "NAMESPACE_COMMANDS",
-    "NO_FOLLOW_COMMANDS",
-    "SHELL_NAMES",
-    "UNSUPPORTED_BUILTINS",
+    "CLIInstall",
+    "CLIRegistry",
 ]

--- a/python/mirage/workspace/cli/registry.py
+++ b/python/mirage/workspace/cli/registry.py
@@ -1,0 +1,113 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from pydantic import BaseModel
+
+from mirage.commands.cli.types import CLISpec
+from mirage.commands.spec import SPECS
+from mirage.workspace.cli.types import CLIInstall
+from mirage.workspace.names import (JOB_BUILTINS, NAMESPACE_COMMANDS,
+                                    SHELL_NAMES)
+
+
+class CLIRegistry:
+    """Installed CLIs, keyed by head word.
+
+    Fully separate from the mount registry: a CLI exists because it was
+    installed (YAML ``clis:`` section or ``register_cli``), never
+    because storage was mounted. Install is fail-loud: a bad name, a
+    colliding name, or a config the spec's ``config_model`` rejects
+    raises at install time, so a workspace that loads has only valid
+    entries.
+    """
+
+    def __init__(self) -> None:
+        self._installs: dict[str, CLIInstall] = {}
+
+    def install(self,
+                name: str,
+                spec: CLISpec,
+                config: dict[str, object] | None = None) -> CLIInstall:
+        """Install a CLI under a head word.
+
+        Args:
+            name (str): head word to install under. Must be a single
+                word and must not collide with another installed CLI, a
+                shell builtin, or a general command (a runtime capture
+                of the same name is fine: the policy steers per line).
+            spec (CLISpec): the program tree.
+            config (dict[str, object] | None): installation config,
+                validated through the spec's ``config_model``.
+        """
+        if not name or any(ch.isspace() for ch in name):
+            raise ValueError(f"CLI name {name!r} must be a single word")
+        if name in self._installs:
+            raise ValueError(f"CLI name {name!r} is already installed")
+        if name in SHELL_NAMES or name in JOB_BUILTINS:
+            raise ValueError(f"CLI name {name!r} collides with a shell "
+                             f"builtin")
+        if name in NAMESPACE_COMMANDS or name in SPECS:
+            raise ValueError(f"CLI name {name!r} collides with a general "
+                             f"command")
+        validated = self._validate_config(name, spec, config)
+        install = CLIInstall(name=name, spec=spec, config=validated)
+        self._installs[name] = install
+        return install
+
+    def _validate_config(self, name: str, spec: CLISpec,
+                         config: dict[str, object] | None) -> BaseModel | None:
+        """Validate an installation config against the spec's model.
+
+        Args:
+            name (str): installed head word, for error attribution.
+            spec (CLISpec): the program tree carrying ``config_model``.
+            config (dict[str, object] | None): raw config mapping.
+        """
+        if spec.config_model is None:
+            if config:
+                raise ValueError(f"CLI {name!r}: config given but "
+                                 f"{spec.name!r} declares no config_model")
+            return None
+        model = spec.config_model
+        # Unknown keys fail loud (a typo'd YAML key must not be
+        # silently ignored) unless the model itself opts into extras.
+        if model.model_config.get("extra") != "allow":
+            unknown = set(config or {}) - set(model.model_fields)
+            if unknown:
+                names = ", ".join(sorted(unknown))
+                raise ValueError(f"CLI {name!r}: unknown config keys: "
+                                 f"{names}")
+        return model(**(config or {}))
+
+    def uninstall(self, name: str) -> None:
+        """Remove an installed CLI; its head word stops resolving (127).
+
+        Args:
+            name (str): installed head word.
+        """
+        if name not in self._installs:
+            raise KeyError(f"CLI name {name!r} is not installed")
+        del self._installs[name]
+
+    def get(self, name: str) -> CLIInstall | None:
+        """Look up an installation by head word.
+
+        Args:
+            name (str): candidate head word.
+        """
+        return self._installs.get(name)
+
+    def items(self) -> dict[str, CLIInstall]:
+        """Snapshot of the installed CLIs keyed by head word."""
+        return dict(self._installs)

--- a/python/mirage/workspace/cli/types.py
+++ b/python/mirage/workspace/cli/types.py
@@ -1,0 +1,41 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+
+from mirage.commands.cli.types import CLISpec
+
+
+@dataclass(frozen=True)
+class CLIInstall:
+    """One installed CLI: a head word bound to a program tree.
+
+    The installed name is the dispatch key, not the spec's own name:
+    two installations of the same spec under different names (two
+    accounts) are two independent entries whose help and errors
+    attribute to their installed head.
+
+    Args:
+        name (str): installed head word (the YAML ``clis:`` key or the
+            first argument of ``register_cli``).
+        spec (CLISpec): the program tree the head dispatches into.
+        config (BaseModel | None): the installation's validated
+            ``config_model`` instance, handed to every leaf ``fn``;
+            None when the spec declares no ``config_model``.
+    """
+    name: str
+    spec: CLISpec
+    config: BaseModel | None = None

--- a/python/mirage/workspace/executor/command/cli.py
+++ b/python/mirage/workspace/executor/command/cli.py
@@ -1,0 +1,124 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from dataclasses import replace
+
+from mirage.commands.cli.walk import walk
+from mirage.commands.config import HELP_OPTION
+from mirage.commands.spec import flag_kwarg_name
+from mirage.commands.spec.help import render_help
+from mirage.io import IOResult
+from mirage.io.stream import materialize
+from mirage.io.types import ByteSource
+from mirage.types import PathSpec
+from mirage.workspace.cli.types import CLIInstall
+from mirage.workspace.executor.command.flags import option_error, parse_flags
+from mirage.workspace.executor.command.run import exec_node
+from mirage.workspace.session import Session
+from mirage.workspace.types import ExecutionNode
+
+
+async def handle_cli(
+    install: CLIInstall,
+    parts: list[str | PathSpec],
+    session: Session,
+    stdin: ByteSource | None = None,
+) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
+    """Execute a line whose head word is an installed CLI.
+
+    Dispatch is by NAME: the install resolves the program tree and the
+    validated config; no mount is consulted and no operand path picks a
+    backend (the one executor divergence from mount commands). The walk
+    consumes subcommand words and group options; the leaf's own argv
+    rides the ordinary spec machinery because a CLISpec IS a
+    CommandSpec, and the leaf handler runs as
+    ``fn(config, paths, *texts, **flags)`` with the installation's
+    config in the accessor's seat.
+
+    Args:
+        install (CLIInstall): the resolved installation (head word,
+            tree, validated config).
+        parts (list[str | PathSpec]): expanded command words including
+            the head; CLI words are shell-expanded strings.
+        session (Session): shell session (cwd for path resolution).
+        stdin (ByteSource | None): stdin data, injected as a kwarg the
+            way mount command handlers receive it.
+    """
+    cmd_str = " ".join(p.virtual if isinstance(p, PathSpec) else p
+                       for p in parts)
+    argv = [p.virtual if isinstance(p, PathSpec) else p for p in parts[1:]]
+
+    result = walk(install.name, install.spec, argv)
+    if result.leaf is None:
+        stderr = result.output if result.stream == "stderr" else b""
+        stdout = result.output if result.stream == "stdout" else None
+        io = IOResult(exit_code=result.exit_code, stderr=stderr)
+        return stdout, io, ExecutionNode(command=cmd_str,
+                                         exit_code=result.exit_code,
+                                         stderr=stderr)
+
+    prog = " ".join((install.name, ) + result.path)
+    leaf = result.leaf
+    # argparse add_help: every leaf answers --help with its own help
+    # unless it declares the flag itself. No injected --version: that is
+    # a GNU coreutils convention, not an argparse one.
+    parse_spec = leaf
+    if not any(option.long == "--help" for option in leaf.options):
+        parse_spec = replace(leaf, options=leaf.options + (HELP_OPTION, ))
+
+    parsed = parse_flags(list(result.argv), parse_spec, prog, session.cwd)
+    if parsed.flag_kwargs.get("help") is True:
+        help_text = render_help(prog, parse_spec).encode()
+        return help_text, IOResult(), ExecutionNode(command=cmd_str,
+                                                    exit_code=0)
+
+    refusal = option_error(prog, parsed)
+    if refusal is not None:
+        msg, _code = refusal
+        # Leaf usage errors exit 2 (argparse), regardless of the
+        # USAGE_EXIT table: prog is an installed name, never a GNU tool
+        # with its own pinned exit.
+        refusal_io = IOResult(exit_code=2, stderr=msg)
+        refusal_node = ExecutionNode(command=cmd_str, exit_code=2, stderr=msg)
+        return None, refusal_io, refusal_node
+
+    # Group flags merge into the one bag: ancestor/descendant collisions
+    # are a build-time CLISpec error, so a group flag can never shadow a
+    # leaf flag.
+    kw: dict[str, object] = {
+        flag_kwarg_name(spelling): value
+        for spelling, value in result.group_flags.items()
+    }
+    kw.update(parsed.flag_kwargs)
+    kw.pop("help", None)
+    if stdin is not None:
+        kw["stdin"] = stdin
+
+    fn = leaf.fn
+    if fn is None:
+        # validate_cli guarantees fn XOR subcommands and walk only
+        # returns fn-bearing nodes as leaf; reaching this is a bug.
+        raise RuntimeError(f"walk returned a leaf without fn for {prog!r}")
+    out = await fn(install.config, parsed.paths, *parsed.texts, **kw)
+    if out is None:
+        stdout, io = None, IOResult()
+    else:
+        stdout, io = out
+
+    if parsed.warnings:
+        warn = "".join(f"{prog}: {w}\n" for w in parsed.warnings).encode()
+        existing = await materialize(io.stderr) if io.stderr else b""
+        io.stderr = warn + existing
+
+    return stdout, io, await exec_node(cmd_str, io, parsed.paths)

--- a/python/mirage/workspace/executor/command/cli.py
+++ b/python/mirage/workspace/executor/command/cli.py
@@ -14,6 +14,8 @@
 
 from dataclasses import replace
 
+from mirage.commands.builtin.utils.safeguard import (maybe_with_timeout,
+                                                     run_with_timeout)
 from mirage.commands.cli.walk import walk
 from mirage.commands.config import HELP_OPTION
 from mirage.commands.spec import flag_kwarg_name
@@ -21,6 +23,7 @@ from mirage.commands.spec.help import render_help
 from mirage.io import IOResult
 from mirage.io.stream import materialize
 from mirage.io.types import ByteSource
+from mirage.runtime.policy.safeguard import resolve_safeguard
 from mirage.types import PathSpec
 from mirage.workspace.cli.types import CLIInstall
 from mirage.workspace.executor.command.flags import option_error, parse_flags
@@ -58,6 +61,7 @@ async def handle_cli(
     cmd_str = " ".join(p.virtual if isinstance(p, PathSpec) else p
                        for p in parts)
     argv = [p.virtual if isinstance(p, PathSpec) else p for p in parts[1:]]
+    stdout: ByteSource | None
 
     result = walk(install.name, install.spec, argv)
     if result.leaf is None:
@@ -110,15 +114,26 @@ async def handle_cli(
         # validate_cli guarantees fn XOR subcommands and walk only
         # returns fn-bearing nodes as leaf; reaching this is a bug.
         raise RuntimeError(f"walk returned a leaf without fn for {prog!r}")
-    out = await fn(install.config, parsed.paths, *parsed.texts, **kw)
+    # The leaf's declared safeguard bounds the handler body and its
+    # streams, exactly like mount dispatch: without the wrap a blocking
+    # leaf hangs forever and an unbounded-output leaf ignores its own
+    # limits.
+    safeguard = resolve_safeguard(prog, command_default=leaf.safeguard)
+    timeout = safeguard.timeout_seconds if safeguard is not None else None
+    out = await run_with_timeout(
+        fn(install.config, parsed.paths, *parsed.texts, **kw), timeout, prog)
     if out is None:
         stdout, io = None, IOResult()
     else:
         stdout, io = out
+    io.safeguard = safeguard
 
     if parsed.warnings:
         warn = "".join(f"{prog}: {w}\n" for w in parsed.warnings).encode()
         existing = await materialize(io.stderr) if io.stderr else b""
         io.stderr = warn + existing
+
+    stdout = maybe_with_timeout(stdout, io.safeguard, prog)
+    io.stderr = maybe_with_timeout(io.stderr, io.safeguard, prog)
 
     return stdout, io, await exec_node(cmd_str, io, parsed.paths)

--- a/python/mirage/workspace/executor/command/command.py
+++ b/python/mirage/workspace/executor/command/command.py
@@ -31,6 +31,7 @@ from mirage.runtime.policy.safeguard import resolve_safeguard
 from mirage.shell.call_stack import CallStack
 from mirage.shell.job_table import JobTable
 from mirage.types import PathSpec
+from mirage.workspace.executor.command.cli import handle_cli
 from mirage.workspace.executor.command.flags import option_error, parse_flags
 from mirage.workspace.executor.command.functions import run_shell_function
 from mirage.workspace.executor.command.routing import (CWD_DEFAULT_RAW,
@@ -98,6 +99,13 @@ async def handle_command(
     if cmd_name in session.functions:
         return await run_shell_function(execute_node, cmd_name, parts, session,
                                         stdin, call_stack)
+
+    # Installed CLIs: dispatch by name, never by operand path. Sits
+    # below functions (a user can wrap an installed CLI, bash-style)
+    # and above every mount branch (a CLI consults no mount).
+    cli_install = registry.clis.get(cmd_name)
+    if cli_install is not None:
+        return await handle_cli(cli_install, parts, session, stdin)
 
     if cmd_name in CWD_DEFAULT_RAW:
         operand = default_cwd_operand(parts, cmd_name, registry, session.cwd,

--- a/python/mirage/workspace/mount/registry.py
+++ b/python/mirage/workspace/mount/registry.py
@@ -302,6 +302,12 @@ class MountRegistry:
         """
         if not words:
             return 0
+        # An installed CLI head wins over any multiword mount command
+        # under the same first word (`himalaya message send`): dispatch
+        # is by name and the subcommand words belong to the tree walk,
+        # so the head alone is the command name.
+        if self.clis.get(words[0]) is not None:
+            return 1
         best = 1
         candidates = list(self._mounts)
         if self._root is not None:

--- a/python/mirage/workspace/mount/registry.py
+++ b/python/mirage/workspace/mount/registry.py
@@ -23,6 +23,7 @@ from mirage.resource.base import BaseResource
 from mirage.resource.dev import DevResource
 from mirage.runtime.base import Runtime
 from mirage.types import ConsistencyPolicy, MountMode, PathSpec
+from mirage.workspace.cli import CLIRegistry
 from mirage.workspace.mount.mount import MountEntry
 
 DEV_PREFIX = "/dev/"
@@ -89,6 +90,13 @@ class MountRegistry:
         # Registry-hosted like runtime_bindings so the executor reaches
         # them without new parameter threading.
         self.policies = Policies([MountRootPolicy()])
+
+        # Installed CLIs. Not mount state: CLIs are fully separate from
+        # mounts (a CLI exists because it was installed, never because
+        # storage was mounted). The registry object is just the vehicle
+        # that already reaches every dispatch site, same as the
+        # runtime fields above.
+        self.clis = CLIRegistry()
         self._consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY
         self._file_cache: FileCacheMixin | None = None
         self._reconciler: ReadReconciler | None = None

--- a/python/mirage/workspace/names.py
+++ b/python/mirage/workspace/names.py
@@ -1,0 +1,43 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from mirage.shell.types import ShellBuiltin
+
+# Reserved command-name pools. A leaf on purpose: both route (dispatch
+# precedence) and the CLI registry (install-time collision rule) read
+# these, and route already imports the mount layer, so the pools cannot
+# live under route without a cycle.
+
+# Bash builtins the parser accepts but the executor cannot honor; they
+# still route to the shell layer so the error names a capability gap.
+UNSUPPORTED_BUILTINS = frozenset({
+    "bg",
+    "disown",
+    "exec",
+    "complete",
+    "compgen",
+    "ulimit",
+})
+
+NAMESPACE_COMMANDS = frozenset({"ln", "readlink"})
+
+# ShellBuiltin subset handled through the job table in the executor.
+JOB_BUILTINS = frozenset({"wait", "fg", "kill", "jobs", "ps"})
+
+# Commands with lstat semantics: they act on the symlink entry itself,
+# so dispatch must not rewrite their operands through the link table.
+NO_FOLLOW_COMMANDS = frozenset(
+    {"rm", "mv", "ln", "readlink", "rmdir", "unlink"})
+
+SHELL_NAMES = frozenset(str(b) for b in ShellBuiltin) | UNSUPPORTED_BUILTINS

--- a/python/mirage/workspace/route/route.py
+++ b/python/mirage/workspace/route/route.py
@@ -22,8 +22,26 @@ def route(name: str, session: Session, registry: MountRegistry) -> Consumer:
     """Route a command name to the layer that consumes it.
 
     Order mirrors dispatch precedence: shell builtins shadow functions,
-    functions shadow mount commands, and a name nobody registers is
-    UNKNOWN (command not found).
+    functions shadow installed CLIs, CLIs shadow mount commands, and a
+    name nobody registers is UNKNOWN (command not found). Install-time
+    collision rules keep the CLI arm honest: a CLI may not take a shell
+    builtin's or a general command's name, so the only shadowing a CLI
+    can actually exert is over a mount-specific custom command.
+
+    The full landscape, in precedence order. The column to watch is
+    what resolves the name: session or workspace state for the named
+    layers, operand paths for mounts::
+
+        Consumer   Example              Resolved by          Words
+        SESSION    cd, echo, export     name in SHELL_NAMES  shell-expanded
+        NAMESPACE  ln -s, readlink      NAMESPACE_COMMANDS   shell-expanded
+        FUNCTION   deploy() {..}        session.functions    shell-expanded
+        CLI        slack message send   registry.clis        shell-expanded
+        MOUNT      grep, cat, du        operand paths        pushdown
+        UNKNOWN    bogus                nobody               untouched, 127
+
+    Runtimes are orthogonal, not a seventh row: a capture decides where
+    a command executes (docker vs vfs), never whether the name exists.
 
     Args:
         name (str): expanded command name.
@@ -36,6 +54,8 @@ def route(name: str, session: Session, registry: MountRegistry) -> Consumer:
         return Consumer.NAMESPACE
     if name in session.functions:
         return Consumer.FUNCTION
+    if registry.clis.get(name) is not None:
+        return Consumer.CLI
     if registry.mount_for_command(name) is not None:
         return Consumer.MOUNT
     return Consumer.UNKNOWN

--- a/python/mirage/workspace/route/types.py
+++ b/python/mirage/workspace/route/types.py
@@ -29,14 +29,18 @@ class Consumer(Enum):
     SESSION = auto()
     NAMESPACE = auto()
     FUNCTION = auto()
+    CLI = auto()
     MOUNT = auto()
     UNKNOWN = auto()
 
 
+# CLI rides with the shell consumers for word policy: an installed CLI
+# is a program, and bash hands programs glob matches, never patterns.
 SHELL_CONSUMERS = frozenset({
     Consumer.SESSION,
     Consumer.NAMESPACE,
     Consumer.FUNCTION,
+    Consumer.CLI,
 })
 
 

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -22,6 +22,8 @@ from mirage.bridge.sync import run_async_from_sync
 from mirage.cache.file.config import CacheConfig
 from mirage.cache.file.mixin import FileCacheMixin
 from mirage.cache.index import IndexConfig
+from mirage.commands.cli import CLISpec
+from mirage.commands.cli.specs import cli_spec_for
 from mirage.io import IOResult
 from mirage.io.types import ByteSource, materialize
 from mirage.observe.observer import Observer
@@ -39,6 +41,7 @@ from mirage.types import (ConsistencyPolicy, DriftPolicy, FileEvent, FileStat,
                           MountBackend, MountMode, PathSpec, StateKey,
                           parse_mount_mode)
 from mirage.utils.ids import new_session_id, new_workspace_id
+from mirage.workspace.cli import CLIInstall
 from mirage.workspace.dispatcher import Dispatcher
 from mirage.workspace.file_prompt import build_file_prompt
 from mirage.workspace.mount import MountEntry, MountRegistry
@@ -99,6 +102,8 @@ class Workspace:
         policy: PolicyFn | None = None,
         guards: list[GuardSpec] | None = None,
         policies: list[Policy | GuardSpec] | None = None,
+        clis: dict[str, tuple[str | CLISpec, dict[str, Any] | None]]
+        | None = None,
     ) -> None:
         self._registry = MountRegistry()
         # Admission policies, consulted in registration order after the
@@ -177,6 +182,16 @@ class Workspace:
             self._execute_line_for_vfs)
         reject_config_script("policy", policy)
         self._policy = policy
+
+        # Installed CLIs, fully separate from mounts: the YAML `clis:`
+        # section arrives as {head: (spec key or tree, config)}; a spec
+        # key resolves against the named registry and every entry
+        # installs through the same fail-loud path as register_cli.
+        if clis:
+            for cli_name, (spec_or_key, cli_config) in clis.items():
+                cli_spec = (spec_or_key if isinstance(spec_or_key, CLISpec)
+                            else cli_spec_for(spec_or_key))
+                self._registry.clis.install(cli_name, cli_spec, cli_config)
 
         for prefix, target_backend, target_point in kernel_targets(specs):
             self.add_fuse_mount(prefix, target_point, backend=target_backend)
@@ -275,6 +290,35 @@ class Workspace:
     @property
     def fuse_mountpoints(self) -> dict[str, str]:
         return self._kernel_mounts.mountpoints
+
+    def register_cli(self,
+                     name: str,
+                     spec: CLISpec,
+                     config: dict[str, object] | None = None) -> CLIInstall:
+        """Install a CLI under a head word, fully separate from mounts.
+
+        Args:
+            name (str): head word to install under (the dispatch key;
+                two installs of one spec under different names are two
+                accounts).
+            spec (CLISpec): the program tree.
+            config (dict[str, object] | None): installation config,
+                validated through the spec's ``config_model`` (fail
+                loud at install time).
+        """
+        return self._registry.clis.install(name, spec, config)
+
+    def unregister_cli(self, name: str) -> None:
+        """Remove an installed CLI; its head word stops resolving (127).
+
+        Args:
+            name (str): installed head word.
+        """
+        self._registry.clis.uninstall(name)
+
+    def clis(self) -> dict[str, CLIInstall]:
+        """Snapshot of the installed CLIs keyed by head word."""
+        return self._registry.clis.items()
 
     def add_runtime(self, runtime: Runtime | str) -> Runtime:
         """Append a runtime entry to the workspace's ordered set.

--- a/python/tests/commands/cli/test_specs.py
+++ b/python/tests/commands/cli/test_specs.py
@@ -1,0 +1,57 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+
+from mirage.commands.cli.specs import (cli_spec_for, register_cli_spec,
+                                       unregister_cli_spec)
+from mirage.commands.cli.types import CLISpec
+from mirage.io import IOResult
+
+
+async def noop(config, paths, *texts, **flags):
+    return None, IOResult()
+
+
+def test_register_resolve_unregister():
+    spec = CLISpec(name="spectest",
+                   subcommands=(CLISpec(name="run", fn=noop), ))
+    register_cli_spec(spec)
+    try:
+        assert cli_spec_for("spectest") is spec
+    finally:
+        unregister_cli_spec("spectest")
+    with pytest.raises(ValueError, match="unknown cli 'spectest'"):
+        cli_spec_for("spectest")
+
+
+def test_duplicate_registration_is_refused():
+    spec = CLISpec(name="spectest2",
+                   subcommands=(CLISpec(name="run", fn=noop), ))
+    register_cli_spec(spec)
+    try:
+        with pytest.raises(ValueError, match="already registered"):
+            register_cli_spec(spec)
+    finally:
+        unregister_cli_spec("spectest2")
+
+
+def test_unregister_unknown_raises():
+    with pytest.raises(KeyError, match="not registered"):
+        unregister_cli_spec("spectest3")
+
+
+def test_unknown_key_names_the_known_specs():
+    with pytest.raises(ValueError, match="known: "):
+        cli_spec_for("spectest4")

--- a/python/tests/config/test_loader.py
+++ b/python/tests/config/test_loader.py
@@ -386,3 +386,48 @@ guards:
                   paths=("/data/prod/*", )),
         GuardSpec(reason="interpreters are off", commands=("python3", )),
     ]
+
+
+def test_clis_section_parses_and_maps_to_kwargs():
+    cfg = load_config({
+        "mounts": {
+            "/data": {
+                "resource": "ram"
+            }
+        },
+        "clis": {
+            "sl": {
+                "cli": "slack",
+                "config": {
+                    "token": "x"
+                }
+            },
+            "bare": {
+                "cli": "gws"
+            },
+        },
+    })
+    kwargs = cfg.to_workspace_kwargs()
+    assert kwargs["clis"] == {
+        "sl": ("slack", {
+            "token": "x"
+        }),
+        "bare": ("gws", {}),
+    }
+
+
+def test_clis_block_refuses_unknown_keys():
+    with pytest.raises(ValueError, match="mode"):
+        load_config({
+            "mounts": {
+                "/data": {
+                    "resource": "ram"
+                }
+            },
+            "clis": {
+                "sl": {
+                    "cli": "slack",
+                    "mode": "write"
+                }
+            },
+        })

--- a/python/tests/e2e/test_cli_dispatch.py
+++ b/python/tests/e2e/test_cli_dispatch.py
@@ -1,0 +1,160 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+from pydantic import BaseModel
+
+from mirage import CLISpec, Workspace
+from mirage.commands.cli.specs import register_cli_spec, unregister_cli_spec
+from mirage.commands.spec.types import Operand, Option
+from mirage.config import load_config
+from mirage.io import IOResult
+from mirage.io.types import materialize
+from mirage.resource.ram import RAMResource
+from mirage.types import MountMode
+
+
+class TokenConfig(BaseModel):
+    token: str
+
+
+async def send(config, paths, *texts, **flags):
+    body = " ".join(texts)
+    to = flags.get("to")
+    return f"sent[{config.token}] to={to}: {body}\n".encode(), IOResult()
+
+
+def make_tree() -> CLISpec:
+    return CLISpec(
+        name="slackish",
+        config_model=TokenConfig,
+        subcommands=(CLISpec(name="message",
+                             subcommands=(CLISpec(
+                                 name="send",
+                                 fn=send,
+                                 write=True,
+                                 options=(Option(short="-t",
+                                                 long="--to",
+                                                 type="str",
+                                                 required=True), ),
+                                 rest=Operand(type="str")), )), ),
+    )
+
+
+@pytest.fixture
+def ws():
+    workspace = Workspace({"/data": (RAMResource(), MountMode.WRITE)},
+                          mode=MountMode.WRITE)
+    yield workspace
+
+
+async def run(ws, line):
+    io = await ws.execute(line)
+    out = await materialize(io.stdout) if io.stdout else b""
+    err = await materialize(io.stderr) if io.stderr else b""
+    return io.exit_code, out, err
+
+
+@pytest.mark.asyncio
+async def test_two_accounts_dispatch_by_installed_name(ws):
+    tree = make_tree()
+    ws.register_cli("slackish", tree, {"token": "eng"})
+    ws.register_cli("slackish-sup", tree, {"token": "sup"})
+    code, out, _ = await run(ws, "slackish message send -t '#e' hi")
+    assert (code, out) == (0, b"sent[eng] to=#e: hi\n")
+    code, out, _ = await run(ws, "slackish-sup message send -t '#s' yo")
+    assert (code, out) == (0, b"sent[sup] to=#s: yo\n")
+
+
+@pytest.mark.asyncio
+async def test_renamed_install_attributes_to_its_own_head(ws):
+    ws.register_cli("sl", make_tree(), {"token": "t"})
+    code, _, err = await run(ws, "sl bogus")
+    assert code == 1
+    assert err == b"sl: 'bogus' is not a sl command. See 'sl --help'.\n"
+    code, out, _ = await run(ws, "sl message send --help")
+    assert code == 0
+    assert out.startswith(b"sl message send\n")
+
+
+@pytest.mark.asyncio
+async def test_leaf_usage_error_exits_2(ws):
+    ws.register_cli("sl", make_tree(), {"token": "t"})
+    code, _, err = await run(ws, "sl message send hi")
+    assert code == 2
+    assert err.startswith(b"sl message send: option '--to' is required")
+
+
+@pytest.mark.asyncio
+async def test_unregister_returns_the_name_to_127(ws):
+    ws.register_cli("sl", make_tree(), {"token": "t"})
+    ws.unregister_cli("sl")
+    code, _, err = await run(ws, "sl message send -t x hi")
+    assert code == 127
+    assert b"sl: command not found" in err
+
+
+@pytest.mark.asyncio
+async def test_cli_head_never_resolves_a_mount(ws):
+    # A CLI line whose words look like mount paths still dispatches by
+    # name; the mount stays untouched and the words arrive as text.
+    ws.register_cli("sl", make_tree(), {"token": "t"})
+    code, out, _ = await run(ws, "sl message send -t x /data/a.txt")
+    assert code == 0
+    assert out == b"sent[t] to=x: /data/a.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_yaml_clis_section_installs_through_load_config():
+    register_cli_spec(make_tree())
+    try:
+        cfg = load_config({
+            "mounts": {
+                "/data": {
+                    "resource": "ram"
+                }
+            },
+            "clis": {
+                "sl": {
+                    "cli": "slackish",
+                    "config": {
+                        "token": "yaml"
+                    }
+                }
+            },
+        })
+        ws = Workspace(**cfg.to_workspace_kwargs())
+        code, out, _ = await run(ws, "sl message send -t x hi")
+        assert (code, out) == (0, b"sent[yaml] to=x: hi\n")
+        await ws.close()
+    finally:
+        unregister_cli_spec("slackish")
+
+
+@pytest.mark.asyncio
+async def test_yaml_unknown_cli_key_fails_loud():
+    cfg = load_config({
+        "mounts": {
+            "/data": {
+                "resource": "ram"
+            }
+        },
+        "clis": {
+            "x": {
+                "cli": "nope"
+            }
+        },
+    })
+    with pytest.raises(ValueError, match="unknown cli 'nope'"):
+        Workspace(**cfg.to_workspace_kwargs())

--- a/python/tests/workspace/cli/test_registry.py
+++ b/python/tests/workspace/cli/test_registry.py
@@ -1,0 +1,110 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from mirage.commands.cli.types import CLISpec
+from mirage.io import IOResult
+from mirage.workspace.cli.registry import CLIRegistry
+
+
+class TokenConfig(BaseModel):
+    token: str
+
+
+async def noop(config, paths, *texts, **flags):
+    return None, IOResult()
+
+
+def tree(config_model=None) -> CLISpec:
+    return CLISpec(name="prog",
+                   config_model=config_model,
+                   subcommands=(CLISpec(name="run", fn=noop), ))
+
+
+def test_install_and_get_and_items():
+    reg = CLIRegistry()
+    install = reg.install("prog", tree())
+    assert reg.get("prog") is install
+    assert reg.get("other") is None
+    assert reg.items() == {"prog": install}
+
+
+def test_two_installs_of_one_spec_hold_their_own_configs():
+    reg = CLIRegistry()
+    spec = tree(TokenConfig)
+    eng = reg.install("prog", spec, {"token": "eng"})
+    sup = reg.install("prog-sup", spec, {"token": "sup"})
+    assert eng.config is not None and eng.config.token == "eng"
+    assert sup.config is not None and sup.config.token == "sup"
+
+
+def test_name_must_be_a_single_word():
+    reg = CLIRegistry()
+    with pytest.raises(ValueError, match="single word"):
+        reg.install("two words", tree())
+    with pytest.raises(ValueError, match="single word"):
+        reg.install("", tree())
+
+
+def test_duplicate_name_is_refused():
+    reg = CLIRegistry()
+    reg.install("prog", tree())
+    with pytest.raises(ValueError, match="already installed"):
+        reg.install("prog", tree())
+
+
+def test_shell_builtin_collision_is_refused():
+    reg = CLIRegistry()
+    with pytest.raises(ValueError, match="shell builtin"):
+        reg.install("cd", tree())
+    with pytest.raises(ValueError, match="shell builtin"):
+        reg.install("kill", tree())
+
+
+def test_general_command_collision_is_refused():
+    reg = CLIRegistry()
+    with pytest.raises(ValueError, match="general command"):
+        reg.install("grep", tree())
+    with pytest.raises(ValueError, match="general command"):
+        reg.install("ln", tree())
+
+
+def test_config_validates_through_the_model_fail_loud():
+    reg = CLIRegistry()
+    with pytest.raises(ValidationError):
+        reg.install("prog", tree(TokenConfig), {})
+    with pytest.raises(ValueError, match="unknown config keys: extra"):
+        reg.install("prog", tree(TokenConfig), {"token": "x", "extra": 1})
+
+
+def test_config_without_model_is_refused():
+    reg = CLIRegistry()
+    with pytest.raises(ValueError, match="declares no config_model"):
+        reg.install("prog", tree(), {"token": "x"})
+
+
+def test_no_config_no_model_installs_with_none():
+    reg = CLIRegistry()
+    assert reg.install("prog", tree()).config is None
+
+
+def test_uninstall_removes_and_unknown_raises():
+    reg = CLIRegistry()
+    reg.install("prog", tree())
+    reg.uninstall("prog")
+    assert reg.get("prog") is None
+    with pytest.raises(KeyError, match="not installed"):
+        reg.uninstall("prog")

--- a/python/tests/workspace/executor/builtins/test_command.py
+++ b/python/tests/workspace/executor/builtins/test_command.py
@@ -2,6 +2,7 @@ import pytest
 
 from mirage.io import IOResult
 from mirage.io.stream import materialize
+from mirage.workspace.cli.registry import CLIRegistry
 from mirage.workspace.executor.builtins.command import (_classify, _describe,
                                                         _parse_flags,
                                                         handle_command_builtin,
@@ -13,6 +14,7 @@ class FakeRegistry:
 
     def __init__(self, commands: set[str]):
         self._commands = commands
+        self.clis = CLIRegistry()
 
     def mount_for_command(self, name: str) -> object | None:
         return object() if name in self._commands else None

--- a/python/tests/workspace/executor/command/test_cli.py
+++ b/python/tests/workspace/executor/command/test_cli.py
@@ -1,0 +1,128 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import pytest
+from pydantic import BaseModel
+
+from mirage.commands.cli.types import CLISpec
+from mirage.commands.spec.types import Operand, Option
+from mirage.io import IOResult
+from mirage.io.types import materialize
+from mirage.workspace.cli.types import CLIInstall
+from mirage.workspace.executor.command.cli import handle_cli
+from mirage.workspace.session import Session
+
+
+class TokenConfig(BaseModel):
+    token: str
+
+
+CALLS: list[dict] = []
+
+
+async def send(config, paths, *texts, **flags):
+    CALLS.append({
+        "config": config,
+        "paths": paths,
+        "texts": texts,
+        "flags": flags
+    })
+    return f"sent[{config.token}]\n".encode(), IOResult()
+
+
+def make_install(name: str = "prog") -> CLIInstall:
+    spec = CLISpec(
+        name="prog",
+        config_model=TokenConfig,
+        options=(Option(short="-v", long="--verbose", count=True), ),
+        subcommands=(CLISpec(name="message",
+                             subcommands=(CLISpec(
+                                 name="send",
+                                 fn=send,
+                                 options=(Option(short="-t",
+                                                 long="--to",
+                                                 type="str",
+                                                 required=True), ),
+                                 rest=Operand(type="str")), )), ),
+    )
+    return CLIInstall(name=name, spec=spec, config=TokenConfig(token="tok"))
+
+
+@pytest.mark.asyncio
+async def test_leaf_runs_with_config_group_flags_and_texts():
+    CALLS.clear()
+    install = make_install()
+    parts = ["prog", "-vv", "message", "send", "-t", "#eng", "hello", "world"]
+    stdout, io, node = await handle_cli(install, parts, Session("t"))
+    assert io.exit_code == 0
+    assert await materialize(stdout) == b"sent[tok]\n"
+    call = CALLS.pop()
+    assert call["config"].token == "tok"
+    assert call["texts"] == ("hello", "world")
+    assert call["flags"]["to"] == "#eng"
+    assert call["flags"]["verbose"] == 2
+    assert node.command == "prog -vv message send -t #eng hello world"
+
+
+@pytest.mark.asyncio
+async def test_unknown_verb_is_git_worded_exit_1():
+    install = make_install("renamed")
+    _, io, node = await handle_cli(install, ["renamed", "bogus"], Session("t"))
+    assert io.exit_code == 1
+    assert io.stderr == (b"renamed: 'bogus' is not a renamed command. "
+                         b"See 'renamed --help'.\n")
+    assert node.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_bare_group_prints_usage_stdout_exit_1():
+    install = make_install()
+    stdout, io, _ = await handle_cli(install, ["prog", "message"],
+                                     Session("t"))
+    assert io.exit_code == 1
+    out = await materialize(stdout)
+    assert b"Usage: prog message" in out
+    assert b"send" in out
+
+
+@pytest.mark.asyncio
+async def test_leaf_help_prints_installed_prog_exit_0():
+    install = make_install("renamed")
+    stdout, io, _ = await handle_cli(install,
+                                     ["renamed", "message", "send", "--help"],
+                                     Session("t"))
+    assert io.exit_code == 0
+    out = await materialize(stdout)
+    assert out.startswith(b"renamed message send\n")
+    assert b"--help" in out
+
+
+@pytest.mark.asyncio
+async def test_leaf_usage_error_exits_2_with_prog_attribution():
+    install = make_install()
+    _, io, _ = await handle_cli(install, ["prog", "message", "send", "hi"],
+                                Session("t"))
+    assert io.exit_code == 2
+    assert io.stderr.startswith(b"prog message send: option '--to' is "
+                                b"required")
+
+
+@pytest.mark.asyncio
+async def test_stdin_is_injected_as_a_kwarg():
+    CALLS.clear()
+    install = make_install()
+    await handle_cli(install, ["prog", "message", "send", "-t", "x"],
+                     Session("t"),
+                     stdin=b"body")
+    assert CALLS.pop()["flags"]["stdin"] == b"body"

--- a/python/tests/workspace/executor/command/test_cli.py
+++ b/python/tests/workspace/executor/command/test_cli.py
@@ -12,13 +12,17 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
+
 import pytest
 from pydantic import BaseModel
 
+from mirage.commands.builtin.utils.safeguard import CommandTimeoutError
 from mirage.commands.cli.types import CLISpec
 from mirage.commands.spec.types import Operand, Option
 from mirage.io import IOResult
 from mirage.io.types import materialize
+from mirage.types import CommandSafeguard
 from mirage.workspace.cli.types import CLIInstall
 from mirage.workspace.executor.command.cli import handle_cli
 from mirage.workspace.session import Session
@@ -116,6 +120,25 @@ async def test_leaf_usage_error_exits_2_with_prog_attribution():
     assert io.exit_code == 2
     assert io.stderr.startswith(b"prog message send: option '--to' is "
                                 b"required")
+
+
+async def slow_send(config, paths, *texts, **flags):
+    await asyncio.sleep(0.5)
+    return None, IOResult()
+
+
+@pytest.mark.asyncio
+async def test_leaf_safeguard_bounds_the_handler():
+    # The declared safeguard wraps the handler body like mount
+    # dispatch: a blocking leaf times out instead of hanging.
+    spec = CLISpec(name="prog",
+                   subcommands=(CLISpec(
+                       name="run",
+                       fn=slow_send,
+                       safeguard=CommandSafeguard(timeout_seconds=0.05)), ))
+    install = CLIInstall(name="prog", spec=spec, config=None)
+    with pytest.raises(CommandTimeoutError, match="prog run"):
+        await handle_cli(install, ["prog", "run"], Session("t"))
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/executor/test_man.py
+++ b/python/tests/workspace/executor/test_man.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock
 
 from mirage.commands.config import RegisteredCommand
 from mirage.commands.spec.types import CommandSpec, Option
+from mirage.workspace.cli.registry import CLIRegistry
 from mirage.workspace.executor.builtins import (_collect_man_hits,
                                                 _render_man_entry,
                                                 _render_man_index, handle_man)
@@ -74,6 +75,7 @@ def _mk_mount(prefix, kind, cmds=None, general=None):
 
 def _mk_registry(mounts, cwd_mount=None):
     reg = MagicMock()
+    reg.clis = CLIRegistry()
     reg.mounts = MagicMock(return_value=mounts)
 
     def _mount_for(path):

--- a/python/tests/workspace/expand/test_globs.py
+++ b/python/tests/workspace/expand/test_globs.py
@@ -21,6 +21,7 @@ from mirage.resource.ram import RAMResource
 from mirage.types import PathSpec
 from mirage.utils.glob_walk import make_resolve_glob
 from mirage.utils.key_prefix import mount_key
+from mirage.workspace.cli.registry import CLIRegistry
 from mirage.workspace.expand.globs import resolve_globs
 
 
@@ -37,6 +38,7 @@ def _mock_registry(resolve_result=None):
     mount.resource.resolve_glob = _resolve_glob
 
     reg = MagicMock()
+    reg.clis = CLIRegistry()
     reg.mount_for = MagicMock(return_value=mount)
     return reg
 

--- a/python/tests/workspace/mount/test_registry.py
+++ b/python/tests/workspace/mount/test_registry.py
@@ -15,6 +15,7 @@
 import pytest
 
 from mirage.cache.file.ram import RAMFileCacheStore
+from mirage.commands.cli.types import CLISpec
 from mirage.commands.registry import command
 from mirage.commands.spec.types import CommandSpec
 from mirage.io.types import IOResult
@@ -97,6 +98,22 @@ def test_match_command_prefix_partial_name_is_not_a_command(registry):
     _register_cmd(registry.mount_for("/data"), "gws docs documents get")
     # "gws docs" alone is not registered; only the bare first token counts.
     assert registry.match_command_prefix(["gws", "docs"]) == 1
+
+
+async def _noop_cli(config, paths, *texts, **flags):
+    return None, IOResult()
+
+
+def test_installed_cli_head_wins_over_multiword_mount_command(registry):
+    # Dispatch is by name: the head alone is the command, the
+    # subcommand words belong to the tree walk, so an installed CLI
+    # must not be swallowed by a same-head multiword mount command.
+    _register_cmd(registry.mount_for("/data"), "gws docs documents get")
+    registry.clis.install(
+        "gws",
+        CLISpec(name="gws", subcommands=(CLISpec(name="run", fn=_noop_cli), )))
+    assert registry.match_command_prefix(["gws", "docs", "documents",
+                                          "get"]) == 1
 
 
 def test_match_command_prefix_unknown_and_empty(registry):

--- a/python/tests/workspace/node/test_execute_node.py
+++ b/python/tests/workspace/node/test_execute_node.py
@@ -21,6 +21,7 @@ from mirage.shell import parse
 from mirage.shell.barrier import BarrierPolicy, apply_barrier
 from mirage.shell.job_table import JobTable
 from mirage.types import MountMode, PathSpec
+from mirage.workspace.cli.registry import CLIRegistry
 from mirage.workspace.mount.namespace import Namespace
 from mirage.workspace.node.execute_node import execute_node as _execute_node
 from mirage.workspace.session import Session
@@ -65,6 +66,9 @@ def _mock_registry():
     reg.mount_for = MagicMock(return_value=mount)
     reg.resolve_mount = AsyncMock(return_value=mount)
     reg.policies.pre_command = AsyncMock(return_value=None)
+    # A bare MagicMock answers clis.get() with a truthy mock, which
+    # would spuriously dispatch every command as an installed CLI.
+    reg.clis = CLIRegistry()
     return reg, mount
 
 

--- a/python/tests/workspace/route/test_route.py
+++ b/python/tests/workspace/route/test_route.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from mirage.commands.cli.types import CLISpec
+from mirage.io import IOResult
 from mirage.resource.ram import RAMResource
 from mirage.types import MountMode
 from mirage.workspace import Workspace
@@ -22,6 +24,14 @@ from mirage.workspace.session import Session
 def _fixture() -> tuple[Session, Workspace]:
     ws = Workspace(resources={"/ram": (RAMResource(), MountMode.WRITE)})
     return Session(session_id="t"), ws
+
+
+async def _noop(config, paths, *texts, **flags):
+    return None, IOResult()
+
+
+def _cli_tree() -> CLISpec:
+    return CLISpec(name="prog", subcommands=(CLISpec(name="run", fn=_noop), ))
 
 
 def test_builtins_route_session():
@@ -70,9 +80,32 @@ def test_unregistered_name_routes_unknown():
     assert route("nosuchcmd", session, ws._registry) is Consumer.UNKNOWN
 
 
+def test_installed_cli_routes_cli():
+    session, ws = _fixture()
+    ws.register_cli("prog", _cli_tree())
+    assert route("prog", session, ws._registry) is Consumer.CLI
+
+
+def test_function_shadows_installed_cli():
+    session, ws = _fixture()
+    ws.register_cli("prog", _cli_tree())
+    session.functions["prog"] = []
+    assert route("prog", session, ws._registry) is Consumer.FUNCTION
+
+
+def test_unregistered_cli_routes_unknown():
+    session, ws = _fixture()
+    ws.register_cli("prog", _cli_tree())
+    ws.unregister_cli("prog")
+    assert route("prog", session, ws._registry) is Consumer.UNKNOWN
+
+
 def test_shell_consumers_resolve_globs():
     assert Consumer.SESSION in SHELL_CONSUMERS
     assert Consumer.NAMESPACE in SHELL_CONSUMERS
     assert Consumer.FUNCTION in SHELL_CONSUMERS
+    # A CLI is a program: bash hands programs glob matches, never
+    # patterns.
+    assert Consumer.CLI in SHELL_CONSUMERS
     assert Consumer.MOUNT not in SHELL_CONSUMERS
     assert Consumer.UNKNOWN not in SHELL_CONSUMERS

--- a/python/tests/workspace/test_expand.py
+++ b/python/tests/workspace/test_expand.py
@@ -20,6 +20,7 @@ from mirage.shell import parse
 from mirage.shell.call_stack import CallStack
 from mirage.shell.helpers import get_parts
 from mirage.types import PathSpec
+from mirage.workspace.cli.registry import CLIRegistry
 from mirage.workspace.expand import (classify_parts, classify_word,
                                      expand_and_classify, expand_node,
                                      expand_parts)
@@ -57,6 +58,7 @@ def _mock_registry(prefixes=None):
             If None, matches everything.
     """
     reg = MagicMock()
+    reg.clis = CLIRegistry()
 
     def _mount_for(path):
         if prefixes is None:

--- a/typescript/packages/core/src/commands/cli/specs.test.ts
+++ b/typescript/packages/core/src/commands/cli/specs.test.ts
@@ -1,0 +1,63 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+
+import { IOResult } from '../../io/types.ts'
+import { cliSpecFor, registerCliSpec, unregisterCliSpec } from './specs.ts'
+import { CLISpec } from './types.ts'
+
+// Mirrors python/tests/commands/cli/test_specs.py.
+
+function noop(): [null, IOResult] {
+  return [null, new IOResult()]
+}
+
+function tree(name: string): CLISpec {
+  return new CLISpec({ name, subcommands: [new CLISpec({ name: 'run', fn: noop })] })
+}
+
+describe('cli spec registry', () => {
+  it('registers, resolves, and unregisters', () => {
+    const spec = tree('spectest')
+    registerCliSpec(spec)
+    try {
+      expect(cliSpecFor('spectest')).toBe(spec)
+    } finally {
+      unregisterCliSpec('spectest')
+    }
+    expect(() => cliSpecFor('spectest')).toThrow(/unknown cli 'spectest'/)
+  })
+
+  it('refuses duplicate registration', () => {
+    registerCliSpec(tree('spectest2'))
+    try {
+      expect(() => {
+        registerCliSpec(tree('spectest2'))
+      }).toThrow(/already registered/)
+    } finally {
+      unregisterCliSpec('spectest2')
+    }
+  })
+
+  it('unregistering an unknown name throws', () => {
+    expect(() => {
+      unregisterCliSpec('spectest3')
+    }).toThrow(/not registered/)
+  })
+
+  it('an unknown key names the known specs', () => {
+    expect(() => cliSpecFor('spectest4')).toThrow(/known: /)
+  })
+})

--- a/typescript/packages/core/src/commands/cli/specs.ts
+++ b/typescript/packages/core/src/commands/cli/specs.ts
@@ -1,0 +1,47 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { CLISpec } from './types.ts'
+
+// Named CLISpec trees the YAML `clis:` section resolves against
+// (`cli: slack` looks up "slack" here). Bundled programs register at
+// import time; user programs register through registerCliSpec before
+// the workspace loads.
+const CLI_SPECS = new Map<string, CLISpec>()
+
+/** Make a CLISpec resolvable by name from YAML; its root name is the key. */
+export function registerCliSpec(spec: CLISpec): void {
+  if (CLI_SPECS.has(spec.name)) {
+    throw new Error(`CLI spec '${spec.name}' is already registered`)
+  }
+  CLI_SPECS.set(spec.name, spec)
+}
+
+/** Remove a named CLISpec from the YAML lookup. */
+export function unregisterCliSpec(name: string): void {
+  if (!CLI_SPECS.has(name)) {
+    throw new Error(`CLI spec '${name}' is not registered`)
+  }
+  CLI_SPECS.delete(name)
+}
+
+/** Resolve a YAML `cli:` key to its registered tree, fail loud. */
+export function cliSpecFor(name: string): CLISpec {
+  const spec = CLI_SPECS.get(name)
+  if (spec === undefined) {
+    const known = [...CLI_SPECS.keys()].sort().join(', ') || 'none registered'
+    throw new Error(`unknown cli '${name}' (known: ${known})`)
+  }
+  return spec
+}

--- a/typescript/packages/core/src/commands/cli/types.ts
+++ b/typescript/packages/core/src/commands/cli/types.ts
@@ -12,10 +12,22 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { ByteSource } from '../../io/types.ts'
 import type { CommandSafeguard, PathSpec } from '../../types.ts'
-import type { CommandFnResult, CommandOpts } from '../config.ts'
+import type { CommandFnResult } from '../config.ts'
 import { compileSpec } from '../spec/compile.ts'
 import { CommandSpec, type CommandSpecInit } from '../spec/types.ts'
+
+/**
+ * The opts bag a CLI leaf receives: the parsed flags (group flags
+ * merged in) and stdin. Narrower than CommandOpts on purpose: a CLI
+ * consults no mount, so there is no resource, no mount prefix, and no
+ * filetype cascade; the config carries whatever the handler needs.
+ */
+export interface CLIVerbOpts {
+  stdin: ByteSource | null
+  flags: Record<string, string | boolean | number | string[]>
+}
 
 /**
  * Leaf handler of a CLISpec node, called with the installation's validated
@@ -27,7 +39,7 @@ export type CLIVerbFn = (
   config: unknown,
   paths: PathSpec[],
   texts: string[],
-  opts: CommandOpts,
+  opts: CLIVerbOpts,
 ) => Promise<CommandFnResult> | CommandFnResult
 
 export interface CLISpecInit extends CommandSpecInit {

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -632,11 +632,15 @@ export {
   CLISpec,
   type CLISpecInit,
   type CLIVerbFn,
+  type CLIVerbOpts,
   type WalkFlagBag,
   WalkResult,
   type WalkResultInit,
 } from './commands/cli/types.ts'
+export { cliSpecFor, registerCliSpec, unregisterCliSpec } from './commands/cli/specs.ts'
 export { nodeHelp, walk } from './commands/cli/walk.ts'
+export { CLIRegistry } from './workspace/cli/registry.ts'
+export type { CLIInstall } from './workspace/cli/types.ts'
 export {
   COMPOUND_EXTENSIONS,
   getExtension,

--- a/typescript/packages/core/src/workspace/cli/registry.test.ts
+++ b/typescript/packages/core/src/workspace/cli/registry.test.ts
@@ -1,0 +1,115 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+
+import { CLISpec } from '../../commands/cli/types.ts'
+import { IOResult } from '../../io/types.ts'
+import { CLIRegistry } from './registry.ts'
+
+// Mirrors python/tests/workspace/cli/test_registry.py.
+
+interface TokenConfig {
+  token: string
+}
+
+function tokenConfig(input: Record<string, unknown>): TokenConfig {
+  const keys = Object.keys(input).filter((k) => k !== 'token')
+  if (keys.length > 0) throw new Error(`unknown config keys: ${keys.sort().join(', ')}`)
+  if (typeof input.token !== 'string') throw new Error('token is required')
+  return { token: input.token }
+}
+
+function noop(): [null, IOResult] {
+  return [null, new IOResult()]
+}
+
+function tree(configModel: ((input: Record<string, unknown>) => unknown) | null = null): CLISpec {
+  return new CLISpec({
+    name: 'prog',
+    configModel,
+    subcommands: [new CLISpec({ name: 'run', fn: noop })],
+  })
+}
+
+describe('CLIRegistry', () => {
+  it('installs, gets, and snapshots', () => {
+    const reg = new CLIRegistry()
+    const install = reg.install('prog', tree())
+    expect(reg.get('prog')).toBe(install)
+    expect(reg.get('other')).toBeNull()
+    expect([...reg.items().keys()]).toEqual(['prog'])
+  })
+
+  it('two installs of one spec hold their own configs', () => {
+    const reg = new CLIRegistry()
+    const spec = tree(tokenConfig)
+    const eng = reg.install('prog', spec, { token: 'eng' })
+    const sup = reg.install('prog-sup', spec, { token: 'sup' })
+    expect((eng.config as TokenConfig).token).toBe('eng')
+    expect((sup.config as TokenConfig).token).toBe('sup')
+  })
+
+  it('requires a single-word name', () => {
+    const reg = new CLIRegistry()
+    expect(() => reg.install('two words', tree())).toThrow(/single word/)
+    expect(() => reg.install('', tree())).toThrow(/single word/)
+  })
+
+  it('refuses a duplicate name', () => {
+    const reg = new CLIRegistry()
+    reg.install('prog', tree())
+    expect(() => reg.install('prog', tree())).toThrow(/already installed/)
+  })
+
+  it('refuses shell builtin collisions', () => {
+    const reg = new CLIRegistry()
+    expect(() => reg.install('cd', tree())).toThrow(/shell builtin/)
+    expect(() => reg.install('kill', tree())).toThrow(/shell builtin/)
+  })
+
+  it('refuses general command collisions', () => {
+    const reg = new CLIRegistry()
+    expect(() => reg.install('grep', tree())).toThrow(/general command/)
+    expect(() => reg.install('ln', tree())).toThrow(/general command/)
+  })
+
+  it('validates config through the model, fail loud', () => {
+    const reg = new CLIRegistry()
+    expect(() => reg.install('prog', tree(tokenConfig), {})).toThrow(/token is required/)
+    expect(() => reg.install('prog', tree(tokenConfig), { token: 'x', extra: 1 })).toThrow(
+      /unknown config keys: extra/,
+    )
+  })
+
+  it('refuses config without a model', () => {
+    const reg = new CLIRegistry()
+    expect(() => reg.install('prog', tree(), { token: 'x' })).toThrow(/declares no configModel/)
+  })
+
+  it('installs with null config when neither is given', () => {
+    const reg = new CLIRegistry()
+    expect(reg.install('prog', tree()).config).toBeNull()
+  })
+
+  it('uninstall removes and unknown throws', () => {
+    const reg = new CLIRegistry()
+    reg.install('prog', tree())
+    reg.uninstall('prog')
+    expect(reg.get('prog')).toBeNull()
+    expect(() => {
+      reg.uninstall('prog')
+    }).toThrow(/not installed/)
+  })
+})

--- a/typescript/packages/core/src/workspace/cli/registry.ts
+++ b/typescript/packages/core/src/workspace/cli/registry.ts
@@ -1,0 +1,91 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { CLISpec } from '../../commands/cli/types.ts'
+import { BUILTIN_SPECS } from '../../commands/spec/builtins.ts'
+import { JOB_BUILTINS, NAMESPACE_COMMANDS, SHELL_NAMES } from '../route/constants.ts'
+import type { CLIInstall } from './types.ts'
+
+/**
+ * Installed CLIs, keyed by head word.
+ *
+ * Fully separate from the mount registry: a CLI exists because it was
+ * installed (YAML `clis:` section or registerCli), never because
+ * storage was mounted. Install is fail-loud: a bad name, a colliding
+ * name, or a config the spec's configModel rejects throws at install
+ * time, so a workspace that loads has only valid entries.
+ */
+export class CLIRegistry {
+  private readonly installs = new Map<string, CLIInstall>()
+
+  /**
+   * Install a CLI under a head word. The name must be a single word and
+   * must not collide with another installed CLI, a shell builtin, or a
+   * general command (a runtime capture of the same name is fine: the
+   * policy steers per line).
+   */
+  install(name: string, spec: CLISpec, config: Record<string, unknown> | null = null): CLIInstall {
+    if (name === '' || /\s/.test(name)) {
+      throw new Error(`CLI name '${name}' must be a single word`)
+    }
+    if (this.installs.has(name)) {
+      throw new Error(`CLI name '${name}' is already installed`)
+    }
+    if (SHELL_NAMES.has(name) || JOB_BUILTINS.has(name)) {
+      throw new Error(`CLI name '${name}' collides with a shell builtin`)
+    }
+    if (NAMESPACE_COMMANDS.has(name) || name in BUILTIN_SPECS) {
+      throw new Error(`CLI name '${name}' collides with a general command`)
+    }
+    const install: CLIInstall = {
+      name,
+      spec,
+      config: this.validateConfig(name, spec, config),
+    }
+    this.installs.set(name, install)
+    return install
+  }
+
+  private validateConfig(
+    name: string,
+    spec: CLISpec,
+    config: Record<string, unknown> | null,
+  ): unknown {
+    if (spec.configModel === null) {
+      if (config !== null && Object.keys(config).length > 0) {
+        throw new Error(`CLI '${name}': config given but '${spec.name}' declares no configModel`)
+      }
+      return null
+    }
+    return spec.configModel(config ?? {})
+  }
+
+  /** Remove an installed CLI; its head word stops resolving (127). */
+  uninstall(name: string): void {
+    if (!this.installs.has(name)) {
+      throw new Error(`CLI name '${name}' is not installed`)
+    }
+    this.installs.delete(name)
+  }
+
+  /** Look up an installation by head word. */
+  get(name: string): CLIInstall | null {
+    return this.installs.get(name) ?? null
+  }
+
+  /** Snapshot of the installed CLIs keyed by head word. */
+  items(): Map<string, CLIInstall> {
+    return new Map(this.installs)
+  }
+}

--- a/typescript/packages/core/src/workspace/cli/types.ts
+++ b/typescript/packages/core/src/workspace/cli/types.ts
@@ -1,0 +1,30 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import type { CLISpec } from '../../commands/cli/types.ts'
+
+/**
+ * One installed CLI: a head word bound to a program tree.
+ *
+ * The installed name is the dispatch key, not the spec's own name: two
+ * installations of the same spec under different names (two accounts)
+ * are two independent entries whose help and errors attribute to their
+ * installed head. `config` is the installation's validated configModel
+ * output, handed to every leaf fn; null when the spec declares none.
+ */
+export interface CLIInstall {
+  readonly name: string
+  readonly spec: CLISpec
+  readonly config: unknown
+}

--- a/typescript/packages/core/src/workspace/cli_dispatch.test.ts
+++ b/typescript/packages/core/src/workspace/cli_dispatch.test.ts
@@ -1,0 +1,154 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { CLISpec, type CLIVerbOpts } from '../commands/cli/types.ts'
+import { Operand, Option } from '../commands/spec/types.ts'
+import { IOResult } from '../io/types.ts'
+import { OpsRegistry } from '../ops/registry.ts'
+import { RAMResource } from '../resource/ram/ram.ts'
+import { createShellParser, type ShellParser } from '../shell/parse.ts'
+import { MountMode, type PathSpec } from '../types.ts'
+import { Workspace } from './workspace.ts'
+
+// Mirrors python/tests/e2e/test_cli_dispatch.py.
+
+const require = createRequire(import.meta.url)
+const engineWasm = readFileSync(require.resolve('web-tree-sitter/web-tree-sitter.wasm'))
+const grammarWasm = readFileSync(require.resolve('tree-sitter-bash/tree-sitter-bash.wasm'))
+
+let parser: ShellParser
+
+beforeAll(async () => {
+  parser = await createShellParser({ engineWasm, grammarWasm })
+})
+
+const dec = new TextDecoder()
+
+function tokenConfig(input: Record<string, unknown>): { token: string } {
+  if (typeof input.token !== 'string') throw new Error('token is required')
+  return { token: input.token }
+}
+
+function send(
+  config: unknown,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CLIVerbOpts,
+): [Uint8Array, IOResult] {
+  const token = (config as { token: string }).token
+  const to = opts.flags.to
+  const body = texts.join(' ')
+  return [new TextEncoder().encode(`sent[${token}] to=${String(to)}: ${body}\n`), new IOResult()]
+}
+
+function makeTree(): CLISpec {
+  return new CLISpec({
+    name: 'slackish',
+    configModel: tokenConfig,
+    subcommands: [
+      new CLISpec({
+        name: 'message',
+        subcommands: [
+          new CLISpec({
+            name: 'send',
+            fn: send,
+            write: true,
+            options: [new Option({ short: '-t', long: '--to', type: 'str', required: true })],
+            rest: new Operand({ type: 'str' }),
+          }),
+        ],
+      }),
+    ],
+  })
+}
+
+function buildWorkspace(): Workspace {
+  const ram = new RAMResource()
+  const registry = new OpsRegistry()
+  registry.registerResource(ram)
+  return new Workspace(
+    { '/data': ram },
+    { mode: MountMode.WRITE, ops: registry, shellParser: parser },
+  )
+}
+
+describe('CLI dispatch e2e', () => {
+  it('two accounts dispatch by installed name', async () => {
+    const ws = buildWorkspace()
+    const tree = makeTree()
+    ws.registerCli('slackish', tree, { token: 'eng' })
+    ws.registerCli('slackish-sup', tree, { token: 'sup' })
+    const eng = await ws.execute("slackish message send -t '#e' hi")
+    expect([eng.exitCode, dec.decode(eng.stdout)]).toEqual([0, 'sent[eng] to=#e: hi\n'])
+    const sup = await ws.execute("slackish-sup message send -t '#s' yo")
+    expect([sup.exitCode, dec.decode(sup.stdout)]).toEqual([0, 'sent[sup] to=#s: yo\n'])
+  })
+
+  it('a renamed install attributes to its own head', async () => {
+    const ws = buildWorkspace()
+    ws.registerCli('sl', makeTree(), { token: 't' })
+    const bogus = await ws.execute('sl bogus')
+    expect(bogus.exitCode).toBe(1)
+    expect(dec.decode(bogus.stderr)).toBe("sl: 'bogus' is not a sl command. See 'sl --help'.\n")
+    const help = await ws.execute('sl message send --help')
+    expect(help.exitCode).toBe(0)
+    expect(dec.decode(help.stdout).startsWith('sl message send\n')).toBe(true)
+  })
+
+  it('leaf usage errors exit 2', async () => {
+    const ws = buildWorkspace()
+    ws.registerCli('sl', makeTree(), { token: 't' })
+    const res = await ws.execute('sl message send hi')
+    expect(res.exitCode).toBe(2)
+    expect(dec.decode(res.stderr)).toMatch(/^sl message send: option '--to' is required/)
+  })
+
+  it('unregister returns the name to 127', async () => {
+    const ws = buildWorkspace()
+    ws.registerCli('sl', makeTree(), { token: 't' })
+    ws.unregisterCli('sl')
+    const res = await ws.execute('sl message send -t x hi')
+    expect(res.exitCode).toBe(127)
+    expect(dec.decode(res.stderr)).toContain('sl: command not found')
+  })
+
+  it('a CLI head never resolves a mount', async () => {
+    const ws = buildWorkspace()
+    ws.registerCli('sl', makeTree(), { token: 't' })
+    const res = await ws.execute('sl message send -t x /data/a.txt')
+    expect(res.exitCode).toBe(0)
+    expect(dec.decode(res.stdout)).toBe('sent[t] to=x: /data/a.txt\n')
+  })
+
+  it('the clis constructor option installs through the same path', async () => {
+    const ram = new RAMResource()
+    const registry = new OpsRegistry()
+    registry.registerResource(ram)
+    const ws = new Workspace(
+      { '/data': ram },
+      {
+        mode: MountMode.WRITE,
+        ops: registry,
+        shellParser: parser,
+        clis: { sl: [makeTree(), { token: 'opt' }] },
+      },
+    )
+    const res = await ws.execute('sl message send -t x hi')
+    expect([res.exitCode, dec.decode(res.stdout)]).toEqual([0, 'sent[opt] to=x: hi\n'])
+  })
+})

--- a/typescript/packages/core/src/workspace/executor/builtins/command.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/command.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { IOResult, materialize } from '../../../io/types.ts'
 import type { ByteSource } from '../../../io/types.ts'
+import { CLIRegistry } from '../../cli/registry.ts'
 import type { MountRegistry } from '../../mount/registry.ts'
 import { Session } from '../../session/session.ts'
 import { handleCommandBuiltin, handleType, parseFlags } from './command.ts'
@@ -24,6 +25,7 @@ const MOUNT_COMMANDS = new Set(['cat', 'grep', 'ls', 'jq'])
 function makeRegistry(): MountRegistry {
   return {
     mountForCommand: (name: string): unknown => (MOUNT_COMMANDS.has(name) ? {} : null),
+    clis: new CLIRegistry(),
   } as unknown as MountRegistry
 }
 

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -49,6 +49,7 @@ import type { ExecuteNodeFn, JobHandlerResult } from './jobs.ts'
 import { handleFg, handleJobs, handleKill, handlePs, handleWait } from './jobs.ts'
 import { versionRequest } from '../../commands/config.ts'
 
+import { handleCli } from './command/cli.ts'
 import { optionError, parseFlags } from './command/flags.ts'
 import { executeShellFunction } from './command/functions.ts'
 import {
@@ -116,6 +117,14 @@ export async function handleCommand(
       stdin,
       callStack,
     )
+  }
+
+  // Installed CLIs: dispatch by name, never by operand path. Sits
+  // below functions (a user can wrap an installed CLI, bash-style)
+  // and above every mount branch (a CLI consults no mount).
+  const cliInstall = registry.clis.get(cmdName)
+  if (cliInstall !== null) {
+    return handleCli(cliInstall, parts, session, stdin)
   }
 
   if (cmdName in CWD_DEFAULT_RAW) {

--- a/typescript/packages/core/src/workspace/executor/command/cli.test.ts
+++ b/typescript/packages/core/src/workspace/executor/command/cli.test.ts
@@ -14,10 +14,10 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { CLISpec, type CLIVerbOpts } from '../../../commands/cli/types.ts'
+import { CLISpec, type CLIVerbFn, type CLIVerbOpts } from '../../../commands/cli/types.ts'
 import { Operand, Option } from '../../../commands/spec/types.ts'
 import { IOResult, materialize } from '../../../io/types.ts'
-import type { PathSpec } from '../../../types.ts'
+import { CommandSafeguard, type PathSpec } from '../../../types.ts'
 import type { CLIInstall } from '../../cli/types.ts'
 import { Session } from '../../session/session.ts'
 import { handleCli } from './cli.ts'
@@ -134,6 +134,29 @@ describe('handleCli', () => {
     expect(dec.decode(await materialize(io.stderr))).toMatch(
       /^prog message send: option '--to' is required/,
     )
+  })
+
+  it('the leaf safeguard bounds the handler', async () => {
+    // The declared safeguard wraps the handler body like mount
+    // dispatch: a blocking leaf times out instead of hanging.
+    const slow: CLIVerbFn = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      return [null, new IOResult()]
+    }
+    const spec = new CLISpec({
+      name: 'prog',
+      subcommands: [
+        new CLISpec({
+          name: 'run',
+          fn: slow,
+          safeguard: new CommandSafeguard({ timeoutSeconds: 0.05 }),
+        }),
+      ],
+    })
+    const install: CLIInstall = { name: 'prog', spec, config: null }
+    await expect(
+      handleCli(install, ['prog', 'run'], new Session({ sessionId: 't' })),
+    ).rejects.toThrow(/prog run: timed out/)
   })
 
   it('injects stdin into the opts bag', async () => {

--- a/typescript/packages/core/src/workspace/executor/command/cli.test.ts
+++ b/typescript/packages/core/src/workspace/executor/command/cli.test.ts
@@ -1,0 +1,151 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+
+import { CLISpec, type CLIVerbOpts } from '../../../commands/cli/types.ts'
+import { Operand, Option } from '../../../commands/spec/types.ts'
+import { IOResult, materialize } from '../../../io/types.ts'
+import type { PathSpec } from '../../../types.ts'
+import type { CLIInstall } from '../../cli/types.ts'
+import { Session } from '../../session/session.ts'
+import { handleCli } from './cli.ts'
+
+// Mirrors python/tests/workspace/executor/command/test_cli.py.
+
+interface Call {
+  config: unknown
+  paths: PathSpec[]
+  texts: string[]
+  opts: CLIVerbOpts
+}
+
+const calls: Call[] = []
+const dec = new TextDecoder()
+
+function send(
+  config: unknown,
+  paths: PathSpec[],
+  texts: string[],
+  opts: CLIVerbOpts,
+): [Uint8Array, IOResult] {
+  calls.push({ config, paths, texts, opts })
+  const token = (config as { token: string }).token
+  return [new TextEncoder().encode(`sent[${token}]\n`), new IOResult()]
+}
+
+function makeInstall(name = 'prog'): CLIInstall {
+  const spec = new CLISpec({
+    name: 'prog',
+    configModel: (input) => input,
+    options: [new Option({ short: '-v', long: '--verbose', count: true })],
+    subcommands: [
+      new CLISpec({
+        name: 'message',
+        subcommands: [
+          new CLISpec({
+            name: 'send',
+            fn: send,
+            options: [new Option({ short: '-t', long: '--to', type: 'str', required: true })],
+            rest: new Operand({ type: 'str' }),
+          }),
+        ],
+      }),
+    ],
+  })
+  return { name, spec, config: { token: 'tok' } }
+}
+
+describe('handleCli', () => {
+  it('runs the leaf with config, group flags, and texts', async () => {
+    calls.length = 0
+    const install = makeInstall()
+    const parts = ['prog', '-vv', 'message', 'send', '-t', '#eng', 'hello', 'world']
+    const [stdout, io, node] = await handleCli(install, parts, new Session({ sessionId: 't' }))
+    expect(io.exitCode).toBe(0)
+    expect(dec.decode(await materialize(stdout))).toBe('sent[tok]\n')
+    const call = calls.pop()
+    expect((call?.config as { token: string }).token).toBe('tok')
+    expect(call?.texts).toEqual(['hello', 'world'])
+    expect(call?.opts.flags.to).toBe('#eng')
+    expect(call?.opts.flags.verbose).toBe(2)
+    expect(node.command).toBe('prog -vv message send -t #eng hello world')
+  })
+
+  it('refuses an unknown verb with git wording, exit 1', async () => {
+    const install = makeInstall('renamed')
+    const [, io, node] = await handleCli(
+      install,
+      ['renamed', 'bogus'],
+      new Session({ sessionId: 't' }),
+    )
+    expect(io.exitCode).toBe(1)
+    expect(dec.decode(await materialize(io.stderr))).toBe(
+      "renamed: 'bogus' is not a renamed command. See 'renamed --help'.\n",
+    )
+    expect(node.exitCode).toBe(1)
+  })
+
+  it('bare group prints usage to stdout, exit 1', async () => {
+    const install = makeInstall()
+    const [stdout, io] = await handleCli(
+      install,
+      ['prog', 'message'],
+      new Session({ sessionId: 't' }),
+    )
+    expect(io.exitCode).toBe(1)
+    const out = dec.decode(await materialize(stdout))
+    expect(out).toContain('Usage: prog message')
+    expect(out).toContain('send')
+  })
+
+  it('leaf --help prints the installed prog, exit 0', async () => {
+    const install = makeInstall('renamed')
+    const [stdout, io] = await handleCli(
+      install,
+      ['renamed', 'message', 'send', '--help'],
+      new Session({ sessionId: 't' }),
+    )
+    expect(io.exitCode).toBe(0)
+    const out = dec.decode(await materialize(stdout))
+    expect(out.startsWith('renamed message send\n')).toBe(true)
+    expect(out).toContain('--help')
+  })
+
+  it('leaf usage errors exit 2 with prog attribution', async () => {
+    const install = makeInstall()
+    const [, io] = await handleCli(
+      install,
+      ['prog', 'message', 'send', 'hi'],
+      new Session({ sessionId: 't' }),
+    )
+    expect(io.exitCode).toBe(2)
+    expect(dec.decode(await materialize(io.stderr))).toMatch(
+      /^prog message send: option '--to' is required/,
+    )
+  })
+
+  it('injects stdin into the opts bag', async () => {
+    calls.length = 0
+    const install = makeInstall()
+    const stdin = new TextEncoder().encode('body')
+    await handleCli(
+      install,
+      ['prog', 'message', 'send', '-t', 'x'],
+      new Session({ sessionId: 't' }),
+      stdin,
+    )
+    expect(calls.pop()?.opts.stdin).toBe(stdin)
+  })
+})

--- a/typescript/packages/core/src/workspace/executor/command/cli.ts
+++ b/typescript/packages/core/src/workspace/executor/command/cli.ts
@@ -1,0 +1,136 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { CLISpec } from '../../../commands/cli/types.ts'
+import { walk } from '../../../commands/cli/walk.ts'
+import { HELP_OPTION } from '../../../commands/config.ts'
+import { flagKwargName } from '../../../commands/spec/constants.ts'
+import { renderHelp } from '../../../commands/spec/help.ts'
+import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
+import { PathSpec } from '../../../types.ts'
+import { concatBytes } from '../../../core/jq/format.ts'
+import type { CLIInstall } from '../../cli/types.ts'
+import type { Session } from '../../session/session.ts'
+import { ExecutionNode } from '../../types.ts'
+import { optionError, parseFlags } from './flags.ts'
+
+/**
+ * Execute a line whose head word is an installed CLI.
+ *
+ * Dispatch is by NAME: the install resolves the program tree and the
+ * validated config; no mount is consulted and no operand path picks a
+ * backend (the one executor divergence from mount commands). The walk
+ * consumes subcommand words and group options; the leaf's own argv
+ * rides the ordinary spec machinery because a CLISpec IS a
+ * CommandSpec, and the leaf handler runs as
+ * `fn(config, paths, texts, opts)` with the installation's config in
+ * the accessor's seat.
+ */
+export async function handleCli(
+  install: CLIInstall,
+  parts: readonly (string | PathSpec)[],
+  session: Session,
+  stdin: ByteSource | null = null,
+): Promise<[ByteSource | null, IOResult, ExecutionNode]> {
+  const words = parts.map((p) => (p instanceof PathSpec ? p.virtual : p))
+  const cmdStr = words.join(' ')
+  const argv = words.slice(1)
+
+  const result = walk(install.name, install.spec, argv)
+  if (result.leaf === null) {
+    const stderr = result.stream === 'stderr' ? result.output : new Uint8Array(0)
+    const stdout = result.stream === 'stdout' ? result.output : null
+    const io = new IOResult({ exitCode: result.exitCode, stderr })
+    return [stdout, io, new ExecutionNode({ command: cmdStr, exitCode: result.exitCode, stderr })]
+  }
+
+  const prog = [install.name, ...result.path].join(' ')
+  const leaf = result.leaf
+  // argparse add_help: every leaf answers --help with its own help
+  // unless it declares the flag itself. No injected --version: that is
+  // a GNU coreutils convention, not an argparse one.
+  const hasHelp = leaf.options.some((option) => option.long === '--help')
+  // CLISpec init accepts instance fields, so the spread is a plain init
+  // bag (the withHelpSupport pattern).
+  const helpSpec = (): CLISpec =>
+    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+    new CLISpec({ ...leaf, options: [...leaf.options, HELP_OPTION] })
+  const parseSpec = hasHelp ? leaf : helpSpec()
+
+  const parsed = parseFlags([...result.argv], parseSpec, prog, session.cwd)
+  const [paths, texts, flagKwargs, warnings] = [parsed[0], parsed[1], parsed[2], parsed[3]]
+  if (flagKwargs.help === true) {
+    const helpText = new TextEncoder().encode(renderHelp(prog, parseSpec))
+    return [helpText, new IOResult(), new ExecutionNode({ command: cmdStr, exitCode: 0 })]
+  }
+
+  const refusal = optionError(
+    prog,
+    parsed[4],
+    parsed[5],
+    parsed[6],
+    parsed[7],
+    parsed[8],
+    parsed[9],
+    parsed[10],
+    parsed[11],
+  )
+  if (refusal !== null) {
+    // Leaf usage errors exit 2 (argparse), regardless of the
+    // USAGE_EXIT table: prog is an installed name, never a GNU tool
+    // with its own pinned exit.
+    const [msg] = refusal
+    return [
+      null,
+      new IOResult({ exitCode: 2, stderr: msg }),
+      new ExecutionNode({ command: cmdStr, exitCode: 2, stderr: msg }),
+    ]
+  }
+
+  // Group flags merge into the one bag: ancestor/descendant collisions
+  // are a build-time CLISpec error, so a group flag can never shadow a
+  // leaf flag.
+  const flags: Record<string, string | boolean | number | string[]> = {}
+  for (const [spelling, value] of Object.entries(result.groupFlags)) {
+    flags[flagKwargName(spelling)] = value
+  }
+  Object.assign(flags, flagKwargs)
+  delete flags.help
+
+  const fn = leaf.fn
+  if (fn === null) {
+    // validateCli guarantees fn XOR subcommands and walk only returns
+    // fn-bearing nodes as leaf; reaching this is a bug.
+    throw new Error(`walk returned a leaf without fn for '${prog}'`)
+  }
+  const out = await fn(install.config, paths, texts, { stdin, flags })
+  let stdout: ByteSource | null = null
+  let io = new IOResult()
+  if (out !== null) {
+    ;[stdout, io] = out
+  }
+
+  if (warnings.length > 0) {
+    const warn = new TextEncoder().encode(warnings.map((w) => `${prog}: ${w}\n`).join(''))
+    const existing = await materialize(io.stderr)
+    io.stderr = concatBytes([warn, existing])
+  }
+
+  const stderrBytes = await materialize(io.stderr)
+  return [
+    stdout,
+    io,
+    new ExecutionNode({ command: cmdStr, stderr: stderrBytes, exitCode: io.exitCode, paths }),
+  ]
+}

--- a/typescript/packages/core/src/workspace/executor/command/cli.ts
+++ b/typescript/packages/core/src/workspace/executor/command/cli.ts
@@ -20,10 +20,20 @@ import { renderHelp } from '../../../commands/spec/help.ts'
 import { IOResult, materialize, type ByteSource } from '../../../io/types.ts'
 import { PathSpec } from '../../../types.ts'
 import { concatBytes } from '../../../core/jq/format.ts'
+import { maybeWithTimeout, runWithTimeout } from '../../../commands/builtin/utils/safeguard.ts'
 import type { CLIInstall } from '../../cli/types.ts'
 import type { Session } from '../../session/session.ts'
 import { ExecutionNode } from '../../types.ts'
+import { resolveSafeguard } from '../policy/safeguard.ts'
 import { optionError, parseFlags } from './flags.ts'
+
+// argparse add_help: a leaf answers --help with its own help unless it
+// declares the flag itself. CLISpec init accepts instance fields, so
+// the spread is a plain init bag (the withHelpSupport pattern).
+function withInjectedHelp(leaf: CLISpec): CLISpec {
+  // eslint-disable-next-line @typescript-eslint/no-misused-spread
+  return new CLISpec({ ...leaf, options: [...leaf.options, HELP_OPTION] })
+}
 
 /**
  * Execute a line whose head word is an installed CLI.
@@ -57,16 +67,10 @@ export async function handleCli(
 
   const prog = [install.name, ...result.path].join(' ')
   const leaf = result.leaf
-  // argparse add_help: every leaf answers --help with its own help
-  // unless it declares the flag itself. No injected --version: that is
-  // a GNU coreutils convention, not an argparse one.
+  // No injected --version: that is a GNU coreutils convention, not an
+  // argparse one.
   const hasHelp = leaf.options.some((option) => option.long === '--help')
-  // CLISpec init accepts instance fields, so the spread is a plain init
-  // bag (the withHelpSupport pattern).
-  const helpSpec = (): CLISpec =>
-    // eslint-disable-next-line @typescript-eslint/no-misused-spread
-    new CLISpec({ ...leaf, options: [...leaf.options, HELP_OPTION] })
-  const parseSpec = hasHelp ? leaf : helpSpec()
+  const parseSpec = hasHelp ? leaf : withInjectedHelp(leaf)
 
   const parsed = parseFlags([...result.argv], parseSpec, prog, session.cwd)
   const [paths, texts, flagKwargs, warnings] = [parsed[0], parsed[1], parsed[2], parsed[3]]
@@ -114,18 +118,32 @@ export async function handleCli(
     // fn-bearing nodes as leaf; reaching this is a bug.
     throw new Error(`walk returned a leaf without fn for '${prog}'`)
   }
-  const out = await fn(install.config, paths, texts, { stdin, flags })
+  // The leaf's declared safeguard bounds the handler body and its
+  // streams, exactly like mount dispatch: without the wrap a blocking
+  // leaf hangs forever and an unbounded-output leaf ignores its own
+  // limits.
+  const safeguard = resolveSafeguard(prog, [], leaf.safeguard)
+  const timeout = safeguard?.timeoutSeconds ?? null
+  const out = await runWithTimeout(
+    Promise.resolve(fn(install.config, paths, texts, { stdin, flags })),
+    timeout,
+    prog,
+  )
   let stdout: ByteSource | null = null
   let io = new IOResult()
   if (out !== null) {
     ;[stdout, io] = out
   }
+  io.safeguard = safeguard
 
   if (warnings.length > 0) {
     const warn = new TextEncoder().encode(warnings.map((w) => `${prog}: ${w}\n`).join(''))
     const existing = await materialize(io.stderr)
     io.stderr = concatBytes([warn, existing])
   }
+
+  stdout = maybeWithTimeout(stdout, io.safeguard, prog)
+  io.stderr = maybeWithTimeout(io.stderr, io.safeguard, prog)
 
   const stderrBytes = await materialize(io.stderr)
   return [

--- a/typescript/packages/core/src/workspace/mount/registry.test.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.test.ts
@@ -14,6 +14,7 @@
 
 import { mountPrefixOf } from '../../utils/key_prefix.ts'
 import { describe, expect, it } from 'vitest'
+import { CLISpec } from '../../commands/cli/types.ts'
 import { command, type CommandFn } from '../../commands/config.ts'
 import { CommandSpec } from '../../commands/spec/types.ts'
 import { IOResult } from '../../io/types.ts'
@@ -378,6 +379,21 @@ describe('MountRegistry.matchCommandPrefix', () => {
 
   it('does not match a partial (unregistered) prefix', () => {
     expect(regWith(['gws docs documents get']).matchCommandPrefix(['gws', 'docs'])).toBe(1)
+  })
+
+  it('an installed CLI head wins over a multiword mount command', () => {
+    // Dispatch is by name: the head alone is the command, the
+    // subcommand words belong to the tree walk, so an installed CLI
+    // must not be swallowed by a same-head multiword mount command.
+    const reg = regWith(['gws docs documents get'])
+    reg.clis.install(
+      'gws',
+      new CLISpec({
+        name: 'gws',
+        subcommands: [new CLISpec({ name: 'run', fn: () => [null, new IOResult()] })],
+      }),
+    )
+    expect(reg.matchCommandPrefix(['gws', 'docs', 'documents', 'get'])).toBe(1)
   })
 
   it('falls back to 1 for unknown and 0 for empty', () => {

--- a/typescript/packages/core/src/workspace/mount/registry.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.ts
@@ -22,6 +22,7 @@ import { cachesReads, type Resource } from '../../resource/base.ts'
 import { DevResource } from '../../resource/dev/dev.ts'
 import { MountRootPolicy, Policies } from '../../policy/index.ts'
 import { ConsistencyPolicy, MountMode, PathSpec } from '../../types.ts'
+import { CLIRegistry } from '../cli/registry.ts'
 import { MountEntry } from './mount.ts'
 import { rstripSlash, stripSlash } from '../../utils/slash.ts'
 
@@ -76,6 +77,11 @@ export class MountRegistry {
   // guards/policies options). Registry-hosted like vfsRuntime so the
   // executor reaches them without new threading.
   readonly policies = new Policies([new MountRootPolicy()])
+  // Installed CLIs. Not mount state: CLIs are fully separate from
+  // mounts (a CLI exists because it was installed, never because
+  // storage was mounted). The registry object is just the vehicle that
+  // already reaches every dispatch site, same as the runtime fields.
+  readonly clis = new CLIRegistry()
 
   setReconciler(reconciler: ReadReconciler): void {
     this.reconciler = reconciler

--- a/typescript/packages/core/src/workspace/mount/registry.ts
+++ b/typescript/packages/core/src/workspace/mount/registry.ts
@@ -366,6 +366,11 @@ export class MountRegistry {
    */
   matchCommandPrefix(words: string[]): number {
     if (words.length === 0) return 0
+    // An installed CLI head wins over any multiword mount command
+    // under the same first word (`himalaya message send`): dispatch is
+    // by name and the subcommand words belong to the tree walk, so the
+    // head alone is the command name.
+    if (words[0] !== undefined && this.clis.get(words[0]) !== null) return 1
     let best = 1
     const candidates = [...this.mountList]
     if (this.rootRef !== null) candidates.push(this.rootRef)

--- a/typescript/packages/core/src/workspace/route/route.test.ts
+++ b/typescript/packages/core/src/workspace/route/route.test.ts
@@ -13,6 +13,8 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
+import { CLISpec } from '../../commands/cli/types.ts'
+import { IOResult } from '../../io/types.ts'
 import { OpsRegistry } from '../../ops/registry.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
 import { MountMode } from '../../types.ts'
@@ -26,6 +28,14 @@ function fixture(): { session: Session; ws: Workspace } {
   registry.registerResource(ram)
   const ws = new Workspace({ '/ram': ram }, { mode: MountMode.WRITE, ops: registry })
   return { session: new Session({ sessionId: 't' }), ws }
+}
+
+function noopVerb(): [null, IOResult] {
+  return [null, new IOResult()]
+}
+
+function cliTree(): CLISpec {
+  return new CLISpec({ name: 'prog', subcommands: [new CLISpec({ name: 'run', fn: noopVerb })] })
 }
 
 describe('route', () => {
@@ -76,10 +86,33 @@ describe('route', () => {
     expect(route('nosuchcmd', session, ws.registry)).toBe(Consumer.UNKNOWN)
   })
 
+  it('routes an installed CLI to CLI', () => {
+    const { session, ws } = fixture()
+    ws.registerCli('prog', cliTree())
+    expect(route('prog', session, ws.registry)).toBe(Consumer.CLI)
+  })
+
+  it('function shadows an installed CLI', () => {
+    const { session, ws } = fixture()
+    ws.registerCli('prog', cliTree())
+    session.functions.prog = []
+    expect(route('prog', session, ws.registry)).toBe(Consumer.FUNCTION)
+  })
+
+  it('an unregistered CLI routes UNKNOWN', () => {
+    const { session, ws } = fixture()
+    ws.registerCli('prog', cliTree())
+    ws.unregisterCli('prog')
+    expect(route('prog', session, ws.registry)).toBe(Consumer.UNKNOWN)
+  })
+
   it('only shell consumers resolve globs', () => {
     expect(SHELL_CONSUMERS.has(Consumer.SESSION)).toBe(true)
     expect(SHELL_CONSUMERS.has(Consumer.NAMESPACE)).toBe(true)
     expect(SHELL_CONSUMERS.has(Consumer.FUNCTION)).toBe(true)
+    // A CLI is a program: bash hands programs glob matches, never
+    // patterns.
+    expect(SHELL_CONSUMERS.has(Consumer.CLI)).toBe(true)
     expect(SHELL_CONSUMERS.has(Consumer.MOUNT)).toBe(false)
     expect(SHELL_CONSUMERS.has(Consumer.UNKNOWN)).toBe(false)
   })

--- a/typescript/packages/core/src/workspace/route/route.ts
+++ b/typescript/packages/core/src/workspace/route/route.ts
@@ -21,13 +21,32 @@ import { Consumer } from './types.ts'
  * Route a command name to the layer that consumes it.
  *
  * Order mirrors dispatch precedence: shell builtins shadow functions,
- * functions shadow mount commands, and a name nobody registers is
- * UNKNOWN (command not found).
+ * functions shadow installed CLIs, CLIs shadow mount commands, and a
+ * name nobody registers is UNKNOWN (command not found). Install-time
+ * collision rules keep the CLI arm honest: a CLI may not take a shell
+ * builtin's or a general command's name, so the only shadowing a CLI
+ * can actually exert is over a mount-specific custom command.
+ *
+ * The full landscape, in precedence order. The column to watch is what
+ * resolves the name: session or workspace state for the named layers,
+ * operand paths for mounts:
+ *
+ *     Consumer   Example              Resolved by          Words
+ *     SESSION    cd, echo, export     name in SHELL_NAMES  shell-expanded
+ *     NAMESPACE  ln -s, readlink      NAMESPACE_COMMANDS   shell-expanded
+ *     FUNCTION   deploy() {..}        session.functions    shell-expanded
+ *     CLI        slack message send   registry.clis        shell-expanded
+ *     MOUNT      grep, cat, du        operand paths        pushdown
+ *     UNKNOWN    bogus                nobody               untouched, 127
+ *
+ * Runtimes are orthogonal, not a seventh row: a capture decides where a
+ * command executes (docker vs vfs), never whether the name exists.
  */
 export function route(name: string, session: Session, registry: MountRegistry): Consumer {
   if (SHELL_NAMES.has(name)) return Consumer.SESSION
   if (NAMESPACE_COMMANDS.has(name)) return Consumer.NAMESPACE
   if (name in session.functions) return Consumer.FUNCTION
+  if (registry.clis.get(name) !== null) return Consumer.CLI
   if (registry.mountForCommand(name) !== null) return Consumer.MOUNT
   return Consumer.UNKNOWN
 }

--- a/typescript/packages/core/src/workspace/route/types.ts
+++ b/typescript/packages/core/src/workspace/route/types.ts
@@ -26,16 +26,20 @@ export const Consumer = Object.freeze({
   SESSION: 'session',
   NAMESPACE: 'namespace',
   FUNCTION: 'function',
+  CLI: 'cli',
   MOUNT: 'mount',
   UNKNOWN: 'unknown',
 } as const)
 
 export type Consumer = (typeof Consumer)[keyof typeof Consumer]
 
+// CLI rides with the shell consumers for word policy: an installed CLI
+// is a program, and bash hands programs glob matches, never patterns.
 export const SHELL_CONSUMERS: ReadonlySet<Consumer> = new Set([
   Consumer.SESSION,
   Consumer.NAMESPACE,
   Consumer.FUNCTION,
+  Consumer.CLI,
 ])
 
 /**

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -24,7 +24,10 @@ import type { Resource } from '../resource/base.ts'
 import { HISTORY_PREFIX, HistoryViewResource } from '../resource/history/history.ts'
 import { resourceStateRequiresOverride } from '../resource/secrets.ts'
 import { GENERAL_COMMANDS } from '../commands/builtin/general/index.ts'
+import { cliSpecFor } from '../commands/cli/specs.ts'
+import type { CLISpec } from '../commands/cli/types.ts'
 import { runWithTimeout } from '../commands/builtin/utils/safeguard.ts'
+import type { CLIInstall } from './cli/types.ts'
 import { resolveSafeguard } from './executor/policy/safeguard.ts'
 import { JobTable } from '../shell/job_table.ts'
 import type { ShellParser } from '../shell/parse.ts'
@@ -172,6 +175,13 @@ export class Workspace {
     // line-level counterpart until it is absorbed as a hook.
     for (const guard of options.guards ?? []) this.registry.policies.add(guard)
     for (const entry of options.policies ?? []) this.registry.policies.add(entry)
+    // Installed CLIs, fully separate from mounts: a spec name resolves
+    // against the named registry and every entry installs through the
+    // same fail-loud path as registerCli.
+    for (const [cliName, [specOrKey, cliConfig]] of Object.entries(options.clis ?? {})) {
+      const cliSpec = typeof specOrKey === 'string' ? cliSpecFor(specOrKey) : specOrKey
+      this.registry.clis.install(cliName, cliSpec, cliConfig)
+    }
     this.policyRouter = new PolicyRouter(
       this.runtimes,
       this.policy,
@@ -265,6 +275,30 @@ export class Workspace {
   /** Append a runtime entry to the workspace's ordered world (last, first capturer still wins). */
   addRuntime(runtime: RuntimeEntry): Runtime {
     return this.runtimes.add(runtime)
+  }
+
+  /**
+   * Install a CLI under a head word, fully separate from mounts. The
+   * name is the dispatch key (two installs of one spec under different
+   * names are two accounts); config validates through the spec's
+   * configModel, fail loud at install time.
+   */
+  registerCli(
+    name: string,
+    spec: CLISpec,
+    config: Record<string, unknown> | null = null,
+  ): CLIInstall {
+    return this.registry.clis.install(name, spec, config)
+  }
+
+  /** Remove an installed CLI; its head word stops resolving (127). */
+  unregisterCli(name: string): void {
+    this.registry.clis.uninstall(name)
+  }
+
+  /** Snapshot of the installed CLIs keyed by head word. */
+  clis(): Map<string, CLIInstall> {
+    return this.registry.clis.items()
   }
 
   /**

--- a/typescript/packages/core/src/workspace/workspace/types.ts
+++ b/typescript/packages/core/src/workspace/workspace/types.ts
@@ -14,6 +14,7 @@
 
 import type { FileCache } from '../../cache/file/mixin.ts'
 import type { IndexConfig } from '../../cache/index/config.ts'
+import type { CLISpec } from '../../commands/cli/types.ts'
 import type { ByteSource } from '../../io/types.ts'
 import type { ObserverStore } from '../../observe/store.ts'
 import type { OpsRegistry } from '../../ops/registry.ts'
@@ -98,6 +99,13 @@ export interface WorkspaceOptions {
    * wins and adding a policy can only tighten the workspace.
    */
   policies?: readonly (Policy | GuardSpec)[]
+  /**
+   * Installed CLIs, fully separate from mounts: key = installed head
+   * word, value = a registered CLISpec name (the YAML `cli:` key) or a
+   * CLISpec instance, plus the installation's own config. Every entry
+   * installs through the same fail-loud path as registerCli.
+   */
+  clis?: Record<string, [string | CLISpec, Record<string, unknown> | null]>
 }
 
 export class ExecuteResult {

--- a/typescript/packages/server/src/config.test.ts
+++ b/typescript/packages/server/src/config.test.ts
@@ -438,3 +438,29 @@ describe('configToWorkspaceArgs', () => {
     await expect(configToWorkspaceArgs(cfg)).rejects.toThrow(/unknown guard key/)
   })
 })
+
+describe('clis section', () => {
+  // Mirrors python/tests/config/test_loader.py's clis tests.
+  it('parses and maps to the Workspace clis option', async () => {
+    const cfg = loadWorkspaceConfig({
+      mounts: { '/data': { resource: 'ram' } },
+      clis: {
+        sl: { cli: 'slack', config: { token: 'x' } },
+        bare: { cli: 'gws' },
+      },
+    })
+    const args = await configToWorkspaceArgs(cfg)
+    expect(args.options.clis).toEqual({
+      sl: ['slack', { token: 'x' }],
+      bare: ['gws', {}],
+    })
+  })
+
+  it('refuses unknown keys in a clis entry', async () => {
+    const cfg = loadWorkspaceConfig({
+      mounts: { '/data': { resource: 'ram' } },
+      clis: { sl: { cli: 'slack', mode: 'write' } },
+    })
+    await expect(configToWorkspaceArgs(cfg)).rejects.toThrow(/unknown keys: mode/)
+  })
+})

--- a/typescript/packages/server/src/config.ts
+++ b/typescript/packages/server/src/config.ts
@@ -331,8 +331,21 @@ interface StoreBlock {
   workspace?: StoreGroupBlock | null
 }
 
+/**
+ * One `clis:` entry: install a named CLISpec with its own config. The
+ * section key is the installed head word; `cli` names the registered
+ * spec tree; `config` validates through that spec's configModel at
+ * install time (fail loud). A CLI never takes a mode and never shares
+ * a mount's credentials: a binary has no mode, the credential does.
+ */
+interface CLIBlock {
+  cli: string
+  config?: Record<string, unknown>
+}
+
 export interface WorkspaceConfigRaw {
   mounts: Record<string, MountBlock>
+  clis?: Record<string, CLIBlock> | null
   runtimes?: (string | Record<string, unknown>)[] | null
   policy?: string | null
   guards?: unknown[] | null
@@ -424,6 +437,7 @@ export interface WorkspaceArgs {
     runtimes?: RuntimeEntry[]
     policy?: ScriptSource
     guards?: GuardSpec[]
+    clis?: Record<string, [string, Record<string, unknown> | null]>
   }
   kernelMounts: Record<string, [MountBackend, string | undefined]>
 }
@@ -524,7 +538,30 @@ export async function configToWorkspaceArgs(cfg: WorkspaceConfigRaw): Promise<Wo
       ...(cfg.guards !== undefined && cfg.guards !== null
         ? { guards: parseGuards(cfg.guards) }
         : {}),
+      ...(cfg.clis !== undefined && cfg.clis !== null ? { clis: buildCliEntries(cfg.clis) } : {}),
     },
     kernelMounts,
   }
+}
+
+function buildCliEntries(
+  clis: Record<string, CLIBlock>,
+): Record<string, [string, Record<string, unknown> | null]> {
+  const out: Record<string, [string, Record<string, unknown> | null]> = {}
+  for (const [name, block] of Object.entries(clis as Record<string, unknown>)) {
+    // The raw config arrives as unvalidated YAML: the CLIBlock type is
+    // a claim, not a guarantee, so validate the shape here.
+    if (!isPlainObject(block) || typeof block.cli !== 'string') {
+      throw new Error(`clis entry '${name}' requires a string \`cli\` key`)
+    }
+    const unknown = Object.keys(block).filter((k) => k !== 'cli' && k !== 'config')
+    if (unknown.length > 0) {
+      throw new Error(`clis entry '${name}': unknown keys: ${unknown.sort().join(', ')}`)
+    }
+    if (block.config !== undefined && !isPlainObject(block.config)) {
+      throw new Error(`clis entry '${name}': config must be a mapping`)
+    }
+    out[name] = [block.cli, block.config ?? {}]
+  }
+  return out
 }

--- a/typescript/packages/server/src/workspace_config.ts
+++ b/typescript/packages/server/src/workspace_config.ts
@@ -88,6 +88,7 @@ export async function buildWorkspaceFromConfig(configPath: string): Promise<Work
     ...(args.options.runtimes !== undefined ? { runtimes: args.options.runtimes } : {}),
     ...(args.options.policy !== undefined ? { policy: args.options.policy } : {}),
     ...(args.options.guards !== undefined ? { guards: args.options.guards } : {}),
+    ...(args.options.clis !== undefined ? { clis: args.options.clis } : {}),
   })
   try {
     for (const [prefix, [backend, mountpoint]] of Object.entries(args.kernelMounts)) {


### PR DESCRIPTION
Phase 3 of the CLI/resource separation: a CLI exists because it was installed, never because storage was mounted. Both languages.

- **CLI install registry** (`workspace/cli/`): `register_cli(name, spec, config)` / `unregister_cli` / `clis()`. The installed head word is the dispatch key, so two installs of one spec under different names are two accounts with their own validated configs, and a renamed install attributes all help/errors to its own head. Install is fail-loud: single-word name, no collision with another CLI / shell builtin / general command (a runtime capture of the same name stays legal), config validated through the spec's `config_model` (unknown keys refused).
- **Dispatch by name**: `route()` gains `Consumer.CLI` between FUNCTION and MOUNT (docstring now carries the full consumer landscape table), and `handle_command` dispatches installed heads through the tree walk into `fn(config, paths, *texts, **flags)` with the validated config in the accessor's seat. Group flags merge into the flag bag (ancestor/descendant collisions are already a build error), leaf `--help` renders argparse-style at exit 0, leaf usage errors exit 2, unknown verbs keep the git wording at exit 1, and an uninstalled name is a plain 127. No mount is consulted anywhere on the path.
- **YAML `clis:` section**: `{head: {cli: <registered spec name>, config: {...}}}` resolves against the named-spec registry (`register_cli_spec`) and installs through the same path as the SDK call; unknown `cli:` keys and unknown block keys fail the load.
- Python's reserved-name pools moved to a leaf module (`workspace/names.py`, re-exported by `route/constants.py`) so the CLI registry can share the collision pools without an import cycle.

Tests: registry/spec-registry/dispatch units plus e2e dispatch scenarios (two accounts, rename attribution, 127 after unregister, CLI head never resolves a mount) mirrored in both languages; loader/config coverage for the new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)