### PR TITLE
fix: printf byte escapes and Google Sheets cell values

### DIFF
--- a/integ/bash/printf/basic.json
+++ b/integ/bash/printf/basic.json
@@ -1642,6 +1642,347 @@
         "stdout": "0\n",
         "stderr": "printf: abc: invalid number\n"
       }
+    },
+    {
+      "id": "printf_hex_escape_is_a_byte",
+      "seq": 501053,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "printf '\\xc3\\xa9' | od -An -tx1",
+      "expect": {
+        "exit": 0,
+        "stdout": "c3 a9\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_hex_escape_outside_utf8",
+      "seq": 501054,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "printf '\\xff' | od -An -tx1",
+      "expect": {
+        "exit": 0,
+        "stdout": "ff\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_octal_escape_is_a_byte",
+      "seq": 501055,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "printf '\\377' | od -An -tx1",
+      "expect": {
+        "exit": 0,
+        "stdout": "ff\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_unicode_escape_is_a_code_point",
+      "seq": 501056,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "printf '\\u00e9' | od -An -tx1",
+      "expect": {
+        "exit": 0,
+        "stdout": "c3 a9\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_b_conversion_reads_byte_escapes",
+      "seq": 501057,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "printf '%b' '\\xff' | od -An -tx1",
+      "expect": {
+        "exit": 0,
+        "stdout": "ff\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_byte_escape_survives_a_file",
+      "seq": 501058,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "mkdir -p /data/pf && printf '\\xff' > /data/pf/b && od -An -tx1 /data/pf/b",
+      "expect": {
+        "exit": 0,
+        "stdout": "ff\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_byte_escape_survives_a_variable",
+      "seq": 501059,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "printf -v x '\\xff'; printf '%s' \"$x\" | od -An -tx1",
+      "expect": {
+        "exit": 0,
+        "stdout": "ff\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_quotes_a_byte_as_octal",
+      "seq": 501060,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "printf -v x '\\xff'; printf '%q\\n' \"$x\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "$'\\377'\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_byte_escape_is_one_character",
+      "seq": 501061,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "printf -v x '\\xff'; echo ${#x}",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_byte_escape_reaches_a_here_string",
+      "seq": 501062,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "printf -v x '\\xff'; grep -c . <<< \"$x\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "echo_hex_escape_is_a_byte",
+      "seq": 501063,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "echo -e '\\xff' | od -An -tx1",
+      "expect": {
+        "exit": 0,
+        "stdout": "ff 0a\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/bash/printf/basic.json
+++ b/integ/bash/printf/basic.json
@@ -1983,6 +1983,192 @@
         "stdout": "ff 0a\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "printf_octal_past_a_byte_keeps_the_low_byte",
+      "seq": 501064,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "printf '\\400' | od -An -tx1",
+      "expect": {
+        "exit": 0,
+        "stdout": "00\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_octal_max_is_the_high_byte",
+      "seq": 501065,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "printf '\\777' | od -An -tx1",
+      "expect": {
+        "exit": 0,
+        "stdout": "ff\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "echo_octal_past_a_byte_keeps_the_low_byte",
+      "seq": 501066,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "echo -en '\\0777' | od -An -tx1",
+      "expect": {
+        "exit": 0,
+        "stdout": "ff\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_non_bmp_character_is_not_a_byte",
+      "seq": 501067,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "printf '\\U00010080' | od -An -tx1",
+      "expect": {
+        "exit": 0,
+        "stdout": "f0 90 82 80\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "echo_non_bmp_character_is_not_a_byte",
+      "seq": 501068,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "echo -n '𐂀' | od -An -tx1",
+      "expect": {
+        "exit": 0,
+        "stdout": "f0 90 82 80\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "printf_mixes_a_non_bmp_character_and_a_byte",
+      "seq": 501069,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "s3-prefix",
+        "databricks-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder"
+      ],
+      "command": "printf '\\U00010080\\xff' | od -An -tx1",
+      "expect": {
+        "exit": 0,
+        "stdout": "f0 90 82 80 ff\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/fixtures/google-apps/v1.json
+++ b/integ/fixtures/google-apps/v1.json
@@ -1,5 +1,5 @@
 [
   {"kind": "doc", "name": "Q1 Plan", "text": "hello gdoc"},
-  {"kind": "sheet", "name": "Metrics", "rows": [["region", "revenue"], ["emea", "120"]]},
+  {"kind": "sheet", "name": "Metrics", "rows": [["region", "revenue", "flag", "code", "exp"], ["emea", "120", "TRUE", "0x10", "1e3"]]},
   {"kind": "slide", "name": "Launch Deck"}
 ]

--- a/integ/resources/google/g.json
+++ b/integ/resources/google/g.json
@@ -136,7 +136,7 @@
       "command": "gws sheets spreadsheets create --json '{\"properties\": {\"title\": \"Data\"}}'",
       "expect": {
         "exit": 0,
-        "stdout": "{\"spreadsheetId\":\"sheet0001\",\"properties\":{\"title\":\"Data\",\"locale\":\"en_US\",\"timeZone\":\"Etc/UTC\"},\"sheets\":[{\"properties\":{\"sheetId\":0,\"title\":\"Sheet1\",\"index\":0,\"sheetType\":\"GRID\",\"gridProperties\":{\"rowCount\":1000,\"columnCount\":26}}}],\"spreadsheetUrl\":\"https://docs.google.com/spreadsheets/d/sheet0001/edit\"}",
+        "stdout": "{\"spreadsheetId\":\"sheet0001\",\"properties\":{\"title\":\"Data\",\"locale\":\"en_US\",\"autoRecalc\":\"ON_CHANGE\",\"timeZone\":\"Etc/GMT\"},\"sheets\":[{\"properties\":{\"sheetId\":0,\"title\":\"Sheet1\",\"index\":0,\"sheetType\":\"GRID\",\"gridProperties\":{\"rowCount\":1000,\"columnCount\":26}}}],\"spreadsheetUrl\":\"https://docs.google.com/spreadsheets/d/sheet0001/edit\"}",
         "stderr": ""
       }
     },
@@ -178,7 +178,7 @@
       "command": "gws sheets spreadsheets get --params '{\"spreadsheetId\": \"sheet0001\"}'",
       "expect": {
         "exit": 0,
-        "stdout": "{\"spreadsheetId\":\"sheet0001\",\"properties\":{\"title\":\"Data\",\"locale\":\"en_US\",\"timeZone\":\"Etc/UTC\"},\"sheets\":[{\"properties\":{\"sheetId\":0,\"title\":\"Sheet1\",\"index\":0,\"sheetType\":\"GRID\",\"gridProperties\":{\"rowCount\":1000,\"columnCount\":26}}}],\"spreadsheetUrl\":\"https://docs.google.com/spreadsheets/d/sheet0001/edit\"}",
+        "stdout": "{\"spreadsheetId\":\"sheet0001\",\"properties\":{\"title\":\"Data\",\"locale\":\"en_US\",\"autoRecalc\":\"ON_CHANGE\",\"timeZone\":\"Etc/GMT\"},\"sheets\":[{\"properties\":{\"sheetId\":0,\"title\":\"Sheet1\",\"index\":0,\"sheetType\":\"GRID\",\"gridProperties\":{\"rowCount\":1000,\"columnCount\":26}}}],\"spreadsheetUrl\":\"https://docs.google.com/spreadsheets/d/sheet0001/edit\"}",
         "stderr": ""
       }
     },
@@ -192,7 +192,7 @@
       "command": "gws sheets spreadsheets batchUpdate --params '{\"spreadsheetId\": \"sheet0001\"}' --json '{\"requests\": [{\"addSheet\": {\"properties\": {\"title\": \"Extra\"}}}]}'",
       "expect": {
         "exit": 0,
-        "stdout": "{\"spreadsheetId\":\"sheet0001\",\"replies\":[{\"addSheet\":{\"properties\":{\"sheetId\":1,\"title\":\"Extra\"}}}]}",
+        "stdout": "{\"spreadsheetId\":\"sheet0001\",\"replies\":[{\"addSheet\":{\"properties\":{\"sheetId\":1,\"title\":\"Extra\",\"index\":1,\"sheetType\":\"GRID\",\"gridProperties\":{\"rowCount\":1000,\"columnCount\":26}}}}]}",
         "stderr": ""
       }
     },

--- a/integ/resources/google/gapp.json
+++ b/integ/resources/google/gapp.json
@@ -283,7 +283,7 @@
       "command": "cat /sheets/owned/*.gsheet.json | jq -c '[.sheets[0].data[0].rowData[].values[].formattedValue]'",
       "expect": {
         "exit": 0,
-        "stdout": "[\"region\",\"revenue\",\"emea\",\"120\",\"apac\",\"90\"]\n",
+        "stdout": "[\"region\",\"revenue\",\"flag\",\"code\",\"exp\",\"emea\",\"120\",\"TRUE\",\"0x10\",\"1.00E+03\",\"apac\",\"90\"]\n",
         "stderr": ""
       }
     },
@@ -309,7 +309,20 @@
       "command": "cat /sheets/owned/*.gsheet.json | jq -c '[.sheets[0].data[0].rowData[] | [.values[].formattedValue]]'",
       "expect": {
         "exit": 0,
-        "stdout": "[[\"region\",\"revenue\"],[\"emea\",\"120\"],[\"apac\",\"90\"]]\n",
+        "stdout": "[[\"region\",\"revenue\",\"flag\",\"code\",\"exp\"],[\"emea\",\"120\",\"TRUE\",\"0x10\",\"1.00E+03\"],[\"apac\",\"90\"]]\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_sheets_cell_types_follow_user_entered",
+      "seq": 520023,
+      "targets": [
+        "gapps"
+      ],
+      "command": "cat /sheets/owned/*.gsheet.json | jq -c '[.sheets[0].data[0].rowData[1].values[] | (.userEnteredValue | keys[0])]'",
+      "expect": {
+        "exit": 0,
+        "stdout": "[\"stringValue\",\"numberValue\",\"boolValue\",\"stringValue\",\"numberValue\"]\n",
         "stderr": ""
       }
     }

--- a/integ/resources/google/gapp.json
+++ b/integ/resources/google/gapp.json
@@ -273,6 +273,45 @@
         "stdout": "",
         "stderr": "cp: cannot create regular file '/docs/owned/in2.txt': Operation not supported\n"
       }
+    },
+    {
+      "id": "gapp_sheets_cells",
+      "seq": 520020,
+      "targets": [
+        "gapps"
+      ],
+      "command": "cat /sheets/owned/*.gsheet.json | jq -c '[.sheets[0].data[0].rowData[].values[].formattedValue]'",
+      "expect": {
+        "exit": 0,
+        "stdout": "[\"region\",\"revenue\",\"emea\",\"120\",\"apac\",\"90\"]\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_sheets_cell_value_is_typed",
+      "seq": 520021,
+      "targets": [
+        "gapps"
+      ],
+      "command": "cat /sheets/owned/*.gsheet.json | jq -c '.sheets[0].data[0].rowData[1].values[1].effectiveValue'",
+      "expect": {
+        "exit": 0,
+        "stdout": "{\"numberValue\":120}\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_sheets_row_is_a_grid_row",
+      "seq": 520022,
+      "targets": [
+        "gapps"
+      ],
+      "command": "cat /sheets/owned/*.gsheet.json | jq -c '[.sheets[0].data[0].rowData[] | [.values[].formattedValue]]'",
+      "expect": {
+        "exit": 0,
+        "stdout": "[[\"region\",\"revenue\"],[\"emea\",\"120\"],[\"apac\",\"90\"]]\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/server/gws_server.ts
+++ b/integ/server/gws_server.ts
@@ -42,6 +42,13 @@ const SHEET_MIME = 'application/vnd.google-apps.spreadsheet'
 const SLIDE_MIME = 'application/vnd.google-apps.presentation'
 const OWNER = { displayName: 'Integ User', emailAddress: 'integ@example.com', me: true }
 
+// The grid a new spreadsheet gets, and the pixel sizes the live API
+// reports for its untouched rows and columns.
+const GRID_ROWS = 1000
+const GRID_COLUMNS = 26
+const ROW_PIXELS = 21
+const COLUMN_PIXELS = 100
+
 interface Revision {
   id: string
   modifiedTime: string
@@ -650,19 +657,62 @@ function rangeLabel(tab: SheetTab, startRow: number, startCol: number, values: s
   return `${tab.title}!${start}:${end}`
 }
 
-function fmtSpreadsheet(id: string): Record<string, unknown> {
+// Verified against the live API on 2026-08-05, writing through mirage's own
+// path (values.update with valueInputOption=USER_ENTERED): a value that
+// parses as a number is stored as one, everything else stays a string, and
+// formattedValue is the text either way. An untouched cell is `{}` — no
+// keys at all, since ExtendedValue with no field set means empty.
+function cellData(text: string): Record<string, unknown> {
+  if (text === '') return {}
+  const numeric = Number.isFinite(Number(text))
+  const value = numeric ? { numberValue: Number(text) } : { stringValue: text }
+  return { userEnteredValue: value, effectiveValue: value, formattedValue: text }
+}
+
+// One GridData per tab, in the shape `includeGridData=true` returns: row
+// entries up to the last written row, cell entries up to the last written
+// column of that row, `{}` for a row with nothing in it, and metadata for
+// every row and column of the grid. `startRow`/`startColumn` are absent
+// because the live API omits them at zero.
+function gridData(tab: SheetTab): Record<string, unknown>[] {
+  const rows = rangeValues({ tab, startRow: 0, startCol: 0, endRow: null, endCol: null })
+  return [
+    {
+      rowData: rows.map((row) => (row.length === 0 ? {} : { values: row.map(cellData) })),
+      rowMetadata: Array.from({ length: GRID_ROWS }, () => ({ pixelSize: ROW_PIXELS })),
+      columnMetadata: Array.from({ length: GRID_COLUMNS }, () => ({ pixelSize: COLUMN_PIXELS })),
+    },
+  ]
+}
+
+function tabProperties(tab: SheetTab, index: number): Record<string, unknown> {
+  return {
+    sheetId: tab.sheetId,
+    title: tab.title,
+    index,
+    sheetType: 'GRID',
+    gridProperties: { rowCount: GRID_ROWS, columnCount: GRID_COLUMNS },
+  }
+}
+
+function fmtSpreadsheet(id: string, includeGridData = false): Record<string, unknown> {
   const sheet = state.sheets.get(id) as Spreadsheet
   return {
     spreadsheetId: id,
-    properties: { title: sheet.title, locale: 'en_US', timeZone: 'Etc/UTC' },
+    // The live API also carries defaultFormat and spreadsheetTheme here,
+    // which are styling this server has no model for and mirage never
+    // reads.
+    properties: {
+      title: sheet.title,
+      locale: 'en_US',
+      autoRecalc: 'ON_CHANGE',
+      timeZone: 'Etc/GMT',
+    },
     sheets: sheet.tabs.map((tab, index) => ({
-      properties: {
-        sheetId: tab.sheetId,
-        title: tab.title,
-        index,
-        sheetType: 'GRID',
-        gridProperties: { rowCount: 1000, columnCount: 26 },
-      },
+      properties: tabProperties(tab, index),
+      // Real Sheets omits `data` entirely without includeGridData, which
+      // is the whole reason mirage asks for it.
+      ...(includeGridData ? { data: gridData(tab) } : {}),
     })),
     spreadsheetUrl: `https://docs.google.com/spreadsheets/d/${id}/edit`,
   }
@@ -682,7 +732,9 @@ function sheetsBatchUpdate(id: string, requests: Record<string, unknown>[]): [nu
       }
       sheet.nextSheetId += 1
       sheet.tabs.push(tab)
-      replies.push({ addSheet: { properties: { sheetId: tab.sheetId, title: tab.title } } })
+      // The live API replies with the whole SheetProperties, not just the
+      // id and title.
+      replies.push({ addSheet: { properties: tabProperties(tab, sheet.tabs.length - 1) } })
     } else if ('deleteSheet' in request) {
       const r = request.deleteSheet as { sheetId?: number }
       sheet.tabs = sheet.tabs.filter((t) => t.sheetId !== r.sheetId)
@@ -1412,7 +1464,7 @@ function route(ctx: Ctx): [number, object | Buffer | null, string?] {
   m = /^\/v4\/spreadsheets\/([^/:]+)$/.exec(path)
   if (m !== null && method === 'GET') {
     if (!state.sheets.has(m[1] as string)) return NOT_FOUND
-    return [200, fmtSpreadsheet(m[1] as string)]
+    return [200, fmtSpreadsheet(m[1] as string, query.get('includeGridData') === 'true')]
   }
   m = /^\/v4\/spreadsheets\/([^/:]+):batchUpdate$/.exec(path)
   if (m !== null && method === 'POST') {
@@ -1453,6 +1505,15 @@ function route(ctx: Ctx): [number, object | Buffer | null, string?] {
         200,
         {
           spreadsheetId: m[1],
+          // The table the append found, which the live API reports only
+          // when there was one; an empty tab has no tableRange at all.
+          ...(extent.rows > 0
+            ? {
+                tableRange:
+                  `${range.tab.title}!A1:` +
+                  `${colIndexToLetter(extent.cols - 1)}${String(extent.rows)}`,
+              }
+            : {}),
           updates: {
             spreadsheetId: m[1],
             updatedRange: rangeLabel(range.tab, startRow, range.startCol, values),

--- a/integ/server/gws_server.ts
+++ b/integ/server/gws_server.ts
@@ -657,15 +657,68 @@ function rangeLabel(tab: SheetTab, startRow: number, startCol: number, values: s
   return `${tab.title}!${start}:${end}`
 }
 
+// Plain decimal only: a sign, digits either side of a point, an optional
+// exponent. `0x10`, `1_000`, `Infinity` and a whitespace-only cell are all
+// strings in live Sheets, which `Number()` would have made numeric.
+const DECIMAL = /^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/
+const BOOLEAN = /^(true|false)$/i
+const EXPONENT = /[eE]/
+const EXPONENT_DIGITS = 2
+
+// A number typed with an exponent keeps a scientific format, which live
+// Sheets renders with two decimals and a two-digit exponent: `1e3` is
+// `"1.00E+03"`, `1e-3` is `"1.00E-03"`, `1e10` is `"1.00E+10"`.
+function scientific(value: number): string {
+  const [mantissa = '', exponent = ''] = value.toExponential(2).split('e')
+  const sign = exponent.startsWith('-') ? '-' : '+'
+  const digits = exponent.replace(/^[+-]/, '').padStart(EXPONENT_DIGITS, '0')
+  return `${mantissa}E${sign}${digits}`
+}
+
+// The grid a tab reports, which the live API grows to hold what was
+// written: 1313 written rows report rowCount 1313, and rowMetadata has one
+// entry per row of the grid rather than a fixed 1000.
+function tabGrid(tab: SheetTab): { rows: number; cols: number } {
+  const used = tabExtent(tab)
+  return {
+    rows: Math.max(GRID_ROWS, used.rows),
+    cols: Math.max(GRID_COLUMNS, used.cols),
+  }
+}
+
 // Verified against the live API on 2026-08-05, writing through mirage's own
-// path (values.update with valueInputOption=USER_ENTERED): a value that
-// parses as a number is stored as one, everything else stays a string, and
-// formattedValue is the text either way. An untouched cell is `{}` — no
-// keys at all, since ExtendedValue with no field set means empty.
+// path (values.update with valueInputOption=USER_ENTERED): `007` is the
+// number 7 and reports `"7"`, `4.50` reports `"4.5"`, `TRUE` and `true` are
+// both the boolean reporting `"TRUE"`, and everything else stays the string
+// it was typed as. An untouched cell is `{}` — no keys at all, since
+// ExtendedValue with no field set means empty.
+//
+// Not modeled, and a string here where live Sheets makes it a number: a
+// currency, percent, thousands-separated or date-shaped cell (`$5`, `50%`,
+// `1,234`, `2026-01-02`), which needs Sheets' locale-aware number formats.
+// A leading `+` is a formula in live Sheets (`+5` is formulaValue `"+5"`)
+// whose rendered value happens to match the number taken here.
 function cellData(text: string): Record<string, unknown> {
   if (text === '') return {}
-  const numeric = Number.isFinite(Number(text))
-  const value = numeric ? { numberValue: Number(text) } : { stringValue: text }
+  const trimmed = text.trim()
+  if (BOOLEAN.test(trimmed)) {
+    const value = { boolValue: trimmed.toLowerCase() === 'true' }
+    return {
+      userEnteredValue: value,
+      effectiveValue: value,
+      formattedValue: trimmed.toUpperCase(),
+    }
+  }
+  if (DECIMAL.test(trimmed)) {
+    const number = Number(trimmed)
+    const value = { numberValue: number }
+    return {
+      userEnteredValue: value,
+      effectiveValue: value,
+      formattedValue: EXPONENT.test(trimmed) ? scientific(number) : String(number),
+    }
+  }
+  const value = { stringValue: text }
   return { userEnteredValue: value, effectiveValue: value, formattedValue: text }
 }
 
@@ -676,22 +729,24 @@ function cellData(text: string): Record<string, unknown> {
 // because the live API omits them at zero.
 function gridData(tab: SheetTab): Record<string, unknown>[] {
   const rows = rangeValues({ tab, startRow: 0, startCol: 0, endRow: null, endCol: null })
+  const grid = tabGrid(tab)
   return [
     {
       rowData: rows.map((row) => (row.length === 0 ? {} : { values: row.map(cellData) })),
-      rowMetadata: Array.from({ length: GRID_ROWS }, () => ({ pixelSize: ROW_PIXELS })),
-      columnMetadata: Array.from({ length: GRID_COLUMNS }, () => ({ pixelSize: COLUMN_PIXELS })),
+      rowMetadata: Array.from({ length: grid.rows }, () => ({ pixelSize: ROW_PIXELS })),
+      columnMetadata: Array.from({ length: grid.cols }, () => ({ pixelSize: COLUMN_PIXELS })),
     },
   ]
 }
 
 function tabProperties(tab: SheetTab, index: number): Record<string, unknown> {
+  const grid = tabGrid(tab)
   return {
     sheetId: tab.sheetId,
     title: tab.title,
     index,
     sheetType: 'GRID',
-    gridProperties: { rowCount: GRID_ROWS, columnCount: GRID_COLUMNS },
+    gridProperties: { rowCount: grid.rows, columnCount: grid.cols },
   }
 }
 

--- a/python/mirage/core/gsheets/read.py
+++ b/python/mirage/core/gsheets/read.py
@@ -26,10 +26,16 @@ from mirage.utils.key_prefix import mount_key, mount_prefix_of
 
 logger = logging.getLogger(__name__)
 
+GRID_DATA_PARAM = "true"
+
 
 async def read_spreadsheet(token_manager: TokenManager,
                            spreadsheet_id: str) -> bytes:
-    """Fetch full spreadsheet JSON.
+    """Fetch full spreadsheet JSON, cell values included.
+
+    `spreadsheets.get` returns no grid data unless asked, so without
+    `includeGridData` the rendered `.gsheet.json` is tab metadata and
+    nothing an agent can read a cell from.
 
     Args:
         token_manager (TokenManager): manages OAuth2 tokens.
@@ -39,7 +45,8 @@ async def read_spreadsheet(token_manager: TokenManager,
         bytes: JSON response as bytes.
     """
     url = f"{sheets_base(token_manager)}/spreadsheets/{spreadsheet_id}"
-    data = await google_get(token_manager, url)
+    data = await google_get(token_manager, url,
+                            {"includeGridData": GRID_DATA_PARAM})
     return json.dumps(data, ensure_ascii=False, separators=(",", ":")).encode()
 
 

--- a/python/mirage/resource/gsheets/prompt.py
+++ b/python/mirage/resource/gsheets/prompt.py
@@ -48,7 +48,7 @@ PROMPT = """\
                     {{ "formattedValue": "...",
                       "userEnteredValue": {{...}},
                       "effectiveValue": {{...}} }}
-                ]}}    # empty cells are omitted, not nullified
+                ]}}    # an empty cell is {{}}, a trailing one absent
               ]
             }}
           ]

--- a/python/mirage/shell/bytes.py
+++ b/python/mirage/shell/bytes.py
@@ -1,0 +1,45 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+SURROGATE_BASE = 0xDC00
+ASCII_MAX = 0x80
+
+
+def byte_char(value: int) -> str:
+    """Stand in for one raw output byte inside a text string.
+
+    `\\xHH` and `\\NNN` name a byte, not a code point: bash writes
+    `\\xff` as the single byte 0xFF, which is not valid UTF-8 on its own
+    and so has no character to stand for it. A byte above ASCII is
+    therefore carried as its surrogate escape, the same convention
+    Python's own filesystem paths use, and `encode_text` turns it back
+    into that byte.
+
+    Args:
+        value (int): the byte the escape asked for, 0-255.
+    """
+    return chr(value) if value < ASCII_MAX else chr(SURROGATE_BASE + value)
+
+
+def encode_text(text: str) -> bytes:
+    """Encode shell text for output, byte escapes included.
+
+    Every place the shell turns its own text into bytes goes through
+    here, because a string that reached it from `byte_char` cannot be
+    encoded as plain UTF-8 at all.
+
+    Args:
+        text (str): the text to write.
+    """
+    return text.encode("utf-8", "surrogateescape")

--- a/python/mirage/shell/bytes.py
+++ b/python/mirage/shell/bytes.py
@@ -14,6 +14,7 @@
 
 SURROGATE_BASE = 0xDC00
 ASCII_MAX = 0x80
+BYTE_MASK = 0xFF
 
 
 def byte_char(value: int) -> str:
@@ -26,10 +27,15 @@ def byte_char(value: int) -> str:
     Python's own filesystem paths use, and `encode_text` turns it back
     into that byte.
 
+    Three octal digits reach past one byte (`\\400` is 256, `\\777` is
+    511) and bash writes the low byte of those, so the value is masked
+    rather than refused.
+
     Args:
-        value (int): the byte the escape asked for, 0-255.
+        value (int): the value the escape asked for, masked to one byte.
     """
-    return chr(value) if value < ASCII_MAX else chr(SURROGATE_BASE + value)
+    byte = value & BYTE_MASK
+    return chr(byte) if byte < ASCII_MAX else chr(SURROGATE_BASE + byte)
 
 
 def encode_text(text: str) -> bytes:

--- a/python/mirage/workspace/executor/builtins/text.py
+++ b/python/mirage/workspace/executor/builtins/text.py
@@ -19,6 +19,7 @@ from mirage.commands.spec.shell import ECHO_OPTION
 from mirage.io import IOResult
 from mirage.io.types import ByteSource
 from mirage.shell.array import array_extent, array_set
+from mirage.shell.bytes import byte_char, encode_text
 from mirage.workspace.expand.variable import _array_index
 from mirage.workspace.session import Session
 from mirage.workspace.types import ExecutionNode
@@ -73,7 +74,7 @@ def _interpret_escapes(text: str) -> str:
                 digits.append(text[j])
                 j += 1
             if digits:
-                out.append(chr(int("".join(digits), 16)))
+                out.append(byte_char(int("".join(digits), 16)))
                 i = j
             else:
                 out.append("\\x")
@@ -85,7 +86,7 @@ def _interpret_escapes(text: str) -> str:
             while j < n and len(digits) < 3 and text[j] in _OCT:
                 digits.append(text[j])
                 j += 1
-            out.append(chr(int("".join(digits), 8)) if digits else "\0")
+            out.append(byte_char(int("".join(digits), 8)) if digits else "\0")
             i = j
         else:
             # unknown escape — pass through literally
@@ -127,7 +128,7 @@ async def handle_echo(
         text = _interpret_escapes(text)
     if not no_newline:
         text += "\n"
-    out = text.encode()
+    out = encode_text(text)
     return out, IOResult(), ExecutionNode(command="echo", exit_code=0)
 
 
@@ -423,7 +424,7 @@ def _expand_escapes(s: str) -> tuple[str, bool]:
 def _quote_shell(s: str) -> str:
     if s == "":
         return "''"
-    data = s.encode("utf-8")
+    data = encode_text(s)
     need_ansic = any(b < 0x20 or b == 0x7F or b >= 0x80 for b in data)
     if need_ansic:
         parts = ["$'"]
@@ -470,7 +471,10 @@ def _read_escape(fmt: str, i: int) -> tuple[str, int, bool]:
             digits.append(fmt[j])
             j += 1
         if digits:
-            return chr(int("".join(digits), 16)), j, False
+            value = int("".join(digits), 16)
+            # \x names a byte; \u and \U name a code point.
+            text = byte_char(value) if ch == "x" else chr(value)
+            return text, j, False
         return "\\" + ch, i + 2, False
     if ch in _OCT:
         digits = []
@@ -482,7 +486,7 @@ def _read_escape(fmt: str, i: int) -> tuple[str, int, bool]:
             j += 1
         if not digits:
             return "\0", j, False
-        return chr(int("".join(digits), 8)), j, False
+        return byte_char(int("".join(digits), 8)), j, False
     return "\\" + ch, i + 2, False
 
 
@@ -754,7 +758,7 @@ async def handle_printf(
         return None, IOResult(exit_code=exit_code, stderr=err_bytes
                               or None), ExecutionNode(command="printf",
                                                       exit_code=exit_code)
-    out = output.encode()
+    out = encode_text(output)
     if errors:
         return out, IOResult(exit_code=1,
                              stderr=err_bytes), ExecutionNode(command="printf",

--- a/python/mirage/workspace/executor/redirect.py
+++ b/python/mirage/workspace/executor/redirect.py
@@ -20,6 +20,7 @@ from mirage.io import IOResult
 from mirage.io.stream import materialize
 from mirage.io.types import ByteSource
 from mirage.shell.barrier import BarrierPolicy, apply_barrier
+from mirage.shell.bytes import encode_text
 from mirage.shell.call_stack import CallStack
 from mirage.shell.types import Redirect, RedirectKind
 from mirage.types import PathSpec
@@ -88,8 +89,8 @@ async def handle_redirect(
                 return _redirect_failure(scope, exc)
             cmd_stdin = file_data
         elif r.kind == RedirectKind.HEREDOC:
-            cmd_stdin = r.target.encode() if isinstance(r.target,
-                                                        str) else r.target
+            cmd_stdin = encode_text(r.target) if isinstance(r.target,
+                                                            str) else r.target
         elif r.kind == RedirectKind.HERESTRING:
             text = r.target
             if isinstance(text, str):
@@ -97,7 +98,7 @@ async def handle_redirect(
                     text = text[1:-1]
                 elif text.startswith("'") and text.endswith("'"):
                     text = text[1:-1]
-                cmd_stdin = (text + "\n").encode()
+                cmd_stdin = encode_text(text + "\n")
             else:
                 cmd_stdin = text
 

--- a/python/mirage/workspace/node/command_dispatch.py
+++ b/python/mirage/workspace/node/command_dispatch.py
@@ -20,6 +20,7 @@ from mirage.io import IOResult
 from mirage.io.types import materialize
 from mirage.policy import CommandContext, resolve_limit
 from mirage.runtime.policy import PolicyDecision
+from mirage.shell.bytes import encode_text
 from mirage.shell.types import NodeType as NT
 from mirage.shell.types import ShellBuiltin as SB
 from mirage.shell.xtrace import trace_command
@@ -194,7 +195,7 @@ async def _dispatch_command_body(
                 for sc in child.named_children:
                     content = await expand_node(sc, session, execute_fn,
                                                 call_stack)
-                    stdin = content.encode() + b"\n"
+                    stdin = encode_text(content) + b"\n"
                     break
 
     # Process substitution: <(cmd) feeds inner stdout as stdin.

--- a/python/tests/core/gsheets/test_read.py
+++ b/python/tests/core/gsheets/test_read.py
@@ -12,13 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from mirage.accessor.gsheets import GSheetsAccessor
 from mirage.cache.index.ram import RAMIndexCacheStore
-from mirage.core.gsheets.read import read
+from mirage.core.gsheets.read import read, read_spreadsheet
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_key
 
@@ -88,3 +89,18 @@ async def test_read_missing_file_raises_after_recursion(accessor, index):
         )
         with pytest.raises(FileNotFoundError):
             await read(accessor, path, index)
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_asks_for_grid_data():
+    # spreadsheets.get returns no cell values unless asked, so the
+    # rendered .gsheet.json would be tab metadata without this.
+    token_manager = SimpleNamespace(config=SimpleNamespace(api_base=""))
+    with patch(
+            "mirage.core.gsheets.read.google_get",
+            new_callable=AsyncMock,
+            return_value={"spreadsheetId": "s1"},
+    ) as get:
+        await read_spreadsheet(token_manager, "s1")
+    assert get.await_args.args[1].endswith("/spreadsheets/s1")
+    assert get.await_args.args[2] == {"includeGridData": "true"}

--- a/python/tests/shell/test_bytes.py
+++ b/python/tests/shell/test_bytes.py
@@ -1,0 +1,20 @@
+from mirage.shell.bytes import byte_char, encode_text
+
+
+def test_ascii_bytes_stand_for_themselves():
+    assert byte_char(0x41) == "A"
+    assert byte_char(0x00) == "\0"
+    assert encode_text(byte_char(0x41)) == b"A"
+
+
+def test_a_byte_above_ascii_round_trips():
+    assert encode_text(byte_char(0xFF)) == b"\xff"
+    assert encode_text(byte_char(0xC3) + byte_char(0xA9)) == b"\xc3\xa9"
+
+
+def test_ordinary_text_still_encodes_as_utf8():
+    assert encode_text("café\n") == "café\n".encode()
+
+
+def test_bytes_and_text_mix():
+    assert encode_text("a" + byte_char(0xFF) + "b") == b"a\xffb"

--- a/python/tests/shell/test_bytes.py
+++ b/python/tests/shell/test_bytes.py
@@ -18,3 +18,15 @@ def test_ordinary_text_still_encodes_as_utf8():
 
 def test_bytes_and_text_mix():
     assert encode_text("a" + byte_char(0xFF) + "b") == b"a\xffb"
+
+
+def test_three_octal_digits_past_a_byte_keep_the_low_byte():
+    # bash writes \400 as 0x00 and \777 as 0xff.
+    assert encode_text(byte_char(0o400)) == b"\x00"
+    assert encode_text(byte_char(0o777)) == b"\xff"
+
+
+def test_a_non_bmp_character_is_not_a_byte():
+    assert encode_text("\U00010080") == "\U00010080".encode()
+    assert encode_text("a\U00010080" +
+                       byte_char(0xFF)) == "a\U00010080".encode() + b"\xff"

--- a/python/tests/workspace/executor/builtins/test_text.py
+++ b/python/tests/workspace/executor/builtins/test_text.py
@@ -1,5 +1,6 @@
 import pytest
 
+from mirage.shell.bytes import byte_char
 from mirage.workspace.executor.builtins.text import handle_echo, handle_printf
 from mirage.workspace.session import Session
 
@@ -42,6 +43,13 @@ async def test_trailing_n_prints_literally():
 @pytest.mark.asyncio
 async def test_cluster_ne():
     assert await echo_bytes(["-ne", "a\\tb"]) == b"a\tb"
+
+
+@pytest.mark.asyncio
+async def test_echo_hex_and_octal_escapes_name_bytes():
+    assert await echo_bytes(["-ne", "\\xff"]) == b"\xff"
+    assert await echo_bytes(["-ne", "\\0377"]) == b"\xff"
+    assert await echo_bytes(["-ne", "\\xc3\\xa9"]) == "é".encode()
 
 
 @pytest.mark.asyncio
@@ -177,6 +185,22 @@ async def test_printf_char_empty_is_nul():
 async def test_printf_unicode_escapes():
     assert await printf_bytes(["\\u00e9\n"]) == "é\n".encode()
     assert await printf_bytes(["\\U0001F600"]) == "😀".encode()
+
+
+@pytest.mark.asyncio
+async def test_printf_hex_and_octal_escapes_name_bytes():
+    # bash writes \xff as the byte 0xFF, which is not valid UTF-8 at
+    # all, rather than as the code point U+00FF.
+    assert await printf_bytes(["\\xff"]) == b"\xff"
+    assert await printf_bytes(["\\377"]) == b"\xff"
+    assert await printf_bytes(["\\xc3\\xa9"]) == "é".encode()
+    assert await printf_bytes(["\\x41\\x42"]) == b"AB"
+    assert await printf_bytes(["%b", "\\xff"]) == b"\xff"
+
+
+@pytest.mark.asyncio
+async def test_printf_quotes_a_raw_byte_as_octal():
+    assert await printf_bytes(["%q\n", byte_char(0xFF)]) == b"$'\\377'\n"
 
 
 @pytest.mark.asyncio

--- a/typescript/packages/core/src/core/gsheets/read.test.ts
+++ b/typescript/packages/core/src/core/gsheets/read.test.ts
@@ -33,7 +33,7 @@ import { PathSpec } from '../../types.ts'
 import type { TokenManager } from '../google/_client.ts'
 import * as drive from '../google/drive.ts'
 import * as client from '../google/_client.ts'
-import { read } from './read.ts'
+import { read, readSpreadsheet } from './read.ts'
 
 const STUB_TOKEN_MANAGER = {
   config: { clientId: 'cid', refreshToken: 'rt' },
@@ -81,5 +81,12 @@ describe('gsheets read auto-bootstrap', () => {
       resourcePath: mountKey('/gsheets/owned/Missing__xyz.gsheet.json', '/gsheets'),
     })
     await expect(read(accessor, path, index)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('asks for grid data, which spreadsheets.get omits by default', async () => {
+    vi.mocked(client.googleGet).mockResolvedValue({ spreadsheetId: 's1' })
+    await readSpreadsheet(STUB_TOKEN_MANAGER, 's1')
+    expect(vi.mocked(client.googleGet).mock.lastCall?.[1]).toMatch(/\/spreadsheets\/s1$/)
+    expect(vi.mocked(client.googleGet).mock.lastCall?.[2]).toEqual({ includeGridData: 'true' })
   })
 })

--- a/typescript/packages/core/src/core/gsheets/read.ts
+++ b/typescript/packages/core/src/core/gsheets/read.ts
@@ -23,12 +23,21 @@ import { enoent } from '../../utils/errors.ts'
 
 const ENC = new TextEncoder()
 
+const GRID_DATA_PARAM = 'true'
+
+/**
+ * Fetch full spreadsheet JSON, cell values included.
+ *
+ * `spreadsheets.get` returns no grid data unless asked, so without
+ * `includeGridData` the rendered `.gsheet.json` is tab metadata and nothing
+ * an agent can read a cell from.
+ */
 export async function readSpreadsheet(
   tm: TokenManager,
   spreadsheetId: string,
 ): Promise<Uint8Array> {
   const url = `${sheetsBase(tm)}/spreadsheets/${spreadsheetId}`
-  const data = await googleGet(tm, url)
+  const data = await googleGet(tm, url, { includeGridData: GRID_DATA_PARAM })
   return ENC.encode(JSON.stringify(data))
 }
 

--- a/typescript/packages/core/src/resource/gsheets/prompt.ts
+++ b/typescript/packages/core/src/resource/gsheets/prompt.ts
@@ -47,7 +47,7 @@ export const GSHEETS_PROMPT = `{prefix}
                     { "formattedValue": "...",
                       "userEnteredValue": {...},
                       "effectiveValue": {...} }
-                ]}    # empty cells are omitted, not nullified
+                ]}    # an empty cell is {}, a trailing one absent
               ]
             }
           ]

--- a/typescript/packages/core/src/shell/bytes.test.ts
+++ b/typescript/packages/core/src/shell/bytes.test.ts
@@ -1,0 +1,37 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { describe, expect, it } from 'vitest'
+import { byteChar, encodeText } from './bytes.ts'
+
+describe('byteChar / encodeText', () => {
+  it('stands for an ASCII byte as itself', () => {
+    expect(byteChar(0x41)).toBe('A')
+    expect(byteChar(0)).toBe('\0')
+    expect([...encodeText(byteChar(0x41))]).toEqual([0x41])
+  })
+
+  it('round trips a byte above ASCII', () => {
+    expect([...encodeText(byteChar(0xff))]).toEqual([0xff])
+    expect([...encodeText(byteChar(0xc3) + byteChar(0xa9))]).toEqual([0xc3, 0xa9])
+  })
+
+  it('still encodes ordinary text as UTF-8', () => {
+    expect([...encodeText('café\n')]).toEqual([...new TextEncoder().encode('café\n')])
+  })
+
+  it('mixes bytes and text', () => {
+    expect([...encodeText('a' + byteChar(0xff) + 'b')]).toEqual([0x61, 0xff, 0x62])
+  })
+})

--- a/typescript/packages/core/src/shell/bytes.test.ts
+++ b/typescript/packages/core/src/shell/bytes.test.ts
@@ -34,4 +34,21 @@ describe('byteChar / encodeText', () => {
   it('mixes bytes and text', () => {
     expect([...encodeText('a' + byteChar(0xff) + 'b')]).toEqual([0x61, 0xff, 0x62])
   })
+
+  it('keeps the low byte of an octal escape past one byte', () => {
+    // bash writes \400 as 0x00 and \777 as 0xff.
+    expect([...encodeText(byteChar(0o400))]).toEqual([0x00])
+    expect([...encodeText(byteChar(0o777))]).toEqual([0xff])
+  })
+
+  it('does not read a non-BMP character as a byte', () => {
+    // U+10080 is the surrogate pair D800 DC80, and DC80 is a sentinel
+    // only when it stands alone.
+    const pair = '\u{10080}'
+    expect([...encodeText(pair)]).toEqual([...new TextEncoder().encode(pair)])
+    expect([...encodeText('a' + pair + byteChar(0xff))]).toEqual([
+      ...new TextEncoder().encode('a' + pair),
+      0xff,
+    ])
+  })
 })

--- a/typescript/packages/core/src/shell/bytes.ts
+++ b/typescript/packages/core/src/shell/bytes.ts
@@ -17,7 +17,10 @@ const ENC = new TextEncoder()
 const SURROGATE_BASE = 0xdc00
 const SURROGATE_LOW = 0xdc80
 const SURROGATE_HIGH = 0xdcff
+const HIGH_SURROGATE_LOW = 0xd800
+const HIGH_SURROGATE_HIGH = 0xdbff
 const ASCII_MAX = 0x80
+const BYTE_MASK = 0xff
 
 /**
  * Stand in for one raw output byte inside a text string.
@@ -27,9 +30,29 @@ const ASCII_MAX = 0x80
  * character to stand for it. A byte above ASCII is therefore carried as
  * its surrogate escape, the same convention Python's own filesystem paths
  * use, and `encodeText` turns it back into that byte.
+ *
+ * Three octal digits reach past one byte (`\400` is 256, `\777` is 511)
+ * and bash writes the low byte of those, so the value is masked rather
+ * than refused.
  */
 export function byteChar(value: number): string {
-  return String.fromCharCode(value < ASCII_MAX ? value : SURROGATE_BASE + value)
+  const byte = value & BYTE_MASK
+  return String.fromCharCode(byte < ASCII_MAX ? byte : SURROGATE_BASE + byte)
+}
+
+/**
+ * Whether the code unit at `i` is a byte this module smuggled in.
+ *
+ * The sentinels are lone low surrogates, and a low surrogate that follows
+ * a high one is half of an ordinary non-BMP character (`𐂀` is
+ * U+D800 U+DC80) that must be encoded as itself.
+ */
+function isByteSentinel(text: string, i: number): boolean {
+  const code = text.charCodeAt(i)
+  if (code < SURROGATE_LOW || code > SURROGATE_HIGH) return false
+  if (i === 0) return true
+  const before = text.charCodeAt(i - 1)
+  return before < HIGH_SURROGATE_LOW || before > HIGH_SURROGATE_HIGH
 }
 
 /**
@@ -42,8 +65,7 @@ export function byteChar(value: number): string {
 export function encodeText(text: string): Uint8Array {
   let first = -1
   for (let i = 0; i < text.length; i++) {
-    const code = text.charCodeAt(i)
-    if (code >= SURROGATE_LOW && code <= SURROGATE_HIGH) {
+    if (isByteSentinel(text, i)) {
       first = i
       break
     }
@@ -52,13 +74,12 @@ export function encodeText(text: string): Uint8Array {
   const parts: Uint8Array[] = []
   let run = ''
   for (let i = 0; i < text.length; i++) {
-    const code = text.charCodeAt(i)
-    if (code >= SURROGATE_LOW && code <= SURROGATE_HIGH) {
+    if (isByteSentinel(text, i)) {
       if (run !== '') {
         parts.push(ENC.encode(run))
         run = ''
       }
-      parts.push(new Uint8Array([code - SURROGATE_BASE]))
+      parts.push(new Uint8Array([text.charCodeAt(i) - SURROGATE_BASE]))
     } else {
       run += text.charAt(i)
     }

--- a/typescript/packages/core/src/shell/bytes.ts
+++ b/typescript/packages/core/src/shell/bytes.ts
@@ -1,0 +1,76 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+const ENC = new TextEncoder()
+
+const SURROGATE_BASE = 0xdc00
+const SURROGATE_LOW = 0xdc80
+const SURROGATE_HIGH = 0xdcff
+const ASCII_MAX = 0x80
+
+/**
+ * Stand in for one raw output byte inside a text string.
+ *
+ * `\xHH` and `\NNN` name a byte, not a code point: bash writes `\xff` as
+ * the single byte 0xFF, which is not valid UTF-8 on its own and so has no
+ * character to stand for it. A byte above ASCII is therefore carried as
+ * its surrogate escape, the same convention Python's own filesystem paths
+ * use, and `encodeText` turns it back into that byte.
+ */
+export function byteChar(value: number): string {
+  return String.fromCharCode(value < ASCII_MAX ? value : SURROGATE_BASE + value)
+}
+
+/**
+ * Encode shell text for output, byte escapes included.
+ *
+ * Every place the shell turns its own text into bytes goes through here,
+ * because a string that reached it from `byteChar` holds a lone surrogate
+ * that `TextEncoder` would write as U+FFFD.
+ */
+export function encodeText(text: string): Uint8Array {
+  let first = -1
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i)
+    if (code >= SURROGATE_LOW && code <= SURROGATE_HIGH) {
+      first = i
+      break
+    }
+  }
+  if (first === -1) return ENC.encode(text)
+  const parts: Uint8Array[] = []
+  let run = ''
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i)
+    if (code >= SURROGATE_LOW && code <= SURROGATE_HIGH) {
+      if (run !== '') {
+        parts.push(ENC.encode(run))
+        run = ''
+      }
+      parts.push(new Uint8Array([code - SURROGATE_BASE]))
+    } else {
+      run += text.charAt(i)
+    }
+  }
+  if (run !== '') parts.push(ENC.encode(run))
+  let total = 0
+  for (const part of parts) total += part.length
+  const out = new Uint8Array(total)
+  let at = 0
+  for (const part of parts) {
+    out.set(part, at)
+    at += part.length
+  }
+  return out
+}

--- a/typescript/packages/core/src/workspace/executor/builtins.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins.test.ts
@@ -18,6 +18,7 @@ import { GENERAL_COMMANDS } from '../../commands/builtin/general/index.ts'
 import { IOResult, materialize } from '../../io/types.ts'
 import type { ByteSource } from '../../io/types.ts'
 import { RAMResource } from '../../resource/ram/ram.ts'
+import { byteChar } from '../../shell/bytes.ts'
 import { CallStack } from '../../shell/call_stack.ts'
 import { FileStat, FileType, MountMode } from '../../types.ts'
 import { MountRegistry } from '../mount/registry.ts'
@@ -381,6 +382,13 @@ describe('handleEcho', () => {
     const [out] = handleEcho(['-e', 'hi\\cgone'])
     expect(decode(out as Uint8Array)).toBe('hi\n')
   })
+
+  it('-e reads \\xHH and \\0NNN as bytes', () => {
+    const bytes = (args: string[]): number[] => [...(handleEcho(args)[0] as Uint8Array)]
+    expect(bytes(['-ne', '\\xff'])).toEqual([0xff])
+    expect(bytes(['-ne', '\\0377'])).toEqual([0xff])
+    expect(bytes(['-ne', '\\xc3\\xa9'])).toEqual([0xc3, 0xa9])
+  })
 })
 
 describe('handlePrintf', () => {
@@ -459,6 +467,24 @@ describe('handlePrintf', () => {
 
   it.each(CASES)('printf %j → %j', (args, expected, code) => {
     expect(run(args)).toEqual([expected, code])
+  })
+
+  it('reads \\xHH and \\NNN as bytes, \\u as a code point', () => {
+    // bash writes \xff as the byte 0xFF, which is not valid UTF-8 at all,
+    // rather than as the code point U+00FF.
+    const bytes = (args: string[]): number[] => [
+      ...(handlePrintf(args, new Session({ sessionId: 'test' }))[0] as Uint8Array),
+    ]
+    expect(bytes(['\\xff'])).toEqual([0xff])
+    expect(bytes(['\\377'])).toEqual([0xff])
+    expect(bytes(['\\xc3\\xa9'])).toEqual([0xc3, 0xa9])
+    expect(bytes(['\\x41\\x42'])).toEqual([0x41, 0x42])
+    expect(bytes(['%b', '\\xff'])).toEqual([0xff])
+    expect(bytes(['\\u00e9'])).toEqual([0xc3, 0xa9])
+  })
+
+  it('quotes a raw byte as octal', () => {
+    expect(stdout(['%q\n', byteChar(0xff)])).toBe("$'\\377'\n")
   })
 
   it('empty args → empty output', () => {

--- a/typescript/packages/core/src/workspace/executor/builtins/text.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/text.ts
@@ -12,10 +12,10 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { interpretEscapes } from '../../../commands/builtin/utils/escapes.ts'
 import { ECHO_OPTION } from '../../../commands/spec/shell.ts'
 import { IOResult } from '../../../io/types.ts'
 import { arrayExtent, arraySet } from '../../../shell/array.ts'
+import { byteChar, encodeText } from '../../../shell/bytes.ts'
 import { arrayIndex } from '../../expand/variable.ts'
 import { sessionEntry, setSessionEntry } from '../../session/session.ts'
 import type { Session } from '../../session/session.ts'
@@ -25,6 +25,78 @@ import type { Result } from './scope.ts'
 // A subscript must be non-empty: bash rejects `a[]` as an invalid
 // identifier, while `a[ ]` is a valid arithmetic 0.
 export const PRINTF_TARGET_RE = /^([A-Za-z_][A-Za-z0-9_]*)(?:\[(.+)\])?$/
+
+const ECHO_SIMPLE_ESCAPES: Readonly<Record<string, string>> = Object.freeze({
+  '\\': '\\',
+  n: '\n',
+  t: '\t',
+  r: '\r',
+  a: '\x07',
+  b: '\b',
+  f: '\f',
+  v: '\v',
+})
+
+const HEX_CHARS = new Set('0123456789abcdefABCDEF')
+const OCT_CHARS = new Set('01234567')
+
+/**
+ * Process C-style escape sequences for `echo -e`.
+ *
+ * Single-pass to handle `\\` correctly (`\\b` → a literal `\b`). Supports
+ * `\\ \n \t \r \a \b \f \v`, `\xHH` (hex), `\0NNN` (octal) and `\c` (stop
+ * output); an unknown escape like `\z` passes through as `\z`. `tr` has
+ * its own reader (`commands/builtin/utils/escapes.ts`) because only the
+ * shell writes bytes: `\xHH` here names a byte, not a code point.
+ */
+function interpretEchoEscapes(text: string): string {
+  const out: string[] = []
+  let i = 0
+  const n = text.length
+  while (i < n) {
+    if (text.charAt(i) !== '\\' || i + 1 >= n) {
+      out.push(text.charAt(i))
+      i += 1
+      continue
+    }
+    const ch = text.charAt(i + 1)
+    const simple = ECHO_SIMPLE_ESCAPES[ch]
+    if (simple !== undefined) {
+      out.push(simple)
+      i += 2
+    } else if (ch === 'c') {
+      break
+    } else if (ch === 'x') {
+      let digits = ''
+      let j = i + 2
+      while (j < n && digits.length < 2 && HEX_CHARS.has(text.charAt(j))) {
+        digits += text.charAt(j)
+        j += 1
+      }
+      if (digits !== '') {
+        out.push(byteChar(parseInt(digits, 16)))
+        i = j
+      } else {
+        out.push('\\x')
+        i += 2
+      }
+    } else if (ch === '0') {
+      let digits = ''
+      let j = i + 2
+      while (j < n && digits.length < 3 && OCT_CHARS.has(text.charAt(j))) {
+        digits += text.charAt(j)
+        j += 1
+      }
+      out.push(digits !== '' ? byteChar(parseInt(digits, 8)) : '\0')
+      i = j
+    } else {
+      out.push('\\')
+      out.push(ch)
+      i += 2
+    }
+  }
+  return out.join('')
+}
 
 /**
  * Print arguments, honoring GNU echo's option rules.
@@ -48,9 +120,9 @@ export function handleEcho(args: string[]): Result {
     idx += 1
   }
   let text = args.slice(idx).join(' ')
-  if (escapes) text = interpretEscapes(text)
+  if (escapes) text = interpretEchoEscapes(text)
   if (!noNewline) text += '\n'
-  const out = new TextEncoder().encode(text)
+  const out = encodeText(text)
   return [out, new IOResult(), new ExecutionNode({ command: 'echo', exitCode: 0 })]
 }
 
@@ -557,7 +629,11 @@ function readEscape(fmt: string, i: number): [string, number, boolean] {
       digits += fmt.charAt(j)
       j += 1
     }
-    if (digits) return [String.fromCodePoint(parseInt(digits, 16)), j, false]
+    if (digits) {
+      const value = parseInt(digits, 16)
+      // \x names a byte; \u and \U name a code point.
+      return [ch === 'x' ? byteChar(value) : String.fromCodePoint(value), j, false]
+    }
     return ['\\' + ch, i + 2, false]
   }
   if (OCT_DIGIT.test(ch)) {
@@ -569,7 +645,7 @@ function readEscape(fmt: string, i: number): [string, number, boolean] {
       j += 1
     }
     if (!digits) return ['\0', j, false]
-    return [String.fromCharCode(parseInt(digits, 8)), j, false]
+    return [byteChar(parseInt(digits, 8)), j, false]
   }
   return ['\\' + ch, i + 2, false]
 }
@@ -594,7 +670,7 @@ function expandEscapes(s: string): [string, boolean] {
 
 function quoteShell(s: string): string {
   if (s === '') return "''"
-  const data = new TextEncoder().encode(s)
+  const data = encodeText(s)
   let needAnsic = false
   for (const b of data) if (b < 0x20 || b === 0x7f || b >= 0x80) needAnsic = true
   if (needAnsic) {
@@ -879,7 +955,7 @@ export function handlePrintf(args: string[], session: Session): Result {
     }
     return [null, new IOResult({ exitCode }), new ExecutionNode({ command: 'printf', exitCode })]
   }
-  const out = new TextEncoder().encode(output)
+  const out = encodeText(output)
   if (errBytes !== null) {
     return [
       out,

--- a/typescript/packages/core/src/workspace/executor/redirect.ts
+++ b/typescript/packages/core/src/workspace/executor/redirect.ts
@@ -17,6 +17,7 @@ import { stripSlash } from '../../utils/slash.ts'
 import type { ByteSource } from '../../io/types.ts'
 import { IOResult, materialize } from '../../io/types.ts'
 import { applyBarrier, BarrierPolicy } from '../../shell/barrier.ts'
+import { encodeText } from '../../shell/bytes.ts'
 import type { CallStack } from '../../shell/call_stack.ts'
 import { type Redirect, RedirectKind } from '../../shell/types.ts'
 import { PathSpec } from '../../types.ts'
@@ -89,8 +90,7 @@ export async function handleRedirect(
       }
       cmdStdin = data as ByteSource | null
     } else if (r.kind === RedirectKind.HEREDOC) {
-      cmdStdin =
-        typeof r.target === 'string' ? new TextEncoder().encode(r.target) : (r.target as ByteSource)
+      cmdStdin = typeof r.target === 'string' ? encodeText(r.target) : (r.target as ByteSource)
     } else if (r.kind === RedirectKind.HERESTRING) {
       const text = r.target
       if (typeof text === 'string') {
@@ -98,7 +98,7 @@ export async function handleRedirect(
         if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) {
           t = t.slice(1, -1)
         }
-        cmdStdin = new TextEncoder().encode(`${t}\n`)
+        cmdStdin = encodeText(`${t}\n`)
       } else {
         cmdStdin = text as ByteSource
       }

--- a/typescript/packages/core/src/workspace/node/command_dispatch.ts
+++ b/typescript/packages/core/src/workspace/node/command_dispatch.ts
@@ -17,6 +17,7 @@ import type { PolicyDecision } from '../executor/policy/index.ts'
 import { mergeSignals } from '../abort.ts'
 import { type ByteSource, IOResult, materialize } from '../../io/types.ts'
 import type { Resource } from '../../resource/base.ts'
+import { encodeText } from '../../shell/bytes.ts'
 import type { CallStack } from '../../shell/call_stack.ts'
 import {
   ProcessSubDirection,
@@ -273,7 +274,7 @@ async function runCommandBody(
       if (child.type === NT.HERESTRING_REDIRECT) {
         for (const sc of child.namedChildren) {
           const content = await expandNode(sc, session, executeFn, callStack)
-          stdin = new TextEncoder().encode(`${content}\n`)
+          stdin = encodeText(`${content}\n`)
           break
         }
       }


### PR DESCRIPTION
Two unrelated bug fixes, one commit each.

## printf byte escapes

`printf '\xc3\xa9'` wrote four bytes where bash writes two: `\xHH` was read as a code point and then UTF-8 encoded, so `\xff` came out as `c3 bf` instead of the single byte it names. Octal escapes and `echo -e` had the same bug.

A byte above ASCII now rides as its surrogate escape (`shell/bytes.py` / `shell/bytes.ts`) and every place the shell turns its own text into bytes decodes it back: printf, echo, `%q`, heredocs, here strings. `\u` and `\U` still name code points.

## Google Sheets cell values

`.gsheet.json` documents cell values at `.sheets[0].data[0].rowData[]` and carried none. `spreadsheets.get` returns no grid data unless the request asks for it, so the file was tab metadata against real Google too, not only against the fake server. Both languages now send `includeGridData=true`.

The fake server implements the endpoint, with the shapes taken from the live API: no `startRow`/`startColumn` at zero, `{}` for an empty cell, numbers parsed under `USER_ENTERED`, row and column metadata, `tableRange` on append, and the whole `SheetProperties` in an `addSheet` reply.

## Test plan

- printf escapes pinned against `debian:stable-slim` bash, identical in both languages
- Sheets shapes diffed against the live API, writing through mirage's own `USER_ENTERED` path
- new unit tests for `shell/bytes` and the grid-data request in both languages
- 11 new integ cases for printf, 3 for the sheets grid; all six gws targets pass on both hosts
- full Python suite, TypeScript core and node suites, `pre-commit --all-files`