### PR TITLE
fix(crossmount): honor wc --total and stop du -h rounding twice

### DIFF
--- a/python/mirage/commands/builtin/generic/crossmount/fanout/du.py
+++ b/python/mirage/commands/builtin/generic/crossmount/fanout/du.py
@@ -13,11 +13,18 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.commands.builtin.generic.crossmount.types import OperandRun
-from mirage.commands.builtin.utils.formatting import _human_size, parse_size
+from mirage.commands.builtin.utils.formatting import _human_size
 
 
 def _format_size(size: int, human: bool) -> str:
     return _human_size(size) if human else str(size)
+
+
+def _humanize_row(line: str) -> str:
+    size_text, tab, label = line.partition("\t")
+    if not tab:
+        return line
+    return _human_size(int(size_text)) + "\t" + label
 
 
 def du_total(results: list[OperandRun], human: bool) -> bytes:
@@ -26,18 +33,24 @@ def du_total(results: list[OperandRun], human: bool) -> bytes:
     Every native run receives ``-c`` so glob operands total natively; the
     per-run totals (always the last row) are removed and re-summed.
 
+    ``run_fanout`` forces the native runs to report exact bytes even under
+    ``-h``, and the sizes are humanized here instead. Summing each run's
+    already-humanized total would round twice, so two 1500-byte operands
+    read back as 1536 each and report ``3.0K`` where one mount says
+    ``2.9K``. Per-run totals cannot be replaced by summing the rows either:
+    without ``-a`` a run prints a row per directory, and those nest.
+
     Args:
         results (list[OperandRun]): Per-operand native du runs.
-        human (bool): Format the total like ``du -h`` does.
+        human (bool): Format the sizes like ``du -h`` does.
     """
-    kept: list[bytes] = []
+    kept: list[str] = []
     total = 0
     for run in results:
         body = run.data.decode(errors="replace").splitlines()
         if body and body[-1].endswith("\ttotal"):
-            total += parse_size(body[-1].rsplit("\t", 1)[0])
+            total += int(body[-1].rsplit("\t", 1)[0])
             body = body[:-1]
-        if body:
-            kept.append(("\n".join(body) + "\n").encode())
-    kept.append((_format_size(total, human) + "\ttotal\n").encode())
-    return b"".join(kept)
+        kept.extend(_humanize_row(line) if human else line for line in body)
+    kept.append(_format_size(total, human) + "\ttotal")
+    return ("\n".join(kept) + "\n").encode()

--- a/python/mirage/commands/builtin/generic/crossmount/fanout/fanout.py
+++ b/python/mirage/commands/builtin/generic/crossmount/fanout/fanout.py
@@ -20,10 +20,11 @@ from mirage.commands.builtin.generic.crossmount.types import (Cmd, CrossResult,
                                                               RunSingle)
 from mirage.commands.builtin.generic.crossmount.utils import (
     merge_operand_ios, run_operands)
+from mirage.commands.builtin.generic.wc import parse_flags as parse_wc_flags
 from mirage.commands.spec import SPECS
 from mirage.commands.spec.types import FlagView
 from mirage.io.stream import materialize
-from mirage.io.types import ByteSource
+from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 
 
@@ -71,6 +72,13 @@ async def run_fanout(cmd_name: str,
     # run: wc must not see a per-run total row it would have to guess at,
     # and du must not sum sizes that were already rounded for -h.
     if cmd_name == Cmd.WC:
+        # The override would mask an invalid --total from every native run,
+        # so the user's value is diagnosed here first, as one mount would.
+        try:
+            parse_wc_flags(flag_kwargs)
+        except ValueError as exc:
+            return None, IOResult(exit_code=1,
+                                  stderr=(str(exc) + "\n").encode())
         flags["total"] = "never"
     du_c = cmd_name == Cmd.DU and FlagView(flag_kwargs,
                                            spec=SPECS[Cmd.DU]).as_bool("c")

--- a/python/mirage/commands/builtin/generic/crossmount/fanout/fanout.py
+++ b/python/mirage/commands/builtin/generic/crossmount/fanout/fanout.py
@@ -67,6 +67,16 @@ async def run_fanout(cmd_name: str,
     if cmd_name in (Cmd.HEAD, Cmd.TAIL) and not FlagView(
             flags, spec=SPECS[cmd_name]).as_bool(quiet_key):
         flags[verbose_key] = True
+    # Both re-totalling combines below need raw per-file rows from every
+    # run: wc must not see a per-run total row it would have to guess at,
+    # and du must not sum sizes that were already rounded for -h.
+    if cmd_name == Cmd.WC:
+        flags["total"] = "never"
+    du_c = cmd_name == Cmd.DU and FlagView(flag_kwargs,
+                                           spec=SPECS[Cmd.DU]).as_bool("c")
+    du_human = du_c and FlagView(flag_kwargs, spec=SPECS[Cmd.DU]).as_bool("h")
+    if du_human:
+        flags["h"] = False
 
     results = await run_operands(run_single,
                                  cmd_name,
@@ -84,10 +94,8 @@ async def run_fanout(cmd_name: str,
 
     if cmd_name == Cmd.WC:
         body = combine_wc(results, flag_kwargs)
-    elif cmd_name == Cmd.DU and FlagView(flag_kwargs,
-                                         spec=SPECS[Cmd.DU]).as_bool("c"):
-        body = du_total(results,
-                        FlagView(flag_kwargs, spec=SPECS[Cmd.DU]).as_bool("h"))
+    elif du_c:
+        body = du_total(results, du_human)
     elif cmd_name == Cmd.TEE:
         body = stdin_bytes or b""
     elif (cmd_name in (Cmd.HEAD, Cmd.TAIL)

--- a/python/mirage/commands/builtin/generic/crossmount/fanout/wc.py
+++ b/python/mirage/commands/builtin/generic/crossmount/fanout/wc.py
@@ -13,9 +13,8 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 from mirage.commands.builtin.generic.crossmount.types import OperandRun
-from mirage.commands.builtin.generic.wc import WCCounts, format_wc_lines
-from mirage.commands.spec import SPECS
-from mirage.commands.spec.types import FlagView
+from mirage.commands.builtin.generic.wc import (WCCounts, format_count_rows,
+                                                parse_flags)
 
 
 def _parse_wc_row(line: str, columns: int) -> tuple[list[int], str]:
@@ -44,34 +43,33 @@ def combine_wc(results: list[OperandRun], flag_kwargs: dict[str,
                                                             object]) -> bytes:
     """Re-total per-operand wc rows with one shared column width.
 
-    Each native run right-aligns its own rows, so the runs cannot simply
-    concatenate: rows are re-parsed and the whole report (plus the global
-    ``total`` row, where max line length maxes instead of summing) is
-    reformatted by the same wc formatter the single-mount command uses.
+    Each native run right-aligns its own rows against its own widest count,
+    so the runs cannot simply concatenate: rows are re-parsed and the whole
+    report is reformatted by the same formatter the single-mount command
+    uses, which is also what applies ``--total``. ``run_fanout`` forces the
+    native runs to ``--total=never``, so every line read here is a file row
+    and the grand total below is the only one the report can carry.
 
     Args:
         results (list[OperandRun]): Per-operand native wc runs.
         flag_kwargs (dict): Flags parsed against the shared wc spec.
     """
-    fl = FlagView(flag_kwargs, spec=SPECS["wc"])
-    sel = dict(lines=fl.as_bool("lines"),
-               words=fl.as_bool("words"),
-               bytes_=fl.as_bool("bytes"),
-               chars=fl.as_bool("chars"),
-               max_line_length=fl.as_bool("max_line_length"))
+    flags = parse_flags(flag_kwargs)
+    sel = dict(lines=flags.lines,
+               words=flags.words,
+               bytes_=flags.bytes_,
+               chars=flags.chars,
+               max_line_length=flags.max_line_length)
     columns = 1 if any(sel.values()) else 3
     rows: list[tuple[WCCounts, str | None]] = []
+    totals = WCCounts()
     for run in results:
-        body = run.data.decode(errors="replace").splitlines()
-        if len(body) > 1:
-            body = body[:-1]
-        for line in body:
+        for line in run.data.decode(errors="replace").splitlines():
             values, label = _parse_wc_row(line, columns)
-            rows.append((_wc_counts(values, **sel), label or None))
-    if not rows:
-        return b""
-    total = WCCounts()
-    for counts, _ in rows:
-        total.merge(counts)
-    lines = format_wc_lines(rows + [(total, "total")], **sel)
-    return ("\n".join(lines) + "\n").encode()
+            counts = _wc_counts(values, **sel)
+            rows.append((counts, label or None))
+            totals.merge(counts)
+    # GNU decides the auto total on the operands *given*, not on the rows
+    # that resolved, so a missing operand still gets a total row. There are
+    # always at least two scopes here, and a glob operand can expand to more.
+    return format_count_rows(rows, totals, max(len(rows), len(results)), flags)

--- a/python/mirage/commands/builtin/utils/constants.py
+++ b/python/mirage/commands/builtin/utils/constants.py
@@ -21,14 +21,6 @@ MONTHS = ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct",
 
 EPOCH_LS_TIME = "Jan  1 00:00"
 
-SIZE_UNITS = {
-    "B": 1,
-    "K": 1024,
-    "M": 1024**2,
-    "G": 1024**3,
-    "T": 1024**4,
-}
-
 TYPE_CHARS = {FileType.DIRECTORY: "d", FileType.SYMLINK: "l"}
 
 # A symlink has no permission bits of its own on Linux: the mode is

--- a/python/mirage/commands/builtin/utils/formatting.py
+++ b/python/mirage/commands/builtin/utils/formatting.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 from mirage.commands.builtin.utils.constants import (DEFAULT_MODES,
                                                      EPOCH_LS_TIME, MONTHS,
                                                      NUMERIC_PREFIX,
-                                                     SIZE_UNITS, TYPE_CHARS)
+                                                     TYPE_CHARS)
 from mirage.types import LINK_TARGET_KEY, FileStat, FileType
 
 
@@ -38,17 +38,6 @@ def _perm_triplet(bits: int, special: str | None = None) -> str:
     else:
         execbit = "x" if bits & 1 else "-"
     return ("r" if bits & 4 else "-") + ("w" if bits & 2 else "-") + execbit
-
-
-def parse_size(text: str) -> int:
-    """Invert ``_human_size``: ``4.0K`` -> 4096, plain digits pass through.
-
-    Args:
-        text (str): size text, optionally suffixed with B/K/M/G/T.
-    """
-    if text and text[-1] in SIZE_UNITS:
-        return round(float(text[:-1]) * SIZE_UNITS[text[-1]])
-    return int(text)
 
 
 def _ls_mode_string(s: FileStat) -> str:

--- a/python/tests/commands/builtin/generic/crossmount/fanout/test_du.py
+++ b/python/tests/commands/builtin/generic/crossmount/fanout/test_du.py
@@ -36,3 +36,20 @@ def testdu_total_strips_per_run_totals_and_sums():
     ]
     out = du_total(runs, human=False).decode()
     assert out == "5\t/a/sub\n3\t/b/c.txt\n8\ttotal\n"
+
+
+def testdu_total_humanizes_from_exact_bytes_without_rounding_twice():
+    # run_fanout forces -h off on the native runs, so the rows arrive in
+    # bytes: 1500 + 1500 is 2.9K, not the 3.0K that summing two "1.5K"
+    # readings back through parse_size would give.
+    runs = [
+        _op(b"1500\t/a/x\n1500\ttotal\n"),
+        _op(b"1500\t/b/z\n1500\ttotal\n"),
+    ]
+    out = du_total(runs, human=True).decode()
+    assert out == "1.5K\t/a/x\n1.5K\t/b/z\n2.9K\ttotal\n"
+
+
+def testdu_total_leaves_a_row_without_a_tab_alone():
+    out = du_total([_op(b"odd-row\n0\ttotal\n")], human=True).decode()
+    assert out == "odd-row\n0B\ttotal\n"

--- a/python/tests/commands/builtin/generic/crossmount/fanout/test_fanout.py
+++ b/python/tests/commands/builtin/generic/crossmount/fanout/test_fanout.py
@@ -125,3 +125,25 @@ def test_run_fanout_partial_failure_keeps_output_and_stderr():
     assert _run(materialize(out)) == b"ok\n"
     assert io.exit_code == 1
     assert b"/a/x" in (io.stderr or b"")
+
+
+def test_run_fanout_forces_wc_total_never_on_native_runs():
+    rs = FakeRunSingle({
+        "/a/x": (b"1 1 1 /a/x\n", 0),
+        "/b/y": (b"2 2 2 /b/y\n", 0)
+    })
+    _run(run_fanout("wc", [_scope("/a/x"), _scope("/b/y")], [], {}, rs))
+    assert [c["flags"]["total"] for c in rs.calls] == ["never", "never"]
+
+
+def test_run_fanout_rejects_invalid_wc_total_before_running_operands():
+    # The forced override would otherwise hide the bad value from every
+    # native run, leaving exit 0 and no diagnostic.
+    rs = FakeRunSingle({"/a/x": (b"", 0), "/b/y": (b"", 0)})
+    body, io = _run(
+        run_fanout("wc", [_scope("/a/x"), _scope("/b/y")], [],
+                   {"total": "bogus"}, rs))
+    assert body is None
+    assert io.exit_code == 1
+    assert io.stderr == b"wc: invalid argument 'bogus' for '--total'\n"
+    assert rs.calls == []

--- a/python/tests/commands/builtin/generic/crossmount/fanout/test_wc.py
+++ b/python/tests/commands/builtin/generic/crossmount/fanout/test_wc.py
@@ -40,9 +40,11 @@ def testcombine_wc_uses_one_global_width():
                    "105 105 420 total\n")
 
 
-def testcombine_wc_drops_per_run_totals_from_glob_operands():
+def testcombine_wc_keeps_every_row_of_a_glob_operand():
+    # run_fanout forces --total=never, so a glob operand's run is all file
+    # rows; the combine must not treat the last one as a per-run total.
     runs = [
-        _op(b"2 /a/one.txt\n1 /a/two.txt\n3 total\n"),
+        _op(b"2 /a/one.txt\n1 /a/two.txt\n"),
         _op(b"1 /b/three.txt\n"),
     ]
     out = combine_wc(runs, {"lines": True}).decode()
@@ -56,3 +58,43 @@ def testcombine_wc_max_line_length_maxes_instead_of_summing():
     runs = [_op(b"9 /a/x\n"), _op(b"4 /b/y\n")]
     out = combine_wc(runs, {"max_line_length": True}).decode()
     assert out.endswith("9 total\n")
+
+
+def testcombine_wc_total_never_prints_no_total_row():
+    runs = [_op(b"2 3 14 /a/x.txt\n"), _op(b"1 3 15 /b/z.txt\n")]
+    out = combine_wc(runs, {"total": "never"}).decode()
+    assert out == (" 2  3 14 /a/x.txt\n"
+                   " 1  3 15 /b/z.txt\n")
+
+
+def testcombine_wc_total_only_prints_the_grand_total_alone():
+    runs = [_op(b"2 3 14 /a/x.txt\n"), _op(b"1 3 15 /b/z.txt\n")]
+    out = combine_wc(runs, {"total": "only"}).decode()
+    assert out == "3 6 29\n"
+
+
+def testcombine_wc_total_always_prints_a_total_for_one_row():
+    out = combine_wc([_op(b"2 3 14 /a/x.txt\n")], {"total": "always"}).decode()
+    assert out == " 2  3 14 /a/x.txt\n 2  3 14 total\n"
+
+
+def testcombine_wc_auto_omits_the_total_for_one_row():
+    out = combine_wc([_op(b"2 3 14 /a/x.txt\n")], {}).decode()
+    assert out == " 2  3 14 /a/x.txt\n"
+
+
+def testcombine_wc_failed_operand_still_gets_a_total_row():
+    # Two operands were given, so GNU prints the total even though only one
+    # of them resolved into a row.
+    runs = [_op(b"1 /a/f.txt\n"), _op(b"", exit_code=1)]
+    out = combine_wc(runs, {"lines": True}).decode()
+    assert out == "1 /a/f.txt\n1 total\n"
+
+
+def testcombine_wc_all_operands_failed_prints_nothing():
+    assert combine_wc([_op(b"", exit_code=1)], {}) == b""
+
+
+def testcombine_wc_total_only_zeroes_when_every_operand_failed():
+    out = combine_wc([_op(b"", exit_code=1)], {"total": "only"}).decode()
+    assert out == "0 0 0\n"

--- a/python/tests/commands/builtin/utils/test_formatting.py
+++ b/python/tests/commands/builtin/utils/test_formatting.py
@@ -12,21 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.commands.builtin.utils.formatting import (_human_size,
-                                                      format_number,
-                                                      parse_size, to_number)
-
-
-def testparse_size_plain_and_human():
-    assert parse_size("123") == 123
-    assert parse_size("4.0K") == 4096
-    assert parse_size("2.5M") == 2621440
-    assert parse_size("7B") == 7
-
-
-def testparse_size_inverts_human_size():
-    for n in (0, 512, 4096, 1024**2, 3 * 1024**3):
-        assert parse_size(_human_size(n)) == n
+from mirage.commands.builtin.utils.formatting import format_number, to_number
 
 
 def test_to_number_gnu_awk_coercion():

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/fanout/du.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/fanout/du.test.ts
@@ -1,0 +1,60 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { IOResult } from '../../../../../io/types.ts'
+import { PathSpec } from '../../../../../types.ts'
+import { mountKey } from '../../../../../utils/key_prefix.ts'
+import type { OperandRun } from '../types.ts'
+import { duTotal } from './du.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+function op(data: string, exitCode = 0): OperandRun {
+  const path = '/a/x'
+  return {
+    scope: new PathSpec({
+      virtual: path,
+      directory: path,
+      resolved: true,
+      resourcePath: mountKey(path, ''),
+    }),
+    data: ENC.encode(data),
+    io: new IOResult({ exitCode }),
+  }
+}
+
+describe('duTotal', () => {
+  it('strips per-run totals and sums', () => {
+    const out = DEC.decode(
+      duTotal([op('5\t/a/sub\n5\ttotal\n'), op('3\t/b/c.txt\n3\ttotal\n')], false),
+    )
+    expect(out).toBe('5\t/a/sub\n3\t/b/c.txt\n8\ttotal\n')
+  })
+
+  it('humanizes from exact bytes without rounding twice', () => {
+    // runFanout forces -h off on the native runs, so the rows arrive in
+    // bytes: 1500 + 1500 is 2.9K, not the 3.0K that summing two "1.5K"
+    // readings back through parseSize would give.
+    const out = DEC.decode(
+      duTotal([op('1500\t/a/x\n1500\ttotal\n'), op('1500\t/b/z\n1500\ttotal\n')], true),
+    )
+    expect(out).toBe('1.5K\t/a/x\n1.5K\t/b/z\n2.9K\ttotal\n')
+  })
+
+  it('leaves a row without a tab alone', () => {
+    expect(DEC.decode(duTotal([op('odd-row\n0\ttotal\n')], true))).toBe('odd-row\n0B\ttotal\n')
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/fanout/du.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/fanout/du.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { humanSize, parseSize } from '../../../utils/formatting.ts'
+import { humanSize } from '../../../utils/formatting.ts'
 import type { OperandRun } from '../types.ts'
 
 const ENC = new TextEncoder()
@@ -22,9 +22,22 @@ function formatSize(size: number, human: boolean): string {
   return human ? humanSize(size) : String(size)
 }
 
+function humanizeRow(line: string): string {
+  const tab = line.indexOf('\t')
+  if (tab < 0) return line
+  return `${humanSize(Number(line.slice(0, tab)))}\t${line.slice(tab + 1)}`
+}
+
 // Strip each run's own total row and emit one global total. Every native run
 // receives `-c` so glob operands total natively; the per-run totals (always
 // the last row) are removed and re-summed.
+//
+// `runFanout` forces the native runs to report exact bytes even under `-h`,
+// and the sizes are humanized here instead. Summing each run's already
+// humanized total would round twice, so two 1500-byte operands read back as
+// 1536 each and report `3.0K` where one mount says `2.9K`. Per-run totals
+// cannot be replaced by summing the rows either: without `-a` a run prints a
+// row per directory, and those nest.
 export function duTotal(results: OperandRun[], human: boolean): Uint8Array {
   const kept: string[] = []
   let total = 0
@@ -34,10 +47,10 @@ export function duTotal(results: OperandRun[], human: boolean): Uint8Array {
       .filter((l) => l !== '')
     const last = body.at(-1)
     if (last?.endsWith('\ttotal') === true) {
-      total += parseSize(last.slice(0, last.lastIndexOf('\t')))
+      total += Number(last.slice(0, last.lastIndexOf('\t')))
       body = body.slice(0, -1)
     }
-    kept.push(...body)
+    kept.push(...(human ? body.map(humanizeRow) : body))
   }
   kept.push(`${formatSize(total, human)}\ttotal`)
   return ENC.encode(kept.join('\n') + '\n')

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/fanout/fanout.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/fanout/fanout.test.ts
@@ -1,0 +1,85 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { IOResult, materialize, type ByteSource } from '../../../../../io/types.ts'
+import { PathSpec } from '../../../../../types.ts'
+import { mountKey } from '../../../../../utils/key_prefix.ts'
+import { Cmd, type CrossResult, type RunSingle } from '../types.ts'
+import { runFanout } from './fanout.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+function scope(path: string): PathSpec {
+  return new PathSpec({
+    virtual: path,
+    directory: path.slice(0, path.lastIndexOf('/') + 1),
+    resolved: true,
+    resourcePath: mountKey(path, ''),
+  })
+}
+
+interface Call {
+  cmd: string
+  paths: string[]
+  flags: Record<string, string | boolean | number | string[]>
+}
+
+function fakeRunSingle(outputs: Record<string, string>): { fn: RunSingle; calls: Call[] } {
+  const calls: Call[] = []
+  const fn: RunSingle = (cmdName, paths, _texts, flagKwargs): Promise<CrossResult> => {
+    calls.push({
+      cmd: cmdName,
+      paths: paths.map((p) => p.virtual),
+      flags: { ...flagKwargs },
+    })
+    const key = paths[0]?.virtual ?? ''
+    return Promise.resolve([ENC.encode(outputs[key] ?? ''), new IOResult()])
+  }
+  return { fn, calls }
+}
+
+async function text(body: ByteSource | null): Promise<string> {
+  if (body === null) return ''
+  return DEC.decode(await materialize(body))
+}
+
+describe('runFanout wc', () => {
+  it('forces --total=never on the native runs', async () => {
+    const { fn, calls } = fakeRunSingle({
+      '/a/x': '1 1 1 /a/x\n',
+      '/b/y': '2 2 2 /b/y\n',
+    })
+    await runFanout(Cmd.WC, [scope('/a/x'), scope('/b/y')], [], {}, fn)
+    expect(calls.map((c) => c.flags.total)).toEqual(['never', 'never'])
+  })
+
+  it('rejects an invalid --total before running any operand', async () => {
+    // The forced override would otherwise hide the bad value from every
+    // native run, leaving exit 0 and no diagnostic.
+    const { fn, calls } = fakeRunSingle({ '/a/x': '', '/b/y': '' })
+    const [body, io] = await runFanout(
+      Cmd.WC,
+      [scope('/a/x'), scope('/b/y')],
+      [],
+      { total: 'bogus' },
+      fn,
+    )
+    expect(await text(body)).toBe('')
+    expect(io.exitCode).toBe(1)
+    expect(await text(io.stderr)).toBe("wc: invalid argument 'bogus' for '--total'\n")
+    expect(calls).toEqual([])
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/fanout/fanout.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/fanout/fanout.ts
@@ -12,8 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { materialize, type ByteSource } from '../../../../../io/types.ts'
+import { IOResult, materialize, type ByteSource } from '../../../../../io/types.ts'
 import type { PathSpec } from '../../../../../types.ts'
+import { parseFlags as parseWcFlags } from '../../wc.ts'
 import { combinedExit } from './exit.ts'
 import { duTotal } from './du.ts'
 import { combineWc } from './wc.ts'
@@ -88,6 +89,12 @@ export async function runFanout(
   // wc must not see a per-run total row it would have to guess at, and du
   // must not sum sizes that were already rounded for -h.
   if (cmdName === Cmd.WC) {
+    // The override would mask an invalid --total from every native run, so
+    // the user's value is diagnosed here first, as one mount would.
+    const checked = parseWcFlags(flagKwargs)
+    if (typeof checked === 'string') {
+      return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(checked) })]
+    }
     flags.total = 'never'
   }
   const duC = cmdName === Cmd.DU && flagKwargs.c === true

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/fanout/fanout.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/fanout/fanout.ts
@@ -84,6 +84,17 @@ export async function runFanout(
   if ((cmdName === Cmd.HEAD || cmdName === Cmd.TAIL) && flags[quietKey] !== true) {
     flags[verboseKey] = true
   }
+  // Both re-totalling combines below need raw per-file rows from every run:
+  // wc must not see a per-run total row it would have to guess at, and du
+  // must not sum sizes that were already rounded for -h.
+  if (cmdName === Cmd.WC) {
+    flags.total = 'never'
+  }
+  const duC = cmdName === Cmd.DU && flagKwargs.c === true
+  const duHuman = duC && flagKwargs.h === true
+  if (duHuman) {
+    flags.h = false
+  }
 
   const results = await runOperands(runSingle, cmdName, scopes, [...textArgs], flags, stdinBytes)
   const errored = results.map((r) => r.io.exitCode !== 0 && r.io.stderr !== null)
@@ -95,11 +106,11 @@ export async function runFanout(
     quiet,
   )
 
-  let body: Uint8Array
+  let body: ByteSource | null
   if (cmdName === Cmd.WC) {
     body = combineWc(results, flagKwargs)
-  } else if (cmdName === Cmd.DU && flagKwargs.c === true) {
-    body = duTotal(results, flagKwargs.h === true)
+  } else if (duC) {
+    body = duTotal(results, duHuman)
   } else if (cmdName === Cmd.TEE) {
     body = stdinBytes ?? new Uint8Array()
   } else if (

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/fanout/wc.test.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/fanout/wc.test.ts
@@ -1,0 +1,104 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { IOResult, materialize, type ByteSource } from '../../../../../io/types.ts'
+import { PathSpec } from '../../../../../types.ts'
+import { mountKey } from '../../../../../utils/key_prefix.ts'
+import type { OperandRun } from '../types.ts'
+import { combineWc } from './wc.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+
+function op(data: string, exitCode = 0): OperandRun {
+  const path = '/a/x'
+  return {
+    scope: new PathSpec({
+      virtual: path,
+      directory: path,
+      resolved: true,
+      resourcePath: mountKey(path, ''),
+    }),
+    data: ENC.encode(data),
+    io: new IOResult({ exitCode }),
+  }
+}
+
+async function text(body: ByteSource | null): Promise<string> {
+  if (body === null) return ''
+  return DEC.decode(await materialize(body))
+}
+
+describe('combineWc', () => {
+  it('uses one global column width across runs', async () => {
+    const out = await text(
+      combineWc([op('100 100 400 /a/big.txt\n'), op('5 5 20 /b/small.txt\n')], {}),
+    )
+    expect(out).toBe('100 100 400 /a/big.txt\n  5   5  20 /b/small.txt\n105 105 420 total\n')
+  })
+
+  it('keeps every row of a glob operand', async () => {
+    // runFanout forces --total=never, so a glob operand's run is all file
+    // rows; the combine must not treat the last one as a per-run total.
+    const out = await text(
+      combineWc([op('2 /a/one.txt\n1 /a/two.txt\n'), op('1 /b/three.txt\n')], { lines: true }),
+    )
+    expect(out).toBe('2 /a/one.txt\n1 /a/two.txt\n1 /b/three.txt\n4 total\n')
+  })
+
+  it('maxes max-line-length instead of summing it', async () => {
+    const out = await text(combineWc([op('9 /a/x\n'), op('4 /b/y\n')], { max_line_length: true }))
+    expect(out.endsWith('9 total\n')).toBe(true)
+  })
+
+  it('prints no total row under --total=never', async () => {
+    const out = await text(
+      combineWc([op('2 3 14 /a/x.txt\n'), op('1 3 15 /b/z.txt\n')], { total: 'never' }),
+    )
+    expect(out).toBe(' 2  3 14 /a/x.txt\n 1  3 15 /b/z.txt\n')
+  })
+
+  it('prints the grand total alone under --total=only', async () => {
+    const out = await text(
+      combineWc([op('2 3 14 /a/x.txt\n'), op('1 3 15 /b/z.txt\n')], { total: 'only' }),
+    )
+    expect(out).toBe('3 6 29\n')
+  })
+
+  it('prints a total for a single row under --total=always', async () => {
+    const out = await text(combineWc([op('2 3 14 /a/x.txt\n')], { total: 'always' }))
+    expect(out).toBe(' 2  3 14 /a/x.txt\n 2  3 14 total\n')
+  })
+
+  it('omits the total for a single row under auto', async () => {
+    const out = await text(combineWc([op('2 3 14 /a/x.txt\n')], {}))
+    expect(out).toBe(' 2  3 14 /a/x.txt\n')
+  })
+
+  it('still totals when one of two operands failed', async () => {
+    // Two operands were given, so GNU prints the total even though only one
+    // of them resolved into a row.
+    const out = await text(combineWc([op('1 /a/f.txt\n'), op('', 1)], { lines: true }))
+    expect(out).toBe('1 /a/f.txt\n1 total\n')
+  })
+
+  it('prints nothing when every operand failed', async () => {
+    expect(await text(combineWc([op('', 1)], {}))).toBe('')
+  })
+
+  it('zeroes the grand total under --total=only when every operand failed', async () => {
+    expect(await text(combineWc([op('', 1)], { total: 'only' }))).toBe('0 0 0\n')
+  })
+})

--- a/typescript/packages/core/src/commands/builtin/generic/crossmount/fanout/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/crossmount/fanout/wc.ts
@@ -12,10 +12,10 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { formatWcLines, type WcRow } from '../../wc.ts'
+import type { ByteSource } from '../../../../../io/types.ts'
+import { formatCountRows, parseFlags, type WcRow } from '../../wc.ts'
 import type { OperandRun } from '../types.ts'
 
-const ENC = new TextEncoder()
 const DEC = new TextDecoder('utf-8', { fatal: false })
 
 function parseWcRow(line: string, columns: number): WcRow {
@@ -26,38 +26,36 @@ function parseWcRow(line: string, columns: number): WcRow {
 }
 
 // Re-total per-operand wc rows with one shared column width. Each native run
-// right-aligns its own rows, so the runs cannot simply concatenate: rows are
-// re-parsed and the whole report (plus the global `total` row, where max line
-// length maxes instead of summing) is reformatted by the same wc formatter
-// the single-mount command uses.
+// right-aligns its own rows against its own widest count, so the runs cannot
+// simply concatenate: rows are re-parsed and the whole report is reformatted
+// by the same formatter the single-mount command uses, which is also what
+// applies `--total`. `runFanout` forces the native runs to `--total=never`,
+// so every line read here is a file row and the grand total below is the only
+// one the report can carry.
 export function combineWc(
   results: OperandRun[],
   flagKwargs: Record<string, string | boolean | number | string[]>,
-): Uint8Array {
+): ByteSource | null {
+  const parsed = parseFlags(flagKwargs)
+  if (typeof parsed === 'string') return null
   const single =
-    flagKwargs.lines === true ||
-    flagKwargs.words === true ||
-    flagKwargs.bytes === true ||
-    flagKwargs.chars === true ||
-    flagKwargs.max_line_length === true
+    parsed.lines || parsed.words || parsed.bytes || parsed.chars || parsed.maxLineLength
   const columns = single ? 1 : 3
-  const maxMode = flagKwargs.max_line_length === true
   const rows: WcRow[] = []
-  for (const run of results) {
-    let body = DEC.decode(run.data)
-      .split('\n')
-      .filter((l) => l !== '')
-    if (body.length > 1) body = body.slice(0, -1)
-    for (const line of body) rows.push(parseWcRow(line, columns))
-  }
-  if (rows.length === 0) return new Uint8Array()
   const total: number[] = new Array<number>(columns).fill(0)
-  for (const row of rows) {
-    for (let i = 0; i < columns; i++) {
-      const v = row.values[i] ?? 0
-      total[i] = maxMode ? Math.max(total[i] ?? 0, v) : (total[i] ?? 0) + v
+  for (const run of results) {
+    for (const line of DEC.decode(run.data).split('\n')) {
+      if (line === '') continue
+      const row = parseWcRow(line, columns)
+      rows.push(row)
+      for (let i = 0; i < columns; i++) {
+        const v = row.values[i] ?? 0
+        total[i] = parsed.maxLineLength ? Math.max(total[i] ?? 0, v) : (total[i] ?? 0) + v
+      }
     }
   }
-  const lines = formatWcLines([...rows, { values: total, label: 'total' }])
-  return ENC.encode(lines.join('\n') + '\n')
+  // GNU decides the auto total on the operands *given*, not on the rows that
+  // resolved, so a missing operand still gets a total row. There are always at
+  // least two scopes here, and a glob operand can expand to more.
+  return formatCountRows(rows, total, Math.max(rows.length, results.length), parsed.total)
 }

--- a/typescript/packages/core/src/commands/builtin/generic/wc.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/wc.ts
@@ -44,7 +44,7 @@ interface WcCounts {
   maxLineLength: number
 }
 
-interface WcFlags {
+export interface WcFlags {
   lines: boolean
   words: boolean
   bytes: boolean
@@ -53,7 +53,9 @@ interface WcFlags {
   total: 'auto' | 'always' | 'only' | 'never'
 }
 
-function parseFlags(flags: Record<string, string | boolean | number | string[]>): WcFlags | string {
+export function parseFlags(
+  flags: Record<string, string | boolean | number | string[]>,
+): WcFlags | string {
   const rawTotal = typeof flags.total === 'string' ? flags.total : 'auto'
   if (!['auto', 'always', 'only', 'never'].includes(rawTotal)) {
     return `wc: invalid argument '${rawTotal}' for '--total'\n`
@@ -127,6 +129,24 @@ export function formatWcLines(rows: WcRow[]): string[] {
   })
 }
 
+// Append the `total` row --total asks for and render the report. `only`
+// prints the grand total alone and unlabeled; `auto` prints one when more
+// than one operand was counted. Returns null when there is nothing to print.
+export function formatCountRows(
+  rows: WcRow[],
+  totalValues: number[],
+  operandCount: number,
+  total: WcFlags['total'],
+): ByteSource | null {
+  if (total === 'only') return ENC.encode(`${totalValues.join(' ')}\n`)
+  const out = [...rows]
+  if (total === 'always' || (total === 'auto' && operandCount > 1)) {
+    out.push({ values: totalValues, label: 'total' })
+  }
+  if (out.length === 0) return null
+  return formatRecords(formatWcLines(out))
+}
+
 export async function wcGeneric(
   paths: PathSpec[],
   texts: string[],
@@ -155,21 +175,11 @@ export async function wcGeneric(
       rows.push({ values: selectedValues(counts, parsed), label: p.rawPath })
       addCounts(total, counts)
     }
-    const includeTotal = parsed.total === 'always' || (parsed.total === 'auto' && paths.length > 1)
-    if (includeTotal || parsed.total === 'only') {
-      rows.push({ values: selectedValues(total, parsed), label: 'total' })
-    }
     const io = new IOResult({
       exitCode: err === '' ? 0 : 1,
       stderr: err === '' ? null : ENC.encode(err),
     })
-    if (parsed.total === 'only') {
-      const out = ENC.encode(`${selectedValues(total, parsed).join(' ')}\n`)
-      return [out, io]
-    }
-    if (rows.length === 0) return [null, io]
-    const out: ByteSource = formatRecords(formatWcLines(rows))
-    return [out, io]
+    return [formatCountRows(rows, selectedValues(total, parsed), paths.length, parsed.total), io]
   }
   let source: AsyncIterable<Uint8Array>
   try {

--- a/typescript/packages/core/src/commands/builtin/utils/constants.ts
+++ b/typescript/packages/core/src/commands/builtin/utils/constants.ts
@@ -31,14 +31,6 @@ export const MONTHS = [
 
 export const EPOCH_LS_TIME = 'Jan  1 00:00'
 
-export const SIZE_UNITS: Record<string, number> = {
-  B: 1,
-  K: 1024,
-  M: 1024 ** 2,
-  G: 1024 ** 3,
-  T: 1024 ** 4,
-}
-
 export const TYPE_CHARS: Partial<Record<FileType, string>> = {
   [FileType.DIRECTORY]: 'd',
   [FileType.SYMLINK]: 'l',

--- a/typescript/packages/core/src/commands/builtin/utils/formatting.ts
+++ b/typescript/packages/core/src/commands/builtin/utils/formatting.ts
@@ -13,14 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { FileType, LINK_TARGET_KEY, type FileStat } from '../../../types.ts'
-import {
-  DEFAULT_MODES,
-  EPOCH_LS_TIME,
-  MONTHS,
-  NUMERIC_PREFIX,
-  SIZE_UNITS,
-  TYPE_CHARS,
-} from './constants.ts'
+import { DEFAULT_MODES, EPOCH_LS_TIME, MONTHS, NUMERIC_PREFIX, TYPE_CHARS } from './constants.ts'
 
 export function humanSize(n: number): string {
   const units = ['B', 'K', 'M', 'G', 'T']
@@ -32,14 +25,6 @@ export function humanSize(n: number): string {
   }
   const s = i === 0 ? Math.round(value).toString() : value.toFixed(1)
   return `${s}${units[i] ?? ''}`
-}
-
-// Invert humanSize: `4.0K` -> 4096, plain digits pass through.
-export function parseSize(text: string): number {
-  const last = text.at(-1) ?? ''
-  const unit = SIZE_UNITS[last]
-  if (unit !== undefined) return Math.round(parseFloat(text.slice(0, -1)) * unit)
-  return parseInt(text, 10)
 }
 
 function permTriplet(bits: number, special?: string): string {


### PR DESCRIPTION
## Problem

The cross-mount FANOUT combiners re-parse each native run's *rendered text* to merge results. Any flag that changes output **shape** rather than content therefore has to be re-implemented inside the combiner, or cross-mount silently diverges from the single-mount path. Two combiners got this wrong.

### `wc` ignored `--total` entirely

It also guessed that any run with more than one row ended in a per-run `total` row and stripped it. That guess is wrong whenever the run did not emit one, so a glob operand silently lost a file.

Two RAM mounts, `/A` holding `x.txt` and `y.txt`, `/B` holding `z.txt`:

```
$ wc --total=never /A/*.txt /B/z.txt      # before
 2  3 14 /A/x.txt
 1  3 15 /B/z.txt                          <- /A/y.txt is GONE
 3  6 29 total                             <- and --total=never asked for no total
```

`--total=only` printed every per-operand row plus a labelled total, where GNU prints one unlabelled grand total.

### `du -c -h` rounded twice

Each run's already-humanized total was parsed back to bytes via `parse_size`, so two 1500 byte operands read as 1536 each:

```
$ du -c -h /A/x /B/z     # cross-mount, before: 3.0K
$ du -c -h /A/x /A/z2    # same sizes, one mount:  2.9K
```

## Fix

Same idiom `run_fanout` already uses to force `grep -H` and `head -v`: make the native runs emit raw, un-summarized data and render once in the combiner.

- `wc`: natives forced to `--total=never`, and `combine_wc` now delegates to the generic's own `format_count_rows` / `parse_flags`, which is what applies `--total` for a single mount. The `body[:-1]` heuristic is deleted rather than patched.
- `du`: natives forced to report exact bytes when `-c -h` is set, and `du_total` humanizes once. Per-run totals still come from each run's own total row, because without `-a` a run prints a row per directory and those nest, so summing rows would double count.
- TypeScript needed `formatCountRows` extracted from `wcGeneric` so both paths share one implementation, which is how Python was already organized.

One subtlety worth flagging for review: the auto total keys off operands **given**, not rows resolved (mirroring `format_multi`'s `len(paths)`), so `wc -l /a/f.txt /b/missing.txt` still prints its total row. `tests/workspace/test_partial_read_errors.py` catches this.

## Dead code

This removed the last production caller of `utils/formatting.parse_size` (the `_human_size` inverse) in both languages. Knip flagged it, so that function and the then-orphaned `SIZE_UNITS` constant are removed from both, along with two Python tests. Note `findParse.parse_size` and `truncate.parse_size` are unrelated functions of the same name and are untouched.

## Tests

13 new TypeScript cases and 7 new Python cases, asserting byte-identical output across the two languages. One existing Python test encoded the old contract (a run emitting its own total row) and is updated to the new one.

- Python: full suite green, 12175 tests
- TypeScript: core green, 6031/6032 (the one failure is a Redis hook timeout in `cache/index/redis.test.ts`, untouched here, and it passes in isolation)
- `pnpm typecheck` clean across all 7 packages
- `pre-commit run --all-files` clean, knip included