### PR TITLE
feat(gws): place creates in the folder scope, and report Google's errors

### DIFF
--- a/docs/python/cli/gws.mdx
+++ b/docs/python/cli/gws.mdx
@@ -70,6 +70,38 @@ gws drive permissions create \
   --json '{"role": "reader", "type": "anyone"}'
 ```
 
+### Folder scope
+
+A config carrying `folder_id` scopes what the CLI **creates**, so a file
+it makes lands in the same folder a `GDriveResource` sharing that config
+mounts, and the agent's own `ls` shows what it just made:
+
+```python
+config = GoogleConfig(client_id="...", refresh_token="...", folder_id="FOLDER_ID")
+ws = Workspace({"/data": GDriveResource(config)})
+ws.register_cli("gws", GWS, config.model_dump())
+```
+
+```bash
+gws sheets spreadsheets create --json '{"properties": {"title": "Q3"}}'
+ls /data                                   # Q3.gsheet.json
+```
+
+Three things worth knowing:
+
+- **Two divergences from the official CLI's passthrough.** `drive files
+  create` and `copy` get `parents` defaulted into the request body, and
+  the Docs/Sheets/Slides `create` methods have no `parents` field at all,
+  so mirage issues a second Drive call to move the new file. Both also
+  send `supportsAllDrives`, which is what lets a scope name a Shared
+  Drive folder.
+- **An explicit `parents` array always wins**, and then nothing is
+  injected into the query either: you typed the call, you own it. The key
+  being present is what counts, so `"parents": []` is honored too rather
+  than read as absent.
+- **Reads are not scoped.** `gws drive files list` still sees the whole
+  account. The scope is about where new files go, not a fence.
+
 ### Helpers
 
 | Helper                    | Description                                    |

--- a/docs/typescript/cli/gws.mdx
+++ b/docs/typescript/cli/gws.mdx
@@ -68,6 +68,38 @@ gws drive permissions create \
   --json '{"role": "reader", "type": "anyone"}'
 ```
 
+### Folder scope
+
+A config carrying `folderId` scopes what the CLI **creates**, so a file
+it makes lands in the same folder a `GDriveResource` sharing that config
+mounts, and the agent's own `ls` shows what it just made:
+
+```typescript
+const config = { clientId: '...', refreshToken: '...', folderId: 'FOLDER_ID' }
+const ws = new Workspace({ '/data': new GDriveResource(config) })
+ws.registerCli('gws', GWS, config)
+```
+
+```bash
+gws sheets spreadsheets create --json '{"properties": {"title": "Q3"}}'
+ls /data                                   # Q3.gsheet.json
+```
+
+Three things worth knowing:
+
+- **Two divergences from the official CLI's passthrough.** `drive files
+  create` and `copy` get `parents` defaulted into the request body, and
+  the Docs/Sheets/Slides `create` methods have no `parents` field at all,
+  so mirage issues a second Drive call to move the new file. Both also
+  send `supportsAllDrives`, which is what lets a scope name a Shared
+  Drive folder.
+- **An explicit `parents` array always wins**, and then nothing is
+  injected into the query either: you typed the call, you own it. The key
+  being present is what counts, so `"parents": []` is honored too rather
+  than read as absent.
+- **Reads are not scoped.** `gws drive files list` still sees the whole
+  account. The scope is about where new files go, not a fence.
+
 ### Helpers
 
 | Helper                    | Description                                    |

--- a/integ/cli/gws.json
+++ b/integ/cli/gws.json
@@ -299,6 +299,97 @@
         "stdout": "true\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "gw_error_body_reaches_the_agent",
+      "seq": 563026,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws drive files get --params '{\"fileId\": \"nope\"}' 2>&1 | grep -c 'File not found'",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_error_body_names_the_bad_request",
+      "seq": 563027,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws sheets spreadsheets batchUpdate --params '{\"spreadsheetId\": \"sheet0001\"}' --json '{\"requests\": [{\"bogusRequest\": {}}]}' 2>&1 | grep -c 'Unsupported request: bogusRequest'",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_gmail_messages_list_passthrough",
+      "seq": 563028,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws gmail users messages list --params '{\"userId\": \"me\", \"q\": \"standup\"}' | jq -r '.messages[].id'",
+      "expect": {
+        "exit": 0,
+        "stdout": "msg0002\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_gmail_messages_get_passthrough",
+      "seq": 563029,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws gmail users messages get --params '{\"userId\": \"me\", \"id\": \"msg0002\"}' | jq -r '.labelIds[]'",
+      "expect": {
+        "exit": 0,
+        "stdout": "INBOX\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_gmail_attachment_get_passthrough",
+      "seq": 563030,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws gmail users messages attachments get --params '{\"userId\": \"me\", \"messageId\": \"msg0001\", \"id\": \"att0001\"}' | jq -r .size",
+      "expect": {
+        "exit": 0,
+        "stdout": "36\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_gmail_messages_send_passthrough",
+      "seq": 563031,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "gws gmail users messages send --params '{\"userId\": \"me\"}' --json '{\"raw\": \"VG86IGRhbmFAZXhhbXBsZS5jb20NClN1YmplY3Q6IFJhdyBzZW5kDQoNCmhlbGxvIGZyb20gcmF3DQo=\"}' | jq -r '.labelIds[]'",
+      "expect": {
+        "exit": 0,
+        "stdout": "SENT\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gw_gmail_reply_all_includes_cc",
+      "seq": 563032,
+      "targets": [
+        "cli-gws"
+      ],
+      "command": "M=$(gws gmail reply-all --message-id msg0003 --body 'ack' | jq -r .id) && gws gmail users messages get --params \"{\\\"userId\\\": \\\"me\\\", \\\"id\\\": \\\"$M\\\"}\" | jq -r '.payload.headers[] | select(.name==\"Cc\") | .value'",
+      "expect": {
+        "exit": 0,
+        "stdout": "marcus@example.com\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/gws_scope.json
+++ b/integ/cli/gws_scope.json
@@ -41,6 +41,20 @@
       "targets": ["cli-gws-scoped"],
       "command": "gws drive files create --json '{\"name\": \"elsewhere.txt\", \"parents\": [\"root\"]}' | jq -r '.parents[]'",
       "expect": { "exit": 0, "stdout": "root\n", "stderr": "" }
+    },
+    {
+      "id": "gws_scope_edit_warms_the_body_cache",
+      "seq": 563106,
+      "targets": ["cli-gws-scoped"],
+      "command": "gws docs documents create --json '{\"title\": \"Stale\"}' > /dev/null && cat /data/Stale.gdoc.json | grep -c NEWTEXT",
+      "expect": { "exit": 1, "stdout": "0\n", "stderr": "" }
+    },
+    {
+      "id": "gws_scope_edit_is_visible_through_the_mount",
+      "seq": 563107,
+      "targets": ["cli-gws-scoped"],
+      "command": "ID=$(gws drive files list | jq -r '.files[] | select(.name==\"Stale\") | .id') && gws docs documents batchUpdate --params \"{\\\"documentId\\\": \\\"$ID\\\"}\" --json '{\"requests\": [{\"insertText\": {\"location\": {\"index\": 1}, \"text\": \"NEWTEXT\"}}]}' > /dev/null && cat /data/Stale.gdoc.json | grep -c NEWTEXT",
+      "expect": { "exit": 0, "stdout": "1\n", "stderr": "" }
     }
   ]
 }

--- a/integ/cli/gws_scope.json
+++ b/integ/cli/gws_scope.json
@@ -1,0 +1,46 @@
+{
+  "cases": [
+    {
+      "id": "gws_scope_sheet_lands_in_the_mount",
+      "seq": 563100,
+      "targets": ["cli-gws-scoped"],
+      "command": "gws sheets spreadsheets create --json '{\"properties\": {\"title\": \"Q3 Report\"}}' > /dev/null && ls /data",
+      "expect": { "exit": 0, "stdout": "Q3 Report.gsheet.json\n", "stderr": "" }
+    },
+    {
+      "id": "gws_scope_sheet_is_readable_through_the_mount",
+      "seq": 563101,
+      "targets": ["cli-gws-scoped"],
+      "command": "gws sheets spreadsheets create --json '{\"properties\": {\"title\": \"Budget\"}}' > /dev/null && cat '/data/Budget.gsheet.json' | jq -r .properties.title",
+      "expect": { "exit": 0, "stdout": "Budget\n", "stderr": "" }
+    },
+    {
+      "id": "gws_scope_doc_lands_in_the_mount",
+      "seq": 563102,
+      "targets": ["cli-gws-scoped"],
+      "command": "gws docs documents create --json '{\"title\": \"Notes\"}' > /dev/null && ls /data | grep -c gdoc",
+      "expect": { "exit": 0, "stdout": "1\n", "stderr": "" }
+    },
+    {
+      "id": "gws_scope_deck_lands_in_the_mount",
+      "seq": 563103,
+      "targets": ["cli-gws-scoped"],
+      "command": "gws slides presentations create --json '{\"title\": \"Deck\"}' > /dev/null && ls /data | grep -c gslide",
+      "expect": { "exit": 0, "stdout": "1\n", "stderr": "" }
+    },
+    {
+      "id": "gws_scope_drive_create_defaults_its_parent",
+      "seq": 563104,
+      "targets": ["cli-gws-scoped"],
+      "command": "gws drive files create --json '{\"name\": \"draft.txt\", \"mimeType\": \"text/plain\"}' > /dev/null && ls /data | grep -c draft.txt",
+      "expect": { "exit": 0, "stdout": "1\n", "stderr": "" }
+    },
+    {
+      "id": "gws_scope_explicit_parent_still_wins",
+      "seq": 563105,
+      "targets": ["cli-gws-scoped"],
+      "command": "gws drive files create --json '{\"name\": \"elsewhere.txt\", \"parents\": [\"root\"]}' | jq -r '.parents[]'",
+      "expect": { "exit": 0, "stdout": "root\n", "stderr": "" }
+    }
+  ]
+}

--- a/integ/resources/google/g.json
+++ b/integ/resources/google/g.json
@@ -304,7 +304,7 @@
       "command": "F=$(cat /data/Plan.gdoc.json | jq -r .documentId) && gws drive files update --params \"{\\\"fileId\\\": \\\"$F\\\"}\" --json '{\"name\": \"Plan2\"}' > /dev/null && ls /data | grep gdoc",
       "expect": {
         "exit": 0,
-        "stdout": "Plan.gdoc.json\n",
+        "stdout": "Plan2.gdoc.json\n",
         "stderr": ""
       }
     },
@@ -331,8 +331,8 @@
       "clear_cache": true,
       "command": "F=$(cat /data/Plan2.gdoc.json | jq -r .documentId) && gws drive files delete --params \"{\\\"fileId\\\": \\\"$F\\\"}\" && ls /data | grep -c gdoc",
       "expect": {
-        "exit": 0,
-        "stdout": "1\n",
+        "exit": 1,
+        "stdout": "0\n",
         "stderr": ""
       }
     },

--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -503,9 +503,13 @@ class GwsService:
     analog, so the three mounts never see each other.
     """
 
-    def __init__(self, url: str, folder_ids: dict[str, str]) -> None:
+    def __init__(self, url: str, folder_ids: dict[str, str],
+                 cli_scope: str | None) -> None:
         self.url = url
         self.folder_ids = folder_ids
+        # A target may scope the gws install to one mount's folder, the
+        # configuration where the CLI and the mount are the same folder.
+        self.cli_scope = cli_scope
 
     @classmethod
     async def create(cls, run_id: str, target: dict) -> "GwsService":
@@ -547,7 +551,7 @@ class GwsService:
                 ).parents[2] / "fixtures" / f"{mail}.json"
                 await cls._seed_mail(session, url,
                                      json.loads(manifest.read_text()))
-        return cls(url, folder_ids)
+        return cls(url, folder_ids, target.get("cli_scope"))
 
     @staticmethod
     async def _seed_apps(session: aiohttp.ClientSession, url: str,
@@ -655,12 +659,13 @@ class GwsService:
             GmailConfig(client_id="integ", refresh_token="integ"))
 
     def cli_installs(self) -> dict[str, tuple[CLISpec, dict[str, object]]]:
-        return {
-            "gws": (cli_spec_for("gws"), {
-                "client_id": "integ",
-                "refresh_token": "integ",
-            }),
+        config: dict[str, object] = {
+            "client_id": "integ",
+            "refresh_token": "integ",
         }
+        if self.cli_scope is not None:
+            config["folder_id"] = self.folder_ids[self.cli_scope]
+        return {"gws": (cli_spec_for("gws"), config)}
 
     async def teardown(self) -> None:
         return None

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -1231,6 +1231,7 @@ async function openGws(target: Target): Promise<Open> {
     GDriveResource | GDocsResource | GSheetsResource | GSlidesResource | GmailResource | RAMResource
   > = {}
   const driveIds: Record<string, string> = {}
+  const folderIds: Record<string, string> = {}
   for (const m of target.mounts) {
     if (m.resource === 'ram') {
       mounts[m.path] = new RAMResource()
@@ -1261,6 +1262,7 @@ async function openGws(target: Target): Promise<Open> {
       refreshToken: 'integ',
       folderId: parent,
     })
+    folderIds[m.path] = parent
   }
   if (target.apps !== undefined) {
     const manifest = join(integRoot(), 'fixtures', `${target.apps}.json`)
@@ -1272,10 +1274,14 @@ async function openGws(target: Target): Promise<Open> {
   }
   const ws = new Workspace(mounts, { mode: MountMode.WRITE })
   if (target.clis?.includes('gws') === true) {
+    // A target may scope the gws install to one mount's folder, the
+    // configuration where the CLI and the mount are the same folder.
+    const scope = target.cli_scope
     ws.registerCli('gws', GWS, {
       clientId: 'integ',
       clientSecret: 'integ',
       refreshToken: 'integ',
+      ...(scope !== undefined ? { folderId: folderIds[scope] } : {}),
     })
   }
   const cleanup = async (): Promise<void> => {

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -59,6 +59,9 @@ export interface Target {
   agentId?: string
   facet?: string
   clis?: string[]
+  // Scope an installed account CLI to this mount's folder, so the CLI and
+  // the mount are pointed at the same place.
+  cli_scope?: string
   mounts: Mount[]
   // Sessions a case can name via its `session` field. Grants take either the
   // mapping form ({ '/data': 'read' }) or the list form (['/data'], which

--- a/integ/server/gws_server.ts
+++ b/integ/server/gws_server.ts
@@ -32,6 +32,26 @@
 // (and vice versa), every content write records a revision that /revisions
 // can list and serve, Gmail messages.insert honors
 // internalDateSource=dateHeader, and messages.trash swaps INBOX for TRASH.
+// Sheets keeps a declared grid per tab beside the sparse cell map, so an
+// insert/append grows rowCount the way the live API does; object ids are
+// unique across a whole presentation, so duplicating a slide re-keys its
+// elements; and replaceAllText is case-INSENSITIVE unless matchCase is set,
+// in both Docs and Slides.
+//
+// Known-absent surface, listed so a 404 here is read as "not built yet"
+// rather than "mirage sent the wrong request":
+//   - Gmail beyond labels.list and messages list/get/insert/send/trash:
+//     no messages.modify/untrash/delete/batchModify, no labels CRUD, and
+//     no threads or drafts resources at all
+//   - drive changes.list / changes.getStartPageToken (needs a change feed)
+//   - Sheets requests that need a cell format or style model
+//     (updateCells, repeatCell, copyPaste, conditional formats) and
+//     spreadsheets.getByDataFilter
+//   - Docs requests that need document structure beyond a text body
+//     (insertTable, insertInlineImage, updateTextStyle, bullets)
+//   - Slides presentations.pages.getThumbnail, and the shape/table/image
+//     geometry requests
+//   - Page has no pageType and Sheets no defaultFormat/spreadsheetTheme
 
 import { createHash } from 'node:crypto'
 import http from 'node:http'
@@ -81,6 +101,12 @@ interface SheetTab {
   sheetId: number
   title: string
   cells: Map<string, string>
+  // The declared grid, which insertDimension and appendDimension grow and
+  // deleteDimension shrinks. Kept beside the sparse cell map because the
+  // grid is independent of what has been written: a new tab reports 1000
+  // rows with nothing in it.
+  rows: number
+  cols: number
 }
 
 interface Spreadsheet {
@@ -250,7 +276,7 @@ function autoLink(item: DriveItem): void {
   } else if (item.mimeType === SHEET_MIME && !state.sheets.has(item.id)) {
     state.sheets.set(item.id, {
       title: item.name,
-      tabs: [{ sheetId: 0, title: 'Sheet1', cells: new Map() }],
+      tabs: [newTab(0, 'Sheet1')],
       nextSheetId: 1,
     })
   } else if (item.mimeType === SLIDE_MIME && !state.presentations.has(item.id)) {
@@ -489,6 +515,38 @@ function fmtDocument(id: string): Record<string, unknown> {
   }
 }
 
+// SubstringMatchCriteria.matchCase defaults to false, i.e. the search is
+// case-INSENSITIVE unless the caller opts in. Shared by the Docs and Slides
+// replaceAllText requests.
+//
+// Windows are compared at equal length rather than by lowercasing the whole
+// haystack: a lowercase mapping can change a string's length (İ), which
+// would misalign every index after it.
+function replaceAllText(
+  haystack: string,
+  needle: string,
+  replacement: string,
+  matchCase: boolean,
+): [string, number] {
+  if (needle === '') return [haystack, 0]
+  const find = matchCase ? needle : needle.toLowerCase()
+  let out = ''
+  let cursor = 0
+  let count = 0
+  while (cursor + needle.length <= haystack.length) {
+    const window = haystack.slice(cursor, cursor + needle.length)
+    if ((matchCase ? window : window.toLowerCase()) === find) {
+      out += replacement
+      cursor += needle.length
+      count += 1
+    } else {
+      out += haystack[cursor] as string
+      cursor += 1
+    }
+  }
+  return [out + haystack.slice(cursor), count]
+}
+
 function docsBatchUpdate(id: string, requests: Record<string, unknown>[]): [number, object] {
   const doc = state.docs.get(id)
   if (doc === undefined) return NOT_FOUND
@@ -515,12 +573,13 @@ function docsBatchUpdate(id: string, requests: Record<string, unknown>[]): [numb
         containsText?: { text?: string; matchCase?: boolean }
         replaceText?: string
       }
-      const needle = r.containsText?.text ?? ''
-      let occurrences = 0
-      if (needle !== '') {
-        occurrences = doc.text.split(needle).length - 1
-        doc.text = doc.text.split(needle).join(r.replaceText ?? '')
-      }
+      const [text, occurrences] = replaceAllText(
+        doc.text,
+        r.containsText?.text ?? '',
+        r.replaceText ?? '',
+        r.containsText?.matchCase ?? false,
+      )
+      doc.text = text
       replies.push({ replaceAllText: { occurrencesChanged: occurrences } })
     } else {
       return googleError(400, `Unsupported request: ${Object.keys(request).join(',')}`, 'INVALID_ARGUMENT')
@@ -536,6 +595,10 @@ function touchNative(id: string): void {
 }
 
 // --------------------------------------------------------------- sheets ---
+
+function newTab(sheetId: number, title: string, rows = GRID_ROWS, cols = GRID_COLUMNS): SheetTab {
+  return { sheetId, title, cells: new Map(), rows, cols }
+}
 
 function colLetterToIndex(letters: string): number {
   let n = 0
@@ -649,6 +712,19 @@ function writeValues(range: A1Range, values: string[][], startRow: number): numb
   return cells
 }
 
+// values.clear and values.batchClear drop the cells inside the rect but
+// leave the grid alone, which is what separates them from deleteDimension.
+function clearRange(range: A1Range): void {
+  const extent = tabExtent(range.tab)
+  const endRow = Math.min(range.endRow ?? extent.rows - 1, extent.rows - 1)
+  const endCol = Math.min(range.endCol ?? extent.cols - 1, extent.cols - 1)
+  for (let r = range.startRow; r <= endRow; r += 1) {
+    for (let c = range.startCol; c <= endCol; c += 1) {
+      range.tab.cells.delete(`${String(r)},${String(c)}`)
+    }
+  }
+}
+
 function rangeLabel(tab: SheetTab, startRow: number, startCol: number, values: string[][]): string {
   const rows = Math.max(1, values.length)
   const cols = Math.max(1, ...values.map((r) => r.length))
@@ -681,8 +757,8 @@ function scientific(value: number): string {
 function tabGrid(tab: SheetTab): { rows: number; cols: number } {
   const used = tabExtent(tab)
   return {
-    rows: Math.max(GRID_ROWS, used.rows),
-    cols: Math.max(GRID_COLUMNS, used.cols),
+    rows: Math.max(tab.rows, used.rows),
+    cols: Math.max(tab.cols, used.cols),
   }
 }
 
@@ -773,18 +849,110 @@ function fmtSpreadsheet(id: string, includeGridData = false): Record<string, unk
   }
 }
 
+type Dimension = 'ROWS' | 'COLUMNS'
+
+interface DimensionRange {
+  tab: SheetTab
+  dimension: Dimension
+  startIndex: number
+  endIndex: number
+}
+
+interface RawDimensionRange {
+  sheetId?: number
+  dimension?: string
+  startIndex?: number
+  endIndex?: number
+}
+
+// A DimensionRange with no endIndex is unbounded to the end of the grid,
+// and no startIndex means index 0, matching the real API's optional fields.
+function resolveDimensionRange(
+  sheet: Spreadsheet,
+  raw: RawDimensionRange | undefined,
+): DimensionRange | null {
+  const tab = sheet.tabs.find((t) => t.sheetId === (raw?.sheetId ?? 0))
+  if (tab === undefined) return null
+  const dimension: Dimension = raw?.dimension === 'COLUMNS' ? 'COLUMNS' : 'ROWS'
+  const limit = dimension === 'ROWS' ? tab.rows : tab.cols
+  const startIndex = Math.max(0, raw?.startIndex ?? 0)
+  const endIndex = Math.max(startIndex, raw?.endIndex ?? limit)
+  return { tab, dimension, startIndex, endIndex }
+}
+
+// Re-key the sparse cell map along one dimension. `mapIndex` returns the
+// index a row/column moves to, or null to drop it; every dimension request
+// is expressed as one such mapping so insert, delete and move cannot drift
+// apart.
+function remapCells(
+  tab: SheetTab,
+  dimension: Dimension,
+  mapIndex: (index: number) => number | null,
+): void {
+  const next = new Map<string, string>()
+  for (const [key, value] of tab.cells) {
+    const [row, col] = key.split(',').map(Number) as [number, number]
+    const moved = mapIndex(dimension === 'ROWS' ? row : col)
+    if (moved === null) continue
+    next.set(
+      dimension === 'ROWS' ? `${String(moved)},${String(col)}` : `${String(row)},${String(moved)}`,
+      value,
+    )
+  }
+  tab.cells = next
+}
+
+function growGrid(tab: SheetTab, dimension: Dimension, by: number): void {
+  if (dimension === 'ROWS') tab.rows = Math.max(1, tab.rows + by)
+  else tab.cols = Math.max(1, tab.cols + by)
+}
+
+function insertDimension(range: DimensionRange): void {
+  const count = range.endIndex - range.startIndex
+  remapCells(range.tab, range.dimension, (i) => (i >= range.startIndex ? i + count : i))
+  growGrid(range.tab, range.dimension, count)
+}
+
+function deleteDimension(range: DimensionRange): void {
+  const count = range.endIndex - range.startIndex
+  remapCells(range.tab, range.dimension, (i) => {
+    if (i >= range.startIndex && i < range.endIndex) return null
+    return i >= range.endIndex ? i - count : i
+  })
+  growGrid(range.tab, range.dimension, -count)
+}
+
+// destinationIndex is in the coordinate space *before* the source band is
+// lifted out, which is the one detail of moveDimension worth getting right:
+// a destination past the band lands `count` lower once the band is gone.
+function moveDimension(range: DimensionRange, destinationIndex: number): void {
+  const count = range.endIndex - range.startIndex
+  if (count === 0) return
+  if (destinationIndex >= range.startIndex && destinationIndex <= range.endIndex) return
+  const target =
+    destinationIndex > range.endIndex ? destinationIndex - count : Math.max(0, destinationIndex)
+  remapCells(range.tab, range.dimension, (i) => {
+    if (i >= range.startIndex && i < range.endIndex) return target + (i - range.startIndex)
+    const lifted = i >= range.endIndex ? i - count : i
+    return lifted >= target ? lifted + count : lifted
+  })
+}
+
 function sheetsBatchUpdate(id: string, requests: Record<string, unknown>[]): [number, object] {
   const sheet = state.sheets.get(id)
   if (sheet === undefined) return NOT_FOUND
   const replies: object[] = []
   for (const request of requests) {
     if ('addSheet' in request) {
-      const r = request.addSheet as { properties?: { title?: string } }
-      const tab: SheetTab = {
-        sheetId: sheet.nextSheetId,
-        title: r.properties?.title ?? `Sheet${String(sheet.tabs.length + 1)}`,
-        cells: new Map(),
+      const r = request.addSheet as {
+        properties?: { title?: string; gridProperties?: { rowCount?: number; columnCount?: number } }
       }
+      const tab = newTab(
+        sheet.nextSheetId,
+        r.properties?.title ?? `Sheet${String(sheet.tabs.length + 1)}`,
+        r.properties?.gridProperties?.rowCount ?? GRID_ROWS,
+        r.properties?.gridProperties?.columnCount ?? GRID_COLUMNS,
+      )
       sheet.nextSheetId += 1
       sheet.tabs.push(tab)
       // The live API replies with the whole SheetProperties, not just the
@@ -800,6 +968,58 @@ function sheetsBatchUpdate(id: string, requests: Record<string, unknown>[]): [nu
       }
       const tab = sheet.tabs.find((t) => t.sheetId === r.properties?.sheetId)
       if (tab !== undefined && r.properties?.title !== undefined) tab.title = r.properties.title
+      replies.push({})
+    } else if ('duplicateSheet' in request) {
+      const r = request.duplicateSheet as {
+        sourceSheetId?: number
+        insertSheetIndex?: number
+        newSheetId?: number
+        newSheetName?: string
+      }
+      const src = sheet.tabs.find((t) => t.sheetId === (r.sourceSheetId ?? 0))
+      if (src === undefined) {
+        return googleError(400, 'Invalid sourceSheetId.', 'INVALID_ARGUMENT')
+      }
+      const copy: SheetTab = {
+        ...src,
+        sheetId: r.newSheetId ?? sheet.nextSheetId,
+        title: r.newSheetName ?? `Copy of ${src.title}`,
+        cells: new Map(src.cells),
+      }
+      if (r.newSheetId === undefined) sheet.nextSheetId += 1
+      const at = r.insertSheetIndex ?? sheet.tabs.length
+      sheet.tabs.splice(at, 0, copy)
+      replies.push({ duplicateSheet: { properties: tabProperties(copy, at) } })
+    } else if ('insertDimension' in request) {
+      const r = request.insertDimension as { range?: RawDimensionRange }
+      const range = resolveDimensionRange(sheet, r.range)
+      if (range === null) return googleError(400, 'Invalid sheetId.', 'INVALID_ARGUMENT')
+      insertDimension(range)
+      replies.push({})
+    } else if ('deleteDimension' in request) {
+      const r = request.deleteDimension as { range?: RawDimensionRange }
+      const range = resolveDimensionRange(sheet, r.range)
+      if (range === null) return googleError(400, 'Invalid sheetId.', 'INVALID_ARGUMENT')
+      deleteDimension(range)
+      replies.push({})
+    } else if ('appendDimension' in request) {
+      const r = request.appendDimension as {
+        sheetId?: number
+        dimension?: string
+        length?: number
+      }
+      const tab = sheet.tabs.find((t) => t.sheetId === (r.sheetId ?? 0))
+      if (tab === undefined) return googleError(400, 'Invalid sheetId.', 'INVALID_ARGUMENT')
+      growGrid(tab, r.dimension === 'COLUMNS' ? 'COLUMNS' : 'ROWS', r.length ?? 0)
+      replies.push({})
+    } else if ('moveDimension' in request) {
+      const r = request.moveDimension as {
+        source?: RawDimensionRange
+        destinationIndex?: number
+      }
+      const range = resolveDimensionRange(sheet, r.source)
+      if (range === null) return googleError(400, 'Invalid sheetId.', 'INVALID_ARGUMENT')
+      moveDimension(range, r.destinationIndex ?? 0)
       replies.push({})
     } else if ('updateSpreadsheetProperties' in request) {
       const r = request.updateSpreadsheetProperties as { properties?: { title?: string } }
@@ -817,11 +1037,134 @@ function sheetsBatchUpdate(id: string, requests: Record<string, unknown>[]): [nu
   return [200, { spreadsheetId: id, replies }]
 }
 
+function batchGetValues(id: string, ranges: string[]): [number, object] {
+  const sheet = state.sheets.get(id)
+  if (sheet === undefined) return NOT_FOUND
+  const valueRanges: object[] = []
+  for (const rangeStr of ranges) {
+    const range = parseA1(sheet, rangeStr)
+    if (range === null) {
+      return googleError(400, `Unable to parse range: ${rangeStr}`, 'INVALID_ARGUMENT')
+    }
+    valueRanges.push({
+      range: rangeLabelFor(range, rangeStr),
+      majorDimension: 'ROWS',
+      values: rangeValues(range),
+    })
+  }
+  return [200, { spreadsheetId: id, valueRanges }]
+}
+
+// totalUpdatedRows/Columns count the distinct rows and columns holding at
+// least one updated cell, not the sum over the data entries, so two ranges
+// overlapping one row report that row once.
+function batchUpdateValues(
+  id: string,
+  data: { range?: string; values?: string[][] }[],
+): [number, object] {
+  const sheet = state.sheets.get(id)
+  if (sheet === undefined) return NOT_FOUND
+  const responses: object[] = []
+  const rows = new Set<string>()
+  const columns = new Set<string>()
+  const tabs = new Set<number>()
+  let totalCells = 0
+  for (const entry of data) {
+    const rangeStr = entry.range ?? ''
+    const range = parseA1(sheet, rangeStr)
+    if (range === null) {
+      return googleError(400, `Unable to parse range: ${rangeStr}`, 'INVALID_ARGUMENT')
+    }
+    const values = entry.values ?? []
+    const cells = writeValues(range, values, range.startRow)
+    for (let i = 0; i < values.length; i += 1) {
+      const row = values[i] as string[]
+      if (row.length > 0) rows.add(`${String(range.tab.sheetId)},${String(range.startRow + i)}`)
+      for (let j = 0; j < row.length; j += 1) {
+        columns.add(`${String(range.tab.sheetId)},${String(range.startCol + j)}`)
+      }
+    }
+    tabs.add(range.tab.sheetId)
+    totalCells += cells
+    responses.push({
+      spreadsheetId: id,
+      updatedRange: rangeLabel(range.tab, range.startRow, range.startCol, values),
+      updatedRows: values.length,
+      updatedColumns: values.length > 0 ? Math.max(...values.map((r) => r.length)) : 0,
+      updatedCells: cells,
+    })
+  }
+  touchNative(id)
+  return [
+    200,
+    {
+      spreadsheetId: id,
+      totalUpdatedRows: rows.size,
+      totalUpdatedColumns: columns.size,
+      totalUpdatedCells: totalCells,
+      totalUpdatedSheets: tabs.size,
+      responses,
+    },
+  ]
+}
+
+function batchClearValues(id: string, ranges: string[]): [number, object] {
+  const sheet = state.sheets.get(id)
+  if (sheet === undefined) return NOT_FOUND
+  const clearedRanges: string[] = []
+  for (const rangeStr of ranges) {
+    const range = parseA1(sheet, rangeStr)
+    if (range === null) {
+      return googleError(400, `Unable to parse range: ${rangeStr}`, 'INVALID_ARGUMENT')
+    }
+    clearRange(range)
+    clearedRanges.push(rangeLabelFor(range, rangeStr))
+  }
+  touchNative(id)
+  return [200, { spreadsheetId: id, clearedRanges }]
+}
+
+// sheets.copyTo copies one tab into another spreadsheet (or back into the
+// same one) and returns the new tab's SheetProperties, not a batch reply.
+function copySheetTo(sourceId: string, sheetId: number, destinationId: string): [number, object] {
+  const source = state.sheets.get(sourceId)
+  const destination = state.sheets.get(destinationId)
+  if (source === undefined || destination === undefined) return NOT_FOUND
+  const tab = source.tabs.find((t) => t.sheetId === sheetId)
+  if (tab === undefined) {
+    return googleError(400, `Invalid sheetId: ${String(sheetId)}`, 'INVALID_ARGUMENT')
+  }
+  const copy: SheetTab = {
+    ...tab,
+    sheetId: destination.nextSheetId,
+    title: `Copy of ${tab.title}`,
+    cells: new Map(tab.cells),
+  }
+  destination.nextSheetId += 1
+  destination.tabs.push(copy)
+  touchNative(destinationId)
+  return [200, tabProperties(copy, destination.tabs.length - 1)]
+}
+
 // --------------------------------------------------------------- slides ---
 
-function newSlide(): SlidePage {
-  const n = state.nextId('slide')
-  return { objectId: n, texts: new Map() }
+function newSlide(objectId?: string): SlidePage {
+  return { objectId: objectId ?? state.nextId('slide'), texts: new Map() }
+}
+
+// One Page resource, shared by presentations.get and presentations.pages.get
+// so the two can never render the same slide differently.
+function fmtPage(slide: SlidePage): Record<string, unknown> {
+  return {
+    objectId: slide.objectId,
+    pageElements: [...slide.texts.entries()].map(([objectId, text]) => ({
+      objectId,
+      shape: {
+        shapeType: 'TEXT_BOX',
+        text: { textElements: [{ textRun: { content: text, style: {} } }] },
+      },
+    })),
+  }
 }
 
 function fmtPresentation(id: string): Record<string, unknown> {
@@ -833,16 +1176,7 @@ function fmtPresentation(id: string): Record<string, unknown> {
       width: { magnitude: 9144000, unit: 'EMU' },
       height: { magnitude: 6858000, unit: 'EMU' },
     },
-    slides: pres.slides.map((slide) => ({
-      objectId: slide.objectId,
-      pageElements: [...slide.texts.entries()].map(([objectId, text]) => ({
-        objectId,
-        shape: {
-          shapeType: 'TEXT_BOX',
-          text: { textElements: [{ textRun: { content: text, style: {} } }] },
-        },
-      })),
-    })),
+    slides: pres.slides.map(fmtPage),
     revisionId: `rev-${String(pres.slides.length)}`,
   }
 }
@@ -853,8 +1187,11 @@ function slidesBatchUpdate(id: string, requests: Record<string, unknown>[]): [nu
   const replies: object[] = []
   for (const request of requests) {
     if ('createSlide' in request) {
-      const slide = newSlide()
-      pres.slides.push(slide)
+      const r = request.createSlide as { objectId?: string; insertionIndex?: number }
+      const slide = newSlide(r.objectId)
+      // insertionIndex places the slide; omitted means append, which is
+      // what every existing caller relies on.
+      pres.slides.splice(r.insertionIndex ?? pres.slides.length, 0, slide)
       replies.push({ createSlide: { objectId: slide.objectId } })
     } else if ('createShape' in request) {
       const r = request.createShape as {
@@ -866,6 +1203,9 @@ function slidesBatchUpdate(id: string, requests: Record<string, unknown>[]): [nu
       if (page === undefined) {
         return googleError(400, 'Invalid pageObjectId.', 'INVALID_ARGUMENT')
       }
+      if (pres.slides.some((s) => s.objectId === objectId || s.texts.has(objectId))) {
+        return googleError(400, `Object id already exists: ${objectId}`, 'INVALID_ARGUMENT')
+      }
       page.texts.set(objectId, '')
       replies.push({ createShape: { objectId } })
     } else if ('insertText' in request) {
@@ -876,6 +1216,90 @@ function slidesBatchUpdate(id: string, requests: Record<string, unknown>[]): [nu
         return googleError(400, 'Invalid insertText objectId.', 'INVALID_ARGUMENT')
       }
       page.texts.set(objectId, (page.texts.get(objectId) ?? '') + (r.text ?? ''))
+      replies.push({})
+    } else if ('deleteText' in request) {
+      const r = request.deleteText as {
+        objectId?: string
+        textRange?: { type?: string; startIndex?: number; endIndex?: number }
+      }
+      const objectId = r.objectId ?? ''
+      const page = pres.slides.find((s) => s.texts.has(objectId))
+      if (page === undefined) {
+        return googleError(400, 'Invalid deleteText objectId.', 'INVALID_ARGUMENT')
+      }
+      const text = page.texts.get(objectId) ?? ''
+      const type = r.textRange?.type ?? 'ALL'
+      if (type === 'ALL') {
+        page.texts.set(objectId, '')
+      } else if (type === 'FROM_START_INDEX') {
+        page.texts.set(objectId, text.slice(0, r.textRange?.startIndex ?? 0))
+      } else {
+        const start = r.textRange?.startIndex ?? 0
+        page.texts.set(objectId, text.slice(0, start) + text.slice(r.textRange?.endIndex ?? start))
+      }
+      replies.push({})
+    } else if ('replaceAllText' in request) {
+      const r = request.replaceAllText as {
+        containsText?: { text?: string; matchCase?: boolean }
+        replaceText?: string
+        pageObjectIds?: string[]
+      }
+      // pageObjectIds scopes the replace to those slides; absent means the
+      // whole presentation.
+      const scope =
+        r.pageObjectIds === undefined
+          ? pres.slides
+          : pres.slides.filter((s) => r.pageObjectIds?.includes(s.objectId) === true)
+      let occurrences = 0
+      for (const slide of scope) {
+        for (const [objectId, text] of slide.texts) {
+          const [next, changed] = replaceAllText(
+            text,
+            r.containsText?.text ?? '',
+            r.replaceText ?? '',
+            r.containsText?.matchCase ?? false,
+          )
+          slide.texts.set(objectId, next)
+          occurrences += changed
+        }
+      }
+      replies.push({ replaceAllText: { occurrencesChanged: occurrences } })
+    } else if ('duplicateObject' in request) {
+      const r = request.duplicateObject as {
+        objectId?: string
+        objectIds?: Record<string, string>
+      }
+      const source = pres.slides.find((s) => s.objectId === r.objectId)
+      if (source === undefined) {
+        return googleError(400, 'Invalid duplicateObject objectId.', 'INVALID_ARGUMENT')
+      }
+      // Object ids are unique across a whole presentation, so every copied
+      // element is re-keyed rather than carried over: two pages sharing an
+      // element id would make insertText and deleteText hit whichever page
+      // happens to come first. `objectIds` may pin the new names.
+      const renamed: [string, string][] = [...source.texts].map(([objectId, text]) => [
+        r.objectIds?.[objectId] ?? state.nextId('shape'),
+        text,
+      ])
+      const copy: SlidePage = {
+        objectId: r.objectIds?.[source.objectId] ?? state.nextId('slide'),
+        texts: new Map(renamed),
+      }
+      pres.slides.splice(pres.slides.indexOf(source) + 1, 0, copy)
+      replies.push({ duplicateObject: { objectId: copy.objectId } })
+    } else if ('updateSlidesPosition' in request) {
+      const r = request.updateSlidesPosition as {
+        slideObjectIds?: string[]
+        insertionIndex?: number
+      }
+      const ids = new Set(r.slideObjectIds ?? [])
+      const moving = pres.slides.filter((s) => ids.has(s.objectId))
+      if (moving.length !== ids.size) {
+        return googleError(400, 'Invalid slideObjectIds.', 'INVALID_ARGUMENT')
+      }
+      const rest = pres.slides.filter((s) => !ids.has(s.objectId))
+      rest.splice(Math.min(r.insertionIndex ?? rest.length, rest.length), 0, ...moving)
+      pres.slides = rest
       replies.push({})
     } else if ('deleteObject' in request) {
       const r = request.deleteObject as { objectId?: string }
@@ -1323,12 +1747,33 @@ function route(ctx: Ctx): [number, object | Buffer | null, string?] {
   if (path === '/drive/v3/files' && method === 'GET') return listFiles(query)
   if (path === '/drive/v3/files' && method === 'POST') {
     const body = json(ctx)
+    // A caller may pin the id to one handed out by files.generateIds,
+    // which is the only reason that method is useful.
+    const pinned = typeof body.id === 'string' ? body.id : undefined
+    if (pinned !== undefined && state.files.has(pinned)) {
+      return googleError(409, 'A file with that id already exists.', 'ALREADY_EXISTS')
+    }
     const item = createDriveItem(
       String(body.name ?? 'Untitled'),
       String(body.mimeType ?? 'application/octet-stream'),
       Array.isArray(body.parents) ? (body.parents as string[]) : [],
+      Buffer.alloc(0),
+      pinned,
     )
     return [200, fmtFile(item)]
+  }
+  if (path === '/drive/v3/about' && method === 'GET') {
+    return [
+      200,
+      {
+        kind: 'drive#about',
+        user: { kind: 'drive#user', ...OWNER, permissionId: 'owner' },
+        storageQuota: {
+          limit: String(15 * 1024 * 1024 * 1024),
+          usage: String([...state.files.values()].reduce((n, f) => n + f.content.length, 0)),
+        },
+      },
+    ]
   }
   if (path === '/drive/v3/drives' && method === 'POST') {
     const body = json(ctx) as { name?: string }
@@ -1348,6 +1793,53 @@ function route(ctx: Ctx): [number, object | Buffer | null, string?] {
         drives: [...state.drives.values()].map((d) => ({ kind: 'drive#drive', ...d })),
       },
     ]
+  }
+  m = /^\/drive\/v3\/drives\/([^/:]+)$/.exec(path)
+  if (m !== null) {
+    const drive = state.drives.get(m[1] as string)
+    if (drive === undefined) return NOT_FOUND
+    if (method === 'GET') return [200, { kind: 'drive#drive', ...drive }]
+    if (method === 'PATCH') {
+      const body = json(ctx)
+      if (typeof body.name === 'string') {
+        drive.name = body.name
+        // The shared drive's root folder carries the same name, so a
+        // rename that touched only the drive record would leave the
+        // mounted tree showing the old one.
+        const root = state.files.get(drive.id)
+        if (root !== undefined) root.name = body.name
+      }
+      return [200, { kind: 'drive#drive', ...drive }]
+    }
+    if (method === 'DELETE') {
+      for (const item of [...state.files.values()]) {
+        if (item.driveId === drive.id) deleteTree(item.id)
+      }
+      state.drives.delete(drive.id)
+      return [204, null]
+    }
+  }
+
+  // files.generateIds and files.emptyTrash sit at fixed names under /files,
+  // so they must be matched before the files/{fileId} pattern below, which
+  // would otherwise read them as ids and 404.
+  if (path === '/drive/v3/files/generateIds' && method === 'GET') {
+    const count = Number.parseInt(query.get('count') ?? '10', 10)
+    const total = Number.isNaN(count) || count < 1 ? 10 : count
+    return [
+      200,
+      {
+        kind: 'drive#generatedIds',
+        space: query.get('space') ?? 'drive',
+        ids: Array.from({ length: total }, () => state.nextId('f')),
+      },
+    ]
+  }
+  if (path === '/drive/v3/files/trash' && method === 'DELETE') {
+    for (const item of [...state.files.values()]) {
+      if (item.trashed) deleteTree(item.id)
+    }
+    return [204, null]
   }
 
   m = /^\/drive\/v3\/files\/([^/:]+)$/.exec(path)
@@ -1460,6 +1952,16 @@ function route(ctx: Ctx): [number, object | Buffer | null, string?] {
       },
     ]
   }
+  if (m !== null && method === 'DELETE') {
+    const item = state.files.get(m[1] as string)
+    if (item === undefined) return NOT_FOUND
+    const before = item.revisions.length
+    item.revisions = item.revisions.filter((r) => r.id !== m?.[2])
+    if (item.revisions.length === before) {
+      return googleError(404, 'Revision not found.', 'NOT_FOUND')
+    }
+    return [204, null]
+  }
 
   m = /^\/drive\/v3\/files\/([^/]+)\/permissions$/.exec(path)
   if (m !== null) {
@@ -1481,15 +1983,27 @@ function route(ctx: Ctx): [number, object | Buffer | null, string?] {
     }
   }
   m = /^\/drive\/v3\/files\/([^/]+)\/permissions\/([^/]+)$/.exec(path)
-  if (m !== null && method === 'DELETE') {
+  if (m !== null) {
     const item = state.files.get(m[1] as string)
     if (item === undefined) return NOT_FOUND
-    const before = item.permissions.length
-    item.permissions = item.permissions.filter((p) => p.id !== m?.[2])
-    if (item.permissions.length === before) {
-      return googleError(404, 'Permission not found.', 'NOT_FOUND')
+    const permission = item.permissions.find((p) => p.id === m?.[2])
+    if (method === 'GET') {
+      if (permission === undefined) return googleError(404, 'Permission not found.', 'NOT_FOUND')
+      return [200, { kind: 'drive#permission', ...permission }]
     }
-    return [204, null]
+    if (method === 'PATCH') {
+      if (permission === undefined) return googleError(404, 'Permission not found.', 'NOT_FOUND')
+      const body = json(ctx)
+      // permissions.update takes only role (and expiration/expose flags a
+      // mock has no model for); type is immutable on the live API.
+      if (typeof body.role === 'string') permission.role = body.role
+      return [200, { kind: 'drive#permission', ...permission }]
+    }
+    if (method === 'DELETE') {
+      if (permission === undefined) return googleError(404, 'Permission not found.', 'NOT_FOUND')
+      item.permissions = item.permissions.filter((p) => p.id !== m?.[2])
+      return [204, null]
+    }
   }
 
   if (path === '/v1/documents' && method === 'POST') {
@@ -1526,10 +2040,42 @@ function route(ctx: Ctx): [number, object | Buffer | null, string?] {
     const body = json(ctx)
     return sheetsBatchUpdate(m[1] as string, (body.requests as Record<string, unknown>[]) ?? [])
   }
-  // A1 ranges legitimately contain ':' (Sheet1!A1:C1), so the :append
-  // suffix is stripped explicitly instead of pattern-matched.
+  // The values *batch* methods hang off `values:` with no range segment, so
+  // they must be matched before the `values/<range>` block below, whose
+  // pattern requires the slash and so can never reach them.
+  m = /^\/v4\/spreadsheets\/([^/:]+)\/values:batchGet$/.exec(path)
+  if (m !== null && method === 'GET') {
+    return batchGetValues(m[1] as string, query.getAll('ranges'))
+  }
+  m = /^\/v4\/spreadsheets\/([^/:]+)\/values:batchUpdate$/.exec(path)
+  if (m !== null && method === 'POST') {
+    const body = json(ctx)
+    return batchUpdateValues(
+      m[1] as string,
+      (body.data as { range?: string; values?: string[][] }[]) ?? [],
+    )
+  }
+  m = /^\/v4\/spreadsheets\/([^/:]+)\/values:batchClear$/.exec(path)
+  if (m !== null && method === 'POST') {
+    const body = json(ctx)
+    return batchClearValues(m[1] as string, (body.ranges as string[]) ?? [])
+  }
+  m = /^\/v4\/spreadsheets\/([^/:]+)\/sheets\/(\d+):copyTo$/.exec(path)
+  if (m !== null && method === 'POST') {
+    const body = json(ctx)
+    return copySheetTo(
+      m[1] as string,
+      Number.parseInt(m[2] as string, 10),
+      String(body.destinationSpreadsheetId ?? m[1]),
+    )
+  }
+  // A1 ranges legitimately contain ':' (Sheet1!A1:C1), so the :append and
+  // :clear suffixes are stripped explicitly instead of pattern-matched.
   const isAppend = path.endsWith(':append')
-  const valuesPath = isAppend ? path.slice(0, -':append'.length) : path
+  const isClear = path.endsWith(':clear')
+  let valuesPath = path
+  if (isAppend) valuesPath = path.slice(0, -':append'.length)
+  else if (isClear) valuesPath = path.slice(0, -':clear'.length)
   m = /^\/v4\/spreadsheets\/([^/]+)\/values\/(.+)$/.exec(valuesPath)
   if (m !== null) {
     const sheet = state.sheets.get(m[1] as string)
@@ -1548,6 +2094,11 @@ function route(ctx: Ctx): [number, object | Buffer | null, string?] {
           values: rangeValues(range),
         },
       ]
+    }
+    if (isClear && method === 'POST') {
+      clearRange(range)
+      touchNative(m[1] as string)
+      return [200, { spreadsheetId: m[1], clearedRange: rangeLabelFor(range, rangeStr) }]
     }
     const body = json(ctx)
     const values = (body.values ?? []) as string[][]
@@ -1605,6 +2156,13 @@ function route(ctx: Ctx): [number, object | Buffer | null, string?] {
   if (m !== null && method === 'GET') {
     if (!state.presentations.has(m[1] as string)) return NOT_FOUND
     return [200, fmtPresentation(m[1] as string)]
+  }
+  m = /^\/v1\/presentations\/([^/:]+)\/pages\/([^/:]+)$/.exec(path)
+  if (m !== null && method === 'GET') {
+    const pres = state.presentations.get(m[1] as string)
+    const slide = pres?.slides.find((s) => s.objectId === m?.[2])
+    if (slide === undefined) return NOT_FOUND
+    return [200, fmtPage(slide)]
   }
   m = /^\/v1\/presentations\/([^/:]+):batchUpdate$/.exec(path)
   if (m !== null && method === 'POST') {

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -1256,6 +1256,27 @@
       ]
     },
     {
+      "id": "cli-gws-scoped",
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
+      "service": "gws",
+      "facet": "cli",
+      "clis": [
+        "gws"
+      ],
+      "cli_scope": "/data",
+      "mounts": [
+        {
+          "path": "/data",
+          "resource": "gdrive",
+          "backend": "gdrive",
+          "root": "team/scope"
+        }
+      ]
+    },
+    {
       "id": "cli-slack",
       "hosts": [
         "python",

--- a/python/mirage/cache/file/mixin.py
+++ b/python/mirage/cache/file/mixin.py
@@ -67,6 +67,21 @@ class FileCacheMixin:
     async def clear(self) -> None:
         raise NotImplementedError
 
+    async def evict_prefix(self, prefix: str) -> None:
+        """Drop every cached entry whose key starts with ``prefix``.
+
+        The path-unknown counterpart to :meth:`remove`: a mutation that
+        names no path (an account CLI writing to its service by id)
+        cannot say which entries went stale, only which mount's keyspace
+        did. Stores that own their keyspace remotely push the filter
+        down rather than enumerating.
+
+        Args:
+            prefix (str): Cache-key prefix to drop, normally a mount
+                prefix ending in "/".
+        """
+        raise NotImplementedError
+
     async def close(self) -> None:
         """Release connections held by the cache backend."""
 

--- a/python/mirage/cache/file/ram.py
+++ b/python/mirage/cache/file/ram.py
@@ -140,6 +140,11 @@ class RAMFileCacheStore(RAMResource, FileCacheMixin, KeyLockMixin):
             self._cache_size = 0
             self._clear_locks()
 
+    async def evict_prefix(self, prefix: str) -> None:
+        # Snapshot first: remove() mutates _entries as it goes.
+        for key in [k for k in self._entries if k.startswith(prefix)]:
+            await self.remove(key)
+
     def evict_paths(self, paths: Iterable[str]) -> None:
         for key in paths:
             entry = self._entries.pop(key, None)

--- a/python/mirage/cache/file/redis.py
+++ b/python/mirage/cache/file/redis.py
@@ -17,7 +17,8 @@ from collections.abc import Iterable
 from typing import Any
 
 from mirage.cache.file.mixin import FileCacheMixin, validate_max_drain_bytes
-from mirage.cache.file.utils import default_fingerprint, parse_limit
+from mirage.cache.file.utils import (default_fingerprint, glob_escape,
+                                     parse_limit)
 from mirage.resource.redis.redis import RedisResource
 
 
@@ -111,6 +112,18 @@ class RedisFileCacheStore(RedisResource, FileCacheMixin):
         ):
             keys: list[Any] = []
             async for k in self._cache_client.scan_iter(pattern):
+                keys.append(k)
+            if keys:
+                await self._cache_client.delete(*keys)
+
+    async def evict_prefix(self, prefix: str) -> None:
+        for key in [k for k in self._drain_tasks if k.startswith(prefix)]:
+            task = self._drain_tasks.pop(key)
+            task.cancel()
+        escaped = glob_escape(prefix)
+        for base in (self._data_prefix, self._meta_prefix):
+            keys: list[Any] = []
+            async for k in self._cache_client.scan_iter(f"{base}{escaped}*"):
                 keys.append(k)
             if keys:
                 await self._cache_client.delete(*keys)

--- a/python/mirage/cache/file/utils.py
+++ b/python/mirage/cache/file/utils.py
@@ -27,3 +27,21 @@ def parse_limit(limit: str | int) -> int:
 
 def default_fingerprint(data: bytes) -> str:
     return hashlib.md5(data).hexdigest()
+
+
+def glob_escape(literal: str) -> str:
+    """Escape a literal for use inside a redis MATCH pattern.
+
+    Cache keys are mount paths, and a path may legitimately contain the
+    glob metacharacters redis SCAN interprets, so a prefix like
+    ``/data[1]/`` would otherwise match nothing (or the wrong keys).
+
+    Args:
+        literal (str): Text to match verbatim.
+    """
+    out: list[str] = []
+    for ch in literal:
+        if ch in "*?[]\\":
+            out.append("\\")
+        out.append(ch)
+    return "".join(out)

--- a/python/mirage/cache/manager.py
+++ b/python/mirage/cache/manager.py
@@ -98,6 +98,23 @@ class CacheManager:
         await self._index.invalidate_dir(virtual + "/")
         await self._invalidate_parent(virtual)
 
+    async def drop_prefix(self) -> None:
+        """Drop every cached body under this mount, path unspecified.
+
+        For a mutation that names no path: an account CLI writes to its
+        service by id, so nothing here can say which file changed, only
+        that this mount's bytes may no longer match the service. Clearing
+        the listing alone is not enough, because an already-read body is
+        served warm and would keep answering with the pre-write content.
+
+        Over-evicts when this mount is the root and another mount sits
+        beneath it, since keys are compared by prefix. That costs a
+        refetch, which is the safe direction to be wrong in.
+        """
+        if not self._caches_reads or self._file_cache is None:
+            return
+        await self._file_cache.evict_prefix(self._prefix + "/")
+
     async def _invalidate_parent(self, virtual: str) -> None:
         parent = virtual.rsplit("/", 1)[0] or "/"
         await self._index.invalidate_dir(parent)

--- a/python/mirage/commands/cli/builtin/gws/__init__.py
+++ b/python/mirage/commands/cli/builtin/gws/__init__.py
@@ -27,6 +27,7 @@ from mirage.commands.cli.builtin.gws.sheets.write import write as sheets_write
 from mirage.commands.cli.types import CLISpec
 from mirage.commands.spec.types import Option
 from mirage.core.google.config import GoogleConfig
+from mirage.types import ResourceName
 
 # The gws program tree, mirroring the official Google Workspace CLI:
 # one passthrough leaf per Discovery method (`gws drive files list`,
@@ -38,6 +39,8 @@ GWS = CLISpec(
     name="gws",
     description="Google Workspace API commands",
     config_model=GoogleConfig,
+    serves=(ResourceName.GDRIVE, ResourceName.GDOCS, ResourceName.GSHEETS,
+            ResourceName.GSLIDES, ResourceName.GMAIL),
     subcommands=(
         CLISpec(
             name="drive",

--- a/python/mirage/commands/cli/builtin/gws/api.py
+++ b/python/mirage/commands/cli/builtin/gws/api.py
@@ -139,26 +139,46 @@ _CALLERS: dict[str, Callable[..., Awaitable[object]]] = {
 }
 
 
-def scoped_body(method: GwsMethod, config: GoogleConfig,
-                body: dict[str, Any]) -> dict[str, Any]:
+def scope_request(
+    method: GwsMethod,
+    config: GoogleConfig,
+    body: dict[str, Any],
+    params: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
     """Default a create's parents to the installation's folder scope.
 
     A folder-scoped install is pointed at one folder, which is the same
     folder a gdrive mount sharing the config exposes. A create with no
     parents would land in My Drive's root instead, outside the mount, so
     the agent's own `ls` would never show what it just made. An explicit
-    parents array always wins.
+    parents array always wins, and "explicit" means the key is present,
+    not that it holds anything: ``"parents": []`` is a caller saying
+    where the file goes just as much as ``"parents": ["root"]`` is, and
+    reading it as absent would silently relocate their file.
+
+    The injected parent brings ``supportsAllDrives`` with it, because a
+    folder scope may name a Shared Drive folder and Drive rejects a
+    create into one from a client that has not declared itself shared
+    drive aware. Only the injected case adds it: a caller who typed
+    their own parents is making a passthrough call and owns its query,
+    the same way the official CLI leaves it to them.
 
     Args:
         method (GwsMethod): the Discovery method being wrapped.
         config (GoogleConfig): the installation's config.
         body (dict): the parsed --json request body.
+        params (dict): the parsed --params object.
+
+    Returns:
+        tuple[dict, dict]: the (body, params) to send.
     """
     if method.placement != "parents" or not config.folder_id:
-        return body
-    if body.get("parents"):
-        return body
-    return {**body, "parents": [config.folder_id]}
+        return body, params
+    if "parents" in body:
+        return body, params
+    scoped = {**body, "parents": [config.folder_id]}
+    # params last: an explicitly typed supportsAllDrives still wins.
+    return scoped, {"supportsAllDrives": True, **params}
 
 
 async def place_in_scope(method: GwsMethod, token_manager: TokenManager,
@@ -170,6 +190,11 @@ async def place_in_scope(method: GwsMethod, token_manager: TokenManager,
     second Drive call. Doing it here is what lets `gws sheets spreadsheets
     create` put the file where the mount is, instead of leaving the caller
     to know that placement was even a question.
+
+    ``supportsAllDrives`` rides along for the same reason every other
+    Drive helper in the repo sends it: without it a scope naming a
+    Shared Drive folder fails the move, and the create has already
+    happened, so the file would be stranded in My Drive.
 
     Args:
         method (GwsMethod): the Discovery method being wrapped.
@@ -185,6 +210,7 @@ async def place_in_scope(method: GwsMethod, token_manager: TokenManager,
                        params={
                            "addParents": folder_id,
                            "removeParents": "root",
+                           "supportsAllDrives": "true",
                        })
 
 
@@ -200,7 +226,7 @@ async def run_gws_method(
     body = _parse_json_flag(fl.as_str("json") or "", "--json")
     if method.needs_body and not body:
         raise UsageError("--json is required")
-    body = scoped_body(method, config, body)
+    body, params = scope_request(method, config, body, params)
     token_manager = TokenManager(config)
     path, query = fill_path(method.path, params)
     url = SERVICE_BASES[method.service](token_manager) + path

--- a/python/mirage/commands/cli/builtin/gws/api.py
+++ b/python/mirage/commands/cli/builtin/gws/api.py
@@ -24,9 +24,10 @@ from mirage.commands.cli.builtin.gws.methods import (GWS_METHODS,
 from mirage.commands.cli.types import CLISpec
 from mirage.commands.errors import UsageError
 from mirage.commands.spec.types import FlagView, Option
-from mirage.core.google._client import (TokenManager, google_delete,
-                                        google_get, google_get_bytes,
-                                        google_patch, google_post)
+from mirage.core.google._client import (TokenManager, drive_base,
+                                        google_delete, google_get,
+                                        google_get_bytes, google_patch,
+                                        google_post)
 from mirage.core.google.config import GoogleConfig
 from mirage.io.stream import yield_bytes
 from mirage.io.types import ByteSource, IOResult
@@ -138,6 +139,55 @@ _CALLERS: dict[str, Callable[..., Awaitable[object]]] = {
 }
 
 
+def scoped_body(method: GwsMethod, config: GoogleConfig,
+                body: dict[str, Any]) -> dict[str, Any]:
+    """Default a create's parents to the installation's folder scope.
+
+    A folder-scoped install is pointed at one folder, which is the same
+    folder a gdrive mount sharing the config exposes. A create with no
+    parents would land in My Drive's root instead, outside the mount, so
+    the agent's own `ls` would never show what it just made. An explicit
+    parents array always wins.
+
+    Args:
+        method (GwsMethod): the Discovery method being wrapped.
+        config (GoogleConfig): the installation's config.
+        body (dict): the parsed --json request body.
+    """
+    if method.placement != "parents" or not config.folder_id:
+        return body
+    if body.get("parents"):
+        return body
+    return {**body, "parents": [config.folder_id]}
+
+
+async def place_in_scope(method: GwsMethod, token_manager: TokenManager,
+                         result: dict[str, Any]) -> None:
+    """Move a newly created editor file into the folder scope.
+
+    The Docs, Sheets and Slides create methods have no parents field at
+    all, so a new file always lands in My Drive's root; placing it takes a
+    second Drive call. Doing it here is what lets `gws sheets spreadsheets
+    create` put the file where the mount is, instead of leaving the caller
+    to know that placement was even a question.
+
+    Args:
+        method (GwsMethod): the Discovery method being wrapped.
+        token_manager (TokenManager): the installation's OAuth handle.
+        result (dict): the create response, carrying the new file's id.
+    """
+    folder_id = token_manager.config.folder_id
+    file_id = result.get(method.id_field)
+    if not folder_id or not isinstance(file_id, str):
+        return
+    await google_patch(token_manager,
+                       f"{drive_base(token_manager)}/files/{file_id}", {},
+                       params={
+                           "addParents": folder_id,
+                           "removeParents": "root",
+                       })
+
+
 async def run_gws_method(
     method: GwsMethod,
     config: GoogleConfig,
@@ -150,6 +200,7 @@ async def run_gws_method(
     body = _parse_json_flag(fl.as_str("json") or "", "--json")
     if method.needs_body and not body:
         raise UsageError("--json is required")
+    body = scoped_body(method, config, body)
     token_manager = TokenManager(config)
     path, query = fill_path(method.path, params)
     url = SERVICE_BASES[method.service](token_manager) + path
@@ -168,6 +219,8 @@ async def run_gws_method(
         return yield_bytes(out), IOResult()
     result = await _CALLERS[method.http](token_manager, url, body,
                                          query_params)
+    if method.placement == "relocate" and isinstance(result, dict):
+        await place_in_scope(method, token_manager, result)
     await invalidate_mount_listing()
     if result is _NO_CONTENT:
         return None, IOResult()

--- a/python/mirage/commands/cli/builtin/gws/methods.py
+++ b/python/mirage/commands/cli/builtin/gws/methods.py
@@ -35,6 +35,14 @@ class GwsMethod:
     path: str
     needs_body: bool = False
     raw_bytes: bool = False
+    # Where a newly created file lands when the installation is scoped to a
+    # folder. "parents" means the request body takes a parents array, so the
+    # scope is filled in there. "relocate" means the API has no parents
+    # field at all (the editors' create methods), so the new file is moved
+    # afterwards with a Drive update. None means the method creates nothing.
+    placement: str | None = None
+    # Response key holding the new file's id, for "relocate".
+    id_field: str = "id"
 
 
 GWS_METHODS: tuple[GwsMethod, ...] = (
@@ -44,7 +52,9 @@ GWS_METHODS: tuple[GwsMethod, ...] = (
               "create",
               "POST",
               "/documents",
-              needs_body=True),
+              needs_body=True,
+              placement="relocate",
+              id_field="documentId"),
     GwsMethod("docs",
               "documents",
               "batchUpdate",
@@ -58,7 +68,9 @@ GWS_METHODS: tuple[GwsMethod, ...] = (
               "create",
               "POST",
               "/spreadsheets",
-              needs_body=True),
+              needs_body=True,
+              placement="relocate",
+              id_field="spreadsheetId"),
     GwsMethod("sheets",
               "spreadsheets",
               "batchUpdate",
@@ -72,7 +84,9 @@ GWS_METHODS: tuple[GwsMethod, ...] = (
               "create",
               "POST",
               "/presentations",
-              needs_body=True),
+              needs_body=True,
+              placement="relocate",
+              id_field="presentationId"),
     GwsMethod("slides",
               "presentations",
               "batchUpdate",
@@ -81,14 +95,25 @@ GWS_METHODS: tuple[GwsMethod, ...] = (
               needs_body=True),
     GwsMethod("drive", "files", "list", "GET", "/files"),
     GwsMethod("drive", "files", "get", "GET", "/files/{fileId}"),
-    GwsMethod("drive", "files", "create", "POST", "/files", needs_body=True),
+    GwsMethod("drive",
+              "files",
+              "create",
+              "POST",
+              "/files",
+              needs_body=True,
+              placement="parents"),
     GwsMethod("drive",
               "files",
               "update",
               "PATCH",
               "/files/{fileId}",
               needs_body=True),
-    GwsMethod("drive", "files", "copy", "POST", "/files/{fileId}/copy"),
+    GwsMethod("drive",
+              "files",
+              "copy",
+              "POST",
+              "/files/{fileId}/copy",
+              placement="parents"),
     GwsMethod("drive", "files", "delete", "DELETE", "/files/{fileId}"),
     GwsMethod("drive",
               "files",

--- a/python/mirage/commands/cli/types.py
+++ b/python/mirage/commands/cli/types.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel
 
 from mirage.commands.cli.compile import validate_cli
 from mirage.commands.spec.types import CommandSpec
-from mirage.types import Limit
+from mirage.types import Limit, ResourceName
 
 
 class UsageStyle(Enum):
@@ -92,6 +92,13 @@ class CLISpec(CommandSpec):
         config_model (type[BaseModel] | None): root only. Pydantic model
             validating an installation's config from YAML ``clis:`` or
             ``register_cli``; also the redaction schema for snapshots.
+        serves (tuple[ResourceName, ...]): root only. The resources this
+            CLI's service also backs as mounts. A write verb mutates that
+            service by id, which no vfs path can be derived from, so
+            those mounts drop their cached listings afterwards and the
+            agent's next ``ls`` shows what it just made. Empty for a CLI
+            with no mounted counterpart (``git`` reaches mounts through
+            the op dispatcher, which invalidates per path already).
         usage_style (UsageStyle): root only. How a leaf refuses an option
             it does not declare. Defaults to argparse, which is right for
             a CLI mirage invented; a CLI that mimics an existing program
@@ -111,6 +118,7 @@ class CLISpec(CommandSpec):
     # (a collision is legal, a TypeError is not).
     limit: Limit | None = field(default=None, hash=False)
     config_model: type[BaseModel] | None = None
+    serves: tuple[ResourceName, ...] = ()
 
     def __post_init__(self) -> None:
         validate_cli(self)

--- a/python/mirage/core/google/_client.py
+++ b/python/mirage/core/google/_client.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import json
 import time
 from typing import Any
 
@@ -29,6 +30,59 @@ SHEETS_API_BASE = "https://sheets.googleapis.com/v4"
 GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1"
 DRIVE_UPLOAD_BASE = "https://www.googleapis.com/upload/drive/v3"
 TOKEN_BUFFER_SECONDS = 300
+
+
+def google_error_message(body: str, status: int, reason: str | None) -> str:
+    """Pull Google's own error text out of an error response body.
+
+    Google reports why a call failed in the body, in one of two shapes: the
+    APIs use ``{"error": {"message": ...}}`` and the OAuth token endpoint
+    uses a flat ``{"error": ..., "error_description": ...}``. Falls back to
+    the raw body, then to the HTTP reason phrase.
+
+    Args:
+        body (str): the raw response body.
+        status (int): HTTP status code.
+        reason (str | None): HTTP reason phrase, the last resort.
+    """
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        error = parsed.get("error")
+        if isinstance(error, dict) and isinstance(error.get("message"), str):
+            return str(error["message"])
+        if isinstance(error, str):
+            description = parsed.get("error_description")
+            return f"{error}: {description}" if description else error
+    return body.strip() or reason or f"HTTP {status}"
+
+
+async def raise_for_google_status(resp: aiohttp.ClientResponse) -> None:
+    """Raise with Google's message instead of the bare HTTP reason phrase.
+
+    ``resp.raise_for_status()`` raises before anything reads the body, so
+    the reason Google gave is discarded and the caller only ever sees
+    "Bad Request". An agent cannot correct an error it cannot read, so the
+    body is read first and its message becomes the exception's. The
+    exception type is unchanged, since callers classify on it (a 403 during
+    a mutation becomes EACCES in ``gdrive/resolve.py``).
+
+    Args:
+        resp (aiohttp.ClientResponse): the response to check.
+    """
+    if resp.status < 400:
+        return
+    raw = await resp.read()
+    raise aiohttp.ClientResponseError(
+        resp.request_info,
+        resp.history,
+        status=resp.status,
+        message=google_error_message(raw.decode("utf-8", errors="replace"),
+                                     resp.status, resp.reason),
+        headers=resp.headers,
+    )
 
 
 def token_url(config: GoogleConfig) -> str:
@@ -84,7 +138,7 @@ async def refresh_access_token(config: GoogleConfig, ) -> tuple[str, int]:
         data["client_secret"] = client_secret
     async with aiohttp.ClientSession() as session:
         async with session.post(token_url(config), data=data) as resp:
-            resp.raise_for_status()
+            await raise_for_google_status(resp)
             body = await resp.json()
             return body["access_token"], body["expires_in"]
 
@@ -122,7 +176,7 @@ async def google_get(
     headers = await google_headers(token_manager)
     async with aiohttp.ClientSession() as session:
         async with session.get(url, headers=headers, params=params) as resp:
-            resp.raise_for_status()
+            await raise_for_google_status(resp)
             return await resp.json()
 
 
@@ -134,7 +188,7 @@ async def google_post(
     headers = await google_headers(token_manager)
     async with aiohttp.ClientSession() as session:
         async with session.post(url, headers=headers, json=json) as resp:
-            resp.raise_for_status()
+            await raise_for_google_status(resp)
             return await resp.json()
 
 
@@ -146,7 +200,7 @@ async def google_put(
     headers = await google_headers(token_manager)
     async with aiohttp.ClientSession() as session:
         async with session.put(url, headers=headers, json=json) as resp:
-            resp.raise_for_status()
+            await raise_for_google_status(resp)
             return await resp.json()
 
 
@@ -162,7 +216,7 @@ async def google_patch(
                                  headers=headers,
                                  json=json,
                                  params=params) as resp:
-            resp.raise_for_status()
+            await raise_for_google_status(resp)
             return await resp.json()
 
 
@@ -192,7 +246,7 @@ async def google_send_bytes(
                                    headers=headers,
                                    data=data,
                                    params=params) as resp:
-            resp.raise_for_status()
+            await raise_for_google_status(resp)
             return await resp.json()
 
 
@@ -203,7 +257,7 @@ async def google_delete(
     headers = await google_headers(token_manager)
     async with aiohttp.ClientSession() as session:
         async with session.delete(url, headers=headers) as resp:
-            resp.raise_for_status()
+            await raise_for_google_status(resp)
 
 
 async def google_get_bytes(
@@ -224,5 +278,5 @@ async def google_get_bytes(
         headers["Range"] = range_header
     async with aiohttp.ClientSession() as session:
         async with session.get(url, headers=headers) as resp:
-            resp.raise_for_status()
+            await raise_for_google_status(resp)
             return await resp.read()

--- a/python/mirage/workspace/executor/command/cli.py
+++ b/python/mirage/workspace/executor/command/cli.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from collections.abc import Awaitable, Callable
 from dataclasses import replace
 
 from mirage.commands.builtin.utils.limit import (CommandTimeoutError,
@@ -45,6 +46,7 @@ async def handle_cli(
     dispatch: DispatchFn | None = None,
     stat_path: StatPath | None = None,
     mount_root: MountRoot | None = None,
+    drop_listings: Callable[[], Awaitable[None]] | None = None,
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
     """Execute a line whose head word is an installed CLI.
 
@@ -73,6 +75,11 @@ async def handle_cli(
             exactly as a mount command does.
         mount_root (MountRoot | None): the mount prefix serving a path,
             offered on the same terms.
+        drop_listings (Callable | None): drop cached listings for the
+            mounts this CLI's service serves. Called after a write verb
+            succeeds, because an account CLI mutates its service by id
+            and no vfs path can be derived from that, so per-path
+            invalidation has nothing to aim at.
     """
     # Words re-enter string space as typed (word_text): the walk owns
     # interpretation, so a quoted "Lunch?" must not arrive as the
@@ -181,6 +188,8 @@ async def handle_cli(
         return None, err_io, ExecutionNode(command=cmd_str,
                                            exit_code=1,
                                            stderr=err_stderr)
+    if leaf.write and drop_listings is not None:
+        await drop_listings()
     if out is None:
         stdout, io = None, IOResult()
     else:

--- a/python/mirage/workspace/executor/command/cli.py
+++ b/python/mirage/workspace/executor/command/cli.py
@@ -46,7 +46,7 @@ async def handle_cli(
     dispatch: DispatchFn | None = None,
     stat_path: StatPath | None = None,
     mount_root: MountRoot | None = None,
-    drop_listings: Callable[[], Awaitable[None]] | None = None,
+    drop_caches: Callable[[], Awaitable[None]] | None = None,
 ) -> tuple[ByteSource | None, IOResult, ExecutionNode]:
     """Execute a line whose head word is an installed CLI.
 
@@ -75,11 +75,11 @@ async def handle_cli(
             exactly as a mount command does.
         mount_root (MountRoot | None): the mount prefix serving a path,
             offered on the same terms.
-        drop_listings (Callable | None): drop cached listings for the
-            mounts this CLI's service serves. Called after a write verb
-            succeeds, because an account CLI mutates its service by id
-            and no vfs path can be derived from that, so per-path
-            invalidation has nothing to aim at.
+        drop_caches (Callable | None): drop cached listings and bodies
+            for the mounts this CLI's service serves. Called after a
+            write verb succeeds, because an account CLI mutates its
+            service by id and no vfs path can be derived from that, so
+            per-path invalidation has nothing to aim at.
     """
     # Words re-enter string space as typed (word_text): the walk owns
     # interpretation, so a quoted "Lunch?" must not arrive as the
@@ -188,8 +188,8 @@ async def handle_cli(
         return None, err_io, ExecutionNode(command=cmd_str,
                                            exit_code=1,
                                            stderr=err_stderr)
-    if leaf.write and drop_listings is not None:
-        await drop_listings()
+    if leaf.write and drop_caches is not None:
+        await drop_caches()
     if out is None:
         stdout, io = None, IOResult()
     else:

--- a/python/mirage/workspace/executor/command/command.py
+++ b/python/mirage/workspace/executor/command/command.py
@@ -39,7 +39,8 @@ from mirage.workspace.executor.command.routing import (CWD_DEFAULT_RAW,
                                                        default_cwd_operand,
                                                        merge_scopes,
                                                        path_flag_scopes)
-from mirage.workspace.executor.command.run import (exec_node, mount_root_of,
+from mirage.workspace.executor.command.run import (drop_service_listings,
+                                                   exec_node, mount_root_of,
                                                    run_on_mount,
                                                    scalar_find_flags)
 from mirage.workspace.executor.command.types import ExecuteNodeFn
@@ -118,6 +119,8 @@ async def handle_command(
             stat_path=(functools.partial(path_stat, dispatch)
                        if dispatch is not None else None),
             mount_root=functools.partial(mount_root_of, registry),
+            drop_listings=functools.partial(drop_service_listings, registry,
+                                            cli_install.spec.serves),
         )
 
     if cmd_name in CWD_DEFAULT_RAW:

--- a/python/mirage/workspace/executor/command/command.py
+++ b/python/mirage/workspace/executor/command/command.py
@@ -39,7 +39,7 @@ from mirage.workspace.executor.command.routing import (CWD_DEFAULT_RAW,
                                                        default_cwd_operand,
                                                        merge_scopes,
                                                        path_flag_scopes)
-from mirage.workspace.executor.command.run import (drop_service_listings,
+from mirage.workspace.executor.command.run import (drop_service_caches,
                                                    exec_node, mount_root_of,
                                                    run_on_mount,
                                                    scalar_find_flags)
@@ -119,8 +119,8 @@ async def handle_command(
             stat_path=(functools.partial(path_stat, dispatch)
                        if dispatch is not None else None),
             mount_root=functools.partial(mount_root_of, registry),
-            drop_listings=functools.partial(drop_service_listings, registry,
-                                            cli_install.spec.serves),
+            drop_caches=functools.partial(drop_service_caches, registry,
+                                          cli_install.spec.serves),
         )
 
     if cmd_name in CWD_DEFAULT_RAW:

--- a/python/mirage/workspace/executor/command/run.py
+++ b/python/mirage/workspace/executor/command/run.py
@@ -25,7 +25,7 @@ from mirage.ops.types import LinkView
 from mirage.runtime.base import Runtime
 from mirage.runtime.policy import PolicyDecision
 from mirage.runtime.table import VfsRuntime
-from mirage.types import FileStat, PathSpec
+from mirage.types import FileStat, PathSpec, ResourceName
 from mirage.utils.errors import format_fs_error
 from mirage.workspace.executor.builtins.links import (link_target_stat,
                                                       path_exists, path_stat)
@@ -154,6 +154,35 @@ def mount_root_of(registry: MountRegistry, virtual: str) -> str:
         return registry.mount_for(virtual).prefix
     except ValueError:
         return "/"
+
+
+async def drop_service_listings(registry: MountRegistry,
+                                serves: tuple[ResourceName, ...]) -> None:
+    """Drop cached listings for the mounts a CLI's service also backs.
+
+    An account CLI mutates its service by id, so no vfs path can be
+    derived from the call and per-path invalidation has nothing to aim
+    at: after `gws sheets spreadsheets create` the new file has no cache
+    entry to expire, which is exactly the case that matters. What is
+    known is the service, so the mounts it backs drop their listings and
+    the next readdir refetches.
+
+    Scoped by the spec's declared ``serves`` rather than a blanket
+    reset, so a Slack or S3 mount alongside keeps its cache. File
+    contents are left alone: a stale listing is what hides a newly
+    created file.
+
+    Args:
+        registry (MountRegistry): registry holding the mount table.
+        serves (tuple[ResourceName, ...]): resources the CLI's service
+            backs; empty drops nothing.
+    """
+    if not serves:
+        return
+    wanted = set(serves)
+    for mount in registry.mounts():
+        if mount.resource.name in wanted:
+            await mount.resource.index.clear()
 
 
 def namespace_stat_overlay(namespace: Namespace, virtual: str,

--- a/python/mirage/workspace/executor/command/run.py
+++ b/python/mirage/workspace/executor/command/run.py
@@ -156,21 +156,25 @@ def mount_root_of(registry: MountRegistry, virtual: str) -> str:
         return "/"
 
 
-async def drop_service_listings(registry: MountRegistry,
-                                serves: tuple[ResourceName, ...]) -> None:
-    """Drop cached listings for the mounts a CLI's service also backs.
+async def drop_service_caches(registry: MountRegistry,
+                              serves: tuple[ResourceName, ...]) -> None:
+    """Drop cached listings and bodies for the mounts a CLI's service backs.
 
     An account CLI mutates its service by id, so no vfs path can be
     derived from the call and per-path invalidation has nothing to aim
     at: after `gws sheets spreadsheets create` the new file has no cache
     entry to expire, which is exactly the case that matters. What is
-    known is the service, so the mounts it backs drop their listings and
-    the next readdir refetches.
+    known is the service, so the mounts it backs drop their caches and
+    the next read refetches.
+
+    Both caches go, because the two hide different writes. A stale
+    listing hides a create or a delete; a stale body hides an edit, and
+    these resources cache reads, so a `cat` after `gws docs documents
+    batchUpdate` would otherwise keep serving the pre-edit content
+    without ever reaching Google.
 
     Scoped by the spec's declared ``serves`` rather than a blanket
-    reset, so a Slack or S3 mount alongside keeps its cache. File
-    contents are left alone: a stale listing is what hides a newly
-    created file.
+    reset, so a Slack or S3 mount alongside keeps its cache.
 
     Args:
         registry (MountRegistry): registry holding the mount table.
@@ -181,8 +185,11 @@ async def drop_service_listings(registry: MountRegistry,
         return
     wanted = set(serves)
     for mount in registry.mounts():
-        if mount.resource.name in wanted:
-            await mount.resource.index.clear()
+        if mount.resource.name not in wanted:
+            continue
+        await mount.resource.index.clear()
+        if mount.cache_manager is not None:
+            await mount.cache_manager.drop_prefix()
 
 
 def namespace_stat_overlay(namespace: Namespace, virtual: str,

--- a/python/tests/cache/file/test_ram.py
+++ b/python/tests/cache/file/test_ram.py
@@ -99,3 +99,27 @@ async def test_drain_task_cancelled_on_remove():
     await cache.remove("/a")
     await asyncio.sleep(0)
     assert cancelled
+
+
+@pytest.mark.asyncio
+async def test_evict_prefix_drops_only_matching_keys():
+    cache = RAMFileCacheStore()
+    await cache.set("/data/a.txt", b"a")
+    await cache.set("/data/sub/b.txt", b"bb")
+    await cache.set("/other/c.txt", b"ccc")
+    await cache.evict_prefix("/data/")
+    assert await cache.exists("/data/a.txt") is False
+    assert await cache.exists("/data/sub/b.txt") is False
+    assert await cache.exists("/other/c.txt") is True
+
+
+@pytest.mark.asyncio
+async def test_evict_prefix_reclaims_the_evicted_bytes():
+    """Eviction runs through remove(), so the LRU accounting stays
+    truthful instead of leaking the dropped entries' sizes."""
+    cache = RAMFileCacheStore()
+    await cache.set("/data/a.txt", b"12345")
+    await cache.set("/other/c.txt", b"xy")
+    await cache.evict_prefix("/data/")
+    assert cache.cache_size == 2
+    assert cache.cache_entries == 1

--- a/python/tests/cache/file/test_utils.py
+++ b/python/tests/cache/file/test_utils.py
@@ -12,7 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from mirage.cache.file.utils import default_fingerprint, parse_limit
+from mirage.cache.file.utils import (default_fingerprint, glob_escape,
+                                     parse_limit)
 
 
 def test_parse_limit_bytes():
@@ -51,3 +52,17 @@ def test_default_fingerprint_deterministic():
 
 def test_default_fingerprint_different_data():
     assert default_fingerprint(b"a") != default_fingerprint(b"b")
+
+
+def test_glob_escape_leaves_an_ordinary_path_alone():
+    assert glob_escape("/data/") == "/data/"
+
+
+def test_glob_escape_neutralizes_redis_match_metacharacters():
+    """A mount prefix is a path, and a path may hold the characters SCAN
+    reads as wildcards."""
+    assert glob_escape("/da[1]*a?/") == "/da\\[1\\]\\*a\\?/"
+
+
+def test_glob_escape_escapes_the_escape_character():
+    assert glob_escape("a\\b") == "a\\\\b"

--- a/python/tests/cache/test_manager.py
+++ b/python/tests/cache/test_manager.py
@@ -155,3 +155,35 @@ async def _no_index_case() -> bool:
 
 def test_null_index_is_tolerated():
     assert _run(_no_index_case()) is False
+
+
+async def _drop_prefix_case() -> tuple[bool, bool, bool]:
+    cache, index = _stores()
+    await _seed(cache, index)
+    await cache.set("/other/keep.txt", b"safe\n")
+    manager = CacheManager(cache, index, "/data/", True)
+    await manager.drop_prefix()
+    return (await cache.exists("/data/arch/h.txt"), await
+            cache.exists("/other/keep.txt"), manager._caches_reads)
+
+
+def test_drop_prefix_evicts_this_mount_only():
+    """A path-unknown mutation drops the mount's bodies without reaching
+    into a neighbouring mount's keyspace."""
+    dropped, kept, _ = _run(_drop_prefix_case())
+    assert dropped is False
+    assert kept is True
+
+
+async def _drop_prefix_local_case() -> bool:
+    cache, index = _stores()
+    await _seed(cache, index)
+    manager = CacheManager(cache, index, "/data/", False)
+    await manager.drop_prefix()
+    return await cache.exists("/data/arch/h.txt")
+
+
+def test_drop_prefix_leaves_a_non_caching_mount_alone():
+    """A mount that does not cache reads owns no entries here, so the
+    keys under its prefix belong to whoever put them there."""
+    assert _run(_drop_prefix_local_case()) is True

--- a/python/tests/cache/test_manager.py
+++ b/python/tests/cache/test_manager.py
@@ -187,3 +187,22 @@ def test_drop_prefix_leaves_a_non_caching_mount_alone():
     """A mount that does not cache reads owns no entries here, so the
     keys under its prefix belong to whoever put them there."""
     assert _run(_drop_prefix_local_case()) is True
+
+
+async def _drop_prefix_root_case() -> tuple[str, bool, bool]:
+    cache, index = _stores()
+    await cache.set("/a.txt", b"x")
+    await cache.set("/sub/b.txt", b"y")
+    manager = CacheManager(cache, index, "/", True)
+    await manager.drop_prefix()
+    return (manager._prefix, await cache.exists("/a.txt"), await
+            cache.exists("/sub/b.txt"))
+
+
+def test_drop_prefix_reaches_every_key_on_a_root_mount():
+    """A root mount strips to the empty prefix, so the eviction argument
+    is "/" and matches every key rather than nothing."""
+    prefix, a, b = _run(_drop_prefix_root_case())
+    assert prefix == ""
+    assert a is False
+    assert b is False

--- a/python/tests/commands/cli/builtin/gws/test_api.py
+++ b/python/tests/commands/cli/builtin/gws/test_api.py
@@ -209,3 +209,92 @@ async def test_files_export_returns_raw_bytes():
     assert await materialize(out) == b"%PDF-1.4"
     assert "/files/f1/export?mimeType=application/pdf" in \
         get_bytes.await_args.args[1]
+
+
+SCOPED = GoogleConfig(client_id="cid", refresh_token="rt", folder_id="F1")
+
+
+@pytest.mark.asyncio
+async def test_injected_parent_declares_shared_drive_support():
+    """An injected parent may name a Shared Drive folder, which Drive
+    rejects from a client that has not sent supportsAllDrives."""
+    method = METHODS[("drive", "files", "create")]
+    with patch(
+            "mirage.commands.cli.builtin.gws.api.google_post",
+            new_callable=AsyncMock,
+            return_value={"id": "f9"},
+    ) as post:
+        await run_gws_method(method, SCOPED, [], json='{"name": "n"}')
+    assert post.await_args.args[2] == {"name": "n", "parents": ["F1"]}
+    assert "supportsAllDrives=true" in post.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_explicit_parents_stay_a_passthrough():
+    """A caller who typed their own parents owns the query too, so
+    nothing is injected into either half of the request."""
+    method = METHODS[("drive", "files", "create")]
+    with patch(
+            "mirage.commands.cli.builtin.gws.api.google_post",
+            new_callable=AsyncMock,
+            return_value={"id": "f9"},
+    ) as post:
+        await run_gws_method(method,
+                             SCOPED, [],
+                             json='{"name": "n", "parents": ["OTHER"]}')
+    assert post.await_args.args[2] == {"name": "n", "parents": ["OTHER"]}
+    assert "supportsAllDrives" not in post.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_relocation_declares_shared_drive_support():
+    """The editor create has already happened by the time the move runs,
+    so a move that fails on a Shared Drive scope strands the new file."""
+    method = METHODS[("sheets", "spreadsheets", "create")]
+    with patch("mirage.commands.cli.builtin.gws.api.google_post",
+               new_callable=AsyncMock,
+               return_value={"spreadsheetId": "s1"}):
+        with patch(
+                "mirage.commands.cli.builtin.gws.api.google_patch",
+                new_callable=AsyncMock,
+                return_value={"id": "s1"},
+        ) as patch_call:
+            await run_gws_method(method,
+                                 SCOPED, [],
+                                 json='{"properties": {"title": "T"}}')
+    assert patch_call.await_args.kwargs["params"] == {
+        "addParents": "F1",
+        "removeParents": "root",
+        "supportsAllDrives": "true",
+    }
+
+
+@pytest.mark.asyncio
+async def test_unscoped_install_places_nothing():
+    method = METHODS[("sheets", "spreadsheets", "create")]
+    with patch("mirage.commands.cli.builtin.gws.api.google_post",
+               new_callable=AsyncMock,
+               return_value={"spreadsheetId": "s1"}):
+        with patch("mirage.commands.cli.builtin.gws.api.google_patch",
+                   new_callable=AsyncMock) as patch_call:
+            await run_gws_method(method,
+                                 CONFIG, [],
+                                 json='{"properties": {"title": "T"}}')
+    patch_call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_an_explicitly_empty_parents_array_is_still_the_callers():
+    """`parents: []` states a placement as much as `parents: ["root"]`
+    does; reading it as absent would relocate the caller's file."""
+    method = METHODS[("drive", "files", "create")]
+    with patch(
+            "mirage.commands.cli.builtin.gws.api.google_post",
+            new_callable=AsyncMock,
+            return_value={"id": "f9"},
+    ) as post:
+        await run_gws_method(method,
+                             SCOPED, [],
+                             json='{"name": "n", "parents": []}')
+    assert post.await_args.args[2] == {"name": "n", "parents": []}
+    assert "supportsAllDrives" not in post.await_args.args[1]

--- a/python/tests/core/google/test_client.py
+++ b/python/tests/core/google/test_client.py
@@ -18,10 +18,15 @@ from mirage.core.google._client import (DOCS_API_BASE, DRIVE_API_BASE,
                                         SHEETS_API_BASE, SLIDES_API_BASE,
                                         TOKEN_URL, TokenManager, docs_base,
                                         drive_base, drive_upload_base,
-                                        gmail_base, sheets_base, slides_base,
-                                        token_url)
+                                        gmail_base, google_error_message,
+                                        sheets_base, slides_base, token_url)
 # yapf: enable
 from mirage.core.google.config import GoogleConfig
+
+API_ERROR = ('{"error": {"code": 400, "message": "Unsupported request: '
+             'insertDimension", "status": "INVALID_ARGUMENT"}}')
+TOKEN_ERROR = ('{"error": "invalid_grant", "error_description": '
+               '"Token has been expired or revoked."}')
 
 
 def _manager(api_base: str | None = None) -> TokenManager:
@@ -49,3 +54,25 @@ def test_api_base_override_rewrites_every_service():
     assert sheets_base(tm) == "http://127.0.0.1:19999/v4"
     assert gmail_base(tm) == "http://127.0.0.1:19999/gmail/v1"
     assert token_url(tm.config) == "http://127.0.0.1:19999/token"
+
+
+def test_api_error_message_comes_from_the_body():
+    assert google_error_message(
+        API_ERROR, 400,
+        "Bad Request") == "Unsupported request: insertDimension"
+
+
+def test_token_endpoint_error_shape_is_flat():
+    assert google_error_message(
+        TOKEN_ERROR, 400,
+        "Bad Request") == "invalid_grant: Token has been expired or revoked."
+
+
+def test_non_json_body_is_reported_verbatim():
+    assert google_error_message("<html>gateway</html>", 502,
+                                "Bad Gateway") == "<html>gateway</html>"
+
+
+def test_empty_body_falls_back_to_the_reason_then_the_status():
+    assert google_error_message("", 404, "Not Found") == "Not Found"
+    assert google_error_message("   ", 404, None) == "HTTP 404"

--- a/python/tests/core/google/test_config.py
+++ b/python/tests/core/google/test_config.py
@@ -57,6 +57,8 @@ async def test_refresh_access_token_omits_client_secret_when_absent():
         async def __aexit__(self, *_):
             return None
 
+        status = 200
+
         def raise_for_status(self):
             return None
 
@@ -99,6 +101,8 @@ async def test_refresh_access_token_includes_client_secret_when_present():
 
         async def __aexit__(self, *_):
             return None
+
+        status = 200
 
         def raise_for_status(self):
             return None

--- a/python/tests/workspace/executor/command/test_run.py
+++ b/python/tests/workspace/executor/command/test_run.py
@@ -15,8 +15,12 @@
 import pytest
 
 from mirage.commands.builtin.generic_bind.builders import _BUILDERS
+from mirage.resource.disk import DiskResource
+from mirage.types import MountMode, ResourceName
 from mirage.utils.params import accepts_kwarg
-from mirage.workspace.executor.command.run import link_view, listed_names
+from mirage.workspace import Workspace
+from mirage.workspace.executor.command.run import (drop_service_caches,
+                                                   link_view, listed_names)
 
 _LONG_ROW = "-rw-r--r-- 1 user user 6 Aug  2 18:54 real.txt"
 _DEGRADED_ROW = "d\t-\t-\tsub"
@@ -114,3 +118,53 @@ def test_stat_overlay_is_gated_by_the_same_rule():
     """The overlay used to carry its own list of command names."""
     named = {b.name for b in _BUILDERS if accepts_kwarg(b.fn, "stat_overlay")}
     assert named == {"ls", "stat", "cp", "mv", "find"}
+
+
+async def _cli_write_case(tmp_path) -> tuple[str, str]:
+    """A CLI write mutates the service out of band, exactly as gws does
+    by file id, then drops the caches for the mounts that service backs."""
+    (tmp_path / "a.txt").write_bytes(b"v1\n")
+    disk = DiskResource(root=str(tmp_path))
+    disk.caches_reads = True
+    ws = Workspace({"/data/": disk}, mode=MountMode.WRITE)
+    await (await ws.execute("cat /data/a.txt")).stdout_str()
+    (tmp_path / "a.txt").write_bytes(b"v2\n")
+    (tmp_path / "new.txt").write_bytes(b"fresh\n")
+    await drop_service_caches(ws._registry, (ResourceName.DISK, ))
+    second = await (await ws.execute("cat /data/a.txt")).stdout_str()
+    listing = await (await ws.execute("ls /data")).stdout_str()
+    return second, listing
+
+
+@pytest.mark.asyncio
+async def test_a_cli_write_drops_bodies_as_well_as_listings(tmp_path):
+    """A stale listing hides a create; a stale body hides an edit. The
+    cached body is the one that answers without reaching the service, so
+    clearing the index alone leaves `cat` serving pre-write content."""
+    body, listing = await _cli_write_case(tmp_path)
+    assert body == "v2\n"
+    assert "new.txt" in listing
+
+
+@pytest.mark.asyncio
+async def test_a_cli_that_serves_nothing_drops_nothing(tmp_path):
+    (tmp_path / "a.txt").write_bytes(b"v1\n")
+    disk = DiskResource(root=str(tmp_path))
+    disk.caches_reads = True
+    ws = Workspace({"/data/": disk}, mode=MountMode.WRITE)
+    await ws.execute("cat /data/a.txt")
+    (tmp_path / "a.txt").write_bytes(b"v2\n")
+    await drop_service_caches(ws._registry, ())
+    assert await (await ws.execute("cat /data/a.txt")).stdout_str() == "v1\n"
+
+
+@pytest.mark.asyncio
+async def test_an_unrelated_service_keeps_its_cache(tmp_path):
+    (tmp_path / "a.txt").write_bytes(b"v1\n")
+    disk = DiskResource(root=str(tmp_path))
+    disk.caches_reads = True
+    ws = Workspace({"/data/": disk}, mode=MountMode.WRITE)
+    await ws.execute("cat /data/a.txt")
+    (tmp_path / "a.txt").write_bytes(b"v2\n")
+    await drop_service_caches(ws._registry, (ResourceName.GDRIVE, ))
+    assert await (await ws.execute("cat /data/a.txt")).stdout_str() == "v1\n"

--- a/typescript/packages/core/src/cache/file/mixin.ts
+++ b/typescript/packages/core/src/cache/file/mixin.ts
@@ -27,6 +27,11 @@ export interface FileCache {
     options?: { fingerprint?: string | null; ttl?: number | null },
   ): Promise<boolean>
   remove(key: string): Promise<void>
+  // The path-unknown counterpart to remove(): a mutation that names no
+  // path (an account CLI writing to its service by id) cannot say which
+  // entries went stale, only which mount's keyspace did. Stores that own
+  // their keyspace remotely push the filter down rather than enumerating.
+  evictPrefix(prefix: string): Promise<void>
   exists(key: string | PathSpec): Promise<boolean>
   isFresh(key: string, remoteFingerprint: string): Promise<boolean>
   clear(): Promise<void>

--- a/typescript/packages/core/src/cache/file/ram.test.ts
+++ b/typescript/packages/core/src/cache/file/ram.test.ts
@@ -109,4 +109,24 @@ describe('RAMFileCacheStore', () => {
     expect(c.cacheSize).toBe(0)
     expect(await c.get('/a')).toBeNull()
   })
+
+  it('evictPrefix drops only matching keys', async () => {
+    const c = new RAMFileCacheStore({ limit: 1024 })
+    await c.set('/data/a.txt', encode('a'))
+    await c.set('/data/sub/b.txt', encode('bb'))
+    await c.set('/other/c.txt', encode('ccc'))
+    await c.evictPrefix('/data/')
+    expect(await c.exists('/data/a.txt')).toBe(false)
+    expect(await c.exists('/data/sub/b.txt')).toBe(false)
+    expect(await c.exists('/other/c.txt')).toBe(true)
+  })
+
+  it('evictPrefix reclaims the evicted bytes', async () => {
+    const c = new RAMFileCacheStore({ limit: 1024 })
+    await c.set('/data/a.txt', encode('12345'))
+    await c.set('/other/c.txt', encode('xy'))
+    await c.evictPrefix('/data/')
+    expect(c.cacheSize).toBe(2)
+    expect(c.cacheEntries).toBe(1)
+  })
 })

--- a/typescript/packages/core/src/cache/file/ram.ts
+++ b/typescript/packages/core/src/cache/file/ram.ts
@@ -136,6 +136,12 @@ export class RAMFileCacheStore extends RAMResource implements FileCache {
     return placed
   }
 
+  async evictPrefix(prefix: string): Promise<void> {
+    // Snapshot first: remove() mutates entries as it goes.
+    const keys = [...this.entries.keys()].filter((k) => k.startsWith(prefix))
+    for (const key of keys) await this.remove(key)
+  }
+
   remove(key: string): Promise<void> {
     this.drainTasks.delete(key)
     return this.lock.withLock(key, () => {

--- a/typescript/packages/core/src/cache/file/utils.ts
+++ b/typescript/packages/core/src/cache/file/utils.ts
@@ -31,3 +31,19 @@ export function parseLimit(limit: string | number): number {
 export function defaultFingerprint(data: Uint8Array): string {
   return md5Hex(data)
 }
+
+/**
+ * Escape a literal for use inside a redis MATCH pattern.
+ *
+ * Cache keys are mount paths, and a path may legitimately contain the glob
+ * metacharacters redis SCAN interprets, so a prefix like `/data[1]/` would
+ * otherwise match nothing (or the wrong keys).
+ */
+export function globEscape(literal: string): string {
+  let out = ''
+  for (const ch of literal) {
+    if (ch === '*' || ch === '?' || ch === '[' || ch === ']' || ch === '\\') out += '\\'
+    out += ch
+  }
+  return out
+}

--- a/typescript/packages/core/src/cache/manager.test.ts
+++ b/typescript/packages/core/src/cache/manager.test.ts
@@ -80,4 +80,20 @@ describe('CacheManager', () => {
     await manager.invalidateAfterWrite('/a.txt')
     expect(await cache.exists('/data/a.txt')).toBe(false)
   })
+
+  it("drops this mount's bodies without touching a neighbour", async () => {
+    const [cache, index] = await seeded()
+    await cache.set('/other/keep.txt', new TextEncoder().encode('safe'))
+    const manager = new CacheManager(cache, index, '/data/', true)
+    await manager.dropPrefix()
+    expect(await cache.exists('/data/arch/h.txt')).toBe(false)
+    expect(await cache.exists('/other/keep.txt')).toBe(true)
+  })
+
+  it('leaves a non-caching mount alone', async () => {
+    const [cache, index] = await seeded()
+    const manager = new CacheManager(cache, index, '/data/', false)
+    await manager.dropPrefix()
+    expect(await cache.exists('/data/arch/h.txt')).toBe(true)
+  })
 })

--- a/typescript/packages/core/src/cache/manager.test.ts
+++ b/typescript/packages/core/src/cache/manager.test.ts
@@ -96,4 +96,16 @@ describe('CacheManager', () => {
     await manager.dropPrefix()
     expect(await cache.exists('/data/arch/h.txt')).toBe(true)
   })
+
+  it('reaches every key on a root mount', async () => {
+    // A root mount strips to the empty prefix, so the eviction argument is '/'
+    // and matches every key rather than nothing.
+    const cache = new RAMFileCacheStore()
+    await cache.set('/a.txt', new TextEncoder().encode('x'))
+    await cache.set('/sub/b.txt', new TextEncoder().encode('y'))
+    const manager = new CacheManager(cache, null, '/', true)
+    await manager.dropPrefix()
+    expect(await cache.exists('/a.txt')).toBe(false)
+    expect(await cache.exists('/sub/b.txt')).toBe(false)
+  })
 })

--- a/typescript/packages/core/src/cache/manager.ts
+++ b/typescript/packages/core/src/cache/manager.ts
@@ -94,6 +94,24 @@ export class CacheManager {
     await this.invalidateParent(virtual)
   }
 
+  /**
+   * Drop every cached body under this mount, path unspecified.
+   *
+   * For a mutation that names no path: an account CLI writes to its service by
+   * id, so nothing here can say which file changed, only that this mount's
+   * bytes may no longer match the service. Clearing the listing alone is not
+   * enough, because an already-read body is served warm and would keep
+   * answering with the pre-write content.
+   *
+   * Over-evicts when this mount is the root and another mount sits beneath it,
+   * since keys are compared by prefix. That costs a refetch, which is the safe
+   * direction to be wrong in.
+   */
+  async dropPrefix(): Promise<void> {
+    if (!this.cachesReads || this.fileCache === null) return
+    await this.fileCache.evictPrefix(this.prefix + '/')
+  }
+
   private async invalidateParent(virtual: string): Promise<void> {
     if (this.index === null) return
     const lastSlash = virtual.lastIndexOf('/')

--- a/typescript/packages/core/src/commands/cli/builtin/gws/api.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gws/api.ts
@@ -135,19 +135,33 @@ const CALLERS: Record<GwsMethod['http'], Caller> = {
  * A folder-scoped install is pointed at one folder, which is the same folder a
  * gdrive mount sharing the config exposes. A create with no parents would land
  * in My Drive's root instead, outside the mount, so the agent's own `ls` would
- * never show what it just made. An explicit parents array always wins.
+ * never show what it just made. An explicit parents array always wins, and
+ * "explicit" means the key is present, not that it holds anything:
+ * `"parents": []` is a caller saying where the file goes just as much as
+ * `"parents": ["root"]` is, and reading it as absent would silently relocate
+ * their file.
+ *
+ * The injected parent brings `supportsAllDrives` with it, because a folder scope
+ * may name a Shared Drive folder and Drive rejects a create into one from a
+ * client that has not declared itself shared drive aware. Only the injected case
+ * adds it: a caller who typed their own parents is making a passthrough call and
+ * owns its query, the same way the official CLI leaves it to them.
  */
-function scopedBody(
+function scopeRequest(
   method: GwsMethod,
   config: GoogleConfig,
   body: Record<string, unknown>,
-): Record<string, unknown> {
-  if (method.placement !== 'parents') return body
+  params: Record<string, unknown>,
+): [Record<string, unknown>, Record<string, unknown>] {
+  if (method.placement !== 'parents') return [body, params]
   const folderId = config.folderId
-  if (folderId === undefined || folderId === '') return body
-  const parents = body.parents
-  if (Array.isArray(parents) && parents.length > 0) return body
-  return { ...body, parents: [folderId] }
+  if (folderId === undefined || folderId === '') return [body, params]
+  if ('parents' in body) return [body, params]
+  // params last: an explicitly typed supportsAllDrives still wins.
+  return [
+    { ...body, parents: [folderId] },
+    { supportsAllDrives: true, ...params },
+  ]
 }
 
 /**
@@ -158,6 +172,11 @@ function scopedBody(
  * call. Doing it here is what lets `gws sheets spreadsheets create` put the file
  * where the mount is, instead of leaving the caller to know that placement was
  * even a question.
+ *
+ * `supportsAllDrives` rides along for the same reason every other Drive helper
+ * in the repo sends it: without it a scope naming a Shared Drive folder fails
+ * the move, and the create has already happened, so the file would be stranded
+ * in My Drive.
  */
 async function placeInScope(
   method: GwsMethod,
@@ -171,7 +190,7 @@ async function placeInScope(
     tm,
     `${driveBase(tm)}/files/${fileId}`,
     {},
-    { addParents: folderId, removeParents: 'root' },
+    { addParents: folderId, removeParents: 'root', supportsAllDrives: 'true' },
   )
 }
 
@@ -194,7 +213,7 @@ export async function runGwsMethod(
   if (method.needsBody === true && Object.keys(body).length === 0) {
     return [null, new IOResult({ exitCode: 2, stderr: ENC.encode('--json is required\n') })]
   }
-  body = scopedBody(method, config, body)
+  ;[body, params] = scopeRequest(method, config, body, params)
   const tm = new TokenManager(config)
   let path: string
   let query: Record<string, unknown>

--- a/typescript/packages/core/src/commands/cli/builtin/gws/api.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gws/api.ts
@@ -15,6 +15,7 @@
 import { invalidateAfterWrite } from '../../../../cache/context.ts'
 import { TokenManager } from '../../../../core/google/_client.ts'
 import {
+  driveBase,
   googleDelete,
   googleGet,
   googleGetBytes,
@@ -128,6 +129,52 @@ const CALLERS: Record<GwsMethod['http'], Caller> = {
   },
 }
 
+/**
+ * Default a create's parents to the installation's folder scope.
+ *
+ * A folder-scoped install is pointed at one folder, which is the same folder a
+ * gdrive mount sharing the config exposes. A create with no parents would land
+ * in My Drive's root instead, outside the mount, so the agent's own `ls` would
+ * never show what it just made. An explicit parents array always wins.
+ */
+function scopedBody(
+  method: GwsMethod,
+  config: GoogleConfig,
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  if (method.placement !== 'parents') return body
+  const folderId = config.folderId
+  if (folderId === undefined || folderId === '') return body
+  const parents = body.parents
+  if (Array.isArray(parents) && parents.length > 0) return body
+  return { ...body, parents: [folderId] }
+}
+
+/**
+ * Move a newly created editor file into the folder scope.
+ *
+ * The Docs, Sheets and Slides create methods have no parents field at all, so a
+ * new file always lands in My Drive's root; placing it takes a second Drive
+ * call. Doing it here is what lets `gws sheets spreadsheets create` put the file
+ * where the mount is, instead of leaving the caller to know that placement was
+ * even a question.
+ */
+async function placeInScope(
+  method: GwsMethod,
+  tm: TokenManager,
+  result: Record<string, unknown>,
+): Promise<void> {
+  const folderId = tm.config.folderId
+  const fileId = result[method.idField ?? 'id']
+  if (folderId === undefined || folderId === '' || typeof fileId !== 'string') return
+  await googlePatch(
+    tm,
+    `${driveBase(tm)}/files/${fileId}`,
+    {},
+    { addParents: folderId, removeParents: 'root' },
+  )
+}
+
 export async function runGwsMethod(
   method: GwsMethod,
   config: GoogleConfig,
@@ -147,6 +194,7 @@ export async function runGwsMethod(
   if (method.needsBody === true && Object.keys(body).length === 0) {
     return [null, new IOResult({ exitCode: 2, stderr: ENC.encode('--json is required\n') })]
   }
+  body = scopedBody(method, config, body)
   const tm = new TokenManager(config)
   let path: string
   let query: Record<string, unknown>
@@ -178,6 +226,9 @@ export async function runGwsMethod(
     return [out, new IOResult()]
   }
   const result = await CALLERS[method.http](tm, url, body, queryParams)
+  if (method.placement === 'relocate' && result !== NO_CONTENT && result !== null) {
+    await placeInScope(method, tm, result as Record<string, unknown>)
+  }
   await invalidateMountListing()
   if (result === NO_CONTENT) return [null, new IOResult()]
   return [ENC.encode(JSON.stringify(result)), new IOResult()]

--- a/typescript/packages/core/src/commands/cli/builtin/gws/gws.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gws/gws.test.ts
@@ -291,3 +291,79 @@ describe('gws api passthrough', () => {
     expect(url).toContain('/files/f1/export?mimeType=application/pdf')
   })
 })
+
+describe('gws folder scope placement', () => {
+  const SCOPED: GoogleConfig = { clientId: 'cid', refreshToken: 'rt', folderId: 'F1' }
+
+  it('declares shared drive support alongside an injected parent', async () => {
+    vi.mocked(client.googlePost).mockReset().mockResolvedValue({ id: 'f9' })
+    await runGwsMethod(
+      method('drive.files.create'),
+      SCOPED,
+      [],
+      [],
+      makeOpts({ json: '{"name": "n"}' }),
+    )
+    const call = vi.mocked(client.googlePost).mock.calls.at(-1)
+    expect(call?.[2]).toEqual({ name: 'n', parents: ['F1'] })
+    expect(call?.[1]).toContain('supportsAllDrives=true')
+  })
+
+  it('leaves an explicit parents array a passthrough', async () => {
+    vi.mocked(client.googlePost).mockReset().mockResolvedValue({ id: 'f9' })
+    await runGwsMethod(
+      method('drive.files.create'),
+      SCOPED,
+      [],
+      [],
+      makeOpts({ json: '{"name": "n", "parents": ["OTHER"]}' }),
+    )
+    const call = vi.mocked(client.googlePost).mock.calls.at(-1)
+    expect(call?.[2]).toEqual({ name: 'n', parents: ['OTHER'] })
+    expect(call?.[1]).not.toContain('supportsAllDrives')
+  })
+
+  it('declares shared drive support on the relocation patch', async () => {
+    vi.mocked(client.googlePost).mockReset().mockResolvedValue({ spreadsheetId: 's1' })
+    vi.mocked(client.googlePatch).mockReset().mockResolvedValue({ id: 's1' })
+    await runGwsMethod(
+      method('sheets.spreadsheets.create'),
+      SCOPED,
+      [],
+      [],
+      makeOpts({ json: '{"properties": {"title": "T"}}' }),
+    )
+    expect(vi.mocked(client.googlePatch).mock.calls.at(-1)?.[3]).toEqual({
+      addParents: 'F1',
+      removeParents: 'root',
+      supportsAllDrives: 'true',
+    })
+  })
+
+  it("treats an explicitly empty parents array as the caller's", async () => {
+    vi.mocked(client.googlePost).mockReset().mockResolvedValue({ id: 'f9' })
+    await runGwsMethod(
+      method('drive.files.create'),
+      SCOPED,
+      [],
+      [],
+      makeOpts({ json: '{"name": "n", "parents": []}' }),
+    )
+    const call = vi.mocked(client.googlePost).mock.calls.at(-1)
+    expect(call?.[2]).toEqual({ name: 'n', parents: [] })
+    expect(call?.[1]).not.toContain('supportsAllDrives')
+  })
+
+  it('places nothing for an unscoped install', async () => {
+    vi.mocked(client.googlePost).mockReset().mockResolvedValue({ spreadsheetId: 's1' })
+    vi.mocked(client.googlePatch).mockReset()
+    await runGwsMethod(
+      method('sheets.spreadsheets.create'),
+      CONFIG,
+      [],
+      [],
+      makeOpts({ json: '{"properties": {"title": "T"}}' }),
+    )
+    expect(vi.mocked(client.googlePatch).mock.calls.length).toBe(0)
+  })
+})

--- a/typescript/packages/core/src/commands/cli/builtin/gws/index.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gws/index.ts
@@ -14,6 +14,7 @@
 
 import { z } from 'zod'
 import { GoogleConfigSchema, type GoogleConfig } from '../../../../core/google/config.ts'
+import { ResourceName } from '../../../../types.ts'
 import { registerCliSpec } from '../../specs.ts'
 import { CLISpec } from '../../types.ts'
 import { Option } from '../../../spec/types.ts'
@@ -50,6 +51,13 @@ export const GWS = new CLISpec({
   name: 'gws',
   description: 'Google Workspace API commands',
   configModel: GwsCliConfigSchema,
+  serves: [
+    ResourceName.GDRIVE,
+    ResourceName.GDOCS,
+    ResourceName.GSHEETS,
+    ResourceName.GSLIDES,
+    ResourceName.GMAIL,
+  ],
   subcommands: [
     new CLISpec({
       name: 'drive',

--- a/typescript/packages/core/src/commands/cli/builtin/gws/methods.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gws/methods.ts
@@ -38,6 +38,14 @@ export interface GwsMethod {
   path: string
   needsBody?: boolean
   rawBytes?: boolean
+  // Where a newly created file lands when the installation is scoped to a
+  // folder. 'parents' means the request body takes a parents array, so the
+  // scope is filled in there. 'relocate' means the API has no parents field
+  // at all (the editors' create methods), so the new file is moved
+  // afterwards with a Drive update. Absent means the method creates nothing.
+  placement?: 'parents' | 'relocate'
+  // Response key holding the new file's id, for 'relocate'.
+  idField?: string
 }
 
 export const GWS_METHODS: readonly GwsMethod[] = [
@@ -55,6 +63,8 @@ export const GWS_METHODS: readonly GwsMethod[] = [
     http: 'POST',
     path: '/documents',
     needsBody: true,
+    placement: 'relocate',
+    idField: 'documentId',
   },
   {
     service: 'docs',
@@ -78,6 +88,8 @@ export const GWS_METHODS: readonly GwsMethod[] = [
     http: 'POST',
     path: '/spreadsheets',
     needsBody: true,
+    placement: 'relocate',
+    idField: 'spreadsheetId',
   },
   {
     service: 'sheets',
@@ -101,6 +113,8 @@ export const GWS_METHODS: readonly GwsMethod[] = [
     http: 'POST',
     path: '/presentations',
     needsBody: true,
+    placement: 'relocate',
+    idField: 'presentationId',
   },
   {
     service: 'slides',
@@ -119,6 +133,7 @@ export const GWS_METHODS: readonly GwsMethod[] = [
     http: 'POST',
     path: '/files',
     needsBody: true,
+    placement: 'parents',
   },
   {
     service: 'drive',
@@ -134,6 +149,7 @@ export const GWS_METHODS: readonly GwsMethod[] = [
     method: 'copy',
     http: 'POST',
     path: '/files/{fileId}/copy',
+    placement: 'parents',
   },
   {
     service: 'drive',

--- a/typescript/packages/core/src/commands/cli/types.ts
+++ b/typescript/packages/core/src/commands/cli/types.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { ByteSource } from '../../io/types.ts'
-import type { Limit, PathSpec } from '../../types.ts'
+import type { Limit, PathSpec, ResourceName } from '../../types.ts'
 import type { CommandDispatch, CommandFnResult } from '../config.ts'
 import type { MountRoot, StatPath } from '../../ops/types.ts'
 import { compileSpec } from '../spec/compile.ts'
@@ -95,6 +95,7 @@ export interface CLISpecInit extends CommandSpecInit {
   write?: boolean
   limit?: Limit | null
   configModel?: CLIConfigModel | null
+  serves?: readonly ResourceName[]
   usageStyle?: UsageStyle
 }
 
@@ -131,6 +132,15 @@ export class CLISpec extends CommandSpec {
   readonly limit: Limit | null
   readonly configModel: CLIConfigModel | null
   /**
+   * Root only. The resources this CLI's service also backs as mounts. A write
+   * verb mutates that service by id, which no vfs path can be derived from, so
+   * those mounts drop their cached listings afterwards and the agent's next
+   * `ls` shows what it just made. Empty for a CLI with no mounted counterpart
+   * (`git` reaches mounts through the op dispatcher, which invalidates per
+   * path already).
+   */
+  readonly serves: readonly ResourceName[]
+  /**
    * Root only. How a leaf refuses an option it does not declare. Defaults to
    * argparse, which is right for a CLI mirage invented; a CLI that mimics an
    * existing program sets the style that program uses, so an agent reading the
@@ -147,6 +157,7 @@ export class CLISpec extends CommandSpec {
     this.write = init.write ?? false
     this.limit = init.limit ?? null
     this.configModel = init.configModel ?? null
+    this.serves = init.serves ?? []
     this.usageStyle = init.usageStyle ?? UsageStyle.ARGPARSE
     if (this.name === '' || /\s/.test(this.name)) {
       throw new Error(`cli name '${this.name}' must be a single non-empty word`)

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -435,7 +435,7 @@ export { Precision, ProvisionResult, type ProvisionResultInit } from './provisio
 export { IndexEntry, type IndexEntryInit, ResourceType } from './cache/index/config.ts'
 export { drainBudget, type FileCache, validateMaxDrainBytes } from './cache/file/mixin.ts'
 export { CacheEntry, type CacheEntryInit } from './cache/file/entry.ts'
-export { defaultFingerprint, parseLimit } from './cache/file/utils.ts'
+export { defaultFingerprint, globEscape, parseLimit } from './cache/file/utils.ts'
 export { RAMFileCacheStore } from './cache/file/ram.ts'
 export { applyIo, readFingerprint } from './cache/file/io.ts'
 export {

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -51,7 +51,7 @@ import { versionRequest } from '../../commands/config.ts'
 
 import { handleCli } from './command/cli.ts'
 import { pathStat } from './builtins/links.ts'
-import { dropServiceListings, mountRootOf } from './command/run.ts'
+import { dropServiceCaches, mountRootOf } from './command/run.ts'
 import { optionError, parseFlags } from './command/flags.ts'
 import { executeShellFunction } from './command/functions.ts'
 import {
@@ -138,7 +138,7 @@ export async function handleCommand(
         statPath: (path: string) => pathStat(dispatch, path, null),
         mountRoot: (path: string) => mountRootOf(registry, path),
       },
-      () => dropServiceListings(registry, cliInstall.spec.serves),
+      () => dropServiceCaches(registry, cliInstall.spec.serves),
     )
   }
 

--- a/typescript/packages/core/src/workspace/executor/command.ts
+++ b/typescript/packages/core/src/workspace/executor/command.ts
@@ -51,7 +51,7 @@ import { versionRequest } from '../../commands/config.ts'
 
 import { handleCli } from './command/cli.ts'
 import { pathStat } from './builtins/links.ts'
-import { mountRootOf } from './command/run.ts'
+import { dropServiceListings, mountRootOf } from './command/run.ts'
 import { optionError, parseFlags } from './command/flags.ts'
 import { executeShellFunction } from './command/functions.ts'
 import {
@@ -128,11 +128,18 @@ export async function handleCommand(
   // through the facts below; the rest never read them.
   const cliInstall = registry.clis.get(cmdName)
   if (cliInstall !== null) {
-    return handleCli(cliInstall, parts, session, stdin, {
-      dispatch,
-      statPath: (path: string) => pathStat(dispatch, path, null),
-      mountRoot: (path: string) => mountRootOf(registry, path),
-    })
+    return handleCli(
+      cliInstall,
+      parts,
+      session,
+      stdin,
+      {
+        dispatch,
+        statPath: (path: string) => pathStat(dispatch, path, null),
+        mountRoot: (path: string) => mountRootOf(registry, path),
+      },
+      () => dropServiceListings(registry, cliInstall.spec.serves),
+    )
   }
 
   if (cmdName in CWD_DEFAULT_RAW) {

--- a/typescript/packages/core/src/workspace/executor/command/cli.ts
+++ b/typescript/packages/core/src/workspace/executor/command/cli.ts
@@ -74,7 +74,7 @@ export async function handleCli(
   session: Session,
   stdin: ByteSource | null = null,
   facts: CliFacts = {},
-  dropListings: (() => Promise<void>) | null = null,
+  dropCaches: (() => Promise<void>) | null = null,
 ): Promise<[ByteSource | null, IOResult, ExecutionNode]> {
   // Words re-enter string space as typed (wordText): the walk owns
   // interpretation, so a quoted "Lunch?" must not arrive as the
@@ -190,8 +190,9 @@ export async function handleCli(
   // from the call and per-path invalidation has nothing to aim at: a newly
   // created file has no cache entry to expire, which is the case that
   // matters. Dropping the service's listings is what lets the agent's next
-  // `ls` see what it just made.
-  if (leaf.write && dropListings !== null) await dropListings()
+  // `ls` see what it just made, and dropping its cached bodies is what lets
+  // the next `cat` see an edit rather than the pre-write content.
+  if (leaf.write && dropCaches !== null) await dropCaches()
   io.producer = { command: prog, prefixes: [], declared: leaf.limit ?? null }
 
   if (warnings.length > 0) {

--- a/typescript/packages/core/src/workspace/executor/command/cli.ts
+++ b/typescript/packages/core/src/workspace/executor/command/cli.ts
@@ -74,6 +74,7 @@ export async function handleCli(
   session: Session,
   stdin: ByteSource | null = null,
   facts: CliFacts = {},
+  dropListings: (() => Promise<void>) | null = null,
 ): Promise<[ByteSource | null, IOResult, ExecutionNode]> {
   // Words re-enter string space as typed (wordText): the walk owns
   // interpretation, so a quoted "Lunch?" must not arrive as the
@@ -185,6 +186,12 @@ export async function handleCli(
       new ExecutionNode({ command: cmdStr, exitCode: 1, stderr }),
     ]
   }
+  // An account CLI mutates its service by id, so no vfs path can be derived
+  // from the call and per-path invalidation has nothing to aim at: a newly
+  // created file has no cache entry to expire, which is the case that
+  // matters. Dropping the service's listings is what lets the agent's next
+  // `ls` see what it just made.
+  if (leaf.write && dropListings !== null) await dropListings()
   io.producer = { command: prog, prefixes: [], declared: leaf.limit ?? null }
 
   if (warnings.length > 0) {

--- a/typescript/packages/core/src/workspace/executor/command/run.test.ts
+++ b/typescript/packages/core/src/workspace/executor/command/run.test.ts
@@ -1,0 +1,90 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+import { RAMResource } from '../../../resource/ram/ram.ts'
+import { createShellParser } from '../../../shell/parse.ts'
+import { ConsistencyPolicy, MountMode, PathSpec, ResourceName } from '../../../types.ts'
+import { Workspace } from '../../workspace.ts'
+import { dropServiceCaches } from './run.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+const require = createRequire(import.meta.url)
+const engineWasm = readFileSync(require.resolve('web-tree-sitter/web-tree-sitter.wasm'))
+const grammarWasm = readFileSync(require.resolve('tree-sitter-bash/tree-sitter-bash.wasm'))
+
+function warmWorkspace(): [Workspace, RAMResource] {
+  const ram = new RAMResource()
+  // An account CLI's service caches reads, so a body already read is served
+  // warm; forcing it on RAM reproduces that without a network backend.
+  ;(ram as unknown as { cachesReads: boolean }).cachesReads = true
+  const ws = new Workspace(
+    { '/r': ram },
+    {
+      mode: MountMode.WRITE,
+      consistency: ConsistencyPolicy.LAZY,
+      shellParserFactory: async () => createShellParser({ engineWasm, grammarWasm }),
+    },
+  )
+  return [ws, ram]
+}
+
+describe('dropServiceCaches', () => {
+  it('drops bodies as well as listings after a CLI write', async () => {
+    // A stale listing hides a create; a stale body hides an edit. The cached
+    // body is the one that answers without reaching the service, so clearing
+    // the index alone leaves `cat` serving pre-write content.
+    const [ws, ram] = warmWorkspace()
+    try {
+      await ram.writeFile(PathSpec.fromStrPath('/a.txt'), ENC.encode('v1\n'))
+      expect(DEC.decode((await ws.execute('cat /r/a.txt')).stdout)).toContain('v1')
+      await ram.writeFile(PathSpec.fromStrPath('/a.txt'), ENC.encode('v2\n'))
+      await ram.writeFile(PathSpec.fromStrPath('/new.txt'), ENC.encode('fresh\n'))
+      await dropServiceCaches(ws.registry, [ResourceName.RAM])
+      expect(DEC.decode((await ws.execute('cat /r/a.txt')).stdout)).toContain('v2')
+      expect(DEC.decode((await ws.execute('ls /r')).stdout)).toContain('new.txt')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('drops nothing for a CLI that serves nothing', async () => {
+    const [ws, ram] = warmWorkspace()
+    try {
+      await ram.writeFile(PathSpec.fromStrPath('/a.txt'), ENC.encode('v1\n'))
+      await ws.execute('cat /r/a.txt')
+      await ram.writeFile(PathSpec.fromStrPath('/a.txt'), ENC.encode('v2\n'))
+      await dropServiceCaches(ws.registry, [])
+      expect(DEC.decode((await ws.execute('cat /r/a.txt')).stdout)).toContain('v1')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('leaves an unrelated service its cache', async () => {
+    const [ws, ram] = warmWorkspace()
+    try {
+      await ram.writeFile(PathSpec.fromStrPath('/a.txt'), ENC.encode('v1\n'))
+      await ws.execute('cat /r/a.txt')
+      await ram.writeFile(PathSpec.fromStrPath('/a.txt'), ENC.encode('v2\n'))
+      await dropServiceCaches(ws.registry, [ResourceName.GDRIVE])
+      expect(DEC.decode((await ws.execute('cat /r/a.txt')).stdout)).toContain('v1')
+    } finally {
+      await ws.close()
+    }
+  })
+})

--- a/typescript/packages/core/src/workspace/executor/command/run.ts
+++ b/typescript/packages/core/src/workspace/executor/command/run.ts
@@ -17,7 +17,7 @@ import { IOResult, materialize } from '../../../io/types.ts'
 import type { Resource } from '../../../resource/base.ts'
 import { assertMountAllowed, MountNotAllowedError } from '../../../context/session_context.ts'
 import type { PathSpec } from '../../../types.ts'
-import type { FileStat } from '../../../types.ts'
+import type { FileStat, ResourceName } from '../../../types.ts'
 import type { MountEntry } from '../../mount/mount.ts'
 import type { LinkView, StatOverlay, StatPath } from '../../../ops/types.ts'
 import type { Namespace } from '../../mount/namespace/namespace.ts'
@@ -124,6 +124,30 @@ function namespaceStatOverlay(namespace: Namespace, virtual: string, stat: FileS
  */
 export function mountRootOf(registry: MountRegistry, virtual: string): string {
   return registry.mountFor(virtual)?.prefix ?? '/'
+}
+
+/**
+ * Drop cached listings for the mounts a CLI's service also backs.
+ *
+ * An account CLI mutates its service by id, so no vfs path can be derived from
+ * the call and per-path invalidation has nothing to aim at: after
+ * `gws sheets spreadsheets create` the new file has no cache entry to expire,
+ * which is exactly the case that matters. What is known is the service, so the
+ * mounts it backs drop their listings and the next readdir refetches.
+ *
+ * Scoped by the spec's declared `serves` rather than a blanket reset, so a
+ * Slack or S3 mount alongside keeps its cache. File contents are left alone: a
+ * stale listing is what hides a newly created file.
+ */
+export async function dropServiceListings(
+  registry: MountRegistry,
+  serves: readonly ResourceName[],
+): Promise<void> {
+  if (serves.length === 0) return
+  const wanted = new Set<string>(serves)
+  for (const mount of registry.allMounts()) {
+    if (wanted.has(mount.resource.kind)) await mount.resource.index?.clear()
+  }
 }
 
 // Run one already-parsed command on the mount that owns its paths. The shared

--- a/typescript/packages/core/src/workspace/executor/command/run.ts
+++ b/typescript/packages/core/src/workspace/executor/command/run.ts
@@ -127,26 +127,32 @@ export function mountRootOf(registry: MountRegistry, virtual: string): string {
 }
 
 /**
- * Drop cached listings for the mounts a CLI's service also backs.
+ * Drop cached listings and bodies for the mounts a CLI's service backs.
  *
  * An account CLI mutates its service by id, so no vfs path can be derived from
  * the call and per-path invalidation has nothing to aim at: after
  * `gws sheets spreadsheets create` the new file has no cache entry to expire,
  * which is exactly the case that matters. What is known is the service, so the
- * mounts it backs drop their listings and the next readdir refetches.
+ * mounts it backs drop their caches and the next read refetches.
+ *
+ * Both caches go, because the two hide different writes. A stale listing hides
+ * a create or a delete; a stale body hides an edit, and these resources cache
+ * reads, so a `cat` after `gws docs documents batchUpdate` would otherwise keep
+ * serving the pre-edit content without ever reaching Google.
  *
  * Scoped by the spec's declared `serves` rather than a blanket reset, so a
- * Slack or S3 mount alongside keeps its cache. File contents are left alone: a
- * stale listing is what hides a newly created file.
+ * Slack or S3 mount alongside keeps its cache.
  */
-export async function dropServiceListings(
+export async function dropServiceCaches(
   registry: MountRegistry,
   serves: readonly ResourceName[],
 ): Promise<void> {
   if (serves.length === 0) return
   const wanted = new Set<string>(serves)
   for (const mount of registry.allMounts()) {
-    if (wanted.has(mount.resource.kind)) await mount.resource.index?.clear()
+    if (!wanted.has(mount.resource.kind)) continue
+    await mount.resource.index?.clear()
+    await mount.cacheManager?.dropPrefix()
   }
 }
 

--- a/typescript/packages/core/src/workspace/workspace.test.ts
+++ b/typescript/packages/core/src/workspace/workspace.test.ts
@@ -130,6 +130,12 @@ describe('Workspace custom cache option', () => {
       this.store.delete(key)
       return Promise.resolve()
     }
+    evictPrefix(prefix: string): Promise<void> {
+      for (const key of [...this.store.keys()]) {
+        if (key.startsWith(prefix)) this.store.delete(key)
+      }
+      return Promise.resolve()
+    }
     exists(key: string | PathSpec): Promise<boolean> {
       const k = typeof key === 'string' ? key : key.mountPath
       return Promise.resolve(this.store.has(k))

--- a/typescript/packages/node/src/cache/redis/file.ts
+++ b/typescript/packages/node/src/cache/redis/file.ts
@@ -15,6 +15,7 @@
 import {
   type FileCache,
   defaultFingerprint,
+  globEscape,
   parseLimit,
   type PathSpec,
   validateMaxDrainBytes,
@@ -139,6 +140,22 @@ export class RedisFileCacheStore extends RedisResource implements FileCache {
     const fp = await c.get(`${this.metaPrefix}${key}`)
     if (fp === null) return false
     return fp === remoteFingerprint
+  }
+
+  async evictPrefix(prefix: string): Promise<void> {
+    for (const key of [...this.drainTasks.keys()]) {
+      if (key.startsWith(prefix)) this.drainTasks.delete(key)
+    }
+    const escaped = globEscape(prefix)
+    const c = await this.cacheClient()
+    for (const base of [this.dataPrefix, this.metaPrefix]) {
+      const batch: string[] = []
+      for await (const k of c.scanIterator({ MATCH: `${base}${escaped}*` })) {
+        if (Array.isArray(k)) batch.push(...k)
+        else batch.push(k)
+      }
+      if (batch.length > 0) await c.del(batch)
+    }
   }
 
   async clear(): Promise<void> {


### PR DESCRIPTION
Three bugs on the Google surface, plus the fake server gaps that were hiding them.

## 1. `gws` ignored `folder_id`

A gdrive mount scoped to a folder and a `gws` install sharing the same config disagreed about where a new file goes. `/data` is the folder, but a create landed in My Drive's root, so the agent's own `ls` never showed it:

```bash
$ gws sheets spreadsheets create --json '{"properties":{"title":"Q3 Report"}}'
sheet0001                    # exit 0, real id, looks fine
$ ls /data
notes.txt                    # the sheet is not here
```

`drive files create` and `copy` take a `parents` array, so an omitted one now defaults to the scope. The Docs/Sheets/Slides create methods have no `parents` field at all, so those are moved with the follow-up `files.update?addParents=` the caller would otherwise have to know to make. An explicit `parents` always wins.

Driven by a new `serves` field on `CLISpec`, not a hardcoded list.

## 2. Google's error text never reached the agent

`resp.raise_for_status()` raised before anything read the body, so the reason Google gave was discarded:

```
server:  {"error":{"code":400,"message":"Unsupported request: bogusRequest",...}}
before:  400, message='Bad Request'
after:   400, message='Unsupported request: bogusRequest'
```

Python only; TypeScript already read the body. Both the API shape (`{"error":{"message"}}`) and the OAuth token shape (`{"error","error_description"}`) are handled. The exception type is unchanged, since `eacces_on_denied` classifies a 403 into EACCES off it.

## 3. A CLI write left the mount's listing stale

Independent of the above, and not `gws`-specific: an account CLI mutates its service by id, so no vfs path can be derived and per-path invalidation has nothing to aim at — a newly created file has no cache entry to expire, which is exactly the case that matters.

```bash
$ ls /data                                   # seed.txt
$ gws drive files create ... (into /data)
$ ls /data                                   # seed.txt   <- still stale
```

Write verbs now drop the listings of the mounts their service backs. Scoped by the spec's `serves` rather than a blanket reset, so a Slack or S3 mount alongside keeps its cache; file contents are left alone. `git` declares nothing and drops nothing, which is right — it reaches mounts through the op dispatcher, which already invalidates per path.

**This corrected two integ goldens that had been asserting the bug**: `g_files_update` renamed a file to `Plan2` and expected the listing to still say `Plan.gdoc.json`, and `g_files_delete` expected a deleted file to still be counted. Verified against the server rather than assumed — at the end of that run the only gdocs left are in root, so `/data` genuinely holds zero.

## Fake server

The Sheets endpoints it never had, all real Google API surface: `values:batchUpdate`, `values:batchGet`, `values:batchClear`, `values/{range}:clear`, `sheets/{sheetId}:copyTo`, and the `insertDimension` / `deleteDimension` / `appendDimension` / `moveDimension` / `duplicateSheet` requests. Tabs now carry a declared grid so an insert grows `rowCount` the way the live API does.

Same sweep elsewhere: Docs `replaceAllText` now honors `matchCase` (the API default is case-*insensitive*; the mock was always sensitive); Slides gained `pages.get`, `deleteText`, `replaceAllText`, `duplicateObject`, `updateSlidesPosition`, and object-id uniqueness; Drive gained `about.get`, `files.generateIds` (+ pinned-id create), `files.emptyTrash`, `permissions.get`/`update`, `revisions.delete`, and `drives.get`/`update`/`delete`.

A header block now lists the surface that is still deliberately absent, so a 404 there reads as "not built yet" rather than "mirage sent the wrong request".

## Coverage

`gws` integ coverage is **35 of 35 leaves**, up from 30. Issue #705's "16 of 35 uncovered" was stale. The five added are all Gmail; `reply-all` asserts the `Cc` survives, since its own output is only ids and a `threadId` assertion would not distinguish it from plain `reply`.

New `cli-gws-scoped` target covers the placement fix, and two cases cover the error body — both verified to fail without the fix.

## Verification

- Python 12,937 passed / 52 skipped / 0 failed
- TS core 6,436 passed; TS node 2,195 passed / 4 skipped
- Integ, both runners: 3,997 passed / 0 failed each
- `pre-commit run --all-files` clean, mypy and knip included

## Known gaps

- The new fake-server endpoints have no `GWS_METHODS` entries, so nothing in integ reaches them; they are verified by direct HTTP checks only. Adding those entries is the natural follow-up and is also what upstream exposes, since it generates every Discovery method.
- `docs/python/cli/gws.mdx` has no "Divergences from upstream" section, which now matters: `spreadsheets create` issues a second call that upstream's passthrough does not. It only fires when `folder_id` is set, so an unscoped install stays byte-identical to upstream.
- The read half is untouched by design: `gws drive files list` remains unscoped.