### PR TITLE
fix(unzip): select archive members, exit 11 on unmatched filespecs

### DIFF
--- a/integ/unix/unzip/p.json
+++ b/integ/unix/unzip/p.json
@@ -1,0 +1,106 @@
+{
+  "cases": [
+    {
+      "id": "unzip_p_member_selects",
+      "seq": 601332,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mkdir -p /data/punzm && printf one > /data/punzm/a.txt && printf two > /data/punzm/b.txt && zip -q -j /data/punzm/mz.zip /data/punzm/a.txt /data/punzm/b.txt && unzip -p /data/punzm/mz.zip a.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "one",
+        "stderr": ""
+      },
+      "flags": [
+        "p"
+      ]
+    },
+    {
+      "id": "unzip_p_member_missing_exits_11",
+      "seq": 601333,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mkdir -p /data/punzn && printf one > /data/punzn/a.txt && zip -q -j /data/punzn/nz.zip /data/punzn/a.txt && unzip -p /data/punzn/nz.zip NOSUCHFILE.xml",
+      "expect": {
+        "exit": 11,
+        "stdout": "",
+        "stderr": "caution: filename not matched:  NOSUCHFILE.xml\n"
+      },
+      "flags": [
+        "p"
+      ]
+    },
+    {
+      "id": "unzip_p_member_hit_and_miss",
+      "seq": 601334,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "gridfs",
+        "s3-prefix",
+        "gridfs-prefix",
+        "hf",
+        "hf-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mkdir -p /data/punzh && printf one > /data/punzh/a.txt && printf two > /data/punzh/b.txt && zip -q -j /data/punzh/hz.zip /data/punzh/a.txt /data/punzh/b.txt && unzip -p /data/punzh/hz.zip a.txt NOSUCHFILE.xml",
+      "expect": {
+        "exit": 11,
+        "stdout": "one",
+        "stderr": "caution: filename not matched:  NOSUCHFILE.xml\n"
+      },
+      "flags": [
+        "p"
+      ]
+    }
+  ]
+}

--- a/python/mirage/commands/builtin/generic/unzip.py
+++ b/python/mirage/commands/builtin/generic/unzip.py
@@ -21,7 +21,7 @@ def _resolve_dest(d: str | PathSpec | None, mount_prefix: str) -> str:
     return dest_raw
 
 
-def _spec_index(name: str, members: tuple[str, ...]) -> int | None:
+def _spec_index(name: bytes, members: tuple[bytes, ...]) -> int | None:
     for i, member in enumerate(members):
         if fnmatch.fnmatchcase(name, member):
             return i
@@ -33,13 +33,17 @@ def _select(
         members: tuple[str, ...]) -> tuple[list[zipfile.ZipInfo], list[str]]:
     if not members:
         return infos, []
+    # Info-ZIP matches filespecs against the encoded name, so `?` stands
+    # for one byte, not one code point: `?.txt` misses `é.txt` and
+    # `??.txt` hits it.
+    encoded = tuple(member.encode() for member in members)
     # Info-ZIP walks the archive in order and charges each entry to the
     # first filespec that matches it, so a spec shadowed by an earlier
     # one reports "filename not matched" even when its file was printed.
     hit = [False] * len(members)
     selected: list[zipfile.ZipInfo] = []
     for info in infos:
-        idx = _spec_index(info.filename, members)
+        idx = _spec_index(info.filename.encode(), encoded)
         if idx is None:
             continue
         hit[idx] = True
@@ -89,7 +93,7 @@ async def unzip(
                     if info.is_dir():
                         continue
                     try:
-                        zf.read(info.filename)
+                        zf.read(info)
                     except zipfile.BadZipFile:
                         bad = info.filename
                         break
@@ -110,7 +114,9 @@ async def unzip(
             chunks: list[bytes] = []
             for info in selected:
                 if not info.is_dir():
-                    chunks.append(zf.read(info.filename))
+                    # Read the selected ZipInfo, not its name: a name
+                    # lookup resolves every duplicate to the last one.
+                    chunks.append(zf.read(info))
             if unmatched:
                 return b"".join(chunks), IOResult(
                     exit_code=11, stderr=_cautions(unmatched).encode())
@@ -124,7 +130,7 @@ async def unzip(
         for info in selected:
             if info.is_dir():
                 continue
-            content = zf.read(info.filename)
+            content = zf.read(info)
             entry_name = info.filename.lstrip("/")
             out_path = dest.rstrip("/") + "/" + entry_name
             parent = out_path.rsplit("/", 1)[0] or "/"

--- a/python/mirage/commands/builtin/generic/unzip.py
+++ b/python/mirage/commands/builtin/generic/unzip.py
@@ -1,3 +1,4 @@
+import fnmatch
 import io
 import zipfile
 from collections.abc import Awaitable, Callable
@@ -5,6 +6,9 @@ from collections.abc import Awaitable, Callable
 from mirage.io.types import ByteSource, IOResult
 from mirage.types import PathSpec
 from mirage.utils.key_prefix import mount_prefix_of
+
+# Info-ZIP's wording and spacing, verbatim (two spaces after the colon).
+CAUTION_PREFIX = "caution: filename not matched:  "
 
 
 def _resolve_dest(d: str | PathSpec | None, mount_prefix: str) -> str:
@@ -17,12 +21,44 @@ def _resolve_dest(d: str | PathSpec | None, mount_prefix: str) -> str:
     return dest_raw
 
 
+def _spec_index(name: str, members: tuple[str, ...]) -> int | None:
+    for i, member in enumerate(members):
+        if fnmatch.fnmatchcase(name, member):
+            return i
+    return None
+
+
+def _select(
+        infos: list[zipfile.ZipInfo],
+        members: tuple[str, ...]) -> tuple[list[zipfile.ZipInfo], list[str]]:
+    if not members:
+        return infos, []
+    # Info-ZIP walks the archive in order and charges each entry to the
+    # first filespec that matches it, so a spec shadowed by an earlier
+    # one reports "filename not matched" even when its file was printed.
+    hit = [False] * len(members)
+    selected: list[zipfile.ZipInfo] = []
+    for info in infos:
+        idx = _spec_index(info.filename, members)
+        if idx is None:
+            continue
+        hit[idx] = True
+        selected.append(info)
+    unmatched = [m for m, h in zip(members, hit) if not h]
+    return selected, unmatched
+
+
+def _cautions(unmatched: list[str]) -> str:
+    return "".join(CAUTION_PREFIX + member + "\n" for member in unmatched)
+
+
 async def unzip(
     paths: list[PathSpec],
     *,
     read_bytes: Callable[..., Awaitable[bytes]],
     write_bytes: Callable[..., Awaitable[None]],
     mkdir_fn: Callable[..., Awaitable[None]],
+    members: tuple[str, ...] = (),
     o: bool = False,
     args_l: bool = False,
     d: str | PathSpec | None = None,
@@ -35,23 +71,49 @@ async def unzip(
     archive_path = paths[0]
     data = await read_bytes(archive_path)
     with zipfile.ZipFile(io.BytesIO(data), "r") as zf:
+        selected, unmatched = _select(zf.infolist(), members)
         if args_l:
             lines = ["  Length      Name", "---------  ----"]
-            for info in zf.infolist():
+            for info in selected:
                 lines.append(f"{info.file_size:>9}  {info.filename}")
-            return ("\n".join(lines) + "\n").encode(), IOResult()
+            listing = ("\n".join(lines) + "\n").encode()
+            # GNU -l prints no caution lines and only exits 11 when the
+            # member list matched nothing at all.
+            if members and not selected:
+                return listing, IOResult(exit_code=11)
+            return listing, IOResult()
         if t:
-            bad = zf.testzip()
-            if bad is None:
-                msg = f"No errors detected in {archive_path.virtual}\n"
+            if members:
+                bad = None
+                for info in selected:
+                    if info.is_dir():
+                        continue
+                    try:
+                        zf.read(info.filename)
+                    except zipfile.BadZipFile:
+                        bad = info.filename
+                        break
             else:
-                msg = f"first bad file: {bad}\n"
+                bad = zf.testzip()
+            if bad is not None:
+                return f"first bad file: {bad}\n".encode(), IOResult()
+            if unmatched:
+                # GNU -t reports unmatched members on stdout and counts
+                # them as errors.
+                msg = _cautions(unmatched) + (
+                    f"At least one error was detected in "
+                    f"{archive_path.virtual}.\n")
+                return msg.encode(), IOResult(exit_code=11)
+            msg = f"No errors detected in {archive_path.virtual}\n"
             return msg.encode(), IOResult()
         if p:
             chunks: list[bytes] = []
-            for info in zf.infolist():
+            for info in selected:
                 if not info.is_dir():
                     chunks.append(zf.read(info.filename))
+            if unmatched:
+                return b"".join(chunks), IOResult(
+                    exit_code=11, stderr=_cautions(unmatched).encode())
             return b"".join(chunks), IOResult()
         mount_prefix = mount_prefix_of(
             archive_path.virtual, archive_path.resource_path) if isinstance(
@@ -59,7 +121,7 @@ async def unzip(
         dest = _resolve_dest(d, mount_prefix)
         writes: dict[str, ByteSource] = {}
         output_lines: list[str] = []
-        for info in zf.infolist():
+        for info in selected:
             if info.is_dir():
                 continue
             content = zf.read(info.filename)
@@ -76,6 +138,10 @@ async def unzip(
                 output_lines.append(f"  inflating: {report_path}")
     output = ("\n".join(output_lines) +
               "\n").encode() if output_lines else None
+    if unmatched:
+        return output, IOResult(exit_code=11,
+                                stderr=_cautions(unmatched).encode(),
+                                writes=writes)
     return output, IOResult(writes=writes)
 
 

--- a/python/mirage/commands/builtin/generic_bind/builders/unzip.py
+++ b/python/mirage/commands/builtin/generic_bind/builders/unzip.py
@@ -46,6 +46,7 @@ async def unzip(
         read_bytes=bound_op(ops.read_bytes, accessor, index),
         write_bytes=partial(ops.require(Operation.WRITE), accessor),
         mkdir_fn=partial(ops.require(Operation.MKDIR), accessor),
+        members=texts,
         o=o,
         args_l=args_l,
         d=d,

--- a/python/mirage/commands/spec/builtin_specs/archive.py
+++ b/python/mirage/commands/spec/builtin_specs/archive.py
@@ -80,7 +80,11 @@ SPECS: dict[str, CommandSpec] = {
             Option(short="-p"),
             Option(short="-t"),
         ),
-        rest=Operand(type="path"),
+        # The archive is the only path operand; everything after it is an
+        # Info-ZIP member pattern matched against archive entry names,
+        # never a filesystem path.
+        positional=(Operand(type="path"), ),
+        rest=Operand(type="str"),
     ),
     'zcat':
     CommandSpec(rest=Operand(type="path")),

--- a/python/tests/commands/builtin/generic/test_unzip.py
+++ b/python/tests/commands/builtin/generic/test_unzip.py
@@ -1,0 +1,246 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import io
+import zipfile
+
+import pytest
+
+from mirage.commands.builtin.generic.unzip import unzip
+from mirage.types import PathSpec
+
+WORKBOOK = b"WORKBOOK-CONTENT\n"
+SHEET = b"SHEET1-CONTENT\n"
+APP = b"APPXML-CONTENT\n"
+MEDIA = b"MEDIA-BYTES\n"
+
+
+def _zip_bytes(names_dirs: tuple[str, ...] = ()) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for d in names_dirs:
+            zf.writestr(d, b"")
+        zf.writestr("docProps/app.xml", APP)
+        zf.writestr("xl/sheet1.xml", SHEET)
+        zf.writestr("xl/media/img.bin", MEDIA)
+        zf.writestr("xl/workbook.xml", WORKBOOK)
+    return buf.getvalue()
+
+
+def _reader(data: bytes):
+
+    async def read_bytes(_p: PathSpec, **_kw) -> bytes:
+        return data
+
+    return read_bytes
+
+
+async def _no_write(_p: PathSpec, _content: bytes) -> None:
+    raise AssertionError("write_bytes must not be called")
+
+
+async def _no_mkdir(_p: PathSpec, parents: bool = False) -> None:
+    raise AssertionError("mkdir_fn must not be called")
+
+
+def _recorder():
+    written: dict[str, bytes] = {}
+
+    async def write_bytes(p: PathSpec, content: bytes) -> None:
+        written[p.virtual] = content
+
+    return written, write_bytes
+
+
+async def _mkdir_ok(_p: PathSpec, parents: bool = False) -> None:
+    return None
+
+
+def _archive() -> list[PathSpec]:
+    return [PathSpec.from_str_path("/a.zip")]
+
+
+async def _run(members: tuple[str, ...], **kw):
+    written, write_bytes = _recorder()
+    out, res = await unzip(
+        _archive(),
+        read_bytes=_reader(_zip_bytes()),
+        write_bytes=write_bytes,
+        mkdir_fn=_mkdir_ok,
+        members=members,
+        **kw,
+    )
+    return out, res, written
+
+
+def _stderr_text(res) -> str:
+    return (res.stderr or b"").decode() if res.stderr is not None else ""
+
+
+@pytest.mark.asyncio
+async def test_p_single_member_outputs_only_that_member():
+    out, res, _ = await _run(("xl/workbook.xml", ), p=True)
+    assert out == WORKBOOK
+    assert res.exit_code == 0
+    assert res.stderr is None
+
+
+@pytest.mark.asyncio
+async def test_p_missing_member_exit_11_caution_on_stderr():
+    out, res, _ = await _run(("NOSUCHFILE.xml", ), p=True)
+    assert out in (None, b"")
+    assert res.exit_code == 11
+    assert _stderr_text(res) == (
+        "caution: filename not matched:  NOSUCHFILE.xml\n")
+
+
+@pytest.mark.asyncio
+async def test_p_hit_and_miss_prints_hit_and_exits_11():
+    out, res, _ = await _run(("xl/workbook.xml", "NOSUCHFILE.xml"), p=True)
+    assert out == WORKBOOK
+    assert res.exit_code == 11
+    assert _stderr_text(res) == (
+        "caution: filename not matched:  NOSUCHFILE.xml\n")
+
+
+@pytest.mark.asyncio
+async def test_p_output_follows_archive_order_not_arg_order():
+    out, res, _ = await _run(("xl/workbook.xml", "docProps/app.xml"), p=True)
+    assert out == APP + WORKBOOK
+    assert res.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_p_wildcard_star_crosses_slash():
+    out, res, _ = await _run(("doc*", ), p=True)
+    assert out == APP
+    assert res.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_p_wildcard_subtree():
+    out, res, _ = await _run(("xl/*", ), p=True)
+    assert out == SHEET + MEDIA + WORKBOOK
+    assert res.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_p_first_match_wins_attribution():
+    out, res, _ = await _run(("*.xml", "xl/workbook.xml"), p=True)
+    assert out == APP + SHEET + WORKBOOK
+    assert res.exit_code == 11
+    assert _stderr_text(res) == (
+        "caution: filename not matched:  xl/workbook.xml\n")
+
+
+@pytest.mark.asyncio
+async def test_p_duplicate_spec_cautions_second():
+    out, res, _ = await _run(("xl/workbook.xml", "xl/workbook.xml"), p=True)
+    assert out == WORKBOOK
+    assert res.exit_code == 11
+    assert _stderr_text(res) == (
+        "caution: filename not matched:  xl/workbook.xml\n")
+
+
+@pytest.mark.asyncio
+async def test_p_dir_entry_spec_matches_with_no_output():
+    out, res = await unzip(
+        _archive(),
+        read_bytes=_reader(_zip_bytes(names_dirs=("xl/", ))),
+        write_bytes=_no_write,
+        mkdir_fn=_no_mkdir,
+        members=("xl/", ),
+        p=True,
+    )
+    assert out in (None, b"")
+    assert res.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_p_no_members_concats_whole_archive():
+    out, res, _ = await _run((), p=True)
+    assert out == APP + SHEET + MEDIA + WORKBOOK
+    assert res.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_l_filters_rows_to_members():
+    out, res, _ = await _run(("xl/workbook.xml", ), args_l=True)
+    text = out.decode()
+    assert "xl/workbook.xml" in text
+    assert "docProps/app.xml" not in text
+    assert res.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_l_all_miss_exits_11_without_stderr():
+    out, res, _ = await _run(("NOSUCHFILE.xml", ), args_l=True)
+    text = out.decode()
+    assert "NOSUCHFILE" not in text
+    assert res.exit_code == 11
+    assert res.stderr is None
+
+
+@pytest.mark.asyncio
+async def test_l_partial_match_exits_0():
+    out, res, _ = await _run(("xl/workbook.xml", "NOSUCHFILE.xml"),
+                             args_l=True)
+    assert "xl/workbook.xml" in out.decode()
+    assert res.exit_code == 0
+    assert res.stderr is None
+
+
+@pytest.mark.asyncio
+async def test_t_member_ok():
+    out, res, _ = await _run(("xl/workbook.xml", ), t=True)
+    assert b"No errors detected" in out
+    assert res.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_t_missing_member_caution_on_stdout_exit_11():
+    out, res, _ = await _run(("xl/workbook.xml", "NOSUCHFILE.xml"), t=True)
+    text = out.decode()
+    assert "caution: filename not matched:  NOSUCHFILE.xml" in text
+    assert "At least one error was detected" in text
+    assert res.exit_code == 11
+    assert res.stderr is None
+
+
+@pytest.mark.asyncio
+async def test_extract_writes_only_selected_members():
+    out, res, written = await _run(("xl/workbook.xml", ))
+    assert set(written) == {"/xl/workbook.xml"}
+    assert written["/xl/workbook.xml"] == WORKBOOK
+    assert "inflating: /xl/workbook.xml" in out.decode()
+    assert "app.xml" not in out.decode()
+    assert res.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_extract_missing_member_caution_stderr_exit_11():
+    out, res, written = await _run(("docProps/app.xml", "NOSUCHFILE.xml"))
+    assert set(written) == {"/docProps/app.xml"}
+    assert res.exit_code == 11
+    assert _stderr_text(res) == (
+        "caution: filename not matched:  NOSUCHFILE.xml\n")
+
+
+@pytest.mark.asyncio
+async def test_extract_wildcard_selects_subtree():
+    out, res, written = await _run(("xl/*", ))
+    assert set(written) == {
+        "/xl/sheet1.xml", "/xl/media/img.bin", "/xl/workbook.xml"
+    }
+    assert res.exit_code == 0

--- a/python/tests/commands/builtin/generic/test_unzip.py
+++ b/python/tests/commands/builtin/generic/test_unzip.py
@@ -26,24 +26,40 @@ APP = b"APPXML-CONTENT\n"
 MEDIA = b"MEDIA-BYTES\n"
 
 
-def _zip_bytes(names_dirs: tuple[str, ...] = ()) -> bytes:
+def _zip_entries(entries: tuple[tuple[str, bytes], ...]) -> bytes:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for d in names_dirs:
-            zf.writestr(d, b"")
-        zf.writestr("docProps/app.xml", APP)
-        zf.writestr("xl/sheet1.xml", SHEET)
-        zf.writestr("xl/media/img.bin", MEDIA)
-        zf.writestr("xl/workbook.xml", WORKBOOK)
+        for name, content in entries:
+            zf.writestr(name, content)
     return buf.getvalue()
 
 
-def _reader(data: bytes):
+def _zip_bytes(names_dirs: tuple[str, ...] = ()) -> bytes:
+    return _zip_entries(
+        tuple((d, b"") for d in names_dirs) + (
+            ("docProps/app.xml", APP),
+            ("xl/sheet1.xml", SHEET),
+            ("xl/media/img.bin", MEDIA),
+            ("xl/workbook.xml", WORKBOOK),
+        ))
 
-    async def read_bytes(_p: PathSpec, **_kw) -> bytes:
-        return data
 
-    return read_bytes
+class _Reader:
+
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+    async def __call__(self, _p: PathSpec, **_kw: object) -> bytes:
+        return self.data
+
+
+class _Recorder:
+
+    def __init__(self) -> None:
+        self.written: dict[str, bytes] = {}
+
+    async def __call__(self, p: PathSpec, content: bytes) -> None:
+        self.written[p.virtual] = content
 
 
 async def _no_write(_p: PathSpec, _content: bytes) -> None:
@@ -54,15 +70,6 @@ async def _no_mkdir(_p: PathSpec, parents: bool = False) -> None:
     raise AssertionError("mkdir_fn must not be called")
 
 
-def _recorder():
-    written: dict[str, bytes] = {}
-
-    async def write_bytes(p: PathSpec, content: bytes) -> None:
-        written[p.virtual] = content
-
-    return written, write_bytes
-
-
 async def _mkdir_ok(_p: PathSpec, parents: bool = False) -> None:
     return None
 
@@ -71,17 +78,17 @@ def _archive() -> list[PathSpec]:
     return [PathSpec.from_str_path("/a.zip")]
 
 
-async def _run(members: tuple[str, ...], **kw):
-    written, write_bytes = _recorder()
+async def _run(members: tuple[str, ...], data: bytes | None = None, **kw):
+    recorder = _Recorder()
     out, res = await unzip(
         _archive(),
-        read_bytes=_reader(_zip_bytes()),
-        write_bytes=write_bytes,
+        read_bytes=_Reader(_zip_bytes() if data is None else data),
+        write_bytes=recorder,
         mkdir_fn=_mkdir_ok,
         members=members,
         **kw,
     )
-    return out, res, written
+    return out, res, recorder.written
 
 
 def _stderr_text(res) -> str:
@@ -157,13 +164,34 @@ async def test_p_duplicate_spec_cautions_second():
 async def test_p_dir_entry_spec_matches_with_no_output():
     out, res = await unzip(
         _archive(),
-        read_bytes=_reader(_zip_bytes(names_dirs=("xl/", ))),
+        read_bytes=_Reader(_zip_bytes(names_dirs=("xl/", ))),
         write_bytes=_no_write,
         mkdir_fn=_no_mkdir,
         members=("xl/", ),
         p=True,
     )
     assert out in (None, b"")
+    assert res.exit_code == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore:Duplicate name:UserWarning")
+async def test_p_duplicate_names_serve_each_entrys_own_data():
+    data = _zip_entries((("dup.txt", b"FIRST\n"), ("dup.txt", b"SECOND\n")))
+    out, res, _ = await _run(("dup.txt", ), data=data, p=True)
+    assert out == b"FIRST\nSECOND\n"
+    assert res.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_p_question_mark_matches_one_byte_not_one_code_point():
+    data = _zip_entries((("é.txt", b"ACCENT\n"), ("ab.txt", b"AB\n")))
+    out, res, _ = await _run(("?.txt", ), data=data, p=True)
+    assert out in (None, b"")
+    assert res.exit_code == 11
+    assert _stderr_text(res) == "caution: filename not matched:  ?.txt\n"
+    out, res, _ = await _run(("??.txt", ), data=data, p=True)
+    assert out == b"ACCENT\nAB\n"
     assert res.exit_code == 0
 
 

--- a/python/tests/commands/native/test_unzip_flags.py
+++ b/python/tests/commands/native/test_unzip_flags.py
@@ -12,6 +12,14 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import asyncio
+import io
+import zipfile
+
+from mirage.resource.ram import RAMResource
+from mirage.types import MountMode
+from mirage.workspace import Workspace
+
 
 def test_unzip_q(env):
     env.create_file("a.txt", b"hello")
@@ -47,3 +55,69 @@ def test_unzip_o(env):
     env.mirage("unzip -o /data/out.zip")
     result = env.mirage("ls /data")
     assert "a.txt" in result
+
+
+def _bytes_of(src) -> bytes:
+    if src is None:
+        return b""
+    if isinstance(src, bytes):
+        return src
+
+    async def drain() -> bytes:
+        out = b""
+        async for chunk in src:
+            out += chunk
+        return out
+
+    return asyncio.run(drain())
+
+
+def test_unzip_p_member_selects_only_that_member(env):
+    env.create_file("a.txt", b"hello\n")
+    env.create_file("b.txt", b"world\n")
+    env.mirage("zip /data/out.zip /data/a.txt /data/b.txt")
+    result = env.mirage("unzip -p /data/out.zip data/a.txt")
+    assert result == "hello\n"
+
+
+def test_unzip_p_missing_member_exits_11(env):
+    env.create_file("a.txt", b"hello\n")
+    env.mirage("zip /data/out.zip /data/a.txt")
+    env.ws._cwd = "/data"
+    io = asyncio.run(env.ws.execute("unzip -p /data/out.zip NOSUCHFILE.xml"))
+    assert io.exit_code == 11
+    assert _bytes_of(io.stdout) == b""
+    assert _bytes_of(io.stderr).decode() == (
+        "caution: filename not matched:  NOSUCHFILE.xml\n")
+
+
+def test_unzip_extract_member_writes_only_that_member(env):
+    env.create_file("a.txt", b"hello\n")
+    env.create_file("b.txt", b"world\n")
+    env.mirage("zip /data/out.zip /data/a.txt /data/b.txt")
+    env.mirage("unzip -q /data/out.zip data/a.txt -d /data/ext")
+    listing = env.mirage("ls /data/ext/data")
+    assert "a.txt" in listing
+    assert "b.txt" not in listing
+
+
+def test_unzip_p_member_is_not_resolved_as_a_path():
+    ws = Workspace(
+        {
+            "/": (RAMResource(), MountMode.WRITE),
+            "/work": (RAMResource(), MountMode.WRITE),
+        },
+        mode=MountMode.WRITE,
+    )
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("xl/workbook.xml", b"WORKBOOK-CONTENT\n")
+        zf.writestr("docProps/app.xml", b"APPXML-CONTENT\n")
+    asyncio.run(ws.execute("tee /work/book.zip", stdin=buf.getvalue()))
+    ws._cwd = "/"
+    result = asyncio.run(ws.execute("unzip -p /work/book.zip xl/workbook.xml"))
+    assert result.exit_code == 0
+    assert _bytes_of(result.stdout) == b"WORKBOOK-CONTENT\n"
+    result = asyncio.run(ws.execute("unzip -p /work/book.zip NOSUCHFILE.xml"))
+    assert result.exit_code == 11
+    assert _bytes_of(result.stdout) == b""

--- a/spec/python/general/unzip.json
+++ b/spec/python/general/unzip.json
@@ -202,10 +202,16 @@
       "value_optional": false
     }
   ],
-  "positional": [],
+  "positional": [
+    {
+      "provided_by": [],
+      "text_when": [],
+      "type": "path"
+    }
+  ],
   "rest": {
     "provided_by": [],
     "text_when": [],
-    "type": "path"
+    "type": "str"
   }
 }

--- a/spec/typescript/browser/general/unzip.json
+++ b/spec/typescript/browser/general/unzip.json
@@ -167,10 +167,16 @@
       "value_optional": false
     }
   ],
-  "positional": [],
+  "positional": [
+    {
+      "provided_by": [],
+      "text_when": [],
+      "type": "path"
+    }
+  ],
   "rest": {
     "provided_by": [],
     "text_when": [],
-    "type": "path"
+    "type": "str"
   }
 }

--- a/spec/typescript/node/general/unzip.json
+++ b/spec/typescript/node/general/unzip.json
@@ -223,10 +223,16 @@
       "value_optional": false
     }
   ],
-  "positional": [],
+  "positional": [
+    {
+      "provided_by": [],
+      "text_when": [],
+      "type": "path"
+    }
+  ],
   "rest": {
     "provided_by": [],
     "text_when": [],
-    "type": "path"
+    "type": "str"
   }
 }

--- a/typescript/packages/core/src/commands/builtin/generic/unzip.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/unzip.ts
@@ -33,6 +33,17 @@ interface ZipEntry {
 // Info-ZIP's wording and spacing, verbatim (two spaces after the colon).
 const CAUTION_PREFIX = 'caution: filename not matched:  '
 
+// Info-ZIP matches filespecs against the encoded name, so `?` stands for
+// one byte, not one code point: `?.txt` misses `é.txt` and `??.txt` hits
+// it. Both sides are flattened to one UTF-16 unit per byte so the regex
+// counts bytes.
+function byteString(s: string): string {
+  const bytes = ENC.encode(s)
+  let out = ''
+  for (const b of bytes) out += String.fromCharCode(b)
+  return out
+}
+
 function memberRegex(pattern: string): RegExp {
   let out = '^'
   let i = 0
@@ -80,11 +91,12 @@ interface MemberSelection {
 // reports "filename not matched" even when its file was printed.
 function selectEntries(entries: ZipEntry[], members: readonly string[]): MemberSelection {
   if (members.length === 0) return { selected: entries, unmatched: [] }
-  const regexes = members.map(memberRegex)
+  const regexes = members.map((m) => memberRegex(byteString(m)))
   const hit = members.map(() => false)
   const selected: ZipEntry[] = []
   for (const e of entries) {
-    const idx = regexes.findIndex((r) => r.test(e.name))
+    const name = byteString(e.name)
+    const idx = regexes.findIndex((r) => r.test(name))
     if (idx === -1) continue
     hit[idx] = true
     selected.push(e)

--- a/typescript/packages/core/src/commands/builtin/generic/unzip.ts
+++ b/typescript/packages/core/src/commands/builtin/generic/unzip.ts
@@ -30,6 +30,73 @@ interface ZipEntry {
   data: Uint8Array
 }
 
+// Info-ZIP's wording and spacing, verbatim (two spaces after the colon).
+const CAUTION_PREFIX = 'caution: filename not matched:  '
+
+function memberRegex(pattern: string): RegExp {
+  let out = '^'
+  let i = 0
+  while (i < pattern.length) {
+    const ch = pattern[i] ?? ''
+    if (ch === '*') {
+      while (pattern[i] === '*') i++
+      out += '[\\s\\S]*'
+      continue
+    }
+    if (ch === '?') {
+      out += '[\\s\\S]'
+      i++
+      continue
+    }
+    if (ch === '[') {
+      let j = i + 1
+      if (pattern[j] === '!' || pattern[j] === '^') j++
+      if (pattern[j] === ']') j++
+      while (j < pattern.length && pattern[j] !== ']') j++
+      if (j >= pattern.length) {
+        out += '\\['
+        i++
+        continue
+      }
+      let cls = pattern.slice(i + 1, j).replace(/\\/g, '\\\\')
+      if (cls.startsWith('!')) cls = '^' + cls.slice(1)
+      out += '[' + cls + ']'
+      i = j + 1
+      continue
+    }
+    out += ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    i++
+  }
+  return new RegExp(out + '$')
+}
+
+interface MemberSelection {
+  selected: ZipEntry[]
+  unmatched: string[]
+}
+
+// Info-ZIP walks the archive in order and charges each entry to the
+// first filespec that matches it, so a spec shadowed by an earlier one
+// reports "filename not matched" even when its file was printed.
+function selectEntries(entries: ZipEntry[], members: readonly string[]): MemberSelection {
+  if (members.length === 0) return { selected: entries, unmatched: [] }
+  const regexes = members.map(memberRegex)
+  const hit = members.map(() => false)
+  const selected: ZipEntry[] = []
+  for (const e of entries) {
+    const idx = regexes.findIndex((r) => r.test(e.name))
+    if (idx === -1) continue
+    hit[idx] = true
+    selected.push(e)
+  }
+  const unmatched = members.filter((_, i) => hit[i] !== true)
+  return { selected, unmatched }
+}
+
+function cautionText(unmatched: readonly string[]): string {
+  return unmatched.map((m) => CAUTION_PREFIX + m + '\n').join('')
+}
+
 function readU16LE(data: Uint8Array, offset: number): number {
   return (data[offset] ?? 0) | ((data[offset + 1] ?? 0) << 8)
 }
@@ -95,6 +162,7 @@ async function ensureParents(
 
 export async function unzipGeneric(
   paths: PathSpec[],
+  members: readonly string[],
   opts: CommandOpts,
   stream: (p: PathSpec) => AsyncIterable<Uint8Array>,
   write: (p: PathSpec, data: Uint8Array) => Promise<void>,
@@ -108,6 +176,7 @@ export async function unzipGeneric(
   if (archivePath === undefined) return [null, new IOResult()]
   const data = await materialize(stream(archivePath))
   const entries = await readZipEntries(data)
+  const { selected, unmatched } = selectEntries(entries, members)
 
   const listMode = fl.asBool('args_l')
   const testMode = fl.asBool('t')
@@ -124,14 +193,26 @@ export async function unzipGeneric(
 
   if (listMode) {
     const lines = ['  Length      Name', '---------  ----']
-    for (const e of entries) {
+    for (const e of selected) {
       lines.push(`${String(e.size).padStart(9, ' ')}  ${e.name}`)
     }
     const out: ByteSource = ENC.encode(lines.join('\n') + '\n')
+    // GNU -l prints no caution lines and only exits 11 when the member
+    // list matched nothing at all.
+    if (members.length > 0 && selected.length === 0) {
+      return [out, new IOResult({ exitCode: 11 })]
+    }
     return [out, new IOResult()]
   }
 
   if (testMode) {
+    // GNU -t reports unmatched members on stdout and counts them as
+    // errors.
+    if (unmatched.length > 0) {
+      const msg =
+        cautionText(unmatched) + `At least one error was detected in ${archivePath.virtual}.\n`
+      return [ENC.encode(msg), new IOResult({ exitCode: 11 })]
+    }
     const msg = `No errors detected in ${archivePath.virtual}\n`
     const out: ByteSource = ENC.encode(msg)
     return [out, new IOResult()]
@@ -139,7 +220,7 @@ export async function unzipGeneric(
 
   if (pipeMode) {
     const chunks: Uint8Array[] = []
-    for (const e of entries) {
+    for (const e of selected) {
       if (!e.name.endsWith('/')) chunks.push(e.data)
     }
     let total = 0
@@ -151,12 +232,15 @@ export async function unzipGeneric(
       offset += c.byteLength
     }
     const out: ByteSource = merged
+    if (unmatched.length > 0) {
+      return [out, new IOResult({ exitCode: 11, stderr: ENC.encode(cautionText(unmatched)) })]
+    }
     return [out, new IOResult()]
   }
 
   const writes: Record<string, Uint8Array> = {}
   const outputLines: string[] = []
-  for (const e of entries) {
+  for (const e of selected) {
     if (e.name.endsWith('/')) continue
     const entryName = lstripSlash(e.name)
     const outPath = rstripSlash(dest) + '/' + entryName
@@ -168,5 +252,11 @@ export async function unzipGeneric(
   }
   const stdout: ByteSource | null =
     outputLines.length > 0 ? ENC.encode(outputLines.join('\n') + '\n') : null
+  if (unmatched.length > 0) {
+    return [
+      stdout,
+      new IOResult({ exitCode: 11, stderr: ENC.encode(cautionText(unmatched)), writes }),
+    ]
+  }
   return [stdout, new IOResult({ writes })]
 }

--- a/typescript/packages/core/src/commands/builtin/generic_bind/builders/unzip.ts
+++ b/typescript/packages/core/src/commands/builtin/generic_bind/builders/unzip.ts
@@ -19,7 +19,7 @@ export const UNZIP_BUILDER: Builder = {
   name: 'unzip',
   write: true,
   requirements: ['write', 'mkdir'],
-  fn: async (ops, accessor, paths, _texts, opts) => {
+  fn: async (ops, accessor, paths, texts, opts) => {
     const idx = opts.index ?? undefined
     const { write, mkdir } = ops
     if (write === undefined || mkdir === undefined) {
@@ -28,6 +28,7 @@ export const UNZIP_BUILDER: Builder = {
     const resolved = paths.length > 0 ? await resolveGlobOf(ops)(accessor, paths, idx) : []
     return unzipGeneric(
       resolved,
+      texts,
       opts,
       (p) => ops.readStream(accessor, p, idx),
       (p, d) => write(accessor, p, d),

--- a/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
@@ -29,6 +29,7 @@ interface CmdResult {
   out: Uint8Array
   writes: Record<string, Uint8Array>
   exitCode: number
+  stderr: Uint8Array
 }
 
 async function runCmd(
@@ -36,24 +37,35 @@ async function runCmd(
   resource: RAMResource,
   paths: PathSpec[],
   flags: Record<string, string | boolean | number | string[]>,
+  texts: string[] = [],
 ): Promise<CmdResult> {
   const cmd = reg[0]
   if (cmd === undefined) throw new Error('not registered')
-  const result = await cmd.fn(resource.accessor, paths, [], {
+  const result = await cmd.fn(resource.accessor, paths, texts, {
     stdin: null,
     flags,
     filetypeFns: null,
     cwd: '/',
     resource,
   })
-  if (result === null) return { out: new Uint8Array(), writes: {}, exitCode: 0 }
-  const [output, io] = result as [unknown, { writes: Record<string, Uint8Array>; exitCode: number }]
+  if (result === null) {
+    return { out: new Uint8Array(), writes: {}, exitCode: 0, stderr: new Uint8Array() }
+  }
+  const [output, io] = result as [
+    unknown,
+    { writes: Record<string, Uint8Array>; exitCode: number; stderr: Uint8Array | null },
+  ]
   let outBytes: Uint8Array = new Uint8Array()
   if (output !== null) {
     outBytes =
       output instanceof Uint8Array ? output : await materialize(output as AsyncIterable<Uint8Array>)
   }
-  return { out: outBytes, writes: io.writes, exitCode: io.exitCode }
+  return {
+    out: outBytes,
+    writes: io.writes,
+    exitCode: io.exitCode,
+    stderr: io.stderr ?? new Uint8Array(),
+  }
 }
 
 describe('tar', () => {
@@ -148,5 +160,127 @@ describe('zip / unzip', () => {
       { q: true },
     )
     expect(out.byteLength).toBe(0)
+  })
+})
+
+describe('unzip members', () => {
+  const APP = 'APPXML-CONTENT\n'
+  const SHEET = 'SHEET1-CONTENT\n'
+  const WORKBOOK = 'WORKBOOK-CONTENT\n'
+  const CAUTION = 'caution: filename not matched:  '
+
+  async function makeBook(): Promise<RAMResource> {
+    const resource = new RAMResource()
+    resource.store.dirs.add('/docProps')
+    resource.store.dirs.add('/xl')
+    resource.store.files.set('/docProps/app.xml', ENC.encode(APP))
+    resource.store.files.set('/xl/sheet1.xml', ENC.encode(SHEET))
+    resource.store.files.set('/xl/workbook.xml', ENC.encode(WORKBOOK))
+    await runCmd(
+      RAM_ZIP,
+      resource,
+      [
+        PathSpec.fromStrPath('/book.zip'),
+        PathSpec.fromStrPath('/docProps/app.xml'),
+        PathSpec.fromStrPath('/xl/sheet1.xml'),
+        PathSpec.fromStrPath('/xl/workbook.xml'),
+      ],
+      {},
+    )
+    return resource
+  }
+
+  function book(): PathSpec[] {
+    return [PathSpec.fromStrPath('/book.zip')]
+  }
+
+  it('-p with a member outputs only that member', async () => {
+    const resource = await makeBook()
+    const r = await runCmd(RAM_UNZIP, resource, book(), { p: true }, ['xl/workbook.xml'])
+    expect(DEC.decode(r.out)).toBe(WORKBOOK)
+    expect(r.exitCode).toBe(0)
+    expect(r.stderr.byteLength).toBe(0)
+  })
+
+  it('-p with a missing member exits 11 with a caution on stderr', async () => {
+    const resource = await makeBook()
+    const r = await runCmd(RAM_UNZIP, resource, book(), { p: true }, ['NOSUCHFILE.xml'])
+    expect(r.out.byteLength).toBe(0)
+    expect(r.exitCode).toBe(11)
+    expect(DEC.decode(r.stderr)).toBe(`${CAUTION}NOSUCHFILE.xml\n`)
+  })
+
+  it('-p output follows archive order, not argument order', async () => {
+    const resource = await makeBook()
+    const r = await runCmd(RAM_UNZIP, resource, book(), { p: true }, [
+      'xl/workbook.xml',
+      'docProps/app.xml',
+    ])
+    expect(DEC.decode(r.out)).toBe(APP + WORKBOOK)
+    expect(r.exitCode).toBe(0)
+  })
+
+  it('-p charges each entry to the first matching spec', async () => {
+    const resource = await makeBook()
+    const r = await runCmd(RAM_UNZIP, resource, book(), { p: true }, ['*.xml', 'xl/workbook.xml'])
+    expect(DEC.decode(r.out)).toBe(APP + SHEET + WORKBOOK)
+    expect(r.exitCode).toBe(11)
+    expect(DEC.decode(r.stderr)).toBe(`${CAUTION}xl/workbook.xml\n`)
+  })
+
+  it('-p wildcard star crosses slashes', async () => {
+    const resource = await makeBook()
+    const r = await runCmd(RAM_UNZIP, resource, book(), { p: true }, ['doc*'])
+    expect(DEC.decode(r.out)).toBe(APP)
+    expect(r.exitCode).toBe(0)
+  })
+
+  it('-p wildcard selects a subtree', async () => {
+    const resource = await makeBook()
+    const r = await runCmd(RAM_UNZIP, resource, book(), { p: true }, ['xl/*'])
+    expect(DEC.decode(r.out)).toBe(SHEET + WORKBOOK)
+    expect(r.exitCode).toBe(0)
+  })
+
+  it('-l filters rows and exits 11 only when nothing matched', async () => {
+    const resource = await makeBook()
+    const hit = await runCmd(RAM_UNZIP, resource, book(), { args_l: true }, ['xl/workbook.xml'])
+    expect(DEC.decode(hit.out)).toContain('xl/workbook.xml')
+    expect(DEC.decode(hit.out)).not.toContain('docProps/app.xml')
+    expect(hit.exitCode).toBe(0)
+    const miss = await runCmd(RAM_UNZIP, resource, book(), { args_l: true }, ['NOSUCHFILE.xml'])
+    expect(miss.exitCode).toBe(11)
+    expect(miss.stderr.byteLength).toBe(0)
+    const partial = await runCmd(RAM_UNZIP, resource, book(), { args_l: true }, [
+      'xl/workbook.xml',
+      'NOSUCHFILE.xml',
+    ])
+    expect(partial.exitCode).toBe(0)
+    expect(partial.stderr.byteLength).toBe(0)
+  })
+
+  it('-t reports unmatched members on stdout and exits 11', async () => {
+    const resource = await makeBook()
+    const r = await runCmd(RAM_UNZIP, resource, book(), { t: true }, [
+      'xl/workbook.xml',
+      'NOSUCHFILE.xml',
+    ])
+    const text = DEC.decode(r.out)
+    expect(text).toContain(`${CAUTION}NOSUCHFILE.xml`)
+    expect(text).toContain('At least one error was detected')
+    expect(r.exitCode).toBe(11)
+    expect(r.stderr.byteLength).toBe(0)
+  })
+
+  it('extraction writes only the selected members', async () => {
+    const resource = await makeBook()
+    const r = await runCmd(RAM_UNZIP, resource, book(), { d: '/ext' }, [
+      'xl/workbook.xml',
+      'NOSUCHFILE.xml',
+    ])
+    expect(resource.store.files.has('/ext/xl/workbook.xml')).toBe(true)
+    expect(resource.store.files.has('/ext/docProps/app.xml')).toBe(false)
+    expect(r.exitCode).toBe(11)
+    expect(DEC.decode(r.stderr)).toBe(`${CAUTION}NOSUCHFILE.xml\n`)
   })
 })

--- a/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
+++ b/typescript/packages/core/src/commands/builtin/ram/archive.test.ts
@@ -242,6 +242,30 @@ describe('unzip members', () => {
     expect(r.exitCode).toBe(0)
   })
 
+  it('-p treats ? as one byte, the way Info-ZIP does', async () => {
+    const resource = new RAMResource()
+    resource.store.files.set('/é.txt', ENC.encode('ACCENT\n'))
+    resource.store.files.set('/ab.txt', ENC.encode('AB\n'))
+    await runCmd(
+      RAM_ZIP,
+      resource,
+      [
+        PathSpec.fromStrPath('/bytes.zip'),
+        PathSpec.fromStrPath('/é.txt'),
+        PathSpec.fromStrPath('/ab.txt'),
+      ],
+      {},
+    )
+    const arch = [PathSpec.fromStrPath('/bytes.zip')]
+    const one = await runCmd(RAM_UNZIP, resource, arch, { p: true }, ['?.txt'])
+    expect(one.out.byteLength).toBe(0)
+    expect(one.exitCode).toBe(11)
+    expect(DEC.decode(one.stderr)).toBe(`${CAUTION}?.txt\n`)
+    const two = await runCmd(RAM_UNZIP, resource, arch, { p: true }, ['??.txt'])
+    expect(DEC.decode(two.out)).toBe('ACCENT\nAB\n')
+    expect(two.exitCode).toBe(0)
+  })
+
   it('-l filters rows and exits 11 only when nothing matched', async () => {
     const resource = await makeBook()
     const hit = await runCmd(RAM_UNZIP, resource, book(), { args_l: true }, ['xl/workbook.xml'])

--- a/typescript/packages/core/src/commands/spec/builtin_specs/archive.ts
+++ b/typescript/packages/core/src/commands/spec/builtin_specs/archive.ts
@@ -67,7 +67,11 @@ export const SPECS: Record<string, CommandSpec> = {
       new Option({ short: '-p' }),
       new Option({ short: '-t' }),
     ],
-    rest: new Operand({ type: 'path' }),
+    // The archive is the only path operand; everything after it is an
+    // Info-ZIP member pattern matched against archive entry names, never
+    // a filesystem path.
+    positional: [new Operand({ type: 'path' })],
+    rest: new Operand({ type: 'str' }),
   }),
   zcat: new CommandSpec({ rest: new Operand({ type: 'path' }) }),
   zip: new CommandSpec({

--- a/typescript/packages/node/src/commands/native_unzip_flags.test.ts
+++ b/typescript/packages/node/src/commands/native_unzip_flags.test.ts
@@ -80,4 +80,49 @@ describe.each(NATIVE_BACKENDS)('native unzip flags (%s backend)', (kind) => {
       await env.cleanup()
     }
   })
+
+  it('unzip -p with a member outputs only that member', async () => {
+    const env = makeEnv(kind)
+    try {
+      env.createFile('a.txt', ENC.encode('hello\n'))
+      env.createFile('b.txt', ENC.encode('world\n'))
+      await env.mirage('zip /data/out.zip /data/a.txt /data/b.txt')
+      const result = await env.mirage('unzip -p /data/out.zip data/a.txt')
+      expect(result).toBe('hello\n')
+    } finally {
+      await env.cleanup()
+    }
+  })
+
+  it('unzip -p with a missing member exits 11 with a caution', async () => {
+    const env = makeEnv(kind)
+    try {
+      env.createFile('a.txt', ENC.encode('hello\n'))
+      await env.mirage('zip /data/out.zip /data/a.txt')
+      env.ws.cwd = '/data'
+      const io = await env.ws.execute('unzip -p /data/out.zip NOSUCHFILE.xml')
+      expect(io.exitCode).toBe(11)
+      expect(new TextDecoder().decode(io.stdout)).toBe('')
+      expect(new TextDecoder().decode(io.stderr)).toBe(
+        'caution: filename not matched:  NOSUCHFILE.xml\n',
+      )
+    } finally {
+      await env.cleanup()
+    }
+  })
+
+  it('unzip extraction writes only the selected member', async () => {
+    const env = makeEnv(kind)
+    try {
+      env.createFile('a.txt', ENC.encode('hello\n'))
+      env.createFile('b.txt', ENC.encode('world\n'))
+      await env.mirage('zip /data/out.zip /data/a.txt /data/b.txt')
+      await env.mirage('unzip -q /data/out.zip data/a.txt -d /data/ext')
+      const listing = await env.mirage('ls /data/ext/data')
+      expect(listing).toContain('a.txt')
+      expect(listing).not.toContain('b.txt')
+    } finally {
+      await env.cleanup()
+    }
+  })
 })


### PR DESCRIPTION
unzip -p ARCHIVE MEMBER concatenated the whole archive, exited 0 for a member that is not there, and resolved member names as filesystem paths, so an absolute archive path tripped the cross-mount guard. Info-ZIP treats every operand after the archive as a member pattern in every mode.

Pinned against Info-ZIP on debian:stable-slim and mirrored in both languages:

- The spec types the archive as the only path operand; members are text, never resolved against the VFS.
- All four modes filter by members. Output follows archive order; each entry is charged to the first matching spec, so a shadowed or duplicate spec still reports "filename not matched". Wildcards match with * crossing /.
- Unmatched specs print `caution: filename not matched:  X` and exit 11: on stderr for -p and extraction, on stdout for -t. -l prints no cautions and exits 11 only when nothing matched.

New unit coverage in both languages plus integ/unix/unzip/p.json member cases (green on ram/disk/opfs, both hosts). Spec JSONs regenerated, parity 93/93.