### PR TITLE
test(native): skip the tac comparison tests when the host has no tac

### DIFF
--- a/python/tests/commands/native/test_tac.py
+++ b/python/tests/commands/native/test_tac.py
@@ -12,12 +12,23 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import shutil
 
+import pytest
+
+skip_no_tac = pytest.mark.skipif(
+    shutil.which("tac") is None,
+    reason="tac is GNU coreutils; macOS ships tail -r instead",
+)
+
+
+@skip_no_tac
 def test_tac_stdin(env):
     data = b"a\nb\nc\n"
     assert env.mirage("tac", stdin=data) == env.native("tac", stdin=data)
 
 
+@skip_no_tac
 def test_tac_file(env):
     env.create_file("f.txt", b"1\n2\n3\n")
     assert env.mirage("tac /data/f.txt") == env.native("tac f.txt")

--- a/typescript/packages/node/src/commands/native_tac.test.ts
+++ b/typescript/packages/node/src/commands/native_tac.test.ts
@@ -12,13 +12,17 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { spawnSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 import { makeEnv, NATIVE_BACKENDS } from './native_fixture.ts'
 
 const ENC = new TextEncoder()
+// tac is GNU coreutils (macOS ships `tail -r`); the fixture captures only
+// native stdout, so a missing tac would silently compare against "".
+const hasTac = spawnSync('/bin/sh', ['-c', 'command -v tac'], { stdio: 'ignore' }).status === 0
 
 describe.each(NATIVE_BACKENDS)('native tac (%s backend)', (kind) => {
-  it('tac stdin matches native', async () => {
+  it.skipIf(!hasTac)('tac stdin matches native', async () => {
     const env = makeEnv(kind)
     try {
       const data = ENC.encode('a\nb\nc\n')
@@ -30,7 +34,7 @@ describe.each(NATIVE_BACKENDS)('native tac (%s backend)', (kind) => {
     }
   })
 
-  it('tac file matches native', async () => {
+  it.skipIf(!hasTac)('tac file matches native', async () => {
     const env = makeEnv(kind)
     try {
       env.createFile('f.txt', ENC.encode('1\n2\n3\n'))


### PR DESCRIPTION
## Problem

`tac` is GNU coreutils — macOS ships `tail -r` instead. The native-comparison
fixtures (`native_fixture.ts`, `tests/commands/native/conftest.py`) capture only
the child process's **stdout**, never its exit code, so on a host without `tac`
the native side silently yields `""`. The tests then fail with a confusing diff
(`"c\nb\na\n"` vs `""`) instead of reporting the absent binary:

- `typescript/packages/node/src/commands/native_tac.test.ts` — 4 tests
- `python/tests/commands/native/test_tac.py` — 6 tests (parametrized over ram/s3/disk)

## Fix

Guard both sides on **the binary's presence** rather than on the platform, so the
tests still run wherever `tac` actually exists — Linux CI, or macOS with GNU
coreutils installed — and skip cleanly where it does not.

Each side follows its own existing sibling convention for the `fmt` tests, which
are guarded the same way (`native_fmt.test.ts` / `test_fmt.py`):

| Side | Guard |
| --- | --- |
| TypeScript | `it.skipIf(!hasTac)`, where `hasTac` comes from `spawnSync('/bin/sh', ['-c', 'command -v tac'])` — the same shell the fixture runs native commands through |
| Python | a module-level `skip_no_tac = pytest.mark.skipif(shutil.which("tac") is None, ...)` applied to each test, matching `test_fmt.py`'s named-mark shape |

`spawnSync` returns `status: null` if the spawn itself fails, which falls to
"skip" rather than "fail" — the safe direction for an undeterminable host.

## Verification

Both directions checked on macOS (no host `tac`):

| | no `tac` on PATH | GNU-equivalent `tac` shim on PATH |
| --- | --- | --- |
| `vitest run src/commands/native_tac.test.ts` | 4 skipped | 4 passed |
| `pytest tests/commands/native/test_tac.py` | 6 skipped | 6 passed |

The shim (`awk '{a[NR]=$0} END{for(i=NR;i>0;i--) print a[i]}'`) reproduces GNU
`tac` for these inputs, so the "with tac" column also confirms mirage's `tac`
output still matches GNU byte-for-byte — the guard hides no real divergence.

Also run: full `pytest tests/commands/native/` (exit 0), the whole
`packages/node` command suite (846 passed / 10 skipped), `pnpm --filter
@struktoai/mirage-node typecheck`, and `pre-commit run --all-files` (all hooks
pass).

## Notes

Test-only change; no runtime or command-semantics code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)