### PR TITLE
fix(google): thread apiBase through TS resources, accept snake_case CLI config

### DIFF
--- a/integ/runners/python/adapters.py
+++ b/integ/runners/python/adapters.py
@@ -49,7 +49,6 @@ from mirage.commands.cli.types import CLISpec
 from mirage.core.databricks_volume.path import configured_root
 from mirage.core.discord.config import DiscordConfig
 from mirage.core.email.config import EmailConfig
-from mirage.core.google import _client as google_client
 from mirage.core.sharepoint import _resolver as sharepoint_resolver
 from mirage.resource.aliyun import AliyunConfig, AliyunResource
 from mirage.resource.backblaze import BackblazeConfig, BackblazeResource
@@ -484,16 +483,6 @@ class NextcloudService:
 FOLDER_MIME = "application/vnd.google-apps.folder"
 
 
-def _use_fake_google_endpoints(url: str) -> None:
-    google_client.TOKEN_URL = f"{url}/token"
-    google_client.DRIVE_API_BASE = f"{url}/drive/v3"
-    google_client.DRIVE_UPLOAD_BASE = f"{url}/upload/drive/v3"
-    google_client.DOCS_API_BASE = f"{url}/v1"
-    google_client.SLIDES_API_BASE = f"{url}/v1"
-    google_client.SHEETS_API_BASE = f"{url}/v4"
-    google_client.GMAIL_API_BASE = f"{url}/gmail/v1"
-
-
 class GwsService:
     """Points gdrive mounts at the fake Google Workspace server.
 
@@ -514,7 +503,6 @@ class GwsService:
     @classmethod
     async def create(cls, run_id: str, target: dict) -> "GwsService":
         url = os.environ["GWS_URL"].rstrip("/")
-        _use_fake_google_endpoints(url)
         folder_ids: dict[str, str] = {}
         drive_ids: dict[str, str] = {}
         # Native mounts (gdocs/gsheets/gslides) render the modified date
@@ -640,28 +628,38 @@ class GwsService:
         return GoogleDriveResource(
             GoogleDriveConfig(client_id="integ",
                               refresh_token="integ",
+                              api_base=self.url,
                               folder_id=self.folder_ids[mount["path"]]))
 
     def gdocs_resource(self) -> GDocsResource:
         return GDocsResource(
-            GDocsConfig(client_id="integ", refresh_token="integ"))
+            GDocsConfig(client_id="integ",
+                        refresh_token="integ",
+                        api_base=self.url))
 
     def gsheets_resource(self) -> GSheetsResource:
         return GSheetsResource(
-            GSheetsConfig(client_id="integ", refresh_token="integ"))
+            GSheetsConfig(client_id="integ",
+                          refresh_token="integ",
+                          api_base=self.url))
 
     def gslides_resource(self) -> GSlidesResource:
         return GSlidesResource(
-            GSlidesConfig(client_id="integ", refresh_token="integ"))
+            GSlidesConfig(client_id="integ",
+                          refresh_token="integ",
+                          api_base=self.url))
 
     def gmail_resource(self) -> GmailResource:
         return GmailResource(
-            GmailConfig(client_id="integ", refresh_token="integ"))
+            GmailConfig(client_id="integ",
+                        refresh_token="integ",
+                        api_base=self.url))
 
     def cli_installs(self) -> dict[str, tuple[CLISpec, dict[str, object]]]:
         config: dict[str, object] = {
             "client_id": "integ",
             "refresh_token": "integ",
+            "api_base": self.url,
         }
         if self.cli_scope is not None:
             config["folder_id"] = self.folder_ids[self.cli_scope]

--- a/integ/runners/python/main.py
+++ b/integ/runners/python/main.py
@@ -115,6 +115,7 @@ async def main() -> None:
         selected = args.targets or list(manifest)
     report = None if args.emit else harness.Report()
     emit: list[dict] | None = [] if args.emit else None
+    ran = 0
     for target_id in selected:
         target = manifest[target_id]
         if HOST not in target["hosts"]:
@@ -178,6 +179,15 @@ async def main() -> None:
             print(f"skip [{target_id}]: LANGFUSE_URL not set", file=sys.stderr)
             continue
         await run_target(target, cases, root, report, emit)
+        ran += 1
+
+    # A skip is one line on stderr and exit 0, so a facet whose service
+    # never came up (or whose env var got renamed in the workflow)
+    # reports green having tested nothing. Every facet has targets on
+    # both hosts, so zero of them running is always a broken job.
+    if args.facet and ran == 0:
+        print(f"facet {args.facet!r} ran no targets", file=sys.stderr)
+        sys.exit(2)
 
     if args.emit:
         Path(args.emit).write_text(json.dumps(emit))

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -118,44 +118,6 @@ const DATABRICKS_ENDPOINT = process.env.DATABRICKS_ENDPOINT
 const NEXTCLOUD_URL = process.env.NEXTCLOUD_URL
 const NEXTCLOUD_USERNAME = process.env.NEXTCLOUD_USERNAME ?? 'admin'
 const NEXTCLOUD_PASSWORD = process.env.NEXTCLOUD_PASSWORD ?? 'admin123'
-const GOOGLE_API_HOSTS = new Set([
-  'oauth2.googleapis.com',
-  'www.googleapis.com',
-  'docs.googleapis.com',
-  'slides.googleapis.com',
-  'sheets.googleapis.com',
-  'gmail.googleapis.com',
-])
-
-type FetchInput = Parameters<typeof globalThis.fetch>[0]
-type FetchInit = Parameters<typeof globalThis.fetch>[1]
-
-let realFetch: typeof globalThis.fetch | null = null
-let fakeGoogleBase = ''
-
-function redirectGoogleUrl(input: FetchInput): FetchInput {
-  if (typeof input !== 'string' && !(input instanceof URL)) return input
-  const raw = input instanceof URL ? input.href : input
-  if (!raw.startsWith('http://') && !raw.startsWith('https://')) return input
-  const url = new URL(raw)
-  if (GOOGLE_API_HOSTS.has(url.hostname)) {
-    return `${fakeGoogleBase}${url.pathname}${url.search}`
-  }
-  return input
-}
-
-function fakeGoogleFetch(input: FetchInput, init?: FetchInit): Promise<Response> {
-  if (realFetch === null) throw new Error('fake Google fetch is not installed')
-  return realFetch(redirectGoogleUrl(input), init)
-}
-
-function useFakeGoogleEndpoints(base: string): void {
-  fakeGoogleBase = base
-  if (realFetch !== null) return
-  realFetch = globalThis.fetch
-  globalThis.fetch = fakeGoogleFetch
-}
-
 function runId(): string {
   return `${String(process.pid)}-${String(Date.now())}`
 }
@@ -459,14 +421,16 @@ async function openEmail(target: Target): Promise<Open> {
   }
   const ws = new Workspace(mounts, { mode: MountMode.WRITE })
   if (target.clis?.includes('himalaya') === true) {
+    // The same snake_case block the Python runner installs; the CLI
+    // registry normalizes it, so one YAML config serves both hosts.
     ws.registerCli('himalaya', HIMALAYA, {
-      imapHost: host,
-      imapPort: EMAIL_IMAP_PORT,
-      smtpHost: host,
-      smtpPort: EMAIL_SMTP_PORT,
+      imap_host: host,
+      imap_port: EMAIL_IMAP_PORT,
+      smtp_host: host,
+      smtp_port: EMAIL_SMTP_PORT,
       username: EMAIL_USERNAME,
       password: EMAIL_PASSWORD,
-      useSsl: false,
+      use_ssl: false,
     })
   }
   return { ws: ws as unknown as ExecWorkspace, cleanup: () => ws.close() }
@@ -1206,8 +1170,11 @@ async function seedGwsMail(base: string, entries: MailEntry[]): Promise<void> {
 
 function gwsNativeResource(
   resource: string,
+  base: string,
 ): GDocsResource | GSheetsResource | GSlidesResource | GmailResource {
-  const config = { clientId: 'integ', clientSecret: 'integ', refreshToken: 'integ' }
+  // apiBase points the backend at the fake server through the same
+  // config field a real embedder uses; nothing is monkey-patched.
+  const config = { clientId: 'integ', clientSecret: 'integ', refreshToken: 'integ', apiBase: base }
   if (resource === 'gdocs') return new GDocsResource(config)
   if (resource === 'gsheets') return new GSheetsResource(config)
   if (resource === 'gmail') return new GmailResource(config)
@@ -1218,7 +1185,6 @@ async function openGws(target: Target): Promise<Open> {
   let base = process.env.GWS_URL ?? ''
   while (base.endsWith('/')) base = base.slice(0, -1)
   if (base === '') throw new Error('gdrive target requires GWS_URL')
-  useFakeGoogleEndpoints(base)
   // Native mounts (gdocs/gsheets/gslides) render the modified date into
   // filenames, so those targets pin the server clock.
   await gwsJson(`${base}/reset`, {
@@ -1238,7 +1204,7 @@ async function openGws(target: Target): Promise<Open> {
       continue
     }
     if (m.resource !== 'gdrive') {
-      mounts[m.path] = gwsNativeResource(m.resource)
+      mounts[m.path] = gwsNativeResource(m.resource, base)
       continue
     }
     // A mount may live inside a Shared Drive: the drive is created once
@@ -1260,6 +1226,7 @@ async function openGws(target: Target): Promise<Open> {
       clientId: 'integ',
       clientSecret: 'integ',
       refreshToken: 'integ',
+      apiBase: base,
       folderId: parent,
     })
     folderIds[m.path] = parent
@@ -1276,12 +1243,15 @@ async function openGws(target: Target): Promise<Open> {
   if (target.clis?.includes('gws') === true) {
     // A target may scope the gws install to one mount's folder, the
     // configuration where the CLI and the mount are the same folder.
+    // The block is the same snake_case mapping the Python runner
+    // installs, pinning that one config serves both hosts.
     const scope = target.cli_scope
     ws.registerCli('gws', GWS, {
-      clientId: 'integ',
-      clientSecret: 'integ',
-      refreshToken: 'integ',
-      ...(scope !== undefined ? { folderId: folderIds[scope] } : {}),
+      client_id: 'integ',
+      client_secret: 'integ',
+      refresh_token: 'integ',
+      api_base: base,
+      ...(scope !== undefined ? { folder_id: folderIds[scope] } : {}),
     })
   }
   const cleanup = async (): Promise<void> => {

--- a/integ/runners/typescript/adapters.ts
+++ b/integ/runners/typescript/adapters.ts
@@ -421,8 +421,10 @@ async function openEmail(target: Target): Promise<Open> {
   }
   const ws = new Workspace(mounts, { mode: MountMode.WRITE })
   if (target.clis?.includes('himalaya') === true) {
-    // The same snake_case block the Python runner installs; the CLI
-    // registry normalizes it, so one YAML config serves both hosts.
+    // Every registerCli in this file installs the same snake_case block
+    // the Python runner does, so the cli facet proves one YAML config
+    // serves both hosts rather than only that each host has some config
+    // it accepts. The registry camelizes onto declared fields.
     ws.registerCli('himalaya', HIMALAYA, {
       imap_host: host,
       imap_port: EMAIL_IMAP_PORT,
@@ -692,8 +694,8 @@ async function openNotion(target: Target): Promise<Open> {
   const ws = new Workspace(mounts, { mode: MountMode.WRITE })
   if (target.clis?.includes('ntn') === true) {
     ws.registerCli('ntn', NTN, {
-      apiKey: 'integ-test',
-      baseUrl: `http://127.0.0.1:${String(port)}/v1`,
+      api_key: 'integ-test',
+      base_url: `http://127.0.0.1:${String(port)}/v1`,
     })
   }
   const cleanup = async (): Promise<void> => {
@@ -1243,8 +1245,6 @@ async function openGws(target: Target): Promise<Open> {
   if (target.clis?.includes('gws') === true) {
     // A target may scope the gws install to one mount's folder, the
     // configuration where the CLI and the mount are the same folder.
-    // The block is the same snake_case mapping the Python runner
-    // installs, pinning that one config serves both hosts.
     const scope = target.cli_scope
     ws.registerCli('gws', GWS, {
       client_id: 'integ',
@@ -1285,8 +1285,8 @@ async function openSlack(target: Target): Promise<Open> {
   if (target.clis?.includes('slack') === true) {
     ws.registerCli('slack', SLACK, {
       token: 'xoxb-integ',
-      searchToken: 'xoxp-integ-search',
-      baseUrl: `${base}/api`,
+      search_token: 'xoxp-integ-search',
+      base_url: `${base}/api`,
     })
   }
   const cleanup = async (): Promise<void> => {
@@ -1395,7 +1395,7 @@ async function openDiscord(target: Target): Promise<Open> {
   if (target.clis?.includes('discord') === true) {
     ws.registerCli('discord', DISCORD, {
       token: 'integ-bot-token',
-      baseUrl: `${endpoint}/api/v10`,
+      base_url: `${endpoint}/api/v10`,
     })
   }
   return { ws: ws as unknown as ExecWorkspace, cleanup: () => ws.close() }
@@ -1423,7 +1423,7 @@ async function openLinear(target: Target): Promise<Open> {
   }
   const ws = new Workspace(mounts, { mode: MountMode.WRITE })
   if (target.clis?.includes('linear') === true) {
-    ws.registerCli('linear', LINEAR, { apiKey: 'integ-key', baseUrl: endpoint })
+    ws.registerCli('linear', LINEAR, { api_key: 'integ-key', base_url: endpoint })
   }
   return { ws: ws as unknown as ExecWorkspace, cleanup: () => ws.close() }
 }

--- a/integ/runners/typescript/main.ts
+++ b/integ/runners/typescript/main.ts
@@ -129,6 +129,7 @@ async function main(): Promise<void> {
   }
   const report = emitPath ? null : new Report()
   const emit: EmitRow[] | null = emitPath ? [] : null
+  let ran = 0
   for (const id of ids) {
     const target = manifest.get(id)
     if (!target) throw new Error(`unknown target: ${id}`)
@@ -228,8 +229,17 @@ async function main(): Promise<void> {
       continue
     }
     await runTarget(target, cases, root, report, emit)
+    ran += 1
   }
 
+  // A skip is one line on stderr and exit 0, so a facet whose service
+  // never came up (or whose env var got renamed in the workflow) reports
+  // green having tested nothing. Every facet has targets on both hosts,
+  // so zero of them running is always a broken job, never a valid run.
+  if (facet !== undefined && ran === 0) {
+    process.stderr.write(`facet '${facet}' ran no targets\n`)
+    process.exit(2)
+  }
   if (emitPath) {
     writeFileSync(emitPath, JSON.stringify(emit))
     return

--- a/typescript/packages/browser/src/resource/box/box.ts
+++ b/typescript/packages/browser/src/resource/box/box.ts
@@ -55,17 +55,11 @@ export class BoxResource implements Resource {
 
   constructor(config: BoxConfig) {
     this.config = config
-    const tm = new BoxTokenManager({
-      ...(config.endpoint !== undefined ? { endpoint: config.endpoint } : {}),
-      ...(config.clientId !== undefined ? { clientId: config.clientId } : {}),
-      ...(config.clientSecret !== undefined ? { clientSecret: config.clientSecret } : {}),
-      ...(config.refreshToken !== undefined ? { refreshToken: config.refreshToken } : {}),
-      ...(config.accessToken !== undefined ? { accessToken: config.accessToken } : {}),
-      ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-      ...(config.onRefreshTokenRotated !== undefined
-        ? { onRefreshTokenRotated: config.onRefreshTokenRotated }
-        : {}),
-    })
+    // The whole config goes to the token manager, never a hand-picked
+    // subset: a field added to BoxConfig would silently stop reaching it
+    // (that is how gdrive lost apiBase and kept refreshing at the real
+    // Google endpoint against a fake server).
+    const tm = new BoxTokenManager(config)
     this.accessor = new BoxAccessor({
       tokenManager: tm,
       ...(config.rootFolderId !== undefined ? { rootFolderId: config.rootFolderId } : {}),

--- a/typescript/packages/browser/src/resource/dropbox/dropbox.ts
+++ b/typescript/packages/browser/src/resource/dropbox/dropbox.ts
@@ -55,13 +55,7 @@ export class DropboxResource implements Resource {
 
   constructor(config: DropboxConfig) {
     this.config = config
-    const tm = new DropboxTokenManager({
-      clientId: config.clientId,
-      ...(config.clientSecret !== undefined ? { clientSecret: config.clientSecret } : {}),
-      refreshToken: config.refreshToken,
-      ...(config.endpoint !== undefined ? { endpoint: config.endpoint } : {}),
-      ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-    })
+    const tm = new DropboxTokenManager(config)
     this.accessor = new DropboxAccessor({
       tokenManager: tm,
       ...(config.rootPath !== undefined ? { rootPath: config.rootPath } : {}),

--- a/typescript/packages/browser/src/resource/gdocs/config.ts
+++ b/typescript/packages/browser/src/resource/gdocs/config.ts
@@ -12,37 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface GDocsConfig {
-  clientId: string
-  clientSecret?: string
-  refreshToken: string
-  refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-}
-
-export interface GDocsConfigRedacted {
-  clientId: string
-  clientSecret?: '<REDACTED>'
-  refreshToken: '<REDACTED>'
-}
-
-const GDocsConfigSchema = z.object({
-  clientId: z.string(),
-  clientSecret: secretStr().optional(),
-  refreshToken: secretStr(),
-})
-
-export function redactGDocsConfig(config: GDocsConfig): GDocsConfigRedacted {
-  return redactConfigWithSchema(GDocsConfigSchema, config) as unknown as GDocsConfigRedacted
-}
-
-export function normalizeGDocsConfig(input: Record<string, unknown>): GDocsConfig {
-  return normalizeFields(input, {
-    rename: {
-      client_id: 'clientId',
-      client_secret: 'clientSecret',
-      refresh_token: 'refreshToken',
-    },
-  }) as unknown as GDocsConfig
-}
+export {
+  normalizeGoogleConfig as normalizeGDocsConfig,
+  redactGoogleConfig as redactGDocsConfig,
+  type GoogleConfig as GDocsConfig,
+  type GoogleConfigRedacted as GDocsConfigRedacted,
+} from '@struktoai/mirage-core'

--- a/typescript/packages/browser/src/resource/gdocs/gdocs.ts
+++ b/typescript/packages/browser/src/resource/gdocs/gdocs.ts
@@ -54,12 +54,7 @@ export class GDocsResource implements Resource {
 
   constructor(config: GDocsConfig) {
     this.config = config
-    const tm = new TokenManager({
-      clientId: config.clientId,
-      ...(config.clientSecret !== undefined ? { clientSecret: config.clientSecret } : {}),
-      refreshToken: config.refreshToken,
-      ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-    })
+    const tm = new TokenManager(config)
     this.accessor = new GDocsAccessor({ tokenManager: tm })
     this.index = new RAMIndexCacheStore({ ttl: 86_400 })
   }

--- a/typescript/packages/browser/src/resource/gdrive/config.ts
+++ b/typescript/packages/browser/src/resource/gdrive/config.ts
@@ -12,40 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface GDriveConfig {
-  clientId: string
-  clientSecret?: string
-  refreshToken: string
-  refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-  folderId?: string
-}
-
-export interface GDriveConfigRedacted {
-  clientId: string
-  clientSecret?: '<REDACTED>'
-  refreshToken: '<REDACTED>'
-}
-
-const GDriveConfigSchema = z.object({
-  clientId: z.string(),
-  clientSecret: secretStr().optional(),
-  refreshToken: secretStr(),
-  folderId: z.string().optional(),
-})
-
-export function redactGDriveConfig(config: GDriveConfig): GDriveConfigRedacted {
-  return redactConfigWithSchema(GDriveConfigSchema, config) as unknown as GDriveConfigRedacted
-}
-
-export function normalizeGDriveConfig(input: Record<string, unknown>): GDriveConfig {
-  return normalizeFields(input, {
-    rename: {
-      client_id: 'clientId',
-      client_secret: 'clientSecret',
-      refresh_token: 'refreshToken',
-      folder_id: 'folderId',
-    },
-  }) as unknown as GDriveConfig
-}
+export {
+  normalizeGoogleConfig as normalizeGDriveConfig,
+  redactGoogleConfig as redactGDriveConfig,
+  type GoogleConfig as GDriveConfig,
+  type GoogleConfigRedacted as GDriveConfigRedacted,
+} from '@struktoai/mirage-core'

--- a/typescript/packages/browser/src/resource/gdrive/gdrive.ts
+++ b/typescript/packages/browser/src/resource/gdrive/gdrive.ts
@@ -53,13 +53,7 @@ export class GDriveResource implements Resource {
 
   constructor(config: GDriveConfig) {
     this.config = config
-    const tm = new TokenManager({
-      clientId: config.clientId,
-      ...(config.clientSecret !== undefined ? { clientSecret: config.clientSecret } : {}),
-      refreshToken: config.refreshToken,
-      ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-      ...(config.folderId !== undefined ? { folderId: config.folderId } : {}),
-    })
+    const tm = new TokenManager(config)
     this.accessor = new GDriveAccessor({ tokenManager: tm })
     this.index = new RAMIndexCacheStore({ ttl: 86_400 })
   }

--- a/typescript/packages/browser/src/resource/gsheets/config.ts
+++ b/typescript/packages/browser/src/resource/gsheets/config.ts
@@ -12,37 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface GSheetsConfig {
-  clientId: string
-  clientSecret?: string
-  refreshToken: string
-  refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-}
-
-export interface GSheetsConfigRedacted {
-  clientId: string
-  clientSecret?: '<REDACTED>'
-  refreshToken: '<REDACTED>'
-}
-
-const GSheetsConfigSchema = z.object({
-  clientId: z.string(),
-  clientSecret: secretStr().optional(),
-  refreshToken: secretStr(),
-})
-
-export function redactGSheetsConfig(config: GSheetsConfig): GSheetsConfigRedacted {
-  return redactConfigWithSchema(GSheetsConfigSchema, config) as unknown as GSheetsConfigRedacted
-}
-
-export function normalizeGSheetsConfig(input: Record<string, unknown>): GSheetsConfig {
-  return normalizeFields(input, {
-    rename: {
-      client_id: 'clientId',
-      client_secret: 'clientSecret',
-      refresh_token: 'refreshToken',
-    },
-  }) as unknown as GSheetsConfig
-}
+export {
+  normalizeGoogleConfig as normalizeGSheetsConfig,
+  redactGoogleConfig as redactGSheetsConfig,
+  type GoogleConfig as GSheetsConfig,
+  type GoogleConfigRedacted as GSheetsConfigRedacted,
+} from '@struktoai/mirage-core'

--- a/typescript/packages/browser/src/resource/gsheets/gsheets.ts
+++ b/typescript/packages/browser/src/resource/gsheets/gsheets.ts
@@ -54,12 +54,7 @@ export class GSheetsResource implements Resource {
 
   constructor(config: GSheetsConfig) {
     this.config = config
-    const tm = new TokenManager({
-      clientId: config.clientId,
-      ...(config.clientSecret !== undefined ? { clientSecret: config.clientSecret } : {}),
-      refreshToken: config.refreshToken,
-      ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-    })
+    const tm = new TokenManager(config)
     this.accessor = new GSheetsAccessor({ tokenManager: tm })
     this.index = new RAMIndexCacheStore({ ttl: 86_400 })
   }

--- a/typescript/packages/browser/src/resource/gslides/config.ts
+++ b/typescript/packages/browser/src/resource/gslides/config.ts
@@ -12,37 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface GSlidesConfig {
-  clientId: string
-  clientSecret?: string
-  refreshToken: string
-  refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-}
-
-export interface GSlidesConfigRedacted {
-  clientId: string
-  clientSecret?: '<REDACTED>'
-  refreshToken: '<REDACTED>'
-}
-
-const GSlidesConfigSchema = z.object({
-  clientId: z.string(),
-  clientSecret: secretStr().optional(),
-  refreshToken: secretStr(),
-})
-
-export function redactGSlidesConfig(config: GSlidesConfig): GSlidesConfigRedacted {
-  return redactConfigWithSchema(GSlidesConfigSchema, config) as unknown as GSlidesConfigRedacted
-}
-
-export function normalizeGSlidesConfig(input: Record<string, unknown>): GSlidesConfig {
-  return normalizeFields(input, {
-    rename: {
-      client_id: 'clientId',
-      client_secret: 'clientSecret',
-      refresh_token: 'refreshToken',
-    },
-  }) as unknown as GSlidesConfig
-}
+export {
+  normalizeGoogleConfig as normalizeGSlidesConfig,
+  redactGoogleConfig as redactGSlidesConfig,
+  type GoogleConfig as GSlidesConfig,
+  type GoogleConfigRedacted as GSlidesConfigRedacted,
+} from '@struktoai/mirage-core'

--- a/typescript/packages/browser/src/resource/gslides/gslides.ts
+++ b/typescript/packages/browser/src/resource/gslides/gslides.ts
@@ -54,12 +54,7 @@ export class GSlidesResource implements Resource {
 
   constructor(config: GSlidesConfig) {
     this.config = config
-    const tm = new TokenManager({
-      clientId: config.clientId,
-      ...(config.clientSecret !== undefined ? { clientSecret: config.clientSecret } : {}),
-      refreshToken: config.refreshToken,
-      ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-    })
+    const tm = new TokenManager(config)
     this.accessor = new GSlidesAccessor({ tokenManager: tm })
     this.index = new RAMIndexCacheStore({ ttl: 86_400 })
   }

--- a/typescript/packages/browser/src/resource/registry.test.ts
+++ b/typescript/packages/browser/src/resource/registry.test.ts
@@ -14,9 +14,27 @@
 
 import type { OAuthClientMetadata } from '@modelcontextprotocol/sdk/shared/auth.js'
 import { describe, expect, it } from 'vitest'
+import { tokenUrl, type TokenManager } from '@struktoai/mirage-core'
 import { buildResource, knownResources, register } from './registry.ts'
 
 describe('browser resource registry', () => {
+  // The four Drive-family resources used to redeclare core's GoogleConfig
+  // without apiBase and hand-pick TokenManager fields, so a mount pointed
+  // at a fake server still refreshed its token at Google's real endpoint.
+  it('threads api_base into every google resource token manager', async () => {
+    const base = 'http://127.0.0.1:9999'
+    for (const name of ['gdrive', 'gdocs', 'gsheets', 'gslides', 'gmail']) {
+      const resource = await buildResource(name, {
+        client_id: 'id',
+        client_secret: 'secret',
+        refresh_token: 'refresh',
+        api_base: base,
+      })
+      const { accessor } = resource as unknown as { accessor: { tokenManager: TokenManager } }
+      expect(tokenUrl(accessor.tokenManager.config), name).toBe(`${base}/token`)
+    }
+  })
+
   it('lists known resources sorted', () => {
     const names = knownResources()
     expect(names).toContain('ram')

--- a/typescript/packages/core/src/workspace/cli/registry.test.ts
+++ b/typescript/packages/core/src/workspace/cli/registry.test.ts
@@ -18,6 +18,12 @@ import { z } from 'zod'
 
 import { CLISpec, type CLIConfigModel } from '../../commands/cli/types.ts'
 import { IOResult } from '../../io/types.ts'
+import { DISCORD } from '../../commands/cli/builtin/discord/index.ts'
+import { GIT } from '../../commands/cli/builtin/git/index.ts'
+import { GWS } from '../../commands/cli/builtin/gws/index.ts'
+import { LINEAR } from '../../commands/cli/builtin/linear/index.ts'
+import { NTN } from '../../commands/cli/builtin/ntn/index.ts'
+import { SLACK } from '../../commands/cli/builtin/slack/index.ts'
 import { CLIRegistry } from './registry.ts'
 
 // Mirrors python/tests/workspace/cli/test_registry.py.
@@ -153,6 +159,22 @@ describe('CLIRegistry zod config schemas', () => {
     )
   })
 
+  it('rejects both spellings of one field', () => {
+    const reg = new CLIRegistry()
+    const model = z.object({ imapHost: z.string() })
+    expect(() => reg.install('prog', tree(model), { imap_host: 'x', imapHost: 'y' })).toThrow(
+      /duplicates field 'imapHost'/,
+    )
+  })
+
+  it('does not read prototype members as declared fields', () => {
+    const reg = new CLIRegistry()
+    const model = z.object({ token: z.string() })
+    expect(() => reg.install('prog', tree(model), { token: 'x', constructor: 'y' })).toThrow(
+      /unknown config keys: constructor/,
+    )
+  })
+
   it('keeps undeclared keys verbatim under a loose schema', () => {
     const reg = new CLIRegistry()
     const install = reg.install('prog', tree(z.looseObject({ imapHost: z.string() })), {
@@ -188,4 +210,50 @@ describe('CLIRegistry zod config schemas', () => {
       ),
     ).toThrow(/must return an object or null/)
   })
+})
+
+// The per-CLI cases above use hand-written schemas, which cannot notice a
+// real builtin declaring a field no snake_case spelling reaches (an
+// acronym like `baseURL` camelizes from `base_url` as `baseUrl`). This
+// walks the shipped specs instead, so a CLI added later is covered
+// without editing the mechanism's tests.
+const BUILTIN_CLIS: readonly (readonly [string, CLISpec])[] = [
+  ['gws', GWS],
+  ['slack', SLACK],
+  ['discord', DISCORD],
+  ['ntn', NTN],
+  ['linear', LINEAR],
+  ['git', GIT],
+]
+
+const SAMPLES: readonly unknown[] = ['x', 1, true, ['x']]
+
+// Capital runs collapse to one word (baseURL -> base_url), because that
+// is the spelling a Python config writer uses; per-capital splitting
+// (base_u_r_l) would round-trip onto the acronym field and hide it.
+function snakeOf(field: string): string {
+  return field.replace(/[A-Z]+/g, (run) => `_${run.toLowerCase()}`)
+}
+
+function sampleFor(schema: z.ZodType): unknown {
+  for (const value of SAMPLES) {
+    if (schema.safeParse(value).success) return value
+  }
+  throw new Error('no sample value satisfies this field')
+}
+
+describe('builtin CLI configs install from the python spelling', () => {
+  for (const [name, spec] of BUILTIN_CLIS) {
+    const model = spec.configModel
+    if (!(model instanceof z.ZodObject)) continue
+    it(`${name} accepts every declared field as snake_case`, () => {
+      const fields = Object.keys(model.shape).filter((f) => f !== 'refreshFn')
+      const config: Record<string, unknown> = {}
+      for (const field of fields) {
+        config[snakeOf(field)] = sampleFor(model.shape[field] as z.ZodType)
+      }
+      const install = new CLIRegistry().install(name, spec, config)
+      expect(Object.keys(install.config as Record<string, unknown>).sort()).toEqual(fields.sort())
+    })
+  }
 })

--- a/typescript/packages/core/src/workspace/cli/registry.test.ts
+++ b/typescript/packages/core/src/workspace/cli/registry.test.ts
@@ -132,6 +132,36 @@ describe('CLIRegistry zod config schemas', () => {
     ).toThrow(/unknown config keys: typo/)
   })
 
+  // The same snake_case YAML config block must serve the Python and TS
+  // sides alike (the resource registries already promise this); the
+  // pydantic arm is snake_case-native, so the zod arm normalizes.
+  it('accepts python-style snake_case keys for camelCase fields', () => {
+    const reg = new CLIRegistry()
+    const model = z.object({ imapHost: z.string(), imapPort: z.number().default(993) })
+    const install = reg.install('prog', tree(model), {
+      imap_host: 'mail.example.com',
+      imap_port: 143,
+    })
+    expect(install.config).toEqual({ imapHost: 'mail.example.com', imapPort: 143 })
+  })
+
+  it('reports an unknown key in the spelling the caller used', () => {
+    const reg = new CLIRegistry()
+    const model = z.object({ imapHost: z.string() })
+    expect(() => reg.install('prog', tree(model), { imap_host: 'x', imap_hostt: 'y' })).toThrow(
+      /unknown config keys: imap_hostt/,
+    )
+  })
+
+  it('keeps undeclared keys verbatim under a loose schema', () => {
+    const reg = new CLIRegistry()
+    const install = reg.install('prog', tree(z.looseObject({ imapHost: z.string() })), {
+      imap_host: 'x',
+      extra_key: 'y',
+    })
+    expect(install.config).toEqual({ imapHost: 'x', extra_key: 'y' })
+  })
+
   it('honors a loose schema that allows extra keys', () => {
     const reg = new CLIRegistry()
     const install = reg.install('prog', tree(z.looseObject({ token: z.string() })), {

--- a/typescript/packages/core/src/workspace/cli/registry.ts
+++ b/typescript/packages/core/src/workspace/cli/registry.ts
@@ -99,18 +99,31 @@ export class CLIRegistry {
       // field is delivered there. Keys that resolve to no field keep the
       // caller's spelling: an unknown key is then reported as typed, and
       // a loose schema's passthrough data stays verbatim like pydantic
-      // extra="allow".
-      const norm: Record<string, unknown> = {}
+      // extra="allow". hasOwn, not `in`: the shape is a plain object, so
+      // `in` would read 'constructor'/'toString' off Object.prototype as
+      // declared fields, and fromEntries keeps a '__proto__' key an own
+      // property instead of silently reassigning the prototype.
+      const pairs: [string, unknown][] = []
+      const taken = new Set<string>()
       for (const [key, value] of Object.entries(config ?? {})) {
         const camel = snakeToCamel(key)
-        norm[camel in model.shape ? camel : key] = value
+        const target = Object.hasOwn(model.shape, camel) ? camel : key
+        // Both spellings of one field is ambiguous, and pydantic already
+        // rejects it (the camelCase one is an unknown key there), so the
+        // zod arm must not silently keep whichever came last.
+        if (taken.has(target)) {
+          throw new Error(`CLI '${name}': config key '${key}' duplicates field '${target}'`)
+        }
+        taken.add(target)
+        pairs.push([target, value])
       }
+      const norm = Object.fromEntries(pairs)
       // Unknown keys fail loud (a typo'd YAML key must not be silently
       // ignored), mirroring the Python pydantic arm; a schema that
       // declares its own extra-key policy (strict/passthrough/catchall)
       // enforces it through parse instead, like pydantic extra="allow".
       if (model.def.catchall === undefined) {
-        const unknown = Object.keys(norm).filter((k) => !(k in model.shape))
+        const unknown = [...taken].filter((k) => !Object.hasOwn(model.shape, k))
         if (unknown.length > 0) {
           throw new Error(`CLI '${name}': unknown config keys: ${unknown.sort().join(', ')}`)
         }

--- a/typescript/packages/core/src/workspace/cli/registry.ts
+++ b/typescript/packages/core/src/workspace/cli/registry.ts
@@ -14,6 +14,7 @@
 
 import type { CLISpec } from '../../commands/cli/types.ts'
 import { BUILTIN_SPECS } from '../../commands/spec/builtins.ts'
+import { snakeToCamel } from '../../utils/normalize.ts'
 import { JOB_BUILTINS, KEYWORDS, NAMESPACE_COMMANDS, SHELL_NAMES } from '../route/constants.ts'
 import { z } from 'zod'
 
@@ -92,17 +93,29 @@ export class CLIRegistry {
     }
     const model = spec.configModel
     if (model instanceof z.ZodObject) {
+      // The same snake_case YAML config block serves Python and TS alike
+      // (the resource registries already promise this), and the pydantic
+      // arm is snake_case-native, so a key that camelizes onto a declared
+      // field is delivered there. Keys that resolve to no field keep the
+      // caller's spelling: an unknown key is then reported as typed, and
+      // a loose schema's passthrough data stays verbatim like pydantic
+      // extra="allow".
+      const norm: Record<string, unknown> = {}
+      for (const [key, value] of Object.entries(config ?? {})) {
+        const camel = snakeToCamel(key)
+        norm[camel in model.shape ? camel : key] = value
+      }
       // Unknown keys fail loud (a typo'd YAML key must not be silently
       // ignored), mirroring the Python pydantic arm; a schema that
       // declares its own extra-key policy (strict/passthrough/catchall)
       // enforces it through parse instead, like pydantic extra="allow".
       if (model.def.catchall === undefined) {
-        const unknown = Object.keys(config ?? {}).filter((k) => !(k in model.shape))
+        const unknown = Object.keys(norm).filter((k) => !(k in model.shape))
         if (unknown.length > 0) {
           throw new Error(`CLI '${name}': unknown config keys: ${unknown.sort().join(', ')}`)
         }
       }
-      return model.parse(config ?? {})
+      return model.parse(norm)
     }
     const result = model(config ?? {})
     // The snapshot stores the normalized config and replays it through

--- a/typescript/packages/node/src/commands/cli/builtin/himalaya/himalaya.test.ts
+++ b/typescript/packages/node/src/commands/cli/builtin/himalaya/himalaya.test.ts
@@ -431,6 +431,26 @@ describe('himalaya dispatch', () => {
     await ws.close()
   })
 
+  // The email resource normalizes snake_case; the CLI install used to
+  // validate the raw keys against the camelCase schema and reject the
+  // very same config block ("unknown config keys: imap_host, ...").
+  it('installs from the same snake_case config block the Python side uses', async () => {
+    const ws = new Workspace({})
+    ws.registerCli('himalaya', HIMALAYA, {
+      imap_host: 'h',
+      imap_port: 993,
+      smtp_host: 'h',
+      smtp_port: 587,
+      username: 'me@example.com',
+      password: 'p',
+      use_ssl: true,
+    })
+    const io = await ws.execute('himalaya message compose --to a@b.com --subject Hi --body yo')
+    expect(io.exitCode).toBe(0)
+    expect(new TextDecoder().decode(io.stdout)).toContain('To: a@b.com')
+    await ws.close()
+  })
+
   it('reports an upstream verb mirage lacks with git wording', async () => {
     const ws = new Workspace({})
     ws.registerCli('himalaya', HIMALAYA, {

--- a/typescript/packages/node/src/resource/box/box.ts
+++ b/typescript/packages/node/src/resource/box/box.ts
@@ -55,18 +55,11 @@ export class BoxResource extends BaseResource implements Resource {
   constructor(config: BoxConfig) {
     super()
     this.config = config
-    const tm = new BoxTokenManager({
-      ...(config.endpoint !== undefined ? { endpoint: config.endpoint } : {}),
-      ...(config.clientId !== undefined ? { clientId: config.clientId } : {}),
-      ...(config.clientSecret !== undefined ? { clientSecret: config.clientSecret } : {}),
-      ...(config.refreshToken !== undefined ? { refreshToken: config.refreshToken } : {}),
-      ...(config.enterpriseId !== undefined ? { enterpriseId: config.enterpriseId } : {}),
-      ...(config.accessToken !== undefined ? { accessToken: config.accessToken } : {}),
-      ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-      ...(config.onRefreshTokenRotated !== undefined
-        ? { onRefreshTokenRotated: config.onRefreshTokenRotated }
-        : {}),
-    })
+    // The whole config goes to the token manager, never a hand-picked
+    // subset: a field added to BoxConfig would silently stop reaching it
+    // (that is how gdrive lost apiBase and kept refreshing at the real
+    // Google endpoint against a fake server).
+    const tm = new BoxTokenManager(config)
     this.accessor = new BoxAccessor({
       tokenManager: tm,
       ...(config.rootFolderId !== undefined ? { rootFolderId: config.rootFolderId } : {}),

--- a/typescript/packages/node/src/resource/dropbox/dropbox.ts
+++ b/typescript/packages/node/src/resource/dropbox/dropbox.ts
@@ -55,13 +55,7 @@ export class DropboxResource extends BaseResource implements Resource {
   constructor(config: DropboxConfig) {
     super()
     this.config = config
-    const tm = new DropboxTokenManager({
-      clientId: config.clientId,
-      clientSecret: config.clientSecret,
-      refreshToken: config.refreshToken,
-      ...(config.endpoint !== undefined ? { endpoint: config.endpoint } : {}),
-      ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-    })
+    const tm = new DropboxTokenManager(config)
     this.accessor = new DropboxAccessor({
       tokenManager: tm,
       ...(config.rootPath !== undefined ? { rootPath: config.rootPath } : {}),

--- a/typescript/packages/node/src/resource/gdocs/config.ts
+++ b/typescript/packages/node/src/resource/gdocs/config.ts
@@ -12,37 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface GDocsConfig {
-  clientId: string
-  clientSecret: string
-  refreshToken: string
-  refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-}
-
-export interface GDocsConfigRedacted {
-  clientId: string
-  clientSecret: '<REDACTED>'
-  refreshToken: '<REDACTED>'
-}
-
-const GDocsConfigSchema = z.object({
-  clientId: z.string(),
-  clientSecret: secretStr(),
-  refreshToken: secretStr(),
-})
-
-export function redactGDocsConfig(config: GDocsConfig): GDocsConfigRedacted {
-  return redactConfigWithSchema(GDocsConfigSchema, config) as unknown as GDocsConfigRedacted
-}
-
-export function normalizeGDocsConfig(input: Record<string, unknown>): GDocsConfig {
-  return normalizeFields(input, {
-    rename: {
-      client_id: 'clientId',
-      client_secret: 'clientSecret',
-      refresh_token: 'refreshToken',
-    },
-  }) as unknown as GDocsConfig
-}
+export {
+  normalizeGoogleConfig as normalizeGDocsConfig,
+  redactGoogleConfig as redactGDocsConfig,
+  type GoogleConfig as GDocsConfig,
+  type GoogleConfigRedacted as GDocsConfigRedacted,
+} from '@struktoai/mirage-core'

--- a/typescript/packages/node/src/resource/gdocs/gdocs.ts
+++ b/typescript/packages/node/src/resource/gdocs/gdocs.ts
@@ -54,12 +54,7 @@ export class GDocsResource extends BaseResource implements Resource {
   constructor(config: GDocsConfig) {
     super()
     this.config = config
-    const tm = new TokenManager({
-      clientId: config.clientId,
-      clientSecret: config.clientSecret,
-      refreshToken: config.refreshToken,
-      ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-    })
+    const tm = new TokenManager(config)
     this.accessor = new GDocsAccessor({ tokenManager: tm })
   }
 

--- a/typescript/packages/node/src/resource/gdrive/config.ts
+++ b/typescript/packages/node/src/resource/gdrive/config.ts
@@ -12,40 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface GDriveConfig {
-  clientId: string
-  clientSecret: string
-  refreshToken: string
-  refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-  folderId?: string
-}
-
-export interface GDriveConfigRedacted {
-  clientId: string
-  clientSecret: '<REDACTED>'
-  refreshToken: '<REDACTED>'
-}
-
-const GDriveConfigSchema = z.object({
-  clientId: z.string(),
-  clientSecret: secretStr(),
-  refreshToken: secretStr(),
-  folderId: z.string().optional(),
-})
-
-export function redactGDriveConfig(config: GDriveConfig): GDriveConfigRedacted {
-  return redactConfigWithSchema(GDriveConfigSchema, config) as unknown as GDriveConfigRedacted
-}
-
-export function normalizeGDriveConfig(input: Record<string, unknown>): GDriveConfig {
-  return normalizeFields(input, {
-    rename: {
-      client_id: 'clientId',
-      client_secret: 'clientSecret',
-      refresh_token: 'refreshToken',
-      folder_id: 'folderId',
-    },
-  }) as unknown as GDriveConfig
-}
+export {
+  normalizeGoogleConfig as normalizeGDriveConfig,
+  redactGoogleConfig as redactGDriveConfig,
+  type GoogleConfig as GDriveConfig,
+  type GoogleConfigRedacted as GDriveConfigRedacted,
+} from '@struktoai/mirage-core'

--- a/typescript/packages/node/src/resource/gdrive/gdrive.ts
+++ b/typescript/packages/node/src/resource/gdrive/gdrive.ts
@@ -53,13 +53,7 @@ export class GDriveResource extends BaseResource implements Resource {
   constructor(config: GDriveConfig) {
     super()
     this.config = config
-    const tm = new TokenManager({
-      clientId: config.clientId,
-      clientSecret: config.clientSecret,
-      refreshToken: config.refreshToken,
-      ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-      ...(config.folderId !== undefined ? { folderId: config.folderId } : {}),
-    })
+    const tm = new TokenManager(config)
     this.accessor = new GDriveAccessor({ tokenManager: tm })
   }
 

--- a/typescript/packages/node/src/resource/gsheets/config.ts
+++ b/typescript/packages/node/src/resource/gsheets/config.ts
@@ -12,37 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface GSheetsConfig {
-  clientId: string
-  clientSecret: string
-  refreshToken: string
-  refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-}
-
-export interface GSheetsConfigRedacted {
-  clientId: string
-  clientSecret: '<REDACTED>'
-  refreshToken: '<REDACTED>'
-}
-
-const GSheetsConfigSchema = z.object({
-  clientId: z.string(),
-  clientSecret: secretStr(),
-  refreshToken: secretStr(),
-})
-
-export function redactGSheetsConfig(config: GSheetsConfig): GSheetsConfigRedacted {
-  return redactConfigWithSchema(GSheetsConfigSchema, config) as unknown as GSheetsConfigRedacted
-}
-
-export function normalizeGSheetsConfig(input: Record<string, unknown>): GSheetsConfig {
-  return normalizeFields(input, {
-    rename: {
-      client_id: 'clientId',
-      client_secret: 'clientSecret',
-      refresh_token: 'refreshToken',
-    },
-  }) as unknown as GSheetsConfig
-}
+export {
+  normalizeGoogleConfig as normalizeGSheetsConfig,
+  redactGoogleConfig as redactGSheetsConfig,
+  type GoogleConfig as GSheetsConfig,
+  type GoogleConfigRedacted as GSheetsConfigRedacted,
+} from '@struktoai/mirage-core'

--- a/typescript/packages/node/src/resource/gsheets/gsheets.ts
+++ b/typescript/packages/node/src/resource/gsheets/gsheets.ts
@@ -54,12 +54,7 @@ export class GSheetsResource extends BaseResource implements Resource {
   constructor(config: GSheetsConfig) {
     super()
     this.config = config
-    const tm = new TokenManager({
-      clientId: config.clientId,
-      clientSecret: config.clientSecret,
-      refreshToken: config.refreshToken,
-      ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-    })
+    const tm = new TokenManager(config)
     this.accessor = new GSheetsAccessor({ tokenManager: tm })
   }
 

--- a/typescript/packages/node/src/resource/gslides/config.ts
+++ b/typescript/packages/node/src/resource/gslides/config.ts
@@ -12,37 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { normalizeFields, redactConfigWithSchema, secretStr, z } from '@struktoai/mirage-core'
-
-export interface GSlidesConfig {
-  clientId: string
-  clientSecret: string
-  refreshToken: string
-  refreshFn?: (refreshToken: string) => Promise<{ accessToken: string; expiresIn: number }>
-}
-
-export interface GSlidesConfigRedacted {
-  clientId: string
-  clientSecret: '<REDACTED>'
-  refreshToken: '<REDACTED>'
-}
-
-const GSlidesConfigSchema = z.object({
-  clientId: z.string(),
-  clientSecret: secretStr(),
-  refreshToken: secretStr(),
-})
-
-export function redactGSlidesConfig(config: GSlidesConfig): GSlidesConfigRedacted {
-  return redactConfigWithSchema(GSlidesConfigSchema, config) as unknown as GSlidesConfigRedacted
-}
-
-export function normalizeGSlidesConfig(input: Record<string, unknown>): GSlidesConfig {
-  return normalizeFields(input, {
-    rename: {
-      client_id: 'clientId',
-      client_secret: 'clientSecret',
-      refresh_token: 'refreshToken',
-    },
-  }) as unknown as GSlidesConfig
-}
+export {
+  normalizeGoogleConfig as normalizeGSlidesConfig,
+  redactGoogleConfig as redactGSlidesConfig,
+  type GoogleConfig as GSlidesConfig,
+  type GoogleConfigRedacted as GSlidesConfigRedacted,
+} from '@struktoai/mirage-core'

--- a/typescript/packages/node/src/resource/gslides/gslides.ts
+++ b/typescript/packages/node/src/resource/gslides/gslides.ts
@@ -54,12 +54,7 @@ export class GSlidesResource extends BaseResource implements Resource {
   constructor(config: GSlidesConfig) {
     super()
     this.config = config
-    const tm = new TokenManager({
-      clientId: config.clientId,
-      clientSecret: config.clientSecret,
-      refreshToken: config.refreshToken,
-      ...(config.refreshFn !== undefined ? { refreshFn: config.refreshFn } : {}),
-    })
+    const tm = new TokenManager(config)
     this.accessor = new GSlidesAccessor({ tokenManager: tm })
   }
 

--- a/typescript/packages/node/src/resource/registry.test.ts
+++ b/typescript/packages/node/src/resource/registry.test.ts
@@ -20,6 +20,8 @@ import {
   OneDriveResource,
   ResourceName,
   resourceStateRequiresOverride,
+  tokenUrl,
+  type TokenManager,
 } from '@struktoai/mirage-core'
 import { normalizeS3Config } from './s3/config.ts'
 import { buildResource, knownResources, register } from './registry.ts'
@@ -41,6 +43,23 @@ describe('node resource registry', () => {
     expect(names).toContain('sharepoint')
     expect(names).toContain('mem0')
     expect(names).toEqual([...names].sort())
+  })
+
+  // The four Drive-family resources used to redeclare core's GoogleConfig
+  // without apiBase and hand-pick TokenManager fields, so a mount pointed
+  // at a fake server still refreshed its token at Google's real endpoint.
+  it('threads api_base into every google resource token manager', async () => {
+    const base = 'http://127.0.0.1:9999'
+    for (const name of ['gdrive', 'gdocs', 'gsheets', 'gslides', 'gmail']) {
+      const resource = await buildResource(name, {
+        client_id: 'id',
+        client_secret: 'secret',
+        refresh_token: 'refresh',
+        api_base: base,
+      })
+      const { accessor } = resource as unknown as { accessor: { tokenManager: TokenManager } }
+      expect(tokenUrl(accessor.tokenManager.config), name).toBe(`${base}/token`)
+    }
   })
 
   it('builds Microsoft Graph and Mem0 resources from snake_case config', async () => {


### PR DESCRIPTION
Two config-path bugs reported from agent runs against a fake Google server:

- gdrive/gdocs/gsheets/gslides (node + browser) redeclared core's GoogleConfig without apiBase and hand-picked TokenManager fields, so a mount configured against a test double still refreshed its token at Google's real endpoint. The four now re-export core's config and pass the whole object to TokenManager, the way gmail already did.
- CLI installs validated raw config keys against the camelCase zod shape, so the snake_case YAML block the Python side accepts was rejected (himalaya, and latently slack/linear/ntn). The CLI registry now camelizes a key only when it lands on a declared field; unknown keys are reported in the caller's spelling and loose-schema passthrough stays verbatim, matching the pydantic arm.

The integ runners used to monkeypatch Google endpoints (module globals in Python, globalThis.fetch in TS), which is why integ never caught the drop. Both hooks are deleted: gws mounts and the gws CLI now reach the mock through config api_base, and the gws/himalaya CLIs install from the same snake_case block on both hosts.

Verified: google and email integ targets green on both hosts against the live mocks (4064 cases each), full core/node/browser suites green.