### PR TITLE
feat(policy): pre_ops/post_ops hooks at the op doors

### DIFF
--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -234,9 +234,6 @@ class Ops:
                                                **kwargs)
         finally:
             push_mount_prefix(prev_prefix)
-        if self._policies is not None:
-            await post_ops_gate(self._policies, op, scope, write, mount_prefix,
-                                result)
         if isinstance(result, (bytes, bytearray)):
             nbytes = len(result)
         else:
@@ -246,6 +243,12 @@ class Ops:
         if write:
             observed = time.time() if op in STAMP_WRITE_OPS else None
             await self._invalidate(path, observed)
+        # Bookkeeping precedes the post gate: a denied result is still a
+        # completed backend op, so the caches and observation must
+        # reflect it before the deny suppresses it.
+        if self._policies is not None:
+            await post_ops_gate(self._policies, op, scope, write, mount_prefix,
+                                result)
         if (op == "stat" and self._stat_overlay is not None
                 and isinstance(result, FileStat)):
             return self._stat_overlay(path, result)

--- a/python/mirage/ops/ops.py
+++ b/python/mirage/ops/ops.py
@@ -26,6 +26,7 @@ from mirage.observe.context import push_mount_prefix
 from mirage.ops.config import (NO_FOLLOW_OPS, STAMP_WRITE_OPS, NamespaceLinks,
                                OpsMount, StatOverlay)
 from mirage.ops.registry import OpsRegistry, RegisteredOp
+from mirage.policy import Policies, post_ops_gate, pre_ops_gate
 from mirage.types import FileStat, MountMode, PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -40,7 +41,8 @@ class Ops:
                  agent_id: str = "default",
                  session_id: str = "default",
                  links: NamespaceLinks | None = None,
-                 stat_overlay: StatOverlay | None = None) -> None:
+                 stat_overlay: StatOverlay | None = None,
+                 policies: Policies | None = None) -> None:
         self._mounts = sorted(mounts,
                               key=lambda m: len(m.prefix),
                               reverse=True)
@@ -51,6 +53,11 @@ class Ops:
         self._session_id = session_id
         self._links = links
         self._stat_overlay = stat_overlay
+        # Admission policies, shared with the workspace registry. This
+        # facade is the door FUSE and programmatic ws.ops come through,
+        # so the pre/post op hooks must fire here too, not only on the
+        # shell's dispatcher.
+        self._policies = policies
         self._registry = OpsRegistry()
         for m in self._mounts:
             for ro in m.ops:
@@ -214,6 +221,8 @@ class Ops:
             directory=path.rsplit("/", 1)[0] or "/",
             resource_path=mount_key(path, mount_prefix),
         )
+        if self._policies is not None:
+            await pre_ops_gate(self._policies, op, scope, write, mount_prefix)
         try:
             result = await self._registry.call(op,
                                                resource_type,
@@ -225,6 +234,9 @@ class Ops:
                                                **kwargs)
         finally:
             push_mount_prefix(prev_prefix)
+        if self._policies is not None:
+            await post_ops_gate(self._policies, op, scope, write, mount_prefix,
+                                result)
         if isinstance(result, (bytes, bytearray)):
             nbytes = len(result)
         else:

--- a/python/mirage/policy/__init__.py
+++ b/python/mirage/policy/__init__.py
@@ -13,12 +13,13 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.policy.base import Policy
-from mirage.policy.errors import PolicyError
+from mirage.policy.errors import PolicyDenied, PolicyError
 from mirage.policy.mount_root import MountRootPolicy
-from mirage.policy.policies import Policies
+from mirage.policy.policies import Policies, post_ops_gate, pre_ops_gate
 from mirage.policy.spec import SpecPolicy, wildcard_regex
 from mirage.policy.types import (VALIDITY, Action, CommandContext, Deny,
-                                 GuardSpec, MountRootQuery)
+                                 GuardSpec, MountRootQuery, OpsContext,
+                                 OpsResultContext)
 
 __all__ = [
     "Action",
@@ -27,10 +28,15 @@ __all__ = [
     "GuardSpec",
     "MountRootPolicy",
     "MountRootQuery",
+    "OpsContext",
+    "OpsResultContext",
     "Policies",
     "Policy",
+    "PolicyDenied",
     "PolicyError",
     "SpecPolicy",
     "VALIDITY",
+    "post_ops_gate",
+    "pre_ops_gate",
     "wildcard_regex",
 ]

--- a/python/mirage/policy/base.py
+++ b/python/mirage/policy/base.py
@@ -12,7 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.policy.types import Action, CommandContext
+from mirage.policy.types import (Action, CommandContext, OpsContext,
+                                 OpsResultContext)
 
 
 class Policy:
@@ -20,7 +21,7 @@ class Policy:
 
     Subclasses override only the hooks they care about; a hook returns
     an Action to state an opinion or None to stay silent, and a hook
-    that raises fails closed (the command is refused, naming the
+    that raises fails closed (the command or op is refused, naming the
     policy). Hooks left un-overridden are detected at the seam and
     never called.
     """
@@ -30,5 +31,25 @@ class Policy:
 
         Args:
             ctx (CommandContext): the classified command.
+        """
+        return None
+
+    async def pre_ops(self, ctx: OpsContext) -> Action | None:
+        """Admit or refuse one VFS op, whatever door it entered.
+
+        The hot path: fires per op (thousands under one recursive
+        command), so keep the hook cheap; expensive decisions belong at
+        pre_command or precomputed into policy state.
+
+        Args:
+            ctx (OpsContext): the op about to run.
+        """
+        return None
+
+    async def post_ops(self, ctx: OpsResultContext) -> Action | None:
+        """Observe one completed VFS op; a Deny suppresses its result.
+
+        Args:
+            ctx (OpsResultContext): the op and its raw result.
         """
         return None

--- a/python/mirage/policy/errors.py
+++ b/python/mirage/policy/errors.py
@@ -20,3 +20,15 @@ class PolicyError(Exception):
     Action kind for the hook, or a value that is not an Action at all,
     is a programming error in the policy, not a refusal.
     """
+
+
+class PolicyDenied(PermissionError):
+    """An op refused by an admission policy at an op door.
+
+    A PermissionError subclass so every existing consumer keeps
+    working: FUSE adapters classify it to EACCES, programmatic callers
+    catch PermissionError, and the shell renders the GNU
+    ``<cmd>: <path>: Permission denied`` line. The distinct type lets
+    handlers that special-case mount-mode refusals (the read-only
+    wording) tell a policy deny apart without guessing from errno.
+    """

--- a/python/mirage/policy/policies.py
+++ b/python/mirage/policy/policies.py
@@ -12,14 +12,69 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import errno
 import logging
+from typing import Any
 
 from mirage.policy.base import Policy
-from mirage.policy.errors import PolicyError
+from mirage.policy.errors import PolicyDenied, PolicyError
 from mirage.policy.spec import SpecPolicy
-from mirage.policy.types import VALIDITY, CommandContext, Deny, GuardSpec
+from mirage.policy.types import (VALIDITY, CommandContext, Deny, GuardSpec,
+                                 OpsContext, OpsResultContext)
+from mirage.types import PathSpec
 
 logger = logging.getLogger(__name__)
+
+
+async def pre_ops_gate(policies: "Policies", op: str, path: PathSpec,
+                       write: bool, prefix: str) -> None:
+    """Fire pre_ops at an op door; a Deny becomes EACCES.
+
+    The one seam helper both doors (the ops facade and the dispatcher)
+    call, so a refusal is byte-identical however the mount is reached:
+    PermissionError with errno EACCES and the virtual path as filename,
+    which the shell renders as "<cmd>: <path>: Permission denied" and
+    FUSE translates to -EACCES.
+
+    Args:
+        policies (Policies): the workspace's admission policies.
+        op (str): operation name.
+        path (PathSpec): the resolved virtual path.
+        write (bool): whether the op mutates the mount.
+        prefix (str): the owning mount's prefix.
+    """
+    if not policies.wants("pre_ops"):
+        return
+    deny = await policies.pre_ops(
+        OpsContext(op=op, path=path, write=write, prefix=prefix))
+    if deny is not None:
+        raise PolicyDenied(errno.EACCES, deny.message.rstrip("\n"),
+                           path.virtual)
+
+
+async def post_ops_gate(policies: "Policies", op: str, path: PathSpec,
+                        write: bool, prefix: str, result: Any) -> None:
+    """Fire post_ops at an op door; a Deny suppresses the result.
+
+    Args:
+        policies (Policies): the workspace's admission policies.
+        op (str): operation name.
+        path (PathSpec): the resolved virtual path.
+        write (bool): whether the op mutated the mount.
+        prefix (str): the owning mount's prefix.
+        result (Any): the op's raw result, offered to the hooks.
+    """
+    if not policies.wants("post_ops"):
+        return
+    deny = await policies.post_ops(
+        OpsResultContext(op=op,
+                         path=path,
+                         write=write,
+                         prefix=prefix,
+                         result=result))
+    if deny is not None:
+        raise PolicyDenied(errno.EACCES, deny.message.rstrip("\n"),
+                           path.virtual)
 
 
 class Policies:
@@ -44,6 +99,8 @@ class Policies:
 
     def __init__(self, policies: list[Policy] | None = None) -> None:
         self._policies: list[Policy] = list(policies or [])
+        self._wanted: frozenset[str] = frozenset()
+        self._rescan()
 
     def add(self, policy: Policy | GuardSpec) -> None:
         """Register a policy after the existing ones.
@@ -54,6 +111,50 @@ class Policies:
         """
         self._policies.append(
             SpecPolicy(policy) if isinstance(policy, GuardSpec) else policy)
+        self._rescan()
+
+    def wants(self, hook: str) -> bool:
+        """True when any policy overrides ``hook``.
+
+        O(1); the op seams gate on it so a workspace with no op
+        policies pays nothing per VFS op.
+
+        Args:
+            hook (str): hook name (pre_command, pre_ops, post_ops).
+        """
+        return hook in self._wanted
+
+    def _rescan(self) -> None:
+        wanted = set()
+        for hook in VALIDITY:
+            base = getattr(Policy, hook)
+            for policy in self._policies:
+                if getattr(type(policy), hook) is not base:
+                    wanted.add(hook)
+                    break
+        self._wanted = frozenset(wanted)
+
+    async def _fire(self, hook: str, ctx: CommandContext | OpsContext
+                    | OpsResultContext, subject: str) -> Deny | None:
+        base = getattr(Policy, hook)
+        for policy in self._policies:
+            if getattr(type(policy), hook) is base:
+                continue
+            name = type(policy).__name__
+            try:
+                action = await getattr(policy, hook)(ctx)
+            except Exception as exc:
+                logger.error("%s policy %s raised: %s", hook, name, exc)
+                return Deny(f"{subject}: policy {name} failed: {exc}\n")
+            if action is None:
+                continue
+            if not isinstance(action,
+                              Deny) or action.kind not in VALIDITY[hook]:
+                raise PolicyError(
+                    f"{hook} of {name} returned {action!r}; "
+                    f"legal kinds here: {sorted(VALIDITY[hook])}")
+            return action
+        return None
 
     async def pre_command(self, ctx: CommandContext) -> Deny | None:
         """Fire pre_command across the policies; first Deny wins.
@@ -61,22 +162,21 @@ class Policies:
         Args:
             ctx (CommandContext): the classified command.
         """
-        for policy in self._policies:
-            if type(policy).pre_command is Policy.pre_command:
-                continue
-            name = type(policy).__name__
-            try:
-                action = await policy.pre_command(ctx)
-            except Exception as exc:
-                logger.error("pre_command policy %s raised: %s", name, exc)
-                return Deny(f"{ctx.command}: policy {name} failed: {exc}\n")
-            if action is None:
-                continue
-            if not isinstance(
-                    action,
-                    Deny) or action.kind not in VALIDITY["pre_command"]:
-                raise PolicyError(
-                    f"pre_command of {name} returned {action!r}; "
-                    f"legal kinds here: {sorted(VALIDITY['pre_command'])}")
-            return action
-        return None
+        return await self._fire("pre_command", ctx, ctx.command)
+
+    async def pre_ops(self, ctx: OpsContext) -> Deny | None:
+        """Fire pre_ops across the policies; first Deny wins.
+
+        Args:
+            ctx (OpsContext): the op about to run.
+        """
+        return await self._fire("pre_ops", ctx, ctx.op)
+
+    async def post_ops(self, ctx: OpsResultContext) -> Deny | None:
+        """Fire post_ops across the policies; a Deny suppresses the
+        result.
+
+        Args:
+            ctx (OpsResultContext): the op and its raw result.
+        """
+        return await self._fire("post_ops", ctx, ctx.op)

--- a/python/mirage/policy/spec.py
+++ b/python/mirage/policy/spec.py
@@ -15,7 +15,8 @@
 import re
 
 from mirage.policy.base import Policy
-from mirage.policy.types import Action, CommandContext, Deny, GuardSpec
+from mirage.policy.types import (Action, CommandContext, Deny, GuardSpec,
+                                 OpsContext)
 
 
 def wildcard_regex(pattern: str) -> re.Pattern[str]:
@@ -61,4 +62,17 @@ class SpecPolicy(Policy):
                 if pattern.match(p.virtual):
                     display = p.raw_path or p.virtual
                     return Deny(f"{ctx.command}: {display}: {spec.reason}\n")
+        return None
+
+    async def pre_ops(self, ctx: OpsContext) -> Action | None:
+        # The op-layer twin: pure path protection (no command scope)
+        # also holds at the op doors, so FUSE, programmatic ops, and
+        # the warm cache cannot bypass it. Command-scoped specs stay
+        # command-layer: an op does not know which command issued it.
+        spec = self.spec
+        if spec.commands or not self._patterns:
+            return None
+        for pattern in self._patterns:
+            if pattern.match(ctx.path.virtual):
+                return Deny(f"{spec.reason}\n")
         return None

--- a/python/mirage/policy/types.py
+++ b/python/mirage/policy/types.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from dataclasses import dataclass
-from typing import ClassVar, Protocol
+from typing import Any, ClassVar, Protocol
 
 from mirage.types import PathSpec
 
@@ -101,6 +101,49 @@ class CommandContext:
     registry: MountRootQuery
 
 
+@dataclass(frozen=True, slots=True)
+class OpsContext:
+    """Facts about one VFS op, as pre_ops hooks see it.
+
+    Fires at the op doors (the ``ws.ops`` facade, which also serves
+    FUSE, and the shell's internal dispatcher), before any backend or
+    cache I/O, so it holds however the mount is reached.
+
+    Args:
+        op (str): operation name (read, write, unlink, readdir, ...).
+        path (PathSpec): the resolved virtual path.
+        write (bool): whether the op mutates the mount.
+        prefix (str): the owning mount's prefix.
+    """
+
+    op: str
+    path: PathSpec
+    write: bool
+    prefix: str
+
+
+@dataclass(frozen=True, slots=True)
+class OpsResultContext:
+    """One completed VFS op, as post_ops hooks see it.
+
+    Args:
+        op (str): operation name.
+        path (PathSpec): the resolved virtual path.
+        write (bool): whether the op mutated the mount.
+        prefix (str): the owning mount's prefix.
+        result (Any): the op's raw result (bytes, FileStat, listing,
+            ...); a Deny here suppresses it.
+    """
+
+    op: str
+    path: PathSpec
+    write: bool
+    prefix: str
+    result: Any
+
+
 VALIDITY: dict[str, frozenset[str]] = {
     "pre_command": frozenset({Deny.kind}),
+    "pre_ops": frozenset({Deny.kind}),
+    "post_ops": frozenset({Deny.kind}),
 }

--- a/python/mirage/workspace/dispatcher.py
+++ b/python/mirage/workspace/dispatcher.py
@@ -34,6 +34,10 @@ _DISPATCH_WRITE_OPS = frozenset({
     "write", "write_bytes", "append", "unlink", "create", "truncate", "mkdir",
     "rmdir", "rename"
 })
+# setattr mutates the mount but keeps its own overlay bookkeeping in
+# _setattr_via, so it is a write for policy admission without joining
+# the dispatcher's post-write invalidation path.
+_POLICY_WRITE_OPS = _DISPATCH_WRITE_OPS | frozenset({"setattr"})
 
 
 class Dispatcher:
@@ -71,7 +75,7 @@ class Dispatcher:
         # early return below: a cached read must be refused exactly
         # like a cold one, or the cache becomes a policy bypass.
         policies = self._namespace.registry.policies
-        write = op in _DISPATCH_WRITE_OPS
+        write = op in _POLICY_WRITE_OPS
         await pre_ops_gate(policies, op, path, write, mount.prefix)
         caches_reads = mount.resource.caches_reads
 

--- a/python/mirage/workspace/dispatcher.py
+++ b/python/mirage/workspace/dispatcher.py
@@ -20,6 +20,7 @@ from mirage.cache.manager import CacheManager
 from mirage.io import IOResult
 from mirage.observe.record import OpRecord
 from mirage.ops.config import NO_FOLLOW_OPS, STAMP_WRITE_OPS
+from mirage.policy import post_ops_gate, pre_ops_gate
 from mirage.types import ConsistencyPolicy, FileStat, PathSpec
 from mirage.utils.key_prefix import mount_key
 from mirage.workspace.mount import MountEntry
@@ -66,12 +67,20 @@ class Dispatcher:
                 path = PathSpec.from_str_path(followed)
         mount = self._namespace.mount_for(path.virtual)
         assert_mount_allowed(mount.prefix)
+        # Admission policies fire at the door, before the warm-cache
+        # early return below: a cached read must be refused exactly
+        # like a cold one, or the cache becomes a policy bypass.
+        policies = self._namespace.registry.policies
+        write = op in _DISPATCH_WRITE_OPS
+        await pre_ops_gate(policies, op, path, write, mount.prefix)
         caches_reads = mount.resource.caches_reads
 
         if caches_reads and op in _DISPATCH_READ_OPS:
             cached = await self._cache.get(path.virtual)
             if cached is not None and await self._reconciler.may_serve_cached(
                     mount, path.virtual):
+                await post_ops_gate(policies, op, path, write, mount.prefix,
+                                    cached)
                 return cached, IOResult(reads={path.virtual: cached})
 
         if op == "rename" and isinstance(kwargs.get("dst"), PathSpec):
@@ -97,6 +106,7 @@ class Dispatcher:
             await self.invalidate_after_write(mount, path, observed=observed)
             if op == "rename" and isinstance(kwargs.get("dst"), PathSpec):
                 await self.invalidate_after_write(mount, kwargs["dst"])
+        await post_ops_gate(policies, op, path, write, mount.prefix, result)
         return result, IOResult()
 
     async def stat(self, path: str) -> FileStat:

--- a/python/mirage/workspace/executor/builtins/metadata.py
+++ b/python/mirage/workspace/executor/builtins/metadata.py
@@ -18,8 +18,9 @@ from datetime import datetime, timezone
 from typing import Any
 
 from mirage.io import IOResult
+from mirage.policy import PolicyDenied
 from mirage.types import FileStat, FileType, PathSpec
-from mirage.utils.errors import FS_ERRORS, fs_strerror
+from mirage.utils.errors import FS_ERRORS, format_fs_error, fs_strerror
 from mirage.utils.mode import DEFAULT_DIR_MODE, DEFAULT_FILE_MODE, parse_mode
 from mirage.utils.path import CycleError, resolve_path
 from mirage.workspace.executor.builtins.shared import (Result, expand_operands,
@@ -136,6 +137,26 @@ def _read_only_error(cmd: str, namespace: Namespace, path: PathSpec) -> str:
     """
     prefix = namespace.mount_for(path.virtual).prefix
     return f"{cmd}: read-only mount at {prefix}\n"
+
+
+def _permission_error(cmd: str, namespace: Namespace, path: PathSpec,
+                      exc: PermissionError) -> str:
+    """Render a metadata-write PermissionError.
+
+    A mount-mode refusal keeps the mirage read-only wording; an
+    admission-policy deny at the op door renders GNU's
+    ``<cmd>: <path>: Permission denied`` instead of mislabeling the
+    mount as read-only.
+
+    Args:
+        cmd (str): command name.
+        namespace (Namespace): addressing authority (mount lookup).
+        path (PathSpec): the refused path.
+        exc (PermissionError): the raised refusal.
+    """
+    if not isinstance(exc, PolicyDenied):
+        return _read_only_error(cmd, namespace, path)
+    return format_fs_error(cmd, exc, [path]).decode()
 
 
 async def _setattr_via(
@@ -291,8 +312,8 @@ async def _apply_attrs(
                            mode=mode,
                            uid=uid,
                            gid=gid)
-    except PermissionError:
-        errors.append(_read_only_error(cmd, namespace, resolved))
+    except PermissionError as exc:
+        errors.append(_permission_error(cmd, namespace, resolved, exc))
 
 
 async def handle_chmod(
@@ -521,8 +542,8 @@ async def handle_touch(
                                resolved,
                                atime=atime,
                                mtime=mtime)
-        except PermissionError:
-            errors.append(_read_only_error("touch", namespace, resolved))
+        except PermissionError as exc:
+            errors.append(_permission_error("touch", namespace, resolved, exc))
         except FS_ERRORS as exc:
             # A destination whose parent chain is not all directories is one
             # failed operand, not an aborted command: GNU reports it and

--- a/python/mirage/workspace/workspace/workspace.py
+++ b/python/mirage/workspace/workspace/workspace.py
@@ -169,7 +169,8 @@ class Workspace:
                         agent_id=agent_id or "",
                         session_id=session_id,
                         links=self._namespace,
-                        stat_overlay=self._merge_overlay)
+                        stat_overlay=self._merge_overlay,
+                        policies=self._registry.policies)
         self._kernel_mounts = KernelMounts(self._ops, self._session_mgr)
 
         self._runtimes, self._policy_router = wire_runtime_world(

--- a/python/tests/policy/test_policies.py
+++ b/python/tests/policy/test_policies.py
@@ -12,10 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import errno
+
 import pytest
 
 from mirage.policy import (Action, CommandContext, Deny, GuardSpec,
-                           MountRootPolicy, Policies, Policy, PolicyError)
+                           MountRootPolicy, OpsContext, OpsResultContext,
+                           Policies, Policy, PolicyError, post_ops_gate,
+                           pre_ops_gate)
 from mirage.resource.ram import RAMResource
 from mirage.types import MountMode, PathSpec
 from mirage.workspace.mount import MountRegistry
@@ -125,3 +129,65 @@ async def test_an_illegal_return_raises_policy_error():
     policies.add(IllegalReturn())
     with pytest.raises(PolicyError, match="IllegalReturn"):
         await policies.pre_command(_ctx("ls"))
+
+
+class DenyReadOps(Policy):
+
+    async def pre_ops(self, ctx: OpsContext) -> Action | None:
+        if ctx.op == "read":
+            return Deny("no reads\n")
+        return None
+
+
+class DenyBigResults(Policy):
+
+    async def post_ops(self, ctx: OpsResultContext) -> Action | None:
+        if isinstance(ctx.result, bytes) and len(ctx.result) > 8:
+            return Deny("result too large\n")
+        return None
+
+
+@pytest.mark.asyncio
+async def test_pre_ops_first_deny_wins_and_wants_gates():
+    policies = Policies()
+    assert not policies.wants("pre_ops")
+    policies.add(DenyReadOps())
+    assert policies.wants("pre_ops")
+    assert not policies.wants("post_ops")
+    ctx = OpsContext(op="read",
+                     path=_path("/data/x"),
+                     write=False,
+                     prefix="/data/")
+    deny = await policies.pre_ops(ctx)
+    assert deny is not None
+    assert deny.message == "no reads\n"
+    write_ctx = OpsContext(op="write",
+                           path=_path("/data/x"),
+                           write=True,
+                           prefix="/data/")
+    assert await policies.pre_ops(write_ctx) is None
+
+
+@pytest.mark.asyncio
+async def test_pre_ops_gate_raises_eacces():
+    policies = Policies()
+    policies.add(DenyReadOps())
+    with pytest.raises(PermissionError) as excinfo:
+        await pre_ops_gate(policies, "read", _path("/data/x"), False, "/data/")
+    assert excinfo.value.errno == errno.EACCES
+    assert excinfo.value.filename == "/data/x"
+    assert "no reads" in str(excinfo.value)
+    # No opinion on writes: the gate passes silently.
+    await pre_ops_gate(policies, "write", _path("/data/x"), True, "/data/")
+
+
+@pytest.mark.asyncio
+async def test_post_ops_gate_suppresses_the_result():
+    policies = Policies()
+    policies.add(DenyBigResults())
+    await post_ops_gate(policies, "read", _path("/data/x"), False, "/data/",
+                        b"tiny")
+    with pytest.raises(PermissionError) as excinfo:
+        await post_ops_gate(policies, "read", _path("/data/x"), False,
+                            "/data/", b"a long secret payload")
+    assert excinfo.value.errno == errno.EACCES

--- a/python/tests/policy/test_spec.py
+++ b/python/tests/policy/test_spec.py
@@ -14,7 +14,8 @@
 
 import pytest
 
-from mirage.policy import CommandContext, GuardSpec, SpecPolicy, wildcard_regex
+from mirage.policy import (CommandContext, GuardSpec, OpsContext, SpecPolicy,
+                           wildcard_regex)
 from mirage.resource.ram import RAMResource
 from mirage.types import MountMode, PathSpec
 from mirage.workspace.mount import MountRegistry
@@ -81,3 +82,35 @@ async def test_spec_policy_without_commands_covers_every_command():
                                     ) is not None
     assert await policy.pre_command(_ctx("rm",
                                          [_path("/data/open/a")])) is None
+
+
+@pytest.mark.asyncio
+async def test_spec_policy_op_twin_holds_for_path_only_specs():
+    # Pure path protection also fires at the op doors, so FUSE and
+    # programmatic ops cannot bypass it.
+    policy = SpecPolicy(GuardSpec(reason="frozen", paths=("/data/locked/*", )))
+    ctx = OpsContext(op="read",
+                     path=_path("/data/locked/a"),
+                     write=False,
+                     prefix="/data/")
+    deny = await policy.pre_ops(ctx)
+    assert deny is not None
+    assert deny.message == "frozen\n"
+    open_ctx = OpsContext(op="read",
+                          path=_path("/data/open/a"),
+                          write=False,
+                          prefix="/data/")
+    assert await policy.pre_ops(open_ctx) is None
+
+
+@pytest.mark.asyncio
+async def test_spec_policy_op_twin_skips_command_scoped_specs():
+    # An op does not know which command issued it; command-scoped
+    # specs stay at the command layer.
+    policy = SpecPolicy(
+        GuardSpec(reason="no rm", commands=("rm", ), paths=("/data/prod/*", )))
+    ctx = OpsContext(op="unlink",
+                     path=_path("/data/prod/x"),
+                     write=True,
+                     prefix="/data/")
+    assert await policy.pre_ops(ctx) is None

--- a/python/tests/workspace/test_dispatcher.py
+++ b/python/tests/workspace/test_dispatcher.py
@@ -30,6 +30,14 @@ class DenyLocked(Policy):
         return None
 
 
+class DenyWrites(Policy):
+
+    async def pre_ops(self, ctx: OpsContext) -> Action | None:
+        if ctx.write:
+            return Deny("no writes\n")
+        return None
+
+
 def _path(virtual: str) -> PathSpec:
     return PathSpec(virtual=virtual,
                     directory=virtual.rsplit("/", 1)[0] or "/",
@@ -77,6 +85,20 @@ async def test_warm_cache_read_serves_when_no_policy_objects():
     result, _ = await dispatcher.dispatch("read", _path("/data/open/a.txt"))
     assert result == b"warm"
     cache.get.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_setattr_classifies_as_a_write():
+    # touch on an existing file mutates via setattr, which is absent
+    # from the dispatcher's own invalidation set; the policy write
+    # classification must still cover it.
+    policies = Policies()
+    policies.add(DenyWrites())
+    dispatcher, _ = _dispatcher(policies)
+    with pytest.raises(PolicyDenied):
+        await dispatcher.dispatch("setattr", _path("/data/a.txt"))
+    result, _ = await dispatcher.dispatch("stat", _path("/data/a.txt"))
+    assert result == b"cold"
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/test_dispatcher.py
+++ b/python/tests/workspace/test_dispatcher.py
@@ -1,0 +1,89 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mirage.policy import (Action, Deny, GuardSpec, OpsContext, Policies,
+                           Policy, PolicyDenied)
+from mirage.types import ConsistencyPolicy, PathSpec
+from mirage.workspace.dispatcher import Dispatcher
+
+
+class DenyLocked(Policy):
+
+    async def pre_ops(self, ctx: OpsContext) -> Action | None:
+        if ctx.path.virtual.startswith("/data/locked/"):
+            return Deny("locked\n")
+        return None
+
+
+def _path(virtual: str) -> PathSpec:
+    return PathSpec(virtual=virtual,
+                    directory=virtual.rsplit("/", 1)[0] or "/",
+                    resource_path="",
+                    raw_path=virtual,
+                    resolved=True)
+
+
+def _dispatcher(policies: Policies) -> tuple[Dispatcher, MagicMock]:
+    namespace = MagicMock()
+    namespace.follow = MagicMock(side_effect=lambda p: p)
+    mount = MagicMock()
+    mount.prefix = "/data/"
+    mount.resource.caches_reads = True
+    mount.execute_op = AsyncMock(return_value=b"cold")
+    namespace.mount_for = MagicMock(return_value=mount)
+    namespace.registry.policies = policies
+    cache = MagicMock()
+    cache.get = AsyncMock(return_value=b"warm")
+    dispatcher = Dispatcher(namespace, cache, ConsistencyPolicy.LAZY)
+    reconciler = MagicMock()
+    reconciler.may_serve_cached = AsyncMock(return_value=True)
+    dispatcher._reconciler = reconciler
+    return dispatcher, cache
+
+
+@pytest.mark.asyncio
+async def test_warm_cache_read_cannot_bypass_pre_ops():
+    # The #241 failure class: a cached read served without consulting
+    # the policy would make the cache a policy bypass. The hook fires
+    # before the cache lookup, so the warm path refuses identically.
+    policies = Policies()
+    policies.add(DenyLocked())
+    dispatcher, cache = _dispatcher(policies)
+    with pytest.raises(PolicyDenied):
+        await dispatcher.dispatch("read", _path("/data/locked/a.txt"))
+    cache.get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_warm_cache_read_serves_when_no_policy_objects():
+    policies = Policies()
+    policies.add(DenyLocked())
+    dispatcher, cache = _dispatcher(policies)
+    result, _ = await dispatcher.dispatch("read", _path("/data/open/a.txt"))
+    assert result == b"warm"
+    cache.get.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_spec_op_twin_holds_on_the_dispatch_door():
+    policies = Policies()
+    policies.add(GuardSpec(reason="frozen", paths=("/data/locked/*", )))
+    dispatcher, _ = _dispatcher(policies)
+    with pytest.raises(PolicyDenied) as excinfo:
+        await dispatcher.dispatch("read", _path("/data/locked/a.txt"))
+    assert "frozen" in str(excinfo.value)

--- a/python/tests/workspace/workspace/test_policies.py
+++ b/python/tests/workspace/workspace/test_policies.py
@@ -12,9 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import errno
+
 import pytest
 
 from mirage import Action, CommandContext, Deny, GuardSpec, Policy, Workspace
+from mirage.policy import OpsContext
 from mirage.resource.ram import RAMResource
 from mirage.types import MountMode
 
@@ -123,5 +126,53 @@ async def test_guards_cover_path_valued_flags():
         assert b"prod is protected" in result.stderr
         listing = await ws.execute("ls /data/prod")
         assert b"out" not in listing.stdout
+    finally:
+        await ws.close()
+
+
+class ReadOnlyProd(Policy):
+
+    async def pre_ops(self, ctx: OpsContext) -> Action | None:
+        if ctx.write and ctx.path.virtual.startswith("/data/prod/"):
+            return Deny("prod is read-only\n")
+        return None
+
+
+@pytest.mark.asyncio
+async def test_path_guards_hold_at_the_programmatic_door():
+    # ws.ops is the same seam FUSE comes through; a path-only guard
+    # must refuse it, not just shell commands (#675).
+    ws = Workspace({"/data/": RAMResource()},
+                   mode=MountMode.WRITE,
+                   guards=[
+                       GuardSpec(reason="prod is protected",
+                                 paths=("/data/prod/*", ))
+                   ])
+    try:
+        await ws.execute("mkdir -p /data/other")
+        await ws.ops.write("/data/other/ok.txt", b"fine\n")
+        with pytest.raises(PermissionError) as excinfo:
+            await ws.ops.write("/data/prod/x.txt", b"nope\n")
+        assert excinfo.value.errno == errno.EACCES
+        assert "prod is protected" in str(excinfo.value)
+        with pytest.raises(PermissionError):
+            await ws.ops.read("/data/prod/x.txt")
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_pre_ops_policy_holds_on_the_dispatcher_door():
+    # touch routes through the shell's internal dispatcher, not
+    # handle_command; a pre_ops-only policy must still refuse it.
+    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
+    try:
+        ws.policies.add(ReadOnlyProd())
+        await ws.execute("mkdir -p /data/prod")
+        result = await ws.execute("touch /data/prod/x")
+        assert result.exit_code != 0
+        assert b"Permission denied" in result.stderr
+        ok = await ws.execute("touch /data/free && echo done")
+        assert b"done" in ok.stdout
     finally:
         await ws.close()

--- a/python/tests/workspace/workspace/test_policies.py
+++ b/python/tests/workspace/workspace/test_policies.py
@@ -17,7 +17,7 @@ import errno
 import pytest
 
 from mirage import Action, CommandContext, Deny, GuardSpec, Policy, Workspace
-from mirage.policy import OpsContext
+from mirage.policy import OpsContext, OpsResultContext
 from mirage.resource.ram import RAMResource
 from mirage.types import MountMode
 
@@ -157,6 +157,46 @@ async def test_path_guards_hold_at_the_programmatic_door():
         assert "prod is protected" in str(excinfo.value)
         with pytest.raises(PermissionError):
             await ws.ops.read("/data/prod/x.txt")
+    finally:
+        await ws.close()
+
+
+class SuppressProdWrites(Policy):
+
+    async def post_ops(self, ctx: OpsResultContext) -> Action | None:
+        if ctx.write and ctx.path.virtual.startswith("/data/prod/"):
+            return Deny("write suppressed\n")
+        return None
+
+
+@pytest.mark.asyncio
+async def test_touch_on_an_existing_file_is_a_write_at_the_op_door():
+    # touch on an existing file mutates via setattr, not create; the
+    # write classification must cover that op too.
+    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
+    try:
+        await ws.execute("mkdir -p /data/prod")
+        await ws.ops.write("/data/prod/x.txt", b"keep\n")
+        ws.policies.add(ReadOnlyProd())
+        result = await ws.execute("touch /data/prod/x.txt")
+        assert result.exit_code != 0
+        assert b"Permission denied" in result.stderr
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_post_ops_deny_still_records_the_completed_write():
+    # A post deny suppresses the result, not the effect: the backend
+    # already mutated, so observation and caches must reflect the op.
+    ws = Workspace({"/data/": RAMResource()}, mode=MountMode.WRITE)
+    try:
+        await ws.execute("mkdir -p /data/prod")
+        ws.policies.add(SuppressProdWrites())
+        with pytest.raises(PermissionError):
+            await ws.ops.write("/data/prod/x.txt", b"data\n")
+        assert any(r.op == "write" for r in ws.ops.records)
+        assert await ws.ops.read("/data/prod/x.txt") == b"data\n"
     finally:
         await ws.close()
 

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -529,6 +529,7 @@ export {
 export {
   MountRootPolicy,
   Policies,
+  PolicyDenied,
   SpecPolicy,
   VALIDITY,
   hasParentsFlag,
@@ -538,6 +539,8 @@ export {
   type Deny,
   type GuardSpec,
   type MountRootQuery,
+  type OpsContext,
+  type OpsResultContext,
   type Policy,
 } from './policy/index.ts'
 export {

--- a/typescript/packages/core/src/policy/base.ts
+++ b/typescript/packages/core/src/policy/base.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import type { Action, CommandContext } from './types.ts'
+import type { Action, CommandContext, OpsContext, OpsResultContext } from './types.ts'
 
 /**
  * One concern's answers to the workspace lifecycle.
@@ -25,4 +25,12 @@ import type { Action, CommandContext } from './types.ts'
  */
 export interface Policy {
   preCommand?(ctx: CommandContext): Action | null | Promise<Action | null>
+  /**
+   * Admit or refuse one VFS op, whatever door it entered. The hot
+   * path: fires per op, so keep the hook cheap; expensive decisions
+   * belong at preCommand or precomputed into policy state.
+   */
+  preOps?(ctx: OpsContext): Action | null | Promise<Action | null>
+  /** Observe one completed VFS op; a Deny suppresses its result. */
+  postOps?(ctx: OpsResultContext): Action | null | Promise<Action | null>
 }

--- a/typescript/packages/core/src/policy/errors.ts
+++ b/typescript/packages/core/src/policy/errors.ts
@@ -24,3 +24,22 @@ export class PolicyError extends Error {
     this.name = 'PolicyError'
   }
 }
+
+/**
+ * An op refused by an admission policy at the op door. Shaped like the
+ * FsError stamps (`code` EACCES plus the virtual path) so every fs
+ * chokepoint renders GNU's "Permission denied" and the FUSE bridge
+ * classifies it to -EACCES; the distinct class lets handlers that
+ * special-case mount-mode refusals (the read-only wording) tell a
+ * policy deny apart.
+ */
+export class PolicyDenied extends Error {
+  readonly code = 'EACCES'
+  readonly virtualPath: string
+
+  constructor(message: string, virtualPath: string) {
+    super(message)
+    this.name = 'PolicyDenied'
+    this.virtualPath = virtualPath
+  }
+}

--- a/typescript/packages/core/src/policy/index.ts
+++ b/typescript/packages/core/src/policy/index.ts
@@ -13,8 +13,9 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 export type { Policy } from './base.ts'
+export { PolicyDenied } from './errors.ts'
 export { MountRootPolicy, hasParentsFlag } from './mount_root.ts'
-export { Policies } from './policies.ts'
+export { Policies, postOpsGate, preOpsGate } from './policies.ts'
 export { SpecPolicy, wildcardRegex } from './spec.ts'
 export {
   VALIDITY,
@@ -23,4 +24,6 @@ export {
   type Deny,
   type GuardSpec,
   type MountRootQuery,
+  type OpsContext,
+  type OpsResultContext,
 } from './types.ts'

--- a/typescript/packages/core/src/policy/policies.test.ts
+++ b/typescript/packages/core/src/policy/policies.test.ts
@@ -24,8 +24,9 @@ import { MountRegistry } from '../workspace/mount/registry.ts'
 import { Workspace } from '../workspace/workspace.ts'
 import type { Policy } from './base.ts'
 import { MountRootPolicy } from './mount_root.ts'
-import { Policies } from './policies.ts'
-import type { Action, CommandContext, GuardSpec } from './types.ts'
+import { PolicyDenied } from './errors.ts'
+import { Policies, postOpsGate, preOpsGate } from './policies.ts'
+import type { Action, CommandContext, GuardSpec, OpsContext, OpsResultContext } from './types.ts'
 
 const require = createRequire(import.meta.url)
 const engineWasm = readFileSync(require.resolve('web-tree-sitter/web-tree-sitter.wasm'))
@@ -57,6 +58,31 @@ class IllegalReturn implements Policy {
 }
 
 const silent: Policy = {}
+
+class DenyReadOps implements Policy {
+  preOps(ctx: OpsContext): Action | null {
+    if (ctx.op === 'read') return { kind: 'deny', message: 'no reads\n', exitCode: 1 }
+    return null
+  }
+}
+
+class DenyBigResults implements Policy {
+  postOps(ctx: OpsResultContext): Action | null {
+    if (ctx.result instanceof Uint8Array && ctx.result.length > 8) {
+      return { kind: 'deny', message: 'result too large\n', exitCode: 1 }
+    }
+    return null
+  }
+}
+
+class ReadOnlyProd implements Policy {
+  preOps(ctx: OpsContext): Action | null {
+    if (ctx.write && ctx.path.virtual.startsWith('/data/prod/')) {
+      return { kind: 'deny', message: 'prod is frozen\n', exitCode: 1 }
+    }
+    return null
+  }
+}
 
 class NoInterpreters implements Policy {
   async preCommand(ctx: CommandContext): Promise<Action | null> {
@@ -148,6 +174,50 @@ describe('Policies', () => {
     const policies = new Policies()
     policies.add(new IllegalReturn())
     await expect(policies.preCommand(ctx('ls'))).rejects.toThrow(/IllegalReturn/)
+  })
+
+  it('preOps first deny wins and wants() gates', async () => {
+    const policies = new Policies()
+    expect(policies.wants('preOps')).toBe(false)
+    policies.add(new DenyReadOps())
+    expect(policies.wants('preOps')).toBe(true)
+    expect(policies.wants('postOps')).toBe(false)
+    const deny = await policies.preOps({
+      op: 'read',
+      path: path('/data/x'),
+      write: false,
+      prefix: '/data/',
+    })
+    expect(deny?.message).toBe('no reads\n')
+    expect(
+      await policies.preOps({ op: 'write', path: path('/data/x'), write: true, prefix: '/data/' }),
+    ).toBeNull()
+  })
+
+  it('preOpsGate throws PolicyDenied with the EACCES stamp', async () => {
+    const policies = new Policies()
+    policies.add(new DenyReadOps())
+    await expect(preOpsGate(policies, 'read', path('/data/x'), false, '/data/')).rejects.toThrow(
+      PolicyDenied,
+    )
+    try {
+      await preOpsGate(policies, 'read', path('/data/x'), false, '/data/')
+    } catch (err) {
+      expect((err as PolicyDenied).code).toBe('EACCES')
+      expect((err as PolicyDenied).virtualPath).toBe('/data/x')
+      expect((err as PolicyDenied).message).toBe('no reads')
+    }
+    // No opinion on writes: the gate passes silently.
+    await preOpsGate(policies, 'write', path('/data/x'), true, '/data/')
+  })
+
+  it('postOpsGate suppresses the result', async () => {
+    const policies = new Policies()
+    policies.add(new DenyBigResults())
+    await postOpsGate(policies, 'read', path('/data/x'), false, '/data/', new Uint8Array(4))
+    await expect(
+      postOpsGate(policies, 'read', path('/data/x'), false, '/data/', new Uint8Array(64)),
+    ).rejects.toThrow(/result too large/)
   })
 
   it('an entry with a hook is a policy even if it carries reason', async () => {
@@ -247,6 +317,39 @@ describe('workspace policies', () => {
       expect(new TextDecoder().decode(refused.stderr)).toContain('prod is protected')
       const listing = await ws.execute('ls /data/prod')
       expect(new TextDecoder().decode(listing.stdout)).not.toContain('out')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('path guards hold at the programmatic door', async () => {
+    // ws.dispatch is the one TS op door (FUSE routes through it); a
+    // path-only guard must refuse it, not just shell commands (#675).
+    const ws = executableWorkspace([{ reason: 'prod is protected', paths: ['/data/prod/*'] }])
+    try {
+      await ws.execute('mkdir -p /data/other')
+      await ws.dispatch('write', '/data/other/ok.txt', [new TextEncoder().encode('fine')])
+      await expect(
+        ws.dispatch('write', '/data/prod/x.txt', [new TextEncoder().encode('nope')]),
+      ).rejects.toThrow(PolicyDenied)
+      await expect(ws.dispatch('read', '/data/prod/x.txt')).rejects.toThrow(/prod is protected/)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('a preOps policy holds on the shell door', async () => {
+    // touch routes through the dispatcher, not handleCommand; a
+    // preOps-only policy must still refuse it with GNU wording.
+    const ws = executableWorkspace()
+    try {
+      ws.policies.add(new ReadOnlyProd())
+      await ws.execute('mkdir -p /data/prod')
+      const refused = await ws.execute('touch /data/prod/x')
+      expect(refused.exitCode).not.toBe(0)
+      expect(new TextDecoder().decode(refused.stderr)).toContain('Permission denied')
+      const ok = await ws.execute('touch /data/free && echo done')
+      expect(new TextDecoder().decode(ok.stdout)).toContain('done')
     } finally {
       await ws.close()
     }

--- a/typescript/packages/core/src/policy/policies.test.ts
+++ b/typescript/packages/core/src/policy/policies.test.ts
@@ -354,4 +354,20 @@ describe('workspace policies', () => {
       await ws.close()
     }
   })
+
+  it('touch on an existing file is a write at the op door', async () => {
+    // touch on an existing file mutates via setattr, not create; the
+    // write classification must cover that op too.
+    const ws = executableWorkspace()
+    try {
+      await ws.execute('mkdir -p /data/prod')
+      await ws.dispatch('write', '/data/prod/x.txt', [new TextEncoder().encode('keep')])
+      ws.policies.add(new ReadOnlyProd())
+      const refused = await ws.execute('touch /data/prod/x.txt')
+      expect(refused.exitCode).not.toBe(0)
+      expect(new TextDecoder().decode(refused.stderr)).toContain('Permission denied')
+    } finally {
+      await ws.close()
+    }
+  })
 })

--- a/typescript/packages/core/src/policy/policies.ts
+++ b/typescript/packages/core/src/policy/policies.ts
@@ -12,10 +12,56 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import type { PathSpec } from '../types.ts'
 import type { Policy } from './base.ts'
-import { PolicyError } from './errors.ts'
+import { PolicyDenied, PolicyError } from './errors.ts'
 import { SpecPolicy } from './spec.ts'
-import { VALIDITY, type CommandContext, type Deny, type GuardSpec } from './types.ts'
+import {
+  VALIDITY,
+  type CommandContext,
+  type Deny,
+  type GuardSpec,
+  type OpsContext,
+  type OpsResultContext,
+} from './types.ts'
+
+type Hook = keyof typeof VALIDITY
+
+/**
+ * Fire preOps at the op door; a Deny becomes a PolicyDenied (EACCES).
+ * The one seam helper the dispatcher calls, so a refusal is identical
+ * however the mount is reached: shell internals, programmatic access,
+ * FUSE, and the warm cache all pass through it.
+ */
+export async function preOpsGate(
+  policies: Policies,
+  op: string,
+  path: PathSpec,
+  write: boolean,
+  prefix: string,
+): Promise<void> {
+  if (!policies.wants('preOps')) return
+  const deny = await policies.preOps({ op, path, write, prefix })
+  if (deny !== null) {
+    throw new PolicyDenied(deny.message.replace(/\n$/, ''), path.virtual)
+  }
+}
+
+/** Fire postOps at the op door; a Deny suppresses the result. */
+export async function postOpsGate(
+  policies: Policies,
+  op: string,
+  path: PathSpec,
+  write: boolean,
+  prefix: string,
+  result: unknown,
+): Promise<void> {
+  if (!policies.wants('postOps')) return
+  const deny = await policies.postOps({ op, path, write, prefix, result })
+  if (deny !== null) {
+    throw new PolicyDenied(deny.message.replace(/\n$/, ''), path.virtual)
+  }
+}
 
 /**
  * Ordered policies; on a pre hook the first Deny wins.
@@ -34,9 +80,27 @@ import { VALIDITY, type CommandContext, type Deny, type GuardSpec } from './type
  */
 export class Policies {
   private readonly policies: Policy[]
+  private wanted: ReadonlySet<Hook> = new Set()
 
   constructor(policies?: readonly Policy[]) {
     this.policies = [...(policies ?? [])]
+    this.rescan()
+  }
+
+  /**
+   * True when any policy defines `hook`. O(1); the op seam gates on it
+   * so a workspace with no op policies pays nothing per VFS op.
+   */
+  wants(hook: Hook): boolean {
+    return this.wanted.has(hook)
+  }
+
+  private rescan(): void {
+    const wanted = new Set<Hook>()
+    for (const hook of Object.keys(VALIDITY) as Hook[]) {
+      if (this.policies.some((p) => p[hook] !== undefined)) wanted.add(hook)
+    }
+    this.wanted = wanted
   }
 
   /**
@@ -47,40 +111,64 @@ export class Policies {
    * the structural equivalent).
    */
   add(entry: Policy | GuardSpec): void {
-    const hooked = typeof (entry as Policy).preCommand === 'function'
+    const candidate = entry as Policy
+    const hooked =
+      typeof candidate.preCommand === 'function' ||
+      typeof candidate.preOps === 'function' ||
+      typeof candidate.postOps === 'function'
     if (!hooked && 'reason' in entry) {
       this.policies.push(new SpecPolicy(entry))
-      return
+    } else {
+      this.policies.push(entry as Policy)
     }
-    this.policies.push(entry as Policy)
+    this.rescan()
   }
 
-  /** Fire preCommand across the policies; the first Deny wins. */
-  async preCommand(ctx: CommandContext): Promise<Deny | null> {
+  private async fire(
+    hook: Hook,
+    ctx: CommandContext | OpsContext | OpsResultContext,
+    subject: string,
+  ): Promise<Deny | null> {
     for (const policy of this.policies) {
-      if (policy.preCommand === undefined) continue
+      const fn = policy[hook]
+      if (fn === undefined) continue
       const name = policy.constructor.name || 'policy'
       let action
       try {
-        action = await policy.preCommand(ctx)
+        action = await fn.call(policy, ctx as CommandContext & OpsContext & OpsResultContext)
       } catch (err) {
         const detail = err instanceof Error ? err.message : String(err)
         return {
           kind: 'deny',
-          message: `${ctx.command}: policy ${name} failed: ${detail}\n`,
+          message: `${subject}: policy ${name} failed: ${detail}\n`,
           exitCode: 1,
         }
       }
       if (action === null) continue
       const kind: unknown = typeof action === 'object' ? action.kind : undefined
-      if (typeof kind !== 'string' || !VALIDITY.preCommand.has(kind)) {
+      if (typeof kind !== 'string' || !VALIDITY[hook].has(kind)) {
         throw new PolicyError(
-          `preCommand of ${name} returned ${JSON.stringify(action)}; ` +
-            `legal kinds here: ${[...VALIDITY.preCommand].join(', ')}`,
+          `${hook} of ${name} returned ${JSON.stringify(action)}; ` +
+            `legal kinds here: ${[...VALIDITY[hook]].join(', ')}`,
         )
       }
       return action
     }
     return null
+  }
+
+  /** Fire preCommand across the policies; the first Deny wins. */
+  async preCommand(ctx: CommandContext): Promise<Deny | null> {
+    return this.fire('preCommand', ctx, ctx.command)
+  }
+
+  /** Fire preOps across the policies; the first Deny wins. */
+  async preOps(ctx: OpsContext): Promise<Deny | null> {
+    return this.fire('preOps', ctx, ctx.op)
+  }
+
+  /** Fire postOps across the policies; a Deny suppresses the result. */
+  async postOps(ctx: OpsResultContext): Promise<Deny | null> {
+    return this.fire('postOps', ctx, ctx.op)
   }
 }

--- a/typescript/packages/core/src/policy/spec.test.ts
+++ b/typescript/packages/core/src/policy/spec.test.ts
@@ -18,6 +18,7 @@ import { RAMResource } from '../resource/ram/ram.ts'
 import { MountMode, PathSpec } from '../types.ts'
 import { MountRegistry } from '../workspace/mount/registry.ts'
 import { SpecPolicy, wildcardRegex } from './spec.ts'
+import type { OpsContext } from './types.ts'
 import type { CommandContext } from './types.ts'
 
 function path(virtual: string, raw?: string): PathSpec {
@@ -71,5 +72,31 @@ describe('SpecPolicy', () => {
     const policy = new SpecPolicy({ reason: 'frozen', paths: ['/data/locked/*'] })
     expect(policy.preCommand(ctx('cat', [path('/data/locked/a')]))).not.toBeNull()
     expect(policy.preCommand(ctx('rm', [path('/data/open/a')]))).toBeNull()
+  })
+})
+
+describe('SpecPolicy preOps twin', () => {
+  function opsCtx(virtual: string): OpsContext {
+    return { op: 'read', path: path(virtual), write: false, prefix: '/data/' }
+  }
+
+  it('holds for path-only specs', () => {
+    // Pure path protection also fires at the op door, so FUSE and
+    // programmatic ops cannot bypass it.
+    const policy = new SpecPolicy({ reason: 'frozen', paths: ['/data/locked/*'] })
+    const deny = policy.preOps(opsCtx('/data/locked/a'))
+    expect(deny && 'message' in deny ? deny.message : '').toBe('frozen\n')
+    expect(policy.preOps(opsCtx('/data/open/a'))).toBeNull()
+  })
+
+  it('skips command-scoped specs', () => {
+    // An op does not know which command issued it; command-scoped
+    // specs stay at the command layer.
+    const policy = new SpecPolicy({
+      reason: 'no rm',
+      commands: ['rm'],
+      paths: ['/data/prod/*'],
+    })
+    expect(policy.preOps(opsCtx('/data/prod/x'))).toBeNull()
   })
 })

--- a/typescript/packages/core/src/policy/spec.ts
+++ b/typescript/packages/core/src/policy/spec.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { Policy } from './base.ts'
-import type { Action, CommandContext, GuardSpec } from './types.ts'
+import type { Action, CommandContext, GuardSpec, OpsContext } from './types.ts'
 
 /**
  * Compile a `*`/`?` wildcard into an anchored regex. Deliberately not
@@ -57,6 +57,21 @@ export class SpecPolicy implements Policy {
             exitCode: 1,
           }
         }
+      }
+    }
+    return null
+  }
+
+  preOps(ctx: OpsContext): Action | null {
+    // The op-layer twin: pure path protection (no command scope) also
+    // holds at the op door, so FUSE, programmatic ops, and the warm
+    // cache cannot bypass it. Command-scoped specs stay command-layer:
+    // an op does not know which command issued it.
+    const commands = this.spec.commands ?? []
+    if (commands.length > 0 || this.patterns.length === 0) return null
+    for (const pattern of this.patterns) {
+      if (pattern.test(ctx.path.virtual)) {
+        return { kind: 'deny', message: `${this.spec.reason}\n`, exitCode: 1 }
       }
     }
     return null

--- a/typescript/packages/core/src/policy/types.ts
+++ b/typescript/packages/core/src/policy/types.ts
@@ -68,6 +68,29 @@ export interface CommandContext {
   registry: MountRootQuery
 }
 
-export const VALIDITY: Readonly<Record<'preCommand', ReadonlySet<string>>> = {
-  preCommand: new Set(['deny']),
+/** Facts about one VFS op, as preOps hooks see it. Fires at the op
+ * door (the dispatcher every access routes through, FUSE included),
+ * before any backend or cache I/O. */
+export interface OpsContext {
+  op: string
+  path: PathSpec
+  write: boolean
+  prefix: string
 }
+
+/** One completed VFS op, as postOps hooks see it; a Deny suppresses
+ * the result. */
+export interface OpsResultContext {
+  op: string
+  path: PathSpec
+  write: boolean
+  prefix: string
+  result: unknown
+}
+
+export const VALIDITY: Readonly<Record<'preCommand' | 'preOps' | 'postOps', ReadonlySet<string>>> =
+  {
+    preCommand: new Set(['deny']),
+    preOps: new Set(['deny']),
+    postOps: new Set(['deny']),
+  }

--- a/typescript/packages/core/src/workspace/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher.ts
@@ -19,6 +19,7 @@ import { applyOpSafeguard, runWithTimeout } from '../commands/builtin/utils/safe
 import { getExtension } from '../commands/resolve.ts'
 import { IOResult } from '../io/types.ts'
 import { eaccesReadOnly } from '../utils/errors.ts'
+import { Policies, postOpsGate, preOpsGate } from '../policy/index.ts'
 import { mountKey } from '../utils/key_prefix.ts'
 import { rstripSlash } from '../utils/slash.ts'
 import { runWithMountPrefix, runWithRevisions } from '../observe/context.ts'
@@ -54,6 +55,7 @@ export class Dispatcher {
   private readonly namespace: Namespace
   private readonly cache: FileCache & Resource
   private readonly opsRegistry: OpsRegistry
+  private readonly policies: Policies
   readonly reconciler: Reconciler
 
   constructor(
@@ -61,10 +63,12 @@ export class Dispatcher {
     cache: FileCache & Resource,
     opsRegistry: OpsRegistry,
     consistency: ConsistencyPolicy = ConsistencyPolicy.LAZY,
+    policies?: Policies,
   ) {
     this.namespace = namespace
     this.cache = cache
     this.opsRegistry = opsRegistry
+    this.policies = policies ?? new Policies()
     this.reconciler = new Reconciler(cache, namespace, opsRegistry, consistency)
   }
 
@@ -76,14 +80,22 @@ export class Dispatcher {
     }
     const [resource, scope, mode] = await this.namespace.resolve(p.virtual, false)
     const mount = this.namespace.mountFor(p.virtual)
+    const mountPrefix = mount?.prefix ?? '/'
+    // Admission policies fire at the door, before the warm-cache early
+    // return below: a cached read must be refused exactly like a cold
+    // one, or the cache becomes a policy bypass. This dispatcher is the
+    // one door in TypeScript: shell internals, programmatic access, and
+    // FUSE all route through Workspace.dispatch.
+    const opWrite = DISPATCH_WRITE_OPS.has(opName)
+    await preOpsGate(this.policies, opName, p, opWrite, mountPrefix)
     const caches = cachesReads(resource)
     if (caches && mount !== null && DISPATCH_READ_OPS.has(opName)) {
       const cached = await this.cache.get(p.virtual)
       if (cached !== null && (await this.reconciler.mayServeCached(mount, p.virtual))) {
+        await postOpsGate(this.policies, opName, p, opWrite, mountPrefix, cached)
         return [cached, new IOResult({ reads: { [p.virtual]: cached } })]
       }
     }
-    const mountPrefix = mount?.prefix ?? '/'
     if (
       effectiveMountMode(mountPrefix, mode) === MountMode.READ &&
       this.opsRegistry.find(opName, resource.kind)?.write === true
@@ -162,8 +174,9 @@ export class Dispatcher {
       }
     }
     if (opName === 'stat' && result instanceof FileStat) {
-      return [mergeOverlayStat(this.namespace.metaFor(p.virtual), result), new IOResult()]
+      result = mergeOverlayStat(this.namespace.metaFor(p.virtual), result)
     }
+    await postOpsGate(this.policies, opName, p, opWrite, mountPrefix, result)
     return [result, new IOResult()]
   }
 

--- a/typescript/packages/core/src/workspace/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher.ts
@@ -48,6 +48,10 @@ const DISPATCH_WRITE_OPS = new Set([
   'rmdir',
   'rename',
 ])
+// setattr mutates the mount but keeps its own overlay bookkeeping in
+// the metadata builtin, so it is a write for policy admission without
+// joining the dispatcher's post-write invalidation path.
+const POLICY_WRITE_OPS = new Set([...DISPATCH_WRITE_OPS, 'setattr'])
 
 export type ResolveFn = (path: string) => Promise<[Resource, PathSpec, MountMode]>
 
@@ -86,7 +90,7 @@ export class Dispatcher {
     // one, or the cache becomes a policy bypass. This dispatcher is the
     // one door in TypeScript: shell internals, programmatic access, and
     // FUSE all route through Workspace.dispatch.
-    const opWrite = DISPATCH_WRITE_OPS.has(opName)
+    const opWrite = POLICY_WRITE_OPS.has(opName)
     await preOpsGate(this.policies, opName, p, opWrite, mountPrefix)
     const caches = cachesReads(resource)
     if (caches && mount !== null && DISPATCH_READ_OPS.has(opName)) {

--- a/typescript/packages/core/src/workspace/executor/builtins/metadata.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/metadata.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { IOResult } from '../../../io/types.ts'
+import { PolicyDenied } from '../../../policy/index.ts'
 import type { FileStat } from '../../../types.ts'
 import { FileType, PathSpec } from '../../../types.ts'
 import { fsStrerror, isFsError, isMissingOp } from '../../../utils/errors.ts'
@@ -230,6 +231,10 @@ function readOnlyError(cmd: string, namespace: Namespace, path: PathSpec): strin
 }
 
 function isReadOnlyError(err: unknown): boolean {
+  // A policy deny is EACCES too but must render GNU's "Permission
+  // denied", not the mount read-only wording, even when its reason
+  // text happens to contain "read-only".
+  if (err instanceof PolicyDenied) return false
   return err instanceof Error && err.message.includes('read-only')
 }
 

--- a/typescript/packages/core/src/workspace/workspace.ts
+++ b/typescript/packages/core/src/workspace/workspace.ts
@@ -191,7 +191,13 @@ export class Workspace {
       stores.namespace,
       options.agentId ?? null,
     )
-    this.dispatcher = new Dispatcher(this.namespace, this.cache, this.opsRegistry, consistency)
+    this.dispatcher = new Dispatcher(
+      this.namespace,
+      this.cache,
+      this.opsRegistry,
+      consistency,
+      this.registry.policies,
+    )
     this.registry.setReconciler(this.dispatcher.reconciler)
     // The file cache is a hidden store (attached above), never a mount. Arg-less
     // commands and root listing resolve against a neutral root anchor: reuse the


### PR DESCRIPTION
Adds the op-layer policy hooks from the unified Policy design (PR 2 of the ladder, after #690).

- `pre_ops` / `post_ops` hooks with `OpsContext` / `OpsResultContext`; Deny-only for now (the Limit arm rides the safeguard-absorption phase).
- Gates fire at every op door: `Ops._call` (the `ws.ops` facade, which also serves FUSE) and the shell's internal `Dispatcher.dispatch` in Python; `Dispatcher.dispatch` in TypeScript. The pre gate fires before the warm-cache lookup, so a cached read is refused exactly like a cold one (the #241 bypass class).
- `GuardSpec` gains an op twin: path-only guards (no `commands`) now hold against FUSE and programmatic access, not just shell commands. Closes #675.
- New `PolicyDenied` (EACCES) so the shell renders GNU "Permission denied", FUSE classifies to -EACCES, and renderers can tell a policy deny from a mount-mode refusal without message sniffing.
- `Policies` grows a shared `_fire` loop and an O(1) `wants()` gate; a workspace with no op policies pays ~71 ns per op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)