### PR TITLE
fix(pyodide): flush mount writes without JSPI

### DIFF
--- a/docs/typescript/python-fs.mdx
+++ b/docs/typescript/python-fs.mdx
@@ -29,7 +29,7 @@ open('/ram/notes.txt', 'w').write('hello')              # writes flush back to R
     open('/ram/out.txt', 'w').write('hello')
     open('/s3/icon.png', 'wb').write(png_bytes)
     ```
-    On `close()`, bytes flush back through the resource's `write` op.
+    `close()` marks the path dirty; when the script finishes, the final bytes flush back through the resource's `write` op (one write per path, however many times the script reopened it).
   </Tab>
   <Tab title="List a directory">
     ```python
@@ -93,7 +93,7 @@ open('/ram/notes.txt', 'w').write('hello')              # writes flush back to R
 
 ## How it works (one paragraph)
 
-Pyodide's in-memory FS (MEMFS) is the sync facade. At `addMount`, Mirage walks the prefix and copies files into MEMFS. Python reads hit MEMFS directly, fast, no network. On a **miss** (path not yet in MEMFS but the prefix is registered), the shim catches the error, calls back through the bridge via JSPI to fetch it, populates MEMFS, and retries. Writes are intercepted on `close()` and flushed back through Mirage's `write` op.
+Pyodide's in-memory FS (MEMFS) is the sync facade. Before each run, Mirage walks any newly mounted prefix and copies files into MEMFS. Python reads hit MEMFS directly, fast, no network. On a **miss** (path not yet in MEMFS but the prefix is registered), the shim catches the error, calls back through the bridge via JSPI to fetch it, populates MEMFS, and retries. Writes are intercepted on `close()`, which marks the path dirty in MEMFS; after the script returns, Mirage flushes each dirty path's final bytes back through Mirage's `write` op (no JSPI involved, and a flush failure lands on stderr with a nonzero exit).
 
 ```
 Python open() / listdir()
@@ -104,10 +104,12 @@ Python open() / listdir()
        miss
         │
         ▼
-   run_sync(_mirage_bridge.list/fetch)
+   run_sync(_mirage_bridge.list/fetch)   ← the one JSPI-dependent hop
         │
         ▼
    populate MEMFS, retry
+
+Python close()  ──►  mark dirty  ──►  script ends  ──►  flush to mount
 ```
 
 ## Quick start (TypeScript)
@@ -153,18 +155,16 @@ new Workspace({}, { python: { autoLoadFromImports: false } })
 
 ## Runtime requirements
 
-The shim uses [JSPI](https://github.com/WebAssembly/js-promise-integration) to bridge sync Python calls to async JS.
+None: preloaded reads, mounts added between runs, and writes all work on any engine. [JSPI](https://github.com/WebAssembly/js-promise-integration) only powers the shim's **lazy backfill**, the mid-run fetch of a path that appeared on the mount after its prefix was preloaded. With JSPI available that miss is filled in place; without it the miss stays a `FileNotFoundError` (a `console.warn: mirage lazy: ...` names the real reason).
 
-- **Chrome / Edge 137+** (May 2025): works out of the box
+Where JSPI is available:
+
+- **Chrome / Edge 137+** (May 2025): out of the box
 - **Firefox**: behind `javascript.options.wasm_js_promise_integration`
-- **Node 24+**: pass `--experimental-wasm-jspi` (vitest config already does this)
+- **Node**: pass `--experimental-wasm-jspi` (vitest config already does this; V8 flags cannot ride `NODE_OPTIONS`)
 - **Cloudflare Workers**: Python Workers with JSPI runtime
 
-<Note>
-Without JSPI, **reads** of preloaded files still work but **writes** throw `RuntimeError: Cannot stack switch` on `close()`.
-</Note>
-
-To run examples directly:
+To run examples with the lazy backfill enabled:
 
 ```bash
 node --experimental-wasm-jspi --import tsx/esm examples/typescript/pyodide/vfs.ts
@@ -176,7 +176,8 @@ node --experimental-wasm-jspi --import tsx/esm examples/typescript/pyodide/vfs.t
 |---|---|
 | `FileNotFoundError [Errno 44]` | Path isn't in MEMFS and lazy fetch failed too. Check the preceding `console.warn: mirage lazy: ...` for the real reason (auth, network, bad path). |
 | `console.warn: mirage lazy: list <path> failed` | The lazy backfill called `_mirage_bridge.list` and got rejected. Followed by `FileNotFoundError`. |
-| `RuntimeError: Cannot stack switch` | JSPI not enabled. Pass the Node flag or upgrade browser. |
+| `python3: failed to flush <path> to mount: ...` on stderr, exit 1 | The script finished but a dirty file could not be written back to its mount (auth, read-only mount, network). MEMFS still holds the bytes. |
+| `RuntimeError: WebAssembly stack switching not supported` in a lazy warn | JSPI not enabled, so a mid-run backfill could not suspend. Reads of preloaded content and all writes are unaffected. |
 | `console.warn: mirage preload: skipping <path>` | A single entry failed during initial preload, others continued. Usually harmless (synthetic listing entries). |
 
 ## See also

--- a/typescript/packages/core/src/workspace/executor/python/mirage_bridge.ts
+++ b/typescript/packages/core/src/workspace/executor/python/mirage_bridge.ts
@@ -52,15 +52,35 @@ export interface MirageBridge {
    * interpreter when mounts are added or removed.
    */
   prefixes(): string[]
+  /**
+   * Record a mount-prefixed path whose MEMFS content changed. This is the
+   * write half of the shim's contract and it is deliberately synchronous:
+   * Python's close() runs inside sync WASM frames where awaiting a bridge
+   * op needs JSPI stack switching, which most engines do not enable. The
+   * bytes already live in MEMFS, so close() only marks the path here and
+   * the runtime flushes after the script returns, where awaiting is free.
+   */
+  markDirty(path: string): void
+  /** Drain the dirty set: the recorded paths, in mark order, cleared. */
+  takeDirty(): string[]
 }
 
 export function createMirageBridge(
   dispatch: BridgeDispatchFn,
   listMounts: () => string[] = () => [],
 ): MirageBridge {
+  const dirty = new Set<string>()
   return {
     prefixes() {
       return listMounts().map((p) => (p.endsWith('/') ? p : p + '/'))
+    },
+    markDirty(path) {
+      dirty.add(path)
+    },
+    takeDirty() {
+      const out = [...dirty]
+      dirty.clear()
+      return out
     },
     async fetch(path) {
       const out = await dispatch('READ', path)

--- a/typescript/packages/core/src/workspace/executor/python/mirage_fs_shim.test.ts
+++ b/typescript/packages/core/src/workspace/executor/python/mirage_fs_shim.test.ts
@@ -14,7 +14,12 @@
 
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { loadPyodideRuntime, type PyodideInterface } from './loader.ts'
-import { createMirageBridge, type BridgeDispatchFn, type MirageEntry } from './mirage_bridge.ts'
+import {
+  createMirageBridge,
+  type BridgeDispatchFn,
+  type MirageBridge,
+  type MirageEntry,
+} from './mirage_bridge.ts'
 import { MIRAGE_FS_SHIM_PY } from './mirage_fs_shim.ts'
 
 interface Call {
@@ -25,6 +30,7 @@ interface Call {
 
 describe('mirage_fs_shim', () => {
   let py: PyodideInterface
+  let bridge: MirageBridge
   const calls: Call[] = []
   const mounts: string[] = []
   const preloaded = new Map<string, Uint8Array>()
@@ -35,6 +41,14 @@ describe('mirage_fs_shim', () => {
   function preload(path: string, bytes: Uint8Array): void {
     preloaded.set(path, bytes)
     py.FS.writeFile(path, bytes)
+  }
+
+  // The runtime's post-run drain: close() only marks paths dirty, the
+  // flush happens host-side where awaiting the bridge needs no JSPI.
+  async function drain(): Promise<void> {
+    for (const path of bridge.takeDirty()) {
+      await bridge.flush(path, py.FS.readFile(path) as Uint8Array)
+    }
   }
 
   function seedLazyFile(path: string, bytes: Uint8Array): void {
@@ -62,10 +76,8 @@ describe('mirage_fs_shim', () => {
       }
       return Promise.resolve(lazyListings.get(path) ?? [])
     }
-    py.registerJsModule(
-      '_mirage_bridge',
-      createMirageBridge(dispatch, () => mounts),
-    )
+    bridge = createMirageBridge(dispatch, () => mounts)
+    py.registerJsModule('_mirage_bridge', bridge)
     await py.runPythonAsync(MIRAGE_FS_SHIM_PY)
     py.FS.mkdirTree('/ram')
     py.FS.mkdirTree('/tmp')
@@ -78,6 +90,7 @@ describe('mirage_fs_shim', () => {
     lazyFiles.clear()
     lazyListings.clear()
     lazyListErrors.clear()
+    bridge.takeDirty()
   })
 
   it('flushes a binary write to the bridge on close', async () => {
@@ -86,6 +99,7 @@ describe('mirage_fs_shim', () => {
 with open('/ram/hello.txt', 'wb') as f:
     f.write(b'world')
 `)
+    await drain()
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -100,6 +114,7 @@ with open('/ram/hello.txt', 'wb') as f:
 with open('/tmp/x.txt', 'wb') as f:
     f.write(b'unbridged')
 `)
+    await drain()
     expect(calls.filter((c) => c.op === 'WRITE')).toHaveLength(0)
   })
 
@@ -109,6 +124,7 @@ with open('/tmp/x.txt', 'wb') as f:
 with open('/ram/x.txt', 'w') as f:
     f.write('hello')
 `)
+    await drain()
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -124,6 +140,7 @@ with open('/ram/x.txt', 'w') as f:
 with open('/ram/log.txt', 'ab') as f:
     f.write(b'b')
 `)
+    await drain()
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -139,6 +156,7 @@ with open('/ram/log.txt', 'ab') as f:
 with open('/ram/x.txt', 'wb') as f:
     f.write(b'nope')
 `)
+    await drain()
     expect(calls.filter((c) => c.op === 'WRITE')).toHaveLength(0)
   })
 
@@ -177,8 +195,25 @@ f.close()
       opened = false
     }
     void opened
+    await drain()
     expect(calls.filter((c) => c.op === 'WRITE' && c.path === '/ram/../etc/x')).toHaveLength(0)
     expect(calls.filter((c) => c.op === 'WRITE' && c.path === '/etc/x')).toHaveLength(0)
+  })
+
+  it('repeated open/close cycles drain to one flush with the final content', async () => {
+    mounts.push('/ram/')
+    await py.runPythonAsync(`
+for i in range(5):
+    with open('/ram/loop.txt', 'ab') as f:
+        f.write(b'x')
+`)
+    await drain()
+    const writes = calls.filter((c) => c.op === 'WRITE')
+    expect(writes).toHaveLength(1)
+    const w0 = writes[0]
+    if (w0?.bytes === undefined) throw new Error('unreachable')
+    expect(w0.path).toBe('/ram/loop.txt')
+    expect(new TextDecoder().decode(w0.bytes)).toBe('xxxxx')
   })
 
   it('r+b mode flushes the modified content on close', async () => {
@@ -189,6 +224,7 @@ with open('/ram/data.bin', 'r+b') as f:
     f.seek(2)
     f.write(b'\\x99\\x99')
 `)
+    await drain()
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -204,6 +240,7 @@ with open('/ram/data.bin', 'r+b') as f:
 with open('/ram/x', 'wb') as f:
     f.write(b'y')
 `)
+    await drain()
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]

--- a/typescript/packages/core/src/workspace/executor/python/mirage_fs_shim.test.ts
+++ b/typescript/packages/core/src/workspace/executor/python/mirage_fs_shim.test.ts
@@ -28,6 +28,14 @@ interface Call {
   bytes?: Uint8Array
 }
 
+// The runtime's post-run drain: close() only marks paths dirty, the
+// flush happens host-side where awaiting the bridge needs no JSPI.
+async function drain(py: PyodideInterface, bridge: MirageBridge): Promise<void> {
+  for (const path of bridge.takeDirty()) {
+    await bridge.flush(path, py.FS.readFile(path) as Uint8Array)
+  }
+}
+
 describe('mirage_fs_shim', () => {
   let py: PyodideInterface
   let bridge: MirageBridge
@@ -41,14 +49,6 @@ describe('mirage_fs_shim', () => {
   function preload(path: string, bytes: Uint8Array): void {
     preloaded.set(path, bytes)
     py.FS.writeFile(path, bytes)
-  }
-
-  // The runtime's post-run drain: close() only marks paths dirty, the
-  // flush happens host-side where awaiting the bridge needs no JSPI.
-  async function drain(): Promise<void> {
-    for (const path of bridge.takeDirty()) {
-      await bridge.flush(path, py.FS.readFile(path) as Uint8Array)
-    }
   }
 
   function seedLazyFile(path: string, bytes: Uint8Array): void {
@@ -99,7 +99,7 @@ describe('mirage_fs_shim', () => {
 with open('/ram/hello.txt', 'wb') as f:
     f.write(b'world')
 `)
-    await drain()
+    await drain(py, bridge)
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -114,7 +114,7 @@ with open('/ram/hello.txt', 'wb') as f:
 with open('/tmp/x.txt', 'wb') as f:
     f.write(b'unbridged')
 `)
-    await drain()
+    await drain(py, bridge)
     expect(calls.filter((c) => c.op === 'WRITE')).toHaveLength(0)
   })
 
@@ -124,7 +124,7 @@ with open('/tmp/x.txt', 'wb') as f:
 with open('/ram/x.txt', 'w') as f:
     f.write('hello')
 `)
-    await drain()
+    await drain(py, bridge)
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -140,7 +140,7 @@ with open('/ram/x.txt', 'w') as f:
 with open('/ram/log.txt', 'ab') as f:
     f.write(b'b')
 `)
-    await drain()
+    await drain(py, bridge)
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -156,7 +156,7 @@ with open('/ram/log.txt', 'ab') as f:
 with open('/ram/x.txt', 'wb') as f:
     f.write(b'nope')
 `)
-    await drain()
+    await drain(py, bridge)
     expect(calls.filter((c) => c.op === 'WRITE')).toHaveLength(0)
   })
 
@@ -195,7 +195,7 @@ f.close()
       opened = false
     }
     void opened
-    await drain()
+    await drain(py, bridge)
     expect(calls.filter((c) => c.op === 'WRITE' && c.path === '/ram/../etc/x')).toHaveLength(0)
     expect(calls.filter((c) => c.op === 'WRITE' && c.path === '/etc/x')).toHaveLength(0)
   })
@@ -207,7 +207,7 @@ for i in range(5):
     with open('/ram/loop.txt', 'ab') as f:
         f.write(b'x')
 `)
-    await drain()
+    await drain(py, bridge)
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -224,7 +224,7 @@ with open('/ram/data.bin', 'r+b') as f:
     f.seek(2)
     f.write(b'\\x99\\x99')
 `)
-    await drain()
+    await drain(py, bridge)
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]
@@ -240,7 +240,7 @@ with open('/ram/data.bin', 'r+b') as f:
 with open('/ram/x', 'wb') as f:
     f.write(b'y')
 `)
-    await drain()
+    await drain(py, bridge)
     const writes = calls.filter((c) => c.op === 'WRITE')
     expect(writes).toHaveLength(1)
     const w0 = writes[0]

--- a/typescript/packages/core/src/workspace/executor/python/mirage_fs_shim.ts
+++ b/typescript/packages/core/src/workspace/executor/python/mirage_fs_shim.ts
@@ -53,6 +53,10 @@ def _is_writable_mode(mode):
             return True
     return False
 
+# close() only marks the path dirty on the bridge (a sync JS call): the
+# bytes are already in MEMFS, and awaiting the async flush op from these
+# sync WASM frames would need JSPI stack switching, which most engines do
+# not enable. The runtime flushes marked paths after the script returns.
 class _FlushOnClose(io.FileIO):
     def __init__(self, path, mode='r', closefd=True, opener=None):
         super().__init__(path, mode=mode, closefd=closefd, opener=opener)
@@ -78,9 +82,7 @@ class _FlushOnClose(io.FileIO):
         was_dirty = self._mirage_dirty and not self.closed
         super().close()
         if was_dirty:
-            with _open(self._mirage_path, 'rb') as src:
-                data = src.read()
-            run_sync(_mb.flush(self._mirage_path, data))
+            _mb.markDirty(self._mirage_path)
 
 def _strip_bt(mode):
     return mode.replace('b', '').replace('t', '')
@@ -105,6 +107,11 @@ def _to_bytes(data):
         return bytes(converted)
     return bytes(data)
 
+# The lazy backfill below is the shim's one JSPI-dependent surface:
+# run_sync suspends the WASM stack while the async bridge op settles, and
+# raises RuntimeError on engines without stack switching. Both callers
+# treat that as a miss (warn, return None), so without JSPI reads fall
+# back to whatever the host preloaded into MEMFS before the run.
 def _list_bridge(target):
     try:
         return run_sync(_mb.list(target))

--- a/typescript/packages/core/src/workspace/executor/python/runtime_mount.test.ts
+++ b/typescript/packages/core/src/workspace/executor/python/runtime_mount.test.ts
@@ -130,6 +130,27 @@ describe('PyodideRuntime mount visibility', () => {
     await rt.close()
   }, 60_000)
 
+  it('a failed flush surfaces on stderr and flips a clean exit to 1', async () => {
+    const dispatch: BridgeDispatchFn = (op) => {
+      if (op === 'WRITE') return Promise.reject(new Error('mount is read-only'))
+      if (op === 'READ') return Promise.resolve(new Uint8Array())
+      return Promise.resolve([])
+    }
+    const rt = new PyodideRuntime()
+    rt.attach(dispatch, () => ['/ram/'])
+    const result = await rt.run({
+      code: `with open('/ram/out.txt', 'wb') as f: f.write(b'data')`,
+      args: [],
+      env: {},
+      stdin: new Uint8Array(),
+    })
+    expect(result.exitCode).toBe(1)
+    const stderr = new TextDecoder().decode(result.stderr ?? new Uint8Array())
+    expect(stderr).toContain('failed to flush /ram/out.txt')
+    expect(stderr).toContain('mount is read-only')
+    await rt.close()
+  }, 60_000)
+
   it('runtime without bridge still runs Python without the shim', async () => {
     const rt = new PyodideRuntime({})
     const result = await rt.run({

--- a/typescript/packages/core/src/workspace/executor/python/runtime_nojspi.test.ts
+++ b/typescript/packages/core/src/workspace/executor/python/runtime_nojspi.test.ts
@@ -1,0 +1,94 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { beforeAll, describe, expect, it } from 'vitest'
+import { PyodideRuntime } from './runtimes/pyodide.ts'
+import type { BridgeDispatchFn } from './mirage_bridge.ts'
+
+// The vitest pool runs every fork with --experimental-wasm-jspi, which no
+// production embedder does (V8 flags cannot ride NODE_OPTIONS), so a JSPI
+// dependency in the write path only ever fails outside CI. Deleting the
+// detection surface before pyodide loads makes this file the production
+// environment: run_sync raises here, and file writes must still land.
+describe('PyodideRuntime without JSPI', () => {
+  beforeAll(() => {
+    delete (WebAssembly as { Suspending?: unknown }).Suspending
+    delete (WebAssembly as { Suspender?: unknown }).Suspender
+    expect('Suspending' in WebAssembly).toBe(false)
+  })
+
+  it('a dirty close flushes to the mount and the script exits 0', async () => {
+    const calls: { op: string; path: string; bytes?: Uint8Array }[] = []
+    const dispatch: BridgeDispatchFn = async (op, path, bytes) => {
+      // settle on a macrotask so a run_sync anywhere in the path would
+      // have to suspend, not ride an already-resolved promise
+      await new Promise((resolve) => setTimeout(resolve, 1))
+      calls.push(bytes ? { op, path, bytes: new Uint8Array(bytes) } : { op, path })
+      if (op === 'READ') return new Uint8Array()
+      if (op === 'LIST') return []
+      return undefined
+    }
+    const rt = new PyodideRuntime()
+    rt.attach(dispatch, () => ['/ram/'])
+    const result = await rt.run({
+      code: `with open('/ram/out.txt', 'wb') as f: f.write(b'landed')`,
+      args: [],
+      env: {},
+      stdin: new Uint8Array(),
+    })
+    expect(new TextDecoder().decode(result.stderr ?? new Uint8Array())).toBe('')
+    expect(result.exitCode).toBe(0)
+    const writes = calls.filter((c) => c.op === 'WRITE')
+    expect(writes).toHaveLength(1)
+    const w0 = writes[0]
+    if (w0?.bytes === undefined) throw new Error('unreachable')
+    expect(w0.path).toBe('/ram/out.txt')
+    expect(new TextDecoder().decode(w0.bytes)).toBe('landed')
+    await rt.close()
+  }, 60_000)
+
+  it('a mount added after boot is preloaded host-side, no lazy backfill needed', async () => {
+    const files = new Map<string, Uint8Array>([
+      ['/late/hello.txt', new TextEncoder().encode('late-mount')],
+    ])
+    const dispatch: BridgeDispatchFn = async (op, path) => {
+      await new Promise((resolve) => setTimeout(resolve, 1))
+      if (op === 'READ') return files.get(path) ?? new Uint8Array()
+      if (op === 'LIST') {
+        const entries = []
+        for (const [p, content] of files) {
+          if (p.startsWith(path) && !p.slice(path.length).includes('/')) {
+            entries.push({ path: p, size: content.length, isDir: false })
+          }
+        }
+        return entries
+      }
+      return undefined
+    }
+    const mounts: string[] = []
+    const rt = new PyodideRuntime()
+    rt.attach(dispatch, () => mounts)
+    await rt.run({ code: 'pass', args: [], env: {}, stdin: new Uint8Array() })
+    mounts.push('/late/')
+    const result = await rt.run({
+      code: `with open('/late/hello.txt') as f: print(f.read())`,
+      args: [],
+      env: {},
+      stdin: new Uint8Array(),
+    })
+    expect(new TextDecoder().decode(result.stdout)).toContain('late-mount')
+    expect(result.exitCode).toBe(0)
+    await rt.close()
+  }, 60_000)
+})

--- a/typescript/packages/core/src/workspace/executor/python/runtimes/pyodide.ts
+++ b/typescript/packages/core/src/workspace/executor/python/runtimes/pyodide.ts
@@ -337,8 +337,12 @@ export class PyodideRuntime extends Runtime implements Evaluator {
     if (this.bridge === null) return
     for (const prefix of this.bridge.prefixes()) {
       if (this.preloadedPrefixes.has(prefix)) continue
-      this.preloadedPrefixes.add(prefix)
+      // Record only after success: preloadInto's one throw path is the
+      // top-level LIST (per-entry failures warn and continue), so a
+      // transient failure surfaces loudly and retries on the next run
+      // instead of poisoning the prefix for the runtime's lifetime.
       await preloadInto(pyodide.FS, this.bridge, prefix)
+      this.preloadedPrefixes.add(prefix)
     }
   }
 

--- a/typescript/packages/core/src/workspace/executor/python/runtimes/pyodide.ts
+++ b/typescript/packages/core/src/workspace/executor/python/runtimes/pyodide.ts
@@ -45,6 +45,16 @@ function bridgeStderr(value: Uint8Array | ArrayLike<number>): Uint8Array | null 
   return bytes.length > 0 ? bytes : null
 }
 
+function appendStderrLines(stderr: Uint8Array | null, lines: string[]): Uint8Array | null {
+  if (lines.length === 0) return stderr
+  const extra = new TextEncoder().encode(lines.map((line) => line + '\n').join(''))
+  if (stderr === null) return extra
+  const out = new Uint8Array(stderr.length + extra.length)
+  out.set(stderr)
+  out.set(extra, stderr.length)
+  return out
+}
+
 // The eval wrapper ships python bytes as {'__mirage_bytes__': <b64>}
 // (bytes are valid EvalValues but not JSON); this reviver restores
 // them to Uint8Array while everything else parses as plain JSON.
@@ -135,6 +145,7 @@ export class PyodideRuntime extends Runtime implements Evaluator {
   private listMounts: () => string[] = () => []
   private readonly home: string | null
   private bridge: MirageBridge | null = null
+  private readonly preloadedPrefixes = new Set<string>()
   // The guest executes on this event loop, so only the watchdog-backed
   // interrupt buffer can stop a busy loop (see interrupt.ts); null
   // where SharedArrayBuffer/workers are unavailable (runs unbounded).
@@ -201,6 +212,7 @@ export class PyodideRuntime extends Runtime implements Evaluator {
       if (armed?.disarm() === 'deadline') {
         throw new EvalError(`pyodide eval timed out after ${String(EVAL_INTERRUPT_SECONDS)}s`)
       }
+      const flushFailures = await this.drainDirty(pyodide)
       const resultProxy = pyodide.globals.get('_eval_result') as
         | {
             toJs?: (opts?: Record<string, unknown>) => unknown
@@ -217,18 +229,21 @@ export class PyodideRuntime extends Runtime implements Evaluator {
       }
       const [valueJson, out, errBytes, ok, syntax] = arr
       if (!ok) {
+        for (const failure of flushFailures) console.warn(failure)
         const detail = new TextDecoder().decode(bridgeBytes(errBytes)).trim()
         throw new EvalError(detail !== '' ? detail : 'evaluation failed', { syntax })
       }
       return {
         value: JSON.parse(valueJson, reviveEvalValue) as EvalValue,
         stdout: bridgeBytes(out),
-        stderr: bridgeStderr(errBytes),
-        exitCode: 0,
+        stderr: appendStderrLines(bridgeStderr(errBytes), flushFailures),
+        exitCode: flushFailures.length > 0 ? 1 : 0,
         status: 'complete',
       }
     } catch (err) {
-      if (armed?.disarm() === 'deadline') {
+      const deadline = armed?.disarm() === 'deadline'
+      for (const failure of await this.drainDirty(pyodide)) console.warn(failure)
+      if (deadline) {
         throw new EvalError(`pyodide eval timed out after ${String(EVAL_INTERRUPT_SECONDS)}s`, {
           cause: err,
         })
@@ -258,6 +273,7 @@ export class PyodideRuntime extends Runtime implements Evaluator {
     this.pyodide = null
     this.initPromise = null
     this.bridge = null
+    this.preloadedPrefixes.clear()
     this.interrupter?.close()
     this.interrupter = null
     this.interrupterTried = false
@@ -274,6 +290,7 @@ export class PyodideRuntime extends Runtime implements Evaluator {
     if (this.pyodide !== null) {
       if (this.bootstrapPromise !== null) await this.bootstrapPromise
       await this.wireBridgeIfNeeded(this.pyodide)
+      await this.preloadNewPrefixes(this.pyodide)
       await this.wireInterruptIfNeeded(this.pyodide)
       return this.pyodide
     }
@@ -295,6 +312,7 @@ export class PyodideRuntime extends Runtime implements Evaluator {
       await this.bootstrapPromise
     }
     await this.wireBridgeIfNeeded(this.pyodide)
+    await this.preloadNewPrefixes(this.pyodide)
     await this.wireInterruptIfNeeded(this.pyodide)
     return this.pyodide
   }
@@ -305,9 +323,53 @@ export class PyodideRuntime extends Runtime implements Evaluator {
     pyodide.registerJsModule('_mirage_bridge', bridge)
     await pyodide.runPythonAsync(MIRAGE_FS_SHIM_PY)
     this.bridge = bridge
-    for (const prefix of bridge.prefixes()) {
-      await preloadInto(pyodide.FS, bridge, prefix)
+  }
+
+  /**
+   * Hydrate MEMFS for mount prefixes not yet preloaded, before every run.
+   * This is the host-side half of read visibility: a mount added after
+   * boot gets its tree here, where awaiting the bridge is free, instead
+   * of relying on the shim's lazy backfill, whose run_sync needs JSPI.
+   * Content changes under an already-preloaded prefix still ride the
+   * lazy path (a full re-list per run would be one API sweep per mount).
+   */
+  private async preloadNewPrefixes(pyodide: PyodideInterface): Promise<void> {
+    if (this.bridge === null) return
+    for (const prefix of this.bridge.prefixes()) {
+      if (this.preloadedPrefixes.has(prefix)) continue
+      this.preloadedPrefixes.add(prefix)
+      await preloadInto(pyodide.FS, this.bridge, prefix)
     }
+  }
+
+  /**
+   * Flush every path the shim marked dirty during the run. The guest
+   * cannot await the bridge from its sync WASM frames without JSPI, so
+   * close() only marks; MEMFS holds the final bytes, and one WRITE per
+   * path covers however many times the script reopened it. Returns one
+   * message per failed flush for the caller's stderr.
+   */
+  private async drainDirty(pyodide: PyodideInterface): Promise<string[]> {
+    if (this.bridge === null) return []
+    const failures: string[] = []
+    for (const path of this.bridge.takeDirty()) {
+      let bytes: Uint8Array
+      try {
+        bytes = pyodide.FS.readFile(path) as Uint8Array
+      } catch {
+        // closed then unlinked locally; unlink does not propagate, so
+        // the mount keeps its previous content
+        console.warn(`mirage flush: ${path} marked dirty but missing from MEMFS, skipped`)
+        continue
+      }
+      try {
+        await this.bridge.flush(path, bytes)
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err)
+        failures.push(`python3: failed to flush ${path} to mount: ${detail}`)
+      }
+    }
+    return failures
   }
 
   private async loadImports(pyodide: PyodideInterface, code: string): Promise<void> {
@@ -352,6 +414,7 @@ export class PyodideRuntime extends Runtime implements Evaluator {
       if (armed?.disarm() === 'deadline' && args.timeoutSeconds !== undefined) {
         throw new CommandTimeoutError(this.name, args.timeoutSeconds)
       }
+      const flushFailures = await this.drainDirty(pyodide)
       const resultProxy = pyodide.globals.get('_result') as
         | {
             toJs?: (opts?: Record<string, unknown>) => unknown
@@ -366,19 +429,26 @@ export class PyodideRuntime extends Runtime implements Evaluator {
       if (arr === undefined) {
         return {
           stdout: new Uint8Array(),
-          stderr: new TextEncoder().encode('python3: runtime returned no result\n'),
+          stderr: appendStderrLines(
+            new TextEncoder().encode('python3: runtime returned no result\n'),
+            flushFailures,
+          ),
           exitCode: 1,
         }
       }
       return {
         stdout: bridgeBytes(arr[0]),
-        stderr: bridgeStderr(arr[1]),
-        exitCode: arr[2],
+        stderr: appendStderrLines(bridgeStderr(arr[1]), flushFailures),
+        exitCode: flushFailures.length > 0 && arr[2] === 0 ? 1 : arr[2],
       }
     } catch (err) {
       // The interrupt can also fire between wrapper statements, where
       // KeyboardInterrupt escapes as a rejection instead of a result.
-      if (armed?.disarm() === 'deadline' && args.timeoutSeconds !== undefined) {
+      // Files closed before the failure are complete in MEMFS, so their
+      // marks still flush; failures can only be warned here.
+      const deadline = armed?.disarm() === 'deadline'
+      for (const failure of await this.drainDirty(pyodide)) console.warn(failure)
+      if (deadline && args.timeoutSeconds !== undefined) {
         throw new CommandTimeoutError(this.name, args.timeoutSeconds)
       }
       throw err
@@ -419,6 +489,7 @@ export class PyodideRuntime extends Runtime implements Evaluator {
 
     try {
       await pyodide.runPythonAsync(PYTHON_REPL_WRAPPER)
+      const flushFailures = await this.drainDirty(pyodide)
       const resultProxy = pyodide.globals.get('_repl_result') as
         | {
             toJs?: (opts?: Record<string, unknown>) => unknown
@@ -433,15 +504,18 @@ export class PyodideRuntime extends Runtime implements Evaluator {
       if (arr === undefined) {
         return {
           stdout: new Uint8Array(),
-          stderr: new TextEncoder().encode('python3: repl returned no result\n'),
+          stderr: appendStderrLines(
+            new TextEncoder().encode('python3: repl returned no result\n'),
+            flushFailures,
+          ),
           exitCode: 1,
           status: 'complete',
         }
       }
       return {
         stdout: bridgeBytes(arr[0]),
-        stderr: bridgeStderr(arr[1]),
-        exitCode: arr[2],
+        stderr: appendStderrLines(bridgeStderr(arr[1]), flushFailures),
+        exitCode: flushFailures.length > 0 && arr[2] === 0 ? 1 : arr[2],
         status: arr[3],
       }
     } finally {

--- a/typescript/vitest.config.ts
+++ b/typescript/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     passWithNoTests: true,
     pool: 'forks',
+    // JSPI serves only the pyodide shim's lazy backfill (run_sync in
+    // mirage_fs_shim.ts); production runs without it, so nothing else
+    // may depend on this flag. runtime_nojspi.test.ts pins the
+    // no-JSPI write path by deleting WebAssembly.Suspending.
     poolOptions: {
       forks: {
         execArgv: ['--experimental-wasm-jspi'],


### PR DESCRIPTION
Every pyodide file write under a mount exited 1 with `RuntimeError: WebAssembly stack switching not supported`, even though the bytes landed: `close()` flushed through `run_sync(_mb.flush(...))`, whose WRITE dispatch starts synchronously before the suspend raises. No production embedder has JSPI (V8 flags cannot ride NODE_OPTIONS); tests only passed because vitest runs every fork with `--experimental-wasm-jspi`.

- `close()` now marks the path dirty via a sync bridge call (`markDirty`/`takeDirty` on `MirageBridge`); the bytes are already in MEMFS.
- `PyodideRuntime` drains after each run/eval/repl: reads the final MEMFS content per dirty path and awaits `bridge.flush` host-side. A failed flush lands on stderr and flips a clean exit to 1. Repeated open/append/close cycles collapse to one WRITE with the final content.
- Mount prefixes added after boot are preloaded host-side before each run, so that case no longer needs JSPI either. The shim's lazy backfill remains the one JSPI-dependent surface.
- `runtime_nojspi.test.ts` pins the production environment by deleting `WebAssembly.Suspending` before pyodide loads.
- docs/typescript/python-fs.mdx updated to the new contract.